### PR TITLE
[node-manager] ignore heartbeat annotation on hook

### DIFF
--- a/modules/040-node-manager/hooks/handle_node_templates.go
+++ b/modules/040-node-manager/hooks/handle_node_templates.go
@@ -42,6 +42,7 @@ const (
 	NodeUnininitalizedTaintKey        = "node.deckhouse.io/uninitialized"
 	masterNodeRoleKey                 = "node-role.kubernetes.io/master"
 	clusterAPIAnnotationKey           = "cluster.x-k8s.io/machine"
+	HeartbeatAnnotationKey            = "kubevirt.internal.virtualization.deckhouse.io/heartbeat"
 )
 
 type NodeSettings struct {
@@ -93,6 +94,12 @@ func actualNodeSettingsFilter(obj *unstructured.Unstructured) (go_hook.FilterRes
 		Annotations:      nodeObj.Annotations,
 		Taints:           nodeObj.Spec.Taints,
 		IsClusterAPINode: isClusterAPINode,
+	}
+
+	// Ignore annotation "kubevirt.internal.virtualization.deckhouse.io/heartbeat" on hook execute.
+	_, isHeartbeat := nodeObj.Annotations[HeartbeatAnnotationKey]
+	if isHeartbeat {
+		delete(nodeObj.Annotations, HeartbeatAnnotationKey)
 	}
 
 	return settings, nil


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
add ignore condition annotation "kubevirt.internal.virtualization.deckhouse.io/heartbeat" when hook  handle_node_templates execute

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this allow to not trigger 'handle_node_templates' queue when annotation "kubevirt.internal.virtualization.deckhouse.io/heartbeat" applies on nodes

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

queue 'handle_node_templates' is not triggered if "kubevirt.internal.virtualization.deckhouse.io/heartbeat" annotation applies on nodes 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix 
summary: ignore heartbeat annotation on hook
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
