### PR TITLE
[testing] Switch to cheaper machines for e2e tests on AWS

### DIFF
--- a/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
@@ -28,7 +28,7 @@ provider:
 masterNodeGroup:
   replicas: ${MASTERS_COUNT}
   instanceClass:
-    instanceType: m5.xlarge
+    instanceType: m5a.xlarge
     ami: ami-0022e2e80fa74c5d7 # Centos 9
 nodeGroups:
 - name: cloud-permanent

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -32,7 +32,7 @@ metadata:
 spec:
   diskSizeGb: 30
   diskType: gp2
-  instanceType: m5.xlarge
+  instanceType: m5a.xlarge
 ---
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController


### PR DESCRIPTION
## Description
Switch to cheaper machines for e2e tests on AWS

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: Switch to cheaper machines for e2e tests on AWS.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
