### PR TITLE
[istio] Getting rid of self-made IP address allocation for public service's ServiceEntry'es in Federation

### DIFF
--- a/ee/modules/110-istio/crds/istiofederation.yaml
+++ b/ee/modules/110-istio/crds/istiofederation.yaml
@@ -97,8 +97,6 @@ spec:
                                       type: string
                                     port:
                                       type: integer
-                              virtualIP:
-                                type: string
                     privateLastFetchTimestamp:
                       format: date-time
                       type: string

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -164,12 +164,6 @@ federationsLoop:
 			input.LogEntry.Warnf("private metadata for IstioFederation %s wasn't fetched yet", federationInfo.Name)
 			continue
 		}
-		//for _, ps := range *federationInfo.PublicServices {
-		//	if ps.VirtualIP == "" {
-		//		input.LogEntry.Warnf("virtualIP wasn't set for publicService %s of IstioFederation %s", ps.Hostname, federationInfo.Name)
-		//		continue federationsLoop
-		//	}
-		//}
 
 		if federationInfo.IngressGateways == nil || len(*federationInfo.IngressGateways) == 0 {
 			input.LogEntry.Warnf("private metadata for IstioFederation %s wasn't fetched yet", federationInfo.Name)

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -164,12 +164,12 @@ federationsLoop:
 			input.LogEntry.Warnf("private metadata for IstioFederation %s wasn't fetched yet", federationInfo.Name)
 			continue
 		}
-		for _, ps := range *federationInfo.PublicServices {
-			if ps.VirtualIP == "" {
-				input.LogEntry.Warnf("virtualIP wasn't set for publicService %s of IstioFederation %s", ps.Hostname, federationInfo.Name)
-				continue federationsLoop
-			}
-		}
+		//for _, ps := range *federationInfo.PublicServices {
+		//	if ps.VirtualIP == "" {
+		//		input.LogEntry.Warnf("virtualIP wasn't set for publicService %s of IstioFederation %s", ps.Hostname, federationInfo.Name)
+		//		continue federationsLoop
+		//	}
+		//}
 
 		if federationInfo.IngressGateways == nil || len(*federationInfo.IngressGateways) == 0 {
 			input.LogEntry.Warnf("private metadata for IstioFederation %s wasn't fetched yet", federationInfo.Name)

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -416,7 +416,7 @@ status:
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("public metadata for IstioMulticluster multicluster-no-public wasn't fetched yet"))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("private metadata for IstioMulticluster multicluster-only-public wasn't fetched yet"))
 
-			// there should be 11 log messages
+			// there should be 10 log messages
 			Expect(strings.Split(strings.Trim(string(f.LogrusOutput.Contents()), "\n"), "\n")).To(HaveLen(10))
 		})
 	})

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -90,7 +90,7 @@ status:
   metadataCache:
     private:
       publicServices:
-      - {"hostname": "aaa", "ports": [{"name": "ppp", "port": 123}], "virtualIP": "169.0.0.0"}
+      - {"hostname": "aaa", "ports": [{"name": "ppp", "port": 123}]}
     public:
       clusterUUID: aaa-bbb-f2
       rootCA: abc-f2
@@ -109,7 +109,7 @@ status:
       ingressGateways:
       - {"address": "bbb", "port": 222}
       publicServices:
-      - {"hostname": "bbb", "ports": [{"name": "ppp", "port": 123},{"name": "zzz", "port": 777}], "virtualIP": "169.0.0.1"}
+      - {"hostname": "bbb", "ports": [{"name": "ppp", "port": 123},{"name": "zzz", "port": 777}]}
     public:
       clusterUUID: aaa-bbb-f3
       rootCA: abc-f3
@@ -128,8 +128,8 @@ status:
       ingressGateways:
       - {"address": "ccc", "port": 222}
       publicServices:
-      - {"hostname": "ccc", "ports": [{"name": "ppp", "port": 123}], "virtualIP": "169.0.0.2"}
-      - {"hostname": "ddd", "ports": [{"name": "xxx", "port": 555}], "virtualIP": "169.0.0.3"}
+      - {"hostname": "ccc", "ports": [{"name": "ppp", "port": 123}]}
+      - {"hostname": "ddd", "ports": [{"name": "xxx", "port": 555}]}
     public:
       clusterUUID: aaa-bbb-f4
       rootCA: abc-f4
@@ -147,7 +147,7 @@ status:
     private:
       ingressGateways: []
       publicServices:
