### PR TITLE
[log-shipper] Cleanup after source

### DIFF
--- a/modules/460-log-shipper/hooks/internal/vector/transform/source.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/source.go
@@ -83,7 +83,6 @@ func CreateLogSourceTransforms(name string, cfg *LogSourceConfig) ([]apis.LogTra
 		transforms = append(transforms, OwnerReferenceSourceTransform())
 	}
 
-	transforms = append(transforms, CleanUpAfterSourceTransform())
 	transforms = append(transforms, LocalTimezoneAfterSourceTransform())
 
 	multilineTransforms, err := CreateMultiLineTransforms(cfg.MultilineType, cfg.MultilineCustomConfig)
@@ -104,6 +103,8 @@ func CreateLogSourceTransforms(name string, cfg *LogSourceConfig) ([]apis.LogTra
 		return nil, err
 	}
 	transforms = append(transforms, logFilterTransforms...)
+	
+	transforms = append(transforms, CleanUpAfterSourceTransform())
 
 	sTransforms, err := BuildFromMapSlice("source", name, transforms)
 	if err != nil {

--- a/modules/460-log-shipper/hooks/internal/vector/transform/source.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/source.go
@@ -103,7 +103,7 @@ func CreateLogSourceTransforms(name string, cfg *LogSourceConfig) ([]apis.LogTra
 		return nil, err
 	}
 	transforms = append(transforms, logFilterTransforms...)
-	
+
 	transforms = append(transforms, CleanUpAfterSourceTransform())
 
 	sTransforms, err := BuildFromMapSlice("source", name, transforms)

--- a/modules/460-log-shipper/hooks/testdata/es-5x/result.json
+++ b/modules/460-log-shipper/hooks/testdata/es-5x/result.json
@@ -26,7 +26,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/09_log_filter"
+        "transform/source/test-source/09_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -55,71 +55,71 @@
       "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_clean_up": {
+    "transform/source/test-source/01_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
-      "type": "remap"
-    },
-    "transform/source/test-source/02_local_timezone": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/test-source/01_clean_up"
-      ],
       "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/03_parse_json": {
+    "transform/source/test-source/02_parse_json": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/02_local_timezone"
+        "transform/source/test-source/01_local_timezone"
       ],
       "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-source/04_log_filter": {
+    "transform/source/test-source/03_log_filter": {
       "condition": "exists(.parsed_data.foo)",
       "inputs": [
-        "transform/source/test-source/03_parse_json"
+        "transform/source/test-source/02_parse_json"
+      ],
+      "type": "filter"
+    },
+    "transform/source/test-source/04_log_filter": {
+      "condition": "!exists(.parsed_data.fo)",
+      "inputs": [
+        "transform/source/test-source/03_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/05_log_filter": {
-      "condition": "!exists(.parsed_data.fo)",
+      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        false;\n    } else {\n        includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    includes([\"wvrr\"], .parsed_data.foo);\n}",
       "inputs": [
         "transform/source/test-source/04_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/06_log_filter": {
-      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        false;\n    } else {\n        includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    includes([\"wvrr\"], .parsed_data.foo);\n}",
+      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        true;\n    } else {\n        !includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    !includes([\"wvrr\"], .parsed_data.foo);\n}",
       "inputs": [
         "transform/source/test-source/05_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/07_log_filter": {
-      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        true;\n    } else {\n        !includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    !includes([\"wvrr\"], .parsed_data.foo);\n}",
+      "condition": "match!(.parsed_data.foo, r'^wvrr$')",
       "inputs": [
         "transform/source/test-source/06_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/08_log_filter": {
-      "condition": "match!(.parsed_data.foo, r'^wvrr$')",
+      "condition": "if exists(.parsed_data.foo) \u0026\u0026 is_string(.parsed_data.foo) {\n    matched = false\n    matched0, err = match(.parsed_data.foo, r'^wvrr$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    !matched\n} else {\n    true\n}",
       "inputs": [
         "transform/source/test-source/07_log_filter"
       ],
       "type": "filter"
     },
-    "transform/source/test-source/09_log_filter": {
-      "condition": "if exists(.parsed_data.foo) \u0026\u0026 is_string(.parsed_data.foo) {\n    matched = false\n    matched0, err = match(.parsed_data.foo, r'^wvrr$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    !matched\n} else {\n    true\n}",
+    "transform/source/test-source/09_clean_up": {
+      "drop_on_abort": false,
       "inputs": [
         "transform/source/test-source/08_log_filter"
       ],
-      "type": "filter"
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "type": "remap"
     }
   },
   "sinks": {

--- a/modules/460-log-shipper/hooks/testdata/file-to-elastic/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-elastic/result.json
@@ -11,7 +11,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -24,20 +24,20 @@
       "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
       "type": "remap"
     },
-    "transform/source/test-source/00_clean_up": {
+    "transform/source/test-source/00_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_local_timezone": {
+    "transform/source/test-source/01_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/00_clean_up"
+        "transform/source/test-source/00_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/result.json
@@ -11,25 +11,25 @@
     "transform/destination/test-kafka-dest/00_cef_values": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if !exists(.cef) {\n  .cef = {};\n};\n\nif !exists(.cef.name) {\n  .cef.name = \"Deckhouse Event\";\n};\n\nif !exists(.cef.severity) {\n  .cef.severity = \"5\";\n} else if is_string(.cef.severity) {\n  if .cef.severity == \"Debug\" {\n    .cef.severity = \"0\";\n  };\n  if .cef.severity == \"Informational\" {\n    .cef.severity = \"3\";\n  };\n  if .cef.severity == \"Notice\" {\n    .cef.severity = \"4\";\n  };\n  if .cef.severity == \"Warning\" {\n    .cef.severity = \"6\";\n  };\n  if .cef.severity == \"Error\" {\n    .cef.severity = \"7\";\n  };\n  if .cef.severity == \"Critical\" {\n    .cef.severity = \"8\";\n  };\n  if .cef.severity == \"Emergency\" {\n    .cef.severity = \"10\";\n  };\n};",
       "type": "remap"
     },
-    "transform/source/test-source/00_clean_up": {
+    "transform/source/test-source/00_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_local_timezone": {
+    "transform/source/test-source/01_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/00_clean_up"
+        "transform/source/test-source/00_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka/result.json
@@ -8,20 +8,20 @@
     }
   },
   "transforms": {
-    "transform/source/test-source/00_clean_up": {
+    "transform/source/test-source/00_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_local_timezone": {
+    "transform/source/test-source/01_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/00_clean_up"
+        "transform/source/test-source/00_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     }
   },
@@ -29,7 +29,7 @@
     "destination/cluster/test-kafka-dest": {
       "type": "kafka",
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/source/test-source/01_clean_up"
       ],
       "healthcheck": {
         "enabled": false

--- a/modules/460-log-shipper/hooks/testdata/file-to-loki/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-loki/result.json
@@ -11,25 +11,25 @@
     "transform/destination/test-loki-dest/00_parse_json": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-source/00_clean_up": {
+    "transform/source/test-source/00_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_local_timezone": {
+    "transform/source/test-source/01_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/00_clean_up"
+        "transform/source/test-source/00_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/file-to-socket-cef-gelf/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-socket-cef-gelf/result.json
@@ -11,7 +11,7 @@
     "transform/destination/test-socket1-dest/00_extra_fields": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}\n\n.cef.severity=\"1\"",
       "type": "remap"
@@ -35,7 +35,7 @@
     "transform/destination/test-socket2-dest/00_del_parsed_data": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
       "type": "remap"
@@ -48,20 +48,20 @@
       "source": "if !exists(.host) {\n  .host = .node\n};\n\nif exists(.timestamp_end) {\n  del(.timestamp_end)\n};\n\n.timestamp = parse_timestamp!(.\"timestamp\", format: \"%+\");\n\n. = flatten(.);\n\n. = map_keys(., recursive: true) -\u003e |key| {\n  key = replace(key, \".\", \"_\");\n  key = replace(key, \"/\", \"_\");\n  key = replace(key, \"-\", \"_\");\n  key\n};\n\n. = map_values(., true) -\u003e |value| {\n  if is_timestamp(value) {\n    value\n  } else if is_float(value) {\n    value\n  } else if is_integer(value) {\n    value\n  } else {\n    join(value, \", \") ?? to_string(value) ?? value\n  }\n};",
       "type": "remap"
     },
-    "transform/source/test-source/00_clean_up": {
+    "transform/source/test-source/00_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_local_timezone": {
+    "transform/source/test-source/01_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/00_clean_up"
+        "transform/source/test-source/00_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/file-to-socket/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-socket/result.json
@@ -11,7 +11,7 @@
     "transform/destination/test-socket1-dest/00_del_parsed_data": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
       "type": "remap"
@@ -19,7 +19,7 @@
     "transform/destination/test-socket2-dest/00_del_parsed_data": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
       "type": "remap"
@@ -35,7 +35,7 @@
     "transform/destination/test-socket3-dest/00_extra_fields": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}\n\n.cef.name=\"d8\" \n .cef.severity=\"1\"",
       "type": "remap"
@@ -51,7 +51,7 @@
     "transform/destination/test-socket4-dest/00_cef_values": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if !exists(.cef) {\n  .cef = {};\n};\n\nif !exists(.cef.name) {\n  .cef.name = \"Deckhouse Event\";\n};\n\nif !exists(.cef.severity) {\n  .cef.severity = \"5\";\n} else if is_string(.cef.severity) {\n  if .cef.severity == \"Debug\" {\n    .cef.severity = \"0\";\n  };\n  if .cef.severity == \"Informational\" {\n    .cef.severity = \"3\";\n  };\n  if .cef.severity == \"Notice\" {\n    .cef.severity = \"4\";\n  };\n  if .cef.severity == \"Warning\" {\n    .cef.severity = \"6\";\n  };\n  if .cef.severity == \"Error\" {\n    .cef.severity = \"7\";\n  };\n  if .cef.severity == \"Critical\" {\n    .cef.severity = \"8\";\n  };\n  if .cef.severity == \"Emergency\" {\n    .cef.severity = \"10\";\n  };\n};",
       "type": "remap"
@@ -64,20 +64,20 @@
       "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
       "type": "remap"
     },
-    "transform/source/test-source/00_clean_up": {
+    "transform/source/test-source/00_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_local_timezone": {
+    "transform/source/test-source/01_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/00_clean_up"
+        "transform/source/test-source/00_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/file-to-splunk/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-splunk/result.json
@@ -11,25 +11,25 @@
     "transform/destination/test-splunk-dest/00_splunk_datetime": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if exists(.\"timestamp\") {\n  .\"datetime\" = .\"timestamp\"\n}",
       "type": "remap"
     },
-    "transform/source/test-source/00_clean_up": {
+    "transform/source/test-source/00_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_local_timezone": {
+    "transform/source/test-source/01_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/00_clean_up"
+        "transform/source/test-source/00_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/file-to-vector/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-vector/result.json
@@ -11,25 +11,25 @@
     "transform/destination/test-vector-dest/00_del_parsed_data": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_local_timezone"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
       "type": "remap"
     },
-    "transform/source/test-source/00_clean_up": {
+    "transform/source/test-source/00_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "cluster_logging_config/test-source"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_local_timezone": {
+    "transform/source/test-source/01_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/00_clean_up"
+        "transform/source/test-source/00_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/many-to-one/result.json
+++ b/modules/460-log-shipper/hooks/testdata/many-to-one/result.json
@@ -32,26 +32,26 @@
     "transform/destination/test-vector-dest/00_del_parsed_data": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-file/01_local_timezone",
-        "transform/source/test-kubernetes/02_local_timezone"
+        "transform/source/test-file/01_clean_up",
+        "transform/source/test-kubernetes/02_clean_up"
       ],
       "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
       "type": "remap"
     },
-    "transform/source/test-file/00_clean_up": {
+    "transform/source/test-file/00_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "cluster_logging_config/test-file"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-file/01_local_timezone": {
+    "transform/source/test-file/01_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-file/00_clean_up"
+        "transform/source/test-file/00_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     },
     "transform/source/test-kubernetes/00_owner_ref": {
@@ -62,20 +62,20 @@
       "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-kubernetes/01_clean_up": {
+    "transform/source/test-kubernetes/01_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "transform/source/test-kubernetes/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-kubernetes/02_local_timezone": {
+    "transform/source/test-kubernetes/02_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-kubernetes/01_clean_up"
+        "transform/source/test-kubernetes/01_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/multiline-custom-pods/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiline-custom-pods/result.json
@@ -26,7 +26,7 @@
     "transform/destination/test-es-dest-pods/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/tests-whispers-pods_whispers-logs-pods/03_multiline"
+        "transform/source/tests-whispers-pods_whispers-logs-pods/03_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -55,35 +55,35 @@
       "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
       "type": "remap"
     },
-    "transform/source/tests-whispers-pods_whispers-logs-pods/01_clean_up": {
+    "transform/source/tests-whispers-pods_whispers-logs-pods/01_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "transform/source/tests-whispers-pods_whispers-logs-pods/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
-      "type": "remap"
-    },
-    "transform/source/tests-whispers-pods_whispers-logs-pods/02_local_timezone": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/tests-whispers-pods_whispers-logs-pods/01_clean_up"
-      ],
       "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/tests-whispers-pods_whispers-logs-pods/03_multiline": {
+    "transform/source/tests-whispers-pods_whispers-logs-pods/02_multiline": {
       "ends_when": "matched, err = match(.message, r'^endsWhen');\nif err != null {\n    true;\n} else {\n    !matched;\n}",
       "group_by": [
         "file",
         "stream"
       ],
       "inputs": [
-        "transform/source/tests-whispers-pods_whispers-logs-pods/02_local_timezone"
+        "transform/source/tests-whispers-pods_whispers-logs-pods/01_local_timezone"
       ],
       "merge_strategies": {
         "message": "concat"
       },
       "type": "reduce"
+    },
+    "transform/source/tests-whispers-pods_whispers-logs-pods/03_clean_up": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/tests-whispers-pods_whispers-logs-pods/02_multiline"
+      ],
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "type": "remap"
     }
   },
   "sinks": {

--- a/modules/460-log-shipper/hooks/testdata/multiline-custom/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiline-custom/result.json
@@ -26,7 +26,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/whispers-logs/03_multiline"
+        "transform/source/whispers-logs/03_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -55,35 +55,35 @@
       "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
       "type": "remap"
     },
-    "transform/source/whispers-logs/01_clean_up": {
+    "transform/source/whispers-logs/01_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "transform/source/whispers-logs/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
-      "type": "remap"
-    },
-    "transform/source/whispers-logs/02_local_timezone": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/whispers-logs/01_clean_up"
-      ],
       "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/whispers-logs/03_multiline": {
+    "transform/source/whispers-logs/02_multiline": {
       "group_by": [
         "file",
         "stream"
       ],
       "inputs": [
-        "transform/source/whispers-logs/02_local_timezone"
+        "transform/source/whispers-logs/01_local_timezone"
       ],
       "merge_strategies": {
         "message": "concat"
       },
       "starts_when": "matched, err = match(.message, r'^startsWhen');\nif err != null {\n    false;\n} else {\n    matched;\n}",
       "type": "reduce"
+    },
+    "transform/source/whispers-logs/03_clean_up": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/whispers-logs/02_multiline"
+      ],
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "type": "remap"
     }
   },
   "sinks": {

--- a/modules/460-log-shipper/hooks/testdata/multiline/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiline/result.json
@@ -26,7 +26,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/tests-whispers_whispers-logs/03_multiline"
+        "transform/source/tests-whispers_whispers-logs/03_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -55,35 +55,35 @@
       "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
       "type": "remap"
     },
-    "transform/source/tests-whispers_whispers-logs/01_clean_up": {
+    "transform/source/tests-whispers_whispers-logs/01_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "transform/source/tests-whispers_whispers-logs/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
-      "type": "remap"
-    },
-    "transform/source/tests-whispers_whispers-logs/02_local_timezone": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/tests-whispers_whispers-logs/01_clean_up"
-      ],
       "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/tests-whispers_whispers-logs/03_multiline": {
+    "transform/source/tests-whispers_whispers-logs/02_multiline": {
       "group_by": [
         "file",
         "stream"
       ],
       "inputs": [
-        "transform/source/tests-whispers_whispers-logs/02_local_timezone"
+        "transform/source/tests-whispers_whispers-logs/01_local_timezone"
       ],
       "merge_strategies": {
         "message": "concat"
       },
       "starts_when": "matched, err = match(.message, r'^\\{');\nif err != null {\n    false;\n} else {\n    matched;\n}",
       "type": "reduce"
+    },
+    "transform/source/tests-whispers_whispers-logs/03_clean_up": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/tests-whispers_whispers-logs/02_multiline"
+      ],
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "type": "remap"
     }
   },
   "sinks": {

--- a/modules/460-log-shipper/hooks/testdata/multiple-dest/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiple-dest/result.json
@@ -26,7 +26,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/15_log_filter"
+        "transform/source/test-source/15_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -50,7 +50,7 @@
     "transform/destination/test-logstash-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/15_log_filter"
+        "transform/source/test-source/15_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -74,7 +74,7 @@
     "transform/destination/test-loki-dest/00_parse_json": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/15_log_filter"
+        "transform/source/test-source/15_clean_up"
       ],
       "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
       "type": "remap"
@@ -87,113 +87,113 @@
       "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_clean_up": {
+    "transform/source/test-source/01_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
-      "type": "remap"
-    },
-    "transform/source/test-source/02_local_timezone": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/test-source/01_clean_up"
-      ],
       "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/03_label_filter": {
+    "transform/source/test-source/02_label_filter": {
       "condition": "exists(.foo)",
       "inputs": [
-        "transform/source/test-source/02_local_timezone"
+        "transform/source/test-source/01_local_timezone"
+      ],
+      "type": "filter"
+    },
+    "transform/source/test-source/03_label_filter": {
+      "condition": "!exists(.fo)",
+      "inputs": [
+        "transform/source/test-source/02_label_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/04_label_filter": {
-      "condition": "!exists(.fo)",
+      "condition": "if is_boolean(.test) || is_float(.test) {\n    data, err = to_string(.test);\n    if err != null {\n        false;\n    } else {\n        includes([111], data);\n    };\n} else if .test == null {\n    false;\n} else {\n    includes([111], .test);\n}",
       "inputs": [
         "transform/source/test-source/03_label_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/05_label_filter": {
-      "condition": "if is_boolean(.test) || is_float(.test) {\n    data, err = to_string(.test);\n    if err != null {\n        false;\n    } else {\n        includes([111], data);\n    };\n} else if .test == null {\n    false;\n} else {\n    includes([111], .test);\n}",
+      "condition": "if is_boolean(.test) || is_float(.test) {\n    data, err = to_string(.test);\n    if err != null {\n        true;\n    } else {\n        !includes([\"test-test\"], data);\n    };\n} else if .test == null {\n    false;\n} else {\n    !includes([\"test-test\"], .test);\n}",
       "inputs": [
         "transform/source/test-source/04_label_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/06_label_filter": {
-      "condition": "if is_boolean(.test) || is_float(.test) {\n    data, err = to_string(.test);\n    if err != null {\n        true;\n    } else {\n        !includes([\"test-test\"], data);\n    };\n} else if .test == null {\n    false;\n} else {\n    !includes([\"test-test\"], .test);\n}",
+      "condition": "match!(.test, r'^test.*$')",
       "inputs": [
         "transform/source/test-source/05_label_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/07_label_filter": {
-      "condition": "match!(.test, r'^test.*$')",
+      "condition": "if exists(.foo) \u0026\u0026 is_string(.foo) {\n    matched = false\n    matched0, err = match(.foo, r'^test.+$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    !matched\n} else {\n    true\n}",
       "inputs": [
         "transform/source/test-source/06_label_filter"
       ],
       "type": "filter"
     },
-    "transform/source/test-source/08_label_filter": {
-      "condition": "if exists(.foo) \u0026\u0026 is_string(.foo) {\n    matched = false\n    matched0, err = match(.foo, r'^test.+$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    !matched\n} else {\n    true\n}",
-      "inputs": [
-        "transform/source/test-source/07_label_filter"
-      ],
-      "type": "filter"
-    },
-    "transform/source/test-source/09_parse_json": {
+    "transform/source/test-source/08_parse_json": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/08_label_filter"
+        "transform/source/test-source/07_label_filter"
       ],
       "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-source/10_log_filter": {
+    "transform/source/test-source/09_log_filter": {
       "condition": "exists(.parsed_data.foo)",
       "inputs": [
-        "transform/source/test-source/09_parse_json"
+        "transform/source/test-source/08_parse_json"
+      ],
+      "type": "filter"
+    },
+    "transform/source/test-source/10_log_filter": {
+      "condition": "!exists(.parsed_data.fo)",
+      "inputs": [
+        "transform/source/test-source/09_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/11_log_filter": {
-      "condition": "!exists(.parsed_data.fo)",
+      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        false;\n    } else {\n        includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    includes([\"wvrr\"], .parsed_data.foo);\n}",
       "inputs": [
         "transform/source/test-source/10_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/12_log_filter": {
-      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        false;\n    } else {\n        includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    includes([\"wvrr\"], .parsed_data.foo);\n}",
+      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        true;\n    } else {\n        !includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    !includes([\"wvrr\"], .parsed_data.foo);\n}",
       "inputs": [
         "transform/source/test-source/11_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/13_log_filter": {
-      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        true;\n    } else {\n        !includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    !includes([\"wvrr\"], .parsed_data.foo);\n}",
+      "condition": "match!(.parsed_data.foo, r'^wvrr$')",
       "inputs": [
         "transform/source/test-source/12_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/14_log_filter": {
-      "condition": "match!(.parsed_data.foo, r'^wvrr$')",
+      "condition": "if exists(.parsed_data.foo) \u0026\u0026 is_string(.parsed_data.foo) {\n    matched = false\n    matched0, err = match(.parsed_data.foo, r'^wvrr$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    !matched\n} else {\n    true\n}",
       "inputs": [
         "transform/source/test-source/13_log_filter"
       ],
       "type": "filter"
     },
-    "transform/source/test-source/15_log_filter": {
-      "condition": "if exists(.parsed_data.foo) \u0026\u0026 is_string(.parsed_data.foo) {\n    matched = false\n    matched0, err = match(.parsed_data.foo, r'^wvrr$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    !matched\n} else {\n    true\n}",
+    "transform/source/test-source/15_clean_up": {
+      "drop_on_abort": false,
       "inputs": [
         "transform/source/test-source/14_log_filter"
       ],
-      "type": "filter"
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "type": "remap"
     }
   },
   "sinks": {

--- a/modules/460-log-shipper/hooks/testdata/namespaced-source/result.json
+++ b/modules/460-log-shipper/hooks/testdata/namespaced-source/result.json
@@ -26,7 +26,7 @@
     "transform/destination/loki-storage/00_parse_json": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/tests-whispers_whispers-logs/09_log_filter"
+        "transform/source/tests-whispers_whispers-logs/09_clean_up"
       ],
       "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
       "type": "remap"
@@ -34,7 +34,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/tests-whispers_whispers-logs/09_log_filter"
+        "transform/source/tests-whispers_whispers-logs/09_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -63,71 +63,71 @@
       "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
       "type": "remap"
     },
-    "transform/source/tests-whispers_whispers-logs/01_clean_up": {
+    "transform/source/tests-whispers_whispers-logs/01_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "transform/source/tests-whispers_whispers-logs/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
-      "type": "remap"
-    },
-    "transform/source/tests-whispers_whispers-logs/02_local_timezone": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/tests-whispers_whispers-logs/01_clean_up"
-      ],
       "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/tests-whispers_whispers-logs/03_parse_json": {
+    "transform/source/tests-whispers_whispers-logs/02_parse_json": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/tests-whispers_whispers-logs/02_local_timezone"
+        "transform/source/tests-whispers_whispers-logs/01_local_timezone"
       ],
       "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
       "type": "remap"
     },
-    "transform/source/tests-whispers_whispers-logs/04_log_filter": {
+    "transform/source/tests-whispers_whispers-logs/03_log_filter": {
       "condition": "exists(.parsed_data.foo)",
       "inputs": [
-        "transform/source/tests-whispers_whispers-logs/03_parse_json"
+        "transform/source/tests-whispers_whispers-logs/02_parse_json"
+      ],
+      "type": "filter"
+    },
+    "transform/source/tests-whispers_whispers-logs/04_log_filter": {
+      "condition": "!exists(.parsed_data.foo)",
+      "inputs": [
+        "transform/source/tests-whispers_whispers-logs/03_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/tests-whispers_whispers-logs/05_log_filter": {
-      "condition": "!exists(.parsed_data.foo)",
+      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        false;\n    } else {\n        includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    includes([\"wvrr\"], .parsed_data.foo);\n}",
       "inputs": [
         "transform/source/tests-whispers_whispers-logs/04_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/tests-whispers_whispers-logs/06_log_filter": {
-      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        false;\n    } else {\n        includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    includes([\"wvrr\"], .parsed_data.foo);\n}",
+      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        true;\n    } else {\n        !includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    !includes([\"wvrr\"], .parsed_data.foo);\n}",
       "inputs": [
         "transform/source/tests-whispers_whispers-logs/05_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/tests-whispers_whispers-logs/07_log_filter": {
-      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        true;\n    } else {\n        !includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    !includes([\"wvrr\"], .parsed_data.foo);\n}",
+      "condition": "match!(.parsed_data.foo, r'^wvrr$')",
       "inputs": [
         "transform/source/tests-whispers_whispers-logs/06_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/tests-whispers_whispers-logs/08_log_filter": {
-      "condition": "match!(.parsed_data.foo, r'^wvrr$')",
+      "condition": "if exists(.parsed_data.foo) \u0026\u0026 is_string(.parsed_data.foo) {\n    matched = false\n    matched0, err = match(.parsed_data.foo, r'^wvrr$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    !matched\n} else {\n    true\n}",
       "inputs": [
         "transform/source/tests-whispers_whispers-logs/07_log_filter"
       ],
       "type": "filter"
     },
-    "transform/source/tests-whispers_whispers-logs/09_log_filter": {
-      "condition": "if exists(.parsed_data.foo) \u0026\u0026 is_string(.parsed_data.foo) {\n    matched = false\n    matched0, err = match(.parsed_data.foo, r'^wvrr$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    !matched\n} else {\n    true\n}",
+    "transform/source/tests-whispers_whispers-logs/09_clean_up": {
+      "drop_on_abort": false,
       "inputs": [
         "transform/source/tests-whispers_whispers-logs/08_log_filter"
       ],
-      "type": "filter"
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "type": "remap"
     }
   },
   "sinks": {

--- a/modules/460-log-shipper/hooks/testdata/one-dest/result.json
+++ b/modules/460-log-shipper/hooks/testdata/one-dest/result.json
@@ -47,7 +47,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/02_local_timezone"
+        "transform/source/test-source/02_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -77,20 +77,20 @@
       "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_clean_up": {
+    "transform/source/test-source/01_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/02_local_timezone": {
+    "transform/source/test-source/02_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_clean_up"
+        "transform/source/test-source/01_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/pair-datastream/result.json
+++ b/modules/460-log-shipper/hooks/testdata/pair-datastream/result.json
@@ -26,7 +26,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/09_log_filter"
+        "transform/source/test-source/09_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -63,71 +63,71 @@
       "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_clean_up": {
+    "transform/source/test-source/01_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
-      "type": "remap"
-    },
-    "transform/source/test-source/02_local_timezone": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/test-source/01_clean_up"
-      ],
       "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/03_parse_json": {
+    "transform/source/test-source/02_parse_json": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/02_local_timezone"
+        "transform/source/test-source/01_local_timezone"
       ],
       "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-source/04_log_filter": {
+    "transform/source/test-source/03_log_filter": {
       "condition": "exists(.parsed_data.foo)",
       "inputs": [
-        "transform/source/test-source/03_parse_json"
+        "transform/source/test-source/02_parse_json"
+      ],
+      "type": "filter"
+    },
+    "transform/source/test-source/04_log_filter": {
+      "condition": "!exists(.parsed_data.fo)",
+      "inputs": [
+        "transform/source/test-source/03_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/05_log_filter": {
-      "condition": "!exists(.parsed_data.fo)",
+      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        false;\n    } else {\n        includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    includes([\"wvrr\"], .parsed_data.foo);\n}",
       "inputs": [
         "transform/source/test-source/04_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/06_log_filter": {
-      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        false;\n    } else {\n        includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    includes([\"wvrr\"], .parsed_data.foo);\n}",
+      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        true;\n    } else {\n        !includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    !includes([\"wvrr\"], .parsed_data.foo);\n}",
       "inputs": [
         "transform/source/test-source/05_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/07_log_filter": {
-      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        true;\n    } else {\n        !includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    !includes([\"wvrr\"], .parsed_data.foo);\n}",
+      "condition": "match!(.parsed_data.foo, r'^wvrr$')",
       "inputs": [
         "transform/source/test-source/06_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/08_log_filter": {
-      "condition": "match!(.parsed_data.foo, r'^wvrr$')",
+      "condition": "if exists(.parsed_data.foo) \u0026\u0026 is_string(.parsed_data.foo) {\n    matched = false\n    matched0, err = match(.parsed_data.foo, r'^wvrr$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    !matched\n} else {\n    true\n}",
       "inputs": [
         "transform/source/test-source/07_log_filter"
       ],
       "type": "filter"
     },
-    "transform/source/test-source/09_log_filter": {
-      "condition": "if exists(.parsed_data.foo) \u0026\u0026 is_string(.parsed_data.foo) {\n    matched = false\n    matched0, err = match(.parsed_data.foo, r'^wvrr$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    !matched\n} else {\n    true\n}",
+    "transform/source/test-source/09_clean_up": {
+      "drop_on_abort": false,
       "inputs": [
         "transform/source/test-source/08_log_filter"
       ],
-      "type": "filter"
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "type": "remap"
     }
   },
   "sinks": {

--- a/modules/460-log-shipper/hooks/testdata/simple-pair/result.json
+++ b/modules/460-log-shipper/hooks/testdata/simple-pair/result.json
@@ -26,7 +26,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/09_log_filter"
+        "transform/source/test-source/09_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -55,71 +55,71 @@
       "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_clean_up": {
+    "transform/source/test-source/01_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
-      "type": "remap"
-    },
-    "transform/source/test-source/02_local_timezone": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/test-source/01_clean_up"
-      ],
       "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/03_parse_json": {
+    "transform/source/test-source/02_parse_json": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/02_local_timezone"
+        "transform/source/test-source/01_local_timezone"
       ],
       "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-source/04_log_filter": {
+    "transform/source/test-source/03_log_filter": {
       "condition": "exists(.parsed_data.foo)",
       "inputs": [
-        "transform/source/test-source/03_parse_json"
+        "transform/source/test-source/02_parse_json"
+      ],
+      "type": "filter"
+    },
+    "transform/source/test-source/04_log_filter": {
+      "condition": "!exists(.parsed_data.fo)",
+      "inputs": [
+        "transform/source/test-source/03_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/05_log_filter": {
-      "condition": "!exists(.parsed_data.fo)",
+      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        false;\n    } else {\n        includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    includes([\"wvrr\"], .parsed_data.foo);\n}",
       "inputs": [
         "transform/source/test-source/04_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/06_log_filter": {
-      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        false;\n    } else {\n        includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    includes([\"wvrr\"], .parsed_data.foo);\n}",
+      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        true;\n    } else {\n        !includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    !includes([\"wvrr\"], .parsed_data.foo);\n}",
       "inputs": [
         "transform/source/test-source/05_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/07_log_filter": {
-      "condition": "if is_boolean(.parsed_data.foo) || is_float(.parsed_data.foo) {\n    data, err = to_string(.parsed_data.foo);\n    if err != null {\n        true;\n    } else {\n        !includes([\"wvrr\"], data);\n    };\n} else if .parsed_data.foo == null {\n    false;\n} else {\n    !includes([\"wvrr\"], .parsed_data.foo);\n}",
+      "condition": "match!(.parsed_data.foo, r'^wvrr$')",
       "inputs": [
         "transform/source/test-source/06_log_filter"
       ],
       "type": "filter"
     },
     "transform/source/test-source/08_log_filter": {
-      "condition": "match!(.parsed_data.foo, r'^wvrr$')",
+      "condition": "if exists(.parsed_data.foo) \u0026\u0026 is_string(.parsed_data.foo) {\n    matched = false\n    matched0, err = match(.parsed_data.foo, r'^wvrr$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    !matched\n} else {\n    true\n}",
       "inputs": [
         "transform/source/test-source/07_log_filter"
       ],
       "type": "filter"
     },
-    "transform/source/test-source/09_log_filter": {
-      "condition": "if exists(.parsed_data.foo) \u0026\u0026 is_string(.parsed_data.foo) {\n    matched = false\n    matched0, err = match(.parsed_data.foo, r'^wvrr$')\n    if err != null {\n        true\n    }\n    matched = matched || matched0\n    !matched\n} else {\n    true\n}",
+    "transform/source/test-source/09_clean_up": {
+      "drop_on_abort": false,
       "inputs": [
         "transform/source/test-source/08_log_filter"
       ],
-      "type": "filter"
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "type": "remap"
     }
   },
   "sinks": {

--- a/modules/460-log-shipper/hooks/testdata/throttle-with-filter/result.json
+++ b/modules/460-log-shipper/hooks/testdata/throttle-with-filter/result.json
@@ -26,7 +26,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/02_local_timezone"
+        "transform/source/test-source/02_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -60,20 +60,20 @@
       "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_clean_up": {
+    "transform/source/test-source/01_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/02_local_timezone": {
+    "transform/source/test-source/02_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_clean_up"
+        "transform/source/test-source/01_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/throttle/result.json
+++ b/modules/460-log-shipper/hooks/testdata/throttle/result.json
@@ -26,7 +26,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/02_local_timezone"
+        "transform/source/test-source/02_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -55,20 +55,20 @@
       "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
       "type": "remap"
     },
-    "transform/source/test-source/01_clean_up": {
+    "transform/source/test-source/01_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
         "transform/source/test-source/00_owner_ref"
       ],
-      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
       "type": "remap"
     },
-    "transform/source/test-source/02_local_timezone": {
+    "transform/source/test-source/02_clean_up": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_clean_up"
+        "transform/source/test-source/01_local_timezone"
       ],
-      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
       "type": "remap"
     }
   },


### PR DESCRIPTION
## Description
Move cleanup transform to be the last transform for a source

## Why do we need it, and what problem does it solve?
If we cleanup the file label before multiline, the [grouping](https://github.com/deckhouse/deckhouse/blob/7e36d7017fa4babcef6a7e33c8a34f907b387289/modules/460-log-shipper/hooks/internal/vector/transform/multiline.go#L40-L44) will not work as expected. As a result, logs from different pods will be concatenated together. 

## Why do we need it in the patch release (if we do)?

Multiline doesn't work!

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: fix
summary: Move cleanup transform to be the last transform for a source. Fixes multiline parsing issue. 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
