### PR TITLE
[candi] check transparent hugepages before disable

### DIFF
--- a/candi/bashible/common-steps/node-group/041_configure_sysctl_tuner.sh.tpl
+++ b/candi/bashible/common-steps/node-group/041_configure_sysctl_tuner.sh.tpl
@@ -85,6 +85,10 @@ sysctl -w kernel.panic={{ $fencingTime }}
 # we use tee for work with globs
 echo 256 | tee /sys/block/*/queue/nr_requests >/dev/null # put more in the request queue, increase throughput
 echo 256 | tee /sys/block/*/queue/read_ahead_kb >/dev/null # the most controversial thing, Netflix recommends increasing a little, but you need to test on different setups, this number looks safe
+transparent_hugepage_current=$(grep -o '\[.*\]' /sys/kernel/mm/transparent_hugepage/enabled | tr -d '[]')
+if [ "$transparent_hugepage_current" != "never" ]; then
+  echo never | tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null
+fi
 echo never | tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null
 echo never | tee /sys/kernel/mm/transparent_hugepage/defrag >/dev/null
 echo 0 | tee /sys/kernel/mm/transparent_hugepage/use_zero_page >/dev/null


### PR DESCRIPTION
## Description

Fixes recurring min_free_kbytes warnings in dmesg caused by user-defined values. Adds a check for transparent_hugepage status before attempting to disable it, preventing unnecessary calls to set_recommended_min_free_kbytes function in linux kernel.

## Why do we need it, and what problem does it solve?

Every 10 minutes `/opt/deckhouse/bin/sysctl-tuner` checks that `transparent_hugepage` is disabled, this causes unwanted warnings in the kernel logs.

## Why do we need it in the patch release (if we do)?


## What is the expected result?

no unnecessary messages in kernel logs.
Logs example:

```
[Thu Oct 24 17:42:22 2024] min_free_kbytes is not updated to 11265 because user defined value 131072 is preferred
[Thu Oct 24 17:44:12 2024] min_free_kbytes is not updated to 11265 because user defined value 131072 is preferred
[Thu Oct 24 17:49:18 2024] min_free_kbytes is not updated to 11265 because user defined value 131072 is preferred
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Check for transparent hugepages before trying to disable them in sysctl-tuner
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
