### PR TITLE
[deckhouse] Fill values dockercfg if anonymous access

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/module_downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/module_downloader.go
@@ -551,22 +551,7 @@ func (rsv *registrySchemaForValues) SetBase(registryBase string) {
 }
 
 func (rsv *registrySchemaForValues) SetDockercfg(dockercfg string) {
-	if len(dockercfg) == 0 {
-		// according to the deckhouse docs, for anonymous registry access we must have the value:
-		// {"auths": { "<PROXY_REGISTRY>": {}}}
-		// but it could be empty for a ModuleSource.
-		// modules are not ready to catch empty string, so we have to fill it with the default value
-		index := strings.Index(rsv.Properties.Base.Default, "/")
-		var registry string
-		if index != -1 {
-			registry = rsv.Properties.Base.Default[:index]
-		} else {
-			registry = rsv.Properties.Base.Default
-		}
-		dockercfg = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"auths": {"%s": {}}}`, registry)))
-	}
-
-	rsv.Properties.Dockercfg.Default = dockercfg
+	rsv.Properties.Dockercfg.Default = DockerCFGForModules(rsv.Properties.Base.Default, dockercfg)
 }
 
 func (rsv *registrySchemaForValues) SetScheme(scheme string) {
@@ -575,6 +560,27 @@ func (rsv *registrySchemaForValues) SetScheme(scheme string) {
 
 func (rsv *registrySchemaForValues) SetCA(ca string) {
 	rsv.Properties.CA.Default = ca
+}
+
+// DockerCFGForModules
+// according to the deckhouse docs, for anonymous registry access we must have the value:
+// {"auths": { "<PROXY_REGISTRY>": {}}}
+// but it could be empty for a ModuleSource.
+// modules are not ready to catch empty string, so we have to fill it with the default value
+func DockerCFGForModules(repo, dockercfg string) string {
+	if len(dockercfg) != 0 {
+		return dockercfg
+	}
+
+	index := strings.Index(repo, "/")
+	var registry string
+	if index != -1 {
+		registry = repo[:index]
+	} else {
+		registry = repo
+	}
+
+	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"auths": {"%s": {}}}`, registry)))
 }
 
 type injectedValues struct {

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -963,7 +963,9 @@ func syncModuleRegistrySpec(downloadedModulesDir, moduleName, moduleVersion stri
 
 	registrySpec := openAPISpec.Properties.Registry.Properties
 
-	if moduleSource.Spec.Registry.CA != registrySpec.CA.Default || moduleSource.Spec.Registry.DockerCFG != registrySpec.DockerCFG.Default || moduleSource.Spec.Registry.Repo != registrySpec.Base.Default || moduleSource.Spec.Registry.Scheme != registrySpec.Scheme.Default {
+	dockercfg := downloader.DockerCFGForModules(moduleSource.Spec.Registry.Repo, moduleSource.Spec.Registry.DockerCFG)
+
+	if moduleSource.Spec.Registry.CA != registrySpec.CA.Default || dockercfg != registrySpec.DockerCFG.Default || moduleSource.Spec.Registry.Repo != registrySpec.Base.Default || moduleSource.Spec.Registry.Scheme != registrySpec.Scheme.Default {
 		err = downloader.InjectRegistryToModuleValues(filepath.Join(downloadedModulesDir, moduleName, moduleVersion), moduleSource)
 	}
 


### PR DESCRIPTION
## Description
Generate dockercfg for anonymous access if ModuleSource's dockercfg is empty

## Why do we need it, and what problem does it solve?
To work with anonymouse access to registry in modules

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Generate empty docker auth for anonymous registry access.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
