### PR TITLE
[candi] extend regexp for detect lvm partition

### DIFF
--- a/candi/bashible/common-steps/node-group/004_resize_partitions.sh.tpl
+++ b/candi/bashible/common-steps/node-group/004_resize_partitions.sh.tpl
@@ -74,7 +74,7 @@ for partition in $(mount | grep -vE "kubernetes.io" | grep "ext4" | awk '{print 
   fi
 
   # partition = /dev/mapper/vgubuntu-root. LVM partition.
-  if [[ "${partition}" =~ ^/dev/mapper/[a-z\-]+$ ]]; then
+  if [[ "${partition}" =~ ^/dev/mapper/[A-Za-z0-9-]+$ ]]; then
     if grow_lvm "${partition}"; then
       resize2fs "${partition}"
     fi


### PR DESCRIPTION
## Description

Extend regexp in `004_resize_partitions.sh` for detect lvm partition with capital letter and digit in name.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

If the logical volume name contains an capital letter or digit (for example `Debian--12-vg--root` in picture below), it will not be defined as an LVM partition. As a result, the PhysicalVolume partition will not be resized and consequently neither will the LogicalVolume:

<img width="1497" alt="image" src="https://github.com/user-attachments/assets/148abef8-4562-43cc-96c2-1ca76a2b45b5">
<img width="597" alt="image" src="https://github.com/user-attachments/assets/969cdd31-9507-4a12-b5cc-2bc1918f0dc3">

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?

Correct resize lvm partition with capital letter and digit in name: 
<img width="1655" alt="image" src="https://github.com/user-attachments/assets/8343e56b-92f7-4262-a302-710229abf388">
<img width="568" alt="image" src="https://github.com/user-attachments/assets/3830e35e-e449-4a29-89e8-29b5307b63da">


<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Extend regexp in `004_resize_partitions.sh` for detect lvm partition with capital letter and digit in name.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
