### PR TITLE
[docs] Added an alert with information in the docs-dev build mode

### DIFF
--- a/docs/documentation/_includes/sidebar.html
+++ b/docs/documentation/_includes/sidebar.html
@@ -1,42 +1,52 @@
-{%- unless page.hide_sidebar or jekyll.environment == "development" %}
-{%- assign sidebar = site.data.sidebars[page.sidebar].entries %}
-
-    <div style="display: flex; justify-content: start; padding-top: 12px; padding-bottom: 35px; gap: 25px;">
-      <div class="channel-menu submenu-parent">
-
-        <!-- documentation-section-badge -->
-        <a data-proofer-ignore="" href="#" class="highlight">{{ site.data.i18n.common.platform[page.lang] | capitalize }}</a>
-        <div class="submenu-container">
-          <ul class="submenu">
-            <li class="submenu-item">
-              <a data-proofer-ignore='' class='submenu-item-link' href='{% if site.mode == "module" %}/{{ page.lang }}{% endif %}/modules/'>
-                <span class="submenu-item-channel">{{ site.data.i18n.common.modules[page.lang] | capitalize }}</span>
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
-
-      {% unless site.mode == 'module' %}
-      <!-- module-version-badge -->
-      <div id="doc-versions-menu" class="channel-menu submenu-parent">
-        <!--#include virtual="/includes/channel-menu-v2.html" -->
-      </div>
-      {% endunless %}
+{%- unless page.hide_sidebar %}
+  {%- if jekyll.environment == "development" %}
+    <div class="sidebar__item" style="font-size: 20px; font-weight: bold; color: black;">
+      {%- if page.lang == "ru" %}
+        В режиме dev сборки меню не генерируется
+      {%- else %}
+        Menu is not generated in dev build mode
+      {%- endif %}
     </div>
-  <div class="sidebar__wrapper-inner">
-    <nav class="sidebar__container">
+  {%- else %}
+      {%- assign sidebar = site.data.sidebars[page.sidebar].entries %}
 
-      <ul class="sidebar" id="mysidebar">
+      <div style="display: flex; justify-content: start; padding-top: 12px; padding-bottom: 35px; gap: 25px;">
+        <div class="channel-menu submenu-parent">
 
-        {%- for entry in sidebar.folders %}
-        {% include sidebar_entry.html entry=entry folder_entry_class="sidebar__item sidebar__item_parent" item_entry_class="sidebar__item" %}
-        {%- endfor %}
-      </ul>
+          <!-- documentation-section-badge -->
+          <a data-proofer-ignore="" href="#" class="highlight">{{ site.data.i18n.common.platform[page.lang] | capitalize }}</a>
+          <div class="submenu-container">
+            <ul class="submenu">
+              <li class="submenu-item">
+                <a data-proofer-ignore='' class='submenu-item-link' href='{% if site.mode == "module" %}/{{ page.lang }}{% endif %}/modules/'>
+                  <span class="submenu-item-channel">{{ site.data.i18n.common.modules[page.lang] | capitalize }}</span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
 
-    </nav>
-  </div>
+        {% unless site.mode == 'module' %}
+        <!-- module-version-badge -->
+        <div id="doc-versions-menu" class="channel-menu submenu-parent">
+          <!--#include virtual="/includes/channel-menu-v2.html" -->
+        </div>
+        {% endunless %}
+      </div>
+      <div class="sidebar__wrapper-inner">
+        <nav class="sidebar__container">
 
-<!-- this highlights the active parent class in the navgoco sidebar. this is critical so that the parent expands when you're viewing a page. This must appear below the sidebar code above. Otherwise, if placed inside customscripts.js, the script runs before the sidebar code runs and the class never gets inserted.-->
-<script>$("li.active").parents('li').toggleClass("active");</script>
+          <ul class="sidebar" id="mysidebar">
+
+            {%- for entry in sidebar.folders %}
+            {% include sidebar_entry.html entry=entry folder_entry_class="sidebar__item sidebar__item_parent" item_entry_class="sidebar__item" %}
+            {%- endfor %}
+          </ul>
+
+        </nav>
+      </div>
+
+      <!-- this highlights the active parent class in the navgoco sidebar. this is critical so that the parent expands when you're viewing a page. This must appear below the sidebar code above. Otherwise, if placed inside customscripts.js, the script runs before the sidebar code runs and the class never gets inserted.-->
+      <script>$("li.active").parents('li').toggleClass("active");</script>
+    {%- endif %}
 {% endunless %}


### PR DESCRIPTION
## Description
Added an alert with information in the docs-dev build mode.



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.



```changes
section: docs
type: chore
summary: Added an alert with information in the docs-dev build mode.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
