### PR TITLE
[docs][OperationPolicy] Fix type of vars in documentation

### DIFF
--- a/modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml
@@ -64,7 +64,7 @@ spec:
                           description: |
                             Список объектов Kubernetes в формате `$apiGroup/$kind` для просмотра аннотаций.
                     requiredProbes:
-                      description: "Список проб, которые необходимы (например, `readinessProbe`)."
+                      description: "Список проб, которые необходимы (например, `readinessProbe` и `livenessProbe`)."
                     maxRevisionHistoryLimit:
                       description: "Максимальное значение для истории ревизий."
                     priorityClassNames:

--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -144,8 +144,9 @@ spec:
                     requiredProbes:
                       type: array
                       x-doc-examples: 
-                        - ["readinessProbe"]
-                      description: "The list of probes that are required (e.g. `readinessProbe`)"
+                        - - readinessProbe
+                          - livenessProbe
+                      description: "The list of probes that are required (e.g. `readinessProbe` and `livenessProbe`)"
                       items:
                         type: string
                         enum:

--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -143,7 +143,8 @@ spec:
                             x-doc-examples: ["apps/Deployment", "/Pod", "networking.k8s.io/Ingress"]
                     requiredProbes:
                       type: array
-                      x-doc-examples: ["livenessProbe", "readinessProbe"]
+                      x-doc-examples: 
+                        - ["readinessProbe"]
                       description: "The list of probes that are required (e.g. `readinessProbe`)"
                       items:
                         type: string


### PR DESCRIPTION
## Description
  Describe your changes in detail.
Change files modules/015-admission-policy-engine/crds/doc-ru-operation-policy.yaml modules/015-admission-policy-engine/crds/operation-policy.yaml for fixing documentation. Some vars in examples in doc must be define in array.


## Why do we need it, and what problem does it solve?
<!---
Current information in docs can confuse users, when they are preparing configs. My fix clarifies, which config must be. 
-->
## What is the expected result?
The quality of documentation will improve

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix 
summary: Change type of vars, which presents in example in documentation.
impact_level:  low
```
