### PR TITLE
[prometheus] Add timeout to exec request for disk metrics hook.

### DIFF
--- a/modules/300-prometheus/hooks/disk_metrics.go
+++ b/modules/300-prometheus/hooks/disk_metrics.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
@@ -164,6 +165,7 @@ func getFsInfo(input *go_hook.HookInput, kubeClient k8s.Client, pod PodFilter) (
 
 func execToPodThroughAPI(kubeClient k8s.Client, command, containerName, podName, namespace string) (string, string, error) {
 	req := kubeClient.CoreV1().RESTClient().Post().
+		Timeout(time.Duration(10) * time.Second).
 		Resource("pods").
 		Name(podName).
 		Namespace(namespace).


### PR DESCRIPTION
## Description
This PR adds timeout to exec request for disk metrics hook.

## Why do we need it, and what problem does it solve?
We urgently require this fix to prevent significant issues that may arise when both the disk subsystem and the Kubernetes API experience substantial slowdowns. Without implementing this solution, Prometheus could potentially enter an infinite waiting state while attempting to retrieve execution results from the API regarding free and used disk space. By addressing these inefficiencies, we ensure smoother operation and more reliable monitoring."

## Why do we need it in the patch release (if we do)?
-

## What is the expected result?
Disk space checking hook must enter timeout state on situations, when disk subsystem, Kubernetes API and whole system goes very slow.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Add timeout to exec request for disk metrics hook.

```changes
section: prometheus
type: fix
summary: Timeout for disk metrics retrieve in Prometheus hook.
impact_level: low
```
