### PR TITLE
[operator-trivy] fix policies bundle download

### DIFF
--- a/ee/modules/500-operator-trivy/images/operator/Dockerfile
+++ b/ee/modules/500-operator-trivy/images/operator/Dockerfile
@@ -20,6 +20,7 @@ COPY patches/005-cis-benchmark-on-startup.patch /src
 COPY patches/006-new-metrics.patch /src
 COPY patches/007-fix-custom-volumes.patch /src
 COPY patches/008-bump-dependencies.patch /src
+COPY patches/009-fix-policies-cache.patch /src
 
 RUN patch -p1 < 001-add-registry-secret-as-dockerconfigjson.patch && \
     patch -p1 < 002-skip-some-checks.patch && \
@@ -27,7 +28,8 @@ RUN patch -p1 < 001-add-registry-secret-as-dockerconfigjson.patch && \
     patch -p1 < 005-cis-benchmark-on-startup.patch && \
     patch -p1 < 006-new-metrics.patch && \
     patch -p1 < 007-fix-custom-volumes.patch && \
-    patch -p1 < 008-bump-dependencies.patch
+    patch -p1 < 008-bump-dependencies.patch && \
+    patch -p1 < 009-fix-policies-cache.patch
 
 RUN go build -ldflags '-s -w -extldflags "-static"' -o operator-trivy ./cmd/trivy-operator/main.go
 

--- a/ee/modules/500-operator-trivy/images/operator/patches/009-fix-policies-cache.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/009-fix-policies-cache.patch
@@ -11,7 +11,7 @@ index da97e78c..fbf78b63 100644
  	return policyLoader, nil
  }
 diff --git a/pkg/policy/loader.go b/pkg/policy/loader.go
