### PR TITLE
[user-authn] Trim user email on dex auth form

### DIFF
--- a/modules/150-user-authn/images/dex/web/templates/password.html
+++ b/modules/150-user-authn/images/dex/web/templates/password.html
@@ -11,7 +11,7 @@
   <form method="post" action="{{ .PostURL }}" class="grid">
     <div>
       <label for="userid" class="input-label">{{ .UsernamePrompt }}:</label>
-	    <input tabindex="1" required id="login" name="login" type="text" class="input" {{ if .Username }} value="{{ .Username }}" {{ else }} autofocus {{ end }}/>
+	    <input tabindex="1" required id="login" name="login" type="text" class="input" {{ if .Username }} value="{{ .Username }}" {{ else }} autofocus onfocusout="this.value = this.value.trim()" {{ end }}/>
     </div>
     <div>
       <label for="password" class="input-label">

--- a/modules/150-user-authn/images/dex/web/templates/password.html
+++ b/modules/150-user-authn/images/dex/web/templates/password.html
@@ -56,4 +56,11 @@
   {{ end }}
 </div>
 
+<script type="text/javascript">
+  document.querySelector('form').onsubmit = function(e) {
+    var el = document.querySelector('#submit-login');
+    el.setAttribute('disabled', 'disabled');
+  };
+</script>
+
 {{ template "footer.html" . }}


### PR DESCRIPTION
## Description
Trim space for username on the dex login form

## Why do we need it, and what problem does it solve?
User can copy email with spaces and it will lead to the error. Also, visually it's hard to find prefix/suffix space in the form.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Before:
<img width="568" alt="image" src="https://github.com/user-attachments/assets/967b437a-21a6-4c80-beae-f6318c11e3fc">


After:
<img width="556" alt="image" src="https://github.com/user-attachments/assets/1975077f-3a37-44ad-b8f1-2a2b492ea6b0">


```changes
section: user-authn
type: fix
summary: Trim spaces from email field on the login form.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
