### PR TITLE
[istio] Restoring the operation of the audit logs.

### DIFF
--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -114,7 +114,6 @@ spec:
     trustDomain: {{ $.Values.global.discovery.clusterDomain | quote }}
     accessLogFile: /dev/stdout
     
-
     # The rules below exclude upmeter-related namespaces from istiod's point of view.
     # So, upmeter's events used to affect the traffic between control-plane and data-plane will be reduced.
     discoverySelectors:

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -112,6 +112,7 @@ spec:
   meshConfig:
     rootNamespace: d8-{{ $.Chart.Name }}
     trustDomain: {{ $.Values.global.discovery.clusterDomain | quote }}
+    accessLogFile: /dev/stdout
 
     # The rules below exclude upmeter-related namespaces from istiod's point of view.
     # So, upmeter's events used to affect the traffic between control-plane and data-plane will be reduced.

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -113,6 +113,7 @@ spec:
     rootNamespace: d8-{{ $.Chart.Name }}
     trustDomain: {{ $.Values.global.discovery.clusterDomain | quote }}
     accessLogFile: /dev/stdout
+    
 
     # The rules below exclude upmeter-related namespaces from istiod's point of view.
     # So, upmeter's events used to affect the traffic between control-plane and data-plane will be reduced.


### PR DESCRIPTION
## Description

Turn on the `Access Logs` and redirect them to `/dev/stdout`.

## Why do we need it, and what problem does it solve?
Currently, it is not possible to display AUDIT logs of AuthorizationPolicy.

## What is the expected result?
When applying Authorization Policy with Action:AUDIT, audit events will be displayed in the sidecar istio-proxy stdout logs.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: chore
summary: Restoring the operation of the audit logs. To see your AuthorizationPolicies AUDIT results, restart application pods with istio sidecars.
impact_level: default
```