### PR TITLE
[dhctl] parallel bootstrap cloudpermanent nodes

### DIFF
--- a/dhctl/pkg/kubernetes/actions/converge/converge.go
+++ b/dhctl/pkg/kubernetes/actions/converge/converge.go
@@ -372,11 +372,15 @@ func (r *Runner) createPreviouslyNotExistedNodeGroup(group config.TerraNodeGroup
 			return err
 		}
 
+		var nodesIndexToCreate []int
+
 		for i := 0; i < group.Replicas; i++ {
-			err = BootstrapAdditionalNode(r.kubeCl, metaConfig, i, "static-node", group.Name, nodeCloudConfig, true, r.terraformContext)
-			if err != nil {
-				return err
-			}
+			nodesIndexToCreate = append(nodesIndexToCreate, i)
+		}
+
+		_, err = ParallelBootstrapAdditionalNodes(r.kubeCl, metaConfig, nodesIndexToCreate, "static-node", group.Name, nodeCloudConfig, true, r.terraformContext)
+		if err != nil {
+			return err
 		}
 
 		return WaitForNodesBecomeReady(r.kubeCl, group.Name, group.Replicas)

--- a/dhctl/pkg/kubernetes/actions/converge/nodebootstrap.go
+++ b/dhctl/pkg/kubernetes/actions/converge/nodebootstrap.go
@@ -15,10 +15,15 @@
 package converge
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
+	"strings"
+	"sync"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
@@ -70,6 +75,121 @@ func BootstrapAdditionalNode(kubeCl *client.KubernetesClient, cfg *config.MetaCo
 	}
 
 	return nil
