### PR TITLE
[cni-cilium, cni-flannel] Fixing a packet dropping issue when using VXLAN on a cluster running on VMware virtual machines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -223,6 +223,15 @@ updates:
   open-pull-requests-limit: 0
 
 - package-ecosystem: "gomod"
+  directory: "/modules/000-common/images/vxlan-offloading-fixer"
+  labels:
+  - "type/dependencies"
+  - "status/ok-to-test"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 0
+
+- package-ecosystem: "gomod"
   directory: "/modules/007-registrypackages/images/toml-merge/src"
   labels:
   - "type/dependencies"

--- a/modules/000-common/images/vxlan-offloading-fixer/go.mod
+++ b/modules/000-common/images/vxlan-offloading-fixer/go.mod
@@ -1,0 +1,3 @@
+module vxlan-offloading-fixer
+
+go 1.23

--- a/modules/000-common/images/vxlan-offloading-fixer/main.go
+++ b/modules/000-common/images/vxlan-offloading-fixer/main.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+var (
+	pathToEthtool = "/ethtool"
+)
+
+func main() {
+	// logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	// slog.SetDefault(logger)
+
+	nodeIP := os.Getenv("NODE_IP")
+	if nodeIP == "" {
+		log.Fatal("NODE_IP environment variable is not set")
+	}
+
+	driverRegexp := regexp.MustCompile(`^driver:\s*(\S+)`)
+	udpSegmentationRegexp := regexp.MustCompile(`tx-udp_tnl-segmentation:\s*(\S+)`)
+	udpCsumSegmentationRegexp := regexp.MustCompile(`tx-udp_tnl-csum-segmentation:\s*(\S+)`)
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		log.Fatalf("could not get network interfaces: %+v\n", err.Error())
+	}
+
+	log.Println("switching off network interfaces vxlan offloading...")
+	for _, iface := range ifaces {
+		if iface.Name == "lo" {
+			continue
+		}
+
+		addresses, err := iface.Addrs()
+		if err != nil {
+			log.Printf("could not get addresses for interface: %+v\n", err.Error())
+			continue
+		}
+		found := false
+		for _, address := range addresses {
+			log.Printf("checking address %s for interface %s\n", address.String(), iface.Name)
+			addressParts := strings.Split(address.String(), "/")
+			if addressParts[0] == nodeIP {
+				found = true
+				log.Printf("found NODE_IP address %s for interface %s\n", nodeIP, iface.Name)
+				break
+			}
+		}
+		if !found {
+			continue
+		}
+
+		cmd := exec.Command(pathToEthtool, "-i", iface.Name)
+		ifaceInfo, err := cmd.Output()
+		if err != nil {
+			log.Printf("could not get driver info for network interface %s: %+v\n", iface.Name, err.Error())
+			continue
+		}
+
+		drvMatches := driverRegexp.FindSubmatch(ifaceInfo)
+		if len(drvMatches) == 0 || string(drvMatches[1]) != "vmxnet3" {
+			continue // we are only interested in network interfaces with the driver vmxnet3
+		}
+
+		cmd = exec.Command(pathToEthtool, "-k", iface.Name)
+		offloadInfo, err := cmd.Output()
+		if err != nil {
+			log.Printf("could not get features info for network interface %s: %+v\n", iface.Name, err.Error())
+			continue
+		}
+
+		// Fix UDP segmentation
+		udpSegmentationMatches := udpSegmentationRegexp.FindSubmatch(offloadInfo)
+		if len(udpSegmentationMatches) > 0 && string(udpSegmentationMatches[1]) == "on" {
+			log.Println("switching off udp segmentation for network interfaces:", iface.Name)
+			cmd = exec.Command(pathToEthtool, "-K", iface.Name, "tx-udp_tnl-segmentation", "off")
+			if err := cmd.Run(); err != nil {
+				log.Printf("could not switch off udp segmentation for network interface %s: %+v\n", iface.Name, err.Error())
+			}
+		}
+
+		// Fix UDP checksum segmentation
+		udpChsumSegmentMatches := udpCsumSegmentationRegexp.FindSubmatch(offloadInfo)
+		if len(udpChsumSegmentMatches) > 0 && string(udpChsumSegmentMatches[1]) == "on" {
+			log.Println("fix udp checksum segmentation for network interfaces:", iface.Name)
+			cmd = exec.Command(pathToEthtool, "-K", iface.Name, "tx-udp_tnl-csum-segmentation", "off")
+			if err := cmd.Run(); err != nil {
+				log.Printf("could not switch off udp checksum segmentation for network interface %s: %+v\n", iface.Name, err.Error())
+			}
+		}
+	}
+	log.Println("correction is complete")
+}

