### PR TITLE
[common] Add /bin/true to init image

### DIFF
--- a/modules/000-common/images/init/werf.inc.yaml
+++ b/modules/000-common/images/init/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $binaries := "/bin/sh /bin/chown /bin/chmod /bin/ls /bin/cp /bin/rm /bin/mkdir /bin/nc /bin/sleep" }}
+{{- $binaries := "/bin/sh /bin/chown /bin/chmod /bin/ls /bin/cp /bin/rm /bin/mkdir /bin/nc /bin/sleep /bin/true" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
@@ -17,4 +17,4 @@ shell:
   - rm -rf /var/lib/apt/lists/* /var/cache/apt/* && mkdir -p /var/lib/apt/lists/partial /var/cache/apt/archives/partial
   install:
   - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
-  
+


### PR DESCRIPTION
## Description
Add `/bin/true` to `init` image
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
fixed https://github.com/deckhouse/deckhouse/pull/9992
upmeter create pod with command `true` https://github.com/deckhouse/deckhouse/blob/6383a6d200067fbaaf3f1483c21ad4187bd57735/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_pod.go#L186-L188 and this binary does not exist in image and we have a errors in events like this
```
2m37s       Normal    Created              pod/upmeter-probe-scheduler-b7e18705                           Created container pause
2m37s       Warning   Failed               pod/upmeter-probe-scheduler-b7e18705                           Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "true": executable file not found in $PATH: unknown
98s         Normal    Scheduled            pod/upmeter-probe-scheduler-b7e18705                           Successfully assigned d8-upmeter/upmeter-probe-scheduler-b7e18705 to kovalkov-master-0
97s         Normal    Pulled               pod/upmeter-probe-scheduler-b7e18705                           Container image "registry.deckhouse.ru/deckhouse/ee@sha256:a93c65398a2532790ce8d6f1ca82261cfceef9bff7c6144a58c3096be8930750" already present on machine
97s         Normal    Created              pod/upmeter-probe-scheduler-b7e18705                           Created container pause
97s         Warning   Failed               pod/upmeter-probe-scheduler-b7e18705                           Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "true": executable file not found in $PATH: unknown
38s         Normal    Scheduled            pod/upmeter-probe-scheduler-b7e18705                           Successfully assigned d8-upmeter/upmeter-probe-scheduler-b7e18705 to kovalkov-master-0
37s         Normal    Pulled               pod/upmeter-probe-scheduler-b7e18705                           Container image "registry.deckhouse.ru/deckhouse/ee@sha256:a93c65398a2532790ce8d6f1ca82261cfceef9bff7c6144a58c3096be8930750" already present on machine
37s         Normal    Created              pod/upmeter-probe-scheduler-b7e18705                           Created container pause
37s         Warning   Failed               pod/upmeter-probe-scheduler-b7e18705                           Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "true": executable file not found in $PATH: unknown
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Container created and started succesfully
```
77s         Normal    Scheduled                 pod/upmeter-probe-scheduler-b7e18705                           Successfully assigned d8-upmeter/upmeter-probe-scheduler-b7e18705 to kovalkov-master-0
77s         Normal    Pulled                    pod/upmeter-probe-scheduler-b7e18705                           Container image "dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:e679a46d72eedb303c7749067e36323600d3fc2397374d581bc6fdf1e40f9916" already present on machine
77s         Normal    Created                   pod/upmeter-probe-scheduler-b7e18705                           Created container pause
77s         Normal    Started                   pod/upmeter-probe-scheduler-b7e18705                           Started container pause
17s         Normal    Scheduled                 pod/upmeter-probe-scheduler-b7e18705                           Successfully assigned d8-upmeter/upmeter-probe-scheduler-b7e18705 to kovalkov-master-0
17s         Normal    Pulled                    pod/upmeter-probe-scheduler-b7e18705                           Container image "dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:e679a46d72eedb303c7749067e36323600d3fc2397374d581bc6fdf1e40f9916" already present on machine
17s         Normal    Created                   pod/upmeter-probe-scheduler-b7e18705                           Created container pause
17s         Normal    Started                   pod/upmeter-probe-scheduler-b7e18705                           Started container pause
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Add `/bin/true` to `init` image
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
