### PR TITLE
[dhctl] Print cloud objects which will be destroyed when dhctl destroy

### DIFF
--- a/dhctl/pkg/terraform/runner.go
+++ b/dhctl/pkg/terraform/runner.go
@@ -513,13 +513,27 @@ func (r *Runner) Destroy() error {
 		return nil
 	}
 
+	planDestroyArgs := []string{
+		"plan",
+		"-destroy",
+		"-no-color",
+		fmt.Sprintf("-var-file=%s", r.variablesPath),
+		fmt.Sprintf("-state=%s", r.statePath),
+	}
+	planDestroyArgs = append(planDestroyArgs, r.workingDir)
+
+	_, err := r.execTerraform(planDestroyArgs...)
+	if err != nil {
+		return fmt.Errorf("Cannot prepare terrafrom destroy plan: %w", err)
+	}
+
 	if !r.changeSettings.AutoApprove {
 		if !r.confirm().WithMessage("Do you want to DELETE objects from the cloud?").Ask() {
 			return fmt.Errorf("terraform destroy aborted")
 		}
 	}
 
-	err := r.runBeforeActionAndWaitReady()
+	err = r.runBeforeActionAndWaitReady()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
print what will be destroyed in cloud when "terraform destroy" in dhctl

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this allow to see what objects in cloud will be destroyed when dhctl destroy cluster

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
print all cloud objects will be destroyed when dhctl destroy cluster

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

```changes
section: dhctl
type: feature
summary: Print cloud objects which will be destroyed when dhctl destroy
impact_level: default 
```