### PR TITLE
fix: e2e

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -632,6 +632,7 @@ check_e2e_labels:
 {!{-   $runsOnLabel = "e2e-vsphere" -}!}
 {!{- end -}!}
 # <template: e2e_run_job_template>
+{!{ tmpl.Exec "check_e2e_labels_job" . | strings.Indent 2 }!}
 {!{ $ctx.jobID }!}:
   name: "{!{ $ctx.jobName }!}"
   if: ${{ github.event.inputs.cri == '{!{ $ctx.cri }!}' && github.event.inputs.k8s_version == '{!{ $ctx.kubernetesVersion }!}' && github.event.inputs.layout == '{!{ $ctx.layout }!}' }}
@@ -664,6 +665,7 @@ check_e2e_labels:
         DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
         DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
         INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+        MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
       run: |
         # Create tmppath for test script.
         TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -693,6 +695,13 @@ check_e2e_labels:
         TERRAFORM_IMAGE_NAME="${BRANCH_REGISTRY_PATH}/e2e-terraform:${DECKHOUSE_IMAGE_TAG}"
 {!{- end }!}
 
+        if [ "${MULTIMASTER}" == true ] ; then
+          MASTERS_COUNT=3
+        else
+          MASTERS_COUNT=1
+        fi
+        echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
         echo '::echo::on'
         echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
         echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
@@ -701,6 +710,7 @@ check_e2e_labels:
         echo "terraform-image-name=${TERRAFORM_IMAGE_NAME}" >> $GITHUB_OUTPUT
 {!{- end }!}
         echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+        echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
         echo '::echo::off'
 
@@ -729,6 +739,7 @@ check_e2e_labels:
         LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
         TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
         PREFIX: ${{ github.event.inputs.cluster_prefix }}
