### PR TITLE
[multitenancy-manager] fix prometheus labels

### DIFF
--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/default/default.yaml
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/default/default.yaml
@@ -191,7 +191,7 @@ spec:
                   kubernetes.io/metadata.name: "d8-monitoring"
               podSelector:
                 matchLabels:
-                  app: prometheus
+                  app.kubernetes.io/name: prometheus
             # Ingress nginx traffic.
             - namespaceSelector:
                 matchLabels:

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/default/secure-with-dedicated-nodes.yaml
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/default/secure-with-dedicated-nodes.yaml
@@ -279,7 +279,7 @@ spec:
                   kubernetes.io/metadata.name: "d8-monitoring"
               podSelector:
                 matchLabels:
-                  app: prometheus
+                  app.kubernetes.io/name: prometheus
             # Ingress nginx traffic.
             - namespaceSelector:
                 matchLabels:

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/default/secure.yaml
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/default/secure.yaml
@@ -228,7 +228,7 @@ spec:
                   kubernetes.io/metadata.name: "d8-monitoring"
               podSelector:
                 matchLabels:
-                  app: prometheus
+                  app.kubernetes.io/name: prometheus
             # Ingress nginx traffic.
             - namespaceSelector:
                 matchLabels:

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/helm/testdata/default_case/template.yaml
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/helm/testdata/default_case/template.yaml
@@ -190,7 +190,7 @@ spec:
                   kubernetes.io/metadata.name: "d8-monitoring"
               podSelector:
                 matchLabels:
-                  app: prometheus
+                  app.kubernetes.io/name: prometheus
             # Ingress nginx traffic.
             - namespaceSelector:
                 matchLabels:

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/helm/testdata/secure_case/template.yaml
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/helm/testdata/secure_case/template.yaml
@@ -227,7 +227,7 @@ spec:
                   kubernetes.io/metadata.name: "d8-monitoring"
               podSelector:
                 matchLabels:
-                  app: prometheus
+                  app.kubernetes.io/name: prometheus
             # Ingress nginx traffic.
             - namespaceSelector:
                 matchLabels:

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/helm/testdata/secure_with_dedicated_node_case/resources.yaml
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/helm/testdata/secure_with_dedicated_node_case/resources.yaml
@@ -76,7 +76,7 @@ spec:
           kubernetes.io/metadata.name: d8-monitoring
       podSelector:
         matchLabels:
-          app: prometheus
+          app.kubernetes.io/name: prometheus
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: d8-ingress-nginx

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/helm/testdata/secure_with_dedicated_node_case/template.yaml
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/helm/testdata/secure_with_dedicated_node_case/template.yaml
@@ -278,7 +278,7 @@ spec:
                   kubernetes.io/metadata.name: "d8-monitoring"
               podSelector:
                 matchLabels:
-                  app: prometheus
+                  app.kubernetes.io/name: prometheus
             # Ingress nginx traffic.
             - namespaceSelector:
                 matchLabels:

--- a/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/helm/testdata/without_ns_case/template.yaml
+++ b/ee/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/helm/testdata/without_ns_case/template.yaml
@@ -182,7 +182,7 @@ spec:
                   kubernetes.io/metadata.name: "d8-monitoring"
                 podSelector:
                   matchLabels:
-                    app: prometheus
+                    app.kubernetes.io/name: prometheus
             # Ingress nginx traffic.
             - namespaceSelector:
                 matchLabels:

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -133,7 +133,7 @@ spec:
         podAffinityTerm:
           labelSelector:
             matchLabels:
-              app: prometheus
+              app.kubernetes.io/name: prometheus
               prometheus: main
           topologyKey: kubernetes.io/hostname
   scrapeInterval: {{ .Values.prometheus.longtermScrapeInterval | default "5m" }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -137,7 +137,7 @@ spec:
         podAffinityTerm:
           labelSelector:
             matchLabels:
-              app: prometheus
+              app.kubernetes.io/name: prometheus
               prometheus: longterm
           topologyKey: kubernetes.io/hostname
 {{- if (include "helm_lib_ha_enabled" .) }}


### PR DESCRIPTION
## Description
It provides fix for incorrect prometheus labels in templates.

## Why do we need it, and what problem does it solve?
NetworkPolicy`s PodSelector in project templates does not work correctly for prometheus pods because they have another label.

## What is the expected result?
NetworkPolicy`s PodSelector in project templates works correctly.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: fix
summary: Fix prometheus labels for ingress traffic in Project templates.
```
```changes
section: prometheus
type: fix
summary: Fix labels for prometheus pod antiAffinity.
```

