### PR TITLE
[ci] Add release date labels to install images

### DIFF
--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -219,15 +219,19 @@ Jobs for visual control allowed editions when approving deploy to environments.
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       {!{- end }!}
 
 {!{/*

--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -199,41 +199,6 @@ Jobs for visual control allowed editions when approving deploy to environments.
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       {!{- end }!}
 
-      {!{ range $werfEnv := slice "CE" "EE" "FE" "BE" "SE" }!}
-      - name: Set release date label for release ({!{ $werfEnv }!})
-        if: ${{ needs.detect_editions.outputs.DEPLOY_{!{ $werfEnv }!} == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: {!{ $werfEnv }!}
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      {!{- end }!}
-
 {!{/*
 Add 'publish' step for each edition to repuplish semver tag images to channel tag:
   - Pull deckhouse images from dev registry.
@@ -284,6 +249,8 @@ is used if DECKHOUSE_REGISTRY_HOST is not set.
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."

--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -199,6 +199,37 @@ Jobs for visual control allowed editions when approving deploy to environments.
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
       {!{- end }!}
 
+      {!{ range $werfEnv := slice "CE" "EE" "FE" "BE" "SE" }!}
+      - name: Set release date label for release ({!{ $werfEnv }!})
+        if: ${{ needs.detect_editions.outputs.DEPLOY_{!{ $werfEnv }!} == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: {!{ $werfEnv }!}
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      {!{- end }!}
+
 {!{/*
 Add 'publish' step for each edition to repuplish semver tag images to channel tag:
   - Pull deckhouse images from dev registry.

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -465,168 +465,6 @@ jobs:
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
 
 
-      - name: Set release date label for release (CE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: CE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (EE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: EE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (FE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: FE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (BE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: BE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (SE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: SE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-
-
 
       - name: Publish release images for CE
         if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
@@ -660,6 +498,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -791,6 +631,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -922,6 +764,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -1053,6 +897,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -1184,6 +1030,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -484,15 +484,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (EE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
@@ -512,15 +516,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (FE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
@@ -540,15 +548,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (BE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
         env:
@@ -568,15 +580,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (SE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
         env:
@@ -596,15 +612,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
 
 
 

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -465,6 +465,148 @@ jobs:
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
 
 
+      - name: Set release date label for release (CE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: CE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (EE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: EE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (FE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: FE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (BE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: BE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (SE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: SE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+
+
 
       - name: Publish release images for CE
         if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -465,168 +465,6 @@ jobs:
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
 
 
-      - name: Set release date label for release (CE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: CE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (EE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: EE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (FE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: FE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (BE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: BE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (SE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: SE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-
-
 
       - name: Publish release images for CE
         if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
@@ -660,6 +498,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -791,6 +631,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -922,6 +764,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -1053,6 +897,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -1184,6 +1030,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -484,15 +484,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (EE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
@@ -512,15 +516,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (FE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
@@ -540,15 +548,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (BE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
         env:
@@ -568,15 +580,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (SE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
         env:
@@ -596,15 +612,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
 
 
 

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -465,6 +465,148 @@ jobs:
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
 
 
+      - name: Set release date label for release (CE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: CE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (EE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: EE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (FE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: FE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (BE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: BE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (SE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: SE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+
+
 
       - name: Publish release images for CE
         if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -465,168 +465,6 @@ jobs:
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
 
 
-      - name: Set release date label for release (CE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: CE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (EE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: EE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (FE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: FE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (BE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: BE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (SE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: SE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-
-
 
       - name: Publish release images for CE
         if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
@@ -660,6 +498,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -791,6 +631,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -922,6 +764,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -1053,6 +897,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -1184,6 +1030,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -484,15 +484,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (EE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
@@ -512,15 +516,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (FE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
@@ -540,15 +548,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (BE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
         env:
@@ -568,15 +580,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (SE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
         env:
@@ -596,15 +612,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
 
 
 

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -465,6 +465,148 @@ jobs:
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
 
 
+      - name: Set release date label for release (CE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: CE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (EE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: EE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (FE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: FE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (BE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: BE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (SE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: SE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+
+
 
       - name: Publish release images for CE
         if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -465,168 +465,6 @@ jobs:
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
 
 
-      - name: Set release date label for release (CE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: CE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (EE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: EE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (FE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: FE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (BE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: BE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (SE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: SE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-
-
 
       - name: Publish release images for CE
         if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
@@ -660,6 +498,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -791,6 +631,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -922,6 +764,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -1053,6 +897,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -1184,6 +1030,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -484,15 +484,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (EE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
@@ -512,15 +516,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (FE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
@@ -540,15 +548,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (BE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
         env:
@@ -568,15 +580,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (SE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
         env:
@@ -596,15 +612,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
 
 
 

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -465,6 +465,148 @@ jobs:
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
 
 
+      - name: Set release date label for release (CE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: CE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (EE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: EE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (FE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: FE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (BE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: BE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (SE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: SE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+
+
 
       - name: Publish release images for CE
         if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -465,168 +465,6 @@ jobs:
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
 
 
-      - name: Set release date label for release (CE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: CE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (EE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: EE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (FE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: FE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (BE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: BE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-      - name: Set release date label for release (SE)
-        if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
-        env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          WERF_ENV: SE
-        run: |
-          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
-          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
-            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
-          fi
-
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-
-          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
-            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
-            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
-
-            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-            docker image push ${SOURCE_IMAGE}
-            docker image push ${SOURCE_INSTALL_IMAGE}
-            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
-          else
-            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
-          fi;
-
-
 
       - name: Publish release images for CE
         if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
@@ -660,6 +498,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -791,6 +631,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -922,6 +764,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -1053,6 +897,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
@@ -1184,6 +1030,8 @@ jobs:
             if [[ ${enable_push} == "true" ]] ; then
               echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
               docker image push ${DST}
+              # add date label to pushed image
+              crane mutate -l io.deckhouse.${RELEASE_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" ${DST}
             fi
 
             echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -484,15 +484,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (EE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
@@ -512,15 +516,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (FE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
@@ -540,15 +548,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (BE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
         env:
@@ -568,15 +580,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
       - name: Set release date label for release (SE)
         if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
         env:
@@ -596,15 +612,19 @@ jobs:
           SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
           SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
 
-          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
-          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
-          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
-          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+          if [[ ! $(docker inspect localhost:5000/registry:latest -f '{{index .Config.Labels "io.deckhouse.${DEPLOY_CHANNEL}-released"}}') ]]; then
+            echo "⚓️ 🏷 [$(date -u)] Add release date label to images."
+            echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+            echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+            echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.${DEPLOY_CHANNEL}-released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
 
-          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
-          docker image push ${SOURCE_IMAGE}
-          docker image push ${SOURCE_INSTALL_IMAGE}
-          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+            echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+            docker image push ${SOURCE_IMAGE}
+            docker image push ${SOURCE_INSTALL_IMAGE}
+            docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+          else
+            echo "⚓️ 🏷 [$(date -u)] Release date label already present. Skipping."
+          fi;
 
 
 

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -465,6 +465,148 @@ jobs:
           docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
 
 
+      - name: Set release date label for release (CE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: CE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (EE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: EE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (FE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: FE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (BE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_BE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: BE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+      - name: Set release date label for release (SE)
+        if: ${{ needs.detect_editions.outputs.DEPLOY_SE == 'true' }}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: SE
+        run: |
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+
+          echo "⚓️ 📤 [$(date -u)] Add release date label to images."
+          echo "FROM ${SOURCE_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_IMAGE}" -
+          echo "FROM ${SOURCE_INSTALL_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_INSTALL_IMAGE}" -
+          echo "FROM ${SOURCE_RELEASE_VERSION_IMAGE}" | docker build --label io.deckhouse.released="$(date -u +%Y-%m-%dT%H:%M:%SZ)" -t "${SOURCE_RELEASE_VERSION_IMAGE}" -
+
+          echo "⚓️ 📤 [$(date -u)] Push images with release date label."
+          docker image push ${SOURCE_IMAGE}
+          docker image push ${SOURCE_INSTALL_IMAGE}
+          docker image push ${SOURCE_RELEASE_VERSION_IMAGE}
+
+
 
       - name: Publish release images for CE
         if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}


### PR DESCRIPTION
## Description
Add release date labels to to dev, dev/install, dev/install-standalone images. Label example:
```
"Labels": {
  "io.deckhouse.alpha-released": "2024-09-30T14:08:36Z"
}
```
## Why do we need it, and what problem does it solve?
Additional information present in image might be useful for debugging.

## What is the expected result?
Labels present.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: feature
summary: Add release date labels to install images.
impact_level: low
```

