### PR TITLE
[dhctl] Deny use defaultCRI type as Docker 

### DIFF
--- a/candi/bashible/openapi.yaml
+++ b/candi/bashible/openapi.yaml
@@ -21,7 +21,7 @@ apiVersions:
         type: string
       cri:
         type: string
-        enum: [Docker, Containerd, NotManaged]
+        enum: [Containerd, NotManaged]
       proxy:
         type: object
         properties:

--- a/ee/modules/030-cloud-provider-openstack/candi
+++ b/ee/modules/030-cloud-provider-openstack/candi
@@ -1,1 +1,1 @@
-/deckhouse/candi/cloud-providers/openstack/
+/deckhouse/candi/cloud-providers/openstack

--- a/ee/modules/030-cloud-provider-vsphere/candi
+++ b/ee/modules/030-cloud-provider-vsphere/candi
@@ -1,1 +1,1 @@
-/deckhouse/candi/cloud-providers/vsphere/
+/deckhouse/candi/cloud-providers/vsphere

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -52,7 +52,7 @@ clusterConfiguration:
     provider: vSphere
   clusterDomain: cluster.local
   clusterType: Cloud
-  defaultCRI: Docker
+  defaultCRI: Containerd
   kind: ClusterConfiguration
   kubernetesVersion: "1.29"
   podSubnetCIDR: 10.111.0.0/16
@@ -199,7 +199,7 @@ internal:
     nodeType: CloudEphemeral
     kubernetesVersion: "1.29"
     cri:
-      type: "Docker"
+      type: "Containerd"
     cloudInstances:
       classReference:
         kind: AzureInstanceClass
@@ -336,7 +336,7 @@ internal:
     nodeType: CloudEphemeral
     kubernetesVersion: "1.29"
     cri:
-      type: "Docker"
+      type: "Containerd"
     cloudInstances:
       classReference:
         kind: OpenStackInstanceClass
@@ -422,7 +422,7 @@ internal:
     nodeType: CloudEphemeral
     kubernetesVersion: "1.29"
     cri:
-      type: "Docker"
+      type: "Containerd"
     cloudInstances:
       classReference:
         kind: OpenStackInstanceClass
@@ -573,7 +573,7 @@ internal:
     nodeType: CloudEphemeral
     kubernetesVersion: "1.29"
     cri:
-      type: "Docker"
+      type: "Containerd"
     cloudInstances:
       classReference:
         kind: YandexInstanceClass
@@ -1803,7 +1803,7 @@ internal:
     nodeType: CloudEphemeral
     kubernetesVersion: "1.24"
     cri:
-      type: "Docker"
+      type: "Containerd"
     cloudInstances:
       classReference:
         kind: VcdInstanceClass
@@ -1826,7 +1826,7 @@ internal:
     nodeType: CloudEphemeral
     kubernetesVersion: "1.24"
     cri:
-      type: "Docker"
+      type: "Containerd"
     cloudInstances:
       classReference:
         kind: VcdInstanceClass

--- a/modules/040-node-manager/template_tests/standby_node_test.go
+++ b/modules/040-node-manager/template_tests/standby_node_test.go
@@ -38,7 +38,7 @@ cloud:
   provider: vSphere
 clusterDomain: cluster.local
 clusterType: Cloud
-defaultCRI: Docker
+defaultCRI: Containerd
 kind: ClusterConfiguration
 kubernetesVersion: "1.29"
 podSubnetCIDR: 10.111.0.0/16


### PR DESCRIPTION
## Description
Deny to use cri type Docker in field defaultCRI in cluster configuration on bootstrap deckhouse .
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
this allow to deny use Docker cri type when field defaultCRI  is prompt as Docker.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
if Docker cri type is prompt as defaultCRI stderr output is "defaultCRI should be one of [Containerd NotManaged]".
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section:  dhctl
type: fix
summary: Deny use defaultCRI type as Docker 
impact_level: default
```
