### PR TITLE
[testing] Move static e2e tests to the separate cloud provider project

### DIFF
--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -33,7 +33,7 @@ standard:
 provider:
   authURL: 'https://api.selvpc.ru/identity/v3'
   domainName: '48348'
-  tenantID: '80625ad45e604fbe86679e63b704f3b8'
+  tenantID: 'ceda80a1b33844adb1cbddd20ee93585'
   username: 'deckhouse-e2e'
   password: '${OS_PASSWORD}'
   region: 'ru-3'

--- a/testing/cloud_layouts/Static/infra.tpl.tf
+++ b/testing/cloud_layouts/Static/infra.tpl.tf
@@ -30,7 +30,7 @@ terraform {
 provider "openstack" {
   auth_url = "https://api.selvpc.ru/identity/v3"
   domain_name = "48348"
-  tenant_id = "80625ad45e604fbe86679e63b704f3b8"
+  tenant_id = "ceda80a1b33844adb1cbddd20ee93585"
   user_name = "deckhouse-e2e"
   password = "${OS_PASSWORD}"
   region = var.region


### PR DESCRIPTION
## Description
Move static tests to the separate `deckhouse-e2e-tests` project on the cloud provider.

## Why do we need it, and what problem does it solve?
Isolate DVP and DKP stands

## What is the expected result?
<!---
e2e openstack test should be created in deckhouse-e2e-tests prject
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: testing
type: feature
summary: Move static tests to the separate `deckhouse-e2e-tests` project on the cloud provider.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
