### PR TITLE
[dhctl] Delete support cri type docker 

### DIFF
--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -51,6 +51,11 @@ if [[ -z "${cri_socket_path}" ]]; then
   exit 1
 fi
 
+{{- else if eq .cri "Containerd" }}
+cri_type="Containerd"
+{{- end }}
+
+
 if [[ "${cri_type}" == "Containerd" || "${cri_type}" == "NotManagedContainerd" ]]; then
   criDir=$(crictl info -o json | jq -r '.config.containerdRootDir')
 fi

--- a/candi/bashible/common-steps/all/083_disable_rsyslog_for_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/083_disable_rsyslog_for_kubelet.sh.tpl
@@ -26,7 +26,4 @@ if [ -d /etc/rsyslog.d ]; then
 :programname,isequal, "kubelet" ~
 END
 
-  bb-sync-file /etc/rsyslog.d/10-dockerd.conf - <<END
-:programname,isequal, "dockerd" ~
-END
 fi

--- a/candi/bashible/openapi.yaml
+++ b/candi/bashible/openapi.yaml
@@ -51,8 +51,6 @@ apiVersions:
             type: string
           ca:
             type: string
-          dockerCfg:
-            type: string
       images:
         type: object
       clusterBootstrap:
@@ -83,20 +81,6 @@ apiVersions:
               '^[0-9.]+$':
                 type: object
                 properties:
-                  docker:
-                    type: object
-                    properties:
-                      desiredVersion:
-                        type: string
-                      allowedPattern:
-                        type: string
-                      containerd:
-                        type: object
-                        properties:
-                          desiredVersion:
-                            type: string
-                          allowedPattern:
-                            type: string
                   containerd:
                     type: object
                     properties:

--- a/candi/control-plane-kubeadm/openapi.yaml
+++ b/candi/control-plane-kubeadm/openapi.yaml
@@ -31,8 +31,6 @@ apiVersions:
             type: string
           ca:
             type: string
-          dockerCfg:
-            type: string
       images:
         type: object
       clusterConfiguration:
@@ -68,20 +66,6 @@ apiVersions:
               '^[0-9.]+$':
                 type: object
                 properties:
-                  docker:
-                    type: object
-                    properties:
-                      desiredVersion:
-                        type: string
-                      allowedPattern:
-                        type: string
-                      containerd:
-                        type: object
-                        properties:
-                          desiredVersion:
-                            type: string
-                          allowedPattern:
-                            type: string
                   containerd:
                     type: object
                     properties:

--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -115,7 +115,6 @@ apiVersions:
           If the value `NotManaged` is used, then Deckhouse does not manage the container runtime (and doesn't install it).
           In this case, it is necessary to use images for NodeGroups on which the container runtime is already installed.
         enum:
-        - "Docker"
         - "Containerd"
         - "NotManaged"
         default: "Containerd"

--- a/modules/040-node-manager/hooks/check_nodes_cri_test.go
+++ b/modules/040-node-manager/hooks/check_nodes_cri_test.go
@@ -107,21 +107,6 @@ var _ = Describe("node-manager :: check_containerd_nodes ", func() {
 		})
 	})
 
-	Context("One node without status.nodeInfo.containerRuntimeVersion set and defaultCRI is "+criTypeDocker, func() {
-		BeforeEach(func() {
-			f.ValuesSet("global.clusterConfiguration.defaultCRI", criTypeDocker)
-			f.BindingContexts.Set(f.KubeStateSet(nodeWithoutContainerVersion))
-			f.RunHook()
-		})
-
-		It(hasNodesWithDocker+" should exist and true", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			value, exists := requirements.GetValue(hasNodesWithDocker)
-			Expect(exists).To(BeTrue())
-			Expect(value).To(BeTrue())
-		})
-	})
-
 	Context("One node with containerD", func() {
 		BeforeEach(func() {
 			f.ValuesSet("global.clusterConfiguration.defaultCRI", criTypeContainerd)

--- a/modules/040-node-manager/hooks/get_crds_test.go
+++ b/modules/040-node-manager/hooks/get_crds_test.go
@@ -252,7 +252,6 @@ spec:
     zones:
     - xxx
 `
-
 		stateNGSimple = `
 ---
 apiVersion: deckhouse.io/v1
@@ -266,8 +265,6 @@ spec:
       kind: D8TestInstanceClass
       name: proper1
 `
-
-
 		stateICProper = `
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/modules/040-node-manager/hooks/get_crds_test.go
+++ b/modules/040-node-manager/hooks/get_crds_test.go
@@ -267,23 +267,6 @@ spec:
       name: proper1
 `
 
-		stateNGDockerUnmanaged = `
----
-apiVersion: deckhouse.io/v1
-kind: NodeGroup
-metadata:
-  name: proper1
-spec:
-  cri:
-    type: Docker
-    docker:
-      manage: false
-  nodeType: CloudEphemeral
-  cloudInstances:
-    classReference:
-      kind: D8TestInstanceClass
-      name: proper1
-`
 
 		stateICProper = `
 ---
@@ -1407,20 +1390,6 @@ spec:
 		})
 	})
 
-	Context("Cluster with proper NG, global cri is set to docker", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(stateNGSimple + stateICProper))
-			setK8sVersionAsClusterConfig(f, "1.27")
-			f.ValuesSet("global.clusterConfiguration.defaultCRI", "Docker")
-			f.RunHook()
-		})
-
-		It("Hook must not fail; cri must be correct", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.cri.type").String()).To(Equal("Docker"))
-		})
-	})
-
 	Context("Cluster with proper NG, global cri is set to containerd", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(stateNGSimple + stateICProper))
@@ -1434,18 +1403,6 @@ spec:
 		It("Hook must not fail; cri must be correct", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.cri.type").String()).To(Equal("Containerd"))
-		})
-	})
-
-	Context("Cluster with proper NG, docker is not managed", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(stateNGDockerUnmanaged + stateICProper))
-			f.RunHook()
-		})
-
-		It("Hook must not fail; zones must be correct", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.cri.type").String()).To(Equal("NotManaged"))
 		})
 	})
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
delete docker support in source code and deny use docker cri type in cluster configuration

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this deny use docker cri type

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
if Docker cri type is prompt as defaultCRI stderr output is "defaultCRI should be one of [Containerd NotManaged]".


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section:  dhctl
type: fix
summary: Delete docker CRI type support.
impact_level: default
```