### PR TITLE
[ingress-nginx] add max_worker_connection and max_worker_procesess metrics

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-10/Dockerfile
@@ -41,6 +41,7 @@ COPY patches/metrics-SetSSLExpireTime.patch /
 COPY patches/util.patch /
 COPY patches/fix-cleanup.patch /
 COPY patches/add-http3.patch /
+COPY patches/new-metrics.patch /
 ENV GOARCH=amd64
 RUN git clone --branch $CONTROLLER_BRANCH --depth 1 ${SOURCE_REPO}/kubernetes/ingress-nginx.git /src && \
     patch -p1 < /lua-info.patch && \
@@ -50,6 +51,7 @@ RUN git clone --branch $CONTROLLER_BRANCH --depth 1 ${SOURCE_REPO}/kubernetes/in
     patch -p1 < /util.patch && \
     patch -p1 < /fix-cleanup.patch && \
     patch -p1 < /add-http3.patch && \
+    patch -p1 < /new-metrics.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # Build nginx for ingress controller

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -64,4 +64,4 @@ Add HTTP/3 support.
 
 ### new metrics
 
-This patch adds max workers connections, max worker processes and max worker open files metrics.
+This patch adds worker max connections, worker processes and worker max open files metrics.

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -61,3 +61,7 @@ Build nginx for controller on ALT Linux.
 ### http3
 
 Add HTTP/3 support.
+
+### new metrics
+
+This patch adds max workers connections, max worker processes and max worker open files metrics.

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/new-metrics.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/new-metrics.patch
@@ -82,7 +82,7 @@ index 284f53209..1f07fd047 100644
  	s.writeSSLSessionTicketKey(cmap, "/etc/ingress-controller/tickets.key")
  }
 diff --git a/internal/ingress/metric/collectors/nginx_status.go b/internal/ingress/metric/collectors/nginx_status.go
-index f3afdc334..d36a5cea7 100644
+index f3afdc334..e196c5c49 100644
 --- a/internal/ingress/metric/collectors/nginx_status.go
 +++ b/internal/ingress/metric/collectors/nginx_status.go
 @@ -39,12 +39,19 @@ type (
@@ -124,19 +124,19 @@ index f3afdc334..d36a5cea7 100644
  
  	p.data = &nginxStatusData{
 +		workerProcesses: prometheus.NewDesc(
-+			prometheus.BuildFQName(namespace, subSystem, "worker_processes"),
++			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_processes"),
 +			"max worker processes",
-+			nil, constLabels),
++			[]string{"state"}, constLabels),
 +
 +		workerConnections: prometheus.NewDesc(
-+			prometheus.BuildFQName(namespace, subSystem, "worker_connections"),
++			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_connections"),
 +			"max worker connections",
-+			nil, constLabels),
++			[]string{"state"}, constLabels),
 +
 +		workerRlimitNofile: prometheus.NewDesc(
-+			prometheus.BuildFQName(namespace, subSystem, "worker_rlimit_nofile"),
++			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_rlimit_nofile"),
 +			"max worker rlimit nofile",
-+			nil, constLabels),
++			[]string{"state"}, constLabels),
 +
  		connectionsTotal: prometheus.NewDesc(
  			prometheus.BuildFQName(PrometheusNamespace, subSystem, "connections_total"),

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/new-metrics.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/new-metrics.patch
@@ -29,10 +29,10 @@ index 284f53209..3e00ae2b5 100644
  }
  
 diff --git a/internal/ingress/metric/collectors/nginx_status.go b/internal/ingress/metric/collectors/nginx_status.go
-index f3afdc334..cf20ab601 100644
+index f3afdc334..c9fe50594 100644
 --- a/internal/ingress/metric/collectors/nginx_status.go
 +++ b/internal/ingress/metric/collectors/nginx_status.go
