### PR TITLE
[kind] Force QEMU on macOS for eviction-thresholds-exporter

### DIFF
--- a/tools/kind-d8.sh
+++ b/tools/kind-d8.sh
@@ -546,6 +546,12 @@ deckhouse_install() {
   fi
 }
 
+macos_force_qemu() {
+  if [ "$OS_NAME" = "mac" ]
+  then ${KUBECTL_PATH} --context kind-"${KIND_CLUSTER_NAME}" patch daemonset node-exporter -n d8-monitoring --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/1/env/-", "value": {"name": "EXPERIMENTAL_DOCKER_DESKTOP_FORCE_QEMU", "value": "1"}}]' 2>/dev/null
+  fi
+}
+
 ingress_check() {
   local retries_max=100
   local retries_count=0
@@ -654,6 +660,7 @@ main() {
   configs_create
   cluster_create
   deckhouse_install
+  macos_force_qemu
   ingress_check
   installation_finish
 }


### PR DESCRIPTION
## Description
Patch `kubelet-eviction-thresholds-exporter` container in `node-exporter` daemonset with variable `EXPERIMENTAL_DOCKER_DESKTOP_FORCE_QEMU=1` if run on macOS

A bit of a hack, but I don't think we should add specific handlers like this outside of the `kind-d8.sh` script.

Fixes https://github.com/deckhouse/deckhouse/issues/7069

## Why do we need it, and what problem does it solve?
The problem with threshold-exporter crashing is caused by enabled Rosetta emulation in Docker Desktop on Apple Silicon Macs
You can target it by passing the aforementioned env to container. Apparently, it even works if container is launched inside of another container such as kind
https://github.com/solo-io/gloo/issues/9800#issuecomment-2253078909

Another fix is to just disable `Use Rosetta for x86_64/amd64 emulation on Apple Silicon` in Docker Desktop settings.
## Why do we need it in the patch release (if we do)?

No

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fix kind clusters on Apple Silicon macs
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
