### PR TITLE
[common] fixed rm common/alpine

### DIFF
--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.32.0
-digest: sha256:7cd5a9eb96eba07095f58adf64176314b49190fa24cc8314c17a66421894d7d0
-generated: "2024-10-14T20:29:19.988672865+03:00"
+  version: 1.32.1
+digest: sha256:3375f073e83ed2f8bd8281e2b66f8c5d9576de65ecd9d1aded9aa91cd1b189b5
+generated: "2024-10-18T17:36:12.885217213+03:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: "Helm helpers"
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.32.0"
+    version: "1.32.1"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.32.0
+version: 1.32.1

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_init_container.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_init_container.tpl
@@ -4,10 +4,10 @@
 {{- define "helm_lib_module_init_container_chown_nobody_volume"  }}
   {{- $context := index . 0 -}}
   {{- $volume_name := index . 1  -}}
-  {{- $image := "alpine" }}
-  {{- if hasKey .Values "init" }}
-    {{- $image := "init" }}
-  {{- end }}
+  {{- $image := "alpine" -}}
+  {{- if hasKey $context.Values.global.modulesImages.digests.common "init" -}}
+    {{- $image = "init" -}}
+  {{- end -}}
 - name: chown-volume-{{ $volume_name }}
   image: {{ include "helm_lib_module_common_image" (list $context $image) }}
   command: ["sh", "-c", "chown -R 65534:65534 /tmp/{{ $volume_name }}"]
@@ -28,10 +28,10 @@
 {{- define "helm_lib_module_init_container_chown_deckhouse_volume"  }}
   {{- $context := index . 0 -}}
   {{- $volume_name := index . 1  -}}
-  {{- $image := "alpine" }}
-  {{- if hasKey .Values "init" }}
-    {{- $image := "init" }}
-  {{- end }}
+  {{- $image := "alpine" -}}
+  {{- if hasKey $context.Values.global.modulesImages.digests.common "init" -}}
+    {{- $image = "init" -}}
+  {{- end -}}
 - name: chown-volume-{{ $volume_name }}
   image: {{ include "helm_lib_module_common_image" (list $context $image) }}
   command: ["sh", "-c", "chown -R 64535:64535 /tmp/{{ $volume_name }}"]

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_init_container.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_init_container.tpl
@@ -4,8 +4,12 @@
 {{- define "helm_lib_module_init_container_chown_nobody_volume"  }}
   {{- $context := index . 0 -}}
   {{- $volume_name := index . 1  -}}
+  {{- $image := "alpine" }}
+  {{- if hasKey .Values "init" }}
+    {{- $image := "init" }}
+  {{- end }}
 - name: chown-volume-{{ $volume_name }}
-  image: {{ include "helm_lib_module_common_image" (list $context "init") }}
+  image: {{ include "helm_lib_module_common_image" (list $context $image) }}
   command: ["sh", "-c", "chown -R 65534:65534 /tmp/{{ $volume_name }}"]
   securityContext:
     runAsNonRoot: false
@@ -24,8 +28,12 @@
 {{- define "helm_lib_module_init_container_chown_deckhouse_volume"  }}
   {{- $context := index . 0 -}}
   {{- $volume_name := index . 1  -}}
+  {{- $image := "alpine" }}
+  {{- if hasKey .Values "init" }}
+    {{- $image := "init" }}
+  {{- end }}
 - name: chown-volume-{{ $volume_name }}
-  image: {{ include "helm_lib_module_common_image" (list $context "init") }}
+  image: {{ include "helm_lib_module_common_image" (list $context $image) }}
   command: ["sh", "-c", "chown -R 64535:64535 /tmp/{{ $volume_name }}"]
   securityContext:
     runAsNonRoot: false

--- a/modules/000-common/images/alpine/Dockerfile
+++ b/modules/000-common/images/alpine/Dockerfile
@@ -1,0 +1,5 @@
+# Depricated
+# You need to use the common/init image
+# TODO: remove after dh 1.70
+ARG BASE_ALPINE
+FROM $BASE_ALPINE

--- a/modules/000-common/images/alpine/Dockerfile
+++ b/modules/000-common/images/alpine/Dockerfile
@@ -1,5 +1,0 @@
-# Depricated
-# You need to use the common/init image
-# TODO: remove after dh 1.70
-ARG BASE_ALPINE
-FROM $BASE_ALPINE

--- a/modules/000-common/images/alpine/werf.inc.yaml
+++ b/modules/000-common/images/alpine/werf.inc.yaml
@@ -1,0 +1,6 @@
+# Depricated
+# You need to use the common/init image
+# TODO: remove after dh 1.70
+---
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/init

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -130,6 +130,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"simpleBridge": "imageHash-cniSimpleBridge-simpleBridge",
 	},
 	"common": map[string]interface{}{
+		"alpine":                    "imageHash-common-alpine",
 		"checkKernelVersion":        "imageHash-common-checkKernelVersion",
 		"csiExternalAttacher126":    "imageHash-common-csiExternalAttacher126",
 		"csiExternalAttacher127":    "imageHash-common-csiExternalAttacher127",

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -130,7 +130,6 @@ var DefaultImagesDigests = map[string]interface{}{
 		"simpleBridge": "imageHash-cniSimpleBridge-simpleBridge",
 	},
 	"common": map[string]interface{}{
-		"alpine":                    "imageHash-common-alpine",
 		"checkKernelVersion":        "imageHash-common-checkKernelVersion",
 		"csiExternalAttacher126":    "imageHash-common-csiExternalAttacher126",
 		"csiExternalAttacher127":    "imageHash-common-csiExternalAttacher127",


### PR DESCRIPTION
## Description
fix image selection logic for helm_lib_module_init_container_chown_nobody_volume and helm_lib_module_init_container_chown_deckhouse_volume.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
You need to leave the image until the modules are migrated.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: fixed pull/9992
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
