### PR TITLE
[bashible] Disable old or another containerd.service

### DIFF
--- a/candi/bashible/common-steps/all/000_preflight_checks.sh
+++ b/candi/bashible/common-steps/all/000_preflight_checks.sh
@@ -19,9 +19,11 @@ if [[ "$FIRST_BASHIBLE_RUN" == "yes" ]]; then
     exit 1
   fi
 else
-  if systemctl is-enabled containerd >/dev/null 2>&1; then
-    bb-log-error "containerd.service is enabled on $HOSTNAME. Deckhouse use only containerd-deckhouse.service. Please disable/uninstall containerd.service to avoid further conflicts."
-    exit 1
+  if systemctl list-unit-files containerd.service >/dev/null 2>&1; then
+    if systemctl is-enabled containerd >/dev/null 2>&1 || systemctl is-active containerd >/dev/null 2>&1; then
+      bb-log-error "containerd.service is enabled or running on $HOSTNAME. Deckhouse use only containerd-deckhouse.service. Please disable/stop/uninstall containerd.service to avoid further conflicts."
+      exit 1
+    fi
   fi
 fi
 {{- end }}

--- a/candi/bashible/common-steps/all/000_preflight_checks.sh
+++ b/candi/bashible/common-steps/all/000_preflight_checks.sh
@@ -18,5 +18,9 @@ if [[ "$FIRST_BASHIBLE_RUN" == "yes" ]]; then
     bb-log-error "containerd is detected on $HOSTNAME. Deckhouse does not support pre-provisioned containerd installations. Please uninstall containerd and try again."
     exit 1
   fi
-fi
+else
+  if systemctl is-enabled containerd >/dev/null 2>&1; then
+    bb-log-error "containerd.service is enabled on $HOSTNAME. Deckhouse use only containerd-deckhouse.service. Please disable/uninstall containerd.service to avoid further conflicts."
+    exit 1
+  fi
 {{- end }}

--- a/candi/bashible/common-steps/all/000_preflight_checks.sh
+++ b/candi/bashible/common-steps/all/000_preflight_checks.sh
@@ -23,4 +23,5 @@ else
     bb-log-error "containerd.service is enabled on $HOSTNAME. Deckhouse use only containerd-deckhouse.service. Please disable/uninstall containerd.service to avoid further conflicts."
     exit 1
   fi
+fi
 {{- end }}

--- a/candi/bashible/common-steps/all/033_restart_containerd_if_needed.sh.tpl
+++ b/candi/bashible/common-steps/all/033_restart_containerd_if_needed.sh.tpl
@@ -16,6 +16,9 @@
 if bb-flag? containerd-need-restart; then
   bb-log-warning "'containerd-need-restart' flag was set, restarting containerd."
   if out=$(containerd config dump 2>&1); then
+    if [[ -f /etc/systemd/system/containerd.service ]] || [[ -f /usr/lib/systemd/system/containerd.service ]] || [[ -f /lib/systemd/system/containerd.service ]]; then
+      systemctl disable --now containerd.service &> /dev/null
+    fi
       systemctl restart containerd-deckhouse.service
   else
       bb-log-error "'containerd config dump' return error: $out"

--- a/candi/bashible/common-steps/all/033_restart_containerd_if_needed.sh.tpl
+++ b/candi/bashible/common-steps/all/033_restart_containerd_if_needed.sh.tpl
@@ -16,9 +16,6 @@
 if bb-flag? containerd-need-restart; then
   bb-log-warning "'containerd-need-restart' flag was set, restarting containerd."
   if out=$(containerd config dump 2>&1); then
-    if [[ -f /etc/systemd/system/containerd.service ]] || [[ -f /usr/lib/systemd/system/containerd.service ]] || [[ -f /lib/systemd/system/containerd.service ]]; then
-      systemctl disable --now containerd.service &> /dev/null
-    fi
       systemctl restart containerd-deckhouse.service
   else
       bb-log-error "'containerd config dump' return error: $out"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
We have some [issue](https://github.com/deckhouse/deckhouse/issues/5830) where two containerd services in single node. Since deckhouse only use `containerd-deckhouse.service` in actual version (since v1.50), we can turn off the other `containerd.service` before restarting this in step [033_restart_containerd_if_needed.sh
](https://github.com/deckhouse/deckhouse/blob/9228fea4b0083a84b83b813627dca8b53e940277/candi/bashible/common-steps/node-group/033_restart_containerd_if_needed.sh.tpl)
In the current situation, another running `containerd.service` breaks step `033_restart_containerd_if_needed` and the update freezes
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: bashible
type: fix
summary: Disable old or another containerd.service
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
