### PR TITLE
[deckhouse] chore: get rid of annoying "defaulted container" message

### DIFF
--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -208,6 +208,9 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 	deckhousePodTemplate := apiv1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: deckhouseDeployment.Spec.Selector.MatchLabels,
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/default-container": "deckhouse",
+			},
 		},
 		Spec: apiv1.PodSpec{
 			HostNetwork:        true,

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -71,6 +71,7 @@ spec:
         app: deckhouse
       annotations:
         checksum/registry: {{ include (print $.Template.BasePath "/registry-secret.yaml") . | sha256sum }}
+        kubectl.kubernetes.io/default-container: deckhouse
     spec:
       affinity:
         nodeAffinity:


### PR DESCRIPTION
## Description

Add "kubectl.kubernetes.io/default-container" annotation to pod template in deploy/deckhouse.

## Why do we need it, and what problem does it solve?

kubectl exec/logs always prints "Defaulted container" when Pod has more than 1 container. Annotation "kubectl.kubernetes.io/default-container" helps to point kubectl to the default container in the Pod.

```
# kubectl -n d8-system exec service/deckhouse-leader -- \
  deckhouse-controller version
Defaulted container "deckhouse" out of: deckhouse, kube-rbac-proxy, init-downloaded-modules (init) 
deckhouse main (addon-operator v0.0.0-20241003110303-48341ac02dda, shell-operator v1.4.12, Golang go1.22.2)
# kubectl -n d8-system patch deploy/deckhouse --type=strategic \
 -p '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/default-container":"deckhouse"}}}}}'
deployment.apps/deckhouse patched
# kubectl -n d8-system exec service/deckhouse-leader -- \
  deckhouse-controller version
deckhouse main (addon-operator v0.0.0-20241003110303-48341ac02dda, shell-operator v1.4.12, Golang go1.22.2)
```

## Why do we need it in the patch release (if we do)?

Not a destructive change, no restarts of critical components are expected.

## What is the expected result?

kubectl exec output can be used as-is without `grep -v "Defaulted"`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: add "kubectl.kubernetes.io/default-container" annotation for kubectl exec
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