--- a/modules/000-common/images/vxlan-offloading-fixer/werf.inc.yaml
+++ b/modules/000-common/images/vxlan-offloading-fixer/werf.inc.yaml
@@ -1,0 +1,76 @@
+{{- $version := "6.11" }}
+{{- $image_version := $version | replace "." "-" }}
+---
+artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+fromArtifact: common/src-artifact
+shell:
+  install:
+  - cd /src
+  - git clone -b libmnl-1.0.5 --depth 1 {{ $.SOURCE_REPO }}/netfilter/libmnl ./src-libmnl
+  - git clone -b v{{ $version }} --depth 1  {{ $.SOURCE_REPO }}/ethtool/ethtool.git ./src-ethtool
+---
+artifact: {{ $.ModuleName }}/ethtool-artifact
+from: {{ $.Images.BASE_ALPINE }}
+import:
+  - artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+    add: /src
+    to: /src
+    before: install
+mount:
+  - fromPath: ~/go-pkg-cache
+    to: /go/pkg
+shell:
+  beforeInstall:
+  {{- include "alpine packages proxy" . | nindent 2 }}
+  - apk add --no-cache autoconf automake make libtool g++ linux-headers pkgconfig
+  setup:
+    - export PKG_CONFIG_PATH=/opt/deckhouse/bin/.libs/pkgconfig
+    - cd /src/src-libmnl
+    - ./autogen.sh
+    - ./configure --enable-static --libdir=/opt/deckhouse/bin/.libs
+    - make && make install
+    - cd /src/src-ethtool
+    - ./autogen.sh
+    - ./configure LDFLAGS=-static --libdir=/opt/deckhouse/bin/.libs
+    - make
+    - ls -la
+    - strip ./ethtool
+    - chown 64535:64535 ./ethtool
+    - chmod 0755 ./ethtool
+    - cp ./ethtool /ethtool
+---
+artifact: {{ $.ModuleName }}/vxlan-offloading-fixer-artifact
+from: {{ $.Images.BASE_GOLANG_23_ALPINE }}
+git:
+  - add: /{{ $.ModulePath }}modules/000-{{ $.ModuleName }}/images/{{ $.ImageName }}
+    to: /src
+    stageDependencies:
+      install:
+        - '**/*'
+shell:
+  install:
+    - export "CGO_ENABLED=0"
+    - export "GOOS=linux"
+    - export "GOARCH=amd64"
+    - cd /src
+    - go build -o /tmp/vxlan-offloading-fixer main.go
+    - chown 64535:64535 /tmp/vxlan-offloading-fixer
+    - chmod 0755 /tmp/vxlan-offloading-fixer
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}
+fromImage: common/distroless
+import:
+  - artifact: {{ $.ModuleName }}/ethtool-artifact
+    add: /ethtool
+    to: /ethtool
+    before: setup
+  - artifact: {{ $.ModuleName }}/vxlan-offloading-fixer-artifact
+    add: /tmp/vxlan-offloading-fixer
+    to: /vxlan-offloading-fixer
+    before: setup
+  - image: common/pause
+    add: /pause
+    to: /pause
+    before: install
+docker:
+  ENTRYPOINT: ["/vxlan-offloading-fixer"]

--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -233,6 +233,28 @@ spec:
           readOnly: true
         - name: xtables-lock
           mountPath: /run/xtables.lock
