### PR TITLE
[deckhouse-controller] change release approval message

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-deploy-patch-release-in-manual-mode.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-deploy-patch-release-in-manual-mode.yaml
@@ -25,7 +25,7 @@ spec:
   version: v1.25.1
 status:
   approved: false
-  message: Waiting for manual approval
+  message: "Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation"
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-patch-mode-minor-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-patch-mode-minor-release.yaml
@@ -28,7 +28,7 @@ spec:
   version: v1.27.0
 status:
   approved: false
-  message: Waiting for manual approval
+  message: "Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation"
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/manual-approval-mode-is-set.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/manual-approval-mode-is-set.yaml
@@ -28,7 +28,7 @@ spec:
   version: v1.26.0
 status:
   approved: false
-  message: Waiting for manual approval
+  message: "Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation"
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/manual-approval-mode-with-canary-process.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/manual-approval-mode-with-canary-process.yaml
@@ -29,7 +29,7 @@ spec:
   version: v1.36.0
 status:
   approved: false
-  message: Waiting for manual approval
+  message: "Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation"
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/manual-mode.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/manual-mode.yaml
@@ -28,7 +28,7 @@ spec:
   version: v1.27.0
 status:
   approved: false
-  message: Waiting for manual approval
+  message: "Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation"
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/pending-manual-release-on-cluster-bootstrap.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/pending-manual-release-on-cluster-bootstrap.yaml
@@ -28,7 +28,7 @@ spec:
   version: v1.46.0
 status:
   approved: false
-  message: Waiting for manual approval
+  message: "Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation"
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/second-run-of-the-hook-in-a-manual-mode-should-not-change-state.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/second-run-of-the-hook-in-a-manual-mode-should-not-change-state.yaml
@@ -28,7 +28,7 @@ spec:
   version: v1.27.0
 status:
   approved: false
-  message: Waiting for manual approval
+  message: "Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation"
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/unknown-mode-minor-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/unknown-mode-minor-release.yaml
@@ -28,7 +28,7 @@ spec:
   version: v1.27.0
 status:
   approved: false
-  message: Waiting for manual approval
+  message: "Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation"
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/pending-manual-release-on-cluster-bootstrap.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/pending-manual-release-on-cluster-bootstrap.yaml
@@ -48,6 +48,6 @@ spec:
   version: "v1.46.0"
 status:
   approved: false
-  message: "Waiting for manual approval"
+  message: "Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation"
   phase: Pending
   transitionTime: "2023-05-20T10:10:10Z"

--- a/docs/documentation/pages/module-development/RUN.md
+++ b/docs/documentation/pages/module-development/RUN.md
@@ -1,4 +1,3 @@
-
 ---
 title: "How to start module in the DKP cluster?"
 permalink: en/module-development/run/
