### PR TITLE
[iptables] Use same iptables in all modules

### DIFF
--- a/ee/be/modules/350-node-local-dns/images/coredns/werf.inc.yaml
+++ b/ee/be/modules/350-node-local-dns/images/coredns/werf.inc.yaml
@@ -1,3 +1,6 @@
+{{- $iptables_version := "1.8.9" }}
+{{- $iptables_image_version := $iptables_version | replace "." "-" }}
+---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
@@ -5,12 +8,12 @@ import:
   add: /relocate
   to: /
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
-  to: /
+  to: /sbin
   includePaths:
-  - lib64/iptables
-  - lib64/libm*
+  - xtables-legacy-multi
+  - xtables-nft-multi
   before: setup
 - image: common/iptables-wrapper
   add: /iptables-wrapper
@@ -39,7 +42,7 @@ shell:
   - chmod -R 0700 /src/coredns
   - chown -R 64535:64535 /src/coredns
 ---
-{{ $corednsBinaries := "/usr/bin/dig /bin/echo /usr/bin/curl /usr/bin/jq /bin/bash /bin/grep /sbin/ip /usr/bin/iptables* /sbin/iptables* /sbin/ip6tables* /sbin/xtables* /sbin/arptables*" }}
+{{ $corednsBinaries := "/usr/bin/dig /bin/echo /usr/bin/curl /usr/bin/jq /bin/bash /bin/grep /sbin/ip" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 from: {{ $.Images.BASE_ALT_DEV }}
@@ -58,4 +61,12 @@ shell:
       for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
         rm -f "/relocate/sbin/${cmd}"
         ln -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
+      done
+    - |
+      for mode in legacy nft; do
+        for basecmd in iptables ip6tables; do
+          for cmd in ${basecmd}-${mode} ${basecmd}-${mode}-save ${basecmd}-${mode}-restore; do
+            ln -sf /sbin/xtables-${mode}-multi "/relocate/sbin/${cmd}"
+          done
+        done
       done

--- a/ee/be/modules/350-node-local-dns/images/iptables-loop/werf.inc.yaml
+++ b/ee/be/modules/350-node-local-dns/images/iptables-loop/werf.inc.yaml
@@ -1,3 +1,6 @@
+{{- $iptables_version := "1.8.9" }}
+{{- $iptables_image_version := $iptables_version | replace "." "-" }}
+---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
@@ -5,12 +8,12 @@ import:
   add: /relocate
   to: /
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
-  to: /
+  to: /sbin
   includePaths:
-  - lib64/iptables
-  - lib64/libm*
+  - xtables-legacy-multi
+  - xtables-nft-multi
   before: setup
 - image: common/iptables-wrapper
   add: /iptables-wrapper
@@ -19,7 +22,7 @@ import:
 docker:
   ENTRYPOINT: ["/iptables-loop.sh"]
 ---
-{{ $iptablesLoopBinaries := "/bin/rm /bin/mkfifo /bin/mktemp /bin/echo /bin/sleep /bin/bash /sbin/ip /usr/bin/iptables* /sbin/iptables* /sbin/ip6tables* /sbin/xtables* /sbin/arptables* /usr/bin/inotifywait" }}
+{{ $iptablesLoopBinaries := "/bin/rm /bin/mkfifo /bin/mktemp /bin/echo /bin/sleep /bin/bash /sbin/ip /usr/bin/inotifywait" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 from: {{ $.Images.BASE_ALT_DEV }}
@@ -38,4 +41,12 @@ shell:
       for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
         rm -f "/relocate/sbin/${cmd}"
         ln -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
+      done
+    - |
+      for mode in legacy nft; do
+        for basecmd in iptables ip6tables; do
+          for cmd in ${basecmd}-${mode} ${basecmd}-${mode}-save ${basecmd}-${mode}-restore; do
+            ln -sf /sbin/xtables-${mode}-multi "/relocate/sbin/${cmd}"
+          done
+        done
       done

--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -1,16 +1,27 @@
-{{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so* /bin/grep /bin/sed /bin/sh /sbin/xtables-nft-multi /sbin/ip6tables-nft /sbin/ip6tables-nft-restore /sbin/ip6tables-nft-save /sbin/iptables-nft /sbin/iptables-nft-restore /sbin/iptables-nft-save /sbin/xtables-legacy-multi /sbin/iptables /sbin/iptables-restore /sbin/iptables-save /sbin/iptables-legacy /sbin/iptables-legacy-restore /sbin/iptables-legacy-save /sbin/ip6tables /sbin/ip6tables-restore /sbin/ip6tables-save /sbin/ip6tables-legacy /sbin/ip6tables-legacy-restore /sbin/ip6tables-legacy-save /usr/lib64/libnetfilter_conntrack.so*" }}
+{{- $iptables_version := "1.8.9" }}
+{{- $iptables_image_version := $iptables_version | replace "." "-" }}
+{{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so* /bin/grep /bin/sed /bin/sh" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   install:
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+    - mkdir -p /relocate/sbin
     - |
-      for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore ip6tables-nft ip6tables-nft-restore ip6tables-nft-save iptables-nft iptables-nft-restore iptables-nft-save; do
-        ln -f -s /iptables-wrapper "/relocate/sbin/${cmd}"
+      for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+        ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
       done
       # broken symlinks are not imported from the artifact
-      touch /iptables-wrapper
+      touch /sbin/iptables-wrapper
+    - |
+      for mode in legacy nft; do
+        for basecmd in iptables ip6tables; do
+          for cmd in ${basecmd}-${mode} ${basecmd}-${mode}-save ${basecmd}-${mode}-restore; do
+            ln -sf /sbin/xtables-${mode}-multi "/relocate/sbin/${cmd}"
+          done
+        done
+      done
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
@@ -30,14 +41,14 @@ import:
   add: /usr/lib64/python3.9
   to: /usr/lib64/python3.9
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
-  to: /
+  to: /sbin
   includePaths:
-  - lib64/iptables
-  - lib64/libm*
+  - xtables-legacy-multi
+  - xtables-nft-multi
   before: setup
 - image: common/iptables-wrapper
   add: /iptables-wrapper
-  to: /iptables-wrapper
+  to: /sbin/iptables-wrapper
   before: setup

--- a/modules/007-registrypackages/images/iptables/werf.inc.yaml
+++ b/modules/007-registrypackages/images/iptables/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{/* Important! The iptables binaries from artifact are also used in kube-router image of network-policy-engine module and cni-simple-bridge. */}}
+{{/* Important! The iptables binaries from artifact are also used in other modules: kube-proxy, cni-simple-bridge, cni-cilium, cni-flannel, node-local-dns, ingress-nginx, openvpn, network-policy-engine and network-gateway. */}}
 {{- $version := "1.8.9" }}
 {{- $image_version := $version | replace "." "-" }}
 ---

--- a/modules/021-cni-cilium/images/agent/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/agent/werf.inc.yaml
@@ -1,3 +1,6 @@
+{{- $iptables_version := "1.8.9" }}
+{{- $iptables_image_version := $iptables_version | replace "." "-" }}
+---
 # #####################################################################
 # Final image of cilium-agent (used in helm-templates)
 # Based on https://github.com/cilium/cilium/blob/v1.14.14/images/runtime/Dockerfile
@@ -59,11 +62,7 @@
 {{ $selfBuiltBinaries := cat $selfBuiltBinaries "/check-n-cleaning-iptables.sh" }}
 # iptables and dependencies
 {{ $selfBuiltBinaries := cat $selfBuiltBinaries "/sbin/xtables*" }}
-{{ $selfBuiltBinaries := cat $selfBuiltBinaries "/sbin/arptables* /sbin/ebtables* /sbin/ip6tables* /sbin/iptables*" }}
 {{ $selfBuiltBinaries := cat $selfBuiltBinaries "/usr/sbin/iptables-wrapper" }}
-{{ $selfBuiltBinaries := cat $selfBuiltBinaries "/usr/bin/iptables-xml" }}
-{{ $selfBuiltBinaries := cat $selfBuiltBinaries "/sbin/nfnl_osf" }}
-{{ $selfBuiltBinaries := cat $selfBuiltBinaries "/lib64/iptables/*" }}
 # #####################################################################
 # Binaries artifact for distroless agent (based on Ubuntu)
 ---
@@ -98,9 +97,12 @@ import:
   add: /out/linux/amd64/bin/gops
   to: /bin/gops
   before: install
-- artifact: {{ $.ModuleName }}/iptables-artifact
-  add: /iptables
-  to: /iptables
+- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+  add: /
+  to: /sbin
+  includePaths:
+  - xtables-legacy-multi
+  - xtables-nft-multi
   before: install
 - image: common/iptables-wrapper
   add: /iptables-wrapper
@@ -149,14 +151,11 @@ import:
   before: setup
 shell:
   install:
-  - rsync -a --keep-dirlinks iptables/* /
-  - rm -rf /iptables
   - chown root:root /usr/sbin/iptables-wrapper
   - chmod 755 /usr/sbin/iptables-wrapper
   #
   - chmod +x /check-n-cleaning-iptables.sh
   beforeSetup:
-
   # common relocate
   - chmod +x /binary_replace.sh
   - mkdir -p /relocate
@@ -165,7 +164,7 @@ shell:
   - /binary_replace.sh -i "{{ $binariesFromALT }}" -o /relocate
   # copy self built binaries and deps
   - /binary_replace.sh -i "{{ $selfBuiltBinaries }}" -o /relocate
-  # additional relocate from runtime
+  # additional relocate for iptables
   - |
     for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
       rm -f "/relocate/sbin/${cmd}"
@@ -173,6 +172,20 @@ shell:
     done
     # broken symlinks are not imported from the artifact
     touch /usr/sbin/iptables-wrapper
+  - |
+    for mode in legacy nft; do
+      for basecmd in iptables ip6tables; do
+        for cmd in ${basecmd}-${mode} ${basecmd}-${mode}-save ${basecmd}-${mode}-restore; do
+          ln -sf /sbin/xtables-${mode}-multi "/relocate/sbin/${cmd}"
+        done
+      done
+    done
+  - |
+    for basecmd in ebtables arptables; do
+      for cmd in ${basecmd}-nft ${basecmd}-nft-save ${basecmd}-nft-restore; do
+        ln -sf /sbin/xtables-nft-multi "/relocate/sbin/${cmd}"
+      done
+    done
   # additional relocate from cilium
   - mkdir -p /relocate/var/lib/cilium
   - cp -a /var/lib/cilium/bpf /relocate/var/lib/cilium

--- a/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
@@ -40,11 +40,6 @@ shell:
   beforeInstall:
   - mkdir -p /go/src/github.com/cilium/cilium
   - git clone --depth 1 --branch v{{ $ciliumVersion }} {{ $.SOURCE_REPO }}/cilium/cilium.git /go/src/github.com/cilium/cilium
-  install:
-  - chmod +x /go/src/github.com/cilium/cilium/images/runtime/*.sh
-  - cd /go/src/github.com/cilium/cilium/images/runtime
-  - mkdir -p orig && cp -a iptables-wrapper-installer.sh orig/
-  - ./iptables-wrapper-installer.sh --no-sanity-check
   setup:
   - export GOROOT=/usr/local/go GOPATH=/go
   # When launching this container via CI, an unexpected path is inserted into the PATH variable.

--- a/modules/035-cni-flannel/images/flanneld/entrypoint/go.mod
+++ b/modules/035-cni-flannel/images/flanneld/entrypoint/go.mod
@@ -3,7 +3,7 @@ module flanneld
 go 1.20
 
 require (
-	github.com/coreos/go-iptables v0.6.0
+	github.com/coreos/go-iptables v0.8.0
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/sys v0.13.0
 	k8s.io/api v0.26.3

--- a/modules/035-cni-flannel/images/flanneld/entrypoint/go.sum
+++ b/modules/035-cni-flannel/images/flanneld/entrypoint/go.sum
@@ -39,8 +39,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
-github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
+github.com/coreos/go-iptables v0.8.0 h1:MPc2P89IhuVpLI7ETL/2tx3XZ61VeICZjYqDEgNsPRc=
+github.com/coreos/go-iptables v0.8.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
+++ b/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
@@ -1,16 +1,25 @@
-{{- $binaries := "/sbin/xtables-nft-multi /sbin/ip6tables-nft /sbin/ip6tables-nft-restore /sbin/ip6tables-nft-save /sbin/iptables-nft /sbin/iptables-nft-restore /sbin/iptables-nft-save /sbin/xtables-legacy-multi /sbin/iptables /sbin/iptables-restore /sbin/iptables-save /sbin/iptables-legacy /sbin/iptables-legacy-restore /sbin/iptables-legacy-save /sbin/ip6tables /sbin/ip6tables-restore /sbin/ip6tables-save /sbin/ip6tables-legacy /sbin/ip6tables-legacy-restore /sbin/ip6tables-legacy-save /usr/lib64/libnetfilter_conntrack.so*" }}
+{{- $iptables_version := "1.8.9" }}
+{{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   install:
-    - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+    - mkdir -p /relocate/sbin
     - |
-      for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore ip6tables-nft ip6tables-nft-restore ip6tables-nft-save iptables-nft iptables-nft-restore iptables-nft-save; do
-        ln -f -s /iptables-wrapper "/relocate/sbin/${cmd}"
+      for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+        ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
       done
       # broken symlinks are not imported from the artifact
-      touch /iptables-wrapper
+      touch /sbin/iptables-wrapper
+    - |
+      for mode in legacy nft; do
+        for basecmd in iptables ip6tables; do
+          for cmd in ${basecmd}-${mode} ${basecmd}-${mode}-save ${basecmd}-${mode}-restore; do
+            ln -sf /sbin/xtables-${mode}-multi "/relocate/sbin/${cmd}"
+          done
+        done
+      done
 ---
 artifact: {{ .ModuleName }}/entrypoint-artifact
 from: {{ $.Images.BASE_GOLANG_21_ALPINE_DEV }}
@@ -40,28 +49,28 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/flanneld-artifact
-  add: /src/dist/flanneld
-  to: /opt/bin/flanneld
-  before: setup
 - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
-  to: /
+  to: /sbin
   includePaths:
-  - lib64/iptables
-  - lib64/libm*
+  - xtables-legacy-multi
+  - xtables-nft-multi
+  before: setup
+- image: common/iptables-wrapper
+  add: /iptables-wrapper
+  to: /sbin/iptables-wrapper
+  before: setup
+- artifact: {{ .ModuleName }}/flanneld-artifact
+  add: /src/dist/flanneld
+  to: /opt/bin/flanneld
   before: setup
 - artifact: {{ .ModuleName }}/entrypoint-artifact
   add: /entrypoint
   to: /entrypoint
-  before: setup
-- image: common/iptables-wrapper
-  add: /iptables-wrapper
-  to: /iptables-wrapper
   before: setup
 docker:
   ENTRYPOINT: ["/entrypoint"]

--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -10,7 +10,7 @@ import:
   before: setup
 - artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
-  to: /sbin/
+  to: /sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi

--- a/modules/036-kube-proxy/images/kube-proxy/werf.inc.yaml
+++ b/modules/036-kube-proxy/images/kube-proxy/werf.inc.yaml
@@ -1,15 +1,27 @@
-{{- $binaries := "/sbin/xtables-nft-multi /sbin/ip6tables-nft /sbin/ip6tables-nft-restore /sbin/ip6tables-nft-save /sbin/iptables-nft /sbin/iptables-nft-restore /sbin/iptables-nft-save /sbin/xtables-legacy-multi /sbin/iptables /sbin/iptables-restore /sbin/iptables-save /sbin/iptables-legacy /sbin/iptables-legacy-restore /sbin/iptables-legacy-save /sbin/ip6tables /sbin/ip6tables-restore /sbin/ip6tables-save /sbin/ip6tables-legacy /sbin/ip6tables-legacy-restore /sbin/ip6tables-legacy-save /usr/sbin/conntrack /usr/lib64/libnetfilter_conntrack.so*" }}
+{{- $iptables_version := "1.8.9" }}
+{{- $iptables_image_version := $iptables_version | replace "." "-" }}
+{{- $binaries := "/usr/sbin/conntrack /usr/lib64/libnetfilter_conntrack.so*" }}
+---
 artifact: {{ .ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   install:
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+    - mkdir -p /relocate/sbin
     - |
-      for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore ip6tables-nft ip6tables-nft-restore ip6tables-nft-save iptables-nft iptables-nft-restore iptables-nft-save; do
-        ln -f -s /iptables-wrapper "/relocate/sbin/${cmd}"
+      for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+        ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
       done
       # broken symlinks are not imported from the artifact
-      touch /iptables-wrapper
+      touch /sbin/iptables-wrapper
+    - |
+      for mode in legacy nft; do
+        for basecmd in iptables ip6tables; do
+          for cmd in ${basecmd}-${mode} ${basecmd}-${mode}-save ${basecmd}-${mode}-restore; do
+            ln -sf /sbin/xtables-${mode}-multi "/relocate/sbin/${cmd}"
+          done
+        done
+      done
   {{- range $key, $value := .CandiVersionMap.k8s }}
   {{- $version := toString $key }}
   {{- $patch := $value.patch | toString }}
@@ -23,20 +35,20 @@ import:
   add: /relocate
   to: /
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
-  to: /
+  to: /sbin
   includePaths:
-  - lib64/iptables
-  - lib64/libm*
+  - xtables-legacy-multi
+  - xtables-nft-multi
+  before: setup
+- image: common/iptables-wrapper
+  add: /iptables-wrapper
+  to: /sbin/iptables-wrapper
   before: setup
 - artifact: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kube-proxy
   to: /usr/local/bin/kube-proxy
-  before: setup
-- image: common/iptables-wrapper
-  add: /iptables-wrapper
-  to: /iptables-wrapper
   before: setup
 docker:
   ENTRYPOINT: ["/usr/bin/kube-proxy"]

--- a/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
+++ b/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
@@ -39,7 +39,7 @@ import:
   before: setup
 - artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
-  to: /sbin/
+  to: /sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi

--- a/modules/402-ingress-nginx/images/proxy-failover-iptables/failover/go.mod
+++ b/modules/402-ingress-nginx/images/proxy-failover-iptables/failover/go.mod
@@ -3,7 +3,7 @@ module proxy-failover-iptables
 go 1.20
 
 require (
-	github.com/coreos/go-iptables v0.6.0
+	github.com/coreos/go-iptables v0.8.0
 	github.com/vishvananda/netlink v1.1.0
 )
 

--- a/modules/402-ingress-nginx/images/proxy-failover-iptables/failover/go.sum
+++ b/modules/402-ingress-nginx/images/proxy-failover-iptables/failover/go.sum
@@ -1,5 +1,7 @@
 github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
 github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
+github.com/coreos/go-iptables v0.8.0 h1:MPc2P89IhuVpLI7ETL/2tx3XZ61VeICZjYqDEgNsPRc=
+github.com/coreos/go-iptables v0.8.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=

--- a/modules/402-ingress-nginx/images/proxy-failover-iptables/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/proxy-failover-iptables/werf.inc.yaml
@@ -1,15 +1,25 @@
-{{- $binaries := "/sbin/xtables-nft-multi /sbin/ip6tables-nft /sbin/ip6tables-nft-restore /sbin/ip6tables-nft-save /sbin/iptables-nft /sbin/iptables-nft-restore /sbin/iptables-nft-save /sbin/xtables-legacy-multi /sbin/iptables /sbin/iptables-restore /sbin/iptables-save /sbin/iptables-legacy /sbin/iptables-legacy-restore /sbin/iptables-legacy-save /sbin/ip6tables /sbin/ip6tables-restore /sbin/ip6tables-save /sbin/ip6tables-legacy /sbin/ip6tables-legacy-restore /sbin/ip6tables-legacy-save /usr/lib64/libnetfilter_conntrack.so*" }}
+{{- $iptables_version := "1.8.9" }}
+{{- $iptables_image_version := $iptables_version | replace "." "-" }}
+---
 artifact: {{ .ModuleName }}/distroless-proxy-failover-iptables-artifact
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   install:
-    - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+    - mkdir -p /relocate/sbin
     - |
-      for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore ip6tables-nft ip6tables-nft-restore ip6tables-nft-save iptables-nft iptables-nft-restore iptables-nft-save; do
-        ln -f -s /iptables-wrapper "/relocate/sbin/${cmd}"
+      for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+        ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
       done
       # broken symlinks are not imported from the artifact
-      touch /iptables-wrapper
+      touch /sbin/iptables-wrapper
+    - |
+      for mode in legacy nft; do
+        for basecmd in iptables ip6tables; do
+          for cmd in ${basecmd}-${mode} ${basecmd}-${mode}-save ${basecmd}-${mode}-restore; do
+            ln -sf /sbin/xtables-${mode}-multi "/relocate/sbin/${cmd}"
+          done
+        done
+      done
 ---
 artifact: {{ .ModuleName }}/failover-artifact
 from: {{ .Images.BASE_GOLANG_21_ALPINE }}
@@ -36,20 +46,20 @@ import:
   add: /relocate
   to: /
   before: setup
-- artifact: {{ $.ModuleName }}/distroless-proxy-failover-iptables-artifact
+- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
-  to: /
+  to: /sbin
   includePaths:
-  - lib64/iptables
-  - lib64/libm*
+  - xtables-legacy-multi
+  - xtables-nft-multi
+  before: setup
+- image: common/iptables-wrapper
+  add: /iptables-wrapper
+  to: /sbin/iptables-wrapper
   before: setup
 - artifact: {{ .ModuleName }}/failover-artifact
   add: /workdir/failover
   to: /failover
-  before: setup
-- image: common/iptables-wrapper
-  add: /iptables-wrapper
-  to: /iptables-wrapper
   before: setup
 docker:
   ENTRYPOINT: ["/failover"]

--- a/modules/500-openvpn/images/openvpn/entrypoint/go.mod
+++ b/modules/500-openvpn/images/openvpn/entrypoint/go.mod
@@ -3,7 +3,7 @@ module entrypoint
 go 1.20
 
 require (
-	github.com/coreos/go-iptables v0.7.0
+	github.com/coreos/go-iptables v0.8.0
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/sys v0.13.0
 )

--- a/modules/500-openvpn/images/openvpn/entrypoint/go.sum
+++ b/modules/500-openvpn/images/openvpn/entrypoint/go.sum
@@ -1,5 +1,7 @@
 github.com/coreos/go-iptables v0.7.0 h1:XWM3V+MPRr5/q51NuWSgU0fqMad64Zyxs8ZUoMsamr8=
 github.com/coreos/go-iptables v0.7.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
+github.com/coreos/go-iptables v0.8.0 h1:MPc2P89IhuVpLI7ETL/2tx3XZ61VeICZjYqDEgNsPRc=
+github.com/coreos/go-iptables v0.8.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=

--- a/modules/500-openvpn/images/openvpn/werf.inc.yaml
+++ b/modules/500-openvpn/images/openvpn/werf.inc.yaml
@@ -10,11 +10,11 @@ fromImage: common/distroless
 import:
 - image: common/iptables-wrapper
   add: /iptables-wrapper
-  to: /iptables-wrapper
+  to: /sbin/iptables-wrapper
   before: setup
 - artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
-  to: /usr/sbin
+  to: /sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
@@ -124,9 +124,19 @@ shell:
   - find /var/lib/apt/lists /var/cache/apt -type f -exec rm -f {} +
   install:
   - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+  - mkdir -p /relocate/sbin
   - |
-    for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore iptables-legacy iptables-legacy-save iptables-legacy-restore ip6tables-legacy ip6tables-legacy-save ip6tables-legacy-restore iptables-nft iptables-nft-save iptables-nft-restore ip6tables-nft ip6tables-nft-save ip6tables-nft-restore; do
-      ln -f -s /iptables-wrapper "/relocate/usr/sbin/${cmd}"
+    for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+      ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
     done
     # broken symlinks are not imported from the artifact
     touch /iptables-wrapper
+  - |
+    for mode in legacy nft; do
+      for basecmd in iptables ip6tables; do
+        for cmd in ${basecmd}-${mode} ${basecmd}-${mode}-save ${basecmd}-${mode}-restore; do
+          ln -sf /sbin/xtables-${mode}-multi "/relocate/sbin/${cmd}"
+        done
+      done
+    done
+


### PR DESCRIPTION
## Description

Using the same binary files of `iptables` in all modules, which we build statically from source code.

## Why do we need it, and what problem does it solve?

From time to time, we encountered problems due to different versions of the `iptables` being used in different modules and on the host system.

## What is the expected result?

In all modules and on the host system, we use the same binary of `iptables` to ensure compatibility and avoid any issues.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-local-dns
type: chore
summary: Replacing iptables with precompiled binaries.
impact: The pods will be restarted.
impact_level: default
```
```changes
section: network-gatewy
type: chore
summary: Replacing iptables with precompiled binaries.
impact: The pods will be restarted.
impact_level: default
```
```changes
section: cni-cilium
type: chore
summary: Replacing iptables with precompiled binaries.
impact: The pods will be restarted.
impact_level: default
```
```changes
section: cni-flannel
type: chore
summary: Replacing iptables with precompiled binaries.
impact: The pods will be restarted.
impact_level: default
```
```changes
section: kube-proxy
type: chore
summary: Replacing iptables with precompiled binaries.
impact: The pods will be restarted.
impact_level: default
```
```changes
section: ingress-nginx
type: chore
summary: Replacing iptables with precompiled binaries.
impact: The pods will be restarted.
impact_level: default
```
```changes
section: openvpn
type: chore
summary: Replacing iptables with precompiled binaries.
impact: The pods will be restarted.
impact_level: default
```


