### PR TITLE
[dhctl] Fix converge through bastion

### DIFF
--- a/dhctl/pkg/kubernetes/actions/converge/master_node_group_controller.go
+++ b/dhctl/pkg/kubernetes/actions/converge/master_node_group_controller.go
@@ -174,6 +174,11 @@ func (c *MasterNodeGroupController) replaceKubeClient(state map[string][]byte) (
 
 	privateKeyPath := filepath.Join(tmpDir, "id_rsa_converger")
 
+	privateKey := session.AgentPrivateKey{
+		Key:        privateKeyPath,
+		Passphrase: c.convergeState.NodeUserCredentials.Password,
+	}
+
 	err = os.WriteFile(privateKeyPath, []byte(c.convergeState.NodeUserCredentials.PrivateKey), 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to write private key for NodeUser: %w", err)
@@ -207,11 +212,8 @@ func (c *MasterNodeGroupController) replaceKubeClient(state map[string][]byte) (
 	}
 
 	c.client.KubeProxy.StopAll()
-	if sshCl != nil {
-		sshCl.Stop()
-	}
 
-	newSSHClient, err := ssh.NewClient(session.NewSession(session.Input{
+	newSSHClient := ssh.NewClient(session.NewSession(session.Input{
 		User:           c.convergeState.NodeUserCredentials.Name,
 		Port:           settings.Port,
 		BastionHost:    settings.BastionHost,
@@ -220,14 +222,18 @@ func (c *MasterNodeGroupController) replaceKubeClient(state map[string][]byte) (
 		ExtraArgs:      settings.ExtraArgs,
 		AvailableHosts: settings.AvailableHosts(),
 		BecomePass:     c.convergeState.NodeUserCredentials.Password,
-	}), []session.AgentPrivateKey{
-		{
-			Key:        privateKeyPath,
-			Passphrase: c.convergeState.NodeUserCredentials.Password,
-		},
-	}).Start()
+	}), []session.AgentPrivateKey{privateKey})
+	// Avoid starting a new ssh agent
+	newSSHClient.InitializeNewAgent = false
+
+	_, err = newSSHClient.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start SSH client: %w", err)
+	}
+
+	err = newSSHClient.Agent.AddKeys(newSSHClient.PrivateKeys)
+	if err != nil {
+		return fmt.Errorf("failed to add keys to ssh agent: %w", err)
 	}
 
 	kubeClient, err := kubernetes.ConnectToKubernetesAPI(ssh.NewNodeInterfaceWrapper(newSSHClient))

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/kube-proxy.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/kube-proxy.go
@@ -86,6 +86,8 @@ func (c *KubeProxyChecker) IsReady(nodeName string) (bool, error) {
 
 	if c.input != nil {
 		sshClient = ssh.NewClient(session.NewSession(*c.input), c.privateKeys)
+		// Avoid starting a new ssh agent
+		sshClient.InitializeNewAgent = false
 	} else {
 		sshClient = ssh.NewClientFromFlags()
 	}

--- a/dhctl/pkg/system/node/ssh/frontend/agent.go
+++ b/dhctl/pkg/system/node/ssh/frontend/agent.go
@@ -61,7 +61,7 @@ func (a *Agent) Start() error {
 	}
 
 	log.DebugLn("agent: run ssh-add for keys")
-	err = a.AddKeys()
+	err = a.AddKeys(a.AgentSettings.PrivateKeys)
 	if err != nil {
 		return fmt.Errorf("add keys: %v", err)
 	}
@@ -70,8 +70,8 @@ func (a *Agent) Start() error {
 }
 
 // TODO replace with x/crypto/ssh/agent ?
-func (a *Agent) AddKeys() error {
-	err := addKeys(a.AgentSettings.AuthSock, a.AgentSettings.PrivateKeys)
+func (a *Agent) AddKeys(keys []session.AgentPrivateKey) error {
+	err := addKeys(a.AgentSettings.AuthSock, keys)
 	if err != nil {
 		return fmt.Errorf("add keys: %w", err)
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Copy the SSH private keys provided by the user and the generated SSH private key(for a special user created for converge) to a new SSH session.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

If we try to converge through bastion, we will get an access denied error.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix converge through bastion
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
