### PR TITLE
[control-plane-manager] patch etcd to support of outputting snapshots to stdout

### DIFF
--- a/modules/040-control-plane-manager/images/etcd/patches/000_etcdctl-snapshot-pipe.patch
+++ b/modules/040-control-plane-manager/images/etcd/patches/000_etcdctl-snapshot-pipe.patch
@@ -1,0 +1,142 @@
+Subject: [PATCH] feature: support for piping snapshot to stdout
+---
+Index: etcdctl/ctlv3/command/snapshot_command.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/etcdctl/ctlv3/command/snapshot_command.go b/etcdctl/ctlv3/command/snapshot_command.go
+--- a/etcdctl/ctlv3/command/snapshot_command.go	(revision f20bbadd404b57c776d1e8876cefd1ac29b03fb5)
++++ b/etcdctl/ctlv3/command/snapshot_command.go	(date 1727874859931)
+@@ -20,11 +20,12 @@
+ 	"os"
+ 
+ 	"github.com/spf13/cobra"
++	"go.uber.org/zap"
++
+ 	"go.etcd.io/etcd/client/pkg/v3/logutil"
+ 	snapshot "go.etcd.io/etcd/client/v3/snapshot"
+ 	"go.etcd.io/etcd/etcdutl/v3/etcdutl"
+ 	"go.etcd.io/etcd/pkg/v3/cobrautl"
+-	"go.uber.org/zap"
+ )
+ 
+ const (
+@@ -45,6 +46,14 @@
+ 	initialMmapSize     uint64
+ )
+ 
++func NewSnapshotPipeCommand() *cobra.Command {
++	return &cobra.Command{
++		Use:   "pipe",
++		Short: "Streams an etcd node backend snapshot to stdout",
++		Run:   snapshotPipeCommandFunc,
++	}
++}
++
+ // NewSnapshotCommand returns the cobra command for "snapshot".
+ func NewSnapshotCommand() *cobra.Command {
+ 	cmd := &cobra.Command{
+@@ -54,6 +63,7 @@
+ 	cmd.AddCommand(NewSnapshotSaveCommand())
+ 	cmd.AddCommand(NewSnapshotRestoreCommand())
+ 	cmd.AddCommand(newSnapshotStatusCommand())
++	cmd.AddCommand(NewSnapshotPipeCommand())
+ 	return cmd
+ }
+ 
+@@ -78,6 +88,27 @@
+ 	}
+ }
+ 
++func snapshotPipeCommandFunc(cmd *cobra.Command, args []string) {
++
++	lg, err := logutil.CreateDefaultZapLogger(zap.InfoLevel)
++	if err != nil {
++		cobrautl.ExitWithError(cobrautl.ExitError, err)
++	}
++	cfg := mustClientCfgFromCmd(cmd)
++
++	// if user does not specify "--command-timeout" flag, there will be no timeout for snapshot pipe command
++	ctx, cancel := context.WithCancel(context.Background())
++	if isCommandTimeoutFlagSet(cmd) {
++		ctx, cancel = commandCtx(cmd)
++	}
++	defer cancel()
++
++	err = snapshot.Pipe(ctx, lg, *cfg, os.Stdout)
++	if err != nil {
++		cobrautl.ExitWithError(cobrautl.ExitInterrupted, err)
++	}
++}
++
+ func NewSnapshotRestoreCommand() *cobra.Command {
+ 	cmd := &cobra.Command{
+ 		Use:   "restore <filename> [options]",
+Index: client/v3/snapshot/v3_snapshot.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/client/v3/snapshot/v3_snapshot.go b/client/v3/snapshot/v3_snapshot.go
+--- a/client/v3/snapshot/v3_snapshot.go	(revision f20bbadd404b57c776d1e8876cefd1ac29b03fb5)
++++ b/client/v3/snapshot/v3_snapshot.go	(date 1727874821225)
+@@ -23,9 +23,10 @@
+ 	"time"
+ 
+ 	"github.com/dustin/go-humanize"
++	"go.uber.org/zap"
++
+ 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+ 	"go.etcd.io/etcd/client/v3"
+-	"go.uber.org/zap"
+ )
+ 
+ // hasChecksum returns "true" if the file size "n"
+@@ -97,3 +98,46 @@
+ 	lg.Info("saved", zap.String("path", dbPath))
+ 	return nil
+ }
++
++// Pipe fetches snapshot from remote etcd server and pipes data
++// into the stream. If the context "ctx" is canceled or timed out,
++// snapshot save stream will error out (e.g. context.Canceled,
++// context.DeadlineExceeded). Make sure to specify only one endpoint
++// in client configuration. Snapshot API must be requested to a
++// selected node, and saved snapshot is the point-in-time state of
++// the selected node.
++func Pipe(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, dst io.Writer) error {
++	cfg.Logger = lg.Named("client")
++	if len(cfg.Endpoints) != 1 {
++		return fmt.Errorf("snapshot must be requested to one selected node, not multiple %v", cfg.Endpoints)
++	}
++	cli, err := clientv3.New(cfg)
++	if err != nil {
++		return err
++	}
++	defer cli.Close()
++
++	now := time.Now()
++	var rd io.ReadCloser
++	rd, err = cli.Snapshot(ctx)
++	if err != nil {
++		return err
++	}
++	lg.Info("fetching snapshot", zap.String("endpoint", cfg.Endpoints[0]))
++	var size int64
++	size, err = io.Copy(dst, rd)
++	if err != nil {
++		return err
++	}
++	if !hasChecksum(size) {
++		return fmt.Errorf("sha256 checksum not found [bytes: %d]", size)
++	}
++
++	lg.Info("fetched snapshot",
++		zap.String("endpoint", cfg.Endpoints[0]),
++		zap.String("size", humanize.Bytes(uint64(size))),
++		zap.String("took", humanize.Time(now)),
++	)
++
++	return nil
++}

--- a/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
@@ -1,9 +1,16 @@
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 fromArtifact: src-artifact
+git:
+- add: /{{ $.ModulePath }}/modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+    - '**/*'
 shell:
   beforeInstall:
   - git clone -b v3.5.16 --depth 1 {{ $.SOURCE_REPO }}/etcd-io/etcd.git /src
+  - cd /src && git apply /patches/*.patch
   - rm -rf /src/tools
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added a etcd patch based on https://github.com/etcd-io/etcd/pull/16243 to allow backups of etcd via Deckhouse CLI from our distroless-based etcd images.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This allows to properly implement etcd backup in Deckhouse CLI.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: feature
summary: patch etcd to support outputting of snapshots to stdout
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
