### PR TITLE
[docs][getting_started] Actual flavor for VKCloud and adjust rootDiskSize

### DIFF
--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.ee.inc
@@ -174,7 +174,7 @@ masterNodeGroup:
     # [<ru>] https://deckhouse.ru/products/kubernetes-platform/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html#openstackclusterconfiguration-masternodegroup-instanceclass-flavorname
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
-    flavorName: Standard-4-8-80
+    flavorName: STD3-4-8
     # [<en>] VM image in use. You can view the list of images using the command 'openstack image list'
     # [<en>] https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html#openstackclusterconfiguration-masternodegroup-instanceclass-imagename
     # [<ru>] Используемый образ виртуальной машины. Посмотреть список образов можно командой 'openstack image list'
@@ -184,7 +184,7 @@ masterNodeGroup:
     imageName: ubuntu-22-202404160933.gitd6495fe9
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.
-    rootDiskSize: 40
+    rootDiskSize: 50
 # [<en>] Public SSH key for accessing cloud nodes.
 # [<en>] This key will be added to the user on created nodes (the user name depends on the image used).
 # [<ru>] Публичная часть SSH-ключа для доступа к узлам облака.

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.ee.inc
@@ -174,7 +174,7 @@ masterNodeGroup:
     # [<ru>] https://deckhouse.ru/products/kubernetes-platform/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html#openstackclusterconfiguration-masternodegroup-instanceclass-flavorname
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
-    flavorName: Standard-4-8-80
+    flavorName: STD3-4-8
     # [<en>] VM image in use. You can view the list of images using the command 'openstack image list'
     # [<en>] https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/030-cloud-provider-openstack/cluster_configuration.html#openstackclusterconfiguration-masternodegroup-instanceclass-imagename
     # [<ru>] Используемый образ виртуальной машины. Посмотреть список образов можно командой 'openstack image list'
@@ -184,7 +184,7 @@ masterNodeGroup:
     imageName: ubuntu-22-202404160933.gitd6495fe9
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.
-    rootDiskSize: 40
+    rootDiskSize: 50
 # [<en>] Public SSH key for accessing cloud nodes.
 # [<en>] This key will be added to the user on created nodes (the user name depends on the image used).
 # [<ru>] Публичная часть SSH-ключа для доступа к узлам облака.

--- a/docs/site/_includes/getting_started/openstack_vk/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/resources.yml.minimal.inc
@@ -11,7 +11,7 @@ spec:
   # [<ru>] Используемый flavor для данного инстанс-класса.
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
-  flavorName: Standard-4-8-80
+  flavorName: STD3-4-8
   rootDiskSize: 30
   # [<en>] VM image in use.
   # [<ru>] Используемый образ виртуальной машины.


### PR DESCRIPTION
## Description
Actual flavor for VKCloud and adjust rootDiskSize.

## Why do we need it, and what problem does it solve?
Flavor `Standard-4-8-80` is legacy for VKCloud.

Also increase `rootDiskSize` to 50G, because with 40G we have error in dhctl like this:
```
Installation aborted: Timeout while "Checking cloud master node system requirements are met": last error: Root disk capacity: expected at  ↵
least 50, but 40 is configured
Please fix this problem or skip it if you're sure with preflight-skip-system-requirements-check flag
```

## Why do we need it in the patch release (if we do)?

Not necessarily.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Actual flavor for VKCloud and adjust rootDiskSize.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