+}
+
+func BootstrapAdditionalNodeForParallelRun(kubeCl *client.KubernetesClient, cfg *config.MetaConfig, index int, step, nodeGroupName, cloudConfig string, isConverge bool, terraformContext *terraform.TerraformContext, buff *bytes.Buffer, saveLogToBuffer bool) error {
+	nodeName := NodeName(cfg, nodeGroupName, index)
+
+	nodeGroupSettings := cfg.FindTerraNodeGroup(nodeGroupName)
+
+	// TODO pass cache as argument or better refact func
+	runner := terraformContext.GetBootstrapNodeRunner(cfg, cache.Global(), terraform.BootstrapNodeRunnerOptions{
+		AutoApprove:     true,
+		NodeName:        nodeName,
+		NodeGroupStep:   step,
+		NodeGroupName:   nodeGroupName,
+		NodeIndex:       index,
+		NodeCloudConfig: cloudConfig,
+		LogToBuffer:     saveLogToBuffer,
+
+		AdditionalStateSaverDestinations: []terraform.SaverDestination{
+			NewNodeStateSaver(kubeCl, nodeName, nodeGroupName, nodeGroupSettings),
+		},
+	})
+
+	outputs, err := terraform.ApplyPipeline(runner, nodeName, terraform.OnlyState)
+	if err != nil {
+		return err
+	}
+
+	if tomb.IsInterrupted() {
+		return ErrConvergeInterrupted
+	}
+
+	err = SaveNodeTerraformState(kubeCl, nodeName, nodeGroupName, outputs.TerraformState, nodeGroupSettings)
+	if err != nil {
+		return err
+	}
+
+	if saveLogToBuffer {
+		logs := runner.GetLog()
+		buff.WriteString(strings.Join(logs, "\n"))
+	}
+
+	return nil
+}
+
+func ParallelBootstrapAdditionalNodes(kubeCl *client.KubernetesClient, cfg *config.MetaConfig, nodesIndexToCreate []int, step, nodeGroupName, cloudConfig string, isConverge bool, terraformContext *terraform.TerraformContext) ([]string, error) {
+
+	var (
+		nodesToWait []string
+		wg          sync.WaitGroup
+	)
+
+	type checkResult struct {
+		name    string
+		buffLog *bytes.Buffer
+		err     error
+	}
+
+	for _, indexCandidate := range nodesIndexToCreate {
+		candidateName := fmt.Sprintf("%s-%s-%v", cfg.ClusterPrefix, nodeGroupName, indexCandidate)
+		nodeExists, err := IsNodeExistsInCluster(kubeCl, candidateName)
+		if err != nil {
+			return nil, err
+		} else if nodeExists {
+			return nil, fmt.Errorf("node with name %s exists in cluster", candidateName)
+		}
+	}
+
+	if len(nodesIndexToCreate) > 1 {
+		log.WarnF("Many pipelines will run in parallel, terraform output for nodes %s-%v will be displayed after main execution.\n\n", nodeGroupName, nodesIndexToCreate[1:])
+	}
+
+	resultsСhan := make(chan checkResult, len(nodesIndexToCreate))
+	for i, indexCandidate := range nodesIndexToCreate {
+		saveLogToBuffer := true
+		candidateName := fmt.Sprintf("%s-%s-%v", cfg.ClusterPrefix, nodeGroupName, indexCandidate)
+		var buffLog bytes.Buffer
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if i == 0 {
+				saveLogToBuffer = false
+			}
+			err := BootstrapAdditionalNodeForParallelRun(kubeCl, cfg, indexCandidate, step, nodeGroupName, cloudConfig, true, terraformContext, &buffLog, saveLogToBuffer)
+
+			resultsСhan <- checkResult{
+				name:    candidateName,
+				buffLog: &buffLog,
+				err:     err,
+			}
+
+			nodesToWait = append(nodesToWait, candidateName)
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultsСhan)
+	}()
+
+	for candidate := range resultsСhan {
+		if candidate.err != nil {
+			return nodesToWait, candidate.err
+		}
+		if candidate.buffLog.Len() == 0 {
+			continue
+		}
+		currentLogger := log.GetProcessLogger()
+		currentLogger.LogProcessStart(fmt.Sprintf("Output log [%s]", candidate.name))
+		scanner := bufio.NewScanner(candidate.buffLog)
+		for scanner.Scan() {
+			log.InfoLn(scanner.Text())
+		}
+		currentLogger.LogProcessEnd()
+	}
+	return nodesToWait, nil
 }
 
 func BootstrapAdditionalMasterNode(kubeCl *client.KubernetesClient, cfg *config.MetaConfig, index int, cloudConfig string, isConverge bool, terraformContext *terraform.TerraformContext) (*terraform.PipelineOutputs, error) {

--- a/dhctl/pkg/terraform/pipeline.go
+++ b/dhctl/pkg/terraform/pipeline.go
@@ -73,6 +73,10 @@ func ApplyPipeline(r RunnerInterface, name string, extractFn func(r RunnerInterf
 		return err
 	}
 
+	if r.IsLogToBuffer() {
+		return extractedData, pipelineFunc()
+	}
+
 	err := log.Process("terraform", fmt.Sprintf("Pipeline %s for %s", r.GetStep(), name), pipelineFunc)
 	return extractedData, err
 }

--- a/dhctl/pkg/terraform/runner_interface.go
+++ b/dhctl/pkg/terraform/runner_interface.go
@@ -33,4 +33,6 @@ type RunnerInterface interface {
 	GetPlanDestructiveChanges() *PlanDestructiveChanges
 	GetPlanPath() string
 	GetTerraformExecutor() Executor
+	IsLogToBuffer() bool
+	GetLog() []string
 }

--- a/dhctl/pkg/terraform/runner_test.go
+++ b/dhctl/pkg/terraform/runner_test.go
@@ -179,7 +179,11 @@ func (s *sleepExecutor) Output(_ ...string) ([]byte, error) {
 	return nil, nil
 }
 
-func (s *sleepExecutor) Exec(_ ...string) (int, error) {
+func (s *sleepExecutor) GetStdout() []string {
+	return nil
+}
+
+func (s *sleepExecutor) Exec(_ bool, _ ...string) (int, error) {
 	ticker := time.NewTicker(time.Second)
 loop:
 	for {

--- a/dhctl/pkg/terraform/terraform_context.go
+++ b/dhctl/pkg/terraform/terraform_context.go
@@ -276,6 +276,7 @@ type BootstrapNodeRunnerOptions struct {
 	NodeIndex                        int
 	NodeCloudConfig                  string
 	AdditionalStateSaverDestinations []SaverDestination
+	LogToBuffer                      bool
 }
 
 func (f *TerraformContext) GetBootstrapNodeRunner(metaConfig *config.MetaConfig, stateCache dstate.Cache, opts BootstrapNodeRunnerOptions) RunnerInterface {
@@ -290,7 +291,8 @@ func (f *TerraformContext) GetBootstrapNodeRunner(metaConfig *config.MetaConfig,
 				WithVariables(nodeConfig).
 				WithName(opts.NodeName).
 				WithAutoApprove(opts.AutoApprove).
-				WithAdditionalStateSaverDestination(opts.AdditionalStateSaverDestinations...)
+				WithAdditionalStateSaverDestination(opts.AdditionalStateSaverDestinations...).
+				WithCatchOutput(opts.LogToBuffer)
 
 			tomb.RegisterOnShutdown(opts.NodeName, r.Stop)
 


### PR DESCRIPTION
## Description

Add parallel bootstrap `cloudpermanent` nodes to dhctl.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Reduce time for bootstrap multiple nodes.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

<details>
  <summary>Before </summary>
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/cc91f914-c0d6-4be6-b868-4431399a47bf">
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/afaeee1b-8f57-45e6-90cf-361dfcdce28b">
</details>

<details>
  <summary>After</summary>
<img width="1275" alt="image" src="https://github.com/user-attachments/assets/64c1a951-2549-48ef-95ec-7b109ed5f313">
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/1e2232ff-0139-48fc-8d00-7e93ffdffe6a">
</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Add parallel bootstrap `cloudpermanent` nodes to dhctl.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
