### PR TITLE
[deckhouse-controller] Add requirements key for desired disabled modules

### DIFF
--- a/go_lib/dependency/requirements/requirements.go
+++ b/go_lib/dependency/requirements/requirements.go
@@ -72,6 +72,8 @@ func CheckRequirement(key, value string, enabledModules ...set.Set) (bool, error
 		if blocked {
 			return false, fmt.Errorf("%q modules have to be disabled", value)
 		}
+
+		return true, nil
 	}
 
 	fs, err := defaultRegistry.GetChecksByKey(key)

--- a/go_lib/dependency/requirements/requirements.go
+++ b/go_lib/dependency/requirements/requirements.go
@@ -22,10 +22,15 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/deckhouse/deckhouse/go_lib/set"
+)
+
+const (
+	disabledModulesKey = "disabledModules"
 )
 
 var (
@@ -60,6 +65,13 @@ func CheckRequirement(key, value string, enabledModules ...set.Set) (bool, error
 	}
 	if defaultRegistry == nil {
 		return true, nil
+	}
+
+	if key == disabledModulesKey && len(enabledModules) > 0 {
+		blocked := hasBlockingEnabledModules(value, enabledModules[0])
+		if blocked {
+			return false, fmt.Errorf("%q modules have to be disabled", value)
+		}
 	}
 
 	fs, err := defaultRegistry.GetChecksByKey(key)
@@ -184,4 +196,21 @@ func (r *requirementsRegistry) GetDisruptionByKey(key string) (DisruptionFunc, e
 	}
 
 	return f, nil
+}
+
+// hasBlockingEnabledModules checks special requirement key `disabledModules` and block the release update
+// if any of these modules is enabled in the cluster
+func hasBlockingEnabledModules(requirementsValue string, enabledModules set.Set) bool {
+	arr := strings.Split(requirementsValue, ",")
+	if len(arr) == 0 {
+		return false
+	}
+
+	for _, moduleName := range arr {
+		if enabledModules.Has(strings.TrimSpace(moduleName)) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/go_lib/dependency/requirements/requirements.go
+++ b/go_lib/dependency/requirements/requirements.go
@@ -70,7 +70,7 @@ func CheckRequirement(key, value string, enabledModules ...set.Set) (bool, error
 	if key == disabledModulesKey && len(enabledModules) > 0 {
 		blocked := hasBlockingEnabledModules(value, enabledModules[0])
 		if blocked {
-			return false, fmt.Errorf("%q modules have to be disabled", value)
+			return false, fmt.Errorf("%q module(s) have to be disabled", value)
 		}
 
 		return true, nil


### PR DESCRIPTION
## Description
Mechanism to check that some modules are disabled be update the Deckhouse release

## Why do we need it, and what problem does it solve?
We have to delete some modules but it should be expectedly by user

## Why do we need it in the patch release (if we do)?
Linked with https://github.com/deckhouse/deckhouse/pull/10177

## What is the expected result?
```console
# kubectl -n d8-system get deckhouserelease
NAME      PHASE     TRANSITIONTIME   MESSAGE
v1.65.0   Pending   2s               "disabledModules" requirement for DeckhouseRelease "1.77.0" not met: "delivery" module(s) have to be disabled
```


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: Add mechanism to check that desired modules are disabled before deckhouse update.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
