### PR TITLE
[deckhouse] Fix update windows validation policy

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -148,7 +148,7 @@ spec:
         ? object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
         : object.spec.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
       reason: Forbidden
-      messageExpression: "'Invalid update windows. Start time (windows.to) should be less than the end time of the update window (windows.from)'"
+      messageExpression: "'Invalid update windows. Start time (windows.from) should be less than the end time of the update window (windows.to)'"
 {{- else }}
   validations:
     - expression: |

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -172,7 +172,6 @@ spec:
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   validationActions: [Deny, Audit]
 {{- end }}
-{{- end }}
 {{/* End deckhouse windows validation */}}
 
 ---
@@ -223,5 +222,5 @@ spec:
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   validationActions: [Deny, Audit]
 {{- end }}
-{{- end }}
 {{/* End mup windows validation */}}
+{{- end }}

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -141,14 +141,23 @@ spec:
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
     - name: 'windows-are-set'
-      expression: 'object.spec.settings.update.windows.size() > 0'
+      expression: 'object.spec.settings.update.windows.size() > 0 || object.spec.update.windows.size() > 0'
   validations:
-    - expression: 'object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) > int(string(w.to).replace(":", "")))'
+    - expression: |
+        // Create a variable `windows` based on whether specific fields exist
+        let windows = has(object.spec.settings.update.windows)
+          ? object.spec.settings.update.windows
+          : object.spec.update.windows;
+        windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))'
       reason: Forbidden
-      messageExpression: '''Invalid update windows. Start time (windows.to) should be less than the end time of the update window (windows.from)'''
+      messageExpression: "'Invalid update windows. Start time (windows.to) should be less than the end time of the update window (windows.from)'"
 {{- else }}
   validations:
-    - expression: '!(object.spec.settings.update.windows.size() > 0 && object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) > int(string(w.to).replace(":", ""))))'
+    - expression: |
+        let windows = has(object.spec.settings.update.windows)
+          ? object.spec.settings.update.windows
+          : object.spec.update.windows;
+        windows.size() > 0 && object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
       reason: Forbidden
 {{- end }}
 ---

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -144,7 +144,7 @@ spec:
       expression: 'object.name == "deckhouse"'
     - name: 'windows-are-set'
       expression: |
