### PR TITLE
[node-manager] fix the module's snapshots debugging

### DIFF
--- a/modules/040-node-manager/hooks/set_instance_class_ng_usage.go
+++ b/modules/040-node-manager/hooks/set_instance_class_ng_usage.go
@@ -86,7 +86,7 @@ func filterCloudEphemeralNG(obj *unstructured.Unstructured) (go_hook.FilterResul
 	}
 
 	return ngUsedInstanceClass{
-		usedInstanceClass: usedInstanceClass{
+		UsedInstanceClass: usedInstanceClass{
 			Kind: ng.Spec.CloudInstances.ClassReference.Kind,
 			Name: ng.Spec.CloudInstances.ClassReference.Name,
 		},
@@ -136,7 +136,7 @@ func setInstanceClassUsage(input *go_hook.HookInput) error {
 
 		usedIC := sn.(ngUsedInstanceClass)
 
-		icNodeConsumers[usedIC.usedInstanceClass] = append(icNodeConsumers[usedIC.usedInstanceClass], usedIC.NodeGroupName)
+		icNodeConsumers[usedIC.UsedInstanceClass] = append(icNodeConsumers[usedIC.UsedInstanceClass], usedIC.NodeGroupName)
 	}
 
 	// find instanceClasses which were unbound from NG (or ng deleted)
@@ -145,8 +145,8 @@ func setInstanceClassUsage(input *go_hook.HookInput) error {
 		icm := sn.(usedInstanceClassWithConsumers)
 
 		// if not found in NGs - remove consumers
-		if _, ok := icNodeConsumers[icm.usedInstanceClass]; !ok {
-			icNodeConsumers[icm.usedInstanceClass] = []string{}
+		if _, ok := icNodeConsumers[icm.UsedInstanceClass]; !ok {
+			icNodeConsumers[icm.UsedInstanceClass] = []string{}
 		}
 	}
 
@@ -175,12 +175,12 @@ type usedInstanceClass struct {
 }
 
 type usedInstanceClassWithConsumers struct {
-	usedInstanceClass
+	UsedInstanceClass usedInstanceClass
 	NodeGroupConsumers []string
 }
 
 type ngUsedInstanceClass struct {
-	usedInstanceClass
+	UsedInstanceClass usedInstanceClass
 	NodeGroupName string
 }
 
@@ -195,7 +195,7 @@ func applyUsedInstanceClassFilter(obj *unstructured.Unstructured) (go_hook.Filte
 	}
 
 	return usedInstanceClassWithConsumers{
-		usedInstanceClass: usedInstanceClass{
+		UsedInstanceClass: usedInstanceClass{
 			Kind: obj.GetKind(),
 			Name: obj.GetName(),
 		},

--- a/modules/040-node-manager/hooks/set_instance_class_ng_usage.go
+++ b/modules/040-node-manager/hooks/set_instance_class_ng_usage.go
@@ -175,13 +175,13 @@ type usedInstanceClass struct {
 }
 
 type usedInstanceClassWithConsumers struct {
-	UsedInstanceClass usedInstanceClass
+	UsedInstanceClass  usedInstanceClass
 	NodeGroupConsumers []string
 }
 
 type ngUsedInstanceClass struct {
 	UsedInstanceClass usedInstanceClass
-	NodeGroupName string
+	NodeGroupName     string
 }
 
 func applyUsedInstanceClassFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {


### PR DESCRIPTION
## Description
Updates the `set_instance_class_ng_usage.go` hook's structures to comprise only exporting fields.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Currently, `deckhouse-controller module snapshots node-manager` command causes a panic with the following stracktrace:
```
{"http_method":"GET","level":"info","msg":"complete","operator.component":"debugEndpoint","panic":"reflect.Value.Interface: cannot return value obtained from unexported field or method","resp_bytes_length":79581,"resp_elapsed_ms":215900,"resp_status":200,"stack": ...
```
Closes #9640 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
The aforementioned command doesn't cause a panic and a listing of  the `node-manager` module's snapshots is provided.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Fix the module's snapshots debugging.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