-      - {"hostname": "bbb", "ports": [{"name": "ppp", "port": 123},{"name": "zzz", "port": 777}], "virtualIP": "169.0.0.3"}
+      - {"hostname": "bbb", "ports": [{"name": "ppp", "port": 123},{"name": "zzz", "port": 777}]}
     public:
       clusterUUID: aaa-bbb-f5
       rootCA: abc-f5
@@ -166,7 +166,7 @@ status:
       ingressGateways:
       - {"address": "ccc", "port": 222}
       publicServices:
-      - {"hostname": "ccc", "ports": [{"name": "ppp", "port": 123}], "virtualIP": "169.0.0.2"}
+      - {"hostname": "ccc", "ports": [{"name": "ppp", "port": 123}]}
       - {"hostname": "ddd", "ports": [{"name": "xxx", "port": 555}]} # no virtualIP, federation should be skipped
     public:
       clusterUUID: aaa-bbb-f4
@@ -328,7 +328,6 @@ status:
             "publicServices": [
               {
                 "hostname": "bbb",
-                "virtualIP": "169.0.0.1",
                 "ports": [{"name": "ppp", "port": 123},{"name": "zzz", "port": 777}]
               }
             ],
@@ -346,12 +345,10 @@ status:
             "publicServices": [
               {
                 "hostname": "ccc",
-                "virtualIP": "169.0.0.2",
                 "ports": [{"name": "ppp", "port": 123}]
               },
               {
                 "hostname": "ddd",
-                "virtualIP": "169.0.0.3",
                 "ports": [{"name": "xxx", "port": 555}]
               }
             ],

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -406,7 +406,6 @@ status:
 `))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("public metadata for IstioFederation federation-empty wasn't fetched yet"))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("private metadata for IstioFederation federation-full-empty-ig-0 wasn't fetched yet"))
-			//Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("virtualIP wasn't set for publicService ddd of IstioFederation federation-full-no-virtualip-0"))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("public metadata for IstioFederation federation-only-ingress wasn't fetched yet"))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("private metadata for IstioFederation federation-only-services wasn't fetched yet"))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("ingressGateways for IstioMulticluster multicluster-empty-ig weren't fetched yet"))

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -154,26 +154,6 @@ status:
       authnKeyPub: xyz-f5
 ---
 apiVersion: deckhouse.io/v1alpha1
-kind: IstioFederation
-metadata:
-  name: federation-full-no-virtualip-0
-spec:
-  trustDomain: "f5"
-  metadataEndpoint: "https://some-proper-host/"
-status:
-  metadataCache:
-    private:
-      ingressGateways:
-      - {"address": "ccc", "port": 222}
-      publicServices:
-      - {"hostname": "ccc", "ports": [{"name": "ppp", "port": 123}]}
-      - {"hostname": "ddd", "ports": [{"name": "xxx", "port": 555}]} # no virtualIP, federation should be skipped
-    public:
-      clusterUUID: aaa-bbb-f4
-      rootCA: abc-f4
-      authnKeyPub: xyz-f4
----
-apiVersion: deckhouse.io/v1alpha1
 kind: IstioMulticluster
 metadata:
   name: multicluster-full-0
@@ -426,10 +406,9 @@ status:
 `))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("public metadata for IstioFederation federation-empty wasn't fetched yet"))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("private metadata for IstioFederation federation-full-empty-ig-0 wasn't fetched yet"))
-			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("virtualIP wasn't set for publicService ddd of IstioFederation federation-full-no-virtualip-0"))
+			//Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("virtualIP wasn't set for publicService ddd of IstioFederation federation-full-no-virtualip-0"))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("public metadata for IstioFederation federation-only-ingress wasn't fetched yet"))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("private metadata for IstioFederation federation-only-services wasn't fetched yet"))
-
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("ingressGateways for IstioMulticluster multicluster-empty-ig weren't fetched yet"))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("private metadata for IstioMulticluster multicluster-no-apiHost wasn't fetched yet"))
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("ingressGateways for IstioMulticluster multicluster-no-ig weren't fetched yet"))
@@ -438,7 +417,7 @@ status:
 			Expect(string(f.LogrusOutput.Contents())).To(ContainSubstring("private metadata for IstioMulticluster multicluster-only-public wasn't fetched yet"))
 
 			// there should be 11 log messages
-			Expect(strings.Split(strings.Trim(string(f.LogrusOutput.Contents()), "\n"), "\n")).To(HaveLen(11))
+			Expect(strings.Split(strings.Trim(string(f.LogrusOutput.Contents()), "\n"), "\n")).To(HaveLen(10))
 		})
 	})
 })

