### PR TITLE
[secret-copier] Add secret creation validation

### DIFF
--- a/modules/600-secret-copier/templates/validating.yml
+++ b/modules/600-secret-copier/templates/validating.yml
@@ -1,0 +1,54 @@
+{{- if and (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicy")) (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicyBinding")) }}
+{{- $policyName := "secret-copier-label.deckhouse.io" }}
+apiVersion:  {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  auditAnnotations:
+    - key: source-user
+      valueExpression: '''User: '' + string(request.userInfo.username) + '' tries to
+      create secret with `secret-copier.deckhouse.io/enabled` label outside of `default` namespace'''
+  failurePolicy: Fail
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - default
+    objectSelector: {}
+    resourceRules:
+      - apiGroups:
+          - ''
+        apiVersions:
+          - 'v1'
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - 'secrets'
+        scope: 'Namespaced'
+  validations:
+  - expression: request.userInfo.username == "system:serviceaccount:d8-system:deckhouse"
+    reason: Forbidden
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
+    messageExpression: '''Creating secrets with `secret-copier.deckhouse.io/enabled` label outside of `default` namespace is forbidden'''
+{{- end }}
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  matchResources:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+  policyName: {{ $policyName }}
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
+  validationActions: [Deny, Audit]
+{{- end }}

--- a/modules/600-secret-copier/templates/validation.yml
+++ b/modules/600-secret-copier/templates/validation.yml
@@ -52,3 +52,4 @@ spec:
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   validationActions: [Deny, Audit]
 {{- end }}
+{{- end }}

--- a/modules/600-secret-copier/templates/validation.yml
+++ b/modules/600-secret-copier/templates/validation.yml
@@ -13,12 +13,7 @@ spec:
   failurePolicy: Fail
   matchConstraints:
     matchPolicy: Equivalent
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - default
+    namespaceSelector: {}
     objectSelector: {}
     resourceRules:
       - apiGroups:
@@ -50,7 +45,12 @@ spec:
     objectSelector:
       matchLabels:
         secret-copier.deckhouse.io/enabled: ""
-    namespaceSelector: {}
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - default
   policyName: {{ $policyName }}
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   validationActions: [Deny, Audit]

--- a/modules/600-secret-copier/templates/validation.yml
+++ b/modules/600-secret-copier/templates/validation.yml
@@ -47,6 +47,9 @@ metadata:
 spec:
   matchResources:
     matchPolicy: Equivalent
+    objectSelector:
+      matchLabels:
+        secret-copier.deckhouse.io/enabled: ""
     namespaceSelector: {}
   policyName: {{ $policyName }}
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}


### PR DESCRIPTION
## Description
Add validation through `ValidatingAdmissionPolicy` to prohibit manual creation of secrets with label `secret-copier.deckhouse.io/enabled` outside of `default` namespace. 

## Why do we need it, and what problem does it solve?
This would help with accidental creation of secrets, including automatic creation with wrong `secretTemplates`, because such secrets would be deleted by `secret-copier` anyway.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: secret-copier
type: chore
summary: Add validation of secrets with secret-copier labels
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
