### PR TITLE
[ci] Fix incorrect keys in e2e-abort

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -632,7 +632,6 @@ check_e2e_labels:
 {!{-   $runsOnLabel = "e2e-vsphere" -}!}
 {!{- end -}!}
 # <template: e2e_run_job_template>
-{!{ tmpl.Exec "check_e2e_labels_job" . }!}
 {!{ $ctx.jobID }!}:
   name: "{!{ $ctx.jobName }!}"
   if: ${{ github.event.inputs.cri == '{!{ $ctx.cri }!}' && github.event.inputs.k8s_version == '{!{ $ctx.kubernetesVersion }!}' && github.event.inputs.layout == '{!{ $ctx.layout }!}' }}

--- a/.github/workflow_templates/e2e.abort.multi.yml
+++ b/.github/workflow_templates/e2e.abort.multi.yml
@@ -102,6 +102,8 @@ jobs:
     steps:
 {!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
 
+{!{ tmpl.Exec "check_e2e_labels_job" $ctx | strings.Indent 2 }!}
+
 {!{/* Jobs for each CRI and Kubernetes version */}!}
 {!{/* Note: it is sufficient to have one workflow 'e2e-abort.yaml' with one 'destroy' job and use provider, cri, k8s_version and layout from inputs. Still there are jobs for each CRI and Kubernetes version for similarity with e2e.multi.yaml */}!}
 {!{- $lastCommentNeeds := slice "started_at" -}!}

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -70,9 +70,6 @@ jobs:
           echo "started_at=${unixTimestamp}" >> $GITHUB_OUTPUT
       # </template: started_at_output>
 
-
-
-  # <template: e2e_run_job_template>
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -105,6 +102,10 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
   # </template: check_e2e_labels_job>
+
+
+
+  # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -395,38 +396,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'aws';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -717,38 +686,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'aws';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1039,38 +976,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'aws';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1361,38 +1266,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'aws';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1683,38 +1556,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'aws';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: AWS, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -2005,38 +1846,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'aws';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: AWS, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -70,9 +70,6 @@ jobs:
           echo "started_at=${unixTimestamp}" >> $GITHUB_OUTPUT
       # </template: started_at_output>
 
-
-
-  # <template: e2e_run_job_template>
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -105,6 +102,10 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
   # </template: check_e2e_labels_job>
+
+
+
+  # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
@@ -399,38 +400,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'azure';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
@@ -725,38 +694,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'azure';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
@@ -1051,38 +988,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'azure';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
@@ -1377,38 +1282,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'azure';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
@@ -1703,38 +1576,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'azure';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: Azure, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
@@ -2029,38 +1870,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'azure';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: Azure, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -70,9 +70,6 @@ jobs:
           echo "started_at=${unixTimestamp}" >> $GITHUB_OUTPUT
       # </template: started_at_output>
 
-
-
-  # <template: e2e_run_job_template>
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -105,6 +102,10 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
   # </template: check_e2e_labels_job>
+
+
+
+  # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -397,38 +398,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'eks';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -721,38 +690,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'eks';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1045,38 +982,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'eks';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1369,38 +1274,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'eks';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1693,38 +1566,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'eks';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: EKS, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -2017,38 +1858,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'eks';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: EKS, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -70,9 +70,6 @@ jobs:
           echo "started_at=${unixTimestamp}" >> $GITHUB_OUTPUT
       # </template: started_at_output>
 
-
-
-  # <template: e2e_run_job_template>
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -105,6 +102,10 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
   # </template: check_e2e_labels_job>
+
+
+
+  # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -393,38 +394,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'gcp';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -713,38 +682,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'gcp';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1033,38 +970,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'gcp';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1353,38 +1258,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'gcp';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1673,38 +1546,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'gcp';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: GCP, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1993,38 +1834,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'gcp';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: GCP, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -70,9 +70,6 @@ jobs:
           echo "started_at=${unixTimestamp}" >> $GITHUB_OUTPUT
       # </template: started_at_output>
 
-
-
-  # <template: e2e_run_job_template>
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -105,6 +102,10 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
   # </template: check_e2e_labels_job>
+
+
+
+  # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
@@ -393,38 +394,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'openstack';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
@@ -713,38 +682,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'openstack';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
@@ -1033,38 +970,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'openstack';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
@@ -1353,38 +1258,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'openstack';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
@@ -1673,38 +1546,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'openstack';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
@@ -1993,38 +1834,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'openstack';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: OpenStack, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -70,9 +70,6 @@ jobs:
           echo "started_at=${unixTimestamp}" >> $GITHUB_OUTPUT
       # </template: started_at_output>
 
-
-
-  # <template: e2e_run_job_template>
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -105,6 +102,10 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
   # </template: check_e2e_labels_job>
+
+
+
+  # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Static' }}
@@ -393,38 +394,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'static';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Static' }}
@@ -713,38 +682,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'static';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Static' }}
@@ -1033,38 +970,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'static';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Static' }}
@@ -1353,38 +1258,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'static';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Static' }}
@@ -1673,38 +1546,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'static';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: Static, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Static' }}
@@ -1993,38 +1834,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'static';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: Static, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Static' }}

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -70,9 +70,6 @@ jobs:
           echo "started_at=${unixTimestamp}" >> $GITHUB_OUTPUT
       # </template: started_at_output>
 
-
-
-  # <template: e2e_run_job_template>
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -105,6 +102,10 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
   # </template: check_e2e_labels_job>
+
+
+
+  # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
@@ -401,38 +402,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'vcd';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
@@ -729,38 +698,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'vcd';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
@@ -1057,38 +994,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'vcd';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
@@ -1385,38 +1290,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'vcd';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
@@ -1713,38 +1586,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'vcd';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: VCD, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
@@ -2041,38 +1882,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'vcd';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: VCD, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -70,9 +70,6 @@ jobs:
           echo "started_at=${unixTimestamp}" >> $GITHUB_OUTPUT
       # </template: started_at_output>
 
-
-
-  # <template: e2e_run_job_template>
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -105,6 +102,10 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
   # </template: check_e2e_labels_job>
+
+
+
+  # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'Standard' }}
@@ -395,38 +396,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'vsphere';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'Standard' }}
@@ -717,38 +686,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'vsphere';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'Standard' }}
@@ -1039,38 +976,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'vsphere';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'Standard' }}
@@ -1361,38 +1266,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'vsphere';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'Standard' }}
@@ -1683,38 +1556,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'vsphere';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: vSphere, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'Standard' }}
@@ -2005,38 +1846,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'vsphere';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: vSphere, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'Standard' }}

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -70,9 +70,6 @@ jobs:
           echo "started_at=${unixTimestamp}" >> $GITHUB_OUTPUT
       # </template: started_at_output>
 
