### PR TITLE
[deckhouse-controller] Fix ModuleRelease sorting

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -343,18 +343,19 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 		}
 		r.metricStorage.GroupedVault.GaugeSet(metricUpdatingGroup, "d8_is_updating", 1, labels)
 	}
+	{
+		var releases v1alpha1.DeckhouseReleaseList
+		err = r.client.List(ctx, &releases)
+		if err != nil {
+			return result, fmt.Errorf("get deckhouse releases: %w", err)
+		}
 
-	var releases v1alpha1.DeckhouseReleaseList
-	err = r.client.List(ctx, &releases)
-	if err != nil {
-		return result, fmt.Errorf("get deckhouse releases: %w", err)
+		pointerReleases := make([]*v1alpha1.DeckhouseRelease, 0, len(releases.Items))
+		for _, rl := range releases.Items {
+			pointerReleases = append(pointerReleases, &rl)
+		}
+		deckhouseUpdater.SetReleases(pointerReleases)
 	}
-
-	pointerReleases := make([]*v1alpha1.DeckhouseRelease, 0, len(releases.Items))
-	for _, rl := range releases.Items {
-		pointerReleases = append(pointerReleases, &rl)
-	}
-	deckhouseUpdater.SetReleases(pointerReleases)
 
 	if deckhouseUpdater.ReleasesCount() == 0 {
 		r.logger.Debug("releases count is zero")

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -505,7 +505,7 @@ func (r *moduleReleaseReconciler) reconcilePendingRelease(ctx context.Context, m
 		modulePath := generateModulePath(moduleName, deployedRelease.Spec.Version.String())
 		if !isModuleExistsOnFS(r.symlinksDir, currentModuleSymlink, modulePath) {
 			newModuleSymlink := path.Join(r.symlinksDir, fmt.Sprintf("%d-%s", deployedRelease.Spec.Weight, moduleName))
-			r.logger.Debugf("Module %q doesn't exist on the filesystem. Restoring", moduleName)
+			r.logger.Warnf("Module %q doesn't exist on the filesystem. Restoring", moduleName)
 			err = enableModule(r.downloadedModulesDir, currentModuleSymlink, newModuleSymlink, modulePath)
 			if err != nil {
 				r.logger.Errorf("Module restore for module %q and release %q failed: %v", moduleName, deployedRelease.Spec.Version.String(), err)

--- a/go_lib/updater/updater.go
+++ b/go_lib/updater/updater.go
@@ -375,7 +375,7 @@ func (u *Updater[R]) predictedRelease() *R {
 	return predictedRelease
 }
 
-func (u *Updater[R]) deployedRelease() *R {
+func (u *Updater[R]) DeployedRelease() *R {
 	if u.currentDeployedReleaseIndex == -1 {
 		return nil // has no deployed
 	}

--- a/go_lib/updater/updater.go
+++ b/go_lib/updater/updater.go
@@ -381,6 +381,7 @@ func (u *Updater[R]) DeployedRelease() *R {
 	}
 
 	deployedRelease := &(u.releases[u.currentDeployedReleaseIndex])
+	u.logger.Debugf("Deployed release found by updater: %v", deployedRelease)
 
 	return deployedRelease
 }


### PR DESCRIPTION
## Description
Fix wrong index detection for deployed ModuleRelease

## Why do we need it, and what problem does it solve?
It can lead to a problem with detection of a deployed module release

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix 
summary: Fix deployed module release detection in the ModuleReleaseController.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