-@@ -17,13 +17,14 @@ limitations under the License.
+@@ -17,13 +17,15 @@ limitations under the License.
  package collectors
  
  import (
@@ -48,10 +48,11 @@ index f3afdc334..cf20ab601 100644
 +	"runtime"
 +	"strconv"
 +	"sync"
++	"syscall"
  )
  
  var (
-@@ -34,6 +35,33 @@ var (
+@@ -34,6 +36,53 @@ var (
  	waiting = regexp.MustCompile(`Waiting: (\d+)`)
  )
  
@@ -62,11 +63,31 @@ index f3afdc334..cf20ab601 100644
 +	Lock               sync.Mutex
 +}
 +
++func rlimitMaxNumFiles() int {
++	var rLimit syscall.Rlimit
++	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {
++		return 0
++	}
++	return int(rLimit.Max)
++}
++
 +func (w *WorkerStatus) Set(workerConnections, workerRlimitNofile int, workerProcesses string) {
 +	w.Lock.Lock()
 +	defer w.Lock.Unlock()
-+	w.WorkerConnections = workerConnections
++	if workerRlimitNofile == 0 {
++		maxOpenFiles := rlimitMaxNumFiles() - 1024
++		if maxOpenFiles < 1024 {
++			maxOpenFiles = 1024
++		}
++		workerRlimitNofile = maxOpenFiles
++	}
 +	w.WorkerRlimitNofile = workerRlimitNofile
++
++	if workerConnections == 0 {
++		workerConnections = int(float64(workerRlimitNofile * 3.0 / 4))
++	}
++	w.WorkerConnections = workerConnections
++
 +	if n, err := strconv.Atoi(workerProcesses); err == nil {
 +		w.WorkerProcesses = n
 +	} else {
@@ -85,7 +106,7 @@ index f3afdc334..cf20ab601 100644
  type (
  	nginxStatusCollector struct {
  		scrapeChan chan scrapeRequest
-@@ -42,9 +70,12 @@ type (
+@@ -42,9 +91,12 @@ type (
  	}
  
  	nginxStatusData struct {
@@ -101,7 +122,7 @@ index f3afdc334..cf20ab601 100644
  	}
  
  	basicStatus struct {
-@@ -86,6 +117,21 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
+@@ -86,6 +138,21 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
  	}
  
  	p.data = &nginxStatusData{
@@ -123,7 +144,7 @@ index f3afdc334..cf20ab601 100644
  		connectionsTotal: prometheus.NewDesc(
  			prometheus.BuildFQName(PrometheusNamespace, subSystem, "connections_total"),
  			"total number of connections with state {accepted, handled}",
-@@ -107,6 +153,9 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
+@@ -107,6 +174,9 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
  
  // Describe implements prometheus.Collector.
  func (p nginxStatusCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -133,7 +154,7 @@ index f3afdc334..cf20ab601 100644
  	ch <- p.data.connectionsTotal
  	ch <- p.data.requestsTotal
  	ch <- p.data.connections
-@@ -179,6 +228,14 @@ func (p nginxStatusCollector) scrape(ch chan<- prometheus.Metric) {
+@@ -179,6 +249,14 @@ func (p nginxStatusCollector) scrape(ch chan<- prometheus.Metric) {
  
  	s := parse(string(data))
  

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/new-metrics.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/new-metrics.patch
@@ -1,0 +1,219 @@
+diff --git a/internal/ingress/controller/nginx.go b/internal/ingress/controller/nginx.go
+index e19ee8bb3..8d340af7c 100644
+--- a/internal/ingress/controller/nginx.go
++++ b/internal/ingress/controller/nginx.go
+@@ -138,7 +138,8 @@ func NewNGINXController(config *Configuration, mc metric.Collector) *NGINXContro
+ 		config.DisableCatchAll,
+ 		config.DeepInspector,
+ 		config.IngressClassConfiguration,
+-		config.DisableSyncEvents)
++		config.DisableSyncEvents,
++		mc)
+ 
+ 	n.syncQueue = task.NewTaskQueue(n.syncIngress)
+ 
+diff --git a/internal/ingress/controller/store/store.go b/internal/ingress/controller/store/store.go
+index 284f53209..1f07fd047 100644
+--- a/internal/ingress/controller/store/store.go
++++ b/internal/ingress/controller/store/store.go
+@@ -23,6 +23,7 @@ import (
+ 	"os"
+ 	"reflect"
+ 	"sort"
++	"strconv"
+ 	"strings"
+ 	"sync"
+ 	"time"
+@@ -55,6 +56,7 @@ import (
+ 	ngx_template "k8s.io/ingress-nginx/internal/ingress/controller/template"
+ 	"k8s.io/ingress-nginx/internal/ingress/defaults"
+ 	"k8s.io/ingress-nginx/internal/ingress/errors"
++	"k8s.io/ingress-nginx/internal/ingress/metric"
+ 	"k8s.io/ingress-nginx/internal/ingress/resolver"
+ 	"k8s.io/ingress-nginx/internal/k8s"
+ 	"k8s.io/ingress-nginx/pkg/apis/ingress"
+@@ -219,6 +221,8 @@ type k8sStore struct {
+ 	// listers contains the cache.Store interfaces used in the ingress controller
+ 	listers *Lister
+ 
++	mc metric.Collector
++
+ 	// sslStore local store of SSL certificates (certificates used in ingress)
+ 	// this is required because the certificates must be present in the
+ 	// container filesystem
+@@ -256,12 +260,14 @@ func New(
+ 	deepInspector bool,
+ 	icConfig *ingressclass.Configuration,
+ 	disableSyncEvents bool,
++	mc metric.Collector,
+ ) Storer {
+ 	store := &k8sStore{
+ 		informers:             &Informer{},
+ 		listers:               &Lister{},
+ 		sslStore:              NewSSLCertTracker(),
+ 		updateCh:              updateCh,
++		mc:                    mc,
+ 		backendConfig:         ngx_config.NewDefault(),
+ 		syncSecretMu:          &sync.Mutex{},
+ 		backendConfigMu:       &sync.RWMutex{},
+@@ -269,6 +275,12 @@ func New(
+ 		defaultSSLCertificate: defaultSSLCertificate,
+ 	}
+ 
++	if n, err := strconv.Atoi(store.backendConfig.WorkerProcesses); err == nil {
++		store.mc.SetWorkerProcesses(n)
++	}
++	store.mc.SetWorkerConnections(store.backendConfig.MaxWorkerConnections)
++	store.mc.SetWorkerRlimitNofile(store.backendConfig.MaxWorkerOpenFiles)
++
+ 	eventBroadcaster := record.NewBroadcaster()
+ 	eventBroadcaster.StartLogging(klog.Infof)
+ 	if !disableSyncEvents {
+@@ -1214,6 +1226,11 @@ func (s *k8sStore) setConfig(cmap *corev1.ConfigMap) {
+ 		klog.Warning("The GeoIP2 feature is enabled but the databases are missing. Disabling")
+ 		s.backendConfig.UseGeoIP2 = false
+ 	}
++	if n, err := strconv.Atoi(s.backendConfig.WorkerProcesses); err == nil {
++		s.mc.SetWorkerProcesses(n)
++	}
++	s.mc.SetWorkerConnections(s.backendConfig.MaxWorkerConnections)
++	s.mc.SetWorkerRlimitNofile(s.backendConfig.MaxWorkerOpenFiles)
+ 
+ 	s.writeSSLSessionTicketKey(cmap, "/etc/ingress-controller/tickets.key")
+ }
+diff --git a/internal/ingress/metric/collectors/nginx_status.go b/internal/ingress/metric/collectors/nginx_status.go
+index f3afdc334..d36a5cea7 100644
+--- a/internal/ingress/metric/collectors/nginx_status.go
++++ b/internal/ingress/metric/collectors/nginx_status.go
+@@ -39,12 +39,19 @@ type (
+ 		scrapeChan chan scrapeRequest
+ 
+ 		data *nginxStatusData
++
++		workerConnections  int
++		workerProcesses    int
++		workerRlimitNofile int
+ 	}
+ 
+ 	nginxStatusData struct {
+-		connectionsTotal *prometheus.Desc
+-		requestsTotal    *prometheus.Desc
+-		connections      *prometheus.Desc
++		workerConnections  *prometheus.Desc
++		workerProcesses    *prometheus.Desc
++		workerRlimitNofile *prometheus.Desc
++		connectionsTotal   *prometheus.Desc
++		requestsTotal      *prometheus.Desc
++		connections        *prometheus.Desc
+ 	}
+ 
+ 	basicStatus struct {
+@@ -69,6 +76,10 @@ type (
+ type NGINXStatusCollector interface {
+ 	prometheus.Collector
+ 
++	SetWorkerConnections(workerConnections int)
++	SetWorkerProcesses(workerProcesses int)
++	SetWorkerRlimitNofile(workerRlimitNofile int)
++
+ 	Start()
+ 	Stop()
+ }
+@@ -86,6 +97,21 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
+ 	}
+ 
+ 	p.data = &nginxStatusData{
++		workerProcesses: prometheus.NewDesc(
++			prometheus.BuildFQName(namespace, subSystem, "worker_processes"),
++			"max worker processes",
++			nil, constLabels),
++
++		workerConnections: prometheus.NewDesc(
++			prometheus.BuildFQName(namespace, subSystem, "worker_connections"),
++			"max worker connections",
++			nil, constLabels),
++
++		workerRlimitNofile: prometheus.NewDesc(
++			prometheus.BuildFQName(namespace, subSystem, "worker_rlimit_nofile"),
++			"max worker rlimit nofile",
++			nil, constLabels),
++
+ 		connectionsTotal: prometheus.NewDesc(
+ 			prometheus.BuildFQName(PrometheusNamespace, subSystem, "connections_total"),
+ 			"total number of connections with state {accepted, handled}",
+@@ -107,6 +133,9 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
+ 
+ // Describe implements prometheus.Collector.
+ func (p nginxStatusCollector) Describe(ch chan<- *prometheus.Desc) {
++	ch <- p.data.workerProcesses
++	ch <- p.data.workerConnections
++	ch <- p.data.workerRlimitNofile
+ 	ch <- p.data.connectionsTotal
+ 	ch <- p.data.requestsTotal
+ 	ch <- p.data.connections
+@@ -131,6 +160,18 @@ func (p nginxStatusCollector) Stop() {
+ 	close(p.scrapeChan)
+ }
+ 
++func (p nginxStatusCollector) SetWorkerConnections(n int) {
++	p.workerConnections = n
++}
++
++func (p nginxStatusCollector) SetWorkerProcesses(n int) {
++	p.workerProcesses = n
++}
++
++func (p nginxStatusCollector) SetWorkerRlimitNofile(n int) {
++	p.workerRlimitNofile = n
++}
++
+ func toInt(data []string, pos int) int {
+ 	if len(data) == 0 {
+ 		return 0
+@@ -179,6 +220,12 @@ func (p nginxStatusCollector) scrape(ch chan<- prometheus.Metric) {
+ 
+ 	s := parse(string(data))
+ 
++	ch <- prometheus.MustNewConstMetric(p.data.workerConnections,
++		prometheus.GaugeValue, float64(p.workerConnections))
++	ch <- prometheus.MustNewConstMetric(p.data.workerProcesses,
++		prometheus.GaugeValue, float64(p.workerProcesses))
++	ch <- prometheus.MustNewConstMetric(p.data.workerRlimitNofile,
++		prometheus.GaugeValue, float64(p.workerRlimitNofile))
+ 	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,
+ 		prometheus.CounterValue, float64(s.Accepted), "accepted")
+ 	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,
+diff --git a/internal/ingress/metric/main.go b/internal/ingress/metric/main.go
+index 93c31622c..4c21c7141 100644
+--- a/internal/ingress/metric/main.go
++++ b/internal/ingress/metric/main.go
+@@ -41,6 +41,10 @@ type Collector interface {
+ 	OnStartedLeading(string)
+ 	OnStoppedLeading(string)
+ 
++	SetWorkerConnections(n int)
++	SetWorkerProcesses(n int)
++	SetWorkerRlimitNofile(n int)
++
+ 	IncCheckCount(string, string)
+ 	IncCheckErrorCount(string, string)
+ 	IncOrphanIngress(string, string, string)
+@@ -115,6 +119,18 @@ func (c *collector) ConfigSuccess(hash uint64, success bool) {
+ 	c.ingressController.ConfigSuccess(hash, success)
+ }
+ 
++func (c *collector) SetWorkerConnections(n int) {
++	c.nginxStatus.SetWorkerConnections(n)
++}
++
++func (c *collector) SetWorkerProcesses(n int) {
++	c.nginxStatus.SetWorkerProcesses(n)
++}
++
++func (c *collector) SetWorkerRlimitNofile(n int) {
++	c.nginxStatus.SetWorkerRlimitNofile(n)
++}
++
+ func (c *collector) IncCheckCount(namespace, name string) {
+ 	c.ingressController.IncCheckCount(namespace, name)
+ }

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/new-metrics.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/new-metrics.patch
@@ -1,98 +1,91 @@
-diff --git a/internal/ingress/controller/nginx.go b/internal/ingress/controller/nginx.go
-index e19ee8bb3..8d340af7c 100644
---- a/internal/ingress/controller/nginx.go
-+++ b/internal/ingress/controller/nginx.go
-@@ -138,7 +138,8 @@ func NewNGINXController(config *Configuration, mc metric.Collector) *NGINXContro
- 		config.DisableCatchAll,
- 		config.DeepInspector,
- 		config.IngressClassConfiguration,
--		config.DisableSyncEvents)
-+		config.DisableSyncEvents,
-+		mc)
- 
- 	n.syncQueue = task.NewTaskQueue(n.syncIngress)
- 
 diff --git a/internal/ingress/controller/store/store.go b/internal/ingress/controller/store/store.go
-index 284f53209..1f07fd047 100644
+index 284f53209..3e00ae2b5 100644
 --- a/internal/ingress/controller/store/store.go
 +++ b/internal/ingress/controller/store/store.go
-@@ -23,6 +23,7 @@ import (
- 	"os"
- 	"reflect"
- 	"sort"
-+	"strconv"
- 	"strings"
- 	"sync"
- 	"time"
-@@ -55,6 +56,7 @@ import (
+@@ -55,6 +55,7 @@ import (
  	ngx_template "k8s.io/ingress-nginx/internal/ingress/controller/template"
  	"k8s.io/ingress-nginx/internal/ingress/defaults"
  	"k8s.io/ingress-nginx/internal/ingress/errors"
-+	"k8s.io/ingress-nginx/internal/ingress/metric"
++	"k8s.io/ingress-nginx/internal/ingress/metric/collectors"
  	"k8s.io/ingress-nginx/internal/ingress/resolver"
  	"k8s.io/ingress-nginx/internal/k8s"
  	"k8s.io/ingress-nginx/pkg/apis/ingress"
-@@ -219,6 +221,8 @@ type k8sStore struct {
- 	// listers contains the cache.Store interfaces used in the ingress controller
- 	listers *Lister
- 
-+	mc metric.Collector
-+
- 	// sslStore local store of SSL certificates (certificates used in ingress)
- 	// this is required because the certificates must be present in the
- 	// container filesystem
-@@ -256,12 +260,14 @@ func New(
- 	deepInspector bool,
- 	icConfig *ingressclass.Configuration,
- 	disableSyncEvents bool,
-+	mc metric.Collector,
- ) Storer {
- 	store := &k8sStore{
- 		informers:             &Informer{},
- 		listers:               &Lister{},
- 		sslStore:              NewSSLCertTracker(),
- 		updateCh:              updateCh,
-+		mc:                    mc,
- 		backendConfig:         ngx_config.NewDefault(),
- 		syncSecretMu:          &sync.Mutex{},
- 		backendConfigMu:       &sync.RWMutex{},
-@@ -269,6 +275,12 @@ func New(
+@@ -269,6 +270,8 @@ func New(
  		defaultSSLCertificate: defaultSSLCertificate,
  	}
  
-+	if n, err := strconv.Atoi(store.backendConfig.WorkerProcesses); err == nil {
-+		store.mc.SetWorkerProcesses(n)
-+	}
-+	store.mc.SetWorkerConnections(store.backendConfig.MaxWorkerConnections)
-+	store.mc.SetWorkerRlimitNofile(store.backendConfig.MaxWorkerOpenFiles)
++	collectors.WorkerStatusInstance.Set(store.backendConfig.MaxWorkerConnections, store.backendConfig.MaxWorkerOpenFiles, store.backendConfig.WorkerProcesses)
 +
  	eventBroadcaster := record.NewBroadcaster()
  	eventBroadcaster.StartLogging(klog.Infof)
  	if !disableSyncEvents {
-@@ -1214,6 +1226,11 @@ func (s *k8sStore) setConfig(cmap *corev1.ConfigMap) {
- 		klog.Warning("The GeoIP2 feature is enabled but the databases are missing. Disabling")
+@@ -1215,6 +1218,8 @@ func (s *k8sStore) setConfig(cmap *corev1.ConfigMap) {
  		s.backendConfig.UseGeoIP2 = false
  	}
-+	if n, err := strconv.Atoi(s.backendConfig.WorkerProcesses); err == nil {
-+		s.mc.SetWorkerProcesses(n)
-+	}
-+	s.mc.SetWorkerConnections(s.backendConfig.MaxWorkerConnections)
-+	s.mc.SetWorkerRlimitNofile(s.backendConfig.MaxWorkerOpenFiles)
  
++	collectors.WorkerStatusInstance.Set(s.backendConfig.MaxWorkerConnections, s.backendConfig.MaxWorkerOpenFiles, s.backendConfig.WorkerProcesses)
++
  	s.writeSSLSessionTicketKey(cmap, "/etc/ingress-controller/tickets.key")
  }
+ 
 diff --git a/internal/ingress/metric/collectors/nginx_status.go b/internal/ingress/metric/collectors/nginx_status.go
-index f3afdc334..e196c5c49 100644
+index f3afdc334..cf20ab601 100644
 --- a/internal/ingress/metric/collectors/nginx_status.go
 +++ b/internal/ingress/metric/collectors/nginx_status.go
-@@ -39,12 +39,19 @@ type (
- 		scrapeChan chan scrapeRequest
+@@ -17,13 +17,14 @@ limitations under the License.
+ package collectors
  
- 		data *nginxStatusData
+ import (
+-	"log"
+-	"regexp"
+-	"strconv"
+-
+ 	"github.com/prometheus/client_golang/prometheus"
+ 	"k8s.io/ingress-nginx/internal/nginx"
+ 	"k8s.io/klog/v2"
++	"log"
++	"regexp"
++	"runtime"
++	"strconv"
++	"sync"
+ )
+ 
+ var (
+@@ -34,6 +35,33 @@ var (
+ 	waiting = regexp.MustCompile(`Waiting: (\d+)`)
+ )
+ 
++type WorkerStatus struct {
++	WorkerConnections  int
++	WorkerProcesses    int
++	WorkerRlimitNofile int
++	Lock               sync.Mutex
++}
 +
-+		workerConnections  int
-+		workerProcesses    int
-+		workerRlimitNofile int
++func (w *WorkerStatus) Set(workerConnections, workerRlimitNofile int, workerProcesses string) {
++	w.Lock.Lock()
++	defer w.Lock.Unlock()
++	w.WorkerConnections = workerConnections
++	w.WorkerRlimitNofile = workerRlimitNofile
++	if n, err := strconv.Atoi(workerProcesses); err == nil {
++		w.WorkerProcesses = n
++	} else {
++		w.WorkerProcesses = runtime.NumCPU()
++	}
++}
++
++func (w *WorkerStatus) Get() (int, int, int) {
++	w.Lock.Lock()
++	defer w.Lock.Unlock()
++	return w.WorkerConnections, w.WorkerProcesses, w.WorkerRlimitNofile
++}
++
++var WorkerStatusInstance = &WorkerStatus{}
++
+ type (
+ 	nginxStatusCollector struct {
+ 		scrapeChan chan scrapeRequest
+@@ -42,9 +70,12 @@ type (
  	}
  
  	nginxStatusData struct {
@@ -108,40 +101,29 @@ index f3afdc334..e196c5c49 100644
  	}
  
  	basicStatus struct {
-@@ -69,6 +76,10 @@ type (
- type NGINXStatusCollector interface {
- 	prometheus.Collector
- 
-+	SetWorkerConnections(workerConnections int)
-+	SetWorkerProcesses(workerProcesses int)
-+	SetWorkerRlimitNofile(workerRlimitNofile int)
-+
- 	Start()
- 	Stop()
- }
-@@ -86,6 +97,21 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
+@@ -86,6 +117,21 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
  	}
  
  	p.data = &nginxStatusData{
 +		workerProcesses: prometheus.NewDesc(
 +			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_processes"),
-+			"max worker processes",
++			"worker processes",
 +			nil, constLabels),
 +
 +		workerConnections: prometheus.NewDesc(
-+			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_connections"),
-+			"max worker connections",
++			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_max_connections"),
++			"worker max connections",
 +			nil, constLabels),
 +
 +		workerRlimitNofile: prometheus.NewDesc(
 +			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_rlimit_nofile"),
-+			"max worker rlimit nofile",
++			"worker rlimit nofile",
 +			nil, constLabels),
 +
  		connectionsTotal: prometheus.NewDesc(
  			prometheus.BuildFQName(PrometheusNamespace, subSystem, "connections_total"),
  			"total number of connections with state {accepted, handled}",
-@@ -107,6 +133,9 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
+@@ -107,6 +153,9 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
  
  // Describe implements prometheus.Collector.
  func (p nginxStatusCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -151,89 +133,18 @@ index f3afdc334..e196c5c49 100644
  	ch <- p.data.connectionsTotal
  	ch <- p.data.requestsTotal
  	ch <- p.data.connections
-@@ -131,6 +160,18 @@ func (p nginxStatusCollector) Stop() {
- 	close(p.scrapeChan)
- }
- 
-+func (p nginxStatusCollector) SetWorkerConnections(n int) {
-+	p.workerConnections = n
-+}
-+
-+func (p nginxStatusCollector) SetWorkerProcesses(n int) {
-+	p.workerProcesses = n
-+}
-+
-+func (p nginxStatusCollector) SetWorkerRlimitNofile(n int) {
-+	p.workerRlimitNofile = n
-+}
-+
- func toInt(data []string, pos int) int {
- 	if len(data) == 0 {
- 		return 0
-@@ -179,6 +220,12 @@ func (p nginxStatusCollector) scrape(ch chan<- prometheus.Metric) {
+@@ -179,6 +228,14 @@ func (p nginxStatusCollector) scrape(ch chan<- prometheus.Metric) {
  
  	s := parse(string(data))
  
++	workerConnections, workerProcesses, workerRlimitNofile := WorkerStatusInstance.Get()
++
 +	ch <- prometheus.MustNewConstMetric(p.data.workerConnections,
-+		prometheus.GaugeValue, float64(p.workerConnections))
++		prometheus.GaugeValue, float64(workerConnections))
 +	ch <- prometheus.MustNewConstMetric(p.data.workerProcesses,
-+		prometheus.GaugeValue, float64(p.workerProcesses))
++		prometheus.GaugeValue, float64(workerProcesses))
 +	ch <- prometheus.MustNewConstMetric(p.data.workerRlimitNofile,
-+		prometheus.GaugeValue, float64(p.workerRlimitNofile))
++		prometheus.GaugeValue, float64(workerRlimitNofile))
  	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,
  		prometheus.CounterValue, float64(s.Accepted), "accepted")
  	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,
-diff --git a/internal/ingress/metric/dummy.go b/internal/ingress/metric/dummy.go
-index 7b1485280..3763d750d 100644
---- a/internal/ingress/metric/dummy.go
-+++ b/internal/ingress/metric/dummy.go
-@@ -62,6 +62,15 @@ func (dc DummyCollector) Start(_ string) {}
- // Stop dummy implementation
- func (dc DummyCollector) Stop(_ string) {}
- 
-+// SetWorkerConnections dummy implementation
-+func (dc DummyCollector) SetWorkerConnections(n int) {}
-+
-+// SetWorkerProcesses dummy implementation
-+func (dc DummyCollector) SetWorkerProcesses(n int) {}
-+
-+// SetWorkerRlimitNofile dummy implementation
-+func (dc DummyCollector) SetWorkerRlimitNofile(n int) {}
-+
- // SetSSLInfo dummy implementation
- func (dc DummyCollector) SetSSLInfo([]*ingress.Server) {}
- 
-diff --git a/internal/ingress/metric/main.go b/internal/ingress/metric/main.go
-index 93c31622c..4c21c7141 100644
---- a/internal/ingress/metric/main.go
-+++ b/internal/ingress/metric/main.go
-@@ -41,6 +41,10 @@ type Collector interface {
- 	OnStartedLeading(string)
- 	OnStoppedLeading(string)
- 
-+	SetWorkerConnections(n int)
-+	SetWorkerProcesses(n int)
-+	SetWorkerRlimitNofile(n int)
-+
- 	IncCheckCount(string, string)
- 	IncCheckErrorCount(string, string)
- 	IncOrphanIngress(string, string, string)
-@@ -115,6 +119,18 @@ func (c *collector) ConfigSuccess(hash uint64, success bool) {
- 	c.ingressController.ConfigSuccess(hash, success)
- }
- 
-+func (c *collector) SetWorkerConnections(n int) {
-+	c.nginxStatus.SetWorkerConnections(n)
-+}
-+
-+func (c *collector) SetWorkerProcesses(n int) {
-+	c.nginxStatus.SetWorkerProcesses(n)
-+}
-+
-+func (c *collector) SetWorkerRlimitNofile(n int) {
-+	c.nginxStatus.SetWorkerRlimitNofile(n)
-+}
-+
- func (c *collector) IncCheckCount(namespace, name string) {
- 	c.ingressController.IncCheckCount(namespace, name)
- }

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/new-metrics.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/new-metrics.patch
@@ -126,17 +126,17 @@ index f3afdc334..e196c5c49 100644
 +		workerProcesses: prometheus.NewDesc(
 +			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_processes"),
 +			"max worker processes",
-+			[]string{"state"}, constLabels),
++			nil, constLabels),
 +
 +		workerConnections: prometheus.NewDesc(
 +			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_connections"),
 +			"max worker connections",
-+			[]string{"state"}, constLabels),
++			nil, constLabels),
 +
 +		workerRlimitNofile: prometheus.NewDesc(
 +			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_rlimit_nofile"),
 +			"max worker rlimit nofile",
-+			[]string{"state"}, constLabels),
++			nil, constLabels),
 +
  		connectionsTotal: prometheus.NewDesc(
  			prometheus.BuildFQName(PrometheusNamespace, subSystem, "connections_total"),

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/new-metrics.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/new-metrics.patch
@@ -183,6 +183,26 @@ index f3afdc334..e196c5c49 100644
  	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,
  		prometheus.CounterValue, float64(s.Accepted), "accepted")
  	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,
+diff --git a/internal/ingress/metric/dummy.go b/internal/ingress/metric/dummy.go
+index 7b1485280..3763d750d 100644
+--- a/internal/ingress/metric/dummy.go
++++ b/internal/ingress/metric/dummy.go
+@@ -62,6 +62,15 @@ func (dc DummyCollector) Start(_ string) {}
+ // Stop dummy implementation
+ func (dc DummyCollector) Stop(_ string) {}
+ 
++// SetWorkerConnections dummy implementation
++func (dc DummyCollector) SetWorkerConnections(n int) {}
++
++// SetWorkerProcesses dummy implementation
++func (dc DummyCollector) SetWorkerProcesses(n int) {}
++
++// SetWorkerRlimitNofile dummy implementation
++func (dc DummyCollector) SetWorkerRlimitNofile(n int) {}
++
+ // SetSSLInfo dummy implementation
+ func (dc DummyCollector) SetSSLInfo([]*ingress.Server) {}
+ 
 diff --git a/internal/ingress/metric/main.go b/internal/ingress/metric/main.go
 index 93c31622c..4c21c7141 100644
 --- a/internal/ingress/metric/main.go

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -59,6 +59,7 @@ COPY patches/metrics-SetSSLExpireTime.patch /
 COPY patches/util.patch /
 COPY patches/fix-cleanup.patch /
 COPY patches/geoip.patch /
+COPY patches/new-metrics.patch /
 ENV GOARCH=amd64
 RUN git clone --branch $CONTROLLER_BRANCH --depth 1 ${SOURCE_REPO}/kubernetes/ingress-nginx.git /src && \
     # jaegertracing hunter deps
@@ -70,6 +71,7 @@ RUN git clone --branch $CONTROLLER_BRANCH --depth 1 ${SOURCE_REPO}/kubernetes/in
     patch -p1 < /util.patch && \
     patch -p1 < /fix-cleanup.patch && \
     patch -p1 < /geoip.patch && \
+    patch -p1 < /new-metrics.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # Build nginx for ingress controller

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/README.md
@@ -61,3 +61,7 @@ Build nginx for controller on ALT Linux.
 ### GeoIP
 
 https://github.com/kubernetes/ingress-nginx/pull/10495
+
+### new metrics
+
+This patch adds worker max connections, worker processes and worker max open files metrics.

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/new-metrics.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/new-metrics.patch
@@ -1,0 +1,171 @@
+diff --git a/internal/ingress/controller/store/store.go b/internal/ingress/controller/store/store.go
+index 284f53209..3e00ae2b5 100644
+--- a/internal/ingress/controller/store/store.go
++++ b/internal/ingress/controller/store/store.go
+@@ -55,6 +55,7 @@ import (
+ 	ngx_template "k8s.io/ingress-nginx/internal/ingress/controller/template"
+ 	"k8s.io/ingress-nginx/internal/ingress/defaults"
+ 	"k8s.io/ingress-nginx/internal/ingress/errors"
++	"k8s.io/ingress-nginx/internal/ingress/metric/collectors"
+ 	"k8s.io/ingress-nginx/internal/ingress/resolver"
+ 	"k8s.io/ingress-nginx/internal/k8s"
+ 	"k8s.io/ingress-nginx/pkg/apis/ingress"
+@@ -269,6 +270,8 @@ func New(
+ 		defaultSSLCertificate: defaultSSLCertificate,
+ 	}
+ 
++	collectors.WorkerStatusInstance.Set(store.backendConfig.MaxWorkerConnections, store.backendConfig.MaxWorkerOpenFiles, store.backendConfig.WorkerProcesses)
++
+ 	eventBroadcaster := record.NewBroadcaster()
+ 	eventBroadcaster.StartLogging(klog.Infof)
+ 	if !disableSyncEvents {
+@@ -1215,6 +1218,8 @@ func (s *k8sStore) setConfig(cmap *corev1.ConfigMap) {
+ 		s.backendConfig.UseGeoIP2 = false
+ 	}
+ 
++	collectors.WorkerStatusInstance.Set(s.backendConfig.MaxWorkerConnections, s.backendConfig.MaxWorkerOpenFiles, s.backendConfig.WorkerProcesses)
++
+ 	s.writeSSLSessionTicketKey(cmap, "/etc/ingress-controller/tickets.key")
+ }
+ 
+diff --git a/internal/ingress/metric/collectors/nginx_status.go b/internal/ingress/metric/collectors/nginx_status.go
+index f3afdc334..c9fe50594 100644
+--- a/internal/ingress/metric/collectors/nginx_status.go
++++ b/internal/ingress/metric/collectors/nginx_status.go
+@@ -17,13 +17,15 @@ limitations under the License.
+ package collectors
+ 
+ import (
+-	"log"
+-	"regexp"
+-	"strconv"
+-
+ 	"github.com/prometheus/client_golang/prometheus"
+ 	"k8s.io/ingress-nginx/internal/nginx"
+ 	"k8s.io/klog/v2"
++	"log"
++	"regexp"
++	"runtime"
++	"strconv"
++	"sync"
++	"syscall"
+ )
+ 
+ var (
+@@ -34,6 +36,53 @@ var (
+ 	waiting = regexp.MustCompile(`Waiting: (\d+)`)
+ )
+ 
++type WorkerStatus struct {
++	WorkerConnections  int
++	WorkerProcesses    int
++	WorkerRlimitNofile int
++	Lock               sync.Mutex
++}
++
++func rlimitMaxNumFiles() int {
++	var rLimit syscall.Rlimit
++	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {
++		return 0
++	}
++	return int(rLimit.Max)
++}
++
++func (w *WorkerStatus) Set(workerConnections, workerRlimitNofile int, workerProcesses string) {
++	w.Lock.Lock()
++	defer w.Lock.Unlock()
++	if workerRlimitNofile == 0 {
++		maxOpenFiles := rlimitMaxNumFiles() - 1024
++		if maxOpenFiles < 1024 {
++			maxOpenFiles = 1024
++		}
++		workerRlimitNofile = maxOpenFiles
++	}
++	w.WorkerRlimitNofile = workerRlimitNofile
++
++	if workerConnections == 0 {
++		workerConnections = int(float64(workerRlimitNofile * 3.0 / 4))
++	}
++	w.WorkerConnections = workerConnections
++
++	if n, err := strconv.Atoi(workerProcesses); err == nil {
++		w.WorkerProcesses = n
++	} else {
++		w.WorkerProcesses = runtime.NumCPU()
++	}
++}
++
++func (w *WorkerStatus) Get() (int, int, int) {
++	w.Lock.Lock()
++	defer w.Lock.Unlock()
++	return w.WorkerConnections, w.WorkerProcesses, w.WorkerRlimitNofile
++}
++
++var WorkerStatusInstance = &WorkerStatus{}
++
+ type (
+ 	nginxStatusCollector struct {
+ 		scrapeChan chan scrapeRequest
+@@ -42,9 +91,12 @@ type (
+ 	}
+ 
+ 	nginxStatusData struct {
+-		connectionsTotal *prometheus.Desc
+-		requestsTotal    *prometheus.Desc
+-		connections      *prometheus.Desc
++		workerConnections  *prometheus.Desc
++		workerProcesses    *prometheus.Desc
++		workerRlimitNofile *prometheus.Desc
++		connectionsTotal   *prometheus.Desc
++		requestsTotal      *prometheus.Desc
++		connections        *prometheus.Desc
+ 	}
+ 
+ 	basicStatus struct {
+@@ -86,6 +138,21 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
+ 	}
+ 
+ 	p.data = &nginxStatusData{
++		workerProcesses: prometheus.NewDesc(
++			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_processes"),
++			"worker processes",
++			nil, constLabels),
++
++		workerConnections: prometheus.NewDesc(
++			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_max_connections"),
++			"worker max connections",
++			nil, constLabels),
++
++		workerRlimitNofile: prometheus.NewDesc(
++			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_rlimit_nofile"),
++			"worker rlimit nofile",
++			nil, constLabels),
++
+ 		connectionsTotal: prometheus.NewDesc(
+ 			prometheus.BuildFQName(PrometheusNamespace, subSystem, "connections_total"),
+ 			"total number of connections with state {accepted, handled}",
+@@ -107,6 +174,9 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
+ 
+ // Describe implements prometheus.Collector.
+ func (p nginxStatusCollector) Describe(ch chan<- *prometheus.Desc) {
++	ch <- p.data.workerProcesses
++	ch <- p.data.workerConnections
++	ch <- p.data.workerRlimitNofile
+ 	ch <- p.data.connectionsTotal
+ 	ch <- p.data.requestsTotal
+ 	ch <- p.data.connections
+@@ -179,6 +249,14 @@ func (p nginxStatusCollector) scrape(ch chan<- prometheus.Metric) {
+ 
+ 	s := parse(string(data))
+ 
++	workerConnections, workerProcesses, workerRlimitNofile := WorkerStatusInstance.Get()
++
++	ch <- prometheus.MustNewConstMetric(p.data.workerConnections,
++		prometheus.GaugeValue, float64(workerConnections))
++	ch <- prometheus.MustNewConstMetric(p.data.workerProcesses,
++		prometheus.GaugeValue, float64(workerProcesses))
++	ch <- prometheus.MustNewConstMetric(p.data.workerRlimitNofile,
++		prometheus.GaugeValue, float64(workerRlimitNofile))
+ 	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,
+ 		prometheus.CounterValue, float64(s.Accepted), "accepted")
+ 	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,


### PR DESCRIPTION
## Description
It provides new metrics for the nginx ingress controller.

## Why do we need it, and what problem does it solve?
Fixes #9914 
New metrics can be useful for analyzing nginx performance.

## What is the expected result?

Worker processes:
<img width="1152" alt="Screenshot 2024-10-17 at 4 07 57 PM" src="https://github.com/user-attachments/assets/ebba254b-91a8-4e48-a3e8-b273eafbf96a">


Worker max connections:
<img width="1185" alt="Screenshot 2024-10-17 at 4 07 16 PM" src="https://github.com/user-attachments/assets/53063388-b64c-47c6-9c72-b1fd83c68636">

Change worker max connections in the config map:
<img width="1196" alt="Screenshot 2024-10-17 at 4 13 24 PM" src="https://github.com/user-attachments/assets/d2d6bd1a-1117-49c4-a610-435eab05d8a1">


Open files limit:
<img width="1170" alt="Screenshot 2024-10-17 at 4 06 24 PM" src="https://github.com/user-attachments/assets/ccb55ee4-9f1d-44b7-bb4c-eee04f247cc3">


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: feature
summary: Add worker_max_connections, worker_processes and worker_rlimit_nofile metrics.
impact: ingress-nginx controllers' pods will be recreated.
impact_level: default
```
