### PR TITLE
[dashboard] grant create secrets permission

### DIFF
--- a/modules/500-dashboard/templates/dashboard/rbac-for-us.yaml
+++ b/modules/500-dashboard/templates/dashboard/rbac-for-us.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "dashboard")) | nindent 2 }}
 rules:
+# Allow Dashboard to create any secrets in its namespace so that it would recreate them if needed
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
 # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
 - apiGroups: [""]
   resources: ["secrets"]

--- a/modules/500-dashboard/templates/dashboard/secret.yaml
+++ b/modules/500-dashboard/templates/dashboard/secret.yaml
@@ -20,14 +20,3 @@ metadata:
 type: Opaque
 data:
   csrf: ""
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kubernetes-dashboard-key-holder
-  namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "dashboard")) | nindent 2 }}
-type: Opaque
-data:
-  priv: ""
-  pub: ""


### PR DESCRIPTION
## Description
Grants `create secrets` permission to `dashboard` service account and deletes `kubernetes-dashboard-key-holder` secret template from the dashboard chart.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
The dashboard machinery is designed to create/update its secret by itself, so we'd better not intervene into this process by creating secrets via helm releases. Otherwise, there might be some reconciliation issues when two controllers subsequently override a secret.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Dashboards works as expected and the `kubernetes-dashboard-key-holder` is in place with correct data.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dashboard
type: chore
summary: Grant create secrets permission.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
