### PR TITLE
[docs][admission-policy-engine] Added a documentation page with Gatekeeper Custom Resources

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -1345,6 +1345,10 @@ entries:
                     en: Custom Resources
                     ru: Custom Resources
                   url: /modules/admission-policy-engine/cr.html
+                - title:
+                    ru: Custom Resources (от Gatekeeper)
+                    en: Custom Resources (by Gatekeeper)
+                  url: /modules/admission-policy-engine/gatekeeper-cr.html
             - title:
                 en: FAQ
                 ru: FAQ

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
@@ -15,7 +15,7 @@ Provides a gatekeeper based on configurable policies for modifying Kubernetes re
 Allows you to modify the `Metadata` section of a resource.
 At the moment, Gatekeeper only allows **adding** `labels` and `annotations` objects. Modification of existing objects is not provided.
 
-An Example of adding the label `owner` with the value `admin` in all namespaces:
+An example of adding the label `owner` with the value `admin` in all namespaces:
 
 ```yaml
 apiVersion: mutations.gatekeeper.sh/v1

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
@@ -4,6 +4,10 @@ title: "The admission-policy-engine module: Custom Resources (by Gatekeeper)"
 
 ## Mutation Custom Resources
 
+{% alert level="info" %}
+The `reinvocationPolicy: IfNeeded` is used in MutatingWebhookConfiguration. More details [in the Kubernetes documentation.](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#reinvocation-policy)
+{% endalert %}  
+
 [Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#mutation-crds)
 
 Provide a configurable set of policies for modifying Kubernetes resources at the time they are deployed.

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
@@ -1,5 +1,5 @@
 ---
-title:  "Модуль admission-policy-engine: Custom Resources (от Gatekeeper)"
+title: "The admission-policy-engine module: Custom Resources (by Gatekeeper)"
 ---
 
 ## Mutation

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
@@ -2,7 +2,7 @@
 title: "The admission-policy-engine module: Custom Resources (by Gatekeeper)"
 ---
 
-## Mutation Custom Resouces
+## Mutation Custom Resources
 
 [Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#mutation-crds)
 

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
@@ -1,0 +1,127 @@
+---
+title:  "Модуль admission-policy-engine: Custom Resources (от Gatekeeper)"
+---
+
+## Mutation
+
+[Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#mutation-crds)
+
+Provides a gatekeeper based on configurable policies for modifying Kubernetes resources at the time they are requested.
+
+### AssignMetadata
+
+[Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#assignmetadata)
+
+Allows you to modify the `Metadata` section of a resource.
+At the moment, Gatekeeper only allows **adding** `labels` and `annotations` objects, modification of existing objects is not provided.
+
+Examples:
+* Add label `owner` with value `admin` in all namespaces
+
+  ```yaml
+  apiVersion: mutations.gatekeeper.sh/v1
+  kind: AssignMetadata
+  metadata:
+    name: demo-annotation-owner
+  spec:
+    match:
+      scope: Namespaced
+    location: "metadata.labels.owner"
+    parameters:
+      assign:
+        value: "admin"
+  ```
+
+### Assign
+
+<!-- 
+[Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#assignmetadata) 
+There is no link in the Gatekeeper documentation for this CR
+-->
+
+Allows you to modify fields outside the `Metadata` section.
+
+Examples:  
+* Set `imagePullPolicy` for all containers to `Always` in all namespaces except the `system` namespace
+
+  ```yaml
+  apiVersion: mutations.gatekeeper.sh/v1
+  kind: Assign
+  metadata:
+    name: demo-image-pull-policy
+  spec:
+    applyTo:
+    - groups: [""]
+      kinds: ["Pod"]
+      versions: ["v1"]
+    match:
+      scope: Namespaced
+      kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod"]
+      excludedNamespaces: ["system"]
+    location: "spec.containers[name:*].imagePullPolicy"
+    parameters:
+      assign:
+        value: Always
+  ```
+
+### ModifySet
+
+[Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#modifyset)
+
+Allows you to add and remove items from a list, such as arguments for running a container.
+New values ​​are added to the end of the list.
+
+Examples:
+* Remove the `--alsologtostderr` argument from all containers in a pod
+
+  ```yaml
+  apiVersion: mutations.gatekeeper.sh/v1
+  kind: ModifySet
+  metadata:
+    name: remove-err-logging
+  spec:
+    applyTo:
+    - groups: [""]
+      kinds: ["Pod"]
+      versions: ["v1"]
+    location: "spec.containers[name: *].args"
+    parameters:
+      operation: prune
+      values:
+        fromList:
+          - --alsologtostderr
+  ```
+
+### AssignImage
+
+[Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#assignimage)
+
+Allows you to make changes to the `Image` parameter of a resource.
+
+Examples:
+* Changing the `Image` parameter to the value `my.registry.io/repo/app@sha256:abcde67890123456789abc345678901a`
+
+  ```yaml
+  apiVersion: mutations.gatekeeper.sh/v1alpha1
+  kind: AssignImage
+  metadata:
+    name: assign-container-image
+  spec:
+    applyTo:
+    - groups: [ "" ]
+      kinds: [ "Pod" ]
+      versions: [ "v1" ]
+    location: "spec.containers[name:*].image"
+    parameters:
+      assignDomain: "my.registry.io"
+      assignPath: "repo/app"
+      assignTag: "@sha256:abcde67890123456789abc345678901a"
+    match:
+      source: "All"
+      scope: Namespaced
+      kinds:
+      - apiGroups: [ "*" ]
+        kinds: [ "Pod" ]
+  ```

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
@@ -13,24 +13,23 @@ Provides a gatekeeper based on configurable policies for modifying Kubernetes re
 [Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#assignmetadata)
 
 Allows you to modify the `Metadata` section of a resource.
-At the moment, Gatekeeper only allows **adding** `labels` and `annotations` objects, modification of existing objects is not provided.
+At the moment, Gatekeeper only allows **adding** `labels` and `annotations` objects. Modification of existing objects is not provided.
 
-Examples:
-* Add label `owner` with value `admin` in all namespaces
+An Example of adding the label `owner` with the value `admin` in all namespaces:
 
-  ```yaml
-  apiVersion: mutations.gatekeeper.sh/v1
-  kind: AssignMetadata
-  metadata:
-    name: demo-annotation-owner
-  spec:
-    match:
-      scope: Namespaced
-    location: "metadata.labels.owner"
-    parameters:
-      assign:
-        value: "admin"
-  ```
+```yaml
+apiVersion: mutations.gatekeeper.sh/v1
+kind: AssignMetadata
+metadata:
+  name: demo-annotation-owner
+spec:
+  match:
+    scope: Namespaced
+  location: "metadata.labels.owner"
+  parameters:
+    assign:
+      value: "admin"
+```
 
 ### Assign
 
@@ -41,87 +40,84 @@ There is no link in the Gatekeeper documentation for this CR
 
 Allows you to modify fields outside the `Metadata` section.
 
-Examples:  
-* Set `imagePullPolicy` for all containers to `Always` in all namespaces except the `system` namespace
+An example of setting `imagePullPolicy` for all containers to `Always` in all namespaces except the `system` namespace:
 
-  ```yaml
-  apiVersion: mutations.gatekeeper.sh/v1
-  kind: Assign
-  metadata:
-    name: demo-image-pull-policy
-  spec:
-    applyTo:
-    - groups: [""]
+```yaml
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: demo-image-pull-policy
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    scope: Namespaced
+    kinds:
+    - apiGroups: ["*"]
       kinds: ["Pod"]
-      versions: ["v1"]
-    match:
-      scope: Namespaced
-      kinds:
-      - apiGroups: ["*"]
-        kinds: ["Pod"]
-      excludedNamespaces: ["system"]
-    location: "spec.containers[name:*].imagePullPolicy"
-    parameters:
-      assign:
-        value: Always
-  ```
+    excludedNamespaces: ["system"]
+  location: "spec.containers[name:*].imagePullPolicy"
+  parameters:
+    assign:
+      value: Always
+```
 
 ### ModifySet
 
 [Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#modifyset)
 
 Allows you to add and remove items from a list, such as arguments for running a container.
-New values ​​are added to the end of the list.
+New values are added to the end of the list.
 
-Examples:
-* Remove the `--alsologtostderr` argument from all containers in a pod
+An example of removing the `--alsologtostderr` argument from all containers in a pod:
 
-  ```yaml
-  apiVersion: mutations.gatekeeper.sh/v1
-  kind: ModifySet
-  metadata:
-    name: remove-err-logging
-  spec:
-    applyTo:
-    - groups: [""]
-      kinds: ["Pod"]
-      versions: ["v1"]
-    location: "spec.containers[name: *].args"
-    parameters:
-      operation: prune
-      values:
-        fromList:
-          - --alsologtostderr
-  ```
+```yaml
+apiVersion: mutations.gatekeeper.sh/v1
+kind: ModifySet
+metadata:
+  name: remove-err-logging
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: "spec.containers[name: *].args"
+  parameters:
+    operation: prune
+    values:
+      fromList:
+        - --alsologtostderr
+```
 
 ### AssignImage
 
 [Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#assignimage)
 
-Allows you to make changes to the `Image` parameter of a resource.
+Allows you to make changes to the `image` parameter of a resource.
 
-Examples:
-* Changing the `Image` parameter to the value `my.registry.io/repo/app@sha256:abcde67890123456789abc345678901a`
+An example of changing the `image` parameter to the value `my.registry.io/repo/app@sha256:abcde67890123456789abc345678901a`:
 
-  ```yaml
-  apiVersion: mutations.gatekeeper.sh/v1alpha1
-  kind: AssignImage
-  metadata:
-    name: assign-container-image
-  spec:
-    applyTo:
-    - groups: [ "" ]
+```yaml
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: AssignImage
+metadata:
+  name: assign-container-image
+spec:
+  applyTo:
+  - groups: [ "" ]
+    kinds: [ "Pod" ]
+    versions: [ "v1" ]
+  location: "spec.containers[name:*].image"
+  parameters:
+    assignDomain: "my.registry.io"
+    assignPath: "repo/app"
+    assignTag: "@sha256:abcde67890123456789abc345678901a"
+  match:
+    source: "All"
+    scope: Namespaced
+    kinds:
+    - apiGroups: [ "*" ]
       kinds: [ "Pod" ]
-      versions: [ "v1" ]
-    location: "spec.containers[name:*].image"
-    parameters:
-      assignDomain: "my.registry.io"
-      assignPath: "repo/app"
-      assignTag: "@sha256:abcde67890123456789abc345678901a"
-    match:
-      source: "All"
-      scope: Namespaced
-      kinds:
-      - apiGroups: [ "*" ]
-        kinds: [ "Pod" ]
-  ```
+```

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
@@ -2,11 +2,11 @@
 title: "The admission-policy-engine module: Custom Resources (by Gatekeeper)"
 ---
 
-## Mutation
+## Mutation Custom Resouces
 
 [Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#mutation-crds)
 
-Provides a gatekeeper based on configurable policies for modifying Kubernetes resources at the time they are requested.
+Provide a configurable set of policies for modifying Kubernetes resources at the time they are deployed.
 
 ### AssignMetadata
 

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR_RU.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR_RU.md
@@ -13,24 +13,23 @@ title: "Модуль admission-policy-engine: Custom Resources (от Gatekeeper)
 [Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#assignmetadata)
 
 Позволяет изменять секцию `Metadata` ресурса.  
-На данный момент сервисом Gatekeeper разрешено только **добавление** объектов `lables` и `annotations`, изменение существующих объектов не предусмотрено.
+На данный момент сервисом Gatekeeper разрешено только **добавление** объектов `lables` и `annotations`. Изменение существующих объектов не предусмотрено.
 
-Примеры:
-* Добавление label `owner` со значением `admin` во всех пространствах имен
+Пример добавления label `owner` со значением `admin` во всех пространствах имен:
   
-  ```yaml
-  apiVersion: mutations.gatekeeper.sh/v1
-  kind: AssignMetadata
-  metadata:
-    name: demo-annotation-owner
-  spec:
-    match:
-      scope: Namespaced
-    location: "metadata.labels.owner"
-    parameters:
-      assign:
-        value: "admin"
-  ```
+```yaml
+apiVersion: mutations.gatekeeper.sh/v1
+kind: AssignMetadata
+metadata:
+  name: demo-annotation-owner
+spec:
+  match:
+    scope: Namespaced
+  location: "metadata.labels.owner"
+  parameters:
+    assign:
+      value: "admin"
+```
 
 ### Assign
 
@@ -41,87 +40,84 @@ title: "Модуль admission-policy-engine: Custom Resources (от Gatekeeper)
 
 Позволяет изменять поля, за пределом секции `Metadata`.
 
-Примеры:  
-* Установка `imagePullPolicy` для всех контейнеров на `Always` во всех пространствах имен, кроме namespace `system`
+Пример установки `imagePullPolicy` для всех контейнеров на `Always` во всех пространствах имен, кроме `system`:
 
-  ```yaml
-  apiVersion: mutations.gatekeeper.sh/v1
-  kind: Assign
-  metadata:
-    name: demo-image-pull-policy
-  spec:
-    applyTo:
-    - groups: [""]
+```yaml
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: demo-image-pull-policy
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  match:
+    scope: Namespaced
+    kinds:
+    - apiGroups: ["*"]
       kinds: ["Pod"]
-      versions: ["v1"]
-    match:
-      scope: Namespaced
-      kinds:
-      - apiGroups: ["*"]
-        kinds: ["Pod"]
-      excludedNamespaces: ["system"]
-    location: "spec.containers[name:*].imagePullPolicy"
-    parameters:
-      assign:
-        value: Always
-  ```
+    excludedNamespaces: ["system"]
+  location: "spec.containers[name:*].imagePullPolicy"
+  parameters:
+    assign:
+      value: Always
+```
 
 ### ModifySet
 
 [Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#modifyset)
 
-Позволяет добавлять и удалять элементы из списка, например аргументов для запуска контейнера.  
+Позволяет добавлять и удалять элементы из списка, например из списка аргументов для запуска контейнера.  
 Новые значения добавляются в конец списка.
 
-Примеры:
-* Удаление аргумента `--alsologtostderr` из всех контейнеров в поде
+Пример удаления аргумента `--alsologtostderr` из всех контейнеров в поде:
 
-  ```yaml
-  apiVersion: mutations.gatekeeper.sh/v1
-  kind: ModifySet
-  metadata:
-    name: remove-err-logging
-  spec:
-    applyTo:
-    - groups: [""]
-      kinds: ["Pod"]
-      versions: ["v1"]
-    location: "spec.containers[name: *].args"
-    parameters:
-      operation: prune
-      values:
-        fromList:
-          - --alsologtostderr
-  ```
+```yaml
+apiVersion: mutations.gatekeeper.sh/v1
+kind: ModifySet
+metadata:
+  name: remove-err-logging
+spec:
+  applyTo:
+  - groups: [""]
+    kinds: ["Pod"]
+    versions: ["v1"]
+  location: "spec.containers[name: *].args"
+  parameters:
+    operation: prune
+    values:
+      fromList:
+        - --alsologtostderr
+```
 
 ### AssignImage
 
 [Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#assignimage)
 
-Позволяет вносить изменения в параметр `Image` ресурса.
+Позволяет вносить изменения в параметр `image` ресурса.
 
-Примеры:
-* Изменение параметра `Image` на значение `my.registry.io/repo/app@sha256:abcde67890123456789abc345678901a`
+Пример изменения параметра `image` на значение `my.registry.io/repo/app@sha256:abcde67890123456789abc345678901a`:
   
-  ```yaml
-  apiVersion: mutations.gatekeeper.sh/v1alpha1
-  kind: AssignImage
-  metadata:
-    name: assign-container-image
-  spec:
-    applyTo:
-    - groups: [ "" ]
+```yaml
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: AssignImage
+metadata:
+  name: assign-container-image
+spec:
+  applyTo:
+  - groups: [ "" ]
+    kinds: [ "Pod" ]
+    versions: [ "v1" ]
+  location: "spec.containers[name:*].image"
+  parameters:
+    assignDomain: "my.registry.io"
+    assignPath: "repo/app"
+    assignTag: "@sha256:abcde67890123456789abc345678901a"
+  match:
+    source: "All"
+    scope: Namespaced
+    kinds:
+    - apiGroups: [ "*" ]
       kinds: [ "Pod" ]
-      versions: [ "v1" ]
-    location: "spec.containers[name:*].image"
-    parameters:
-      assignDomain: "my.registry.io"
-      assignPath: "repo/app"
-      assignTag: "@sha256:abcde67890123456789abc345678901a"
-    match:
-      source: "All"
-      scope: Namespaced
-      kinds:
-      - apiGroups: [ "*" ]
-        kinds: [ "Pod" ]
-  ```
+```

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR_RU.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR_RU.md
@@ -2,11 +2,11 @@
 title: "Модуль admission-policy-engine: Custom Resources (от Gatekeeper)"
 ---
 
-## Mutation
+## Mutation Custom Resources
 
 [Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#mutation-crds)
 
-Позволяет Gatekeeper на основе настраиваемых политик изменять ресурсы Kubernetes в момент их запроса.
+Представляют собой набор настраиваемых политик модификации ресурсов Kubernets в момент их создания.
 
 ### AssignMetadata
 

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR_RU.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR_RU.md
@@ -4,6 +4,10 @@ title: "Модуль admission-policy-engine: Custom Resources (от Gatekeeper)
 
 ## Mutation Custom Resources
 
+{% alert level="info" %}
+Для мутационных хуков используется настройка `reinvocationPolicy: IfNeeded` в MutatingWebhookConfiguration. Подробнее [в документации Kubernetes.](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#reinvocation-policy)
+{% endalert %}  
+
 [Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#mutation-crds)
 
 Представляют собой набор настраиваемых политик модификации ресурсов Kubernets в момент их создания.

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR_RU.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR_RU.md
@@ -1,0 +1,127 @@
+---
+title:  "The admission-policy-engine module: Custom Resources (by Gatekeeper)"
+---
+
+## Mutation
+
+[Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#mutation-crds)
+
+Позволяет Gatekeeper на основе настраиваемых политик изменять ресурсы Kubernetes в момент их запроса.
+
+### AssignMetadata
+
+[Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#assignmetadata)
+
+Позволяет изменять секцию `Metadata` ресурса.  
+На данный момент сервисом Gatekeeper разрешено только **добавление** объектов `lables` и `annotations`, изменение существующих объектов не предусмотрено.
+
+Примеры:
+* Добавление label `owner` со значением `admin` во всех пространствах имен
+  
+  ```yaml
+  apiVersion: mutations.gatekeeper.sh/v1
+  kind: AssignMetadata
+  metadata:
+    name: demo-annotation-owner
+  spec:
+    match:
+      scope: Namespaced
+    location: "metadata.labels.owner"
+    parameters:
+      assign:
+        value: "admin"
+  ```
+
+### Assign
+
+<!-- 
+[Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#assignmetadata) 
+Отдельной ссылки в документации Gatekeeper на данный CR нет
+-->
+
+Позволяет изменять поля, за пределом секции `Metadata`.
+
+Примеры:  
+* Установка `imagePullPolicy` для всех контейнеров на `Always` во всех пространствах имен, кроме namespace `system`
+
+  ```yaml
+  apiVersion: mutations.gatekeeper.sh/v1
+  kind: Assign
+  metadata:
+    name: demo-image-pull-policy
+  spec:
+    applyTo:
+    - groups: [""]
+      kinds: ["Pod"]
+      versions: ["v1"]
+    match:
+      scope: Namespaced
+      kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod"]
+      excludedNamespaces: ["system"]
+    location: "spec.containers[name:*].imagePullPolicy"
+    parameters:
+      assign:
+        value: Always
+  ```
+
+### ModifySet
+
+[Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#modifyset)
+
+Позволяет добавлять и удалять элементы из списка, например аргументов для запуска контейнера.  
+Новые значения добавляются в конец списка.
+
+Примеры:
+* Удаление аргумента `--alsologtostderr` из всех контейнеров в поде
+
+  ```yaml
+  apiVersion: mutations.gatekeeper.sh/v1
+  kind: ModifySet
+  metadata:
+    name: remove-err-logging
+  spec:
+    applyTo:
+    - groups: [""]
+      kinds: ["Pod"]
+      versions: ["v1"]
+    location: "spec.containers[name: *].args"
+    parameters:
+      operation: prune
+      values:
+        fromList:
+          - --alsologtostderr
+  ```
+
+### AssignImage
+
+[Reference](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/#assignimage)
+
+Позволяет вносить изменения в параметр `Image` ресурса.
+
+Примеры:
+* Изменение параметра `Image` на значение `my.registry.io/repo/app@sha256:abcde67890123456789abc345678901a`
+  
+  ```yaml
+  apiVersion: mutations.gatekeeper.sh/v1alpha1
+  kind: AssignImage
+  metadata:
+    name: assign-container-image
+  spec:
+    applyTo:
+    - groups: [ "" ]
+      kinds: [ "Pod" ]
+      versions: [ "v1" ]
+    location: "spec.containers[name:*].image"
+    parameters:
+      assignDomain: "my.registry.io"
+      assignPath: "repo/app"
+      assignTag: "@sha256:abcde67890123456789abc345678901a"
+    match:
+      source: "All"
+      scope: Namespaced
+      kinds:
+      - apiGroups: [ "*" ]
+        kinds: [ "Pod" ]
+  ```

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR_RU.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR_RU.md
@@ -1,5 +1,5 @@
 ---
-title:  "The admission-policy-engine module: Custom Resources (by Gatekeeper)"
+title: "Модуль admission-policy-engine: Custom Resources (от Gatekeeper)"
 ---
 
 ## Mutation

--- a/modules/015-admission-policy-engine/docs/README.md
+++ b/modules/015-admission-policy-engine/docs/README.md
@@ -158,29 +158,10 @@ To apply the policy, it will be sufficient to set the label `enforce: "mypolicy"
 
 ### Modifying Kubernetes resources
 
