### PR TITLE
[metallb] Pre-upgrade compatibility check for metallb configuration

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -26,6 +26,8 @@ import (
 	_ "github.com/deckhouse/deckhouse/ee/modules/450-network-gateway/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/modules/500-operator-trivy/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/modules/650-runtime-audit-engine/hooks"
+	_ "github.com/deckhouse/deckhouse/ee/se/modules/380-metallb/hooks"
+	_ "github.com/deckhouse/deckhouse/ee/se/modules/380-metallb/requirements"
 	_ "github.com/deckhouse/deckhouse/global-hooks"
 	_ "github.com/deckhouse/deckhouse/global-hooks/deckhouse-config"
 	_ "github.com/deckhouse/deckhouse/global-hooks/discovery"

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
@@ -122,19 +122,19 @@ func checkAllRequirementsForUpgrade(input *go_hook.HookInput) error {
 		l2Advertisement := l2AdvertisementSnap.(L2AdvertisementInfo)
 		// Check a namespace
 		if l2Advertisement.Namespace != "d8-metallb" {
-			requirements.SaveValue(metallbConfigurationStatusKey, "nsMismatch")
+			requirements.SaveValue(metallbConfigurationStatusKey, "NSMismatch")
 			return nil
 		}
 
 		// There should only be one matchLabels (not matchExpressions) in nodeSelectors
 		if len(l2Advertisement.NodeSelectors) > 0 {
 			if len(l2Advertisement.NodeSelectors) != 1 {
-				requirements.SaveValue(metallbConfigurationStatusKey, "nodeSelectorsMismatch")
+				requirements.SaveValue(metallbConfigurationStatusKey, "NodeSelectorsMismatch")
 				return nil
 			}
 			nodeSelector := l2Advertisement.NodeSelectors[0]
 			if len(nodeSelector.MatchExpressions) > 0 {
-				requirements.SaveValue(metallbConfigurationStatusKey, "nodeSelectorsMismatch")
+				requirements.SaveValue(metallbConfigurationStatusKey, "NodeSelectorsMismatch")
 				return nil
 			}
 		}
@@ -155,7 +155,7 @@ func checkAllRequirementsForUpgrade(input *go_hook.HookInput) error {
 	sort.Strings(ipAddressPollNamesFromL2A) // Only layer2 pools
 	sort.Strings(ipAddressPollNamesFromIAP) // All pools of cluster
 	if !slices.Equal(ipAddressPollNamesFromL2A, ipAddressPollNamesFromIAP) {
-		requirements.SaveValue(metallbConfigurationStatusKey, "addressPollsMismatch")
+		requirements.SaveValue(metallbConfigurationStatusKey, "AddressPoolsMismatch")
 		return nil
 	}
 	requirements.SaveValue(metallbConfigurationStatusKey, "OK")

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
@@ -6,7 +6,7 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package hooks
 
 import (
-	"reflect"
+	"slices"
 	"sort"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -154,7 +154,7 @@ func checkAllRequirementsForUpgrade(input *go_hook.HookInput) error {
 	// Are only layer2 pools in the cluster?
 	sort.Strings(ipAddressPollNamesFromL2A) // Only layer2 pools
 	sort.Strings(ipAddressPollNamesFromIAP) // All pools of cluster
-	if !reflect.DeepEqual(ipAddressPollNamesFromL2A, ipAddressPollNamesFromIAP) {
+	if !slices.Equal(ipAddressPollNamesFromL2A, ipAddressPollNamesFromIAP) {
 		requirements.SaveValue(metallbConfigurationStatusKey, "addressPollsMismatch")
 		return nil
 	}

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+type L2Advertisement struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   L2AdvertisementSpec   `json:"spec,omitempty"`
+	Status L2AdvertisementStatus `json:"status,omitempty"`
+}
+
+type L2AdvertisementSpec struct {
+	IPAddressPools         []string               `json:"ipAddressPools,omitempty"`
+	IPAddressPoolSelectors []metav1.LabelSelector `json:"ipAddressPoolSelectors,omitempty"`
+	NodeSelectors          []metav1.LabelSelector `json:"nodeSelectors,omitempty"`
+	Interfaces             []string               `json:"interfaces,omitempty"`
+}
+
+type L2AdvertisementStatus struct {
+}
+
+type IPAddressPool struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   IPAddressPoolSpec   `json:"spec"`
+	Status IPAddressPoolStatus `json:"status,omitempty"`
+}
+
+type IPAddressPoolSpec struct {
+	Addresses     []string           `json:"addresses"`
+	AutoAssign    *bool              `json:"autoAssign,omitempty"`
+	AvoidBuggyIPs bool               `json:"avoidBuggyIPs,omitempty"`
+	AllocateTo    *ServiceAllocation `json:"serviceAllocation,omitempty"`
+}
+
+type ServiceAllocation struct {
+	Priority           int                    `json:"priority,omitempty"`
+	Namespaces         []string               `json:"namespaces,omitempty"`
+	NamespaceSelectors []metav1.LabelSelector `json:"namespaceSelectors,omitempty"`
+	ServiceSelectors   []metav1.LabelSelector `json:"serviceSelectors,omitempty"`
+}
+
+type IPAddressPoolStatus struct {
+}
+
+type L2AdvertisementInfo struct {
+	IPAddressPools []string
+	NodeSelectors  []metav1.LabelSelector
+	Namespace      string
+}
+
+const (
+	metallbConfigurationStatusKey = "metallb:ConfigurationStatus"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "l2advertisements",
+			ApiVersion: "metallb.io/v1beta1",
+			Kind:       "L2Advertisement",
+			FilterFunc: applyL2AdvertisementFilter,
+		},
+		{
+			Name:       "ipaddresspools",
+			ApiVersion: "metallb.io/v1beta1",
+			Kind:       "IPAddressPool",
+			FilterFunc: applyIPAddressPoolFilter,
+		},
+	},
+}, checkAllRequirementsForUpgrade)
+
+func applyL2AdvertisementFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	l2Advertisement := &L2Advertisement{}
+	err := sdk.FromUnstructured(obj, l2Advertisement)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(l2Advertisement.Spec.IPAddressPools) == 0 {
+		return nil, nil
+	}
+
+	return L2AdvertisementInfo{
+		IPAddressPools: l2Advertisement.Spec.IPAddressPools,
+		NodeSelectors:  l2Advertisement.Spec.NodeSelectors,
+		Namespace:      l2Advertisement.Namespace,
+	}, nil
+}
+
+func applyIPAddressPoolFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	ipAddressPool := &IPAddressPool{}
+	err := sdk.FromUnstructured(obj, ipAddressPool)
+	if err != nil {
+		return nil, err
+	}
+
+	return ipAddressPool.Name, err
+}
+
+func checkAllRequirementsForUpgrade(input *go_hook.HookInput) error {
+	ipAddressPollNamesFromL2A := make([]string, 0, 8)
+	l2AdvertisementSnaps := input.Snapshots["l2advertisements"]
+	for _, l2AdvertisementSnap := range l2AdvertisementSnaps {
+		l2Advertisement := l2AdvertisementSnap.(L2AdvertisementInfo)
+		// Check a namespace
+		if l2Advertisement.Namespace != "d8-metallb" {
+			requirements.SaveValue(metallbConfigurationStatusKey, "nsMismatch")
+			return nil
+		}
+
+		// There should only be one matchLabels (not matchExpressions) in nodeSelectors
+		if len(l2Advertisement.NodeSelectors) > 0 {
+			if len(l2Advertisement.NodeSelectors) != 1 {
+				requirements.SaveValue(metallbConfigurationStatusKey, "nodeSelectorsMismatch")
+				return nil
+			}
+			nodeSelector := l2Advertisement.NodeSelectors[0]
+			if len(nodeSelector.MatchExpressions) > 0 {
+				requirements.SaveValue(metallbConfigurationStatusKey, "nodeSelectorsMismatch")
+				return nil
+			}
+		}
+
+		// Collect names of ipAddressPolls from L2Advertisement
+		ipAddressPollNamesFromL2A = append(ipAddressPollNamesFromL2A, l2Advertisement.IPAddressPools...)
+	}
+
+	ipAddressPollNamesFromIAP := make([]string, 0, 8)
+	ipAddressPoolSnaps := input.Snapshots["ipaddresspools"]
+	for _, ipAddressPoolSnap := range ipAddressPoolSnaps {
+		ipAddressPoolName := ipAddressPoolSnap.(string)
+		// Collect names of ipAddressPolls from IPAddressPools
+		ipAddressPollNamesFromIAP = append(ipAddressPollNamesFromIAP, ipAddressPoolName)
+	}
+
+	// Are only layer2 pools in the cluster?
+	sort.Strings(ipAddressPollNamesFromL2A) // Only layer2 pools
+	sort.Strings(ipAddressPollNamesFromIAP) // All pools of cluster
+	if !reflect.DeepEqual(ipAddressPollNamesFromL2A, ipAddressPollNamesFromIAP) {
+		requirements.SaveValue(metallbConfigurationStatusKey, "addressPollsMismatch")
+		return nil
+	}
+	requirements.SaveValue(metallbConfigurationStatusKey, "OK")
+	return nil
+}

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
@@ -116,7 +116,7 @@ func applyIPAddressPoolFilter(obj *unstructured.Unstructured) (go_hook.FilterRes
 }
 
 func checkAllRequirementsForUpgrade(input *go_hook.HookInput) error {
-	ipAddressPollNamesFromL2A := make([]string, 0, 8)
+	ipAddressPoolNamesFromL2A := make([]string, 0, 8)
 	l2AdvertisementSnaps := input.Snapshots["l2advertisements"]
 	for _, l2AdvertisementSnap := range l2AdvertisementSnaps {
 		l2Advertisement := l2AdvertisementSnap.(L2AdvertisementInfo)
@@ -139,22 +139,22 @@ func checkAllRequirementsForUpgrade(input *go_hook.HookInput) error {
 			}
 		}
 
-		// Collect names of ipAddressPolls from L2Advertisement
-		ipAddressPollNamesFromL2A = append(ipAddressPollNamesFromL2A, l2Advertisement.IPAddressPools...)
+		// Collect names of ipAddressPools from L2Advertisement
+		ipAddressPoolNamesFromL2A = append(ipAddressPoolNamesFromL2A, l2Advertisement.IPAddressPools...)
 	}
 
