### PR TITLE
[docs] Fixed broken links in control plane manager

### DIFF
--- a/modules/040-control-plane-manager/docs/README.md
+++ b/modules/040-control-plane-manager/docs/README.md
@@ -83,6 +83,6 @@ By default, in a cluster with Deckhouse, a basic policy is created for logging e
 - committed from the names of ServiceAccounts from the "system" Namespace `kube-system`, `d8-*`;
 - committed with resources in the "system" Namespace `kube-system`, `d8-*`.
 
-A basic policy can be disabled by setting the [basicAuditPolicyEnabled](configuration.html#parameters-apiserver-basicauditpolicyenabled) flag to `false`.
+A basic policy can be disabled by setting the [basicAuditPolicyEnabled](cconfiguration.html#parameters-apiserver-basicauditpolicyenabled) flag to `false`.
 
 You can find how to set up policies in [a special FAQ section](faq.html#how-do-i-configure-additional-audit-policies).


### PR DESCRIPTION
## Description
Fixed broken links in control plane manager.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

```changes
section: docs
type: fchore
summary: Fixed broken links in control plane manager.
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: low
```