### PR TITLE
[dhctl] Fix only one resource will create for namespace if it namespace does not exist

### DIFF
--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -190,6 +190,7 @@ func (c *Creator) ensureRequiredNamespacesExist() (map[int]struct{}, error) {
 				resourcesToSkipInCurrentIteration[i] = struct{}{}
 				knownNamespaces[nsName] = false
 				log.DebugF("Namespace was not found for resource %s\n", res.String())
+				continue
 			}
 			cancel()
 			knownNamespaces[nsName] = true

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -75,3 +75,29 @@ metadata:
   namespace: d8-system
 data:
   .file: "content"
+---
+# testing creating multiple resources for one non exists resource
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller-sa
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/name: argocd-application-controller-sa
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+  annotations:
+    kubernetes.io/service-account.name: argocd-application-controller-sa
+type: kubernetes.io/service-account-token

--- a/testing/cloud_layouts/Azure/Standard/resources.yaml
+++ b/testing/cloud_layouts/Azure/Standard/resources.yaml
@@ -65,3 +65,29 @@ metadata:
   namespace: d8-system
 data:
   .file: "content"
+---
+# testing creating multiple resources for one non exists resource
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller-sa
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/name: argocd-application-controller-sa
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+  annotations:
+    kubernetes.io/service-account.name: argocd-application-controller-sa
+type: kubernetes.io/service-account-token

--- a/testing/cloud_layouts/EKS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/resources.yaml
@@ -20,3 +20,29 @@ metadata:
   namespace: d8-system
 data:
   .file: "content"
+---
+# testing creating multiple resources for one non exists resource
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller-sa
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/name: argocd-application-controller-sa
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+  annotations:
+    kubernetes.io/service-account.name: argocd-application-controller-sa
+type: kubernetes.io/service-account-token

--- a/testing/cloud_layouts/GCP/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/GCP/WithoutNAT/resources.yaml
@@ -59,3 +59,29 @@ metadata:
   namespace: d8-system
 data:
   .file: "content"
+---
+# testing creating multiple resources for one non exists resource
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller-sa
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/name: argocd-application-controller-sa
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+  annotations:
+    kubernetes.io/service-account.name: argocd-application-controller-sa
+type: kubernetes.io/service-account-token

--- a/testing/cloud_layouts/OpenStack/Standard/resources.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/resources.yaml
@@ -71,3 +71,29 @@ metadata:
   namespace: d8-system
 data:
   .file: "content"
+---
+# testing creating multiple resources for one non exists resource
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller-sa
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/name: argocd-application-controller-sa
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+  annotations:
+    kubernetes.io/service-account.name: argocd-application-controller-sa
+type: kubernetes.io/service-account-token

--- a/testing/cloud_layouts/Static/resources.tpl.yaml
+++ b/testing/cloud_layouts/Static/resources.tpl.yaml
@@ -159,3 +159,29 @@ metadata:
   namespace: d8-system
 data:
   .file: "content"
+---
+# testing creating multiple resources for one non exists resource
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller-sa
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/name: argocd-application-controller-sa
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+  annotations:
+    kubernetes.io/service-account.name: argocd-application-controller-sa
+type: kubernetes.io/service-account-token

--- a/testing/cloud_layouts/VCD/Standard/resources.tpl.yaml
+++ b/testing/cloud_layouts/VCD/Standard/resources.tpl.yaml
@@ -74,3 +74,29 @@ metadata:
   namespace: d8-system
 data:
   .file: "content"
+---
+# testing creating multiple resources for one non exists resource
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller-sa
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/name: argocd-application-controller-sa
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+  annotations:
+    kubernetes.io/service-account.name: argocd-application-controller-sa
+type: kubernetes.io/service-account-token

--- a/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/resources.yaml
@@ -80,3 +80,29 @@ metadata:
   namespace: d8-system
 data:
   .file: "content"
+---
+# testing creating multiple resources for one non exists resource
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller-sa
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/name: argocd-application-controller-sa
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+  annotations:
+    kubernetes.io/service-account.name: argocd-application-controller-sa
+type: kubernetes.io/service-account-token

--- a/testing/cloud_layouts/vSphere/Standard/resources.yaml
+++ b/testing/cloud_layouts/vSphere/Standard/resources.yaml
@@ -97,3 +97,29 @@ metadata:
   namespace: d8-system
 data:
   .file: "content"
+---
+# testing creating multiple resources for one non exists resource
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller-sa
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/name: argocd-application-controller-sa
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-application-controller-sa
+  namespace: test-ns-with-multiple-resources
+  annotations:
+    kubernetes.io/service-account.name: argocd-application-controller-sa
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
## Description
Fix only one resource will create for namespace if it namespace does not exist
Affect DKP == 1.64.3

Fix https://github.com/deckhouse/deckhouse/pull/9714

## Why do we need it, and what problem does it solve?
When multiple resources will be created in namespace (which will be created in resources.yaml), we wait namespace creation only one firs resource. Another resources will skip by bug in the code 


## Why do we need it in the patch release (if we do)?

Cannot create all resources by resources.yaml

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Only one resource will create for namespace if it namespace does not exist.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