-	ipAddressPollNamesFromIAP := make([]string, 0, 8)
+	ipAddressPoolNamesFromIAP := make([]string, 0, 8)
 	ipAddressPoolSnaps := input.Snapshots["ipaddresspools"]
 	for _, ipAddressPoolSnap := range ipAddressPoolSnaps {
 		ipAddressPoolName := ipAddressPoolSnap.(string)
-		// Collect names of ipAddressPolls from IPAddressPools
-		ipAddressPollNamesFromIAP = append(ipAddressPollNamesFromIAP, ipAddressPoolName)
+		// Collect names of ipAddressPools from IPAddressPools
+		ipAddressPoolNamesFromIAP = append(ipAddressPoolNamesFromIAP, ipAddressPoolName)
 	}
 
 	// Are only layer2 pools in the cluster?
-	sort.Strings(ipAddressPollNamesFromL2A) // Only layer2 pools
-	sort.Strings(ipAddressPollNamesFromIAP) // All pools of cluster
-	if !slices.Equal(ipAddressPollNamesFromL2A, ipAddressPollNamesFromIAP) {
+	sort.Strings(ipAddressPoolNamesFromL2A) // Only layer2 pools
+	sort.Strings(ipAddressPoolNamesFromIAP) // All pools of cluster
+	if !slices.Equal(ipAddressPoolNamesFromL2A, ipAddressPoolNamesFromIAP) {
 		requirements.SaveValue(metallbConfigurationStatusKey, "AddressPoolsMismatch")
 		return nil
 	}

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	l2Advertisement = `
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: zone-a
+  namespace: d8-metallb
+spec:
+  ipAddressPools:
+  - pool-1
+  - pool-2
+  nodeSelectors:
+  - matchLabels:
+      zone: a
+`
+	ipAddressPolls = `
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: pool-1
+  namespace: d8-metallb
+spec:
+  addresses:
+  - 11.11.11.11/32
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: pool-2
+  namespace: d8-metallb
+spec:
+  addresses:
+  - 22.22.22.22/32
+`
+	ipAddressPolls2 = `
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: pool-1
+  namespace: d8-metallb
+spec:
+  addresses:
+  - 11.11.11.11/32
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: pool-3
+  namespace: d8-metallb
+spec:
+  addresses:
+  - 33.33.33.33/32
+`
+	l2Advertisement2 = `
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: zone-b
+  namespace: metallb
+spec:
+  ipAddressPools:
+  - pool-1
+  nodeSelectors:
+  - matchLabels:
+      zone: b
+`
+	l2Advertisement3 = `
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: zone-a
+  namespace: d8-metallb
+spec:
+  ipAddressPools:
+  - pool-2
+  nodeSelectors:
+  - matchLabels:
+      zone: a
+`
+	l2Advertisement4 = `
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: zone-b
+  namespace: d8-metallb
+spec:
+  ipAddressPools:
+  - pool-1
+  nodeSelectors:
+  - matchExpressions: []
+  - matchLabels:
+      zone: b
+`
+)
+
+var _ = Describe("Metallb hooks :: check requirements for upgrade ::", func() {
+	f := HookExecutionConfigInit(`{}`, `{"global":{"discovery":{}}}`)
+	f.RegisterCRD("metallb.io", "v1beta1", "L2Advertisement", true)
+	f.RegisterCRD("metallb.io", "v1beta1", "IPAddressPool", true)
+
+	Context("Check correct configurations", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(l2Advertisement + ipAddressPolls))
+			f.RunHook()
+		})
+		It("Check the set variable", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
+			Expect(exists).To(BeTrue())
+			configurationStatus := configurationStatusRaw.(string)
+			Expect(configurationStatus).To(Equal("OK"))
+		})
+	})
+
+	Context("Check addressPollsMismatch error", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(l2Advertisement + ipAddressPolls2))
+			f.RunHook()
+		})
+
+		It("Check the set variable", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
+			Expect(exists).To(BeTrue())
+			configurationStatus := configurationStatusRaw.(string)
+			Expect(configurationStatus).To(Equal("addressPollsMismatch"))
+		})
+	})
+
+	Context("Check nsMismatch error", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(l2Advertisement2 + l2Advertisement3))
+			f.RunHook()
+		})
+
+		It("Check the set variable", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
+			Expect(exists).To(BeTrue())
+			configurationStatus := configurationStatusRaw.(string)
+			Expect(configurationStatus).To(Equal("nsMismatch"))
+		})
+	})
+
+	Context("Check nodeSelectorsMismatch error", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(l2Advertisement3 + l2Advertisement4))
+			f.RunHook()
+		})
+
+		It("Check the set variable", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
+			Expect(exists).To(BeTrue())
+			configurationStatus := configurationStatusRaw.(string)
+			Expect(configurationStatus).To(Equal("nodeSelectorsMismatch"))
+		})
+	})
+})

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Metallb hooks :: check requirements for upgrade ::", func() {
 		})
 	})
 
