### PR TITLE
[docs] Fix second level topnav menu for GS and guides sections

### DIFF
--- a/docs/site/js/customscripts.js
+++ b/docs/site/js/customscripts.js
@@ -5,6 +5,18 @@ $( document ).ready(function() {
             if (e.target.value.length > 0 ) $(".search__results").addClass("active");
             else $(".search__results").removeClass("active");
           });
+
+    // Fix second level topnav menu for GS and guides sections.
+    let subUrls = ['/gs/', '/guides/'];
+    subUrls.forEach(function(element) {
+      if (window.location.pathname.toLowerCase().includes(element)) {
+        $('.header.header__product-menu ul.nav li').each(function () {
+          if ($(this).find('a').attr('href').toLowerCase().includes(element)) $(this).addClass('active');
+          else $(this).removeClass('active');
+        });
+      }
+    });
+
 });
 
 document.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
## Description
Fix second level topnav menu for GS and guides sections on the site.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix second level topnav menu for GS and guides sections on the site.
impact_level: low
```
