### PR TITLE
[candi] fix AltLinux 11 bootstrap ( udev error )

### DIFF
--- a/ee/be/candi/bashible/bundles/altlinux/all/000_fix_udev_xgrp_error.sh.tpl
+++ b/ee/be/candi/bashible/bundles/altlinux/all/000_fix_udev_xgrp_error.sh.tpl
@@ -1,0 +1,21 @@
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# FIX systemd-udevd[*]: /usr/lib/udev/rules.d/50-udev-default.rules:51 Unknown group 'xgrp', ignoring.
+#
+
+if grep -q xgrp /usr/lib/udev/rules.d/50-udev-default.rules && ! getent group xgrp > /dev/null; then
+  groupadd xgrp
+fi


### PR DESCRIPTION
## Description

AltLinux 11 bootstrap process may experience a udev-related error when running apt-get install or apt-get remove commands. This error leads to a dramatic increase in apt-get's runtime, extending it by 5 to 10 times. 

## Why do we need it, and what problem does it solve?

This solves the timeout problem in the AltLinux 11 node bootstrap process. 

## Why do we need it in the patch release (if we do)?

## What is the expected result?

bashible creates the `xgrp` system group if it is specified in the udev config but is not present on the system. As a result, the system stops slowing down.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix 
summary: fix AltLinux 11 bootstrap ( udev error )
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
