### PR TITLE
[deckhouse-controller] Add disable control for important modules

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -177,12 +177,12 @@ func run(ctx context.Context, operator *addon_operator.AddonOperator) error {
 		return err
 	}
 
-	validation.RegisterAdmissionHandlers(operator)
-
 	dController, err := controller.NewDeckhouseController(ctx, operator.KubeClient().RestConfig(), operator.ModuleManager, operator.MetricStorage)
 	if err != nil {
 		return err
 	}
+
+	validation.RegisterAdmissionHandlers(operator, dController, operator.MetricStorage)
 
 	operator.ModuleManager.SetModuleEventsChannel(kubeConfigChannel)
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_config.go
@@ -36,6 +36,8 @@ var (
 	}
 )
 
+const AllowDisableAnnotation = "modules.deckhouse.io/allow-disable"
+
 var _ runtime.Object = (*ModuleConfig)(nil)
 
 // +genclient

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
@@ -16,11 +16,20 @@ limitations under the License.
 
 package validation
 
-import addon_operator "github.com/flant/addon-operator/pkg/addon-operator"
+import (
+	addon_operator "github.com/flant/addon-operator/pkg/addon-operator"
+	"github.com/flant/shell-operator/pkg/metric_storage"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/models"
+)
+
+type ModuleStorage interface {
+	GetModuleByName(name string) (*models.DeckhouseModule, error)
+}
 
 // RegisterAdmissionHandlers register validation webhook handlers for admission server built-in in addon-operator
