### PR TITLE
[dhctl] Fix panic during creation resources and add timestamps to debug log

### DIFF
--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -221,10 +221,10 @@ func (c *Creator) createSingleResource(resource *template.Resource) error {
 	// Wait up to 10 minutes
 	return retry.NewLoop(fmt.Sprintf("Create %s resources", resource.GVK.String()), 60, 10*time.Second).Run(func() error {
 		gvr, docCopy, err := resourceToGVR(c.kubeCl, resource)
-		namespace := docCopy.GetNamespace()
 		if err != nil {
 			return err
 		}
+		namespace := docCopy.GetNamespace()
 		manifestTask := actions.ManifestTask{
 			Name:     getUnstructuredName(docCopy),
 			Manifest: func() interface{} { return nil },

--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/gookit/color"
 	"github.com/sirupsen/logrus"
@@ -724,7 +725,10 @@ func (d *TeeLogger) writeToFile(content string) {
 		return
 	}
 
-	if _, err := d.buf.Write([]byte(content)); err != nil {
+	timestamp := time.Now().Format(time.DateTime)
+	contentWithTimestamp := fmt.Sprintf("%s - %s", timestamp, content)
+
+	if _, err := d.buf.Write([]byte(contentWithTimestamp)); err != nil {
 		d.l.LogDebugF("Cannot write to TeeLog: %v", err)
 	}
 


### PR DESCRIPTION
## Description
Fix panic during creation resources and add timestamps to debug log

Affect DKP >= 1.64

## Why do we need it, and what problem does it solve?
Bootstrap can fail with panic.
Improve debug information.

## Why do we need it in the patch release (if we do)?
Bootstrap can fail with panic.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
![image](https://github.com/user-attachments/assets/e8527eed-e893-4f6b-a928-17e17f3f7b36)


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix panic during creation resources and add timestamps to debug log
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
