### PR TITLE
[candi][bashible] Added explicit addition of PACKAGES_PROXY_ADDRESSES into the NO_PROXY parameter

### DIFF
--- a/candi/bashible/bashbooster/50_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_registrypackages.sh
@@ -58,7 +58,9 @@ function check_python() {
 bb-package-fetch-blob() {
   local REPOSITORY="${REPOSITORY:-}"
   local REPOSITORY_PATH="${REPOSITORY_PATH:-}"
-
+  local no_proxy=${PACKAGES_PROXY_ADDRESSES}
+  local NO_PROXY=${PACKAGES_PROXY_ADDRESSES}
+  
   check_python
 
   cat - <<EOF | $python_binary

--- a/candi/bashible/bb_package_install.sh.tpl
+++ b/candi/bashible/bb_package_install.sh.tpl
@@ -102,7 +102,9 @@ bb-package-fetch-blobs() {
 bb-package-fetch-blob() {
   local REPOSITORY="${REPOSITORY:-}"
   local REPOSITORY_PATH="${REPOSITORY_PATH:-}"
-
+  local no_proxy=${PACKAGES_PROXY_ADDRESSES}
+  local NO_PROXY=${PACKAGES_PROXY_ADDRESSES}
+  
   check_python
 
   cat - <<EOFILE | $python_binary


### PR DESCRIPTION
## Description

In the current implementation of DH, when installing in a closed environment, it is required to explicitly specify all single (not a network with a mask) IP addresses of master nodes in the no_proxy parameter, since the python library used in the `bb-package-fetch-blob` function cannot handle specifying a network with a mask (for example, `192.168.0.0/16`)

Since the `bb-package-fetch-blob` function is used only to receive packets from `bashible-apiserver`, I suggest explicitly adding the `bashible-apiserver` address to the `no_proxy` parameter within the function context.

## Why do we need it, and what problem does it solve?

With this change, it is no longer necessary to specify single (not a network with a mask) IP addresses of master nodes in the `no_proxy` parameter.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: candi 
type: fix 
summary:  Added explicit addition of basible-server address into the NO_PROXY parameter
impact_level: low
```
