### PR TITLE
[docs] Add Information About Openstack API Access Requirement  

### DIFF
--- a/ee/candi/cloud-providers/openstack/docs/ENVIRONMENT.md
+++ b/ee/candi/cloud-providers/openstack/docs/ENVIRONMENT.md
@@ -3,7 +3,9 @@ title: "Cloud provider — OpenStack: Preparing environment"
 description: "Configuring OpenStack for Deckhouse cloud provider operation."
 ---
 
-To manage resources in an OpenStack cloud, Deckhouse connects to the OpenStack API. The user credentials required to connect to the OpenStack API are located in the openrc file (OpenStack RC file).
+To manage resources in an OpenStack cloud, Deckhouse connects to the OpenStack API.  
+The list of OpenStack API services that need to be accessed for deployment is available in the [settings](./configuration.html#list-of-required-openstack-services) section.  
+The user credentials required to connect to the OpenStack API are located in the openrc file (OpenStack RC file).
 
 You can read the [OpenStack documentation](https://docs.openstack.org/ocata/admin-guide/common/cli-set-environment-variables-using-openstack-rc.html#download-and-source-the-openstack-rc-file) to get information about getting and using an openrc file with the standard OpenStack web interface.
 

--- a/ee/candi/cloud-providers/openstack/docs/ENVIRONMENT_RU.md
+++ b/ee/candi/cloud-providers/openstack/docs/ENVIRONMENT_RU.md
@@ -3,7 +3,8 @@ title: "Cloud provider — OpenStack: подготовка окружения"
 description: "Настройка Openstack для работы облачного провайдера Deckhouse."
 ---
 
-Чтобы Deckhouse мог управлять ресурсами в облаке OpenStack, ему необходимо подключиться к OpenStack API.
+Чтобы Deckhouse мог управлять ресурсами в облаке OpenStack, ему необходимо подключиться к OpenStack API.  
+Перечень API-сервисов OpenStack, доступ до которых необходим для развертывания, доступен в разделе [настройки](./configuration.html#список-необходимых-сервисов-openstack).  
 Доступы пользователя, необходимые для подключения к OpenStack API, находятся в openrc-файле (OpenStack RC file).
 
 Информация о получении openrc-файла с помощью стандартного веб-интерфейса OpenStack и о способах его использования доступна в [документации OpenStack](https://docs.openstack.org/ocata/admin-guide/common/cli-set-environment-variables-using-openstack-rc.html#download-and-source-the-openstack-rc-file).

--- a/ee/modules/030-cloud-provider-openstack/docs/CONFIGURATION.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/CONFIGURATION.md
@@ -29,4 +29,7 @@ A list of OpenStack services required for Deckhouse Kubernetes Platform to work 
 
 &#8432;  If you need to order a Load Balancer.
 
+In case of using public clouds, API addresses and ports can be found in the official documentation of the service:
+* [VK Cloud](https://cloud.vk.com/docs/en/tools-for-using-services/api/rest-api/endpoints)
+
 {% include module-settings.liquid %}

--- a/ee/modules/030-cloud-provider-openstack/docs/CONFIGURATION_RU.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/CONFIGURATION_RU.md
@@ -29,4 +29,7 @@ title: "Сloud provider — OpenStack: настройки"
 
 &#8432;  Если нужно заказывать Load Balancer.
 
+В случае использования публичных облаков, адреса и порты API можно узнать в официальной документации сервиса:  
+* [VK Cloud](https://cloud.vk.com/docs/tools-for-using-services/api/rest-api/endpoints)
+
 {% include module-settings.liquid %}


### PR DESCRIPTION
## Description

Added information about the need for Openstack API access for deployment.  
Additionally, a reference has been added to the endpoint API docs links for VK Cloud (built on Openstack)

## Why do we need it, and what problem does it solve?
Deployment frequently requires access to Openstack's API; however, this was not previously clarified. This update will make it easier for users to understand the requirements. Additionally, by providing a reference to VK Cloud's endpoint API pathways, we're saving users' time they would otherwise spend searching for this information.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix 
summary:  Added Information About Openstack API Access Requirement  
impact_level: low
```
