### PR TITLE
[istio] Exclusion of the upmeter from Istio (in one more place)

### DIFF
--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -84,6 +84,8 @@ spec:
           value: "true"
         - name: ISTIO_MULTIROOT_MESH
           value: "true"
+        - name: ENABLE_ENHANCED_RESOURCE_SCOPING
+          value: "true"
   {{- if $.Values.istio.enableHTTP10 }}
         - name: PILOT_HTTP10
           value: "1"
@@ -113,7 +115,7 @@ spec:
     rootNamespace: d8-{{ $.Chart.Name }}
     trustDomain: {{ $.Values.global.discovery.clusterDomain | quote }}
     accessLogFile: /dev/stdout
-    
+
     # The rules below exclude upmeter-related namespaces from istiod's point of view.
     # So, upmeter's events used to affect the traffic between control-plane and data-plane will be reduced.
     discoverySelectors:


### PR DESCRIPTION
## Description
Enhancing upmeter-related resources ignoring by istiod.

## Why do we need it, and what problem does it solve?
The ENABLE_ENHANCED_RESOURCE_SCOPING flag extends the resources istiod will ignore by discoverySelectors in IOP. So, istiod will cool down a bit.
Also, [this flag is enabled by default in 1.22](https://github.com/istio/istio/issues/49696).

## What is the expected result?
istiod has no logs about upmeter-related resources.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix 
summary: Enhancing upmeter-related resources ignoring by istiod
impact_level: low
```

