### PR TITLE
[docs] Fixing the link in the DNS name template

### DIFF
--- a/docs/site/_includes/getting_started/existing/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/existing/STEP_FINALIZE.md
@@ -3,13 +3,13 @@
 
 To access the web interfaces of Deckhouse services, you need to:
 - configure DNS
-- specify [template for DNS names](../../products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#parameters-modules-publicdomaintemplate)
+- specify [template for DNS names](../../documentation/v1/deckhouse-configure-global.html#parameters-modules-publicdomaintemplate)
 
 The *DNS names template* is used to configure Ingress resources of system applications. For example, the name `deckhouse` is assigned to the in-cluster documentation module interface. Then, for the template `%s.kube.company.my` Grafana will be available at `deckhouse.kube.company.my`, etc.
 
 The guide will use [sslip.io](https://sslip.io/) to simplify configuration.
 
-Run the following command to configure [template for DNS names](../../products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#parameters-modules-publicdomaintemplate) to use the *sslip.io* (specify the public IP address of the node where the Ingress controller is running):
+Run the following command to configure [template for DNS names](../../documentation/v1/deckhouse-configure-global.html#parameters-modules-publicdomaintemplate) to use the *sslip.io* (specify the public IP address of the node where the Ingress controller is running):
 {% snippetcut %}
 {% raw %}
 ```shell

--- a/docs/site/_includes/getting_started/existing/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/existing/STEP_FINALIZE_RU.md
@@ -3,13 +3,13 @@
 
 Для того чтобы получить доступ к веб-интерфейсам компонентов Deckhouse, нужно:
 - настроить работу DNS
-- указать в параметрах Deckhouse [шаблон DNS-имен](../../products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#parameters-modules-publicdomaintemplate)
+- указать в параметрах Deckhouse [шаблон DNS-имен](../../documentation/v1/deckhouse-configure-global.html#parameters-modules-publicdomaintemplate)
 
 *Шаблон DNS-имен* используется для настройки Ingress-ресурсов системных приложений. Например, за интерфейсом модуля внутренней документации закреплено имя `deckhouse`. Тогда, для шаблона `%s.kube.company.my` Grafana будет доступна по адресу `deckhouse.kube.company.my`, и т.д.
 
 Чтобы упростить настройку, далее будет использоваться сервис [sslip.io](https://sslip.io/).
 
-Выполните следующую команду, чтобы настроить [шаблон DNS-имен](../../products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#parameters-modules-publicdomaintemplate) сервисов Deckhouse на использование *sslip.io* (укажите публичный IP-адрес узла, где запущен Ingress-контролллер):
+Выполните следующую команду, чтобы настроить [шаблон DNS-имен](../../documentation/v1/deckhouse-configure-global.html#parameters-modules-publicdomaintemplate) сервисов Deckhouse на использование *sslip.io* (укажите публичный IP-адрес узла, где запущен Ingress-контролллер):
 {% snippetcut %}
 {% raw %}
 ```shell


### PR DESCRIPTION
## Description
Fixing the link in the DNS name template.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

```changes
section: docs
type: chore
summary: Fixing the link in the DNS name template.
impact_level: low
```
