### PR TITLE
[dhctl] In commander mode connect to controlled clusters via commander agent instead of SSH

### DIFF
--- a/dhctl/pkg/kubernetes/actions/converge/master_node_group_controller.go
+++ b/dhctl/pkg/kubernetes/actions/converge/master_node_group_controller.go
@@ -281,12 +281,14 @@ func (c *MasterNodeGroupController) addNodes() error {
 	}
 
 	if len(masterIPForSSHList) > 0 {
-		sshCl := c.client.NodeInterfaceAsSSHClient()
-		if sshCl == nil {
-			panic("NodeInterface is not ssh")
-		}
+		if !c.commanderMode {
+			sshCl := c.client.NodeInterfaceAsSSHClient()
+			if sshCl == nil {
+				panic("NodeInterface is not ssh")
+			}
 
-		sshCl.Settings.AddAvailableHosts(masterIPForSSHList...)
+			sshCl.Settings.AddAvailableHosts(masterIPForSSHList...)
+		}
 
 		// we hide deckhouse logs because we always have config
 		nodeCloudConfig, err := GetCloudConfig(c.client, c.name, HideDeckhouseLogs, nodeInternalIPList...)

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/kube-proxy.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/kube-proxy.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
@@ -145,7 +145,7 @@ func (c *KubeProxyChecker) Name() string {
 	return "Ssh access and kube-proxy availability"
 }
 
-func (c *KubeProxyChecker) printNs(cm *apiv1.ConfigMap) {
+func (c *KubeProxyChecker) printNs(cm *corev1.ConfigMap) {
 	if !c.logCheckResult {
 		return
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

In commander mode dhctl will now connect to puppet clusters via commander-agent api server tunneling instead of using ssh connections

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: In commander mode connect to controlled clusters via commander agent instead of SSH
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
