### PR TITLE
[many] marked the old api *.deckhouse.io as deprecated

### DIFF
--- a/modules/040-node-manager/crds/nodeuser.yaml
+++ b/modules/040-node-manager/crds/nodeuser.yaml
@@ -17,6 +17,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
+      deprecated: true
       schema: &schema
         openAPIV3Schema:
           type: object

--- a/modules/140-user-authz/crds/clusterauthorizationrule.yaml
+++ b/modules/140-user-authz/crds/clusterauthorizationrule.yaml
@@ -17,6 +17,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
+      deprecated: true
       schema:
         openAPIV3Schema:
           type: object

--- a/modules/150-user-authn/crds/dex-authenticator.yaml
+++ b/modules/150-user-authn/crds/dex-authenticator.yaml
@@ -18,7 +18,8 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
+      deprecated: true
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -165,6 +166,6 @@ spec:
           type: string
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema: *schema
       additionalPrinterColumns: *additionalPrinterColumns

--- a/modules/150-user-authn/crds/dex-client.yaml
+++ b/modules/150-user-authn/crds/dex-client.yaml
@@ -16,7 +16,8 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
+      deprecated: true
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -56,5 +57,5 @@ spec:
                     type: string
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema: *schema

--- a/modules/150-user-authn/crds/dex-provider.yaml
+++ b/modules/150-user-authn/crds/dex-provider.yaml
@@ -16,7 +16,8 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
+      deprecated: true
       schema:
         openAPIV3Schema:
           type: object
@@ -500,7 +501,7 @@ spec:
           type: string
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema:
         openAPIV3Schema:
           type: object

--- a/modules/150-user-authn/crds/user.yaml
+++ b/modules/150-user-authn/crds/user.yaml
@@ -17,7 +17,8 @@ spec:
     - name: v1alpha1
       served: true
       storage: false
-      schema: &schema
+      deprecated: true
+      schema:
         openAPIV3Schema:
           type: object
           description: |
@@ -104,6 +105,7 @@ spec:
     - name: v1
       served: true
       storage: true
+      deprecated: false
       schema:
         openAPIV3Schema:
           type: object
@@ -179,4 +181,4 @@ spec:
                   items:
                     type: string
       subresources: *subresources
-      additionalPrinterColumns: &additionalPrinterColumns
+      additionalPrinterColumns: *additionalPrinterColumns

--- a/modules/150-user-authn/crds/user.yaml
+++ b/modules/150-user-authn/crds/user.yaml
@@ -105,7 +105,6 @@ spec:
     - name: v1
       served: true
       storage: true
-      deprecated: false
       schema:
         openAPIV3Schema:
           type: object

--- a/modules/300-prometheus/crds/customprometheusrules.yaml
+++ b/modules/300-prometheus/crds/customprometheusrules.yaml
@@ -17,7 +17,8 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
+      deprecated: true
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -79,5 +80,5 @@ spec:
                               type: string
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema: *schema

--- a/modules/300-prometheus/crds/grafanaadditionaldatasources.yaml
+++ b/modules/300-prometheus/crds/grafanaadditionaldatasources.yaml
@@ -17,7 +17,8 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
+      deprecated: true
       schema:
         openAPIV3Schema:
           type: object
@@ -70,7 +71,7 @@ spec:
                   description: JSON-data object to be saved encrypted.
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema:
         openAPIV3Schema:
           type: object

--- a/modules/300-prometheus/crds/grafanadashboarddefinition.yaml
+++ b/modules/300-prometheus/crds/grafanadashboarddefinition.yaml
@@ -17,7 +17,8 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
+      deprecated: true
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -51,6 +52,6 @@ spec:
           type: string
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema: *schema
       additionalPrinterColumns: *additionalPrinterColumns

--- a/modules/300-prometheus/crds/prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/prometheusremotewrite.yaml
@@ -16,7 +16,8 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
+      deprecated: true
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -120,6 +121,6 @@ spec:
           description: 'Prometheus Remote write URL.'
     - name: v1
       served: true
-      storage: false
+      storage: true
       schema: *schema
       additionalPrinterColumns: *additionalPrinterColumns

--- a/modules/301-prometheus-metrics-adapter/crds/clusterpodmetrics.yaml
+++ b/modules/301-prometheus-metrics-adapter/crds/clusterpodmetrics.yaml
@@ -37,5 +37,4 @@ spec:
     - name: v1beta1
       served: true
       storage: true
-      deprecated: false
       schema: *schema

--- a/modules/301-prometheus-metrics-adapter/crds/clusterpodmetrics.yaml
+++ b/modules/301-prometheus-metrics-adapter/crds/clusterpodmetrics.yaml
@@ -16,7 +16,8 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
+      deprecated: true
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -35,5 +36,6 @@ spec:
                     PromQL-query which returns unambiguous value for your metric. Use grouping operators like sum() by(), max() by() etc. Also use keywords: <<.LabelMatchers>> with your optional applied comma-separated labels as label selector and <<.GroupBy>> as group-by-labels. Example: max(mymetric{<<.LabelMatchers>>,queue="messages"}) by(<<.GroupBy>>)
     - name: v1beta1
       served: true
-      storage: false
+      storage: true
+      deprecated: false
       schema: *schema

--- a/modules/302-vertical-pod-autoscaler/crds/verticalpodautoscaler.yaml
+++ b/modules/302-vertical-pod-autoscaler/crds/verticalpodautoscaler.yaml
@@ -275,9 +275,11 @@ spec:
       openAPIV3Schema: *schema
     served: true
     storage: false
+    deprecated: true
   - name: v1beta1
     served: false
     storage: false
+    deprecated: true
     schema:
       openAPIV3Schema: *schema
 status:

--- a/modules/302-vertical-pod-autoscaler/crds/verticalpodautoscalercheckpoint.yaml
+++ b/modules/302-vertical-pod-autoscaler/crds/verticalpodautoscalercheckpoint.yaml
@@ -106,9 +106,11 @@ spec:
       openAPIV3Schema: *schema
     served: true
     storage: false
+    deprecated: true
   - name: v1beta1
     served: false
     storage: false
+    deprecated: true
     schema:
       openAPIV3Schema: *schema
 status:

--- a/modules/500-upmeter/crds/upmeterremotewrite.yaml
+++ b/modules/500-upmeter/crds/upmeterremotewrite.yaml
@@ -17,7 +17,8 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
+      deprecated: true
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -86,5 +87,6 @@ spec:
                     - 300
     - name: v1
       served: true
-      storage: false
+      storage: true
+      deprecated: false
       schema: *schema

--- a/modules/500-upmeter/crds/upmeterremotewrite.yaml
+++ b/modules/500-upmeter/crds/upmeterremotewrite.yaml
@@ -88,5 +88,4 @@ spec:
     - name: v1
       served: true
       storage: true
-      deprecated: false
       schema: *schema


### PR DESCRIPTION
## Description
Mark old api as deprecated.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
---
section: node-manager
type:  chore
summary: marked the old api *.deckhouse.io as deprecated
impact_level: default
---
section: user-authz
type:  chore
summary: marked the old api *.deckhouse.io as deprecated
impact_level: default 
---
section: user-authn
type:  chore
summary: marked the old api *.deckhouse.io as deprecated
impact_level: default 
---
section: prometheus
type:  chore
summary: marked the old api *.deckhouse.io as deprecated
impact_level: default 
---
section: vertical-pod-autoscaler
type:  chore
summary: marked the old api *.deckhouse.io as deprecated
impact_level: default 
---
section: upmeter
type:  chore
summary: marked the old api *.deckhouse.io as deprecated
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
