### PR TITLE
[prometheus] Add backup label to publicly used CRDs

### DIFF
--- a/modules/300-prometheus/crds/customalertmanager.yaml
+++ b/modules/300-prometheus/crds/customalertmanager.yaml
@@ -6,7 +6,7 @@ metadata:
     heritage: deckhouse
     module: prometheus
     app: alertmanager
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/300-prometheus/crds/customalertmanager.yaml
+++ b/modules/300-prometheus/crds/customalertmanager.yaml
@@ -6,6 +6,7 @@ metadata:
     heritage: deckhouse
     module: prometheus
     app: alertmanager
+    backup.deckhouse.io/cluster-config: ""
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/300-prometheus/crds/customprometheusrules.yaml
+++ b/modules/300-prometheus/crds/customprometheusrules.yaml
@@ -6,6 +6,7 @@ metadata:
     heritage: deckhouse
     module: prometheus
     app: prometheus
+    backup.deckhouse.io/cluster-config: ""
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/300-prometheus/crds/customprometheusrules.yaml
+++ b/modules/300-prometheus/crds/customprometheusrules.yaml
@@ -6,7 +6,7 @@ metadata:
     heritage: deckhouse
     module: prometheus
     app: prometheus
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/300-prometheus/crds/grafanaadditionaldatasources.yaml
+++ b/modules/300-prometheus/crds/grafanaadditionaldatasources.yaml
@@ -6,6 +6,7 @@ metadata:
     heritage: deckhouse
     module: prometheus
     app: prometheus
+    backup.deckhouse.io/cluster-config: ""
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/300-prometheus/crds/grafanaadditionaldatasources.yaml
+++ b/modules/300-prometheus/crds/grafanaadditionaldatasources.yaml
@@ -6,7 +6,7 @@ metadata:
     heritage: deckhouse
     module: prometheus
     app: prometheus
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/300-prometheus/crds/grafanaalertschannel.yaml
+++ b/modules/300-prometheus/crds/grafanaalertschannel.yaml
@@ -6,6 +6,7 @@ metadata:
     heritage: deckhouse
     module: prometheus
     app: grafana
+    backup.deckhouse.io/cluster-config: ""
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/300-prometheus/crds/grafanaalertschannel.yaml
+++ b/modules/300-prometheus/crds/grafanaalertschannel.yaml
@@ -6,7 +6,7 @@ metadata:
     heritage: deckhouse
     module: prometheus
     app: grafana
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/300-prometheus/crds/grafanadashboarddefinition.yaml
+++ b/modules/300-prometheus/crds/grafanadashboarddefinition.yaml
@@ -6,6 +6,7 @@ metadata:
     heritage: deckhouse
     module: prometheus
     app: grafana
+    backup.deckhouse.io/cluster-config: ""
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/300-prometheus/crds/grafanadashboarddefinition.yaml
+++ b/modules/300-prometheus/crds/grafanadashboarddefinition.yaml
@@ -6,7 +6,7 @@ metadata:
     heritage: deckhouse
     module: prometheus
     app: grafana
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/300-prometheus/crds/prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/prometheusremotewrite.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: prometheus
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/300-prometheus/crds/prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/prometheusremotewrite.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: prometheus
+    backup.deckhouse.io/cluster-config: ""
 spec:
   group: deckhouse.io
   scope: Cluster


### PR DESCRIPTION
## Description
Add backup label to publicly used CRDs

## Why do we need it, and what problem does it solve?
Adding this label to CRD instructs `d8 backup cluster-config` command to backup all CRs of a Kind. It's great to have it at all publicly used CRDs

## Why do we need it in the patch release (if we do)?
We don't

## What is the expected result?
`d8 backup cluster-config` command backups all CRs for these CRDs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->
```changes
section: prometheus
type: feature
summary: Added `backup.deckhouse.io/cluster-config` label to relevant module CRDs.
impact_level: default
```
<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
