### PR TITLE
[docs] fixed build in shell

### DIFF
--- a/docs/documentation/werf.yaml
+++ b/docs/documentation/werf.yaml
@@ -70,8 +70,8 @@ shell:
 
         # "Add permalinks"
         for i in $(find . -regex '.*.md' -print); do
-          if [ $(grep -q "^---" $i) -gt 0 ]; then continue; fi
-          if [ $(cat $i | tr -d '\n' | grep -lv "^---.*permalink: .*---" &> /dev/null) -eq 0 ]; then
+          if ! grep -q "^---" "$i"; then continue; fi
+          if cat $i | tr -d '\n' | grep -qv "^---.*permalink: .*---"; then
             # permalink is absent, add permalink
             PERMALINK="/$(echo $i | sed -E 's#(modules_)(en|ru)/#\2/modules/#' | sed 's#docs/##g'| tr '[:upper:]' '[:lower:]' | sed 's#\.md$#.html#' | sed 's#^\.\/##' | sed 's#readme\.html$##' )"
             sed -i "1apermalink: $PERMALINK" $i

--- a/modules/810-documentation/images/web/werf.inc.yaml
+++ b/modules/810-documentation/images/web/werf.inc.yaml
@@ -30,7 +30,6 @@ from: {{ .Images.BASE_JEKYLL }}
 shell:
   setup:
   - |
-        set -x
         echo "Ruby: $(ruby --version)"
         echo "Gem: $(gem --version)"
         bundle --version
@@ -52,8 +51,8 @@ shell:
 
         # "Adding permalinks..."
         for i in $(find . -regex '.*.md' -print); do
-          if [ $(grep -q "^---" $i) -gt 0 ]; then continue; fi
-          if [ $(cat $i | tr -d '\n' | grep -lv "^---.*permalink: .*---" &> /dev/null) -eq 0 ]; then
+          if ! grep -q "^---" "$i"; then continue; fi
+          if cat $i | tr -d '\n' | grep -qv "^---.*permalink: .*---"; then
             # permalink is absent, add permalink
             PERMALINK="/$(echo $i | sed -E 's#(modules_)(en|ru)/#\2/modules/#' | sed 's#docs/##g'| tr '[:upper:]' '[:lower:]' | sed 's#\.md$#.html#' | sed 's#^\.\/##' | sed 's#readme\.html$##' )"
             sed -i "1apermalink: $PERMALINK" $i


### PR DESCRIPTION
## Description
Fix documentation build.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Fix documentation build.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
