### PR TITLE
[cni-cilium] Disabling the upload of the service image base-cilium-dev to the final container registry. cherry-pick to release-1.64

### DIFF
--- a/modules/021-cni-cilium/images/base-cilium-dev/werf.inc.yaml.txt
+++ b/modules/021-cni-cilium/images/base-cilium-dev/werf.inc.yaml.txt
@@ -26,6 +26,7 @@
 ---
 image: {{ $.ModuleName }}/base-cilium-dev
 from: {{ $.Images.BASE_ALT }}
+final: false
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg


### PR DESCRIPTION
## Description

Disabling the upload of the service image `base-cilium-dev` to the final container registry.

## Why do we need it, and what problem does it solve?

`base-cilium-dev` is a service build image and it should not be included in the final container registry.

## Why do we need it in the patch release (if we do)?

There should be no service images in the final container registry.

## What is the expected result?

There should be no service images in the final container registry.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Disabling the upload of the service image `base-cilium-dev` to the final container registry.
impact: All cilium-agent pods will be restarted.
impact_level: default
```