### PR TITLE
[monitoring-deckhouse] Add CentOS 7 to D8NodeHasDeprecatedOSVersion alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1210,20 +1210,7 @@ alerts:
       description: |-
         Some nodes have deprecated OS versions. Please update nodes to actual OS version.
 
-        To observe affected nodes use the expr `kube_node_info{os_image=~"Debian GNU/Linux 10.*"}` in Prometheus.
-      summary: |
-        Nodes have deprecated OS versions.
-      severity: "4"
-      markupFormat: markdown
-    - name: D8NodeHasDeprecatedOSVersion
-      sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/node-os-requirements.yaml
-      moduleUrl: 340-monitoring-deckhouse
-      module: monitoring-deckhouse
-      edition: ce
-      description: |-
-        Some nodes have deprecated OS versions. Please update nodes to actual OS version.
-
-        To observe affected nodes use the expr `kube_node_info{os_image=~"Ubuntu 18.04.*"}` in Prometheus.
+        To observe affected nodes use the expr `kube_node_info{os_image=~"Ubuntu 18.04.*|Debian GNU/Linux 10.*|CentOS Linux 7.*"}` in Prometheus.
       summary: |
         Nodes have deprecated OS versions.
       severity: "4"

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/node-os-requirements.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/node-os-requirements.yaml
@@ -2,7 +2,7 @@
   rules:
     - alert: D8NodeHasDeprecatedOSVersion
       expr: >-
-        count(kube_node_info{os_image=~"Ubuntu 18.04.*"}) > 0
+        count(kube_node_info{os_image=~"Ubuntu 18.04.*|Debian GNU/Linux 10.*|CentOS Linux 7.*"}) > 0
       for: 5m
       labels:
         severity_level: "4"
@@ -14,19 +14,4 @@
         description: |-
           Some nodes have deprecated OS versions. Please update nodes to actual OS version.
 
-          To observe affected nodes use the expr `kube_node_info{os_image=~"Ubuntu 18.04.*"}` in Prometheus.
-    - alert: D8NodeHasDeprecatedOSVersion
-      expr: >-
-        count(kube_node_info{os_image=~"Debian GNU/Linux 10.*"}) > 0
-      for: 5m
-      labels:
-        severity_level: "4"
-        tier: cluster
-      annotations:
-        plk_markup_format: markdown
-        plk_protocol_version: "1"
-        summary: Nodes have deprecated OS versions.
-        description: |-
-          Some nodes have deprecated OS versions. Please update nodes to actual OS version.
-
-          To observe affected nodes use the expr `kube_node_info{os_image=~"Debian GNU/Linux 10.*"}` in Prometheus.
+          To observe affected nodes use the expr `kube_node_info{os_image=~"Ubuntu 18.04.*|Debian GNU/Linux 10.*|CentOS Linux 7.*"}` in Prometheus.


### PR DESCRIPTION
## Description

Add centos 7 to D8NodeHasDeprecatedOSVersion alert.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

CentOS Linux 7 End of Life: June 30, 2024.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-deckhouse
type: chore
summary: Add CentOS 7 to the `D8NodeHasDeprecatedOSVersion` alert.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
