### PR TITLE
[testing] Fixed missing backslash in testing script

### DIFF
--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -346,7 +346,7 @@ function prepare_environment() {
         CRI="$CRI" \
         DEV_BRANCH="$DEV_BRANCH" \
         PREFIX="$PREFIX" \
-        MASTERS_COUNT="$MASTERS_COUNT"
+        MASTERS_COUNT="$MASTERS_COUNT" \
         DECKHOUSE_DOCKERCFG="$DECKHOUSE_DOCKERCFG" \
         VCD_SERVER="$LAYOUT_VCD_SERVER" \
         VCD_USERNAME="$LAYOUT_VCD_USERNAME" \


### PR DESCRIPTION
## Description
Fixed missing backslash in testing script.

## Why do we need it, and what problem does it solve?
Missing backslash breaks test script for vCD.

## What is the expected result?
Working vCD e2e test.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: fix
summary: Fixed missing backslash in testing script.
impact_level: low
```

