### PR TITLE
[docs] Added info about anonymous access to the container registry

### DIFF
--- a/deckhouse-controller/crds/doc-ru-module-source.yaml
+++ b/deckhouse-controller/crds/doc-ru-module-source.yaml
@@ -20,7 +20,7 @@ spec:
                       type: string
                       description: Адрес репозитория образов контейнеров.
                     dockerCfg:
-                      description: Строка с токеном доступа к container registry в Base64. В случае использования анонимного доступа к container registry — не заполняйте это поле.
+                      description: Строка с токеном доступа к container registry в Base64. В случае использования анонимного доступа к container registry не заполняйте это поле.
                     ca:
                       description: |
                         Корневой сертификат (В формате PEM), которым можно проверить сертификат registry при работе по HTTPS (если registry использует самоподписанные SSL-сертификаты).

--- a/deckhouse-controller/crds/doc-ru-module-source.yaml
+++ b/deckhouse-controller/crds/doc-ru-module-source.yaml
@@ -20,7 +20,7 @@ spec:
                       type: string
                       description: Адрес репозитория образов контейнеров.
                     dockerCfg:
-                      description: Строка с токеном доступа к container registry в Base64.
+                      description: Строка с токеном доступа к container registry в Base64. В случае использования анонимного доступа к container registry — не заполняйте это поле.
                     ca:
                       description: |
                         Корневой сертификат (В формате PEM), которым можно проверить сертификат registry при работе по HTTPS (если registry использует самоподписанные SSL-сертификаты).

--- a/deckhouse-controller/crds/module-source.yaml
+++ b/deckhouse-controller/crds/module-source.yaml
@@ -65,7 +65,7 @@ spec:
                       x-doc-examples: ['registry.example.io/deckhouse/modules']
                     dockerCfg:
                       type: string
-                      description: Container registry access token in Base64.
+                      description: Container registry access token in Base64. If using anonymous access to the container registry, do not fill in this field.
                     ca:
                       type: string
                       description: |

--- a/docs/site/_includes/getting_started/global/step_cluster_setup.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup.html
@@ -123,6 +123,9 @@
     <span class="info">
       It is a string from the Docker client configuration file (in Linux it is usually <code>$HOME/.docker/config.json</code>), Base64-encoded.<br />Read more about the parameter <a href="/products/kubernetes-platform/documentation/v1/installing/configuration.html#initconfiguration-deckhouse-registrydockercfg">in the documentation</a>.
     </span>
+    <span class="info">
+      If using anonymous access to the container registry, do not fill in this field.
+    </span>
   </div>
 
   <div class="form__row">

--- a/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
@@ -119,7 +119,7 @@
       class="textfield"
       type="text" id="registryDockerCfg"
       name="registryDockerCfg" placeholder=""
-      autocomplete="off" /> 
+      autocomplete="off" />
     <span class="info">
       Строка авторизации из файла конфигурации Docker-клиента (в Linux обычно это <code>$HOME/.docker/config.json</code>), закодированная в Base64.<br />Подробнее про этот параметр читайте <a href="/products/kubernetes-platform/documentation/v1/installing/configuration.html#initconfiguration-deckhouse-registrydockercfg">в документации</a>.
     </span>

--- a/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
@@ -119,9 +119,12 @@
       class="textfield"
       type="text" id="registryDockerCfg"
       name="registryDockerCfg" placeholder=""
-      autocomplete="off" />
+      autocomplete="off" />  
     <span class="info">
       Строка авторизации из файла конфигурации Docker-клиента (в Linux обычно это <code>$HOME/.docker/config.json</code>), закодированная в Base64.<br />Подробнее про этот параметр читайте <a href="/products/kubernetes-platform/documentation/v1/installing/configuration.html#initconfiguration-deckhouse-registrydockercfg">в документации</a>.
+    </span>
+    <span class="info">
+      В случае использования анонимного доступа к хранилищу образов контейнеров — не заполняйте это поле.
     </span>
   </div>
 

--- a/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
@@ -119,7 +119,7 @@
       class="textfield"
       type="text" id="registryDockerCfg"
       name="registryDockerCfg" placeholder=""
-      autocomplete="off" />  
+      autocomplete="off" /> 
     <span class="info">
       Строка авторизации из файла конфигурации Docker-клиента (в Linux обычно это <code>$HOME/.docker/config.json</code>), закодированная в Base64.<br />Подробнее про этот параметр читайте <a href="/products/kubernetes-platform/documentation/v1/installing/configuration.html#initconfiguration-deckhouse-registrydockercfg">в документации</a>.
     </span>

--- a/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
@@ -124,7 +124,7 @@
       Строка авторизации из файла конфигурации Docker-клиента (в Linux обычно это <code>$HOME/.docker/config.json</code>), закодированная в Base64.<br />Подробнее про этот параметр читайте <a href="/products/kubernetes-platform/documentation/v1/installing/configuration.html#initconfiguration-deckhouse-registrydockercfg">в документации</a>.
     </span>
     <span class="info">
-      В случае использования анонимного доступа к хранилищу образов контейнеров — не заполняйте это поле.
+      В случае использования анонимного доступа к хранилищу образов контейнеров не заполняйте это поле.
     </span>
   </div>
 


### PR DESCRIPTION
## Description
Added info about anonymous access to the container registry at specs and gs.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


```changes
section: docs
type: chore
summary: Added info about anonymous access to the container registry.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
