### PR TITLE
[cloud-provider-zvirt] Fix csi-node 401 Unauthorized

### DIFF
--- a/ee/modules/030-cloud-provider-zvirt/templates/csi/secret.yaml
+++ b/ee/modules/030-cloud-provider-zvirt/templates/csi/secret.yaml
@@ -9,6 +9,9 @@ ovirt_cafile: "/etc/cloud/ca/zvirt_ca.pem"
   {{- end }}
 clusterid: {{ .Values.global.discovery.clusterUUID }}
 {{- end }}
+
+{{- $providerClusterConfiguration := .Values.cloudProviderZvirt.internal.providerClusterConfiguration | required "internal.providerClusterConfiguration is required" -}}
+{{- if and (ne $providerClusterConfiguration.provider.server "") (ne $providerClusterConfiguration.provider.username "") (ne $providerClusterConfiguration.provider.password "") (ne .Values.global.discovery.clusterUUID "") }}
 ---
 apiVersion: v1
 kind: Secret
@@ -19,6 +22,8 @@ metadata:
 type: Opaque
 data:
   cloud-config: {{ include "csi_cloud_config" . | b64enc | quote }}
+{{- end }}
+
 {{- if not (eq .Values.cloudProviderZvirt.internal.providerClusterConfiguration.provider.caBundle "") }}
 ---
 apiVersion: v1


### PR DESCRIPTION
## Description
This PR fixes 401 Unauthorized error in zvirt csi node
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
To fix 401 Unauthorized error in zvirt csi node
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
No 401 Unauthorized errors in zvirt csi node logs
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-zvirt
type: fix
summary: 401 Unauthorized error fixed in zvirt csi-node.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
