### PR TITLE
[webhook-handler] Cannot replace the webhook-handler pod after several control-plain nodes have converged into one

### DIFF
--- a/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
@@ -35,7 +35,13 @@ metadata:
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "webhook-handler")) | nindent 2 }}
 spec:
-  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
+  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
+  {{- if (include "helm_lib_ha_enabled" .) }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
@@ -36,7 +36,6 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "webhook-handler")) | nindent 2 }}
 spec:
   replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
-  {{- if (include "helm_lib_ha_enabled" .) }}
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
## Description

Fix RollingUpdate strategy for deployment.apps/webhook-handler.

Right now we use this strategy for `deployment.apps/webhook-handler` ( configuration is enabled only for deckhouse in ha mode)

```
{{- if (include "helm_lib_ha_enabled" .) }}
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxSurge: 0
    maxUnavailable: 1
{{- end }}
```

We also use the affinity settings for this deployment.
When HA mode is disabled, maxSurge is reset to default settings. As a result, we have two replicasets at the moment. The old one with affinity settings, the new one without affinity. The new replicasets can't start, because affinity from the old replicasets prevents it, the old one can't terminate because of maxSurge.

## Why do we need it, and what problem does it solve?

After reducing number of masters from 3 to 1 we have a hung webhook-handler deployment.

## Why do we need it in the patch release (if we do)?


## What is the expected result?

After reducing number of masters from 3 to 1 we have actual state of  webhook-handler deployment.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fix for scaling down of webhook-handler deployment when ha mode is disabled
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
