### PR TITLE
[docs] Added experimental alert at static-routing-manager module

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -579,6 +579,7 @@ entries:
                     ru: Настройки
                   url: /modules/350-node-local-dns/configuration.html
             - title: static-routing-manager
+              featureStatus: experimental
               folders:
                 - title:
                     en: Description

--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -579,7 +579,7 @@ entries:
                     ru: Настройки
                   url: /modules/350-node-local-dns/configuration.html
             - title: static-routing-manager
-              featureStatus: experimental
+              d8Revision: ee
               folders:
                 - title:
                     en: Description

--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -155,7 +155,7 @@ defaults:
       path: "*/025-static-routing-manager"
       type: "pages"
     values:
-      featureStatus: experimental  
+      d8Revision: ee  
   - scope:
       path: "*/380-metallb"
       type: "pages"

--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -152,6 +152,11 @@ defaults:
     values:
       d8Revision: ee
   - scope:
+      path: "*/025-static-routing-manager"
+      type: "pages"
+    values:
+      featureStatus: experimental  
+  - scope:
       path: "*/380-metallb"
       type: "pages"
     values:


### PR DESCRIPTION
## Description
Added experimental alert at static-routing-manager module.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


```changes
section: docs
type: fix
summary: Added experimental alert at static-routing-manager module.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
