### PR TITLE
[testing] Switch OpenStack testing server flavor

### DIFF
--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -41,7 +41,7 @@ masterNodeGroup:
   replicas: ${MASTERS_COUNT}
   instanceClass:
     rootDiskSize: 50
-    flavorName: m1.large
+    flavorName: e2e
     imageName: "redos-STD-MINIMAL-8.0.0"
   volumeTypeMap:
     ru-3a: "fast.ru-3a"

--- a/testing/cloud_layouts/OpenStack/Standard/resources.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/resources.yaml
@@ -27,7 +27,7 @@ metadata:
   name: system
 spec:
   rootDiskSize: 30
-  flavorName: m1.large
+  flavorName: e2e
   imageName: "debian-12-genericcloud-amd64"
 ---
 apiVersion: deckhouse.io/v1


### PR DESCRIPTION
## Description
Switch OpenStack testing server flavor to custom

## Why do we need it, and what problem does it solve?
Allows to change allocated resources on e2e tests

## What is the expected result?
Changed available resources on e2e

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: Switch OpenStack testing server flavor.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
