### PR TITLE
[kind] Accomodate for base64 BSD/Linux differences

### DIFF
--- a/tools/kind-d8.sh
+++ b/tools/kind-d8.sh
@@ -147,7 +147,7 @@ os_detect() {
   OS_NAME="${OS_NAME// /}"
 
   # Supported on ...
-  if [[ ("$OS_NAME" == "Ubuntu") || ("$OS_NAME" == "Debian") || ("$OS_NAME" == "debian") ]]; then
+  if [[ ("$OS_NAME" == "Ubuntu") || ("$OS_NAME" == "ubuntu") || ("$OS_NAME" == "Debian") || ("$OS_NAME" == "debian") ]]; then
     OS_NAME=linux
   elif [[ ("$OS_NAME" != "mac") && ("$OS_NAME" != "linux") ]]; then
     OS_NAME=

--- a/tools/kind-d8.sh
+++ b/tools/kind-d8.sh
@@ -578,8 +578,9 @@ ingress_check() {
 }
 
 generate_ee_access_string() {
-  auth_part=$(echo -n "license-token:$1" | base64 -w0)
-  D8_EE_ACCESS_STRING=$(echo -n "{\"auths\": { \"$D8_REGISTRY_ADDRESS\": { \"username\": \"license-token\", \"password\": \"$1\", \"auth\": \"$auth_part\"}}}" | base64 -w0)
+  if [ "$OS_NAME" != "mac" ]; then B64_ARG="-w0"; else B64_ARG=""; fi
+  auth_part=$(echo -n "license-token:$1" | base64 $B64_ARG)
+  D8_EE_ACCESS_STRING=$(echo -n "{\"auths\": { \"$D8_REGISTRY_ADDRESS\": { \"username\": \"license-token\", \"password\": \"$1\", \"auth\": \"$auth_part\"}}}" | base64 $B64_ARG)
 
   if [ "$?" -ne "0" ]; then
     echo "Error generation container registry access string for Deckhouse Kubernetes Platform Enterprise Edition"

--- a/tools/kind-d8.sh
+++ b/tools/kind-d8.sh
@@ -147,7 +147,7 @@ os_detect() {
   OS_NAME="${OS_NAME// /}"
 
   # Supported on ...
-  if [[ ("$OS_NAME" == "Ubuntu") || ("$OS_NAME" == "Debian") ]]; then
+  if [[ ("$OS_NAME" == "Ubuntu") || ("$OS_NAME" == "Debian") || ("$OS_NAME" == "debian") ]]; then
     OS_NAME=linux
   elif [[ ("$OS_NAME" != "mac") && ("$OS_NAME" != "linux") ]]; then
     OS_NAME=


### PR DESCRIPTION
## Description
- Added a check condition to construct correct base64 arguments on different platforms
- Fix ubuntu/debian detection for lowercase distribution names

## Why do we need it, and what problem does it solve?
Base64 program versions for macOS  and Linux take different arguments. I've added a check condition to fix following error when installing from macOS:
```
base64: invalid option -- w
```

## Why do we need it in the patch release (if we do)?


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fixes for Kind Getting Started EE installation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