-
-
-  # <template: e2e_run_job_template>
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -105,6 +102,10 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
   # </template: check_e2e_labels_job>
+
+
+
+  # <template: e2e_run_job_template>
   run_containerd_1_26:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.26"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.26' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -397,38 +398,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'yandex-cloud';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_27:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.27"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.27' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -721,38 +690,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'yandex-cloud';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_28:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.28"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.28' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1045,38 +982,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'yandex-cloud';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_29:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.29"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.29' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1369,38 +1274,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'yandex-cloud';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_30:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.30"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.30' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -1693,38 +1566,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'yandex-cloud';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_1_31:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes 1.31"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == '1.31' && github.event.inputs.layout == 'WithoutNAT' }}
@@ -2017,38 +1858,6 @@ jobs:
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
-  # <template: check_e2e_labels_job>
-  check_e2e_labels:
-    name: Check e2e labels
-    runs-on: ubuntu-latest
-    outputs:
-
-      run_containerd_1_26: ${{ steps.check.outputs.run_containerd_1_26 }}
-      run_containerd_1_27: ${{ steps.check.outputs.run_containerd_1_27 }}
-      run_containerd_1_28: ${{ steps.check.outputs.run_containerd_1_28 }}
-      run_containerd_1_29: ${{ steps.check.outputs.run_containerd_1_29 }}
-      run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
-      run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
-      run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
-      multimaster: ${{ steps.check.outputs.multimaster }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Check e2e labels
-        id: check
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const provider = 'yandex-cloud';
-            const kubernetesDefaultVersion = '1.27';
-
-            const ci = require('./.github/scripts/js/ci');
-            return await ci.checkE2ELabels({github, context, core, provider, kubernetesDefaultVersion});
-  # </template: check_e2e_labels_job>
   run_containerd_automatic:
     name: "destroy cluster: Yandex.Cloud, Containerd, Kubernetes Automatic"
     if: ${{ github.event.inputs.cri == 'containerd' && github.event.inputs.k8s_version == 'Automatic' && github.event.inputs.layout == 'WithoutNAT' }}


### PR DESCRIPTION
## Description
Mistaken edit in #9947 broke e2e-abort completely. Fixed.

## Why do we need it, and what problem does it solve?
Incorrect edit broke the abort pipeline.


## What is the expected result?
Working pipeline

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: ci
type: fix
summary: Fix incorrect keys in e2e-abort.
impact_level: low
```
