### PR TITLE
Secure PodMonitor CRD usage

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -35,3 +36,4 @@ spec:
   namespaceSelector:
     matchNames:
       - d8-cloud-provider-openstack
+{{- end }}

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -35,3 +36,4 @@ spec:
   namespaceSelector:
     matchNames:
       - d8-cloud-provider-vcd
+{{- end }}

--- a/ee/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -35,3 +36,4 @@ spec:
   namespaceSelector:
     matchNames:
       - d8-cloud-provider-vsphere
+{{- end }}

--- a/ee/modules/030-cloud-provider-zvirt/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/ee/modules/030-cloud-provider-zvirt/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -35,3 +36,4 @@ spec:
   namespaceSelector:
     matchNames:
       - d8-cloud-provider-zvirt
+{{- end }}

--- a/ee/modules/110-istio/templates/alliance/ingressgateway/podmonitor.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/podmonitor.yaml
@@ -1,4 +1,5 @@
 {{- if or .Values.istio.federation.enabled (and .Values.istio.multicluster.enabled .Values.istio.internal.multiclustersNeedIngressGateway) }}
+{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -48,4 +49,5 @@ spec:
       - key: app
         operator: In
         values: ["ingressgateway"]
+{{- end }}
 {{- end }}

--- a/modules/030-cloud-provider-yandex/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -35,3 +36,4 @@ spec:
   namespaceSelector:
     matchNames:
       - d8-cloud-provider-yandex
+{{- end }}

--- a/modules/110-istio/templates/cni/podmonitor.yaml
+++ b/modules/110-istio/templates/cni/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
 {{- if eq $.Values.istio.dataPlane.trafficRedirectionSetupMode "CNIPlugin" }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -28,4 +29,5 @@ spec:
   namespaceSelector:
     matchNames:
       - d8-{{ .Chart.Name }}
+{{- end }}
 {{- end }}

--- a/modules/110-istio/templates/ingress-gateway-controller/podmonitor.yaml
+++ b/modules/110-istio/templates/ingress-gateway-controller/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
 {{- if .Values.istio.internal.ingressControllers }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -48,4 +49,5 @@ spec:
       - key: app
         operator: In
         values: ["ingress-gateway-controller"]
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
Protect PodMonitor CRD usage

## Why do we need it, and what problem does it solve?
it doesn't work during the cluster bootstrap

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack,cloud-provider-vcd,cloud-provider-yandex,cloud-provider-vsphere,cloud-provider-zvirt,istio
type: fix
summary: Protect PodMonitor CRD usage with module dependency.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
