### PR TITLE
[deckhouse-tools] Correct the link for d8-cli for windows

### DIFF
--- a/modules/800-deckhouse-tools/images/web/static/tools.json
+++ b/modules/800-deckhouse-tools/images/web/static/tools.json
@@ -16,7 +16,7 @@
         "platform": "MacOS (ARM)"
       },
       {
-        "link": "/files/d8-cli/windows-amd64/d8",
+        "link": "/files/d8-cli/windows-amd64/d8.exe",
         "platform": "Windows (Intel)"
       }
     ]


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Correct the link for d8-cli for windows in deckhouse-tools web, add extension of file in link

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The d8-cli has a name d8.exe , but the extension was not specified in the incorrect link, so it was impossible to download the file.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
We need a valid download link for d8-cli for windows.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
We have correctly link for download d8-cli for windows. We don't get a 404 response.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-tools 
type: fix 
summary: Corrected the link to d8-cli for windowsOS, add a extension of file to link&
impact_level: low
```