+        MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
         INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
         DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
 {!{- if eq $provider "eks" }!}

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -73,6 +73,38 @@ jobs:
 
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'aws';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_26:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -177,6 +209,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -201,11 +234,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -230,6 +271,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -353,6 +395,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'aws';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -457,6 +531,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -481,11 +556,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -510,6 +593,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -633,6 +717,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'aws';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -737,6 +853,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -761,11 +878,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -790,6 +915,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -913,6 +1039,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'aws';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1017,6 +1175,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1041,11 +1200,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1070,6 +1237,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1193,6 +1361,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'aws';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1297,6 +1497,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1321,11 +1522,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1350,6 +1559,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1473,6 +1683,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'aws';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1577,6 +1819,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1601,11 +1844,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1630,6 +1881,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1652,6 +1904,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -1665,6 +1918,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -1751,6 +2005,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'aws';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: AWS, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1855,6 +2141,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1879,11 +2166,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1908,6 +2203,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -73,6 +73,38 @@ jobs:
 
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'azure';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_26:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
@@ -177,6 +209,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -201,11 +234,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -230,6 +271,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -357,6 +399,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'azure';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
@@ -461,6 +535,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -485,11 +560,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -514,6 +597,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -641,6 +725,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'azure';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
@@ -745,6 +861,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -769,11 +886,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -798,6 +923,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -925,6 +1051,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'azure';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
@@ -1029,6 +1187,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1053,11 +1212,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1082,6 +1249,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1209,6 +1377,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'azure';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
@@ -1313,6 +1513,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1337,11 +1538,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1366,6 +1575,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1493,6 +1703,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'azure';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
@@ -1597,6 +1839,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1621,11 +1864,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1650,6 +1901,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1674,6 +1926,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -1687,6 +1940,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -1775,6 +2029,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'azure';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: Azure, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
@@ -1879,6 +2165,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1903,11 +2190,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1932,6 +2227,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -73,6 +73,38 @@ jobs:
 
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'eks';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_26:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -177,6 +209,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -204,12 +237,20 @@ jobs:
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           TERRAFORM_IMAGE_NAME="${BRANCH_REGISTRY_PATH}/e2e-terraform:${DECKHOUSE_IMAGE_TAG}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "terraform-image-name=${TERRAFORM_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -234,6 +275,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           TERRAFORM_IMAGE_NAME: ${{ steps.setup.outputs.terraform-image-name }}
@@ -355,6 +397,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'eks';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -459,6 +533,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -486,12 +561,20 @@ jobs:
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           TERRAFORM_IMAGE_NAME="${BRANCH_REGISTRY_PATH}/e2e-terraform:${DECKHOUSE_IMAGE_TAG}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "terraform-image-name=${TERRAFORM_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -516,6 +599,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           TERRAFORM_IMAGE_NAME: ${{ steps.setup.outputs.terraform-image-name }}
@@ -637,6 +721,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'eks';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -741,6 +857,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -768,12 +885,20 @@ jobs:
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           TERRAFORM_IMAGE_NAME="${BRANCH_REGISTRY_PATH}/e2e-terraform:${DECKHOUSE_IMAGE_TAG}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "terraform-image-name=${TERRAFORM_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -798,6 +923,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           TERRAFORM_IMAGE_NAME: ${{ steps.setup.outputs.terraform-image-name }}
@@ -919,6 +1045,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'eks';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1023,6 +1181,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1050,12 +1209,20 @@ jobs:
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           TERRAFORM_IMAGE_NAME="${BRANCH_REGISTRY_PATH}/e2e-terraform:${DECKHOUSE_IMAGE_TAG}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "terraform-image-name=${TERRAFORM_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1080,6 +1247,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           TERRAFORM_IMAGE_NAME: ${{ steps.setup.outputs.terraform-image-name }}
@@ -1201,6 +1369,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'eks';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1305,6 +1505,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1332,12 +1533,20 @@ jobs:
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           TERRAFORM_IMAGE_NAME="${BRANCH_REGISTRY_PATH}/e2e-terraform:${DECKHOUSE_IMAGE_TAG}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "terraform-image-name=${TERRAFORM_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1362,6 +1571,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           TERRAFORM_IMAGE_NAME: ${{ steps.setup.outputs.terraform-image-name }}
@@ -1483,6 +1693,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'eks';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1587,6 +1829,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1614,12 +1857,20 @@ jobs:
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           TERRAFORM_IMAGE_NAME="${BRANCH_REGISTRY_PATH}/e2e-terraform:${DECKHOUSE_IMAGE_TAG}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "terraform-image-name=${TERRAFORM_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1644,6 +1895,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           TERRAFORM_IMAGE_NAME: ${{ steps.setup.outputs.terraform-image-name }}
@@ -1668,6 +1920,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -1764,6 +2017,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'eks';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: EKS, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1868,6 +2153,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1895,12 +2181,20 @@ jobs:
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           TERRAFORM_IMAGE_NAME="${BRANCH_REGISTRY_PATH}/e2e-terraform:${DECKHOUSE_IMAGE_TAG}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "terraform-image-name=${TERRAFORM_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1925,6 +2219,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           TERRAFORM_IMAGE_NAME: ${{ steps.setup.outputs.terraform-image-name }}

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -73,6 +73,38 @@ jobs:
 
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'gcp';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_26:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -177,6 +209,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -201,11 +234,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -230,6 +271,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -351,6 +393,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'gcp';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -455,6 +529,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -479,11 +554,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -508,6 +591,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -629,6 +713,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'gcp';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -733,6 +849,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -757,11 +874,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -786,6 +911,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -907,6 +1033,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'gcp';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1011,6 +1169,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1035,11 +1194,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1064,6 +1231,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1185,6 +1353,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'gcp';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1289,6 +1489,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1313,11 +1514,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1342,6 +1551,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1463,6 +1673,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'gcp';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1567,6 +1809,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1591,11 +1834,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1620,6 +1871,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1641,6 +1893,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -1654,6 +1907,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -1739,6 +1993,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'gcp';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: GCP, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1843,6 +2129,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1867,11 +2154,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1896,6 +2191,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -73,6 +73,38 @@ jobs:
 
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'openstack';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_26:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
@@ -177,6 +209,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -201,11 +234,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -230,6 +271,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -351,6 +393,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'openstack';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
@@ -455,6 +529,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -479,11 +554,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -508,6 +591,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -629,6 +713,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'openstack';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
@@ -733,6 +849,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -757,11 +874,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -786,6 +911,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -907,6 +1033,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'openstack';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
@@ -1011,6 +1169,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1035,11 +1194,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1064,6 +1231,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1185,6 +1353,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'openstack';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
@@ -1289,6 +1489,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1313,11 +1514,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1342,6 +1551,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1463,6 +1673,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'openstack';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
@@ -1567,6 +1809,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1591,11 +1834,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1620,6 +1871,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1641,6 +1893,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -1654,6 +1907,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -1739,6 +1993,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'openstack';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
@@ -1843,6 +2129,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1867,11 +2154,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1896,6 +2191,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -73,6 +73,38 @@ jobs:
 
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'static';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_26:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Static' }}
@@ -177,6 +209,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -201,11 +234,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -230,6 +271,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -351,6 +393,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'static';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Static' }}
@@ -455,6 +529,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -479,11 +554,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -508,6 +591,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -629,6 +713,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'static';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Static' }}
@@ -733,6 +849,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -757,11 +874,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -786,6 +911,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -907,6 +1033,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'static';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Static' }}
@@ -1011,6 +1169,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1035,11 +1194,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1064,6 +1231,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1185,6 +1353,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'static';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Static' }}
@@ -1289,6 +1489,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1313,11 +1514,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1342,6 +1551,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1463,6 +1673,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'static';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Static' }}
@@ -1567,6 +1809,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1591,11 +1834,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1620,6 +1871,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1641,6 +1893,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -1654,6 +1907,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -1739,6 +1993,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'static';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: Static, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Static' }}
@@ -1843,6 +2129,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1867,11 +2154,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1896,6 +2191,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -73,6 +73,38 @@ jobs:
 
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vcd';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_26:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
@@ -177,6 +209,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -201,11 +234,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -230,6 +271,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -359,6 +401,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vcd';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
@@ -463,6 +537,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -487,11 +562,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -516,6 +599,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -645,6 +729,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vcd';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
@@ -749,6 +865,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -773,11 +890,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -802,6 +927,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -931,6 +1057,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vcd';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
@@ -1035,6 +1193,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1059,11 +1218,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1088,6 +1255,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1217,6 +1385,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vcd';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
@@ -1321,6 +1521,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1345,11 +1546,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1374,6 +1583,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1503,6 +1713,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vcd';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
@@ -1607,6 +1849,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1631,11 +1874,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1660,6 +1911,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1685,6 +1937,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -1698,6 +1951,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -1787,6 +2041,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vcd';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: VCD, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
@@ -1891,6 +2177,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1915,11 +2202,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1944,6 +2239,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -73,6 +73,38 @@ jobs:
 
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vsphere';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_26:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
@@ -177,6 +209,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -201,11 +234,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -230,6 +271,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -353,6 +395,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vsphere';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
@@ -457,6 +531,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -481,11 +556,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -510,6 +593,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -633,6 +717,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vsphere';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
@@ -737,6 +853,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -761,11 +878,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -790,6 +915,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -913,6 +1039,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vsphere';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
@@ -1017,6 +1175,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1041,11 +1200,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1070,6 +1237,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1193,6 +1361,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vsphere';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
@@ -1297,6 +1497,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1321,11 +1522,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1350,6 +1559,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1473,6 +1683,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vsphere';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
@@ -1577,6 +1819,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1601,11 +1844,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1630,6 +1881,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1652,6 +1904,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -1665,6 +1918,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -1751,6 +2005,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'vsphere';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: vSphere, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}
@@ -1855,6 +2141,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1879,11 +2166,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1908,6 +2203,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -73,6 +73,38 @@ jobs:
 
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'yandex-cloud';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_26:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -177,6 +209,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -201,11 +234,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -230,6 +271,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -355,6 +397,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'yandex-cloud';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -459,6 +533,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -483,11 +558,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -512,6 +595,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -637,6 +721,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'yandex-cloud';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -741,6 +857,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -765,11 +882,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -794,6 +919,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -919,6 +1045,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'yandex-cloud';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1023,6 +1181,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1047,11 +1206,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1076,6 +1243,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1201,6 +1369,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'yandex-cloud';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1305,6 +1505,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1329,11 +1530,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1358,6 +1567,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1483,6 +1693,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'yandex-cloud';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1587,6 +1829,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1611,11 +1854,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1640,6 +1891,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}
@@ -1663,6 +1915,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -1676,6 +1929,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -1763,6 +2017,38 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
+    # <template: check_e2e_labels_job>
+    check_e2e_labels:
+      name: Check e2e labels
+      runs-on: ubuntu-latest
+      outputs:
+
+        run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
+        run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
+        run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
+        run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
+        run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
+        run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
+        run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+        multimaster: ${{ steps.check.outputs.multimaster }}
+      steps:
+
+        # <template: checkout_step>
+        - name: Checkout sources
+          uses: actions/checkout@v3.5.2
+
+        # </template: checkout_step>
+        - name: Check e2e labels
+          id: check
+          uses: actions/github-script@v6.4.1
+          with:
+            script: |
+              const provider = 'yandex-cloud';
+              const kubernetesDefaultVersion = '1.27';
+
+              const ci = require('./.github/scripts/js/ci');
+              return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
+    # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1867,6 +2153,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
           DHCTL_PREFIX: ${{ github.event.inputs.cluster_prefix }}
           INSTALL_IMAGE_PATH: ${{ github.event.inputs.installer_image_path }}
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Create tmppath for test script.
           TMP_DIR_PATH="/mnt/cloud-layouts/layouts/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${DHCTL_PREFIX}"
@@ -1891,11 +2178,19 @@ jobs:
           arrPath=(${INSTALL_IMAGE_PATH//:/ })
           DECKHOUSE_IMAGE_TAG="${arrPath[1]}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           echo '::echo::on'
           echo "tmp-dir-path=${TMP_DIR_PATH}" >> $GITHUB_OUTPUT
           echo "install-image-full=${INSTALL_IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "deckhouse-image-tag=${DECKHOUSE_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -1920,6 +2215,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ github.event.inputs.cluster_prefix }}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-full }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           SSH_MASTER_CONNECTION_STRING: ${{ github.event.inputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -2747,6 +2747,7 @@ jobs:
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2828,6 +2829,13 @@ jobs:
           SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
           echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
           docker pull "${INSTALL_IMAGE_NAME}"
@@ -2842,6 +2850,7 @@ jobs:
           echo "deckhouse-image-tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "install-image-path=${IMAGE_INSTALL_PATH}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -2857,6 +2866,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           INITIAL_IMAGE_TAG: ${{ steps.setup.outputs.initial-image-tag }}
@@ -2879,6 +2889,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2910,6 +2921,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -2964,6 +2976,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
@@ -2985,6 +2998,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2998,6 +3012,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -2787,6 +2787,7 @@ jobs:
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2868,6 +2869,13 @@ jobs:
           SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
           echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
           docker pull "${INSTALL_IMAGE_NAME}"
@@ -2882,6 +2890,7 @@ jobs:
           echo "deckhouse-image-tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "install-image-path=${IMAGE_INSTALL_PATH}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -2897,6 +2906,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           INITIAL_IMAGE_TAG: ${{ steps.setup.outputs.initial-image-tag }}
@@ -2921,6 +2931,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2952,6 +2963,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -3008,6 +3020,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
@@ -3031,6 +3044,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -3044,6 +3058,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -2952,6 +2952,7 @@ jobs:
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -3037,6 +3038,13 @@ jobs:
           SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
           echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
           docker pull "${INSTALL_IMAGE_NAME}"
@@ -3053,6 +3061,7 @@ jobs:
           echo "deckhouse-image-tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "install-image-path=${IMAGE_INSTALL_PATH}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -3068,6 +3077,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           TERRAFORM_IMAGE_NAME: ${{ steps.setup.outputs.terraform-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
@@ -3092,6 +3102,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -3213,6 +3224,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           TERRAFORM_IMAGE_NAME: ${{ steps.setup.outputs.terraform-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
@@ -3236,6 +3248,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -2727,6 +2727,7 @@ jobs:
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2808,6 +2809,13 @@ jobs:
           SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
           echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
           docker pull "${INSTALL_IMAGE_NAME}"
@@ -2822,6 +2830,7 @@ jobs:
           echo "deckhouse-image-tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "install-image-path=${IMAGE_INSTALL_PATH}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -2837,6 +2846,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           INITIAL_IMAGE_TAG: ${{ steps.setup.outputs.initial-image-tag }}
@@ -2858,6 +2868,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2889,6 +2900,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -2942,6 +2954,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
@@ -2962,6 +2975,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2975,6 +2989,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -2727,6 +2727,7 @@ jobs:
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2808,6 +2809,13 @@ jobs:
           SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
           echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
           docker pull "${INSTALL_IMAGE_NAME}"
@@ -2822,6 +2830,7 @@ jobs:
           echo "deckhouse-image-tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "install-image-path=${IMAGE_INSTALL_PATH}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -2837,6 +2846,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           INITIAL_IMAGE_TAG: ${{ steps.setup.outputs.initial-image-tag }}
@@ -2858,6 +2868,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2889,6 +2900,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -2942,6 +2954,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
@@ -2962,6 +2975,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2975,6 +2989,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -2727,6 +2727,7 @@ jobs:
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2808,6 +2809,13 @@ jobs:
           SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
           echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
           docker pull "${INSTALL_IMAGE_NAME}"
@@ -2822,6 +2830,7 @@ jobs:
           echo "deckhouse-image-tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "install-image-path=${IMAGE_INSTALL_PATH}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -2837,6 +2846,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           INITIAL_IMAGE_TAG: ${{ steps.setup.outputs.initial-image-tag }}
@@ -2858,6 +2868,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2889,6 +2900,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -2942,6 +2954,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
@@ -2962,6 +2975,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2975,6 +2989,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -2807,6 +2807,7 @@ jobs:
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2888,6 +2889,13 @@ jobs:
           SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
           echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
           docker pull "${INSTALL_IMAGE_NAME}"
@@ -2902,6 +2910,7 @@ jobs:
           echo "deckhouse-image-tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "install-image-path=${IMAGE_INSTALL_PATH}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -2917,6 +2926,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           INITIAL_IMAGE_TAG: ${{ steps.setup.outputs.initial-image-tag }}
@@ -2942,6 +2952,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2973,6 +2984,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -3030,6 +3042,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
@@ -3054,6 +3067,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -3067,6 +3081,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -2747,6 +2747,7 @@ jobs:
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2828,6 +2829,13 @@ jobs:
           SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
           echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
           docker pull "${INSTALL_IMAGE_NAME}"
@@ -2842,6 +2850,7 @@ jobs:
           echo "deckhouse-image-tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "install-image-path=${IMAGE_INSTALL_PATH}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -2857,6 +2866,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           INITIAL_IMAGE_TAG: ${{ steps.setup.outputs.initial-image-tag }}
@@ -2879,6 +2889,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2910,6 +2921,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -2964,6 +2976,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
@@ -2985,6 +2998,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2998,6 +3012,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -2767,6 +2767,7 @@ jobs:
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
+          MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2848,6 +2849,13 @@ jobs:
           SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
           echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
+          if [ "${MULTIMASTER}" == true ] ; then
+            MASTERS_COUNT=3
+          else
+            MASTERS_COUNT=1
+          fi
+          echo "Multimaster set ${MULTIMASTER}, MASTERS_COUNT set ${MASTERS_COUNT}"
+
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
           docker pull "${INSTALL_IMAGE_NAME}"
@@ -2862,6 +2870,7 @@ jobs:
           echo "deckhouse-image-tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "initial-image-tag=${INITIAL_IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "install-image-path=${IMAGE_INSTALL_PATH}" >> $GITHUB_OUTPUT
+          echo "masters-count=${MASTERS_COUNT}" >> $GITHUB_OUTPUT
 
           echo '::echo::off'
 
@@ -2877,6 +2886,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
           INITIAL_IMAGE_TAG: ${{ steps.setup.outputs.initial-image-tag }}
@@ -2900,6 +2910,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -2931,6 +2942,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
@@ -2986,6 +2998,7 @@ jobs:
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
           TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
           PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
+          MASTERS_COUNT: ${{ steps.setup.outputs.masters-count }}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
           DECKHOUSE_IMAGE_TAG: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
@@ -3008,6 +3021,7 @@ jobs:
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
             TMP_DIR_PATH=${TMP_DIR_PATH}
+            MASTERS_COUNT=${MASTERS_COUNT}
           "
 
           ls -lh $(pwd)/testing
@@ -3021,6 +3035,7 @@ jobs:
           docker run --rm \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
+            -e MASTERS_COUNT=${MASTERS_COUNT} \
             -e DECKHOUSE_IMAGE_TAG=${DECKHOUSE_IMAGE_TAG} \
             -e INITIAL_IMAGE_TAG=${INITIAL_IMAGE_TAG} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed e2e test for containerd 1.31
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Сan't run e2e for containerd 1.31
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not related to release
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
E2e test successful
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->
Fixed e2e test for containerd 1.31
```changes
section: ci
type: fix
summary: Fixed e2e test for containerd 1.31.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
