### PR TITLE
[deckhouse-controller] Fix deckhouse and global mc edit

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -65,7 +65,7 @@ func moduleConfigValidationHandler(moduleStorage ModuleStorage, metricStorage *m
 				// we check module
 				// we check confirmation restriction and confirmation message
 				_, ok = cfg.Annotations[v1alpha1.AllowDisableAnnotation]
-				if !ok && *cfg.Spec.Enabled {
+				if !ok && cfg.Spec.Enabled != nil && *cfg.Spec.Enabled {
 					// we can delete unknown module without any further check
 					module, err := moduleStorage.GetModuleByName(obj.GetName())
 					if err == nil {
@@ -115,7 +115,7 @@ func moduleConfigValidationHandler(moduleStorage ModuleStorage, metricStorage *m
 			// we check confirmation restriction and confirmation message
 			_, ok = cfg.Annotations[v1alpha1.AllowDisableAnnotation]
 			_, oldOk := oldModuleMeta.Annotations[v1alpha1.AllowDisableAnnotation]
-			if !ok && !oldOk && !*cfg.Spec.Enabled {
+			if !ok && !oldOk && cfg.Spec.Enabled != nil && !*cfg.Spec.Enabled {
 				// we can disable unknown module without any further check
 				module, err := moduleStorage.GetModuleByName(obj.GetName())
 				if err == nil {
@@ -134,7 +134,7 @@ func moduleConfigValidationHandler(moduleStorage ModuleStorage, metricStorage *m
 
 		var allowedToDisableMetric float64
 		_, ok = cfg.Annotations[v1alpha1.AllowDisableAnnotation]
-		if ok && *cfg.Spec.Enabled {
+		if ok && cfg.Spec.Enabled != nil && *cfg.Spec.Enabled {
 			allowedToDisableMetric = 1
 		}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Checked pointers before dereference

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When we change log-level in deckhouse ModuleConfig, we have an webhook error
```bash
# kubectl edit mc deckhouse
error: moduleconfigs.deckhouse.io "deckhouse" could not be patched: Internal error occurred: failed calling webhook "module-configs.deckhouse-webhook.deckhouse.io": failed to call webhook: Post "https://deckhouse.d8-system.svc:4223/validate/v1alpha1/module-configs?timeout=10s": EOF
You can run `kubectl replace -f /tmp/kubectl-edit-680662504.yaml` to try this update again
```
Same with editing global ModuleConfig
```bash
# kubectl edit mc global
error: moduleconfigs.deckhouse.io "global" could not be patched: Internal error occurred: failed calling webhook "module-configs.deckhouse-webhook.deckhouse.io": failed to call webhook: Post "https://deckhouse.d8-system.svc:4223/validate/v1alpha1/module-configs?timeout=10s": EOF
You can run `kubectl replace -f /tmp/kubectl-edit-2121061983.yaml` to try this update again.
```
## Why do we need it in the patch release (if we do)?
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Fixed errors from webhooks

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix ModuleConfig validation webhook.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
