### PR TITLE
[dhctl] fix empty registry credentials preflight check failure

### DIFF
--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -294,8 +294,9 @@ func prepareAuthRequest(
 	if err != nil {
 		return nil, fmt.Errorf("prepare auth request: %w", err)
 	}
-
-	req.Header.Add("Authorization", "Basic "+authData)
+	if authData != "" {
+		req.Header.Add("Authorization", "Basic "+authData)
+	}
 
 	return req, nil
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fix registry credentials preflight check failure when `registryDockerCfg` contains empty auth for host, for example `{"auths":{"registry.deckhouse.io":{}}}`

```yaml
apiVersion: deckhouse.io/v1
kind: InitConfiguration
deckhouse:
  imagesRepo: registry.deckhouse.io/deckhouse/ce
  registryDockerCfg: eyJhdXRocyI6eyJyZWdpc3RyeS5kZWNraG91c2UuaW8iOnt9fX0=
```

```
🎈 ~ Common: Global preflight checks
│ ┌ Checking PublicDomainTemplate is correctly
│ │ 🎉 Succeeded!
│ └ Checking PublicDomainTemplate is correctly (0.00 seconds)
│
│ ┌ Checking registry credentials are correct
│ │ ️⛱️️ Attempt #1 of 1 |
│ │ 	Checking registry credentials are correct failed, next attempt will be in 10s"
│ │ 	Error: authentication failed
│ │
│ └ Checking registry credentials are correct (0.49 seconds) FAILED
└ 🎈 ~ Common: Global preflight checks (0.49 seconds) FAILED

Installation aborted: Timeout while "Checking registry credentials are correct": last error: authentication failed
Please fix this problem or skip it if you're sure with preflight-skip-registry-credential flag
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix empty registry credentials preflight check failure.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
