### PR TITLE
[node-manager] add patch for processing advanced daemonset pods

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -105,7 +105,7 @@ k8s:
     status: available
     patch: 6
     bashible: *bashible
-    clusterAutoscalerPatch: 1
+    clusterAutoscalerPatch: '0'
     crictlPatch: 1
     ccm:
       openstack: v1.30.0
@@ -133,7 +133,7 @@ k8s:
     status: preview
     patch: 1
     bashible: *bashible
-    clusterAutoscalerPatch: 1
+    clusterAutoscalerPatch: '0'
     crictlPatch: 1
     ccm:
       openstack: v1.31.0

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.27/kruise-ads.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.27/kruise-ads.patch
@@ -1,0 +1,80 @@
+diff --git a/cluster-autoscaler/simulator/cluster.go b/cluster-autoscaler/simulator/cluster.go
+index 23ccd037e..b9b82d7b6 100644
+--- a/cluster-autoscaler/simulator/cluster.go
++++ b/cluster-autoscaler/simulator/cluster.go
+@@ -234,6 +234,10 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
+ 
+ 	newpods := make([]*apiv1.Pod, 0, len(pods))
+ 	for _, podptr := range pods {
++		controllerRef := drain.ControllerRef(podptr)
++		if controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++			continue
++		}
+ 		newpod := *podptr
+ 		newpod.Spec.NodeName = ""
+ 		newpods = append(newpods, &newpod)
+diff --git a/cluster-autoscaler/utils/drain/drain.go b/cluster-autoscaler/utils/drain/drain.go
+index 02ddb7a12..b2a1f89f6 100644
+--- a/cluster-autoscaler/utils/drain/drain.go
++++ b/cluster-autoscaler/utils/drain/drain.go
+@@ -116,7 +116,7 @@ func GetPodsForDeletionOnNodeDrain(
+ 
+ 		if skipNodesWithCustomControllerPods {
+ 			// TODO(vadasambar): remove this when we get rid of skipNodesWithCustomControllerPods
+-			replicated, isDaemonSetPod, blockingPod, err = legacyCheckForReplicatedPods(listers, pod, minReplica)
++			replicated, isDaemonSetPod, blockingPod, err = legacyCheckForReplicatedPods(listers, pod, pdbs, minReplica)
+ 			if err != nil {
+ 				return []*apiv1.Pod{}, []*apiv1.Pod{}, blockingPod, err
+ 			}
+@@ -155,7 +155,7 @@ func GetPodsForDeletionOnNodeDrain(
+ 	return pods, daemonSetPods, nil, nil
+ }
+ 
+-func legacyCheckForReplicatedPods(listers kube_util.ListerRegistry, pod *apiv1.Pod, minReplica int32) (replicated bool, isDaemonSetPod bool, blockingPod *BlockingPod, err error) {
++func legacyCheckForReplicatedPods(listers kube_util.ListerRegistry, pod *apiv1.Pod, pdbs []*policyv1.PodDisruptionBudget, minReplica int32) (replicated bool, isDaemonSetPod bool, blockingPod *BlockingPod, err error) {
+ 	replicated = false
+ 	refKind := ""
+ 	checkReferences := listers != nil
+@@ -188,15 +188,33 @@ func legacyCheckForReplicatedPods(listers kube_util.ListerRegistry, pod *apiv1.P
+ 			replicated = true
+ 		}
+ 	} else if pod_util.IsDaemonSetPod(pod) {
+-		isDaemonSetPod = true
+-		// don't have listener for other DaemonSet kind
+-		// TODO: we should use a generic client for checking the reference.
+-		if checkReferences && refKind == "DaemonSet" {
+-			_, err := listers.DaemonSetLister().DaemonSets(controllerNamespace).Get(controllerRef.Name)
+-			if apierrors.IsNotFound(err) {
+-				return replicated, isDaemonSetPod, &BlockingPod{Pod: pod, Reason: ControllerNotFound}, fmt.Errorf("daemonset for %s/%s is not present, err: %v", pod.Namespace, pod.Name, err)
+-			} else if err != nil {
+-				return replicated, isDaemonSetPod, &BlockingPod{Pod: pod, Reason: UnexpectedError}, fmt.Errorf("error when trying to get daemonset for %s/%s , err: %v", pod.Namespace, pod.Name, err)
++		// kruise daemonset
++		if controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++			var pdbFound bool
++			for _, pdb := range pdbs {
++				if pdb.Namespace == controllerNamespace && pdb.Name == controllerRef.Name {
++					pdbFound = true
++					if pdb.Status.CurrentHealthy > minReplica {
++						replicated = true
++					}
++					break
++				}
++			}
++			if !pdbFound {
++				return replicated, isDaemonSetPod, &BlockingPod{Pod: pod, Reason: ControllerNotFound}, fmt.Errorf("pdb controlle for %s/%s is not present, err: %v", pod.Namespace, pod.Name, err)
++			}
++			// common daemonset
++		} else {
++			isDaemonSetPod = true
++			// don't have listener for other DaemonSet kind
++			// TODO: we should use a generic client for checking the reference.
++			if checkReferences && refKind == "DaemonSet" {
++				_, err := listers.DaemonSetLister().DaemonSets(controllerNamespace).Get(controllerRef.Name)
++				if apierrors.IsNotFound(err) {
++					return replicated, isDaemonSetPod, &BlockingPod{Pod: pod, Reason: ControllerNotFound}, fmt.Errorf("daemonset for %s/%s is not present, err: %v", pod.Namespace, pod.Name, err)
++				} else if err != nil {
++					return replicated, isDaemonSetPod, &BlockingPod{Pod: pod, Reason: UnexpectedError}, fmt.Errorf("error when trying to get daemonset for %s/%s , err: %v", pod.Namespace, pod.Name, err)
++				}
+ 			}
+ 		}
+ 	} else if refKind == "Job" {

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.28/kruise-ads.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.28/kruise-ads.patch
@@ -1,0 +1,81 @@
+diff --git a/cluster-autoscaler/simulator/cluster.go b/cluster-autoscaler/simulator/cluster.go
+index 23ccd037e..e3c7c144f 100644
+--- a/cluster-autoscaler/simulator/cluster.go
++++ b/cluster-autoscaler/simulator/cluster.go
+@@ -234,6 +234,11 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
+ 
+ 	newpods := make([]*apiv1.Pod, 0, len(pods))
+ 	for _, podptr := range pods {
++		controllerRef := drain.ControllerRef(podptr)
++		if controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++			continue
++		}
++
+ 		newpod := *podptr
+ 		newpod.Spec.NodeName = ""
+ 		newpods = append(newpods, &newpod)
+diff --git a/cluster-autoscaler/utils/drain/drain.go b/cluster-autoscaler/utils/drain/drain.go
+index 28802c9a8..c28b8f350 100644
+--- a/cluster-autoscaler/utils/drain/drain.go
++++ b/cluster-autoscaler/utils/drain/drain.go
+@@ -112,7 +112,7 @@ func GetPodsForDeletionOnNodeDrain(
+ 
+ 		if skipNodesWithCustomControllerPods {
+ 			// TODO(vadasambar): remove this when we get rid of skipNodesWithCustomControllerPods
+-			replicated, isDaemonSetPod, blockingPod, err = legacyCheckForReplicatedPods(listers, pod, minReplica)
++			replicated, isDaemonSetPod, blockingPod, err = legacyCheckForReplicatedPods(listers, pod, pdbs, minReplica)
+ 			if err != nil {
+ 				return []*apiv1.Pod{}, []*apiv1.Pod{}, blockingPod, err
+ 			}
+@@ -151,7 +151,7 @@ func GetPodsForDeletionOnNodeDrain(
+ 	return pods, daemonSetPods, nil, nil
+ }
+ 
+-func legacyCheckForReplicatedPods(listers kube_util.ListerRegistry, pod *apiv1.Pod, minReplica int32) (replicated bool, isDaemonSetPod bool, blockingPod *BlockingPod, err error) {
++func legacyCheckForReplicatedPods(listers kube_util.ListerRegistry, pod *apiv1.Pod, pdbs []*policyv1.PodDisruptionBudget, minReplica int32) (replicated bool, isDaemonSetPod bool, blockingPod *BlockingPod, err error) {
+ 	replicated = false
+ 	refKind := ""
+ 	checkReferences := listers != nil
+@@ -184,15 +184,33 @@ func legacyCheckForReplicatedPods(listers kube_util.ListerRegistry, pod *apiv1.P
+ 			replicated = true
+ 		}
+ 	} else if pod_util.IsDaemonSetPod(pod) {
+-		isDaemonSetPod = true
+-		// don't have listener for other DaemonSet kind
+-		// TODO: we should use a generic client for checking the reference.
+-		if checkReferences && refKind == "DaemonSet" {
+-			_, err := listers.DaemonSetLister().DaemonSets(controllerNamespace).Get(controllerRef.Name)
+-			if apierrors.IsNotFound(err) {
+-				return replicated, isDaemonSetPod, &BlockingPod{Pod: pod, Reason: ControllerNotFound}, fmt.Errorf("daemonset for %s/%s is not present, err: %v", pod.Namespace, pod.Name, err)
+-			} else if err != nil {
+-				return replicated, isDaemonSetPod, &BlockingPod{Pod: pod, Reason: UnexpectedError}, fmt.Errorf("error when trying to get daemonset for %s/%s , err: %v", pod.Namespace, pod.Name, err)
++		// kruise daemonset
++		if controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++			var pdbFound bool
++			for _, pdb := range pdbs {
++				if pdb.Namespace == controllerNamespace && pdb.Name == controllerRef.Name {
++					pdbFound = true
++					if pdb.Status.CurrentHealthy > minReplica {
++						replicated = true
++					}
++					break
++				}
++			}
++			if !pdbFound {
++				return replicated, isDaemonSetPod, &BlockingPod{Pod: pod, Reason: ControllerNotFound}, fmt.Errorf("pdb controller for %s/%s is not present, err: %v", pod.Namespace, pod.Name, err)
++			}
++			// common daemonset
++		} else {
++			isDaemonSetPod = true
++			// don't have listener for other DaemonSet kind
++			// TODO: we should use a generic client for checking the reference.
++			if checkReferences && refKind == "DaemonSet" {
++				_, err := listers.DaemonSetLister().DaemonSets(controllerNamespace).Get(controllerRef.Name)
++				if apierrors.IsNotFound(err) {
++					return replicated, isDaemonSetPod, &BlockingPod{Pod: pod, Reason: ControllerNotFound}, fmt.Errorf("daemonset for %s/%s is not present, err: %v", pod.Namespace, pod.Name, err)
++				} else if err != nil {
++					return replicated, isDaemonSetPod, &BlockingPod{Pod: pod, Reason: UnexpectedError}, fmt.Errorf("error when trying to get daemonset for %s/%s , err: %v", pod.Namespace, pod.Name, err)
++				}
+ 			}
+ 		}
+ 	} else if refKind == "Job" {

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/kruise-ads.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/kruise-ads.patch
@@ -1,0 +1,69 @@
+diff --git a/cluster-autoscaler/simulator/cluster.go b/cluster-autoscaler/simulator/cluster.go
+index d568becef..d8b3ff8c0 100644
+--- a/cluster-autoscaler/simulator/cluster.go
++++ b/cluster-autoscaler/simulator/cluster.go
+@@ -230,6 +230,10 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
+ 
+ 	newpods := make([]*apiv1.Pod, 0, len(pods))
+ 	for _, podptr := range pods {
++		controllerRef := drain.ControllerRef(podptr)
++		if controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++			continue
++		}
+ 		newpod := *podptr
+ 		newpod.Spec.NodeName = ""
+ 		newpods = append(newpods, &newpod)
+diff --git a/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go b/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
+index 9c9e89cf8..9efbb30d3 100644
+--- a/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
++++ b/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
+@@ -39,9 +39,20 @@ func (r *Rule) Name() string {
+ 
+ // Drainable decides how to handle pods with pdbs on node drain.
+ func (Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
++	kruiseAds := false
++	controllerRef := drain.ControllerRef(pod)
++	if controllerRef.APIVersion == "apps.kruise.io/v1alpha1" && controllerRef.Kind == "DaemonSet" {
++		kruiseAds = true
++	}
+ 	for _, pdb := range drainCtx.RemainingPdbTracker.MatchingPdbs(pod) {
+-		if pdb.Status.DisruptionsAllowed < 1 {
+-			return drainability.NewBlockedStatus(drain.NotEnoughPdb, fmt.Errorf("not enough pod disruption budget to move %s/%s", pod.Namespace, pod.Name))
++		if kruiseAds {
++			if pdb.Status.CurrentHealthy <= 1 {
++				return drainability.NewBlockedStatus(drain.NotEnoughPdb, fmt.Errorf("not enough healthy pods to move %s/%s", pod.Namespace, pod.Name))
++			}
++		} else {
++			if pdb.Status.DisruptionsAllowed < 1 {
++				return drainability.NewBlockedStatus(drain.NotEnoughPdb, fmt.Errorf("not enough pod disruption budget to move %s/%s", pod.Namespace, pod.Name))
++			}
+ 		}
+ 	}
+ 	return drainability.NewUndefinedStatus()
+diff --git a/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go b/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
+index 5a760d6bf..97e99420f 100644
+--- a/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
++++ b/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
+@@ -48,7 +48,7 @@ func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) dr
+ 
+ 	if r.skipNodesWithCustomControllerPods {
+ 		// TODO(vadasambar): remove this when we get rid of skipNodesWithCustomControllerPods
+-		replicated = replicated && replicatedKind[controllerRef.Kind]
++		replicated = replicated && (replicatedKind[controllerRef.Kind] || (controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1"))
+ 	}
+ 
+ 	if !replicated {
+diff --git a/cluster-autoscaler/utils/pod/pod.go b/cluster-autoscaler/utils/pod/pod.go
+index b85b14ac3..77dd43a87 100644
+--- a/cluster-autoscaler/utils/pod/pod.go
++++ b/cluster-autoscaler/utils/pod/pod.go
+@@ -32,6 +32,9 @@ const (
+ func IsDaemonSetPod(pod *apiv1.Pod) bool {
+ 	controllerRef := metav1.GetControllerOf(pod)
+ 	if controllerRef != nil && controllerRef.Kind == "DaemonSet" {
++		if controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++			return false
++		}
+ 		return true
+ 	}
+ 

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.30/kruise-ads.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.30/kruise-ads.patch
@@ -1,0 +1,69 @@
+diff --git a/cluster-autoscaler/simulator/cluster.go b/cluster-autoscaler/simulator/cluster.go
+index d568becef..d8b3ff8c0 100644
+--- a/cluster-autoscaler/simulator/cluster.go
++++ b/cluster-autoscaler/simulator/cluster.go
+@@ -230,6 +230,10 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
+ 
+ 	newpods := make([]*apiv1.Pod, 0, len(pods))
+ 	for _, podptr := range pods {
++		controllerRef := drain.ControllerRef(podptr)
++		if controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++			continue
++		}
+ 		newpod := *podptr
+ 		newpod.Spec.NodeName = ""
+ 		newpods = append(newpods, &newpod)
+diff --git a/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go b/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
+index 9c9e89cf8..9efbb30d3 100644
+--- a/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
++++ b/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
+@@ -39,9 +39,20 @@ func (r *Rule) Name() string {
+ 
+ // Drainable decides how to handle pods with pdbs on node drain.
+ func (Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
++	kruiseAds := false
++	controllerRef := drain.ControllerRef(pod)
++	if controllerRef.APIVersion == "apps.kruise.io/v1alpha1" && controllerRef.Kind == "DaemonSet" {
++		kruiseAds = true
++	}
+ 	for _, pdb := range drainCtx.RemainingPdbTracker.MatchingPdbs(pod) {
+-		if pdb.Status.DisruptionsAllowed < 1 {
+-			return drainability.NewBlockedStatus(drain.NotEnoughPdb, fmt.Errorf("not enough pod disruption budget to move %s/%s", pod.Namespace, pod.Name))
++		if kruiseAds {
++			if pdb.Status.CurrentHealthy <= 1 {
++				return drainability.NewBlockedStatus(drain.NotEnoughPdb, fmt.Errorf("not enough healthy pods to move %s/%s", pod.Namespace, pod.Name))
++			}
++		} else {
++			if pdb.Status.DisruptionsAllowed < 1 {
++				return drainability.NewBlockedStatus(drain.NotEnoughPdb, fmt.Errorf("not enough pod disruption budget to move %s/%s", pod.Namespace, pod.Name))
++			}
+ 		}
+ 	}
+ 	return drainability.NewUndefinedStatus()
+diff --git a/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go b/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
+index 5a760d6bf..97e99420f 100644
+--- a/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
++++ b/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
+@@ -48,7 +48,7 @@ func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) dr
+ 
+ 	if r.skipNodesWithCustomControllerPods {
+ 		// TODO(vadasambar): remove this when we get rid of skipNodesWithCustomControllerPods
+-		replicated = replicated && replicatedKind[controllerRef.Kind]
++		replicated = replicated && (replicatedKind[controllerRef.Kind] || (controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1"))
+ 	}
+ 
+ 	if !replicated {
+diff --git a/cluster-autoscaler/utils/pod/pod.go b/cluster-autoscaler/utils/pod/pod.go
+index b85b14ac3..77dd43a87 100644
+--- a/cluster-autoscaler/utils/pod/pod.go
++++ b/cluster-autoscaler/utils/pod/pod.go
+@@ -32,6 +32,9 @@ const (
+ func IsDaemonSetPod(pod *apiv1.Pod) bool {
+ 	controllerRef := metav1.GetControllerOf(pod)
+ 	if controllerRef != nil && controllerRef.Kind == "DaemonSet" {
++		if controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++			return false
++		}
+ 		return true
+ 	}
+ 

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.31/kruise-ads.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.31/kruise-ads.patch
@@ -1,0 +1,69 @@
+diff --git a/cluster-autoscaler/simulator/cluster.go b/cluster-autoscaler/simulator/cluster.go
+index d568becef..d8b3ff8c0 100644
+--- a/cluster-autoscaler/simulator/cluster.go
++++ b/cluster-autoscaler/simulator/cluster.go
+@@ -230,6 +230,10 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
+ 
+ 	newpods := make([]*apiv1.Pod, 0, len(pods))
+ 	for _, podptr := range pods {
++		controllerRef := drain.ControllerRef(podptr)
++		if controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++			continue
++		}
+ 		newpod := *podptr
+ 		newpod.Spec.NodeName = ""
+ 		newpods = append(newpods, &newpod)
+diff --git a/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go b/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
+index 9c9e89cf8..9efbb30d3 100644
+--- a/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
++++ b/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
+@@ -39,9 +39,20 @@ func (r *Rule) Name() string {
+ 
+ // Drainable decides how to handle pods with pdbs on node drain.
+ func (Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
++	kruiseAds := false
++	controllerRef := drain.ControllerRef(pod)
++	if controllerRef.APIVersion == "apps.kruise.io/v1alpha1" && controllerRef.Kind == "DaemonSet" {
++		kruiseAds = true
++	}
+ 	for _, pdb := range drainCtx.RemainingPdbTracker.MatchingPdbs(pod) {
+-		if pdb.Status.DisruptionsAllowed < 1 {
+-			return drainability.NewBlockedStatus(drain.NotEnoughPdb, fmt.Errorf("not enough pod disruption budget to move %s/%s", pod.Namespace, pod.Name))
++		if kruiseAds {
++			if pdb.Status.CurrentHealthy <= 1 {
++				return drainability.NewBlockedStatus(drain.NotEnoughPdb, fmt.Errorf("not enough healthy pods to move %s/%s", pod.Namespace, pod.Name))
++			}
++		} else {
++			if pdb.Status.DisruptionsAllowed < 1 {
++				return drainability.NewBlockedStatus(drain.NotEnoughPdb, fmt.Errorf("not enough pod disruption budget to move %s/%s", pod.Namespace, pod.Name))
++			}
+ 		}
+ 	}
+ 	return drainability.NewUndefinedStatus()
+diff --git a/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go b/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
+index 5a760d6bf..97e99420f 100644
+--- a/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
++++ b/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
+@@ -48,7 +48,7 @@ func (r *Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) dr
+ 
+ 	if r.skipNodesWithCustomControllerPods {
+ 		// TODO(vadasambar): remove this when we get rid of skipNodesWithCustomControllerPods
+-		replicated = replicated && replicatedKind[controllerRef.Kind]
++		replicated = replicated && (replicatedKind[controllerRef.Kind] || (controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1"))
+ 	}
+ 
+ 	if !replicated {
+diff --git a/cluster-autoscaler/utils/pod/pod.go b/cluster-autoscaler/utils/pod/pod.go
+index b85b14ac3..77dd43a87 100644
+--- a/cluster-autoscaler/utils/pod/pod.go
++++ b/cluster-autoscaler/utils/pod/pod.go
+@@ -32,6 +32,9 @@ const (
+ func IsDaemonSetPod(pod *apiv1.Pod) bool {
+ 	controllerRef := metav1.GetControllerOf(pod)
+ 	if controllerRef != nil && controllerRef.Kind == "DaemonSet" {
++		if controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++			return false
++		}
+ 		return true
+ 	}
+ 

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/README.md
@@ -5,3 +5,9 @@
 We want to scale a node group from zero but our MCM revision does not support generic MachineClass CRs. 
 With this patch we adds an ability to calculate node-group capacity from MachineDeployment annotations.
 It makes sense only for calculation node-group capacity from zero, when we have no nodes presented.
+
+## Kruise advanced daemonsets
+
+Cluster autoscaler can't tell the difference between pods created by apps/v1 and apps.kruise.io/v1alpha1 
+daemonsets when simulating if a node can be terminated. This patch makes cluster autoscaler check PDB 
+instead of checking if an apps/v1 daemonset exists, when it bumps into a pod created by an advanced daemonset.

--- a/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
+++ b/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
@@ -21,7 +21,7 @@ shell:
   - cd /src
     {{- $clusterAutoscalerVersion := $version }}
     {{- if semverCompare ">=1.30" $version }}
-      {{- $clusterAutoscalerVersion = "1.29" }}
+      {{- $clusterAutoscalerVersion = "1.30" }}
     {{- end }}
   - git clone --depth 1 --branch v{{ $clusterAutoscalerVersion }}.{{ $value.clusterAutoscalerPatch }} {{ $.SOURCE_REPO }}/gardener/autoscaler.git .
   - git apply /patches/{{ $version }}/*.patch --verbose


### PR DESCRIPTION
## Description
Provides patches for 1.26-1.30 versions of the cluster autoscaler to support scaling for nodes running advanced daemonsets.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Without these patches, the cluster-autoscale of versions greater than 1.28 may experience problems scaling down a node running a pod created by an openkruise advanced daemonset. An example of such an error:
```
I1025 12:28:48.862141       1 cluster.go:160] node k8s-dev-worker-e5588484-5b8c9-vzkr7 cannot be removed: daemonset for d8-ingress-nginx/controller-nginx-b8sfm is not present, err: daemonset.apps "controller-nginx" not found
```
Also, these patches introduce yet additional logic when scaling down a node running advanced daemonset pods:
if a node group is set to something like: min:0 max:3, the autoscaler won't scale down the group to zero because last ADS pod blocks deletion of the last node in the group ( corresponding PodDisruptionBudget status is checked and if the PDB reports CurrentHealthy pods to be 1 or less, it is considered as a trigger to block eviction of the pod ). Thus, it serves as an additional protection against frontend nodegroups misconfiguration.
All the aforementioned logic considers only advanced daemonsets, other paths of the scale-down processing weren't changed by the patches.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


## What is the expected result?
The autoscaler is capable of scaling down nodes running advanced daemonsets.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Scale down for nodes running advanced daemonsets.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
