### PR TITLE
[istio] Fix metrics display issue in Kiali

### DIFF
--- a/modules/110-istio/templates/kiali/rbac-for-us.yaml
+++ b/modules/110-istio/templates/kiali/rbac-for-us.yaml
@@ -167,6 +167,7 @@ rules:
   - deployments/http
   verbs:
   - create
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description
Add Kiali permissions to Prometheus to receive and display metrics.

## Why do we need it, and what problem does it solve?
- Kiali WEB-interface does not display metrics.
- There are errors in the logs:
```json
{"level":"error","time":"2024-10-15T11:41:18Z","message":"Failed to fetch Prometheus configuration: client_error: client error: 403"}
{"level":"error","time":"2024-10-15T11:41:18Z","message":"Failed to fetch Prometheus flags: client_error: client error: 403"}

```
![image](https://github.com/user-attachments/assets/93950f22-4031-4386-b6fc-2d6929fb8d3d)

## What is the expected result?
Metrics in Kiali are displayed correctly.

<img width="940" alt="image" src="https://github.com/user-attachments/assets/5ff05070-2e8b-4578-8d48-dece0596c87d">

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fixed metrics display issue in Kiali.
impact_level: default
```