### PR TITLE
[prometheus] Require route in internal spec of CustomAlertManager

### DIFF
--- a/modules/300-prometheus/crds/customalertmanager.yaml
+++ b/modules/300-prometheus/crds/customalertmanager.yaml
@@ -132,6 +132,8 @@ spec:
                           default: false
                 internal:
                   type: object
+                  required:
+                  - route
                   description: Internal Alertmanager parameters.
                   properties:
                     inhibitRules:
@@ -872,14 +874,14 @@ spec:
                             description: List of Telegram configurations.
                             items:
                               description: |
-                                Configures notifications via Telegram. 
-                                
+                                Configures notifications via Telegram.
+
                                 Read more in the [Prometheus documentation](https://prometheus.io/docs/alerting/latest/configuration/#telegram_config).
                               properties:
                                 apiURL:
                                   description: |
                                     The Telegram API URL i.e. `https://api.telegram.org`.
-                                    
+
                                     If not specified, the default API URL will be used.
                                   type: string
                                 botToken:

--- a/modules/300-prometheus/crds/doc-ru-customalertmanager.yaml
+++ b/modules/300-prometheus/crds/doc-ru-customalertmanager.yaml
@@ -48,6 +48,8 @@ spec:
                           description: Отключение проверки сертификата.
                 internal:
                   type: object
+                  required:
+                    - route
                   description: Параметры настройки внутренного Alertmanager.
                   properties:
                     inhibitRules:


### PR DESCRIPTION
## Description
Add `required` setting for `spec.internal.route` in CustomAlertManager CRD


## Why do we need it, and what problem does it solve?
Root route is required by prometheus-operator:
```
level=error ts=2024-10-15T13:51:39.125341794Z caller=klog.go:116 component=k8s_client_runtime func=ErrorDepth msg="sync \"d8-monitoring/alerts-email\" failed: provision alertmanager configuration: failed to initialize from global AlertmangerConfig: root route must exist"
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: chore
summary: Added required parameter for `internal.route` spec in CustomAlertManager CRD.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
