### PR TITLE
[prometheus] Add podAntiAffinity param for longterm

### DIFF
--- a/modules/300-prometheus/openapi/config-values.yaml
+++ b/modules/300-prometheus/openapi/config-values.yaml
@@ -288,6 +288,14 @@ properties:
       The same as in the Pods' `spec.nodeSelector` parameter in Kubernetes.
 
       If the parameter is omitted or `false`, it will be determined [automatically](https://deckhouse.io/products/kubernetes-platform/documentation/v1/#advanced-scheduling).
+  longtermPodAntiAffinity:
+    type: string
+    default: "Preferred"
+    description: |
+      Defines the podAntiAffinity configuration for the Prometheus longterm instance relative to the Prometheus main instance.
+      - `Preferred` — allows scheduling Prometheus longterm instance alongside the Prometheus main instance if it is not possible to place them on different nodes.
+      - `Required` — does not allow scheduling Prometheus longterm instance on the same node as the Prometheus main instance.
+    enum: [Preferred, Required]
   tolerations:
     type: array
     items:

--- a/modules/300-prometheus/openapi/doc-ru-config-values.yaml
+++ b/modules/300-prometheus/openapi/doc-ru-config-values.yaml
@@ -169,6 +169,12 @@ properties:
       Структура, аналогичная `spec.nodeSelector` пода Kubernetes.
 
       Если значение не указано или указано `false`, будет использоваться [автоматика](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
+  longtermPodAntiAffinity:
+    type: string
+    description: |
+      Устанавливает конфигурацию podAntiAffinity для Prometheus longterm по отношению к Prometheus main.
+      - `Preferred` — позволяет размещать Prometheus longterm на одном узле с Prometheus main, если нет возможности их разместить на разных узлах.
+      - `Required` — не позволяет размещать Prometheus longterm на одном узле с Prometheus main ни при каких условиях.
   tolerations:
     type: array
     description: |

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -113,14 +113,23 @@ spec:
   {{- end }}
   affinity:
     podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
+      {{- if eq .Values.prometheus.longtermPodAntiAffinity "Required" }}
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
             matchLabels:
               app.kubernetes.io/name: prometheus
               prometheus: main
           topologyKey: kubernetes.io/hostname
+      {{- else }}
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: prometheus
+                prometheus: main
+            topologyKey: kubernetes.io/hostname
+      {{- end }}
   scrapeInterval: {{ .Values.prometheus.longtermScrapeInterval | default "5m" }}
   evaluationInterval: {{ .Values.prometheus.longtermScrapeInterval | default "5m" }}
 {{- if .Values.global.modules.publicDomainTemplate }}


### PR DESCRIPTION
## Description

Adds an option to switch podAntiAffinity rule type for longterm Prometheus instance.

## Why do we need it, and what problem does it solve?

* Resolves an issue where the Kubernetes scheduler places both the longterm and main Prometheus instances on the same node after a failure of one of the nodes, leading to resource contention. Even after the node is fixed, this setup persists, worsening performance. Switching podAntiAffinty to `Required` ensures longterm instance won't be scheduled on the same node as main.
* Fixes https://github.com/deckhouse/deckhouse/issues/7216.

## Why do we need it in the patch release (if we do)?


## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: prometheus
type: feature
summary: Added `longtermPodAntiAffinity` options to module.
```