-The module also allows you to use the Gatekeeper's Custom Resources to easily modify objects in the cluster, such as
-- `AssignMetadata` — defines changes to the metadata section of a resource.
-- `Assign` —  any change outside the metadata section.
+The module also allows you to use the [Custom Resources by Gatekeeper](./gatekeeper-cr.html) to easily modify objects in the cluster, such as
+- `AssignMetadata` — defines changes to the `metadata` section of a resource.
+- `Assign` —  any change outside the `metadata` section.
 - `ModifySet` —  adds or removes entries from a list, such as the arguments to a container.
-
-Example:
-
-```yaml
-apiVersion: mutations.gatekeeper.sh/v1
-kind: AssignMetadata
-metadata:
-  name: demo-annotation-owner
-spec:
-  match:
-    scope: Namespaced
-    namespaces: ["default"]
-    kinds:
-      - apiGroups: [""]
-        kinds: ["Pod"]
-  location: "metadata.annotations.foo"
-  parameters:
-    assign:
-      value: "bar"
-```
+- `AssignImage` - to change the `image` parameter of the resource.
 
 You can read more about the available options in the [gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/) documentation.

--- a/modules/015-admission-policy-engine/docs/README.md
+++ b/modules/015-admission-policy-engine/docs/README.md
@@ -158,10 +158,10 @@ To apply the policy, it will be sufficient to set the label `enforce: "mypolicy"
 
 ### Modifying Kubernetes resources
 
-The module also allows you to use the [Custom Resources by Gatekeeper](./gatekeeper-cr.html) to easily modify objects in the cluster, such as
-- `AssignMetadata` — defines changes to the `metadata` section of a resource.
-- `Assign` —  any change outside the `metadata` section.
-- `ModifySet` —  adds or removes entries from a list, such as the arguments to a container.
-- `AssignImage` - to change the `image` parameter of the resource.
+The module allows you to use the [Gatekeeper Custom Resources](gatekeeper-cr.html) to modify objects in the cluster, such as
+- [AssignMetadata](gatekeeper-cr.html#assignmetadata) — defines changes to the `metadata` section of a resource.
+- [Assign](gatekeeper-cr.html#assign) — any change outside the `metadata` section.
+- [ModifySet](gatekeeper-cr.html#modifyset) — adds or removes entries from a list, such as the arguments to a container.
+- [AssignImage](gatekeeper-cr.html#assignimage) — to change the `image` parameter of the resource.
 
 You can read more about the available options in the [gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/) documentation.

--- a/modules/015-admission-policy-engine/docs/README_RU.md
+++ b/modules/015-admission-policy-engine/docs/README_RU.md
@@ -157,29 +157,10 @@ spec:
 
 ### Изменение ресурсов Kubernetes
 
-Модуль также позволяет использовать custom resource'ы Gatekeeper для легкой модификации объектов в кластере, такие как:
-- `AssignMetadata` — для изменения секции metadata в ресурсе;
-- `Assign` — для изменения других полей, кроме metadata;
+Модуль также позволяет использовать [Custom Resource от Gatekeeper](./gatekeeper-cr.html) для легкой модификации объектов в кластере, такие как:
+- `AssignMetadata` — для изменения секции `metadata` в ресурсе;
+- `Assign` — для изменения других полей, кроме `metadata`;
 - `ModifySet` — для добавления или удаления значений из списка, например аргументов для запуска контейнера.
-
-Пример:
-
-```yaml
-apiVersion: mutations.gatekeeper.sh/v1
-kind: AssignMetadata
-metadata:
-  name: demo-annotation-owner
-spec:
-  match:
-    scope: Namespaced
-    namespaces: ["default"]
-    kinds:
-    - apiGroups: [""]
-      kinds: ["Pod"]
-  location: "metadata.annotations.foo"
-  parameters:
-    assign:
-      value:  "bar"
-```
+- `AssignImage` - для изменения параметра `image` ресурса.
 
 Подробнее про доступные варианты можно прочитать в документации [Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/).

--- a/modules/015-admission-policy-engine/docs/README_RU.md
+++ b/modules/015-admission-policy-engine/docs/README_RU.md
@@ -157,10 +157,10 @@ spec:
 
 ### Изменение ресурсов Kubernetes
 
-Модуль также позволяет использовать [Custom Resource от Gatekeeper](./gatekeeper-cr.html) для легкой модификации объектов в кластере, такие как:
-- `AssignMetadata` — для изменения секции `metadata` в ресурсе;
-- `Assign` — для изменения других полей, кроме `metadata`;
-- `ModifySet` — для добавления или удаления значений из списка, например аргументов для запуска контейнера.
-- `AssignImage` - для изменения параметра `image` ресурса.
+Модуль позволяет использовать [кастомные ресурсы Gatekeeper](gatekeeper-cr.html) для модификации объектов в кластере, такие как:
+- [AssignMetadata](gatekeeper-cr.html#assignmetadata) — для изменения секции `metadata` в ресурсе;
+- [Assign](gatekeeper-cr.html#assign) — для изменения других полей, кроме `metadata`;
+- [ModifySet](gatekeeper-cr.html#modifyset) — для добавления или удаления значений из списка, например аргументов для запуска контейнера.
+- [AssignImage](gatekeeper-cr.html#assignimage) — для изменения параметра `image` ресурса.
 
 Подробнее про доступные варианты можно прочитать в документации [Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/).


### PR DESCRIPTION
## Description
The current version of the documentation mentions gatekepeer's custom resources, but there is no separate page in the documentation listing these resources, as is done for the istio module.
This has raised questions among users of the documentation

## Why do we need it, and what problem does it solve?
Creating a separate page with Gatekeeper's custom resources will make the documentation more standardized, as such a page exists for the isito module.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs, admission-policy-engine
type: fix 
summary:  Added a documentation page with Gatekeeper's Custom Resources.
impact_level: low
```