### PR TITLE
[cni-cilium] Disable the metrics server in the egress-gateway-agent.

### DIFF
--- a/ee/modules/021-cni-cilium/images/egress-gateway-agent/cmd/main.go
+++ b/ee/modules/021-cni-cilium/images/egress-gateway-agent/cmd/main.go
@@ -11,6 +11,8 @@ import (
 	"flag"
 	"os"
 
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -73,6 +75,7 @@ func main() {
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         false,
+		Metrics:                metricsserver.Options{BindAddress: ":0"},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/ee/modules/021-cni-cilium/images/egress-gateway-agent/werf.inc.yaml
+++ b/ee/modules/021-cni-cilium/images/egress-gateway-agent/werf.inc.yaml
@@ -11,6 +11,7 @@ docker:
 {{ $discovererAbsPath := "/deckhouse/ee/modules/021-cni-cilium/images/egress-gateway-agent" }}
   {{ $discovererRelPath := printf "%s/modules/021-cni-cilium/images/egress-gateway-agent" .ModulePath }}
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+fromCacheVersion: 20241021-1
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 shell:
   install:


### PR DESCRIPTION
## Description

Disable the metrics server in the `egress-gateway-agent` because we don't use it.

## Why do we need it, and what problem does it solve?

If the metrics server has not been explicitly turned off, it will by default be bound to *:8080. 
This can cause confusion, as if another application is already using this port, our application will not be able to start.

## What is the expected result?

The `egress-gateway-agent` starts correctly even if port 8080 is already occupied by another application.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Disable the metrics server in the "egress-gateway-agent" because we don't use it.
impact: The pods of the egress-gateway-agent will be restarted.
impact_level: default 
```