-	Context("Check addressPollsMismatch error", func() {
+	Context("Check AddressPoolsMismatch error", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(l2Advertisement + ipAddressPolls2))
 			f.RunHook()
@@ -144,11 +144,11 @@ var _ = Describe("Metallb hooks :: check requirements for upgrade ::", func() {
 			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
 			Expect(exists).To(BeTrue())
 			configurationStatus := configurationStatusRaw.(string)
-			Expect(configurationStatus).To(Equal("addressPollsMismatch"))
+			Expect(configurationStatus).To(Equal("AddressPoolsMismatch"))
 		})
 	})
 
-	Context("Check nsMismatch error", func() {
+	Context("Check NSMismatch error", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(l2Advertisement2 + l2Advertisement3))
 			f.RunHook()
@@ -159,11 +159,11 @@ var _ = Describe("Metallb hooks :: check requirements for upgrade ::", func() {
 			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
 			Expect(exists).To(BeTrue())
 			configurationStatus := configurationStatusRaw.(string)
-			Expect(configurationStatus).To(Equal("nsMismatch"))
+			Expect(configurationStatus).To(Equal("NSMismatch"))
 		})
 	})
 
-	Context("Check nodeSelectorsMismatch error", func() {
+	Context("Check NodeSelectorsMismatch error", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(l2Advertisement3 + l2Advertisement4))
 			f.RunHook()
@@ -174,7 +174,7 @@ var _ = Describe("Metallb hooks :: check requirements for upgrade ::", func() {
 			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
 			Expect(exists).To(BeTrue())
 			configurationStatus := configurationStatusRaw.(string)
-			Expect(configurationStatus).To(Equal("nodeSelectorsMismatch"))
+			Expect(configurationStatus).To(Equal("NodeSelectorsMismatch"))
 		})
 	})
 })

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
@@ -29,7 +29,7 @@ spec:
   - matchLabels:
       zone: a
 `
-	ipAddressPolls = `
+	ipAddressPools = `
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
@@ -49,7 +49,7 @@ spec:
   addresses:
   - 22.22.22.22/32
 `