--- a/ee/modules/110-istio/hooks/ee/federation_discovery.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery.go
@@ -99,14 +99,14 @@ func applyFederationFilter(obj *unstructured.Unstructured) (go_hook.FilterResult
 	me := federation.Spec.MetadataEndpoint
 	me = strings.TrimSuffix(me, "/")
 
-	var psvips = make(map[string]string)
-	if federation.Status.MetadataCache.Private != nil && federation.Status.MetadataCache.Private.PublicServices != nil {
-		for _, ps := range *federation.Status.MetadataCache.Private.PublicServices {
-			if ps.VirtualIP != "" {
-				psvips[ps.Hostname] = ps.VirtualIP
-			}
-		}
-	}
+	//var psvips = make(map[string]string)
+	//if federation.Status.MetadataCache.Private != nil && federation.Status.MetadataCache.Private.PublicServices != nil {
+	//	for _, ps := range *federation.Status.MetadataCache.Private.PublicServices {
+	//		if ps.VirtualIP != "" {
+	//			psvips[ps.Hostname] = ps.VirtualIP
+	//		}
+	//	}
+	//}
 	return IstioFederationDiscoveryCrdInfo{
 		Name:                    federation.GetName(),
 		TrustDomain:             federation.Spec.TrustDomain,
@@ -243,7 +243,6 @@ func federationDiscovery(input *go_hook.HookInput, dc dependency.Container) erro
 		//		continue
 		//	}
 		//}
-		federationInfo.SetMetricMetadataEndpointError(input.MetricsCollector, federationInfo.PrivateMetadataEndpoint, 0)
 		err = federationInfo.PatchMetadataCache(input.PatchCollector, "private", privateMetadata)
 		if err != nil {
 			return err

--- a/ee/modules/110-istio/hooks/ee/federation_discovery.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery.go
@@ -34,7 +34,7 @@ type IstioFederationDiscoveryCrdInfo struct {
 	PublicMetadataEndpoint  string
 	PrivateMetadataEndpoint string
 	//                       map[hostname]IP
-	PublicServicesVirtualIPs map[string]string
+	//PublicServicesVirtualIPs map[string]string
 }
 
 func (i *IstioFederationDiscoveryCrdInfo) SetMetricMetadataEndpointError(mc go_hook.MetricsCollector, endpoint string, isError float64) {
@@ -108,12 +108,12 @@ func applyFederationFilter(obj *unstructured.Unstructured) (go_hook.FilterResult
 		}
 	}
 	return IstioFederationDiscoveryCrdInfo{
-		Name:                     federation.GetName(),
-		TrustDomain:              federation.Spec.TrustDomain,
-		ClusterUUID:              clusterUUID,
-		PublicMetadataEndpoint:   me + "/public/public.json",
-		PrivateMetadataEndpoint:  me + "/private/federation.json",
-		PublicServicesVirtualIPs: psvips,
+		Name:                    federation.GetName(),
+		TrustDomain:             federation.Spec.TrustDomain,
+		ClusterUUID:             clusterUUID,
+		PublicMetadataEndpoint:  me + "/public/public.json",
+		PrivateMetadataEndpoint: me + "/private/federation.json",
+		//PublicServicesVirtualIPs: psvips,
 	}, nil
 }
 
@@ -145,15 +145,15 @@ func federationDiscovery(input *go_hook.HookInput, dc dependency.Container) erro
 
 	var myTrustDomain = input.Values.Get("global.discovery.clusterDomain").String()
 
-	var virtualIPInUseMap = make(map[string]bool)
+	//var virtualIPInUseMap = make(map[string]bool)
 	for _, federation := range input.Snapshots["federations"] {
 		federationInfo := federation.(IstioFederationDiscoveryCrdInfo)
 		if federationInfo.TrustDomain == myTrustDomain {
 			continue
 		}
-		for _, vip := range federationInfo.PublicServicesVirtualIPs {
-			virtualIPInUseMap[vip] = true
-		}
+		//for _, vip := range federationInfo.PublicServicesVirtualIPs {
+		//	virtualIPInUseMap[vip] = true
+		//}
 	}
 	//var ipi = ipIterator{
 	//	IPInUseMap: virtualIPInUseMap,
@@ -234,15 +234,15 @@ func federationDiscovery(input *go_hook.HookInput, dc dependency.Container) erro
 			federationInfo.SetMetricMetadataEndpointError(input.MetricsCollector, federationInfo.PrivateMetadataEndpoint, 1)
 			continue
 		}
-		for i, ps := range *privateMetadata.PublicServices {
-			if vip, ok := federationInfo.PublicServicesVirtualIPs[ps.Hostname]; ok {
-				(*privateMetadata.PublicServices)[i].VirtualIP = vip
-			} else {
-				input.LogEntry.Warnf("can't get VirtualIP for service %s in IstioFederation %s", ps.Hostname, federationInfo.Name)
-				federationInfo.SetMetricMetadataEndpointError(input.MetricsCollector, federationInfo.PrivateMetadataEndpoint, 1)
-				continue
-			}
-		}
+		//for i, ps := range *privateMetadata.PublicServices {
+		//	if vip, ok := federationInfo.PublicServicesVirtualIPs[ps.Hostname]; ok {
+		//		(*privateMetadata.PublicServices)[i].VirtualIP = vip
+		//	} else {
+		//		input.LogEntry.Warnf("can't get VirtualIP for service %s in IstioFederation %s", ps.Hostname, federationInfo.Name)
+		//		federationInfo.SetMetricMetadataEndpointError(input.MetricsCollector, federationInfo.PrivateMetadataEndpoint, 1)
+		//		continue
+		//	}
+		//}
 		federationInfo.SetMetricMetadataEndpointError(input.MetricsCollector, federationInfo.PrivateMetadataEndpoint, 0)
 		err = federationInfo.PatchMetadataCache(input.PatchCollector, "private", privateMetadata)
 		if err != nil {

--- a/ee/modules/110-istio/hooks/ee/federation_discovery.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery.go
@@ -243,6 +243,7 @@ func federationDiscovery(input *go_hook.HookInput, dc dependency.Container) erro
 		//		continue
 		//	}
 		//}
+		federationInfo.SetMetricMetadataEndpointError(input.MetricsCollector, federationInfo.PrivateMetadataEndpoint, 0)
 		err = federationInfo.PatchMetadataCache(input.PatchCollector, "private", privateMetadata)
 		if err != nil {
 			return err

--- a/ee/modules/110-istio/hooks/ee/federation_discovery_test.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery_test.go
@@ -124,7 +124,7 @@ status:
       publicServices:
       - {"hostname": "some-actual.host-1", "ports": [{"name": "ppp", "port": 111}]} # should be saved
       - {"hostname": "some-outdated.host-2", "ports": [{"name": "ppp", "port": 111}]} # should be deleted
-      - {"hostname": "some-actual.host-3", "ports": [{"name": "ppp", "port": 111}]} # virtualIP should be saved, port should be changed to 222
+      - {"hostname": "some-actual.host-3", "ports": [{"name": "ppp", "port": 111}]} # port should be changed to 222
 `))
 
 			respMap := map[string]map[string]HTTPMockResponse{

--- a/ee/modules/110-istio/hooks/ee/federation_discovery_test.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery_test.go
@@ -123,8 +123,8 @@ status:
       - {"address": "some-outdatad.host-2", "port": 111} # should be deleted
       publicServices:
       - {"hostname": "some-actual.host-1", "ports": [{"name": "ppp", "port": 111}]} # should be saved
-      - {"hostname": "some-outdated.host-2", "ports": [{"name": "ppp", "port": 111}], virtualIP: "169.254.0.42"} # should be deleted
-      - {"hostname": "some-actual.host-3", "ports": [{"name": "ppp", "port": 111}], virtualIP: "169.254.0.1"} # virtualIP should be saved, port should be changed to 222
+      - {"hostname": "some-outdated.host-2", "ports": [{"name": "ppp", "port": 111}]} # should be deleted
+      - {"hostname": "some-actual.host-3", "ports": [{"name": "ppp", "port": 111}]} # virtualIP should be saved, port should be changed to 222
 `))
 
 			respMap := map[string]map[string]HTTPMockResponse{
@@ -282,20 +282,20 @@ status:
 
 			Expect(f.KubernetesGlobalResource("IstioFederation", "proper-federation-0").Field("status.metadataCache.private.publicServices").String()).To(MatchJSON(`
             [
-              {"hostname": "a.b.c", "ports": [{"name": "ppp", "port": 123}], "virtualIP": "169.254.0.2"},
-              {"hostname": "1.2.3.4", "ports": [{"name": "ppp", "port": 234}], "virtualIP": "169.254.0.3"}
+              {"hostname": "a.b.c", "ports": [{"name": "ppp", "port": 123}]},
+              {"hostname": "1.2.3.4", "ports": [{"name": "ppp", "port": 234}]}
             ]
 `))
 			Expect(f.KubernetesGlobalResource("IstioFederation", "proper-federation-1").Field("status.metadataCache.private.publicServices").String()).To(MatchJSON(`
             [
-              {"hostname": "some-actual.host", "ports": [{"name": "ppp", "port": 111}], "virtualIP": "169.254.0.4"}
+              {"hostname": "some-actual.host", "ports": [{"name": "ppp", "port": 111}]}
             ]
 `))
 			Expect(f.KubernetesGlobalResource("IstioFederation", "proper-federation-2").Field("status.metadataCache.private.publicServices").String()).To(MatchJSON(`
             [
-              {"hostname": "some-actual.host-1", "ports": [{"name": "ppp", "port": 111}], "virtualIP": "169.254.0.5"},
-              {"hostname": "some-actual.host-2", "ports": [{"name": "ppp", "port": 111}], "virtualIP": "169.254.0.6"},
-              {"hostname": "some-actual.host-3", "ports": [{"name": "ppp", "port": 222}], "virtualIP": "169.254.0.1"}
+              {"hostname": "some-actual.host-1", "ports": [{"name": "ppp", "port": 111}]},
+              {"hostname": "some-actual.host-2", "ports": [{"name": "ppp", "port": 111}]},
+              {"hostname": "some-actual.host-3", "ports": [{"name": "ppp", "port": 222}]}
             ]
 `))
 

--- a/ee/modules/110-istio/hooks/ee/lib/crd/istiofederation.go
+++ b/ee/modules/110-istio/hooks/ee/lib/crd/istiofederation.go
@@ -51,5 +51,4 @@ type FederationPublicServices struct {
 		Name string `json:"name"`
 		Port uint   `json:"port"`
 	} `json:"ports"`
-	//VirtualIP string `json:"virtualIP,omitempty"`
 }

--- a/ee/modules/110-istio/hooks/ee/lib/crd/istiofederation.go
+++ b/ee/modules/110-istio/hooks/ee/lib/crd/istiofederation.go
@@ -51,5 +51,4 @@ type FederationPublicServices struct {
 		Name string `json:"name"`
 		Port uint   `json:"port"`
 	} `json:"ports"`
-	VirtualIP string `json:"virtualIP,omitempty"`
 }

