### PR TITLE
[user-authn] Add claimMappingOverride option

### DIFF
--- a/modules/150-user-authn/crds/dex-provider.yaml
+++ b/modules/150-user-authn/crds/dex-provider.yaml
@@ -269,6 +269,13 @@ spec:
                           default: preferred_username
                           description: |
                             The [claim](https://openid.net/specs/openid-connect-core-1_0.html#Claims) to use as the user preferred username.
+                    claimMappingOverride:
+                      type: boolean
+                      description: |
+                        If enabled, the claim mapping will override the standard OIDC claims.
+
+                        By default, the claim mapping will be used only if the standard OIDC claims are not present, e.g., if there is no `email` claim in the id_token, the `claimMapping.email` will be used.
+                      default: false
                     scopes:
                       type: array
                       default: ["openid", "profile", "email", "groups", "offline_access"]

--- a/modules/150-user-authn/crds/doc-ru-dex-provider.yaml
+++ b/modules/150-user-authn/crds/doc-ru-dex-provider.yaml
@@ -186,6 +186,11 @@ spec:
                         preferred_username:
                           description: |
                             [Claim](https://openid.net/specs/openid-connect-core-1_0.html#Claims), который будет использован для получения предпочтительного имени пользователя.
+                    claimMappingOverride:
+                      description: |
+                        Если включено, сопоставление claim'ов (`claimMapping`) будет переопределять стандартные claim'ы OIDC.
+
+                        По умолчанию сопоставление claim'ов будет использоваться только в том случае, если стандартные claim'ы OIDC отсутствуют, например, если в id_token нет claim'а `email`, будет использоваться `claimMapping.email`.
                     scopes:
                       description: |
                         Список [полей](https://github.com/dexidp/website/blob/main/content/docs/configuration/custom-scopes-claims-clients.md) для включения в ответ при запросе токена.

--- a/modules/150-user-authn/openapi/values.yaml
+++ b/modules/150-user-authn/openapi/values.yaml
@@ -250,6 +250,7 @@ properties:
                 email: mail
                 groups: roles
                 preferred_username: name
+              claimMappingOverride: true
           - id: bitbucket
             displayName: bitbucket
             type: BitbucketCloud

--- a/modules/150-user-authn/templates/dex/config.yaml
+++ b/modules/150-user-authn/templates/dex/config.yaml
@@ -159,6 +159,9 @@
           groups: {{ $provider.oidc.claimMapping.groups }}
           preferred_username: {{ $provider.oidc.claimMapping.preferred_username }}
         {{- end }}
+        {{- if $provider.oidc.claimMappingOverride }}
+        overrideClaimMapping: true
+        {{- end }}
         scopes:
         {{- if $provider.oidc.scopes }}
            {{- range $scope := $provider.oidc.scopes }}


### PR DESCRIPTION
## Description
Add the new `claimMappingOverride` option that configures Dex's behavior.

With this option enabled, dex will use claims from claimMapping even if the token has a standard claim.
By default (when the option is disabled), dex tries to get the value of the default claim, e.g., email, and only if the claim is not present, falls back to claim mapping.

## Why do we need it, and what problem does it solve?
This is the case of one of our clients. They have no emails in tokens, but the email claim is present in the token and equals the `(unverified)` value, which does not work.

https://dexidp.io/docs/connectors/oidc/

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: feature
summary: Add claimMappingOverride option for OIDC Dex provider
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
