### PR TITLE
[deckhouse-controller] updated the documentation with the latest changes to the collect-debug-info command

### DIFF
--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -104,6 +104,11 @@ func createTarball() *bytes.Buffer {
 			Args: []string{"get", "nodes", "-A", "-o", "json"},
 		},
 		{
+			File: "machines.json",
+			Cmd:  "kubectl",
+			Args: []string{"get", "machines.machine.sapcloud.io", "-A", "-o", "json"},
+		},
+		{
 			File: "instances.json",
 			Cmd:  "kubectl",
 			Args: []string{"get", "instances.deckhouse.io", "-o", "json"},

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -104,9 +104,14 @@ func createTarball() *bytes.Buffer {
 			Args: []string{"get", "nodes", "-A", "-o", "json"},
 		},
 		{
-			File: "machines.json",
+			File: "instances.json",
 			Cmd:  "kubectl",
-			Args: []string{"get", "machines", "-A", "-o", "json"},
+			Args: []string{"get", "instances.deckhouse.io", "-o", "json"},
+		},
+		{
+			File: "staticinstances.json",
+			Cmd:  "kubectl",
+			Args: []string{"get", "staticinstances.deckhouse.io", "-o", "json"},
 		},
 		{
 			File: "deckhouse-version.json",

--- a/modules/002-deckhouse/docs/FAQ.md
+++ b/modules/002-deckhouse/docs/FAQ.md
@@ -52,6 +52,7 @@ Data that will be collected:
 * controllers and pods manifests from namespaces owned by Deckhouse
 * `nodegroups` state
 * `nodes` state
+* `machines` state
 * `instances` state
 * `staticinstances` state
 * deckhouse pods version

--- a/modules/002-deckhouse/docs/FAQ.md
+++ b/modules/002-deckhouse/docs/FAQ.md
@@ -46,13 +46,14 @@ We always appreciate helping users with debugging complex issues. Please follow 
 
 Data that will be collected:
 * Deckhouse queue state
-* global Deckhouse values
+* global Deckhouse values. Except for the values of `kubeRBACProxyCA` and `registry.dockercfg`
 * enabled modules list
 * `events` from all namespaces
 * controllers and pods manifests from namespaces owned by Deckhouse
 * `nodegroups` state
 * `nodes` state
-* `machines` state
+* `instances` state
+* `staticinstances` state
 * deckhouse pods version
 * all `deckhousereleases` objects
 * Deckhouse logs
@@ -63,7 +64,7 @@ Data that will be collected:
 * Vertical Pod Autoscaler recommender logs
 * Vertical Pod Autoscaler updater logs
 * Prometheus logs
-* terraform-state-exporter metrics
+* terraform-state-exporter metrics. Except for the values in `provider` from `providerClusterConfiguration`.
 * all firing alerts from Prometheus
 
 ## How to debug pod problems with ephemeral containers?

--- a/modules/002-deckhouse/docs/FAQ_RU.md
+++ b/modules/002-deckhouse/docs/FAQ_RU.md
@@ -46,13 +46,14 @@ kubectl logs job.batch/kube-bench
 
 Данные, которые будут собраны:
 * состояние очереди Deckhouse;
-* Deckhouse values;
+* Deckhouse values. За исключением значений `kubeRBACProxyCA` и `registry.dockercfg`;
 * список включенных модулей;
 * `events` из всех пространств имен;
 * манифесты controller'ов и подов из всех пространств имен Deckhouse;
 * все объекты `nodegroups`;
 * все объекты `nodes`;
-* все объекты `machines`;
+* все объекты `instances`;
+* все объекты `staticinstances`;
 * данные о текущей версии пода deckhouse;
 * все объекты `deckhousereleases`;
 * логи Deckhouse;
@@ -63,7 +64,7 @@ kubectl logs job.batch/kube-bench
 * логи Vertical Pod Autoscaler recommender;
 * логи Vertical Pod Autoscaler updater;
 * логи Prometheus;
-* метрики terraform-state-exporter;
+* метрики terraform-state-exporter. За исключением значений в `provider` из `providerClusterConfiguration`.
 * все горящие уведомления в Prometheus.
 
 ## Как отлаживать проблемы в подах с помощью ephemeral containers?

--- a/modules/002-deckhouse/docs/FAQ_RU.md
+++ b/modules/002-deckhouse/docs/FAQ_RU.md
@@ -52,6 +52,7 @@ kubectl logs job.batch/kube-bench
 * манифесты controller'ов и подов из всех пространств имен Deckhouse;
 * все объекты `nodegroups`;
 * все объекты `nodes`;
+* все объекты `machines`;
 * все объекты `instances`;
 * все объекты `staticinstances`;
 * данные о текущей версии пода deckhouse;

--- a/modules/002-deckhouse/docs/FAQ_RU.md
+++ b/modules/002-deckhouse/docs/FAQ_RU.md
@@ -64,7 +64,7 @@ kubectl logs job.batch/kube-bench
 * логи Vertical Pod Autoscaler recommender;
 * логи Vertical Pod Autoscaler updater;
 * логи Prometheus;
-* метрики terraform-state-exporter. За исключением значений в `provider` из `providerClusterConfiguration`.
+* метрики terraform-state-exporter. За исключением значений в `provider` из `providerClusterConfiguration`;
 * все горящие уведомления в Prometheus.
 
 ## Как отлаживать проблемы в подах с помощью ephemeral containers?


### PR DESCRIPTION
## Description
Update the documentation about the list of data the `collect-debug-info` command collects.

## Why do we need it, and what problem does it solve?
Brought the documentation up to date with the actual behavior.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Update the documentation about the list of data the `collect-debug-info` command collects.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