-func RegisterAdmissionHandlers(operator *addon_operator.AddonOperator) {
-	operator.AdmissionServer.RegisterHandler("/validate/v1alpha1/module-configs", moduleConfigValidationHandler())
+func RegisterAdmissionHandlers(operator *addon_operator.AddonOperator, moduleStorage ModuleStorage, metricStorage *metric_storage.MetricStorage) {
+	operator.AdmissionServer.RegisterHandler("/validate/v1alpha1/module-configs", moduleConfigValidationHandler(moduleStorage, metricStorage))
 	operator.AdmissionServer.RegisterHandler("/validate/v1alpha1/modules", moduleValidationHandler())
 	operator.AdmissionServer.RegisterHandler("/validate/v1/configuration-secret", kubernetesVersionHandler(operator.ModuleManager))
 }

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -17,12 +17,15 @@ limitations under the License.
 package validation
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
+	"github.com/flant/shell-operator/pkg/metric_storage"
 	kwhhttp "github.com/slok/kubewebhook/v2/pkg/http"
-	"github.com/slok/kubewebhook/v2/pkg/model"
 	kwhmodel "github.com/slok/kubewebhook/v2/pkg/model"
 	kwhvalidating "github.com/slok/kubewebhook/v2/pkg/webhook/validating"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,25 +34,114 @@ import (
 	d8config "github.com/deckhouse/deckhouse/go_lib/deckhouse-config"
 )
 
+type AnnotationsOnly struct {
+	ObjectMeta `json:"metadata,omitempty"`
+}
+
+type ObjectMeta struct {
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+const disableReasonSuffix = "Please annotate ModuleConfig with `modules.deckhouse.io/allow-disable=true` if you're sure that you want to disable the module."
+
 // moduleConfigValidationHandler validations for ModuleConfig creation
-func moduleConfigValidationHandler() http.Handler {
-	vf := kwhvalidating.ValidatorFunc(func(_ context.Context, review *model.AdmissionReview, obj metav1.Object) (result *kwhvalidating.ValidatorResult, err error) {
+func moduleConfigValidationHandler(moduleStorage ModuleStorage, metricStorage *metric_storage.MetricStorage) http.Handler {
+	vf := kwhvalidating.ValidatorFunc(func(_ context.Context, review *kwhmodel.AdmissionReview, obj metav1.Object) (result *kwhvalidating.ValidatorResult, err error) {
+		var (
+			cfg = new(v1alpha1.ModuleConfig)
+			ok  bool
+		)
+
 		switch review.Operation {
 		case kwhmodel.OperationDelete:
-			// Always allow deletion.
-			return allowResult("")
+			{
+				cfg, ok = obj.(*v1alpha1.ModuleConfig)
+				if !ok {
+					return nil, fmt.Errorf("expect ModuleConfig as unstructured, got %T", obj)
+				}
 
+				// if we have no annotation and module enabled
+				//
+				// we check module
+				// we check confirmation restriction and confirmation message
+				_, ok = cfg.Annotations[v1alpha1.AllowDisableAnnotation]
+				if !ok && *cfg.Spec.Enabled {
+					// we can delete unknown module without any further check
+					module, err := moduleStorage.GetModuleByName(obj.GetName())
+					if err == nil {
+						reason, needConfirm := module.GetConfirmationReason()
+						if needConfirm {
+							if !strings.HasSuffix(reason, ".") {
+								reason += "."
+							}
+							reason += disableReasonSuffix
+
+							return rejectResult(reason)
+						}
+					}
+				}
+
+				metricStorage.GaugeSet("d8_moduleconfig_allowed_to_disable", 0, map[string]string{"module": cfg.GetName()})
+
+				// if module is already disabled - we don't need to warn user about disabling module
+				return allowResult("")
+			}
 		case kwhmodel.OperationConnect, kwhmodel.OperationUnknown:
 			return rejectResult(fmt.Sprintf("operation '%s' is not applicable", review.Operation))
+		case kwhmodel.OperationCreate:
+			cfg, ok = obj.(*v1alpha1.ModuleConfig)
+			if !ok {
+				return nil, fmt.Errorf("expect ModuleConfig as unstructured, got %T", obj)
+			}
+		case kwhmodel.OperationUpdate:
+			oldModuleMeta := new(AnnotationsOnly)
+
+			buf := bytes.NewBuffer(review.OldObjectRaw)
+			err = json.NewDecoder(buf).Decode(oldModuleMeta)
+			if err != nil {
+				return nil, fmt.Errorf("can not parse old module config: %w", err)
+			}
+
+			cfg, ok = obj.(*v1alpha1.ModuleConfig)
+			if !ok {
+				return nil, fmt.Errorf("expect ModuleConfig as unstructured, got %T", obj)
+			}
+
+			// if we have no annotation on current ModuleConfig
+			// and we have no annotation on previous ModuleConfig (if we want to take off annotation, while disabled)
+			// and module is disabled
+			//
+			// we check module
+			// we check confirmation restriction and confirmation message
+			_, ok = cfg.Annotations[v1alpha1.AllowDisableAnnotation]
+			_, oldOk := oldModuleMeta.Annotations[v1alpha1.AllowDisableAnnotation]
+			if !ok && !oldOk && !*cfg.Spec.Enabled {
+				// we can disable unknown module without any further check
+				module, err := moduleStorage.GetModuleByName(obj.GetName())
+				if err == nil {
+					reason, needConfirm := module.GetConfirmationReason()
+					if needConfirm {
+						if !strings.HasSuffix(reason, ".") {
+							reason += "."
+						}
+						reason += disableReasonSuffix
+
+						return rejectResult(reason)
+					}
+				}
+			}
 		}
 
-		cfg, ok := obj.(*v1alpha1.ModuleConfig)
-		if !ok {
-			return nil, fmt.Errorf("expect ModuleConfig as unstructured, got %T", obj)
+		var allowedToDisableMetric float64
+		_, ok = cfg.Annotations[v1alpha1.AllowDisableAnnotation]
+		if ok && *cfg.Spec.Enabled {
+			allowedToDisableMetric = 1
 		}
 
 		// Allow changing configuration for unknown modules.
 		if !d8config.Service().PossibleNames().Has(cfg.Name) {
+			metricStorage.GaugeSet("d8_moduleconfig_allowed_to_disable", allowedToDisableMetric, map[string]string{"module": cfg.GetName()})
+
 			return allowResult(fmt.Sprintf("module name '%s' is unknown for deckhouse", cfg.Name))
 		}
 
@@ -59,6 +151,8 @@ func moduleConfigValidationHandler() http.Handler {
 		if res.HasError() {
 			return rejectResult(res.Error)
 		}
+
+		metricStorage.GaugeSet("d8_moduleconfig_allowed_to_disable", allowedToDisableMetric, map[string]string{"module": cfg.GetName()})
 
 		// Return allow with warning.
 		return allowResult(res.Warning)

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -34,7 +35,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	coordv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -229,6 +230,17 @@ func NewDeckhouseController(ctx context.Context, config *rest.Config, mm *module
 	}, nil
 }
 
+var ErrModuleIsNotFound = errors.New("module is not found")
+
+func (dml *DeckhouseController) GetModuleByName(name string) (*models.DeckhouseModule, error) {
+	module, ok := dml.deckhouseModules[name]
+	if !ok {
+		return nil, ErrModuleIsNotFound
+	}
+
+	return module, nil
+}
+
 // discovers modules on the fs, runs modules events loop (register/delete/etc)
 func (dml *DeckhouseController) DiscoverDeckhouseModules(ctx context.Context, moduleEventC <-chan events.ModuleEvent, deckhouseConfigC <-chan utils.Values) error {
 	err := dml.searchAndLoadDeckhouseModules()
@@ -334,7 +346,7 @@ func (dml *DeckhouseController) runDeckhouseConfigObserver(deckhouseConfigC <-ch
 
 // InitModulesAndConfigsStatuses inits and moduleconfigs' status fields at start up
 func (dml *DeckhouseController) InitModulesAndConfigsStatuses() error {
-	return retry.OnError(retry.DefaultRetry, errors.IsServiceUnavailable, func() error {
+	return retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 		modules, err := dml.kubeClient.DeckhouseV1alpha1().Modules().List(dml.ctx, v1.ListOptions{})
 		if err != nil {
 			return err
@@ -376,7 +388,7 @@ func (dml *DeckhouseController) runEventLoop(moduleEventCh <-chan events.ModuleE
 		case events.ModuleConfigChanged:
 			if d8config.IsServiceInited() {
 				err := dml.updateModuleConfigStatus(event.ModuleName)
-				if err != nil && !errors.IsNotFound(err) {
+				if err != nil && !apierrors.IsNotFound(err) {
 					log.Errorf("Error occurred when updating module config %s: %s", event.ModuleName, err)
 				}
 			}
@@ -418,7 +430,7 @@ func (dml *DeckhouseController) runEventLoop(moduleEventCh <-chan events.ModuleE
 }
 
 func (dml *DeckhouseController) updateModuleConfigStatus(configName string) error {
-	return retry.OnError(retry.DefaultRetry, errors.IsServiceUnavailable, func() error {
+	return retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			metricGroup := fmt.Sprintf("%s_%s", "obsoleteVersion", configName)
 			dml.metricStorage.GroupedVault.ExpireGroupMetrics(metricGroup)
@@ -457,10 +469,10 @@ func (dml *DeckhouseController) updateModuleConfigStatus(configName string) erro
 			}
 
 			// update the related module if it exists
-			if moduleErr == nil || (moduleErr != nil && errors.IsNotFound(moduleErr)) {
+			if moduleErr == nil || (moduleErr != nil && apierrors.IsNotFound(moduleErr)) {
 				err := dml.updateModuleStatus(configName)
 				// it's possible that such a module doesn't exist
-				if err != nil && !errors.IsNotFound(err) {
+				if err != nil && !apierrors.IsNotFound(err) {
 					return err
 				}
 			}
@@ -470,7 +482,7 @@ func (dml *DeckhouseController) updateModuleConfigStatus(configName string) erro
 }
 
 func (dml *DeckhouseController) updateModuleStatus(moduleName string) error {
-	return retry.OnError(retry.DefaultRetry, errors.IsServiceUnavailable, func() error {
+	return retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			module, err := dml.kubeClient.DeckhouseV1alpha1().Modules().Get(dml.ctx, moduleName, v1.GetOptions{})
 			if err != nil {
@@ -479,7 +491,7 @@ func (dml *DeckhouseController) updateModuleStatus(moduleName string) error {
 
 			moduleConfig, err := dml.kubeClient.DeckhouseV1alpha1().ModuleConfigs().Get(dml.ctx, moduleName, v1.GetOptions{})
 			if err != nil {
-				if errors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					moduleConfig = nil
 				} else {
 					return err
@@ -505,19 +517,19 @@ func (dml *DeckhouseController) updateModuleStatus(moduleName string) error {
 // handleConvergeDone after converge we delete all absent Modules CR, which were not filled during this operator startup
 func (dml *DeckhouseController) handleConvergeDone() error {
 	epochLabelStr := fmt.Sprintf("%s!=%s", epochLabelKey, epochLabelValue)
-	return retry.OnError(retry.DefaultRetry, errors.IsServiceUnavailable, func() error {
+	return retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 		return dml.kubeClient.DeckhouseV1alpha1().Modules().DeleteCollection(dml.ctx, v1.DeleteOptions{}, v1.ListOptions{LabelSelector: epochLabelStr})
 	})
 }
 
 func (dml *DeckhouseController) handleModulePurge(m *models.DeckhouseModule) error {
-	return retry.OnError(retry.DefaultRetry, errors.IsServiceUnavailable, func() error {
+	return retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 		return dml.kubeClient.DeckhouseV1alpha1().Modules().Delete(dml.ctx, m.GetBasicModule().GetName(), v1.DeleteOptions{})
 	})
 }
 
 func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModule) error {
-	return retry.OnError(retry.DefaultRetry, errors.IsServiceUnavailable, func() error {
+	return retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			moduleName := m.GetBasicModule().GetName()
 			src := dml.sourceModules[moduleName]
@@ -530,7 +542,7 @@ func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModu
 
 			existModule, err := dml.kubeClient.DeckhouseV1alpha1().Modules().Get(dml.ctx, newModule.GetName(), v1.GetOptions{})
 			if err != nil {
-				if errors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) {
 					_, err = dml.kubeClient.DeckhouseV1alpha1().Modules().Create(dml.ctx, newModule, v1.CreateOptions{})
 					return err
 				}
@@ -553,7 +565,7 @@ func (dml *DeckhouseController) handleModuleRegistration(m *models.DeckhouseModu
 }
 
 func (dml *DeckhouseController) handleEnabledModule(m *models.DeckhouseModule, enable bool) error {
-	return retry.OnError(retry.DefaultRetry, errors.IsServiceUnavailable, func() error {
+	return retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			module, err := dml.kubeClient.DeckhouseV1alpha1().Modules().Get(dml.ctx, m.GetBasicModule().GetName(), v1.GetOptions{})
 			if err != nil {

--- a/deckhouse-controller/pkg/controller/models/definition.go
+++ b/deckhouse-controller/pkg/controller/models/definition.go
@@ -20,6 +20,11 @@ const (
 	ModuleDefinitionFile = "module.yaml"
 )
 
+type DisableOptions struct {
+	Confirmation bool   `yaml:"confirmation"`
+	Message      string `yaml:"message"`
+}
+
 type DeckhouseModuleDefinition struct {
 	Name         string            `yaml:"name"`
 	Weight       uint32            `yaml:"weight,omitempty"`
@@ -27,6 +32,8 @@ type DeckhouseModuleDefinition struct {
 	Stage        string            `yaml:"stage"`
 	Description  string            `yaml:"description"`
 	Requirements map[string]string `json:"requirements"`
+
+	DisableOptions DisableOptions `yaml:"disable"`
 
 	Path string `yaml:"-"`
 }

--- a/deckhouse-controller/pkg/controller/models/module.go
+++ b/deckhouse-controller/pkg/controller/models/module.go
@@ -33,6 +33,9 @@ type DeckhouseModule struct {
 	description string
 	stage       string
 	labels      map[string]string
+
+	needConfirm               bool
+	needConfirmDisableMessage string
 }
 
 func NewDeckhouseModule(def DeckhouseModuleDefinition, staticValues utils.Values, configBytes, valuesBytes []byte) (*DeckhouseModule, error) {
@@ -51,10 +54,12 @@ func NewDeckhouseModule(def DeckhouseModuleDefinition, staticValues utils.Values
 	}
 
 	return &DeckhouseModule{
-		basic:       basic,
-		labels:      labels,
-		description: def.Description,
-		stage:       def.Stage,
+		basic:                     basic,
+		labels:                    labels,
+		description:               def.Description,
+		stage:                     def.Stage,
+		needConfirm:               def.DisableOptions.Confirmation,
+		needConfirmDisableMessage: def.DisableOptions.Message,
 	}, nil
 }
 
@@ -83,6 +88,10 @@ func (dm DeckhouseModule) AsKubeObject(source string) *v1alpha1.Module {
 			Description: dm.description,
 		},
 	}
+}
+
+func (dm DeckhouseModule) GetConfirmationReason() (string, bool) {
+	return dm.needConfirmDisableMessage, dm.needConfirm
 }
 
 func calculateLabels(name string) map[string]string {

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -908,6 +908,25 @@ alerts:
         Prometheus is unable to scrape Grafana metrics.
       severity: "6"
       markupFormat: markdown
+    - name: D8HasModuleConfigAllowedToDisable
+      sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+      moduleUrl: 340-monitoring-deckhouse
+      module: monitoring-deckhouse
+      edition: ce
+      description: |
+        ModuleConfig is waiting for disable.
+
+        It is recommended to keep clean your module configurations from approve annotations.
+
+        If you ignore this alert and do not clear the annotation, it may cause the module to be accidentally removed from the cluster.
+
+        Removing a module from a cluster can lead to a number of irreparable consequences.
+
+        Please run `kubectl annotate moduleconfig {{ $labels.module }} modules.deckhouse.io/allow-disable-` to stop this alert.
+      summary: |
+        ModuleConfig annotation for allow to disable is setted.
+      severity: "4"
+      markupFormat: markdown
     - name: D8ImageAvailabilityExporterMalfunctioning
       sourceFile: modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/image-availability-exporter-health.yaml
       moduleUrl: 340-extended-monitoring

--- a/modules/002-deckhouse/templates/admission/validation.yaml
+++ b/modules/002-deckhouse/templates/admission/validation.yaml
@@ -43,6 +43,7 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+          - DELETE
     admissionReviewVersions:
       - v1
     matchPolicy: Equivalent

--- a/modules/040-node-manager/module.yaml
+++ b/modules/040-node-manager/module.yaml
@@ -1,0 +1,4 @@
+name: node-manager
+weight: 040
+description: |
+    Managing nodes

--- a/modules/040-node-manager/module.yaml
+++ b/modules/040-node-manager/module.yaml
@@ -1,4 +1,4 @@
 name: node-manager
-weight: 040
+weight: 40
 description: |
     Managing nodes

--- a/modules/300-prometheus/module.yaml
+++ b/modules/300-prometheus/module.yaml
@@ -1,0 +1,4 @@
+name: prometheus
+weight: 300
+description: |
+    The Prometheus monitoring module

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -117,3 +117,26 @@
         Please run `kubectl annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"` for confirmation.
       summary: |
         Module release is waiting for manual approval.
+  - alert: D8HasModuleConfigAllowedToDisable
+    expr: max by (module) (d8_moduleconfig_allowed_to_disable) >= 1
+    for: 3m
+    labels:
+      severity_level: "4"
+      d8_module: deckhouse
+      d8_component: deckhouse
+      tier: cluster
+    annotations:
+      plk_markup_format: "markdown"
+      plk_protocol_version: "1"
+      description: |
+        ModuleConfig is waiting for disable.
+
+        It is recommended to keep clean your module configurations from approve annotations.
+
+        If you ignore this alert and do not clear the annotation, it may cause the module to be accidentally removed from the cluster.
+        
+        Removing a module from a cluster can lead to a number of irreparable consequences.
+
+        Please run `kubectl annotate moduleconfig {{ $labels.module }} modules.deckhouse.io/allow-disable-` to stop this alert.
+      summary: |
+        ModuleConfig annotation for allow to disable is setted.

--- a/modules/500-cilium-hubble/module.yaml
+++ b/modules/500-cilium-hubble/module.yaml
@@ -1,0 +1,4 @@
+name: cilium-hubble
+weight: 500
+description: |
+    The cilium-hubble module


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
deckhouse-controller:
add validation for ModuleConfig file 
add alerts when module config has annotation

modules:
add new yaml parameters to make new validation behaviour. at now, `module.yaml` file is must have in every module folder

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
User can accidentally remove module. We need to warn him about consequences and waiting for his approve.
Until we not have user approve - we did'nt disable/delete module from cluster.

## Why do we need it in the patch release (if we do)?
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
When we are trying to disable the module via the enabled: false or deleting the ModuleConfig, we have to ask for a confirmation, via the annotations.

If annotation is set 'modules.deckhouse.io/allow-disable: "true"' we can:
1) Mark ModuleConfig as disabled (spec.Enabled: false) 
2) Delete the ModuleConfig

Otherwise we want to deny the request with the message, which is set in the disable.message field of `module.yaml`.

If ModuleConfig already disabled (spec.Enabled:false), we can delete it without adding annotations.

In every module folder `module.yaml`:
```yaml
disable:
  confirmation: true|false
  message: "string"
```

```bash
# deleting ModuleConfig without annotation and not marked as disabled
kubectl delete moduleconfig node-manager

Error from server: admission webhook "module-configs.deckhouse-webhook.deckhouse.io" denied the request: Disabling this module will delete all nodes created via NodeGroup
```

```bash
# updating ModuleConfig spec.Enabled to false, without annotation 
kubectl edit moduleconfig node-manager

error: moduleconfigs.deckhouse.io "node-manager" could not be patched: admission webhook "module-configs.deckhouse-webhook.deckhouse.io" denied the request: Disabling this module will delete all nodes created via NodeGroup
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: Add disable confirmation settings for critical modules.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
