### PR TITLE
[candi] kubelet files strict permissions fix

### DIFF
--- a/candi/bashible/common-steps/all/098_set_permissions.sh.tpl
+++ b/candi/bashible/common-steps/all/098_set_permissions.sh.tpl
@@ -15,12 +15,4 @@
 find /etc/kubernetes -type d -exec chmod 700 {} \;
 find /etc/kubernetes -type f -exec chmod 600 {} \;
 
-find /var/lib/kubelet \
-  \( -path "/var/lib/kubelet/plugins" -o -path "/var/lib/kubelet/plugins/*" \
-  -o -path "/var/lib/kubelet/pods" -o -path "/var/lib/kubelet/pods/*" \) \
-  -prune -o -type d -exec chmod 700 {} \;
-
-find /var/lib/kubelet \
-  \( -path "/var/lib/kubelet/plugins" -o -path "/var/lib/kubelet/plugins/*" \
-  -o -path "/var/lib/kubelet/pods" -o -path "/var/lib/kubelet/pods/*" \) \
-  -prune -o -type f -exec chmod 600 {} \;
+chmod 700 /var/lib/kubelet/

--- a/candi/bashible/common-steps/all/098_set_permissions.sh.tpl
+++ b/candi/bashible/common-steps/all/098_set_permissions.sh.tpl
@@ -15,6 +15,12 @@
 find /etc/kubernetes -type d -exec chmod 700 {} \;
 find /etc/kubernetes -type f -exec chmod 600 {} \;
 
-find /var/lib/kubelet ! -path "/var/lib/kubelet/plugins*" ! -path "/var/lib/kubelet/pods*" -type d -exec chmod 700 {} \;
-find /var/lib/kubelet ! -path "/var/lib/kubelet/plugins*" ! -path "/var/lib/kubelet/pods*" -type f -exec chmod 600 {} \;
+find /var/lib/kubelet \
+  \( -path "/var/lib/kubelet/plugins" -o -path "/var/lib/kubelet/plugins/*" \
+  -o -path "/var/lib/kubelet/pods" -o -path "/var/lib/kubelet/pods/*" \) \
+  -prune -o -type d -exec chmod 700 {} \;
 
+find /var/lib/kubelet \
+  \( -path "/var/lib/kubelet/plugins" -o -path "/var/lib/kubelet/plugins/*" \
+  -o -path "/var/lib/kubelet/pods" -o -path "/var/lib/kubelet/pods/*" \) \
+  -prune -o -type f -exec chmod 600 {} \;


### PR DESCRIPTION
## Description

fix for this [pr](https://github.com/deckhouse/deckhouse/pull/9494)  exluded plugins folder

Stricter permissions (0700 for directories, 0600 for files) to all kubelet config files and PKI files. This is done to improve security.

## Why do we need it, and what problem does it solve?

These changes are needed to make the Kubernetes cluster more secure. With these permissions, only the necessary services and the root user can access important configuration files, reducing the risk of unauthorized access.

## Why do we need it in the patch release (if we do)?


## What is the expected result?

After these changes, the permissions on kubelet directories and files will be stricter—0700 for directories and 0600 for files. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Stricter permissions (0700/0600) applied to kubelet configuration and PKI files to improve security.
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
