### PR TITLE
[dhctl] fix(dhctl-for-commander): fix sshBastionPort spec (int -> integer)

### DIFF
--- a/candi/openapi/dhctl/ssh_configuration.yaml
+++ b/candi/openapi/dhctl/ssh_configuration.yaml
@@ -45,6 +45,6 @@ apiVersions:
       sshBastionHost:
         type: string
       sshBastionPort:
-        type: int
+        type: integer
       sshBastionUser:
         type: string

--- a/dhctl/pkg/config/connection_test.go
+++ b/dhctl/pkg/config/connection_test.go
@@ -77,6 +77,9 @@ func TestParseConnectionConfig(t *testing.T) {
 							Passphrase: "test",
 						},
 					},
+					SSHBastionHost: "158.160.111.65",
+					SSHBastionPort: pointer.Int32(22),
+					SSHBastionUser: "ubuntu",
 				},
 				SSHHosts: []SSHHost{
 					{
@@ -206,6 +209,9 @@ sshAgentPrivateKeys:
 - key: |
     %s
   passphrase: test
+sshBastionHost: 158.160.111.65
+sshBastionPort: 22
+sshBastionUser: ubuntu
 ---
 apiVersion: dhctl.deckhouse.io/v1
 kind: SSHHost


### PR DESCRIPTION
## Description
This pull request addresses a YAML specification error by correcting the type of the sshBastionPort field from int (which is not a valid type) to integer within the SSHConfig. This change ensures that the sshBastionPort is parsed correctly without any issues.

## Why do we need it, and what problem does it solve?
This change resolves a bug where the incorrect type definition for sshBastionPort in the YAML specification could lead to parsing errors. 

```changes
section: dhctl
type: fix
summary: Fix sshBastionPort spec type
impact_level: default
```
