### PR TITLE
Removed migrator init containers from upmeter, loki and prometheus modules

### DIFF
--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -61,21 +61,6 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
-  initContainers:
-  - command:
-    - sh
-    - -c
-    - chown -vfR 64535:64535 /prometheus-db/
-    image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
-    imagePullPolicy: IfNotPresent
-    name: fix-permissions
-    securityContext:
-      runAsNonRoot: false
-      runAsUser: 0
-    volumeMounts:
-    - mountPath: /prometheus-db
-      name: prometheus-longterm-db
-      subPath: prometheus-db
   containers:
   - name: prometheus
     startupProbe:

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -65,21 +65,6 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
-  initContainers:
-  - command:
-    - sh
-    - -c
-    - chown -vfR 64535:64535 /prometheus-db/
-    image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
-    imagePullPolicy: IfNotPresent
-    name: fix-permissions
-    securityContext:
-      runAsNonRoot: false
-      runAsUser: 0
-    volumeMounts:
-    - mountPath: /prometheus-db
-      name: prometheus-main-db
-      subPath: prometheus-db
   containers:
   - name: prometheus
     startupProbe:

--- a/modules/462-loki/templates/statefulset.yaml
+++ b/modules/462-loki/templates/statefulset.yaml
@@ -40,23 +40,6 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . | nindent 6 }}
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - chown -vfR 64535:64535 /loki/
-        image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
-        imagePullPolicy: IfNotPresent
-        name: fix-permissions
-        securityContext:
-          runAsNonRoot: false
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /loki
-          name: storage
-        resources:
-          requests:
-            {{ include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
       containers:
       - name: loki
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -66,12 +66,9 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "monitoring" "without-storage-problems") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
-      {{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . | nindent 6 }}
       initContainers:
 {{- $storageClass := .Values.upmeter.internal.effectiveStorageClass }}
-{{- if $storageClass }}
-      {{- include "helm_lib_module_init_container_chown_deckhouse_volume" (tuple . "data") | nindent 6 }}
-{{- end }}
       - name: migrator
         image: {{ include "helm_lib_module_image" (list . "upmeter") }}
         command:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Cherry-pick of #10150 to 1.64.

Remove migrator init containers from modules:
- upmeter
- loki
- prometheus

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In some cases, this component can cause a CrashLoopBackoff in Pods within the modules.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

We have clients who are experiencing issues due to this component.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: upmeter, loki, prometheus
type: fix
summary: Removed migrator init containers from modules
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
