### PR TITLE
[deckhouse-tools] Rebuild d8-cli images when used version changes

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -123,4 +123,4 @@ k8s:
       snapshotter: v8.0.0
       livenessprobe: v2.13.0
 d8:
-  d8CliVersion: v0.3.2
+  d8CliVersion: v0.3.7

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -17,7 +17,7 @@ docker:
     d8: {{ .CandiVersionMap.d8.d8CliVersion }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ $.Images.BASE_GOLANG_22_BULLSEYE_DEV }}
+from: {{ $.Images.BASE_GOLANG_23_BULLSEYE }}
 git:
   - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
     to: /
@@ -27,8 +27,11 @@ git:
 shell:
   setup:
   - export GOPROXY={{ $.GOPROXY }}
+  - go install github.com/go-task/task/v3/cmd/task@latest
   - git clone --depth 1 --branch {{ .CandiVersionMap.d8.d8CliVersion }} {{ $.SOURCE_REPO }}/deckhouse/deckhouse-cli.git
   - cd /deckhouse-cli
+  {{- include "debian packages proxy" . | nindent 2 }}
+  - apt-get install -y libbtrfs-dev
   - task build:dist:linux:amd64
   - mv ./dist/{{ .CandiVersionMap.d8.d8CliVersion }}/linux-amd64/d8 /d8
   - chmod +x /d8 /install /uninstall

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -18,7 +18,8 @@ docker:
   ENTRYPOINT: [ "/opt/nginx-static/sbin/nginx", "-g", "daemon off;" ]
 ---
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ .Images.BASE_GOLANG_22_BULLSEYE_DEV }}
+from: {{ .Images.BASE_GOLANG_23_BULLSEYE }}
+fromCacheVersion: {{ .CandiVersionMap.d8.d8CliVersion }}
 git:
   - add: /{{ $.ModulePath }}modules/800-{{ $.ModuleName }}/images/{{ $.ImageName }}/static
     to: /static
@@ -32,7 +33,10 @@ import:
     before: setup
 shell:
   setup:
+    {{- include "debian packages proxy" . | nindent 4 }}
     - export GOPROXY={{ $.GOPROXY }}
+    - apt-get install -y libbtrfs-dev jq
+    - go install github.com/go-task/task/v3/cmd/task@latest
     - git clone --depth 1 --branch {{ .CandiVersionMap.d8.d8CliVersion }} {{ $.SOURCE_REPO }}/deckhouse/deckhouse-cli.git
     - cd /deckhouse-cli
     - task build:dist:all


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added `fromCacheVersion: <d8-cli version>` directive to d8-cli builds of deckhouse-tools module and adapted builds of d8 within deckhouse codebase to use go 1.23.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

werf stuck using old cached build and so clients were not getting the latest versions with features and bugfixes

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

deckhouse-tools shows current release of d8-cli from version_map.yaml in it's interface instead of 0.3.2

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-tools
type: fix
summary: Rebuild d8-cli images when used version changes
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
