### PR TITLE
chore(dhctl-for-commander): test converge for master changes

### DIFF
--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -100,6 +100,8 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 		c.lastState = state
 	}
 
+	panic("TEST PANIC")
+
 	if err := c.applyParams(); err != nil {
 		return nil, err
 	}

--- a/dhctl/pkg/server/server/singlethreaded/server.go
+++ b/dhctl/pkg/server/server/singlethreaded/server.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
@@ -30,6 +29,8 @@ import (
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 
 	dhctllog "github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	pbdhctl "github.com/deckhouse/deckhouse/dhctl/pkg/server/pb/dhctl"


### PR DESCRIPTION
## Description

This PR is not intended to merge. PR only needed to test new converge of masters feature, which will be available in the 1.65 dhctl release.