@@ -117,17 +116,17 @@ kubectl annotate mr <module_release_name> modules.deckhouse.io/approved="true"
 Follow these steps to deploy a module from a different module source:
 1. Find out what [update policy](#module-update-policy) is used for the module:
 
-```shell
+   ```shell
    kubectl get mr
-```
+   ```
 
    Look up the `UPDATE POLICY` for the module releases.
 
 2. Before dropping this update policy, make sure there are no releases awaiting to be deployed (in Pending state) that fall under the policy being dropped or modified (or the _labelSelector_ used by the policy no longer matches your module):
 
-```shell
+   ```shell
    kubectl delete mup <POLICY_NAME>
-```
+   ```
 
 3. Create a new [ModuleSource](#module-source) resource.
 
@@ -135,9 +134,9 @@ Follow these steps to deploy a module from a different module source:
 
 5. Confirm that new _ModuleReleases_ for a module are created from a new _ModuleSource_ according to the update policy.
 
-```shell
+   ```shell
    kubectl get mr
-```
+   ```
 
 ## Module update policy
 

--- a/docs/documentation/pages/module-development/RUN.md
+++ b/docs/documentation/pages/module-development/RUN.md
@@ -183,58 +183,58 @@ spec:
 - Apply the policy to all _ModuleSource_ `deckhouse` modules:
 
   ```yaml
-    moduleReleaseSelector:
-      labelSelector:
-        matchLabels:
-          source: deckhouse
+  moduleReleaseSelector:
+    labelSelector:
+      matchLabels:
+        source: deckhouse
   ```
 
 - Apply the policy to the `deckhouse-admin` module independently of _ModuleSource_:
 
   ```yaml
-    moduleReleaseSelector:
-      labelSelector:
-        matchLabels:
-          module: deckhouse-admin
+  moduleReleaseSelector:
+    labelSelector:
+      matchLabels:
+        module: deckhouse-admin
   ```
 
 - Apply the policy to the `deckhouse-admin` module from the `deckhouse` _ModuleSource_:
   
   ```yaml
-    moduleReleaseSelector:
-      labelSelector:
-        matchLabels:
-          module: deckhouse-admin
-          source: deckhouse
+  moduleReleaseSelector:
+    labelSelector:
+      matchLabels:
+        module: deckhouse-admin
+        source: deckhouse
   ```
 
 - Apply the policy only to the `deckhouse-admin` and `secrets-store-integration` modules in the `deckhouse` _ModuleSource_:
   
   ```yaml
-    moduleReleaseSelector:
-      labelSelector:
-        matchExpressions:
-        - key: module
-          operator: In
-          values:
-          - deckhouse-admin
-          - secrets-store-integration
-        matchLabels:
-          source: deckhouse
+  moduleReleaseSelector:
+    labelSelector:
+      matchExpressions:
+      - key: module
+        operator: In
+        values:
+        - deckhouse-admin
+        - secrets-store-integration
+      matchLabels:
+        source: deckhouse
   ```
 
 - Apply the policy to all `deckhouse` _ModuleSource_ modules except for `deckhouse-admin`:
 
   ```yaml
-    moduleReleaseSelector:
-      labelSelector:
-        matchExpressions:
-        - key: module
-          operator: NotIn
-          values:
-          - deckhouse-admin
-        matchLabels:
-          source: deckhouse
+  moduleReleaseSelector:
+    labelSelector:
+      matchExpressions:
+      - key: module
+        operator: NotIn
+        values:
+        - deckhouse-admin
+      matchLabels:
+        source: deckhouse
   ```
 
 ## Enabling the module
@@ -273,15 +273,15 @@ You can enable the module similarly to built-in DKP modules using any of the fol
   Below is an example of a [ModuleConfig](../../cr.html#moduleconfig) that enables and configures the `module-1` module in the cluster:
 
   ```yaml
-    apiVersion: deckhouse.io/v1alpha1
-    kind: ModuleConfig
-    metadata:
-      name: module-1
-    spec:
-      enabled: true
-      settings:
-        parameter: value
-      version: 1
+  apiVersion: deckhouse.io/v1alpha1
+  kind: ModuleConfig
+  metadata:
+    name: module-1
+  spec:
+    enabled: true
+    settings:
+      parameter: value
+    version: 1
   ```
 
 ### Troubleshooting

--- a/docs/documentation/pages/module-development/RUN.md
+++ b/docs/documentation/pages/module-development/RUN.md
@@ -1,3 +1,4 @@
+
 ---
 title: "How to start module in the DKP cluster?"
 permalink: en/module-development/run/
@@ -96,7 +97,7 @@ module-two-v1.2.0          Superseded   deckhouse       48d
 module-two-v1.2.1          Superseded   deckhouse       48d              
 module-two-v1.2.3          Deployed     deckhouse       48d              
 module-two-v1.2.4          Superseded   deckhouse       44d              
-module-two-v1.2.5          Pending      deckhouse       44d              Waiting for manual approval
+module-two-v1.2.5          Pending      deckhouse       44d              Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation
 
 ```
 
@@ -116,17 +117,17 @@ kubectl annotate mr <module_release_name> modules.deckhouse.io/approved="true"
 Follow these steps to deploy a module from a different module source:
 1. Find out what [update policy](#module-update-policy) is used for the module:
 
-   ```shell
+```shell
    kubectl get mr
-   ```
+```
 
    Look up the `UPDATE POLICY` for the module releases.
 
 2. Before dropping this update policy, make sure there are no releases awaiting to be deployed (in Pending state) that fall under the policy being dropped or modified (or the _labelSelector_ used by the policy no longer matches your module):
 
-   ```shell
+```shell
    kubectl delete mup <POLICY_NAME>
-   ```
+```
 
 3. Create a new [ModuleSource](#module-source) resource.
 
@@ -134,9 +135,9 @@ Follow these steps to deploy a module from a different module source:
 
 5. Confirm that new _ModuleReleases_ for a module are created from a new _ModuleSource_ according to the update policy.
 
-   ```shell
+```shell
    kubectl get mr
-   ```
+```
 
 ## Module update policy
 
@@ -183,35 +184,35 @@ spec:
 
 - Apply the policy to all _ModuleSource_ `deckhouse` modules:
 
-  ```yaml
+```yaml
   moduleReleaseSelector:
     labelSelector:
       matchLabels:
         source: deckhouse
-  ```
+```
 
 - Apply the policy to the `deckhouse-admin` module independently of _ModuleSource_:
 
-  ```yaml
+```yaml
   moduleReleaseSelector:
     labelSelector:
       matchLabels:
         module: deckhouse-admin
-  ```
+```
 
 - Apply the policy to the `deckhouse-admin` module from the `deckhouse` _ModuleSource_:
   
-  ```yaml
+```yaml
   moduleReleaseSelector:
     labelSelector:
       matchLabels:
         module: deckhouse-admin
         source: deckhouse
-  ```
+```
 
 - Apply the policy only to the `deckhouse-admin` and `secrets-store-integration` modules in the `deckhouse` _ModuleSource_:
   
-  ```yaml
+```yaml
   moduleReleaseSelector:
     labelSelector:
       matchExpressions:
@@ -222,11 +223,11 @@ spec:
         - secrets-store-integration
       matchLabels:
         source: deckhouse
-  ```
+```
 
 - Apply the policy to all `deckhouse` _ModuleSource_ modules except for `deckhouse-admin`:
 
-  ```yaml
+```yaml
   moduleReleaseSelector:
     labelSelector:
       matchExpressions:
@@ -236,7 +237,7 @@ spec:
         - deckhouse-admin
       matchLabels:
         source: deckhouse
-  ```
+```
 
 ## Enabling the module
 
@@ -265,15 +266,15 @@ If the module is not in the list, check that [module source](#module-source) is 
 You can enable the module similarly to built-in DKP modules using any of the following methods:
 - Run the command below (specify the name of the module):
 
-  ```shell
+```shell
   kubectl -ti -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module enable <MODULE_NAME>
-  ```
+```
 
 - Create a `ModuleConfig` resource containing the `enabled: true` parameter and module settings..
 
  Below is an example of a [ModuleConfig](../../cr.html#moduleconfig) that enables and configures the `module-1` module in the cluster:
 
-  ```yaml
+```yaml
   apiVersion: deckhouse.io/v1alpha1
   kind: ModuleConfig
   metadata:
@@ -283,26 +284,26 @@ You can enable the module similarly to built-in DKP modules using any of the fol
     settings:
       parameter: value
     version: 1
-  ```
+```
 
 ### Troubleshooting
 
 If there were errors while enabling a module in the cluster, you can learn about them as follows:
 - View the DKP log:
 
-  ```shell
+```shell
   kubectl -n d8-system logs -l app=deckhouse
-  ```
+```
 
 - View the `ModuleConfig` resource of the module:
 
   Here is an example of the error message for `module-1`:
 
-  ```shell
+```shell
   $ kubectl get moduleconfig module-1
   NAME        ENABLED   VERSION   AGE   MESSAGE
   module-1    true                7s    Ignored: unknown module name
-  ```
+```
 
 Similar to [_DeckhouseRelease_](../../cr.html#deckhouserelease) (a DKP release resource), modules have a [_ModuleRelease_](../../cr.html#modulerelease) resource. DKP creates _ModuleRelease_ resources based on what is stored in the container registry. When troubleshooting module issues, check the module releases available in the cluster as well:
 
@@ -315,7 +316,7 @@ Output example:
 ```shell
 $ kubectl get mr
 NAME                 PHASE        UPDATE POLICY          TRANSITIONTIME   MESSAGE
-module-1-v1.23.2     Pending      example-update-policy  3m               Waiting for manual approval
+module-1-v1.23.2     Pending      example-update-policy  3m               Waiting for the 'release.deckhouse.io/approved: "true"' annotation
 ```
 
 The example output above illustrates _ModuleRelease_ message when the update mode ([update.mode](../../cr.html#moduleupdatepolicy-v1alpha1-spec-update-mode) of the _ModuleUpdatePolicy_ resource is set to `Manual`. In this case, you must manually confirm the installation of the new module version by adding the `modules.deckhouse.io/approved="true"` annotation to the release:

--- a/docs/documentation/pages/module-development/RUN.md
+++ b/docs/documentation/pages/module-development/RUN.md
@@ -97,7 +97,6 @@ module-two-v1.2.1          Superseded   deckhouse       48d
 module-two-v1.2.3          Deployed     deckhouse       48d              
 module-two-v1.2.4          Superseded   deckhouse       44d              
 module-two-v1.2.5          Pending      deckhouse       44d              Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation
-
 ```
 
 If there is a module release in `Deployed` status, this module can be [enabled](#enabling-the-module) in the cluster. If a module release is in `Superseded` status, it means that the module release is out of date, and there is a newer release to replace it.
@@ -183,60 +182,60 @@ spec:
 
 - Apply the policy to all _ModuleSource_ `deckhouse` modules:
 
-```yaml
-  moduleReleaseSelector:
-    labelSelector:
-      matchLabels:
-        source: deckhouse
-```
+  ```yaml
+    moduleReleaseSelector:
+      labelSelector:
+        matchLabels:
+          source: deckhouse
+  ```
 
 - Apply the policy to the `deckhouse-admin` module independently of _ModuleSource_:
 
-```yaml
-  moduleReleaseSelector:
-    labelSelector:
-      matchLabels:
-        module: deckhouse-admin
-```
+  ```yaml
+    moduleReleaseSelector:
+      labelSelector:
+        matchLabels:
+          module: deckhouse-admin
+  ```
 
 - Apply the policy to the `deckhouse-admin` module from the `deckhouse` _ModuleSource_:
   
-```yaml
-  moduleReleaseSelector:
-    labelSelector:
-      matchLabels:
-        module: deckhouse-admin
-        source: deckhouse
-```
+  ```yaml
+    moduleReleaseSelector:
+      labelSelector:
+        matchLabels:
+          module: deckhouse-admin
+          source: deckhouse
+  ```
 
 - Apply the policy only to the `deckhouse-admin` and `secrets-store-integration` modules in the `deckhouse` _ModuleSource_:
   
-```yaml
-  moduleReleaseSelector:
-    labelSelector:
-      matchExpressions:
-      - key: module
-        operator: In
-        values:
-        - deckhouse-admin
-        - secrets-store-integration
-      matchLabels:
-        source: deckhouse
-```
+  ```yaml
+    moduleReleaseSelector:
+      labelSelector:
+        matchExpressions:
+        - key: module
+          operator: In
+          values:
+          - deckhouse-admin
+          - secrets-store-integration
+        matchLabels:
+          source: deckhouse
+  ```
 
 - Apply the policy to all `deckhouse` _ModuleSource_ modules except for `deckhouse-admin`:
 
-```yaml
-  moduleReleaseSelector:
-    labelSelector:
-      matchExpressions:
-      - key: module
-        operator: NotIn
-        values:
-        - deckhouse-admin
-      matchLabels:
-        source: deckhouse
-```
+  ```yaml
+    moduleReleaseSelector:
+      labelSelector:
+        matchExpressions:
+        - key: module
+          operator: NotIn
+          values:
+          - deckhouse-admin
+        matchLabels:
+          source: deckhouse
+  ```
 
 ## Enabling the module
 
@@ -265,44 +264,44 @@ If the module is not in the list, check that [module source](#module-source) is 
 You can enable the module similarly to built-in DKP modules using any of the following methods:
 - Run the command below (specify the name of the module):
 
-```shell
-  kubectl -ti -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module enable <MODULE_NAME>
-```
+  ```shell
+    kubectl -ti -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module enable <MODULE_NAME>
+  ```
 
 - Create a `ModuleConfig` resource containing the `enabled: true` parameter and module settings..
 
- Below is an example of a [ModuleConfig](../../cr.html#moduleconfig) that enables and configures the `module-1` module in the cluster:
+  Below is an example of a [ModuleConfig](../../cr.html#moduleconfig) that enables and configures the `module-1` module in the cluster:
 
-```yaml
-  apiVersion: deckhouse.io/v1alpha1
-  kind: ModuleConfig
-  metadata:
-    name: module-1
-  spec:
-    enabled: true
-    settings:
-      parameter: value
-    version: 1
-```
+  ```yaml
+    apiVersion: deckhouse.io/v1alpha1
+    kind: ModuleConfig
+    metadata:
+      name: module-1
+    spec:
+      enabled: true
+      settings:
+        parameter: value
+      version: 1
+  ```
 
 ### Troubleshooting
 
 If there were errors while enabling a module in the cluster, you can learn about them as follows:
 - View the DKP log:
 
-```shell
-  kubectl -n d8-system logs -l app=deckhouse
-```
+  ```shell
+    kubectl -n d8-system logs -l app=deckhouse
+  ```
 
 - View the `ModuleConfig` resource of the module:
 
   Here is an example of the error message for `module-1`:
 
-```shell
-  $ kubectl get moduleconfig module-1
-  NAME        ENABLED   VERSION   AGE   MESSAGE
-  module-1    true                7s    Ignored: unknown module name
-```
+  ```shell
+    $ kubectl get moduleconfig module-1
+    NAME        ENABLED   VERSION   AGE   MESSAGE
+    module-1    true                7s    Ignored: unknown module name
+  ```
 
 Similar to [_DeckhouseRelease_](../../cr.html#deckhouserelease) (a DKP release resource), modules have a [_ModuleRelease_](../../cr.html#modulerelease) resource. DKP creates _ModuleRelease_ resources based on what is stored in the container registry. When troubleshooting module issues, check the module releases available in the cluster as well:
 

--- a/docs/documentation/pages/module-development/RUN.md
+++ b/docs/documentation/pages/module-development/RUN.md
@@ -265,7 +265,7 @@ You can enable the module similarly to built-in DKP modules using any of the fol
 - Run the command below (specify the name of the module):
 
   ```shell
-    kubectl -ti -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module enable <MODULE_NAME>
+  kubectl -ti -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module enable <MODULE_NAME>
   ```
 
 - Create a `ModuleConfig` resource containing the `enabled: true` parameter and module settings..
@@ -290,17 +290,17 @@ If there were errors while enabling a module in the cluster, you can learn about
 - View the DKP log:
 
   ```shell
-    kubectl -n d8-system logs -l app=deckhouse
+  kubectl -n d8-system logs -l app=deckhouse
   ```
 
 - View the `ModuleConfig` resource of the module:
 
   Here is an example of the error message for `module-1`:
 
-  ```shell
-    $ kubectl get moduleconfig module-1
-    NAME        ENABLED   VERSION   AGE   MESSAGE
-    module-1    true                7s    Ignored: unknown module name
+  ```console
+  $ kubectl get moduleconfig module-1
+  NAME        ENABLED   VERSION   AGE   MESSAGE
+  module-1    true                7s    Ignored: unknown module name
   ```
 
 Similar to [_DeckhouseRelease_](../../cr.html#deckhouserelease) (a DKP release resource), modules have a [_ModuleRelease_](../../cr.html#modulerelease) resource. DKP creates _ModuleRelease_ resources based on what is stored in the container registry. When troubleshooting module issues, check the module releases available in the cluster as well:

--- a/docs/documentation/pages/module-development/RUN_RU.md
+++ b/docs/documentation/pages/module-development/RUN_RU.md
@@ -1,4 +1,3 @@
-
 ---
 title: "Запуск модуля в кластере"
 permalink: ru/module-development/run/
@@ -118,17 +117,17 @@ kubectl annotate mr <module_release_name> modules.deckhouse.io/approved="true"
 Если необходимо развернуть модуль из другого источника модулей, выполните следующие шаги:
 1. Определите, под какую [политику обновлений](#политика-обновления-модуля) подпадает модуль:
 
-```shell
+   ```shell
    kubectl get mr
-```
+   ```
 
    Проверьте `UPDATE POLICY` для релизов модуля.
 
 2. Прежде чем удалить эту политику обновления, убедитесь, что нет ожидающих развертывания (в состоянии Pending) релизов, которые подпадают под удаляемую или изменяемую политику (или _labelSelector_, используемый политикой, больше не соответствует вашему модулю):
 
-```shell
+   ```shell
    kubectl delete mup <POLICY_NAME>
-```
+   ```
 
 3. Создайте новый [ресурс ModuleSource](#источник-модулей).
 
@@ -136,9 +135,9 @@ kubectl annotate mr <module_release_name> modules.deckhouse.io/approved="true"
 
 5. Проверьте, что новые _ModuleRelease_ для модуля создаются из нового _ModuleSource_ в соответствии с политикой обновления.
 
-```shell
+   ```shell
    kubectl get mr
-```
+   ```
 
 ## Политика обновления модуля
 

--- a/docs/documentation/pages/module-development/RUN_RU.md
+++ b/docs/documentation/pages/module-development/RUN_RU.md
@@ -184,60 +184,60 @@ spec:
 
 - Применить политику ко всем модулям _ModuleSource_ `deckhouse`:
 
-```yaml
-  moduleReleaseSelector:
-    labelSelector:
-      matchLabels:
-        source: deckhouse
-```
+  ```yaml
+    moduleReleaseSelector:
+      labelSelector:
+        matchLabels:
+          source: deckhouse
+  ```
 
 - Применить политику к модулю `deckhouse-admin` независимо от _ModuleSource_:
 
-```yaml
-  moduleReleaseSelector:
-    labelSelector:
-      matchLabels:
-        module: deckhouse-admin
-```
+  ```yaml
+    moduleReleaseSelector:
+      labelSelector:
+        matchLabels:
+          module: deckhouse-admin
+  ```
 
 - Применить политику к модулю `deckhouse-admin` из _ModuleSource_ `deckhouse`:
 
-```yaml
-  moduleReleaseSelector:
-    labelSelector:
-      matchLabels:
-        module: deckhouse-admin
-        source: deckhouse
-```
+  ```yaml
+    moduleReleaseSelector:
+      labelSelector:
+        matchLabels:
+          module: deckhouse-admin
+          source: deckhouse
+  ```
 
 - Применить политику только к модулям `deckhouse-admin` и `secrets-store-integration` в _ModuleSource_ `deckhouse`:
 
-```yaml
-  moduleReleaseSelector:
-    labelSelector:
-      matchExpressions:
-      - key: module
-        operator: In
-        values:
-        - deckhouse-admin
-        - secrets-store-integration
-      matchLabels:
-        source: deckhouse
-```
+  ```yaml
+    moduleReleaseSelector:
+      labelSelector:
+        matchExpressions:
+        - key: module
+          operator: In
+          values:
+          - deckhouse-admin
+          - secrets-store-integration
+        matchLabels:
+          source: deckhouse
+  ```
 
 - Применить политику ко всем модулям _ModuleSource_ `deckhouse`, кроме `deckhouse-admin`:
 
-```yaml
-  moduleReleaseSelector:
-    labelSelector:
-      matchExpressions:
-      - key: module
-        operator: NotIn
-        values:
-        - deckhouse-admin
-      matchLabels:
-        source: deckhouse
-```
+  ```yaml
+    moduleReleaseSelector:
+      labelSelector:
+        matchExpressions:
+        - key: module
+          operator: NotIn
+          values:
+          - deckhouse-admin
+        matchLabels:
+          source: deckhouse
+  ```
 
 ## Включение модуля в кластере
 
@@ -266,44 +266,44 @@ module-test                           900      Disabled   example
 Включить модуль можно аналогично встроенному модулю DKP любым из следующих способов:
 - Выполнить следующую команду (укажите имя модуля):
 
-```shell
-  kubectl -ti -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module enable <MODULE_NAME>
-```
+  ```shell
+    kubectl -ti -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module enable <MODULE_NAME>
+  ```
 
 - Создать ресурс `ModuleConfig` с параметром `enabled: true` и настройками модуля.
 
   Пример [ModuleConfig](../../cr.html#moduleconfig), для включения и настройки модуля `module-1` в кластере:
 
-```yaml
-  apiVersion: deckhouse.io/v1alpha1
-  kind: ModuleConfig
-  metadata:
-    name: module-1
-  spec:
-    enabled: true
-    settings:
-      parameter: value
-    version: 1
-```
+  ```yaml
+    apiVersion: deckhouse.io/v1alpha1
+    kind: ModuleConfig
+    metadata:
+      name: module-1
+    spec:
+      enabled: true
+      settings:
+        parameter: value
+      version: 1
+  ```
 
 ### Если что-то пошло не так
 
 Если при включении модуля в кластере возникли ошибки, то получить информацию о них можно следующими способами:
 - Посмотреть журнал DKP:
 
-```shell
-  kubectl -n d8-system logs -l app=deckhouse
-```
+  ```shell
+    kubectl -n d8-system logs -l app=deckhouse
+  ```
 
 - Посмотреть ресурс `ModuleConfig` модуля:
 
   Пример вывода информации об ошибке модуля `module-1`:
 
-```shell
-  $ kubectl get moduleconfig module-1
-  NAME        ENABLED   VERSION   AGE   MESSAGE
-  module-1    true                7s    Ignored: unknown module name
-```
+  ```shell
+    $ kubectl get moduleconfig module-1
+    NAME        ENABLED   VERSION   AGE   MESSAGE
+    module-1    true                7s    Ignored: unknown module name
+  ```
 
 По аналогии [с _DeckhouseRelease_](../../cr.html#deckhouserelease) (ресурсом релиза DKP) у модулей есть аналогичный ресурс — [_ModuleRelease_](../../cr.html#modulerelease). DKP создает ресурсы _ModuleRelease_ исходя из того, что хранится в container registry. При поиске проблем с модулем проверьте также доступные в кластере релизы модуля:
 

--- a/docs/documentation/pages/module-development/RUN_RU.md
+++ b/docs/documentation/pages/module-development/RUN_RU.md
@@ -1,3 +1,4 @@
+
 ---
 title: "Запуск модуля в кластере"
 permalink: ru/module-development/run/
@@ -97,7 +98,7 @@ module-two-v1.2.0          Superseded   deckhouse       48d
 module-two-v1.2.1          Superseded   deckhouse       48d              
 module-two-v1.2.3          Deployed     deckhouse       48d              
 module-two-v1.2.4          Superseded   deckhouse       44d              
-module-two-v1.2.5          Pending      deckhouse       44d              Waiting for manual approval
+module-two-v1.2.5          Pending      deckhouse       44d              Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation
 
 ```
 
@@ -117,17 +118,17 @@ kubectl annotate mr <module_release_name> modules.deckhouse.io/approved="true"
 Если необходимо развернуть модуль из другого источника модулей, выполните следующие шаги:
 1. Определите, под какую [политику обновлений](#политика-обновления-модуля) подпадает модуль:
 
-   ```shell
+```shell
    kubectl get mr
-   ```
+```
 
    Проверьте `UPDATE POLICY` для релизов модуля.
 
 2. Прежде чем удалить эту политику обновления, убедитесь, что нет ожидающих развертывания (в состоянии Pending) релизов, которые подпадают под удаляемую или изменяемую политику (или _labelSelector_, используемый политикой, больше не соответствует вашему модулю):
 
-   ```shell
+```shell
    kubectl delete mup <POLICY_NAME>
-   ```
+```
 
 3. Создайте новый [ресурс ModuleSource](#источник-модулей).
 
@@ -135,9 +136,9 @@ kubectl annotate mr <module_release_name> modules.deckhouse.io/approved="true"
 
 5. Проверьте, что новые _ModuleRelease_ для модуля создаются из нового _ModuleSource_ в соответствии с политикой обновления.
 
-   ```shell
+```shell
    kubectl get mr
-   ```
+```
 
 ## Политика обновления модуля
 
@@ -184,35 +185,35 @@ spec:
 
 - Применить политику ко всем модулям _ModuleSource_ `deckhouse`:
 
-  ```yaml
+```yaml
   moduleReleaseSelector:
     labelSelector:
       matchLabels:
         source: deckhouse
-  ```
+```
 
 - Применить политику к модулю `deckhouse-admin` независимо от _ModuleSource_:
 
-  ```yaml
+```yaml
   moduleReleaseSelector:
     labelSelector:
       matchLabels:
         module: deckhouse-admin
-  ```
+```
 
 - Применить политику к модулю `deckhouse-admin` из _ModuleSource_ `deckhouse`:
 
-  ```yaml
+```yaml
   moduleReleaseSelector:
     labelSelector:
       matchLabels:
         module: deckhouse-admin
         source: deckhouse
-  ```
+```
 
 - Применить политику только к модулям `deckhouse-admin` и `secrets-store-integration` в _ModuleSource_ `deckhouse`:
 
-  ```yaml
+```yaml
   moduleReleaseSelector:
     labelSelector:
       matchExpressions:
@@ -223,11 +224,11 @@ spec:
         - secrets-store-integration
       matchLabels:
         source: deckhouse
-  ```
+```
 
 - Применить политику ко всем модулям _ModuleSource_ `deckhouse`, кроме `deckhouse-admin`:
 
-  ```yaml
+```yaml
   moduleReleaseSelector:
     labelSelector:
       matchExpressions:
@@ -237,7 +238,7 @@ spec:
         - deckhouse-admin
       matchLabels:
         source: deckhouse
-  ```
+```
 
 ## Включение модуля в кластере
 
@@ -266,15 +267,15 @@ module-test                           900      Disabled   example
 Включить модуль можно аналогично встроенному модулю DKP любым из следующих способов:
 - Выполнить следующую команду (укажите имя модуля):
 
-  ```shell
+```shell
   kubectl -ti -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module enable <MODULE_NAME>
-  ```
+```
 
 - Создать ресурс `ModuleConfig` с параметром `enabled: true` и настройками модуля.
 
   Пример [ModuleConfig](../../cr.html#moduleconfig), для включения и настройки модуля `module-1` в кластере:
 
-  ```yaml
+```yaml
   apiVersion: deckhouse.io/v1alpha1
   kind: ModuleConfig
   metadata:
@@ -284,26 +285,26 @@ module-test                           900      Disabled   example
     settings:
       parameter: value
     version: 1
-  ```
+```
 
 ### Если что-то пошло не так
 
 Если при включении модуля в кластере возникли ошибки, то получить информацию о них можно следующими способами:
 - Посмотреть журнал DKP:
 
-  ```shell
+```shell
   kubectl -n d8-system logs -l app=deckhouse
-  ```
+```
 
 - Посмотреть ресурс `ModuleConfig` модуля:
 
   Пример вывода информации об ошибке модуля `module-1`:
 
-  ```shell
+```shell
   $ kubectl get moduleconfig module-1
   NAME        ENABLED   VERSION   AGE   MESSAGE
   module-1    true                7s    Ignored: unknown module name
-  ```
+```
 
 По аналогии [с _DeckhouseRelease_](../../cr.html#deckhouserelease) (ресурсом релиза DKP) у модулей есть аналогичный ресурс — [_ModuleRelease_](../../cr.html#modulerelease). DKP создает ресурсы _ModuleRelease_ исходя из того, что хранится в container registry. При поиске проблем с модулем проверьте также доступные в кластере релизы модуля:
 
@@ -316,7 +317,7 @@ kubectl get mr
 ```shell
 $ kubectl get mr
 NAME                 PHASE        UPDATE POLICY          TRANSITIONTIME   MESSAGE
-module-1-v1.23.2     Pending      example-update-policy  3m               Waiting for manual approval
+module-1-v1.23.2     Pending      example-update-policy  3m               Waiting for the 'release.deckhouse.io/approved: "true"' annotation
 ```
 
 В примере вывода показан _ModuleRelease_, когда режим обновления (параметр [update.mode](../../cr.html#moduleupdatepolicy-v1alpha1-spec-update-mode) ресурса _ModuleUpdatePolicy_ установлен в `Manual`. В этом случае необходимо вручную подтвердить установку новой версии модуля, установив на релиз аннотацию `modules.deckhouse.io/approved="true"`:

--- a/docs/documentation/pages/module-development/RUN_RU.md
+++ b/docs/documentation/pages/module-development/RUN_RU.md
@@ -185,58 +185,58 @@ spec:
 - Применить политику ко всем модулям _ModuleSource_ `deckhouse`:
 
   ```yaml
-    moduleReleaseSelector:
-      labelSelector:
-        matchLabels:
-          source: deckhouse
+  moduleReleaseSelector:
+    labelSelector:
+      matchLabels:
+        source: deckhouse
   ```
 
 - Применить политику к модулю `deckhouse-admin` независимо от _ModuleSource_:
 
   ```yaml
-    moduleReleaseSelector:
-      labelSelector:
-        matchLabels:
-          module: deckhouse-admin
+  moduleReleaseSelector:
+    labelSelector:
+      matchLabels:
+        module: deckhouse-admin
   ```
 
 - Применить политику к модулю `deckhouse-admin` из _ModuleSource_ `deckhouse`:
 
   ```yaml
-    moduleReleaseSelector:
-      labelSelector:
-        matchLabels:
-          module: deckhouse-admin
-          source: deckhouse
+  moduleReleaseSelector:
+    labelSelector:
+      matchLabels:
+        module: deckhouse-admin
+        source: deckhouse
   ```
 
 - Применить политику только к модулям `deckhouse-admin` и `secrets-store-integration` в _ModuleSource_ `deckhouse`:
 
   ```yaml
-    moduleReleaseSelector:
-      labelSelector:
-        matchExpressions:
-        - key: module
-          operator: In
-          values:
-          - deckhouse-admin
-          - secrets-store-integration
-        matchLabels:
-          source: deckhouse
+  moduleReleaseSelector:
+    labelSelector:
+      matchExpressions:
+      - key: module
+        operator: In
+        values:
+        - deckhouse-admin
+        - secrets-store-integration
+      matchLabels:
+        source: deckhouse
   ```
 
 - Применить политику ко всем модулям _ModuleSource_ `deckhouse`, кроме `deckhouse-admin`:
 
   ```yaml
-    moduleReleaseSelector:
-      labelSelector:
-        matchExpressions:
-        - key: module
-          operator: NotIn
-          values:
-          - deckhouse-admin
-        matchLabels:
-          source: deckhouse
+  moduleReleaseSelector:
+    labelSelector:
+      matchExpressions:
+      - key: module
+        operator: NotIn
+        values:
+        - deckhouse-admin
+      matchLabels:
+        source: deckhouse
   ```
 
 ## Включение модуля в кластере
@@ -275,15 +275,15 @@ module-test                           900      Disabled   example
   Пример [ModuleConfig](../../cr.html#moduleconfig), для включения и настройки модуля `module-1` в кластере:
 
   ```yaml
-    apiVersion: deckhouse.io/v1alpha1
-    kind: ModuleConfig
-    metadata:
-      name: module-1
-    spec:
-      enabled: true
-      settings:
-        parameter: value
-      version: 1
+  apiVersion: deckhouse.io/v1alpha1
+  kind: ModuleConfig
+  metadata:
+    name: module-1
+  spec:
+    enabled: true
+    settings:
+      parameter: value
+    version: 1
   ```
 
 ### Если что-то пошло не так

--- a/docs/documentation/pages/module-development/RUN_RU.md
+++ b/docs/documentation/pages/module-development/RUN_RU.md
@@ -267,7 +267,7 @@ module-test                           900      Disabled   example
 - Выполнить следующую команду (укажите имя модуля):
 
   ```shell
-    kubectl -ti -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module enable <MODULE_NAME>
+  kubectl -ti -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module enable <MODULE_NAME>
   ```
 
 - Создать ресурс `ModuleConfig` с параметром `enabled: true` и настройками модуля.
@@ -292,17 +292,17 @@ module-test                           900      Disabled   example
 - Посмотреть журнал DKP:
 
   ```shell
-    kubectl -n d8-system logs -l app=deckhouse
+  kubectl -n d8-system logs -l app=deckhouse
   ```
 
 - Посмотреть ресурс `ModuleConfig` модуля:
 
   Пример вывода информации об ошибке модуля `module-1`:
 
-  ```shell
-    $ kubectl get moduleconfig module-1
-    NAME        ENABLED   VERSION   AGE   MESSAGE
-    module-1    true                7s    Ignored: unknown module name
+  ```console
+  $ kubectl get moduleconfig module-1
+  NAME        ENABLED   VERSION   AGE   MESSAGE
+  module-1    true                7s    Ignored: unknown module name
   ```
 
 По аналогии [с _DeckhouseRelease_](../../cr.html#deckhouserelease) (ресурсом релиза DKP) у модулей есть аналогичный ресурс — [_ModuleRelease_](../../cr.html#modulerelease). DKP создает ресурсы _ModuleRelease_ исходя из того, что хранится в container registry. При поиске проблем с модулем проверьте также доступные в кластере релизы модуля:
@@ -313,7 +313,7 @@ kubectl get mr
 
 Пример вывода:
 
-```shell
+```console
 $ kubectl get mr
 NAME                 PHASE        UPDATE POLICY          TRANSITIONTIME   MESSAGE
 module-1-v1.23.2     Pending      example-update-policy  3m               Waiting for the 'release.deckhouse.io/approved: "true"' annotation

--- a/go_lib/updater/updater.go
+++ b/go_lib/updater/updater.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	waitingManualApprovalMsg = "Waiting for manual approval"
+	waitingManualApprovalMsg = "Waiting for the 'release.deckhouse.io/approved: \"true\"' annotation"
 )
 
 const (


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Change manual approve message

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
It would be printed even for AutoPatch release. So we have to change it.

## Why do we need it in the patch release (if we do)?
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
### Before
```
v1.64.1    Pending      90s              Waiting for manual approval
```

### Now
```
v1.64.1    Pending      90s              Waiting for the 'release.deckhouse.io/approved: "true"' annotation
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: go_lib
type: fix
summary: Change release approval message
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
