### PR TITLE
[docs] Fixed command at ModulePullOverride

### DIFF
--- a/docs/documentation/pages/module-development/DEVELOPMENT.md
+++ b/docs/documentation/pages/module-development/DEVELOPMENT.md
@@ -34,7 +34,7 @@ You can specify a longer interval to force a refresh, and use the `renew=“”`
 Below is an example of the command:
 
 ```sh
-kubectl annotate mop <name> renew=""
+kubectl annotate mpo <name> renew=""
 ```
 
 ## How it works

--- a/docs/documentation/pages/module-development/DEVELOPMENT_RU.md
+++ b/docs/documentation/pages/module-development/DEVELOPMENT_RU.md
@@ -35,7 +35,7 @@ spec:
 Пример команды:
 
 ```sh
-kubectl annotate mop <name> renew=""
+kubectl annotate mpo <name> renew=""
 ```
 
 ## Принцип действия


### PR DESCRIPTION
## Description
Fixed incorrect spelling of the command at ModulePullOverride.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

```changes
section: docs
type: fix
summary: Fixed incorrect spelling of the command at ModulePullOverride.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
