### PR TITLE
[node-manager] CAPI sa migration

### DIFF
--- a/modules/040-node-manager/hooks/migration/migrate_existing_capi_sa.go
+++ b/modules/040-node-manager/hooks/migration/migrate_existing_capi_sa.go
@@ -72,11 +72,9 @@ func applyServiceAccountFilter(obj *unstructured.Unstructured) (go_hook.FilterRe
 	}
 
 	_, isLabeledWithHelmManaged := serviceAccount.Labels[labelHelmManagedBy]
-	_, isAnnotatedWithReleseName := serviceAccount.Annotations[annotationReleaseName]
-	_, isAnnotatedWithReleseNamespace := serviceAccount.Annotations[annotationReleaseNamespace]
 
 	return ServiceAccountInfo{
-		IsLabeledAndAnnotated: isLabeledWithHelmManaged && isAnnotatedWithReleseName && isAnnotatedWithReleseNamespace,
+		IsLabeledAndAnnotated: isLabeledWithHelmManaged,
 		Name:                  serviceAccount.GetName(),
 	}, nil
 }
@@ -86,6 +84,9 @@ func migrateServiceAccounts(input *go_hook.HookInput) error {
 		"metadata": map[string]interface{}{
 			"labels": map[string]string{
 				labelHelmManagedBy: "Helm",
+				"app":              "capi-controller-manager",
+				"heritage":         "deckhouse",
+				"module":           "node-manager",
 			},
 			"annotations": map[string]string{
 				annotationReleaseName:      "node-manager",

--- a/modules/040-node-manager/hooks/migration/migrate_existing_capi_sa.go
+++ b/modules/040-node-manager/hooks/migration/migrate_existing_capi_sa.go
@@ -33,11 +33,14 @@ type ServiceAccountInfo struct {
 }
 
 const (
+	labelDhApp                 = "app"
+	labelDhHeritage            = "heritage"
+	labelDhModule              = "module"
 	labelHelmManagedBy         = "app.kubernetes.io/managed-by"
 	annotationReleaseName      = "meta.helm.sh/release-name"
 	annotationReleaseNamespace = "meta.helm.sh/release-namespace"
-	saName                     = "capi-controller-manager"
 	clusterAPINamespace        = "d8-cloud-instance-manager"
+	saName                     = "capi-controller-manager"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -81,9 +84,9 @@ func migrateServiceAccounts(input *go_hook.HookInput) error {
 		"metadata": map[string]interface{}{
 			"labels": map[string]string{
 				labelHelmManagedBy: "Helm",
-				"app":              "capi-controller-manager",
-				"heritage":         "deckhouse",
-				"module":           "node-manager",
+				labelDhApp:         "capi-controller-manager",
+				labelDhHeritage:    "deckhouse",
+				labelDhModule:      "node-manager",
 			},
 			"annotations": map[string]string{
 				annotationReleaseName:      "node-manager",

--- a/modules/040-node-manager/hooks/migration/migrate_existing_capi_sa.go
+++ b/modules/040-node-manager/hooks/migration/migrate_existing_capi_sa.go
@@ -19,18 +19,12 @@ package hooks
 import (
 	"fmt"
 
-	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/utils/ptr"
-)
-
-const (
-	clusterAPINamespace = "d8-cloud-instance-manager"
 )
 
 type ServiceAccountInfo struct {
@@ -43,6 +37,7 @@ const (
 	annotationReleaseName      = "meta.helm.sh/release-name"
 	annotationReleaseNamespace = "meta.helm.sh/release-namespace"
 	saName                     = "capi-controller-manager"
+	clusterAPINamespace        = "d8-cloud-instance-manager"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -50,12 +45,14 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 1},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:                         "capi_sa",
-			ExecuteHookOnSynchronization: ptr.To(false),
-			ExecuteHookOnEvents:          ptr.To(false),
-			ApiVersion:                   "v1",
-			Kind:                         "ServiceAccount",
-			NamespaceSelector:            lib.NsSelector(),
+			Name:       "capi_sa",
+			ApiVersion: "v1",
+			Kind:       "ServiceAccount",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{clusterAPINamespace},
+				},
+			},
 			NameSelector: &types.NameSelector{
 				MatchNames: []string{saName},
 			},

--- a/modules/040-node-manager/hooks/migration/migrate_existing_capi_sa.go
+++ b/modules/040-node-manager/hooks/migration/migrate_existing_capi_sa.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	clusterAPINamespace = "d8-cloud-instance-manager"
+)
+
+type ServiceAccountInfo struct {
+	IsLabeledAndAnnotated bool
+	Name                  string
+}
+
+const (
+	labelHelmManagedBy         = "app.kubernetes.io/managed-by"
+	annotationReleaseName      = "meta.helm.sh/release-name"
+	annotationReleaseNamespace = "meta.helm.sh/release-namespace"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue:        "/modules/node-manager",
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 1},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                         "capi_sa",
+			ExecuteHookOnSynchronization: ptr.To(false),
+			ExecuteHookOnEvents:          ptr.To(false),
+			ApiVersion:                   "v1",
+			Kind:                         "ServiceAccount",
+			NamespaceSelector:            lib.NsSelector(),
+			FilterFunc:                   applyServiceAccountFilter,
+		},
+	},
+}, migrateServiceAccounts)
+
+func applyServiceAccountFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	serviceAccount := &v1.ServiceAccount{}
+	err := sdk.FromUnstructured(obj, serviceAccount)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert ServiceAccount to struct: %v", err)
+	}
+
+	_, isLabeledWithHelmManaged := serviceAccount.Labels[labelHelmManagedBy]
+	_, isAnnotatedWithReleseName := serviceAccount.Annotations[annotationReleaseName]
+	_, isAnnotatedWithReleseNamespace := serviceAccount.Annotations[annotationReleaseNamespace]
+
+	return ServiceAccountInfo{
+		IsLabeledAndAnnotated: isLabeledWithHelmManaged && isAnnotatedWithReleseName && isAnnotatedWithReleseNamespace,
+		Name:                  serviceAccount.GetName(),
+	}, nil
+}
+
+func migrateServiceAccounts(input *go_hook.HookInput) error {
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": map[string]string{
+				labelHelmManagedBy: "Helm",
+			},
+			"annotations": map[string]string{
+				annotationReleaseName:      "node-manager",
+				annotationReleaseNamespace: "d8-system",
+			},
+		},
+	}
+
+	snap := input.Snapshots
+	for _, serviceAccountSnap := range snap["capi_sa"] {
+		serviceAccount := serviceAccountSnap.(ServiceAccountInfo)
+		if !serviceAccount.IsLabeledAndAnnotated {
+			input.PatchCollector.MergePatch(patch, "v1", "ServiceAccount", "d8-cloud-instance-manager", serviceAccount.Name, object_patch.IgnoreMissingObject())
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

Migration for existing capi-controller-manager sa which adopts it for use in helm.

## Why do we need it, and what problem does it solve?

Without this migration, we got an error:

{"binding":"ConvergeModules","event.type":"OperatorStartup","level":"error","module":"node-manager","modules":"control-plane-manager,node-manager","msg":"ModuleRun failed in phase 'CanRunHelm'. Requeue task to retry after delay. Failed count is 9. Error: helm upgrade failed: Unable to continue with update: ServiceAccount \"capi-controller-manager\" in namespace \"d8-cloud-instance-manager\" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key \"app.kubernetes.io/managed-by\": must be set to \"Helm\"; annotation validation error: missing key \"meta.helm.sh/release-name\": must be set to \"node-manager\"; annotation validation error: missing key \"meta.helm.sh/release-namespace\": must be set to \"d8-system\"\n","order":"40","queue":"main","task.id":"98766ade-a00d-4263-8818-1ffed5ba37fa","time":"2024-10-18T17:14:55Z"}


## Why do we need it in the patch release (if we do)?

## What is the expected result?

Migration adds the necessary labels for sa if it has already been created

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix 
summary: CAPI sa migration
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
