### PR TITLE
[monitoring-kubernetes] collect tcp_mem metric and make alert when tcp memory pressure.

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4588,6 +4588,17 @@ alerts:
         Unsupported version of CRI {{$labels.container_runtime_version}} installed for Kubernetes version: {{$labels.kubelet_version}}
       severity: undefined
       markupFormat: markdown
+    - name: NodeTCPMemoryExhaust
+      sourceFile: modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node.yaml
+      moduleUrl: 340-monitoring-kubernetes
+      module: monitoring-kubernetes
+      edition: ce
+      description: |
+        The target is close to TCP memory pressure state. Less than 5% left to the threshold.
+      summary: |
+        High TCP stack memory usage.
+      severity: "4"
+      markupFormat: markdown
 modules-having-alerts:
     - admission-policy-engine
     - cert-manager

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node.yaml
@@ -118,3 +118,22 @@
         If cgroupDriver is set to systemd then reboot is required to roll back to cgroupfs driver. Please, drain and reboot the node.
 
         You can check this [issue](https://github.com/deckhouse/deckhouse/issues/2152) for extra information.
+
+  - alert: NodeTCPMemoryExhaust
+    expr: max by (node) (node_sockstat_TCP_mem_bytes > node_sysctl_net_ipv4_tcp_mem{index="1"} * 4096 * 0.95)
+    for: 1m
+    labels:
+      severity_level: "4"
+      tier: cluster
+    annotations:
+      plk_markup_format: "markdown"
+      plk_protocol_version: "1"
+      plk_create_group_if_not_exists__cluster_has_node_alerts: "ClusterHasNodeAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__cluster_has_node_alerts: "ClusterHasNodeAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      summary: The {{ $labels.node }} Node has high TCP stack memory usage.
+      description: |-
+        The {{ $labels.node }} Node TCP stack is under memory pressure.
+
+        Source of the problem can be application with TCP networking functionality.
+
+        You can check this [issue](https://github.com/deckhouse/deckhouse/issues/4605) for extra information.

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node.yaml
@@ -135,5 +135,3 @@
         The {{ $labels.node }} Node TCP stack is under memory pressure.
 
         Source of the problem can be application with TCP networking functionality.
-
-        You can check this [issue](https://github.com/deckhouse/deckhouse/issues/4605) for extra information.

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -96,6 +96,9 @@ spec:
         - '/host/textfile*'
         - '--collector.netstat.fields'
         - '^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_.*|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$'
+# tcp_mem metric collection https://github.com/deckhouse/deckhouse/issues/4605
+        - '--collector.sysctl'
+        - '--collector.sysctl.include=net.ipv4.tcp_mem'
         env:
         - name: HOST_IP
           valueFrom:


### PR DESCRIPTION
## Description
Adds collecting of thresholds of sysctl parameter `net.ipv4.tcp_mem` and alert when `node_sockstat_TCP_mem_bytes` metric passes this threshold.

## Why do we need it, and what problem does it solve?
This fixes issue https://github.com/deckhouse/deckhouse/issues/4605 and improves monitoring over TCP.

## Why do we need it in the patch release (if we do)?

-

## What is the expected result?
We expect existance of alerts when TCP stack memory passes thresholds from second value of `net.ipv4.tcp_mem` vector multiplied by 4096 (memory page size) and multiplied by 0.95 (5% padding).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Added alert for `node_sockstat_TCP_mem_bytes` metric when it passes safe TCP memory pressure threshold.

```changes
section: monitoring-kubernetes
type: chore
summary: increase quality of network stack monitoring
impact_level: low
```
