### PR TITLE
[deckhouse-controller] feat: adding an alert that manual confirmation is required to install mr

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -455,7 +455,7 @@ func (c *moduleReleaseReconciler) reconcilePendingRelease(ctx context.Context, m
 	}
 
 	k8 := newKubeAPI(ctx, c.logger, c.client, c.downloadedModulesDir, c.symlinksDir, c.moduleManager, c.dc)
-	releaseUpdater := newModuleUpdater(c.logger, nConfig, policy.Spec.Update.Mode, k8, c.moduleManager.GetEnabledModuleNames())
+	releaseUpdater := newModuleUpdater(c.logger, nConfig, policy.Spec.Update.Mode, k8, c.moduleManager.GetEnabledModuleNames(), c.metricStorage)
 
 	otherReleases := new(v1alpha1.ModuleReleaseList)
 	err = c.client.List(ctx, otherReleases, client.MatchingLabels{"module": moduleName})

--- a/deckhouse-controller/pkg/controller/module-controllers/release/updater.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/updater.go
@@ -38,10 +38,6 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/updater"
 )
 
-const (
-	metricReleasesGroup = "d8_module_releases"
-)
-
 func newModuleUpdater(logger logger.Logger, nConfig *updater.NotificationConfig, mode string,
 	kubeAPI updater.KubeAPI[*v1alpha1.ModuleRelease], enabledModules []string, metricStorage *metric_storage.MetricStorage) *updater.Updater[*v1alpha1.ModuleRelease] {
 	return updater.NewUpdater[*v1alpha1.ModuleRelease](logger, nConfig, mode,
@@ -237,7 +233,7 @@ func (m *metricsUpdater) ReleaseBlocked(_, _ string) {
 }
 
 func (m *metricsUpdater) WaitingManual(name string, _ float64) {
-	m.metricStorage.CounterAdd("d8_module_release_waiting_manual", 1, map[string]string{"name": name})
+	m.metricStorage.GaugeSet("d8_module_release_waiting_manual", 1, map[string]string{"name": name})
 }
 
 type settings struct{}

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2418,6 +2418,19 @@ alerts:
         Deprecated ModuleConfig was found.
       severity: "9"
       markupFormat: markdown
+    - name: ModuleReleaseIsWaitingManualApproval
+      sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+      moduleUrl: 340-monitoring-deckhouse
+      module: monitoring-deckhouse
+      edition: ce
+      description: |
+        Module release is waiting for manual approval.
+
+        Please run `kubectl annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"` for confirmation.
+      summary: |
+        Module release is waiting for manual approval.
+      severity: "6"
+      markupFormat: markdown
     - name: NATInstanceWithDeprecatedAvailabilityZone
       sourceFile: modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
       moduleUrl: 030-cloud-provider-yandex

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -103,3 +103,18 @@
         If you are ready to deploy this release, run: `kubectl annotate DeckhouseRelease {{ $labels.name }} release.deckhouse.io/disruption-approved=true`.
       summary: |
         Deckhouse release disruption approval required.
+  - alert: ModuleReleaseIsWaitingManualApproval
+    expr: max by (name) (d8_module_release_waiting_manual) >= 1
+    labels:
+      severity_level: "6"
+      d8_module: $labels.name
+    annotations:
+      plk_markup_format: "markdown"
+      plk_protocol_version: "1"
+      plk_ignore_labels: "name"
+      description: |
+        Module release is waiting for manual approval.
+
+        Please run `kubectl annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"` for confirmation.
+      summary: |
+        Module release is waiting for manual approval.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -107,7 +107,6 @@
     expr: max by (name) (d8_module_release_waiting_manual) >= 1
     labels:
       severity_level: "6"
-      d8_module: $labels.name
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"


### PR DESCRIPTION
## Description

If the module is set to manual installation mode, we need to approve its installation when a new version appears.

## Why do we need it, and what problem does it solve?

In order to know that a new version has appeared and that we need to check and approve these changes, we need to add an alert to Prometheus.

## What is the expected result?

If the cluster contains modules that require confirmation of installation, then when a new version appears, an alert will appear in Prometheus.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: feature
summary: adding an alert that manual confirmation is required to install mr
impact_level: default
```

