### PR TITLE
[ceph-csi] Make ceph-csi module deprecated

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -1219,6 +1219,8 @@ entries:
     - title:
         en: Storage
         ru: Хранилище
+        moduleName: delivery
+      featureStatus: deprecated
       folders:
         - title: ceph-csi
           folders:

--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -1219,7 +1219,7 @@ entries:
     - title:
         en: Storage
         ru: Хранилище
-        moduleName: delivery
+        moduleName: ceph-csi
       featureStatus: deprecated
       folders:
         - title: ceph-csi

--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -130,6 +130,11 @@ defaults:
       d8Revision: ee
       featureStatus: deprecated
   - scope:
+      path: "*/031-ceph-csi"
+      type: "pages"
+    values:
+      featureStatus: deprecated    
+  - scope:
       path: "*/381-l2-load-balancer"
       type: "pages"
     values:
@@ -189,3 +194,4 @@ defaults:
       d8Revision: ee
       featureStatus: experimental
 timezone: Europe/Moscow
+


### PR DESCRIPTION
## Description
Added deprecated alert at ceph-csi module.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


```changes
section: ceph-csi
type: feature
summary: Make ceph-csi module deprecated.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
