### PR TITLE
feat: add CloudPermanent for aws e2e

### DIFF
--- a/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
@@ -30,6 +30,15 @@ masterNodeGroup:
   instanceClass:
     instanceType: m5.xlarge
     ami: ami-0022e2e80fa74c5d7 # Centos 9
+nodeGroups:
+- name: cloud-permanent
+  nodeTemplate:
+    labels:
+      node-role.kubernetes.io/worker: ''
+  replicas: 1
+  instanceClass:
+    instanceType: t2.medium
+    ami: ami-0022e2e80fa74c5d7 # Centos 9
 nodeNetworkCIDR: "172.16.0.0/22"
 vpcNetworkCIDR: "172.16.0.0/16"
 sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSNdUmV2ekit0rFrQE9IoRsVqKTJfR8h+skMYjXHBv/nJN6J2eBvQlebnhfZngxTvHYYxl0XeRu3KEz5v23gIidT21o9x0+tD4b2PcyZ24o64GwnF/oFnQ9mYBJDRisZNdXYPadTp/RafQ0qNUX/6h8vZYlSPM77dhW7Oyf6hcbaniAmOD30bO89UM//VHbllGgfhlIbU382/EnPOfGvAHReATADBBHmxxtTCLbu48rN35DlOtMgPob3ZwOsJI3keRrIZOf5qxeF3VB0Ox4inoR6PUzWMFLCJyIMp7hzY+JLakO4dqfvRJZjgTZHQUvjDs+aeUcH8tD4Wd5NDzmxnHLtJup0lkHkqgjo6vqWIcQeDXuXsk3+YGw0PwMpwO2HMVPs2SnfT6cZ+Mo6Dmq0t1EjtSBXLMe5C5aac5w6NrXuypRQDoce7p3uZP2TVsxmpyvkd6RyiWr+wuOOB3h/k8q+kRh4LKzivJMEkZoZeCxkJiIWDknxEAU1sl25W4hEU="

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -26,6 +26,32 @@ spec:
   nodeType: CloudEphemeral
 ---
 apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: system-b
+spec:
+  chaos:
+    mode: Disabled
+  cloudInstances:
+    classReference:
+      kind: AWSInstanceClass
+      name: system
+    maxPerZone: 1
+    minPerZone: 1
+    zones:
+    - eu-central-1a
+  disruptions:
+    approvalMode: Manual
+  nodeTemplate:
+    labels:
+      node-role.deckhouse.io/system: ""
+    taints:
+    - effect: NoExecute
+      key: dedicated.deckhouse.io
+      value: system
+  nodeType: CloudPermanent
+---
+apiVersion: deckhouse.io/v1
 kind: AWSInstanceClass
 metadata:
   name: system

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -26,32 +26,6 @@ spec:
   nodeType: CloudEphemeral
 ---
 apiVersion: deckhouse.io/v1
-kind: NodeGroup
-metadata:
-  name: system-b
-spec:
-  chaos:
-    mode: Disabled
-  cloudInstances:
-    classReference:
-      kind: AWSInstanceClass
-      name: system
-    maxPerZone: 1
-    minPerZone: 1
-    zones:
-    - eu-central-1a
-  disruptions:
-    approvalMode: Manual
-  nodeTemplate:
-    labels:
-      node-role.deckhouse.io/system: ""
-    taints:
-    - effect: NoExecute
-      key: dedicated.deckhouse.io
-      value: system
-  nodeType: CloudPermanent
----
-apiVersion: deckhouse.io/v1
 kind: AWSInstanceClass
 metadata:
   name: system


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
https://github.com/deckhouse/deckhouse/issues/3082
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
CloudPermanent nodes are created by dhctl (via terraform). Adding such a node to each test will increase the required resources and time. It is also not possible to just substitute the CloudEphemeral node with the CloudPermanent, because, in this case, we stop testing the most frequent case of node creation.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not releted to release
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
CloudPermanent nodes starts on e2e tests
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

```changes
section: ci
type: feature
summary: new CloudPermanent nodes starts on e2e tests.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
