### PR TITLE
[deckhouse] Update validation for ModuleConfig with windows

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -154,11 +154,11 @@ spec:
 {{- else }}
   validations:
     - expression: |
-        object.metadata.name == "deckhouse" &&
+        !(object.metadata.name == "deckhouse" &&
         has(object.spec.settings.update) &&
         has(object.spec.settings.update.windows) &&
         object.spec.settings.update.windows.size() > 0 &&
-        object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) < int(string(w.to).replace(":", "")))
+        object.spec.settings.update.windows.all(w, int(string(w.from).replace(":", "")) >= int(string(w.to).replace(":", ""))))
       reason: Forbidden
 {{- end }}
 ---


### PR DESCRIPTION
## Description
Fix validation

## Why do we need it, and what problem does it solve?
We have to revert condition to avoid other ModuleConfigs

## Why do we need it in the patch release (if we do)?

In the kubernetes 1.26 other ModuleConfigs then `deckhouse` could not be updated

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Fix validation policy for update windows in kubernetes 1.26
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
