### PR TITLE
[prometheus] Fix Grafana server root URL

### DIFF
--- a/modules/300-prometheus/templates/grafana/deployment-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment-v10.yaml
@@ -81,7 +81,7 @@ spec:
         env:
         {{- if .Values.global.modules.publicDomainTemplate }}
         - name: GF_SERVER_ROOT_URL
-          value: {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "grafana-v10") }}
+          value: {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "grafana") }}
         {{- end }}
         - name: GF_AUTH_BASIC_ENABLED
           value: "false"


### PR DESCRIPTION
## Description
Change grafana server root url to https://grafana.%publicDomainTemplate%

## Why do we need it, and what problem does it solve?
The `GF_SERVER_ROOT_URL` environment variable was left intact by a mistake while switching Grafana v10 to the default domain. This leads us to several problems, e.g.: Grafana generates the wrong URL for chart snapshots.

## Why do we need it in the patch release (if we do)?
It would be nice to have this fix in any upcoming hotfix release to improve user experience.

## What is the expected result?
Chart snapshots are generated with the correct URL: https://grafana.%publicDomainTemplate%

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fix Grafana root URL
impact: Grafana deployment will be rollout restarted due to environment variable change
impact_level: default
```
