### PR TITLE
Build other editions only after FE

### DIFF
--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -95,6 +95,7 @@ jobs:
       - git_info
       - go_generate
       - workflow_render
+      - build_fe
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "EE"
@@ -108,6 +109,7 @@ jobs:
       - git_info
       - go_generate
       - workflow_render
+      - build_fe
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "SE"
@@ -121,6 +123,7 @@ jobs:
       - git_info
       - go_generate
       - workflow_render
+      - build_fe
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "BE"
@@ -134,6 +137,7 @@ jobs:
       - git_info
       - go_generate
       - workflow_render
+      - build_fe
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "CE"

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -691,6 +691,7 @@ jobs:
       - git_info
       - go_generate
       - workflow_render
+      - build_fe
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "EE"
@@ -1011,6 +1012,7 @@ jobs:
       - git_info
       - go_generate
       - workflow_render
+      - build_fe
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "SE"
@@ -1331,6 +1333,7 @@ jobs:
       - git_info
       - go_generate
       - workflow_render
+      - build_fe
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "BE"
@@ -1651,6 +1654,7 @@ jobs:
       - git_info
       - go_generate
       - workflow_render
+      - build_fe
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "CE"


### PR DESCRIPTION
## Description
Build other editions only after FE

## Why do we need it, and what problem does it solve?
This allows for faster builds thanks to using cache

## What is the expected result?
FE should build first

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: feature
summary: Build other editions only after FE.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
