### PR TITLE
disable extended monitoring for standby-holder

### DIFF
--- a/modules/040-node-manager/templates/standby-holder/deployment.yaml
+++ b/modules/040-node-manager/templates/standby-holder/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: standby-holder-{{ $ng.name }}
   namespace: d8-cloud-instance-manager
-  {{- include "helm_lib_module_labels" (list $ (dict "app" "standby-holder" "extended-monitoring.deckhouse.io/enabled" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $ (dict "app" "standby-holder" "extended-monitoring.deckhouse.io/enabled" "false")) | nindent 2 }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
## Description
Disabled the alert for `standby-holder-nodes` as it was generating unnecessary noise. It is recommended to use `d8_node_group-*` metrics for nodeGroup monitoring.

## Why do we need it, and what problem does it solve?

Fixes the issue of unnecessary alerts when the node group reaches maximum capacity.

## Why do we need it in the patch release (if we do)?


## What is the expected result?

The alert for `standby-holder-nodes` will no longer trigger when the node group reaches maximum capacity.

## Changelog entries

section: node-manager  
type: fix  
summary: "Disabled unnecessary alert for `standby-holder-nodes` when node group reaches maximum capacity."  
impact_level: low