### PR TITLE
[upmeter] Fix typo in alert description

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2395,7 +2395,7 @@ alerts:
 
         Some of the objects were left by old upmeter-agent pods due to Upmeter update or downscale.
 
-        Leave only newest objects corresponding to upemter-agent pods, when the reason it investigated.
+        Leave only newest objects corresponding to upmeter-agent pods, when the reason it investigated.
 
         See `kubectl get upmeterhookprobes.deckhouse.io`.
       summary: |

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -397,7 +397,7 @@
 
           Some of the objects were left by old upmeter-agent pods due to Upmeter update or downscale.
 
-          Leave only newest objects corresponding to upemter-agent pods, when the reason it investigated.
+          Leave only newest objects corresponding to upmeter-agent pods, when the reason it investigated.
 
           See `kubectl get upmeterhookprobes.deckhouse.io`.
 


### PR DESCRIPTION
## Description
Fix typo in alert description

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: upmeter
type: chore
summary: Fix typo in alert description
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