--- a/ee/modules/110-istio/hooks/ee/lib/crd/istiofederation.go
+++ b/ee/modules/110-istio/hooks/ee/lib/crd/istiofederation.go
@@ -51,4 +51,5 @@ type FederationPublicServices struct {
 		Name string `json:"name"`
 		Port uint   `json:"port"`
 	} `json:"ports"`
+	//VirtualIP string `json:"virtualIP,omitempty"`
 }

--- a/ee/modules/110-istio/templates/federation/remote-services.yaml
+++ b/ee/modules/110-istio/templates/federation/remote-services.yaml
@@ -17,8 +17,6 @@ spec:
   - name: {{ $port.name }}
     number: {{ $port.port }}
       {{- end }}
-  addresses:
-  - {{ $publicService.virtualIP }}
   resolution: STATIC
   endpoints:
       {{- range $ingressGateway := $federation.ingressGateways }}

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -358,9 +358,6 @@ neighbour-0:
               ports:
                 aaa: 123
             `))
-			Expect(se.Field("spec.addresses").String()).To(MatchYAML(`
-            - 2.2.2.2
-            `))
 
 			Expect(f.KubernetesResource("Deployment", "d8-istio", "metadata-exporter").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "metadata-exporter").Exists()).To(BeTrue())

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -327,7 +327,6 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
     port: 123
   publicServices:
   - hostname: xxx.yyy
-    virtualIP: 2.2.2.2
     ports:
     - name: aaa
       port: 456

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -128,6 +128,7 @@ spec:
       proxyMetadata:
         CLOUD_PLATFORM: {{ $cloudPlatform }}
         ISTIO_META_DNS_CAPTURE: "true"
+        ISTIO_META_DNS_AUTO_ALLOCATE: "true"
         PROXY_CONFIG_XDS_AGENT: "true"
         ISTIO_META_IDLE_TIMEOUT: {{ $.Values.istio.proxyConfig.idleTimeout }}
       holdApplicationUntilProxyStarts: {{ $.Values.istio.proxyConfig.holdApplicationUntilProxyStarts }}


### PR DESCRIPTION
## Description
Enabling automatic DNS name allocated the Istio service and excluding self-made IP address allocation for public service's ServiceEntry'es in Federation.

## Why do we need it, and what problem does it solve?
The self-made IP address iterator is no longer needed after enabling the automatic DNS name allocation of Istio service.

## What is the expected result?
Istio Federation no longer contains information about the IP addresses of public services and interaction with them takes place using DNS names and internal IP addresses allocated by istio.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: chore
summary: Got rid of self-made IP address allocation for public service's ServiceEntries in Federation
impact_level: default
```