### PR TITLE
[dhctl] [cloud-provider-openstack] Add Openstack API availability check inside the cluster during deployment

### DIFF
--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -46,6 +46,7 @@ const (
 	PythonChecksArgName              = "preflight-skip-python-checks"
 	SudoAllowedCheckArgName          = "preflight-skip-sudo-allowed"
 	SystemRequirementsArgName        = "preflight-skip-system-requirements-check"
+	CloudAPIAccessibilityArgName     = "preflight-cloud-api-accesibility-check"
 	OneSSHHostCheckArgName           = "preflight-skip-one-ssh-host"
 )
 

--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -31,6 +31,7 @@ var (
 	PreflightSkipSudoIsAllowedForUserCheck = false
 	PreflightSkipSystemRequirementsCheck   = false
 	PreflightSkipOneSSHHost                = false
+	PreflightSkipCloudAPIAccessibility     = false
 )
 
 const (
@@ -60,6 +61,7 @@ var (
 		PublicDomainTemplateCheckArgName: &PreflightSkipPublicDomainTemplateCheck,
 		SSHCredentialsCheckArgName:       &PreflightSkipSSHCredentialsCheck,
 		RegistryCredentialsCheckArgName:  &PreflightSkipRegistryCredentials,
+		CloudAPIAccessibilityArgName:     &PreflightSkipCloudAPIAccessibility,
 		ContainerdExistCheckArgName:      &PreflightSkipContainerdExistCheck,
 		PythonChecksArgName:              &PreflightSkipPythonChecks,
 		SudoAllowedCheckArgName:          &PreflightSkipSudoIsAllowedForUserCheck,
@@ -104,6 +106,9 @@ func DefinePreflight(cmd *kingpin.CmdClause) {
 	cmd.Flag(RegistryCredentialsCheckArgName, "Skip verifying registry credentials").
 		Envar(configEnvName("PREFLIGHT_SKIP_REGISTRY_CREDENTIALS")).
 		BoolVar(PreflightSkipOptionsMap[RegistryCredentialsCheckArgName])
+	cmd.Flag(CloudAPIAccessibilityArgName, "Skip verifying Cloud API").
+		Envar(configEnvName("PREFLIGHT_SKIP_CLOUD_API_CHECK")).
+		BoolVar(PreflightSkipOptionsMap[CloudAPIAccessibilityArgName])
 	cmd.Flag(ContainerdExistCheckArgName, "Skip verifying contanerd exist").
 		Envar(configEnvName("PREFLIGHT_SKIP_CONTAINERD_EXIST")).
 		BoolVar(PreflightSkipOptionsMap[ContainerdExistCheckArgName])

--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -18,7 +18,7 @@ import "gopkg.in/alecthomas/kingpin.v2"
 
 var (
 	PreflightSkipAll                       = false
-	PreflightSkipSSHForword                = false
+	PreflightSkipSSHForward                = false
 	PreflightSkipAvailabilityPorts         = false
 	PreflightSkipResolvingLocalhost        = false
 	PreflightSkipDeckhouseVersionCheck     = false
@@ -53,7 +53,7 @@ const (
 
 var (
 	PreflightSkipOptionsMap = map[string]*bool{
-		SSHForwardArgName:                &PreflightSkipSSHForword,
+		SSHForwardArgName:                &PreflightSkipSSHForward,
 		PortsAvailabilityArgName:         &PreflightSkipAvailabilityPorts,
 		ResolvingLocalhostArgName:        &PreflightSkipResolvingLocalhost,
 		DeckhouseVersionCheckArgName:     &PreflightSkipDeckhouseVersionCheck,

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -20,11 +20,11 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/google/uuid"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/converge"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/resources"

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -17,9 +17,10 @@ package bootstrap
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"reflect"
 	"time"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 
 	"github.com/google/uuid"
 
@@ -389,6 +390,11 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		if err := WaitForSSHConnectionOnMaster(wrapper.Client()); err != nil {
 			return fmt.Errorf("failed to wait for SSH connection on master: %v", err)
 		}
+	}
+
+	err = preflightChecker.PostCloud()
+	if err != nil {
+		return err
 	}
 
 	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.ExecuteBashibleBundlePhase, false, stateCache, nil); err != nil {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -392,9 +392,11 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		}
 	}
 
-	err = preflightChecker.PostCloud()
-	if err != nil {
-		return err
+	if metaConfig.ClusterType == config.CloudClusterType {
+		err = preflightChecker.PostCloud()
+		if err != nil {
+			return err
+		}
 	}
 
 	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.ExecuteBashibleBundlePhase, false, stateCache, nil); err != nil {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
-
 	"github.com/google/uuid"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"

--- a/dhctl/pkg/operations/bootstrap/state.go
+++ b/dhctl/pkg/operations/bootstrap/state.go
@@ -66,6 +66,11 @@ func (s *State) CloudPreflightchecksWasRan() (bool, error) {
 	return preflightcachefile, err
 }
 
+func (s *State) PostCloudPreflightchecksWasRan() (bool, error) {
+	preflightcachefile, err := s.cache.InCache(PreflightBootstrapPostCloudResultCacheKey)
+	return preflightcachefile, err
+}
+
 func (s *State) SetStaticPreflightchecksWasRan() error {
 	return s.cache.Save(PreflightBootstrapStaticResultCacheKey, []byte("yes"))
 }

--- a/dhctl/pkg/operations/bootstrap/state.go
+++ b/dhctl/pkg/operations/bootstrap/state.go
@@ -22,6 +22,7 @@ import (
 
 const PostBootstrapResultCacheKey = "post-bootstrap-result"
 const PreflightBootstrapCloudResultCacheKey = "preflight-bootstrap-cloud-result"
+const PreflightBootstrapPostCloudResultCacheKey = "preflight-bootstrap-post-cloud-result"
 const PreflightBootstrapGlobalResultCacheKey = "preflight-bootstrap-global-result"
 const PreflightBootstrapStaticResultCacheKey = "preflight-bootstrap-static-result"
 
@@ -54,6 +55,10 @@ func (s *State) GlobalPreflightchecksWasRan() (bool, error) {
 
 func (s *State) SetCloudPreflightchecksWasRan() error {
 	return s.cache.Save(PreflightBootstrapCloudResultCacheKey, []byte("yes"))
+}
+
+func (s *State) SetPostCloudPreflightchecksWasRan() error {
+	return s.cache.Save(PreflightBootstrapPostCloudResultCacheKey, []byte("yes"))
 }
 
 func (s *State) CloudPreflightchecksWasRan() (bool, error) {

--- a/dhctl/pkg/preflight/check-cloud-api/providers.go
+++ b/dhctl/pkg/preflight/check-cloud-api/providers.go
@@ -1,0 +1,58 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkcloudapi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func HandleOpenStackProvider(providerClusterConfig []byte) (CloudApiConfig, error) {
+	var openStackConfig OpenStackProvider
+	err := json.Unmarshal(providerClusterConfig, &openStackConfig)
+	if err != nil {
+		return CloudApiConfig{}, fmt.Errorf("unable to unmarshal provider config for OpenStack: %v", err)
+	}
+
+	url, err := urlParse(openStackConfig.AuthURL)
+	if err != nil {
+		return CloudApiConfig{}, err
+	}
+
+	return CloudApiConfig{
+		URL:      url,
+		CACert:   openStackConfig.CACert,
+		Insecure: false,
+	}, nil
+}
+
+func HandleVSphereProvider(providerClusterConfig []byte) (CloudApiConfig, error) {
+	var vsphereConfig VSphereProvider
+	err := json.Unmarshal(providerClusterConfig, &vsphereConfig)
+	if err != nil {
+		return CloudApiConfig{}, fmt.Errorf("unable to unmarshal provider config for OpenStack: %v", err)
+	}
+
+	url, err := urlParse(vsphereConfig.Server)
+	if err != nil {
+		return CloudApiConfig{}, err
+	}
+
+	return CloudApiConfig{
+		URL:      url,
+		CACert:   "",
+		Insecure: vsphereConfig.Insecure,
+	}, nil
+}

--- a/dhctl/pkg/preflight/check-cloud-api/types.go
+++ b/dhctl/pkg/preflight/check-cloud-api/types.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkcloudapi
+
+import "net/url"
+
+type OpenStackProvider struct {
+	AuthURL    string `json:"authURL,omitempty" yaml:"authURL,omitempty"`
+	CACert     string `json:"caCert,omitempty" yaml:"caCert,omitempty"`
+	DomainName string `json:"domainName,omitempty" yaml:"domainName,omitempty"`
+	TenantName string `json:"tenantName,omitempty" yaml:"tenantName,omitempty"`
+	TenantID   string `json:"tenantID,omitempty" yaml:"tenantID,omitempty"`
+	Username   string `json:"username,omitempty" yaml:"username,omitempty"`
+	Password   string `json:"password,omitempty" yaml:"password,omitempty"`
+	Region     string `json:"region,omitempty" yaml:"region,omitempty"`
+}
+
+type VSphereProvider struct {
+	Server   string `json:"server"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Insecure bool   `json:"insecure"`
+}
+
+type CloudApiConfig struct {
+	URL      *url.URL
+	Insecure bool
+	CACert   string
+}

--- a/dhctl/pkg/preflight/check-cloud-api/utils.go
+++ b/dhctl/pkg/preflight/check-cloud-api/utils.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkcloudapi
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+func urlParse(urlString string) (*url.URL, error) {
+	if urlString == "" {
+		return nil, errors.New("cloud API URL is empty")
+	}
+	if !strings.Contains(urlString, "://") {
+		urlString = "https://" + urlString
+	}
+	url, err := url.Parse(urlString)
+	return url, err
+}

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Flant JSC
+// Copyright 2024 Flant JSC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -247,5 +247,4 @@ func ensureUrlHasScheme(u *url.URL) {
 	if u.Scheme == "" {
 		u.Scheme = "https"
 	}
-	fmt.Printf("port: %v\n", u.Port())
 }

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -1,0 +1,117 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh/frontend"
+)
+
+func (pc *Checker) CheckCloudAPIAccessibility() error {
+	log.DebugLn("Checking if Cloud Api is accessible from first master host")
+	wrapper, ok := pc.nodeInterface.(*ssh.NodeInterfaceWrapper)
+
+	if !ok {
+		log.InfoLn("Checking if Cloud Api is accessible through proxy was skipped (local run)")
+		return nil
+	}
+
+	cloudApiUrl, err := getCloudApiURLFromMetaConfig(pc.metaConfig)
+
+	if err != nil {
+		log.ErrorF("cannot parse cloudApiUrl from CloudApiConfiguration: %v", err)
+	}
+
+	tun, err := setupSSHTunnelToCloudApi(wrapper.Client(), cloudApiUrl)
+	if err != nil {
+		return fmt.Errorf(`cannot setup tunnel to control-plane host: %w.
+Please check connectivity to control-plane host and that the sshd config parameter 'AllowTcpForwarding' set to 'yes' on control-plane node`, err)
+	}
+	defer tun.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodHead, cloudApiUrl.String(), nil)
+	httpCl := buildHTTPClientWithLocalhostProxy(cloudApiUrl)
+	resp, err := httpCl.Do(req)
+
+	if err != nil {
+		log.ErrorF("Error making request: %v", err)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.ErrorF("Error reading response body: %v", err)
+	}
+	body := string(bodyBytes)
+
+	fmt.Printf("status, response: %s %s\n", resp.Status, body)
+	return nil
+}
+
+func getCloudApiURLFromMetaConfig(metaConfig *config.MetaConfig) (*url.URL, error) {
+	providerClusterConfig, exists := metaConfig.ProviderClusterConfig["provider"]
+	var cloudApiURLStr string
+	var providerConfig map[string]string
+
+	if !exists {
+		return nil, fmt.Errorf("provider configuration not found in ProviderClusterConfig")
+	}
+
+	if err := json.Unmarshal(providerClusterConfig, &providerConfig); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal provider from ProviderClusterConfig: %v", err)
+	}
+
+	switch providerName := metaConfig.ProviderName; providerName {
+	case "OpenStack":
+		cloudApiURLStr = providerConfig["authURL"]
+	case "vSphere":
+		cloudApiURLStr = providerConfig["server"]
+	default:
+		return nil, fmt.Errorf("unsupported provider name: %s", providerName)
+	}
+
+	if cloudApiURLStr == "" {
+		return nil, fmt.Errorf("cloud API URL is empty for provider: %s", metaConfig.ProviderName)
+	}
+	cloudApiURL, err := url.Parse(cloudApiURLStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cloud API URL '%s': %v", cloudApiURLStr, err)
+	}
+
+	return cloudApiURL, nil
+}
+
+func setupSSHTunnelToCloudApi(sshCl *ssh.Client, cloudApiUrl *url.URL) (*frontend.Tunnel, error) {
+	tunnel := strings.Join([]string{ProxyTunnelPort, cloudApiUrl.Hostname(), cloudApiUrl.Port()}, ":")
+	tun := sshCl.Tunnel("L", tunnel)
+	err := tun.Up()
+	if err != nil {
+		return nil, err
+	}
+	return tun, nil
+}

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -93,6 +93,7 @@ Please check connectivity to control-plane host and that the sshd config paramet
 	resp, err := executeHTTPRequest(ctx, http.MethodGet, cloudApiConfig)
 
 	if err != nil {
+		log.ErrorF("Error while accessing Cloud API: %v", err)
 		return ErrCloudApiUnreachable
 	}
 	if resp.StatusCode >= 500 {

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -92,7 +92,10 @@ Please check connectivity to control-plane host and that the sshd config paramet
 
 	resp, err := executeHTTPRequest(ctx, http.MethodGet, cloudApiConfig)
 
-	if resp.StatusCode >= 500 || err != nil {
+	if err != nil {
+		return ErrCloudApiUnreachable
+	}
+	if resp.StatusCode >= 500 {
 		return ErrCloudApiUnreachable
 	}
 
@@ -191,7 +194,7 @@ func getCloudApiConfigFromMetaConfig(metaConfig *config.MetaConfig) (*CloudApiCo
 		insecure = vsphereConfig.Insecure
 
 	default:
-		log.DebugLn("[Skip] Checking if Cloud Api is accessible from first master host. Unsupported provider: %v", providerName)
+		log.DebugF("[Skip] Checking if Cloud Api is accessible from first master host. Unsupported provider: %v", providerName)
 		return nil, nil
 	}
 

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -89,6 +89,7 @@ Please check connectivity to control-plane host and that the sshd config paramet
 		log.ErrorF("Error while accessing Cloud API: %v", err)
 		return ErrCloudApiUnreachable
 	}
+	log.InfoF("GET %s: %d/%s", cloudAPIConfig.URL.String(), resp.StatusCode, resp.Status)
 	if resp.StatusCode >= 500 {
 		return ErrCloudApiUnreachable
 	}

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
@@ -228,9 +229,11 @@ func getCloudApiConfigFromMetaConfig(metaConfig *config.MetaConfig) (*CloudApiCo
 	if cloudApiURLStr == "" {
 		return nil, fmt.Errorf("cloud API URL is empty for provider: %s", metaConfig.ProviderName)
 	}
+	if !strings.Contains(cloudApiURLStr, "://") {
+		cloudApiURLStr = "https://" + cloudApiURLStr
+	}
 
 	cloudApiURL, err := url.Parse(cloudApiURLStr)
-	ensureUrlHasScheme(cloudApiURL)
 
 	if err != nil {
 		return nil, fmt.Errorf("invalid cloud API URL '%s': %v", cloudApiURLStr, err)
@@ -241,10 +244,4 @@ func getCloudApiConfigFromMetaConfig(metaConfig *config.MetaConfig) (*CloudApiCo
 		Insecure: insecure,
 		CACert:   cacert,
 	}, nil
-}
-
-func ensureUrlHasScheme(u *url.URL) {
-	if u.Scheme == "" {
-		u.Scheme = "https"
-	}
 }

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -46,7 +46,6 @@ func (pc *Checker) CheckCloudAPIAccessibility() error {
 	}
 
 	if cloudApiUrl == nil {
-		log.DebugLn("[Skip] Checking if Cloud Api is accessible from first master host")
 		return nil
 	}
 
@@ -97,7 +96,7 @@ func getCloudApiURLFromMetaConfig(metaConfig *config.MetaConfig) (*url.URL, erro
 	case "vsphere":
 		cloudApiURLStr = providerConfig["server"]
 	default:
-		log.DebugF("providerName: %v", providerName)
+		log.DebugLn("[Skip] Checking if Cloud Api is accessible from first master host providerName: %v", cloudApiURLStr)
 		return nil, nil
 	}
 

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -100,15 +100,13 @@ Please check connectivity to control-plane host and that the sshd config paramet
 }
 
 func buildCloudApiHTTPClientTransport(client *http.Client, cloudApiConfig *CloudApiConfig) (*http.Client, error) {
-	cloudApiUrl := cloudApiConfig.URL
-
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	defaultTransport, ok := client.Transport.(*http.Transport)
 	if !ok {
 		return nil, fmt.Errorf("unexpected transport type")
 	}
 	httpTransport := defaultTransport.Clone()
 
-	if strings.ToLower(cloudApiUrl.Scheme) == "https" {
+	if strings.ToLower(cloudApiConfig.URL.Scheme) == "https" {
 		tlsConfig := &tls.Config{}
 
 		if cloudApiConfig.Insecure {

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -89,7 +89,7 @@ Please check connectivity to control-plane host and that the sshd config paramet
 		log.ErrorF("Error while accessing Cloud API: %v", err)
 		return ErrCloudApiUnreachable
 	}
-	log.InfoF("GET %s: %d/%s", cloudAPIConfig.URL.String(), resp.StatusCode, resp.Status)
+	log.InfoF("GET %s: %s\n", cloudAPIConfig.URL.String(), resp.Status)
 	if resp.StatusCode >= 500 {
 		return ErrCloudApiUnreachable
 	}

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -230,6 +230,8 @@ func getCloudApiConfigFromMetaConfig(metaConfig *config.MetaConfig) (*CloudApiCo
 	}
 
 	cloudApiURL, err := url.Parse(cloudApiURLStr)
+	ensureUrlHasScheme(cloudApiURL)
+
 	if err != nil {
 		return nil, fmt.Errorf("invalid cloud API URL '%s': %v", cloudApiURLStr, err)
 	}
@@ -239,4 +241,11 @@ func getCloudApiConfigFromMetaConfig(metaConfig *config.MetaConfig) (*CloudApiCo
 		Insecure: insecure,
 		CACert:   cacert,
 	}, nil
+}
+
+func ensureUrlHasScheme(u *url.URL) {
+	if u.Scheme == "" {
+		u.Scheme = "https"
+	}
+	fmt.Printf("port: %v\n", u.Port())
 }

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -20,7 +20,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -89,7 +88,7 @@ Please check connectivity to control-plane host and that the sshd config paramet
 		log.ErrorF("Error while accessing Cloud API: %v", err)
 		return ErrCloudApiUnreachable
 	}
-	log.InfoF("GET %s: %s\n", cloudAPIConfig.URL.String(), resp.Status)
+	log.DebugF("GET %s: %s\n", cloudAPIConfig.URL.String(), resp.Status)
 	if resp.StatusCode >= 500 {
 		return ErrCloudApiUnreachable
 	}
@@ -160,17 +159,6 @@ func executeHTTPRequest(ctx context.Context, method string, cloudAPIConfig *cca.
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
-
-	defer resp.Body.Close()
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.ErrorF("Error reading response body: %v", err)
-	}
-	body := string(bodyBytes)
-	statusCode := resp.StatusCode
-	log.DebugF("status, response: %d %s", statusCode, body)
-
 	return resp, nil
 }
 

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -91,9 +91,7 @@ Please check connectivity to control-plane host and that the sshd config paramet
 	defer cancel()
 
 	resp, err := executeHTTPRequest(ctx, http.MethodGet, cloudApiConfig)
-	if err != nil {
-		return ErrCloudApiUnreachable
-	}
+
 	if resp.StatusCode >= 500 || err != nil {
 		return ErrCloudApiUnreachable
 	}

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -185,7 +185,6 @@ func executeHTTPRequest(ctx context.Context, method string, cloudAPIConfig *Clou
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
 
-	// Debug
 	defer resp.Body.Close()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
@@ -195,7 +194,6 @@ func executeHTTPRequest(ctx context.Context, method string, cloudAPIConfig *Clou
 	body := string(bodyBytes)
 	statusCode := resp.StatusCode
 	log.DebugF("status, response: %d %s", statusCode, body)
-	// Debug
 
 	return resp, nil
 }

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -45,6 +45,11 @@ func (pc *Checker) CheckCloudAPIAccessibility() error {
 		log.ErrorF("cannot parse cloudApiUrl from CloudApiConfiguration: %v", err)
 	}
 
+	if cloudApiUrl == nil {
+		log.DebugLn("[Skip] Checking if Cloud Api is accessible from first master host")
+		return nil
+	}
+
 	tun, err := setupSSHTunnelToCloudApi(wrapper.Client(), cloudApiUrl)
 	if err != nil {
 		return fmt.Errorf(`cannot setup tunnel to control-plane host: %w.
@@ -92,7 +97,7 @@ func getCloudApiURLFromMetaConfig(metaConfig *config.MetaConfig) (*url.URL, erro
 	case "vSphere":
 		cloudApiURLStr = providerConfig["server"]
 	default:
-		return nil, fmt.Errorf("unsupported provider name: %s", providerName)
+		return nil, nil
 	}
 
 	if cloudApiURLStr == "" {

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -92,11 +92,12 @@ func getCloudApiURLFromMetaConfig(metaConfig *config.MetaConfig) (*url.URL, erro
 	}
 
 	switch providerName := metaConfig.ProviderName; providerName {
-	case "OpenStack":
+	case "openstack":
 		cloudApiURLStr = providerConfig["authURL"]
-	case "vSphere":
+	case "vsphere":
 		cloudApiURLStr = providerConfig["server"]
 	default:
+		log.DebugF("providerName: %v", providerName)
 		return nil, nil
 	}
 

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	ErrCloudApiUnreachable = errors.New("could not reach Cloud API over proxy")
+	ErrCloudApiUnreachable = errors.New("could not reach Cloud API from master node")
 )
 
 type OpenStackProvider struct {
@@ -90,6 +90,7 @@ func (pc *Checker) CheckCloudAPIAccessibility() error {
 	}
 
 	if proxyUrl == nil || shouldSkipProxyCheck(cloudApiConfig.URL.Hostname(), noProxyAddresses) {
+		proxyUrl = nil
 		tun, err = setupSSHTunnelToProxyAddr(wrapper.Client(), cloudApiConfig.URL)
 	} else {
 		tun, err = setupSSHTunnelToProxyAddr(wrapper.Client(), proxyUrl)

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -112,6 +112,8 @@ func buildCloudApiHTTPClientTransport(client *http.Client, cloudApiConfig *Cloud
 	if strings.ToLower(cloudApiConfig.URL.Scheme) == "https" {
 		tlsConfig := &tls.Config{}
 
+		tlsConfig.ServerName = cloudApiConfig.URL.Host
+
 		if cloudApiConfig.Insecure {
 			tlsConfig.InsecureSkipVerify = true
 		}

--- a/dhctl/pkg/preflight/check_cloud_api.go
+++ b/dhctl/pkg/preflight/check_cloud_api.go
@@ -16,6 +16,7 @@ package preflight
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -73,6 +74,11 @@ func executeHTTPRequest(ctx context.Context, method string, cloudApiUrl *url.URL
 	}
 
 	httpCl := buildHTTPClientWithLocalhostProxy(cloudApiUrl)
+
+	transport, _ := httpCl.Transport.(*http.Transport)
+	transport.TLSClientConfig = &tls.Config{
+		ServerName: cloudApiUrl.Host,
+	}
 
 	resp, err := httpCl.Do(req)
 

--- a/dhctl/pkg/preflight/check_cloud_api_test.go
+++ b/dhctl/pkg/preflight/check_cloud_api_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package preflight
 
 import (

--- a/dhctl/pkg/preflight/check_cloud_api_test.go
+++ b/dhctl/pkg/preflight/check_cloud_api_test.go
@@ -18,7 +18,7 @@ func TestGetCloudApiURLFromMetaConfig(t *testing.T) {
 	}{
 		{
 			name:         "OpenStack provider",
-			providerName: "OpenStack",
+			providerName: "openstack",
 			providerConfigJSON: `{
 				"authURL": "https://openstack.example.com/v3/auth",
 				"domainName": "provider.local",
@@ -31,7 +31,7 @@ func TestGetCloudApiURLFromMetaConfig(t *testing.T) {
 		},
 		{
 			name:         "vSphere provider",
-			providerName: "vSphere",
+			providerName: "vsphere",
 			providerConfigJSON: `{
 				"server": "https://vsphere.example.com/sdk",
 				"username": "vsphereUser",
@@ -60,7 +60,11 @@ deckhouse:
 				"provider": json.RawMessage(tt.providerConfigJSON),
 			}
 			s.Equal(tt.providerName, metaConfig.ProviderName)
-			cloudApiURL, err := getCloudApiURLFromMetaConfig(metaConfig)
+			cloudApiConfig, err := getCloudApiConfigFromMetaConfig(metaConfig)
+			t.Logf("cloudApiConfig: %+v, error: %v", cloudApiConfig, err)
+			s.NoError(err, "getCloudApiConfigFromMetaConfig must be not nil")
+			s.NotNil(cloudApiConfig, "cloudApiConfig must be not nil")
+			cloudApiURL := cloudApiConfig.URL.String()
 			s.NoError(err)
 			s.Equal(tt.expectedURL, cloudApiURL)
 		})

--- a/dhctl/pkg/preflight/check_cloud_api_test.go
+++ b/dhctl/pkg/preflight/check_cloud_api_test.go
@@ -39,6 +39,16 @@ func TestGetCloudApiURLFromMetaConfig(t *testing.T) {
 			}`,
 			expectedURL: "https://vsphere.example.com/sdk",
 		},
+		{
+			name:         "vSphere provider",
+			providerName: "vsphere",
+			providerConfigJSON: `{
+				"server": "vcenter.bob.com",
+				"username": "vsphereUser",
+				"password": "vspherePass"
+			}`,
+			expectedURL: "https://vcenter.bob.com",
+		},
 	}
 
 	for _, tt := range tests {

--- a/dhctl/pkg/preflight/check_cloud_api_test.go
+++ b/dhctl/pkg/preflight/check_cloud_api_test.go
@@ -1,0 +1,68 @@
+package preflight
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+)
+
+func TestGetCloudApiURLFromMetaConfig(t *testing.T) {
+	tests := []struct {
+		name               string
+		providerName       string
+		providerConfigJSON string
+		expectedURL        string
+	}{
+		{
+			name:         "OpenStack provider",
+			providerName: "OpenStack",
+			providerConfigJSON: `{
+				"authURL": "https://openstack.example.com/v3/auth",
+				"domainName": "provider.local",
+				"tenantID": "tenantID",
+				"username": "username",
+				"password": "password",
+				"region": "eu-3"
+			}`,
+			expectedURL: "https://openstack.example.com/v3/auth",
+		},
+		{
+			name:         "vSphere provider",
+			providerName: "vSphere",
+			providerConfigJSON: `{
+				"server": "https://vsphere.example.com/sdk",
+				"username": "vsphereUser",
+				"password": "vspherePass"
+			}`,
+			expectedURL: "https://vsphere.example.com/sdk",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			s := require.New(t)
+			clusterConfigYAML := `
+---
+apiVersion: deckhouse.io/v1
+kind: InitConfiguration
+deckhouse:
+  imagesRepo: registry.deckhouse.io/deckhouse/ce
+  releaseChannel: Alpha
+`
+			metaConfig, err := config.ParseConfigFromData(clusterConfigYAML)
+			s.NoError(err)
+			metaConfig.ProviderName = tt.providerName
+			metaConfig.ProviderClusterConfig = map[string]json.RawMessage{
+				"provider": json.RawMessage(tt.providerConfigJSON),
+			}
+			s.Equal(tt.providerName, metaConfig.ProviderName)
+			cloudApiURL, err := getCloudApiURLFromMetaConfig(metaConfig)
+			s.NoError(err)
+			s.Equal(tt.expectedURL, cloudApiURL)
+		})
+	}
+}

--- a/dhctl/pkg/preflight/common.go
+++ b/dhctl/pkg/preflight/common.go
@@ -45,6 +45,7 @@ func setupSSHTunnelToProxyAddr(sshCl *ssh.Client, proxyUrl *url.URL) (*frontend.
 			port = "80"
 		case "https":
 			port = "443"
+		}
 	}
 	tunnel := strings.Join([]string{ProxyTunnelPort, proxyUrl.Hostname(), port}, ":")
 	tun := sshCl.Tunnel("L", tunnel)

--- a/dhctl/pkg/preflight/common.go
+++ b/dhctl/pkg/preflight/common.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh/frontend"
 )
@@ -48,9 +49,8 @@ func setupSSHTunnelToProxyAddr(sshCl *ssh.Client, proxyUrl *url.URL) (*frontend.
 		}
 	}
 	tunnel := strings.Join([]string{ProxyTunnelPort, proxyUrl.Hostname(), port}, ":")
+	log.DebugF("tunnel string: %s", tunnel)
 	tun := sshCl.Tunnel("L", tunnel)
-	fmt.Printf("tun.String(): %s", tun.String())
-	fmt.Printf("tunnel: %s", tunnel)
 	err := tun.Up()
 	if err != nil {
 		return nil, err

--- a/dhctl/pkg/preflight/common.go
+++ b/dhctl/pkg/preflight/common.go
@@ -1,0 +1,50 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh/frontend"
+)
+
+func buildHTTPClientWithLocalhostProxy(proxyUrl *url.URL) *http.Client {
+	localhostProxy := proxyUrl
+	localhostProxy.Host = net.JoinHostPort("localhost", ProxyTunnelPort)
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:             http.ProxyURL(localhostProxy),
+			DisableKeepAlives: true,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+}
+
+func setupSSHTunnelToProxyAddr(sshCl *ssh.Client, proxyUrl *url.URL) (*frontend.Tunnel, error) {
+	tunnel := strings.Join([]string{ProxyTunnelPort, proxyUrl.Hostname(), proxyUrl.Port()}, ":")
+	tun := sshCl.Tunnel("L", tunnel)
+	err := tun.Up()
+	if err != nil {
+		return nil, err
+	}
+	return tun, nil
+}

--- a/dhctl/pkg/preflight/common.go
+++ b/dhctl/pkg/preflight/common.go
@@ -38,7 +38,15 @@ func buildHTTPClientWithLocalhostProxy(proxyUrl *url.URL) *http.Client {
 }
 
 func setupSSHTunnelToProxyAddr(sshCl *ssh.Client, proxyUrl *url.URL) (*frontend.Tunnel, error) {
-	tunnel := strings.Join([]string{ProxyTunnelPort, proxyUrl.Hostname(), proxyUrl.Port()}, ":")
+	port := proxyUrl.Port()
+	if port == "" {
+		switch proxyUrl.Scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+	}
+	tunnel := strings.Join([]string{ProxyTunnelPort, proxyUrl.Hostname(), port}, ":")
 	tun := sshCl.Tunnel("L", tunnel)
 	err := tun.Up()
 	if err != nil {

--- a/dhctl/pkg/preflight/common.go
+++ b/dhctl/pkg/preflight/common.go
@@ -15,7 +15,6 @@
 package preflight
 
 import (
-	"crypto/tls"
 	"net"
 	"net/http"
 	"net/url"
@@ -32,9 +31,6 @@ func buildHTTPClientWithLocalhostProxy(proxyUrl *url.URL) *http.Client {
 		Transport: &http.Transport{
 			Proxy:             http.ProxyURL(localhostProxy),
 			DisableKeepAlives: true,
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
 		},
 	}
 }

--- a/dhctl/pkg/preflight/common.go
+++ b/dhctl/pkg/preflight/common.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Flant JSC
+// Copyright 2024 Flant JSC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ func setupSSHTunnelToProxyAddr(sshCl *ssh.Client, proxyUrl *url.URL) (*frontend.
 	}
 	tunnel := strings.Join([]string{ProxyTunnelPort, proxyUrl.Hostname(), port}, ":")
 	tun := sshCl.Tunnel("L", tunnel)
+	fmt.Printf("tun.String(): %s", tun.String())
+	fmt.Printf("tunnel: %s", tunnel)
 	err := tun.Up()
 	if err != nil {
 		return nil, err

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -183,7 +183,7 @@ func (pc *Checker) PostCloud() error {
 	err = pc.do("Cloud deployment preflight checks", []checkStep{
 		{
 			fun:            pc.CheckCloudAPIAccessibility,
-			successMessage: "Check access to cloud api from master host",
+			successMessage: "access to cloud api from master host",
 			skipFlag:       app.CloudAPIAccessibilityArgName,
 		},
 	})

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -100,7 +100,7 @@ func (pc *Checker) Static() error {
 		{
 			fun:            pc.CheckStaticNodeSystemRequirements,
 			successMessage: "that node meets system requirements",
-			skipFlag:       app.SystemRequirementsArgName,
+			skipFlag:       app.RegistryThroughProxyCheckArgName,
 		},
 		{
 			fun:            pc.CheckPythonAndItsModules,
@@ -158,7 +158,7 @@ func (pc *Checker) Cloud() error {
 		{
 			fun:            pc.CheckCloudAPIAccessibility,
 			successMessage: "Check access to cloud api from master host",
-			skipFlag:       app.SystemRequirementsArgName,
+			skipFlag:       app.CloudAPIAccessibilityArgName,
 		},
 	})
 

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -30,7 +30,9 @@ type State interface {
 	SetGlobalPreflightchecksWasRan() error
 	GlobalPreflightchecksWasRan() (bool, error)
 	SetCloudPreflightchecksWasRan() error
+	SetPostCloudPreflightchecksWasRan() error
 	CloudPreflightchecksWasRan() (bool, error)
+	PostCloudPreflightchecksWasRan() (bool, error)
 	SetStaticPreflightchecksWasRan() error
 	StaticPreflightchecksWasRan() (bool, error)
 }
@@ -167,6 +169,35 @@ func (pc *Checker) Cloud() error {
 	}
 
 	return pc.bootstrapState.SetCloudPreflightchecksWasRan()
+
+}
+
+func (pc *Checker) PostCloud() error {
+
+	ready, err := pc.bootstrapState.PostCloudPreflightchecksWasRan()
+
+	if err != nil {
+		msg := fmt.Sprintf("Can not get state from cache: %v", err)
+		return errors.New(msg)
+	}
+
+	if ready {
+		return nil
+	}
+
+	err = pc.do("Cloud deployment preflight checks", []checkStep{
+		{
+			fun:            pc.CheckCloudAPIAccessibility,
+			successMessage: "Check access to cloud api from master host",
+			skipFlag:       app.CloudAPIAccessibilityArgName,
+		},
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return pc.bootstrapState.SetPostCloudPreflightchecksWasRan()
 
 }
 

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -102,7 +102,7 @@ func (pc *Checker) Static() error {
 		{
 			fun:            pc.CheckStaticNodeSystemRequirements,
 			successMessage: "that node meets system requirements",
-			skipFlag:       app.RegistryThroughProxyCheckArgName,
+			skipFlag:       app.SystemRequirementsArgName,
 		},
 		{
 			fun:            pc.CheckPythonAndItsModules,

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -113,11 +113,6 @@ func (pc *Checker) Static() error {
 			skipFlag:       app.RegistryThroughProxyCheckArgName,
 		},
 		{
-			fun:            pc.CheckCloudAPIAccessibility,
-			successMessage: "Check access to cloud api",
-			skipFlag:       app.RegistryThroughProxyCheckArgName,
-		},
-		{
 			fun:            pc.CheckAvailabilityPorts,
 			successMessage: "required ports availability",
 			skipFlag:       app.PortsAvailabilityArgName,
@@ -158,6 +153,11 @@ func (pc *Checker) Cloud() error {
 		{
 			fun:            pc.CheckCloudMasterNodeSystemRequirements,
 			successMessage: "cloud master node system requirements are met",
+			skipFlag:       app.SystemRequirementsArgName,
+		},
+		{
+			fun:            pc.CheckCloudAPIAccessibility,
+			successMessage: "Check access to cloud api from master host",
 			skipFlag:       app.SystemRequirementsArgName,
 		},
 	})

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -157,11 +157,6 @@ func (pc *Checker) Cloud() error {
 			successMessage: "cloud master node system requirements are met",
 			skipFlag:       app.SystemRequirementsArgName,
 		},
-		{
-			fun:            pc.CheckCloudAPIAccessibility,
-			successMessage: "Check access to cloud api from master host",
-			skipFlag:       app.CloudAPIAccessibilityArgName,
-		},
 	})
 
 	if err != nil {

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -113,6 +113,11 @@ func (pc *Checker) Static() error {
 			skipFlag:       app.RegistryThroughProxyCheckArgName,
 		},
 		{
+			fun:            pc.CheckCloudAPIAccessibility,
+			successMessage: "Check access to cloud api",
+			skipFlag:       app.RegistryThroughProxyCheckArgName,
+		},
+		{
 			fun:            pc.CheckAvailabilityPorts,
 			successMessage: "required ports availability",
 			skipFlag:       app.PortsAvailabilityArgName,

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -20,7 +20,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -71,7 +70,7 @@ func (pc *Checker) CheckRegistryAccessThroughProxy() error {
 		return nil
 	}
 
-	if tryToSkippingCheck(pc.metaConfig.Registry.Address, noProxyAddresses) {
+	if shouldSkipProxyCheck(pc.metaConfig.Registry.Address, noProxyAddresses) {
 		log.DebugLn("Registry address found in proxy.noProxy list, skipping check")
 		return nil
 	}
@@ -107,80 +106,6 @@ Please check connectivity from the control-plane node to the proxy and from the 
 	}
 
 	return nil
-}
-
-func tryToSkippingCheck(registryAddress string, noProxyAddresses []string) bool {
-	for _, noProxyAddress := range noProxyAddresses {
-		if registryAddress == noProxyAddress {
-			return true
-		}
-
-		registryIPAddr, _ := net.ResolveIPAddr("ip", registryAddress)
-		if registryIPAddr == nil {
-			continue
-		}
-
-		noProxyAddressIPAddr, _ := net.ResolveIPAddr("ip", noProxyAddress)
-		if noProxyAddressIPAddr != nil {
-			if noProxyAddressIPAddr.IP.Equal(registryIPAddr.IP) {
-				return true
-			}
-
-			continue
-		}
-
-		_, noProxyIPNet, _ := net.ParseCIDR(noProxyAddress)
-		if noProxyIPNet != nil && noProxyIPNet.Contains(registryIPAddr.IP) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func getProxyFromMetaConfig(metaConfig *config.MetaConfig) (*url.URL, []string, error) {
-	proxyConfig, err := metaConfig.EnrichProxyData()
-	switch {
-	case err != nil:
-		return nil, nil, err
-	case proxyConfig == nil:
-		return nil, nil, nil
-	}
-
-	var proxyAddrClause any
-	if proxyAddr, hasHTTPSProxy := proxyConfig["httpsProxy"]; hasHTTPSProxy {
-		proxyAddrClause = proxyAddr
-	} else if proxyAddr, hasHTTPProxy := proxyConfig["httpProxy"]; hasHTTPProxy {
-		proxyAddrClause = proxyAddr
-	} else {
-		return nil, nil, fmt.Errorf("%w: no proxy address was given", ErrBadProxyConfig)
-	}
-
-	noProxyClause, hasNoProxy := proxyConfig["noProxy"]
-	var noProxyAddresses []string
-	if hasNoProxy {
-		addrs, isStringSlice := noProxyClause.([]string)
-		if !isStringSlice {
-			return nil, nil, fmt.Errorf("proxy.noProxy is not a set of addresses")
-		}
-		noProxyAddresses = addrs
-	}
-
-	proxyAddr, proxyAddrIsString := proxyAddrClause.(string)
-	if !proxyAddrIsString {
-		return nil, nil, fmt.Errorf(
-			`%w: malformed proxy address: "%v"`,
-			ErrBadProxyConfig,
-			proxyAddr,
-		)
-	}
-
-	proxyUrl, err := url.Parse(proxyAddr)
-	if err != nil {
-		return nil, nil, fmt.Errorf(`%s: %w`, ErrBadProxyConfig, err)
-	}
-
-	return proxyUrl, noProxyAddresses, nil
 }
 
 func checkResponseIsFromDockerRegistry(resp *http.Response) error {

--- a/dhctl/pkg/preflight/registry.go
+++ b/dhctl/pkg/preflight/registry.go
@@ -146,6 +146,9 @@ func buildHTTPClientWithLocalhostProxy(proxyUrl *url.URL) *http.Client {
 		Transport: &http.Transport{
 			Proxy:             http.ProxyURL(localhostProxy),
 			DisableKeepAlives: true,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
 		},
 	}
 }

--- a/dhctl/pkg/preflight/registry_test.go
+++ b/dhctl/pkg/preflight/registry_test.go
@@ -41,7 +41,15 @@ func (s *testState) SetCloudPreflightchecksWasRan() error {
 	return nil
 }
 
+func (s *testState) SetPostCloudPreflightchecksWasRan() error {
+	return nil
+}
+
 func (s *testState) CloudPreflightchecksWasRan() (bool, error) {
+	return false, nil
+}
+
+func (s *testState) PostCloudPreflightchecksWasRan() (bool, error) {
 	return false, nil
 }
 
@@ -146,28 +154,28 @@ func TestTryToSkippingCheck(t *testing.T) {
 	s := require.New(t)
 
 	var tests = []struct {
-		registryAddress  string
+		registryAddress   string
 		registryDockerCfg string
-		noProxyAddresses []string
-		skipped          bool
+		noProxyAddresses  []string
+		skipped           bool
 	}{
 		{
-			registryAddress:  "192.168.199.129/d8/deckhouse/ee",
+			registryAddress:   "192.168.199.129/d8/deckhouse/ee",
 			registryDockerCfg: "registryDockerCfg: eyJhdXRocyI6eyIxOTIuMTY4LjE5OS4xMjkiOnsiYXV0aCI6ImEyOTJZV3hyYjNZNldHVnBiamxoWm1VPSJ9fX0K",
-			noProxyAddresses: []string{"127.0.0.1", "192.168.199.0/24"},
-			skipped:          true,
+			noProxyAddresses:  []string{"127.0.0.1", "192.168.199.0/24"},
+			skipped:           true,
 		},
 		{
-			registryAddress:  "registry.deckhouse.io/ce",
+			registryAddress:   "registry.deckhouse.io/ce",
 			registryDockerCfg: "",
-			noProxyAddresses: []string{"registry.deckhouse.io"},
-			skipped:          true,
+			noProxyAddresses:  []string{"registry.deckhouse.io"},
+			skipped:           true,
 		},
 		{
-			registryAddress:  "quay.io",
+			registryAddress:   "quay.io",
 			registryDockerCfg: "registryDockerCfg: eyJhdXRocyI6eyJxdWF5LmlvIjp7fX19",
-			noProxyAddresses: []string{"docker.io"},
-			skipped:          false,
+			noProxyAddresses:  []string{"docker.io"},
+			skipped:           false,
 		},
 	}
 

--- a/dhctl/pkg/preflight/registry_test.go
+++ b/dhctl/pkg/preflight/registry_test.go
@@ -150,7 +150,7 @@ func getProxyFromMetaConfigSuccessNoProxy(t *testing.T) {
 	s.Nil(noProxyList)
 }
 
-func TestTryToSkippingCheck(t *testing.T) {
+func TestshouldSkipProxyCheck(t *testing.T) {
 	s := require.New(t)
 
 	var tests = []struct {

--- a/dhctl/pkg/preflight/ssh.go
+++ b/dhctl/pkg/preflight/ssh.go
@@ -33,7 +33,7 @@ const (
 var ErrAuthSSHFailed = errors.New("authentication failed")
 
 func (pc *Checker) CheckSSHTunnel() error {
-	if app.PreflightSkipSSHForword {
+	if app.PreflightSkipSSHForward {
 		log.InfoLn("SSH forward preflight check was skipped (via skip flag)")
 		return nil
 	}


### PR DESCRIPTION
## Description
Added a new `PostCloud` step that is executed only when bootstrapping occurs in a cloud environment. The `PostCloud` step runs after the first master server is created and SSH connectivity is verified. Within `PostCloud`, a check for "access to cloud API from the master host" has been implemented specifically for the cloud providers vSphere and OpenStack.

Two methods are used for this verification:
- **With HTTP Proxy**: An SSH tunnel is established to the master server, forwarding a port to the proxy. A GET request is then made to the cloud API using `localhost:22323` as the proxy.
- **Without HTTP Proxy**: A port is forwarded directly to the cloud API (e.g., `-L 22323:api.selvpc.ru:443`). A GET request is made to `localhost:22323` while specifying the original TLS SNI.

These changes ensure that the master host can successfully communicate with the cloud API.

## Why do we need it, and what problem does it solve?

> At the moment, there is a situation when, when deploying via an external installation container, the first master node is successfully deployed using Terraform, but further VMs and objects are not created from within the cluster because the Openstack API is not available from within the cluster.

Now we check this situation before the cluster is installed

Fixes issue https://github.com/deckhouse/deckhouse/issues/9970

## Why do we need it in the patch release (if we do)?


*(Remove this section if the PR is not intended for a patch release.)*

## What is the expected result?

After applying these changes:
- When bootstrapping in a cloud environment (vSphere or OpenStack), the `PostCloud` step will execute.
- The system will verify access to the cloud API from the master host.
- Successful verification ensures that the master host can communicate with the cloud API.
- In case of verification failure, the bootstrap process will provide clear error messages indicating the inability to access the cloud API.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: dhctl
type: feature
summary: Add PostCloud step to verify cloud API access from master host during bootstrap
impact:
impact_level: default
```