-	ipAddressPolls2 = `
+	ipAddressPools2 = `
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
@@ -121,7 +121,7 @@ var _ = Describe("Metallb hooks :: check requirements for upgrade ::", func() {
 
 	Context("Check correct configurations", func() {
 		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(l2Advertisement + ipAddressPolls))
+			f.BindingContexts.Set(f.KubeStateSet(l2Advertisement + ipAddressPools))
 			f.RunHook()
 		})
 		It("Check the set variable", func() {
@@ -135,7 +135,7 @@ var _ = Describe("Metallb hooks :: check requirements for upgrade ::", func() {
 
 	Context("Check AddressPoolsMismatch error", func() {
 		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(l2Advertisement + ipAddressPolls2))
+			f.BindingContexts.Set(f.KubeStateSet(l2Advertisement + ipAddressPools2))
 			f.RunHook()
 		})
 

--- a/ee/se/modules/380-metallb/hooks/common_test.go
+++ b/ee/se/modules/380-metallb/hooks/common_test.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}

--- a/ee/se/modules/380-metallb/requirements/check.go
+++ b/ee/se/modules/380-metallb/requirements/check.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package requirements
+
+import (
+	"errors"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+const (
+	metallbConfigurationStatusKey             = "metallb:ConfigurationStatus"
+	metallbConfigurationStatusRequirementsKey = "metallbHasStandardConfiguration"
+)
+
+func init() {
+	checkRequirementConfigurationStatus := func(_ string, getter requirements.ValueGetter) (bool, error) {
+		configurationStatusRaw, exists := getter.Get(metallbConfigurationStatusKey)
+		if !exists {
+			return true, nil
+		}
+
+		configurationStatus := configurationStatusRaw.(string)
+		switch {
+		case configurationStatus == "nsMismatch":
+			return false, errors.New(
+				"metallb: all L2Advertisement must be in the d8-metallb namespace",
+			)
+		case configurationStatus == "nodeSelectorsMismatch":
+			return false, errors.New(
+				"metallb: nodeSelectors in L2Advertisement must contain only " +
+					"one matchLabels (not matchExpressions)",
+			)
+		case configurationStatus == "addressPollsMismatch":
+			return false, errors.New(
+				"metallb: there should not be layer2 and bgp pools in the cluster at the same time",
+			)
+		}
+		return true, nil
+	}
+	requirements.RegisterCheck(metallbConfigurationStatusRequirementsKey, checkRequirementConfigurationStatus)
+}

--- a/ee/se/modules/380-metallb/requirements/check.go
+++ b/ee/se/modules/380-metallb/requirements/check.go
@@ -23,18 +23,17 @@ func init() {
 			return true, nil
 		}
 
-		configurationStatus := configurationStatusRaw.(string)
-		switch {
-		case configurationStatus == "nsMismatch":
+		switch configurationStatus := configurationStatusRaw.(string); configurationStatus {
+		case "nsMismatch":
 			return false, errors.New(
 				"[metallb] all L2Advertisement must be in the d8-metallb namespace",
 			)
-		case configurationStatus == "nodeSelectorsMismatch":
+		case "nodeSelectorsMismatch":
 			return false, errors.New(
 				"[metallb] nodeSelectors in L2Advertisement must contain only " +
 					"one matchLabels (not matchExpressions)",
 			)
-		case configurationStatus == "addressPollsMismatch":
+		case "addressPollsMismatch":
 			return false, errors.New(
 				"[metallb] there should not be layer2 and bgp pools in the cluster at the same time",
 			)

--- a/ee/se/modules/380-metallb/requirements/check.go
+++ b/ee/se/modules/380-metallb/requirements/check.go
@@ -24,16 +24,16 @@ func init() {
 		}
 
 		switch configurationStatus := configurationStatusRaw.(string); configurationStatus {
-		case "nsMismatch":
+		case "NSMismatch":
 			return false, errors.New(
 				"[metallb] all L2Advertisement must be in the d8-metallb namespace",
 			)
-		case "nodeSelectorsMismatch":
+		case "NodeSelectorsMismatch":
 			return false, errors.New(
 				"[metallb] nodeSelectors in L2Advertisement must contain only " +
 					"one matchLabels (not matchExpressions)",
 			)
-		case "addressPollsMismatch":
+		case "AddressPoolsMismatch":
 			return false, errors.New(
 				"[metallb] there should not be layer2 and bgp pools in the cluster at the same time",
 			)

--- a/ee/se/modules/380-metallb/requirements/check.go
+++ b/ee/se/modules/380-metallb/requirements/check.go
@@ -27,16 +27,16 @@ func init() {
 		switch {
 		case configurationStatus == "nsMismatch":
 			return false, errors.New(
-				"metallb: all L2Advertisement must be in the d8-metallb namespace",
+				"[metallb] all L2Advertisement must be in the d8-metallb namespace",
 			)
 		case configurationStatus == "nodeSelectorsMismatch":
 			return false, errors.New(
-				"metallb: nodeSelectors in L2Advertisement must contain only " +
+				"[metallb] nodeSelectors in L2Advertisement must contain only " +
 					"one matchLabels (not matchExpressions)",
 			)
 		case configurationStatus == "addressPollsMismatch":
 			return false, errors.New(
-				"metallb: there should not be layer2 and bgp pools in the cluster at the same time",
+				"[metallb] there should not be layer2 and bgp pools in the cluster at the same time",
 			)
 		}
 		return true, nil

--- a/ee/se/modules/380-metallb/requirements/check_test.go
+++ b/ee/se/modules/380-metallb/requirements/check_test.go
@@ -22,22 +22,22 @@ func TestKubernetesVersionRequirement(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("fail: nsMismatch", func(t *testing.T) {
-		requirements.SaveValue(metallbConfigurationStatusKey, "nsMismatch")
+	t.Run("fail: NSMismatch", func(t *testing.T) {
+		requirements.SaveValue(metallbConfigurationStatusKey, "NSMismatch")
 		ok, err := requirements.CheckRequirement(metallbConfigurationStatusRequirementsKey, "")
 		assert.False(t, ok)
 		require.Error(t, err)
 	})
 
-	t.Run("fail: nodeSelectorsMismatch", func(t *testing.T) {
-		requirements.SaveValue(metallbConfigurationStatusKey, "nodeSelectorsMismatch")
+	t.Run("fail: NodeSelectorsMismatch", func(t *testing.T) {
+		requirements.SaveValue(metallbConfigurationStatusKey, "NodeSelectorsMismatch")
 		ok, err := requirements.CheckRequirement(metallbConfigurationStatusRequirementsKey, "")
 		assert.False(t, ok)
 		require.Error(t, err)
 	})
 
-	t.Run("fail: addressPollsMismatch", func(t *testing.T) {
-		requirements.SaveValue(metallbConfigurationStatusKey, "nodeSelectorsMismatch")
+	t.Run("fail: AddressPoolsMismatch", func(t *testing.T) {
+		requirements.SaveValue(metallbConfigurationStatusKey, "AddressPoolsMismatch")
 		ok, err := requirements.CheckRequirement(metallbConfigurationStatusRequirementsKey, "")
 		assert.False(t, ok)
 		require.Error(t, err)

--- a/ee/se/modules/380-metallb/requirements/check_test.go
+++ b/ee/se/modules/380-metallb/requirements/check_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package requirements
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+func TestKubernetesVersionRequirement(t *testing.T) {
+	t.Run("complies with the requirements", func(t *testing.T) {
+		requirements.SaveValue(metallbConfigurationStatusKey, "")
+		ok, err := requirements.CheckRequirement(metallbConfigurationStatusRequirementsKey, "")
+		assert.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("fail: nsMismatch", func(t *testing.T) {
+		requirements.SaveValue(metallbConfigurationStatusKey, "nsMismatch")
+		ok, err := requirements.CheckRequirement(metallbConfigurationStatusRequirementsKey, "")
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
+
+	t.Run("fail: nodeSelectorsMismatch", func(t *testing.T) {
+		requirements.SaveValue(metallbConfigurationStatusKey, "nodeSelectorsMismatch")
+		ok, err := requirements.CheckRequirement(metallbConfigurationStatusRequirementsKey, "")
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
+
+	t.Run("fail: addressPollsMismatch", func(t *testing.T) {
+		requirements.SaveValue(metallbConfigurationStatusKey, "nodeSelectorsMismatch")
+		ok, err := requirements.CheckRequirement(metallbConfigurationStatusRequirementsKey, "")
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Description
Add a check of the settings of the `metallb` module and its resources for compliance with the requirements of the new version of the module.

## Why do we need it, and what problem does it solve?
We require the customer to change the settings in the cluster themselves before cluster upgrade.

## What is the expected result?
`Deckhouse` can't be upgraded until the settings meet the new module version requirements.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: feature
summary: Added pre-upgrade compatibility check for metallb configuration.
impact_level: default
```

