### PR TITLE
[docs] Added link to description of clusterDomain parameter

### DIFF
--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -103,6 +103,8 @@ apiVersions:
           Cluster domain (used for local routing).
 
           **Please note:** the domain must not match the domain used in the DNS name template in the [publicDomainTemplate](../deckhouse-configure-global.html#parameters-modules-publicdomaintemplate) parameter. For example, you cannot set `cluster Domain: cluster.local` and `publicDomainTemplate: %s.cluster.local` at the same time.
+          
+          > If you need to change a parameter in a running cluster, it is recommended to use [instructions](../modules/042-kube-dns/faq.html#how-do-i-replace-the-cluster-domain-with-minimal-downtime)
         default: "cluster.local"
       defaultCRI:
         type: string

--- a/candi/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/openapi/doc-ru-cluster_configuration.yaml
@@ -50,7 +50,9 @@ apiVersions:
         description: |
           Домен кластера (используется для маршрутизации внутри кластера).
 
-          **Обратите внимание:** домен не должен совпадать с доменом, используемым в шаблоне DNS-имен в параметре [publicDomainTemplate](../deckhouse-configure-global.html#parameters-modules-publicdomaintemplate). Например, нельзя одновременно устанавливать `clusterDomain: cluster.local` и `publicDomainTemplate: %s.cluster.local`.
+          **Обратите внимание:** домен не должен совпадать с доменом, используемым в шаблоне DNS-имен в параметре [publicDomainTemplate](../deckhouse-configure-global.html#parameters-modules-publicdomaintemplate). Например, нельзя одновременно устанавливать `clusterDomain: cluster.local` и `publicDomainTemplate: %s.cluster.local`.  
+          
+          > При необходимости смены параметра в уже развернутом кластере рекомендуется воспользоваться [инструкцией](../modules/042-kube-dns/faq.html#как-поменять-домен-кластера-с-минимальным-простоем)
       defaultCRI:
         description: |
           Тип container runtime, используемый на узлах кластера (в NodeGroup'ах) по умолчанию.


### PR DESCRIPTION
## Description
This PR adds a cross-reference for the `clusterDomain` parameter in the description to a section with recommendations on changing the value in a working cluster. 
This improves the ease of finding necessary information and enhances the user experience.


## Why do we need it, and what problem does it solve?
Previously, the mentioned section was not logically placed, making it difficult for users to locate it. 


## What is the expected result?
This upgrade eases the navigation within the documentation and heightens its user-friendliness. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix 
summary: Add link to description of clusterDomain parameter.
impact_level: low
```

