### PR TITLE
[multitenancy-manager] json logs format

### DIFF
--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/cmd/main.go
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/cmd/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	// setup logger
 	log := ctrl.Log.WithName("multitenancy-manager")
-	ctrllog.SetLogger(zap.New(zap.Level(zapcore.Level(-4)), zap.UseDevMode(true)))
+	ctrllog.SetLogger(zap.New(zap.Level(zapcore.Level(-4)), zap.StacktraceLevel(zapcore.PanicLevel)))
 
 	log.Info(fmt.Sprintf("starting multitenancy-manager with %v allow orphan namespaces option", allowOrphanNamespaces))
 


### PR DESCRIPTION
## Description
It provides json formatted logs.

## Why do we need it, and what problem does it solve?
With the dev mode logs seems to be panic and cannot be collected in json format.

## Why do we need it in the patch release (if we do)?
It helps to analyze logs.

## What is the expected result?
Logs are in json format.

<img width="1506" alt="Screenshot 2024-10-02 at 5 30 19 PM" src="https://github.com/user-attachments/assets/2425cbad-c2c6-4d3d-8ada-575efcfb54da">


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: fix
summary: Change logs format to json format.
```