### PR TITLE
[prometheus-operator] Add backup label to publicly used CRDs

### DIFF
--- a/modules/200-operator-prometheus/crds/podmonitors.yaml
+++ b/modules/200-operator-prometheus/crds/podmonitors.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
+  labels:
+    backup.deckhouse.io/cluster-config: ""
   name: podmonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/modules/200-operator-prometheus/crds/probes.yaml
+++ b/modules/200-operator-prometheus/crds/probes.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
+  labels:
+    backup.deckhouse.io/cluster-config: ""
   name: probes.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/modules/200-operator-prometheus/crds/prometheusrules.yaml
+++ b/modules/200-operator-prometheus/crds/prometheusrules.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
+  labels:
+    backup.deckhouse.io/cluster-config: ""
   name: prometheusrules.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/modules/200-operator-prometheus/crds/scrapeconfigs.yaml
+++ b/modules/200-operator-prometheus/crds/scrapeconfigs.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
+  labels:
+    backup.deckhouse.io/cluster-config: ""
   name: scrapeconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/modules/200-operator-prometheus/crds/servicemonitors.yaml
+++ b/modules/200-operator-prometheus/crds/servicemonitors.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
+  labels:
+    backup.deckhouse.io/cluster-config: ""
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com


### PR DESCRIPTION
## Description
Add backup label to publicly used CRDs

## Why do we need it, and what problem does it solve?
Adding this label to CRD instructs `d8 backup cluster-config` command to backup all CRs of a Kind. It's great to have it at all publicly used CRDs. Since we allow direct use of the `PodMonitor`, `ServiceMonitor`, `ScrapeConfig`, `Probe` and `PrometheusRule` resources user may expect to find them in the backup as well.

## Why do we need it in the patch release (if we do)?
We don't

## What is the expected result?
`d8 backup cluster-config` command backups all CRs for these CRDs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