-index d8b439ab..598944ec 100644
+index d8b439ab..675fe710 100644
 --- a/pkg/policy/loader.go
 +++ b/pkg/policy/loader.go
 @@ -58,6 +58,7 @@ func (pl *policyLoader) GetPoliciesAndBundlePath() ([]string, []string, error) {
@@ -22,20 +22,23 @@ index d8b439ab..598944ec 100644
  		policies, bundlePaths, err = pl.LoadPoliciesAndCommands()
  		if err != nil {
  			log.V(1).Error(err, "failed to load policies")
-@@ -80,10 +81,12 @@ func (pl *policyLoader) getPoliciesFromCache() (interface{}, interface{}, error)
+@@ -78,12 +79,15 @@ func (pl *policyLoader) GetPoliciesAndBundlePath() ([]string, []string, error) {
+ func (pl *policyLoader) getPoliciesFromCache() (interface{}, interface{}, error) {
+ 	pl.mutex.RLock()
  	defer pl.mutex.RUnlock()
++	log := pl.logger.WithName("Get policies from cache")
  	policies, err := pl.cache.Get(bundlePolicies)
  	if err != nil {
-+		pl.logger.Error(err, "failed to load bundle policies")
++		log.V(1).Info("failed to load bundle policies from cache", "err", err.Error())
  		return nil, nil, err
  	}
  	bundlePath, err := pl.cache.Get(bundlePath)
  	if err != nil {
-+		pl.logger.Error(err, "failed to load bundle path")
++		log.V(1).Info("failed to load bundle path from cache", "err", err.Error())
  		return nil, nil, err
  	}
  	return policies, bundlePath, nil
-@@ -100,8 +103,8 @@ func (pl *policyLoader) LoadPoliciesAndCommands() ([]string, []string, error) {
+@@ -100,8 +104,8 @@ func (pl *policyLoader) LoadPoliciesAndCommands() ([]string, []string, error) {
  	if err != nil {
  		return []string{}, []string{}, fmt.Errorf("failed to download policies: %w", err)
  	}

--- a/ee/modules/500-operator-trivy/images/operator/patches/009-fix-policies-cache.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/009-fix-policies-cache.patch
@@ -1,8 +1,41 @@
+diff --git a/pkg/operator/operator.go b/pkg/operator/operator.go
+index da97e78c..fbf78b63 100644
+--- a/pkg/operator/operator.go
++++ b/pkg/operator/operator.go
+@@ -445,6 +445,6 @@ func buildPolicyLoader(tc trivyoperator.ConfigData) (policy.Loader, error) {
+ 		}
+ 		artifact.RegistryOptions = ro
+ 	}
+-	policyLoader := policy.NewPolicyLoader(tc.PolicyBundleOciRef(), gcache.New(1).LRU().Build(), ro, mp.WithOCIArtifact(artifact))
++	policyLoader := policy.NewPolicyLoader(tc.PolicyBundleOciRef(), gcache.New(2).LRU().Build(), ro, mp.WithOCIArtifact(artifact))
+ 	return policyLoader, nil
+ }
 diff --git a/pkg/policy/loader.go b/pkg/policy/loader.go
-index d8b439ab..f7c9c7c7 100644
+index d8b439ab..598944ec 100644
 --- a/pkg/policy/loader.go
 +++ b/pkg/policy/loader.go
-@@ -100,8 +100,8 @@ func (pl *policyLoader) LoadPoliciesAndCommands() ([]string, []string, error) {
+@@ -58,6 +58,7 @@ func (pl *policyLoader) GetPoliciesAndBundlePath() ([]string, []string, error) {
+ 		if !errors.Is(err, gcache.KeyNotFoundError) {
+ 			return []string{}, []string{}, err
+ 		}
++		log.V(1).Info("values not found in cache", "err", err.Error())
+ 		policies, bundlePaths, err = pl.LoadPoliciesAndCommands()
+ 		if err != nil {
+ 			log.V(1).Error(err, "failed to load policies")
+@@ -80,10 +81,12 @@ func (pl *policyLoader) getPoliciesFromCache() (interface{}, interface{}, error)
+ 	defer pl.mutex.RUnlock()
+ 	policies, err := pl.cache.Get(bundlePolicies)
+ 	if err != nil {
++		pl.logger.Error(err, "failed to load bundle policies")
+ 		return nil, nil, err
+ 	}
+ 	bundlePath, err := pl.cache.Get(bundlePath)
+ 	if err != nil {
++		pl.logger.Error(err, "failed to load bundle path")
+ 		return nil, nil, err
+ 	}
+ 	return policies, bundlePath, nil
+@@ -100,8 +103,8 @@ func (pl *policyLoader) LoadPoliciesAndCommands() ([]string, []string, error) {
  	if err != nil {
  		return []string{}, []string{}, fmt.Errorf("failed to download policies: %w", err)
  	}
@@ -12,3 +45,4 @@ index d8b439ab..f7c9c7c7 100644
 +	_ = pl.cache.Set(bundlePath, bundlePaths)
  	return contentData, bundlePaths, nil
  }
+ 

--- a/ee/modules/500-operator-trivy/images/operator/patches/009-fix-policies-cache.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/009-fix-policies-cache.patch
@@ -1,0 +1,14 @@
+diff --git a/pkg/policy/loader.go b/pkg/policy/loader.go
+index d8b439ab..f7c9c7c7 100644
+--- a/pkg/policy/loader.go
++++ b/pkg/policy/loader.go
+@@ -100,8 +100,8 @@ func (pl *policyLoader) LoadPoliciesAndCommands() ([]string, []string, error) {
+ 	if err != nil {
+ 		return []string{}, []string{}, fmt.Errorf("failed to download policies: %w", err)
+ 	}
+-	_ = pl.cache.SetWithExpire(bundlePolicies, contentData, *pl.expiration)
+-	_ = pl.cache.SetWithExpire(bundlePath, bundlePaths, *pl.expiration)
++	_ = pl.cache.Set(bundlePolicies, contentData)
++	_ = pl.cache.Set(bundlePath, bundlePaths)
+ 	return contentData, bundlePaths, nil
+ }

--- a/ee/modules/500-operator-trivy/images/operator/patches/README.md
+++ b/ee/modules/500-operator-trivy/images/operator/patches/README.md
@@ -31,3 +31,11 @@ This patch adds primaryLink metric for reports.
 
 [PR](https://github.com/aquasecurity/trivy-operator/pull/2241)
 [Issue](https://github.com/aquasecurity/trivy-operator/issues/2240)
+
+### 008-bump-dependencies.patch
+
+This patch updates vulnerable dependencies.
+
+### 009-fix-policies-cache.patch
+
+The operator of v0.22.0 cannot redownload policies if the image of the policies has been changed, it tries to download the old one.

--- a/ee/modules/500-operator-trivy/images/operator/patches/README.md
+++ b/ee/modules/500-operator-trivy/images/operator/patches/README.md
@@ -38,4 +38,4 @@ This patch updates vulnerable dependencies.
 
 ### 009-fix-policies-cache.patch
 
-The operator of v0.22.0 cannot redownload policies if the image of the policies has been changed, it tries to download the old one.
+The operator of v0.22.0 cannot re-download policies if the image of the policies has been changed, it tries to download the old one.


### PR DESCRIPTION
## Description
It provides fix for policies redownload error.

## Why do we need it, and what problem does it solve?
The operator tries to reload policies, but uses the old image.

## What is the expected result?
The operator does not try to reload policies

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: operator-trivy
type: fix
summary: Fix policies bundle error.
```

