### PR TITLE
[ci] Get new PR info on each run of the Check PR milestone job

### DIFF
--- a/.github/workflow_templates/check-pr-milestone.yml
+++ b/.github/workflow_templates/check-pr-milestone.yml
@@ -14,17 +14,8 @@
 
 name: Check Milestone
 on:
-  pull_request_target:
-     types:
-      - opened
-      - reopened
-      - ready_for_review
-      - edited
-      - synchronize
   pull_request:
-    types:
-    - milestoned
-    - demilestoned
+    types: [opened, milestoned, demilestoned]
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
 concurrency:
@@ -36,8 +27,17 @@ jobs:
     name: Check milestone
     runs-on: ubuntu-latest
     steps:
-      - name: milestone is not set
-        if: github.event.pull_request.milestone == null
-        run: |
-          echo 1>&2 "The pull request has no milestone. Set a milestone for the pull request."
-          exit 1
+    - name: Check milestone
+      uses: {!{ index (ds "actions") "actions/github-script" }!}
+      with:
+        script: |
+          const { data } = await github.request("GET /repos/{owner}/{repo}/pulls/{pr}", {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pr: context.payload.pull_request.number
+          });
+          if (data.milestone) {
+            core.info(`This pull request has a milestone set: ${data.milestone.title}`);
+          } else {
+            core.setFailed(`The pull request has no milestone. Set a milestone for the pull request.`);
+          }

--- a/.github/workflows/check-pr-milestone.yml
+++ b/.github/workflows/check-pr-milestone.yml
@@ -18,17 +18,8 @@
 
 name: Check Milestone
 on:
-  pull_request_target:
-     types:
-      - opened
-      - reopened
-      - ready_for_review
-      - edited
-      - synchronize
   pull_request:
-    types:
-    - milestoned
-    - demilestoned
+    types: [opened, milestoned, demilestoned]
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
 concurrency:
@@ -40,8 +31,17 @@ jobs:
     name: Check milestone
     runs-on: ubuntu-latest
     steps:
-      - name: milestone is not set
-        if: github.event.pull_request.milestone == null
-        run: |
-          echo 1>&2 "The pull request has no milestone. Set a milestone for the pull request."
-          exit 1
+    - name: Check milestone
+      uses: actions/github-script@v6.4.1
+      with:
+        script: |
+          const { data } = await github.request("GET /repos/{owner}/{repo}/pulls/{pr}", {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pr: context.payload.pull_request.number
+          });
+          if (data.milestone) {
+            core.info(`This pull request has a milestone set: ${data.milestone.title}`);
+          } else {
+            core.setFailed(`The pull request has no milestone. Set a milestone for the pull request.`);
+          }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Get new PR info on each run of the Check PR milestone job. This fixes the problem when developers need to make a commit to retrigger the job.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