+      {{- if eq $context.Values.cniCilium.internal.mode "VXLAN" }}
+      - name: handle-vxlan-offload
+        image: {{ include "helm_lib_module_common_image" (list $context "vxlanOffloadingFixer") }}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" $context | nindent 12 }}
+        securityContext:
+          capabilities:
+            add:
+              - NET_ADMIN
+            drop:
+              - ALL
+          privileged: false
+        terminationMessagePolicy: FallbackToLogsOnError
+      {{- end }}
       - name: config
         image: {{ include "helm_lib_module_image" (list $context "agentDistroless") }}
         imagePullPolicy: IfNotPresent

--- a/modules/021-cni-cilium/templates/safe-agent-updater/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/safe-agent-updater/daemonset.yaml
@@ -122,6 +122,15 @@ spec:
             cpu: "10m"
             memory: "1Mi"
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-
-
-
+      {{- if eq .Values.cniCilium.internal.mode "VXLAN" }}
+      - name: pause-handle-vxlan-offload
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        image: {{ include "helm_lib_module_common_image" (list . "vxlanOffloadingFixer") }}
+        command:
+        - /pause
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "1Mi"
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+      {{- end }}

--- a/modules/035-cni-flannel/templates/daemonset.yaml
+++ b/modules/035-cni-flannel/templates/daemonset.yaml
@@ -59,6 +59,29 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ .Chart.Name }}
+      initContainers:
+      {{- if eq .Values.cniFlannel.internal.podNetworkMode "vxlan" }}
+      - name: handle-vxlan-offload
+        image: {{ include "helm_lib_module_common_image" (list . "vxlanOffloadingFixer") }}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        resources:
+          requests:
+          {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            drop:
+            - ALL
+          privileged: false
+        terminationMessagePolicy: FallbackToLogsOnError
+      {{- end }}
       containers:
       - name: kube-flannel
         {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "NET_ADMIN" "NET_RAW")) | nindent 8 }}

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -176,6 +176,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"pythonStatic":              "imageHash-common-pythonStatic",
 		"redisStatic":               "imageHash-common-redisStatic",
 		"shellOperator":             "imageHash-common-shellOperator",
+		"vxlanOffloadingFixer":      "imageHash-common-vxlanOffloadingFixer",
 	},
 	"controlPlaneManager": map[string]interface{}{
 		"controlPlaneManager126":   "imageHash-controlPlaneManager-controlPlaneManager126",


### PR DESCRIPTION
## Description
An `init container` has been added to check and disable `tunnel segmentation offloading` on interfaces if a Node is running on VMware.

## Why do we need it, and what problem does it solve?
On nodes that are VMware virtual machines, enabling VXLAN leads to network errors. For example:
```
kubectl -n d8-ingress-nginx logs controller-nginx-xxxxx
...
E0923 15:17:59.744809       7 main.go:234] "Unexpected error discovering Kubernetes version" err="Get \"https://10.122.0.1:443/version\": dial tcp 10.122.0.1:443: i/o timeout" attempt=0
E0923 15:18:30.816854       7 main.go:234] "Unexpected error discovering Kubernetes version" err="Get \"https://10.122.0.1:443/version\": dial tcp 10.122.0.1:443: i/o timeout" attempt=1
```

and

```
kubectl -n d8-cni-cilium exec -ti agent-ppppp -c cilium-agent -- cilium-health status
...
  node-yyyy:
    Host connectivity to 10.222.15.31:
      ICMP to stack:   OK, RTT=1.122673ms
      HTTP to agent:   OK, RTT=1.448486ms
    Endpoint connectivity to 10.245.6.5:
      ICMP to stack:   OK, RTT=1.201896ms
      HTTP to agent:   Get "http://10.245.6.5:4240/hello": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```
TCP packets can also be blocked, while ICMP and UDP packets continue to pass correctly.

## What is the expected result?

Normal operation of the VMWare VMs node with VXLAN enabled.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Fixed package dropping issues with VXLAN and VMWare-hosted nodes.
impact_level: default
---
section: cni-flannel
type: fix
summary: Fixed package dropping issues with VXLAN and VMWare-hosted nodes.
impact_level: default
```