-        has(object.spec.settings.update &&
+        has(object.spec.settings.update) &&
         has(object.spec.settings.update.windows) &&
         object.spec.settings.update.windows.size() > 0
   validations:

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -124,7 +124,7 @@ spec:
 
 ---
 {{/* Check update windows in the deckhouse ModuleConfig */}}
-{{- $policyName := "update-windows.deckhouse.io" }}
+{{- $policyName := "mc-update-windows.deckhouse.io" }}
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
 kind: ValidatingAdmissionPolicy
 metadata:
@@ -137,29 +137,28 @@ spec:
     - apiGroups:   ["deckhouse.io"]
       apiVersions: ["*"]
       operations:  ["CREATE", "UPDATE"]
-      resources:   ["moduleconfigs", "moduleupdatepolicies"]
+      resources:   ["moduleconfigs"]
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
-    - name: 'update-field-exists'
-      expression: 'has(object.spec.settings.update) || has(object.spec.update)'
-    - name: 'windows-field-exists'
-      expression: 'has(object.spec.settings.update.windows) || has(object.spec.update.windows)'
+    - name: 'deckhouse-mc'
+      expression: 'object.name == "deckhouse"'
     - name: 'windows-are-set'
-      expression: 'object.spec.settings.update.windows.size() > 0 || object.spec.update.windows.size() > 0'
+      expression: |
+        has(object.spec.settings.update &&
+        has(object.spec.settings.update.windows) &&
+        object.spec.settings.update.windows.size() > 0
   validations:
-    - expression: |
-        has(object.spec.settings.update.windows)
-        ? object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
-        : object.spec.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
+    - expression: 'object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))'
       reason: Forbidden
       messageExpression: "'Invalid update windows. Start time (windows.from) should be less than the end time of the update window (windows.to)'"
 {{- else }}
   validations:
     - expression: |
-        (has(object.spec.settings.update) || has(object.spec.update)) && (has(object.spec.settings.update.windows) || has(object.spec.update.windows)) &&
-        has(object.spec.settings.update.windows)
-        ? object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
-        : object.spec.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
+        object.name == "deckhouse" &&
+        has(object.spec.settings.update) &&
+        has(object.spec.settings.update.windows) &&
+        object.spec.settings.update.windows.size() > 0 &&
+        object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
       reason: Forbidden
 {{- end }}
 ---
@@ -174,4 +173,55 @@ spec:
   validationActions: [Deny, Audit]
 {{- end }}
 {{- end }}
-{{/* End windows validation */}}
+{{/* End deckhouse windows validation */}}
+
+---
+{{/* Check update windows in the ModuleUpdatePolicy */}}
+{{- $policyName := "mup-update-windows.deckhouse.io" }}
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   ["deckhouse.io"]
+        apiVersions: ["*"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["moduleupdatepolicies"]
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
+  matchConditions:
+    - name: 'windows-are-set'
+      expression: |
+        has(object.spec.update &&
+        has(object.spec.update.windows) &&
+        object.spec.update.windows.size() > 0
+  validations:
+    - expression: 'object.spec.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))'
+      reason: Forbidden
+      messageExpression: "'Invalid update windows. Start time (windows.from) should be less than the end time of the update window (windows.to)'"
+{{- else }}
+  validations:
+    - expression: |
+        object.name == "deckhouse" &&
+        has(object.spec.settings.update) &&
+        has(object.spec.settings.update.windows) &&
+        object.spec.settings.update.windows.size() > 0 &&
+        object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
+      reason: Forbidden
+{{- end }}
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  policyName: {{ $policyName }}
+{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
+  validationActions: [Deny, Audit]
+{{- end }}
+{{- end }}
+{{/* End mup windows validation */}}

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -122,6 +122,7 @@ spec:
   validationActions: [Deny]
 {{- end }}
 
+
 ---
 {{/* Check update windows in the deckhouse ModuleConfig */}}
 {{- $policyName := "update-windows.deckhouse.io" }}

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -148,7 +148,7 @@ spec:
         let windows = has(object.spec.settings.update.windows)
           ? object.spec.settings.update.windows
           : object.spec.update.windows;
-        windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))'
+        windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
       reason: Forbidden
       messageExpression: "'Invalid update windows. Start time (windows.to) should be less than the end time of the update window (windows.from)'"
 {{- else }}

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -122,7 +122,6 @@ spec:
   validationActions: [Deny]
 {{- end }}
 
-
 ---
 {{/* Check update windows in the deckhouse ModuleConfig */}}
 {{- $policyName := "update-windows.deckhouse.io" }}
@@ -142,7 +141,7 @@ spec:
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
     - name: 'windows-are-set'
-      expression: 'object.spec.settings.update.windows.size() > 0 || object.spec.update.windows.size() > 0'
+      expression: '(has(object.spec.settings.update.windows) &&object.spec.settings.update.windows.size() > 0) || (has(object.spec.update.windows) && object.spec.update.windows.size() > 0)'
   validations:
     - expression: |
         has(object.spec.settings.update.windows)

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -144,20 +144,17 @@ spec:
       expression: 'object.spec.settings.update.windows.size() > 0 || object.spec.update.windows.size() > 0'
   validations:
     - expression: |
-        // Create a variable `windows` based on whether specific fields exist
-        let windows = has(object.spec.settings.update.windows)
-          ? object.spec.settings.update.windows
-          : object.spec.update.windows;
-        windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
+        has(object.spec.settings.update.windows)
+        ? object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
+        : object.spec.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
       reason: Forbidden
       messageExpression: "'Invalid update windows. Start time (windows.to) should be less than the end time of the update window (windows.from)'"
 {{- else }}
   validations:
     - expression: |
-        let windows = has(object.spec.settings.update.windows)
-          ? object.spec.settings.update.windows
-          : object.spec.update.windows;
-        windows.size() > 0 && object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
+        has(object.spec.settings.update.windows)
+        ? object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
+        : object.spec.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
       reason: Forbidden
 {{- end }}
 ---

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -140,8 +140,12 @@ spec:
       resources:   ["moduleconfigs", "moduleupdatepolicies"]
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
+    - name: 'update-field-exists'
+      expression: 'has(object.spec.settings.update) || has(object.spec.update)'
+    - name: 'windows-field-exists'
+      expression: 'has(object.spec.settings.update.windows) || has(object.spec.update.windows)'
     - name: 'windows-are-set'
-      expression: '(has(object.spec.settings.update.windows) &&object.spec.settings.update.windows.size() > 0) || (has(object.spec.update.windows) && object.spec.update.windows.size() > 0)'
+      expression: 'object.spec.settings.update.windows.size() > 0 || object.spec.update.windows.size() > 0'
   validations:
     - expression: |
         has(object.spec.settings.update.windows)
@@ -152,6 +156,7 @@ spec:
 {{- else }}
   validations:
     - expression: |
+        (has(object.spec.settings.update) || has(object.spec.update)) && (has(object.spec.settings.update.windows) || has(object.spec.update.windows)) &&
         has(object.spec.settings.update.windows)
         ? object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
         : object.spec.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -123,7 +123,8 @@ spec:
 {{- end }}
 
 ---
-{{- $policyName := "moduleconfigs-settings.deckhouse.io" }}
+{{/* Check update windows in the deckhouse ModuleConfig */}}
+{{- $policyName := "update-windows.deckhouse.io" }}
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
 kind: ValidatingAdmissionPolicy
 metadata:
@@ -136,12 +137,19 @@ spec:
     - apiGroups:   ["deckhouse.io"]
       apiVersions: ["*"]
       operations:  ["CREATE", "UPDATE"]
-      resources:   ["moduleconfigs"]
-  validations:
-    - expression: '!(object.metadata.name == "deckhouse" && has(object.spec.settings.update) && has(object.spec.settings.update.windows) && object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) > int(string(w.to).replace(":", ""))))'
-      reason: Forbidden
+      resources:   ["moduleconfigs", "moduleupdatepolicies"]
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
+  matchConditions:
+    - name: 'windows-are-set'
+      expression: 'object.spec.settings.update.windows.size() > 0'
+  validations:
+    - expression: 'object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) > int(string(w.to).replace(":", "")))'
+      reason: Forbidden
       messageExpression: '''Invalid update windows. Start time (windows.to) should be less than the end time of the update window (windows.from)'''
+{{- else }}
+  validations:
+    - expression: '!(object.spec.settings.update.windows.size() > 0 && object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) > int(string(w.to).replace(":", ""))))'
+      reason: Forbidden
 {{- end }}
 ---
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
@@ -155,3 +163,4 @@ spec:
   validationActions: [Deny, Audit]
 {{- end }}
 {{- end }}
+{{/* End windows validation */}}

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -204,7 +204,6 @@ spec:
 {{- else }}
   validations:
     - expression: |
-        object.name == "deckhouse" &&
         has(object.spec.settings.update) &&
         has(object.spec.settings.update.windows) &&
         object.spec.settings.update.windows.size() > 0 &&

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -204,10 +204,10 @@ spec:
 {{- else }}
   validations:
     - expression: |
-        has(object.spec.settings.update) &&
-        has(object.spec.settings.update.windows) &&
-        object.spec.settings.update.windows.size() > 0 &&
-        object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
+        has(object.spec.update) &&
+        has(object.spec.update.windows) &&
+        object.spec.update.windows.size() > 0 &&
+        object.spec.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
       reason: Forbidden
 {{- end }}
 ---

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -194,7 +194,7 @@ spec:
   matchConditions:
     - name: 'windows-are-set'
       expression: |
-        has(object.spec.update &&
+        has(object.spec.update) &&
         has(object.spec.update.windows) &&
         object.spec.update.windows.size() > 0
   validations:

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -141,7 +141,7 @@ spec:
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
     - name: 'deckhouse-mc'
-      expression: 'object.name == "deckhouse"'
+      expression: 'object.metadata.name == "deckhouse"'
     - name: 'windows-are-set'
       expression: |
         has(object.spec.settings.update) &&
@@ -154,7 +154,7 @@ spec:
 {{- else }}
   validations:
     - expression: |
-        object.name == "deckhouse" &&
+        object.metadata.name == "deckhouse" &&
         has(object.spec.settings.update) &&
         has(object.spec.settings.update.windows) &&
         object.spec.settings.update.windows.size() > 0 &&


### PR DESCRIPTION
## Description
Fix ValidatingAdmissionPolicy for checking update windows

## Why do we need it, and what problem does it solve?
If windows fields is empty slice it gives false negative

## Why do we need it in the patch release (if we do)?

Avoid false negative check

## What is the expected result?
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: deckhouse
spec:
  settings:
    update:
      mode: AutoPatch
      windows:
      - from: "11:00"
        to: "12:00"
      - from: "15:23"
        to: "12:13"
  version: 1
```

```console
kubectl apply -f wrong-window.yaml
Error from server (Forbidden): error when creating "wrong-window.yaml": moduleconfigs.deckhouse.io "deck" is forbidden: ValidatingAdmissionPolicy 'update-windows.deckhouse.io' with binding 'update-windows.deckhouse.io' denied request: Invalid update windows. Start time (windows.from) should be less than the end time of the update window (windows.to)
```
---
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: deckdeckhouse
spec:
  settings:
    update:
      mode: AutoPatch
      windows:
      - from: "11:00"
        to: "12:00"
  version: 1
```

```console
moduleconfig.deckhouse.io/dechouse updated
```
---
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: deckhouse
spec:
  settings:
    update:
      mode: AutoPatch
  version: 1
```
and
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: deckhouse
spec:
  settings:
    update:
      mode: AutoPatch
      windows: []
  version: 1
```

```console
moduleconfig.deckhouse.io/dechouse updated
```

---
MUP

```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleUpdatePolicy
metadata:
  annotations:
  name: tmpa
spec:
  moduleReleaseSelector:
    labelSelector:
      matchLabels:
        source: test
  releaseChannel: Alpha
  update:
    mode: Auto
    windows:
      - from: "10:00"
        to: "09:11"
```

```console
# kubectl apply -f wrong-window.yaml
Error from server (Forbidden): error when creating "wrong-window.yaml": moduleupdatepolicies.deckhouse.io "tmpa" is forbidden: ValidatingAdmissionPolicy 'mup-update-windows.deckhouse.io' with binding 'mup-update-windows.deckhouse.io' denied request: Invalid update windows. Start time (windows.from) should be less than the end time of the update window (windows.to)
```
---
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleUpdatePolicy
metadata:
  annotations:
  name: tmpa
spec:
  moduleReleaseSelector:
    labelSelector:
      matchLabels:
        source: test
  releaseChannel: Alpha
  update:
    mode: Auto
    windows: []
```

```console
# kubectl apply -f no-window.yaml
moduleupdatepolicy.deckhouse.io/tmpa created
```
---
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleUpdatePolicy
metadata:
  annotations:
  name: tmpa
spec:
  moduleReleaseSelector:
    labelSelector:
      matchLabels:
        source: test
  releaseChannel: Alpha
  update:
    mode: Auto
    windows:
      - from: "10:00"
        to: "12:11"
```

```console
# kubectl apply -f right-window.yaml
moduleupdatepolicy.deckhouse.io/tmpa created
```
---

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fix ValidatingAdmissionPolicy for checking update windows.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
