### PR TITLE
[istio] Optimize the Kiali RBAC rules

### DIFF
--- a/modules/110-istio/templates/kiali/rbac-for-us.yaml
+++ b/modules/110-istio/templates/kiali/rbac-for-us.yaml
@@ -18,13 +18,6 @@ rules:
   - configmaps
   - endpoints
   - pods/log
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - namespaces
   - pods
   - replicationcontrollers
@@ -139,14 +132,6 @@ rules:
   verbs:
   - create
 - apiGroups:
-  - apps
-  resourceNames:
-  - trickster
-  resources:
-  - deployments/http"
-  verbs:
-  - get
-- apiGroups:
   - monitoring.coreos.com
   resources:
   - prometheuses
@@ -182,4 +167,3 @@ subjects:
 - kind: ServiceAccount
   name: kiali
   namespace: d8-{{ $.Chart.Name }}
----


### PR DESCRIPTION
## Description
This PR focuses on optimizing and refactoring the existing RBAC rules by consolidating duplicate entries that granted the same permissions to overlapping resources. The rules have been streamlined to improve readability and maintainability while aligning with current Kubernetes API groups.

## Why do we need it, and what problem does it solve?
This change reduces redundancy in the RBAC configuration, minimizing complexity and improving future maintenance. The refactor ensures a more efficient and understandable access control policy, reducing the likelihood of errors or confusion.

## What is the expected result?
- RBAC rules do not contain duplicates.
- Split rules are organized into groups.
- The formalization of rules follows the YAML format.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
impact_level: low
```