### PR TITLE
[user-authn] fix: numbers in dex groups

### DIFF
--- a/modules/150-user-authn/templates/dex/passwords.yaml
+++ b/modules/150-user-authn/templates/dex/passwords.yaml
@@ -18,7 +18,7 @@ userID: {{ $crd.name | quote }}
   {{- if $crd.spec.groups }}
 groups:
 {{- range $group := $crd.spec.groups }}
-- {{ $group }}
+- {{ $group | quote }}
 {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Fixes: #9706

## Why do we need it, and what problem does it solve?

Incorrect handling of group names for users in static configuration.

## What is the expected result?

When users are created with groups containing only numbers, user login is performed without problems.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: numbers in dex groups
impact_level: default
```
