### PR TITLE
[deckhouse-controller] Added backup.deckhouse.io/cluster-config label to Deckhouse CRD

### DIFF
--- a/deckhouse-controller/crds/module-config.yaml
+++ b/deckhouse-controller/crds/module-config.yaml
@@ -6,6 +6,7 @@ metadata:
     heritage: deckhouse
     app.kubernetes.io/name: deckhouse
     app.kubernetes.io/part-of: deckhouse
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/deckhouse-controller/crds/module-source.yaml
+++ b/deckhouse-controller/crds/module-source.yaml
@@ -6,6 +6,7 @@ metadata:
     heritage: deckhouse
     app.kubernetes.io/name: deckhouse
     app.kubernetes.io/part-of: deckhouse
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/deckhouse-controller/crds/module-update-policy.yaml
+++ b/deckhouse-controller/crds/module-update-policy.yaml
@@ -6,6 +6,7 @@ metadata:
     heritage: deckhouse
     app.kubernetes.io/name: deckhouse
     app.kubernetes.io/part-of: deckhouse
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/ee/modules/160-multitenancy-manager/crds/projects.yaml
+++ b/ee/modules/160-multitenancy-manager/crds/projects.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: deckhouse
+    backup.deckhouse.io/cluster-config: "true"
   name: projects.deckhouse.io
 spec:
   group: deckhouse.io

--- a/ee/modules/160-multitenancy-manager/crds/projecttemplate.yaml
+++ b/ee/modules/160-multitenancy-manager/crds/projecttemplate.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: deckhouse
+    backup.deckhouse.io/cluster-config: "true"
   name: projecttemplates.deckhouse.io
 spec:
   group: deckhouse.io

--- a/ee/modules/650-runtime-audit-engine/crds/falco-audit-rules.yaml
+++ b/ee/modules/650-runtime-audit-engine/crds/falco-audit-rules.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: runtime-audit-engine
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: admission-policy-engine
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/015-admission-policy-engine/crds/security-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/security-policy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: admission-policy-engine
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/101-cert-manager/crds/crd-clusterissuers.yaml
+++ b/modules/101-cert-manager/crds/crd-clusterissuers.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     app.kubernetes.io/version: 'v1.12.3'
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: cert-manager.io
   names:

--- a/modules/101-cert-manager/crds/crd-issuers.yaml
+++ b/modules/101-cert-manager/crds/crd-issuers.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     app.kubernetes.io/version: 'v1.12.3'
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: cert-manager.io
   names:

--- a/modules/140-user-authz/crds/authorizationrule.yaml
+++ b/modules/140-user-authz/crds/authorizationrule.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authz
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Namespaced

--- a/modules/140-user-authz/crds/clusterauthorizationrule.yaml
+++ b/modules/140-user-authz/crds/clusterauthorizationrule.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authz
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/150-user-authn/crds/dex-authenticator.yaml
+++ b/modules/150-user-authn/crds/dex-authenticator.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authn
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Namespaced

--- a/modules/150-user-authn/crds/dex-provider.yaml
+++ b/modules/150-user-authn/crds/dex-provider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authn
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/150-user-authn/crds/group.yaml
+++ b/modules/150-user-authn/crds/group.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authn
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/150-user-authn/crds/user.yaml
+++ b/modules/150-user-authn/crds/user.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authn
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: ingress-nginx
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: log-shipper
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/460-log-shipper/crds/cluster-logging-config.yaml
+++ b/modules/460-log-shipper/crds/cluster-logging-config.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: log-shipper
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/460-log-shipper/crds/pod-logging-config.yaml
+++ b/modules/460-log-shipper/crds/pod-logging-config.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: log-shipper
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Namespaced


### PR DESCRIPTION
## Description
Added backup.deckhouse.io/cluster-config label to Deckhouse CRD
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Close https://github.com/deckhouse/deckhouse/issues/10091
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: Added backup.deckhouse.io/cluster-config label to Deckhouse CRD
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
