### PR TITLE
[cni-cilium] wiping unwanted iptables-legacy rules

### DIFF
--- a/modules/021-cni-cilium/images/agent/check-n-cleaning-iptables.sh
+++ b/modules/021-cni-cilium/images/agent/check-n-cleaning-iptables.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeuo pipefail
+
+function are_there_cilium_rules_in_legacy_iptables() {
+  if iptables-legacy-save | grep -E "cilium|CILIUM" 2>&1 >/dev/null; then
+    echo "### There are cilium rules in iptables-legacy"
+    return 0
+  fi
+  return 1
+}
+
+function delete_cilium_legacy_iptables_rules_and_chains() {
+  echo "### Start removing cilium rules and chains from iptables-legacy"
+  for table in $(iptables-legacy-save | grep -E "^\*" | sed s/\*//g); do
+    iptables-legacy --table $table --list-rules | grep -E "^-A.*(cilium|CILIUM)" | sed "s/-A/iptables-legacy --table $table -D/pe"
+    iptables-legacy --table $table --list-rules | grep -E "^-N.*(cilium|CILIUM)" | sed "s/-N/iptables-legacy --table $table -X/pe"
+  done
+  echo "### Cilium rules and chains have been removed from iptables-legacy"
+}
+
+function flush_common_legacy_iptables_rules_and_chains() {
+  for table in $(iptables-legacy-save | grep -E "^\*" | sed s/\*//g); do
+    iptables-legacy --table $table -F
+    iptables-legacy --table $table -X
+    ip6tables-legacy --table $table -F
+    ip6tables-legacy --table $table -X
+  done
+  echo "### Common chains have been flushed in iptables-legacy"
+}
+
+function delete_legacy_iptables() {
+  for x in _raw _mangle _security _nat _filter; do
+    modprobe -r "iptable${x}"
+    modprobe -r "ip6table${x}"
+  done
+  echo "### iptables-legacy have been deleted"
+}
+
+function is_current_iptables_mode_eq_nft() {
+  if [[ -v CURRENT_IPTABLES_MODE ]] && [[ "${CURRENT_IPTABLES_MODE}" = "nft" ]] ; then
+    return 0
+  fi
+  return 1
+}
+
+if is_current_iptables_mode_eq_nft && are_there_cilium_rules_in_legacy_iptables; then
+  delete_cilium_legacy_iptables_rules_and_chains
+  flush_common_legacy_iptables_rules_and_chains
+  delete_legacy_iptables
+fi
+
+echo "### The script has completed successfully"

--- a/modules/021-cni-cilium/images/agent/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/agent/werf.inc.yaml
@@ -55,6 +55,8 @@
 {{ $selfBuiltBinaries := cat $selfBuiltBinaries "/pause" }}
 # from /jq
 {{ $selfBuiltBinaries := cat $selfBuiltBinaries "/usr/bin/jq" }}
+# for check and cleaning unnecessary iptables
+{{ $selfBuiltBinaries := cat $selfBuiltBinaries "/check-n-cleaning-iptables.sh" }}
 # iptables and dependencies
 {{ $selfBuiltBinaries := cat $selfBuiltBinaries "/sbin/xtables*" }}
 {{ $selfBuiltBinaries := cat $selfBuiltBinaries "/sbin/arptables* /sbin/ebtables* /sbin/ip6tables* /sbin/iptables*" }}
@@ -72,9 +74,10 @@ git:
   to: /
   includePaths:
   - binary_replace.sh
+  - check-n-cleaning-iptables.sh
   stageDependencies:
     install:
-    - binary_replace.sh
+    - "**/*.sh"
 import:
 - artifact: {{ $.ModuleName }}/llvm-artifact
   add: /usr/local/bin/
@@ -150,7 +153,10 @@ shell:
   - rm -rf /iptables
   - chown root:root /usr/sbin/iptables-wrapper
   - chmod 755 /usr/sbin/iptables-wrapper
+  #
+  - chmod +x /check-n-cleaning-iptables.sh
   beforeSetup:
+
   # common relocate
   - chmod +x /binary_replace.sh
   - mkdir -p /relocate

--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -206,6 +206,33 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       {{- include "module_init_container_check_linux_kernel" (tuple $context ">= 4.9.17") | nindent 6 }}
+      - name: clearing-unnecessary-iptables
+        image: {{ include "helm_lib_module_image" (list $context "agentDistroless") }}
+        imagePullPolicy: IfNotPresent
+        command:
+          - "/check-n-cleaning-iptables.sh"
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" $context | nindent 12 }}
+        securityContext:
+          seLinuxOptions:
+            level: 's0'
+            type: 'spc_t'
+          capabilities:
+            add:
+              - NET_ADMIN
+              - NET_RAW
+              - SYS_MODULE
+            drop:
+              - ALL
+          privileged: false
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
       - name: config
         image: {{ include "helm_lib_module_image" (list $context "agentDistroless") }}
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Description

The init-container for cilium-agent pod checks iptables-legacy for any unwanted rules and deletes them if found.

## Why do we need it, and what problem does it solve?

Previously, due to a configuration error, cilium-agent was always creating its rules in the iptables-legacy. 
The configuration error has now been fixed, and cilium-agent is creating its own rules in the correct table. 
However, previously created rules remain in the iptables-legacy table, even if the system is using iptables-nft.

## Why do we need it in the patch release (if we do)?

Such behavior does not have a negative impact.
But having the rules in the wrong table can be confusing.

## What is the expected result?

The rules created by the cilium-agent are present only in those iptables tables (nft or lagacy) that are used by the entire node.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: wiping unwanted iptables-legacy rules
impact: All cilium-agent pods will be restarted.
impact_level: default
```
