### PR TITLE
[deckhouse] use Golang 1.23 for deckhouse-controller

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -7,10 +7,10 @@ steps:
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
   {!{ tmpl.Exec "werf_install_step"            . | strings.Indent 2 }!}
 
-  - name: Set up Go 1.22
+  - name: Set up Go 1.23
     uses: actions/setup-go@v3
     with:
-      go-version: '1.22'
+      go-version: '1.23'
 
   - name: Run go generate
     run: |

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -464,10 +464,10 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
-      - name: Set up Go 1.22
+      - name: Set up Go 1.23
         uses: actions/setup-go@v3
         with:
-          go-version: '1.22'
+          go-version: '1.23'
 
       - name: Run go generate
         run: |

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -181,10 +181,10 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
-      - name: Set up Go 1.22
+      - name: Set up Go 1.23
         uses: actions/setup-go@v3
         with:
-          go-version: '1.22'
+          go-version: '1.23'
 
       - name: Run go generate
         run: |

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -231,10 +231,10 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
-      - name: Set up Go 1.22
+      - name: Set up Go 1.23
         uses: actions/setup-go@v3
         with:
-          go-version: '1.22'
+          go-version: '1.23'
 
       - name: Run go generate
         run: |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,6 +22,7 @@ linters-settings:
   goimports:
     local-prefixes: github.com/deckhouse/
   errcheck:
+    # Is Depricateed, use exclude-functions: https://github.com/kisielk/errcheck#excluding-functions
     ignore: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
 
 linters:

--- a/dhctl/go.mod
+++ b/dhctl/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/deckhouse/dhctl
 
-go 1.22
+go 1.23.1
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/ee/modules/025-static-routing-manager/hooks/iprulesets_handler.go
+++ b/ee/modules/025-static-routing-manager/hooks/iprulesets_handler.go
@@ -227,7 +227,7 @@ func ipRuleSetsHandler(input *go_hook.HookInput) error {
 			}
 			if iprule.Actions.Lookup.RoutingTableName == "" {
 				errr := fmt.Sprintf("can't get RoutingTableID in IPRuleSet %v for rule %v", irsi.Name, irsi.IPRules)
-				input.LogEntry.Warnf(errr)
+				input.LogEntry.Warn(errr)
 				tmpDIRSStatus.localErrors = append(tmpDIRSStatus.localErrors, errr)
 				continue
 			}
@@ -236,7 +236,7 @@ func ipRuleSetsHandler(input *go_hook.HookInput) error {
 				irsi.IPRules[i].Actions.Lookup.IPRoutingTableID = rtID
 			} else {
 				errr := fmt.Sprintf("can't get RoutingTableID in IPRuleSet %v for rule %v", irsi.Name, irsi.IPRules)
-				input.LogEntry.Warnf(errr)
+				input.LogEntry.Warn(errr)
 				tmpDIRSStatus.localErrors = append(tmpDIRSStatus.localErrors, errr)
 			}
 		}

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -280,7 +280,7 @@ func apiServerEndpoints(input *go_hook.HookInput) ([]string, error) {
 		// in bash hook we don't subscribe for deleting pods
 		// it is emulating this behaviour
 		if !versions.Exists() || !minVer.Exists() {
-			return nil, fmt.Errorf(msg)
+			return nil, fmt.Errorf("%s", msg)
 		}
 
 		input.LogEntry.Warnln(msg)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/deckhouse
 
-go 1.22.8
+go 1.23.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -218,12 +218,12 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(input *go_hook.HookInp
 			// and we don't need to create Crontab schedule
 			caOutdated, err := isOutdatedCA(cert.CA)
 			if err != nil {
-				input.LogEntry.Errorf(err.Error())
+				input.LogEntry.Error(err.Error())
 			}
 
 			certOutdated, err := isIrrelevantCert(cert.Cert, sans)
 			if err != nil {
-				input.LogEntry.Errorf(err.Error())
+				input.LogEntry.Error(err.Error())
 			}
 
 			// In case of errors, both these flags are false to avoid regeneration loop for the

--- a/modules/002-deckhouse/hooks/migrate/remove_deckhouse_label_from_provider_cluster_static_cluster_config.go
+++ b/modules/002-deckhouse/hooks/migrate/remove_deckhouse_label_from_provider_cluster_static_cluster_config.go
@@ -17,8 +17,6 @@ limitations under the License.
 package migrate
 
 import (
-	"fmt"
-
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
@@ -117,7 +115,7 @@ func removeLabelHeritageDeckhouse(input *go_hook.HookInput) error {
 			},
 		}
 
-		input.LogEntry.Warnf(fmt.Sprintf("Remove label 'heritage: deckhouse' from %s", snapSecretName))
+		input.LogEntry.Warnf("Remove label 'heritage: deckhouse' from %s", snapSecretName)
 		input.PatchCollector.MergePatch(patch, "v1", "Secret", "kube-system", snapSecretName)
 	}
 

--- a/modules/040-node-manager/hooks/chaos_monkey.go
+++ b/modules/040-node-manager/hooks/chaos_monkey.go
@@ -97,7 +97,7 @@ func handleChaosMonkey(input *go_hook.HookInput) error {
 
 	nodeGroups, machines, nodes, err := prepareChaosData(input)
 	if err != nil {
-		input.LogEntry.Infof(err.Error()) // just info message, already have a victim
+		input.LogEntry.Info(err.Error()) // just info message, already have a victim
 		return nil
 	}
 

--- a/modules/150-user-authn/template_tests/kubeconfig_generator_config_test.go
+++ b/modules/150-user-authn/template_tests/kubeconfig_generator_config_test.go
@@ -210,7 +210,7 @@ Multiline
 					Expect(cl.Get("client_secret").String()).To(Equal(dexClientAppSecret))
 					Expect(cl.Get("issuer").String()).To(Equal("https://dex.example.com/"))
 					Expect(cl.Get("k8s_master_uri").String()).To(Equal(a.masterURI))
-					Expect(cl.Get("name").String()).To(Equal(fmt.Sprintf(a.id)))
+					Expect(cl.Get("name").String()).To(Equal(fmt.Sprintf("%s", a.id)))
 					Expect(cl.Get("redirect_uri").String()).To(Equal(fmt.Sprintf("https://kubeconfig.example.com/callback/%v", i)))
 					Expect(cl.Get("short_description").String()).To(Equal(a.desc))
 					Expect(cl.Get("scopes.0").String()).To(Equal("audience:server:client_id:kubernetes"))

--- a/modules/150-user-authn/template_tests/kubeconfig_generator_config_test.go
+++ b/modules/150-user-authn/template_tests/kubeconfig_generator_config_test.go
@@ -210,7 +210,7 @@ Multiline
 					Expect(cl.Get("client_secret").String()).To(Equal(dexClientAppSecret))
 					Expect(cl.Get("issuer").String()).To(Equal("https://dex.example.com/"))
 					Expect(cl.Get("k8s_master_uri").String()).To(Equal(a.masterURI))
-					Expect(cl.Get("name").String()).To(Equal(fmt.Sprintf("%s", a.id)))
+					Expect(cl.Get("name").String()).To(Equal(a.id))
 					Expect(cl.Get("redirect_uri").String()).To(Equal(fmt.Sprintf("https://kubeconfig.example.com/callback/%v", i)))
 					Expect(cl.Get("short_description").String()).To(Equal(a.desc))
 					Expect(cl.Get("scopes.0").String()).To(Equal("audience:server:client_id:kubernetes"))

--- a/modules/402-ingress-nginx/hooks/update_ingress_address.go
+++ b/modules/402-ingress-nginx/hooks/update_ingress_address.go
@@ -61,7 +61,7 @@ func filterIngressServiceAddress(obj *unstructured.Unstructured) (go_hook.Filter
 	if err := sdk.FromUnstructured(obj, &svc); err != nil {
 		return nil, err
 	}
-	if svc.Status.LoadBalancer.Ingress != nil && len(svc.Status.LoadBalancer.Ingress) != 0 {
+	if len(svc.Status.LoadBalancer.Ingress) != 0 {
 		return loadBalancerService{
 			name:     svc.Labels["name"],
 			ip:       svc.Status.LoadBalancer.Ingress[0].IP,

--- a/modules/460-log-shipper/hooks/validate_test.go
+++ b/modules/460-log-shipper/hooks/validate_test.go
@@ -65,7 +65,7 @@ func TestValidateConfigWithVector(t *testing.T) {
 		cmd.Stderr = os.Stderr
 
 		if err := cmd.Run(); err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 	})
 }

--- a/modules/500-upmeter/hooks/smokemini/internal/scheduler/deleter.go
+++ b/modules/500-upmeter/hooks/smokemini/internal/scheduler/deleter.go
@@ -76,7 +76,7 @@ type loggingDeleter struct {
 
 func (d *loggingDeleter) Delete(name string) {
 	d.delegate.Delete(name)
-	d.logger.Warnf(d.message(name))
+	d.logger.Warn(d.message(name))
 }
 
 // objDeleter is the generic implementation of a Deleter interface

--- a/testing/matrix/linter/rules/errors/errors.go
+++ b/testing/matrix/linter/rules/errors/errors.go
@@ -90,5 +90,5 @@ func (l *LintRuleErrorsList) ConvertToError() error {
 		}
 		builder.WriteString("\n")
 	}
-	return fmt.Errorf(builder.String())
+	return fmt.Errorf("%s", builder.String())
 }

--- a/testing/matrix/linter/rules/modules/images.go
+++ b/testing/matrix/linter/rules/modules/images.go
@@ -227,6 +227,7 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 							"MODULE001",
 							fmt.Sprintf("module = %s, image = %s", name, relativeFilePath),
 							fromTrimmed,
+							"%s",
 							message,
 						)
 					}
@@ -253,6 +254,7 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 				"MODULE001",
 				fmt.Sprintf("module = %s, image = %s", name, relativeFilePath),
 				fromInstruction,
+				"%s",
 				message,
 			)
 		}

--- a/testing/matrix/linter/rules/modules/monitoring.go
+++ b/testing/matrix/linter/rules/modules/monitoring.go
@@ -36,6 +36,7 @@ func dirExists(moduleName, modulePath string, path ...string) (bool, errors.Lint
 			"MODULE060",
 			moduleLabel(moduleName),
 			path,
+			"%s",
 			err.Error(),
 		)
 	}
@@ -86,6 +87,7 @@ func monitoringModuleRule(moduleName, modulePath, moduleNamespace string) errors
 			"MODULE060",
 			moduleLabel(moduleName),
 			searchingFilePath,
+			"%s",
 			err.Error(),
 		)
 	}

--- a/testing/matrix/linter/rules/modules/oss.go
+++ b/testing/matrix/linter/rules/modules/oss.go
@@ -39,6 +39,7 @@ func ossModuleRule(name, moduleRoot string) linterrors.LintRuleErrorsList {
 				"MODULE001",
 				moduleLabel(name),
 				nil,
+				"%s",
 				ossFileErrorMessage(err),
 			)
 

--- a/testing/matrix/linter/rules/modules/testgo.go
+++ b/testing/matrix/linter/rules/modules/testgo.go
@@ -91,6 +91,7 @@ func commonTestGoForHooks(name, path string) errors.LintRuleError {
 			"MODULE001",
 			moduleLabel(name),
 			nil,
+			"%s",
 			errstr,
 		)
 	}

--- a/testing/matrix/linter/rules/roles/wildcards.go
+++ b/testing/matrix/linter/rules/roles/wildcards.go
@@ -153,7 +153,8 @@ func checkRoles(object storage.StoreObject) errors.LintRuleError {
 				"WILDCARD001",
 				object.Identity(),
 				object.Path,
-				strings.Join(objs, ", ")+" contains a wildcards. Replace them with an explicit list of resources",
+				"%s contains a wildcards. Replace them with an explicit list of resources",
+				strings.Join(objs, ", "),
 			)
 		}
 	}

--- a/testing/matrix/linter/rules/rules.go
+++ b/testing/matrix/linter/rules/rules.go
@@ -509,7 +509,8 @@ func objectSecurityContext(object storage.StoreObject) errors.LintRuleError {
 			"MANIFEST003",
 			object.Identity(),
 			nil,
-			fmt.Sprintf("GetPodSecurityContext failed: %v", err),
+			"GetPodSecurityContext failed: %v",
+			err,
 		)
 	}
 
@@ -651,7 +652,8 @@ func objectHostNetworkPorts(object storage.StoreObject) errors.LintRuleError {
 			"MANIFEST003",
 			object.Identity(),
 			nil,
-			fmt.Sprintf("IsHostNetwork failed: %v", err),
+			"IsHostNetwork failed: %v",
+			err,
 		)
 	}
 
@@ -661,7 +663,8 @@ func objectHostNetworkPorts(object storage.StoreObject) errors.LintRuleError {
 			"MANIFEST003",
 			object.Identity(),
 			nil,
-			fmt.Sprintf("GetContainers failed: %v", err),
+			"GetContainers failed: %v",
+			err,
 		)
 	}
 	initContainers, err := object.GetInitContainers()
@@ -670,7 +673,8 @@ func objectHostNetworkPorts(object storage.StoreObject) errors.LintRuleError {
 			"MANIFEST003",
 			object.Identity(),
 			nil,
-			fmt.Sprintf("GetInitContainers failed: %v", err),
+			"GetInitContainers failed: %v",
+			err,
 		)
 	}
 	containers = append(containers, initContainers...)

--- a/testing/matrix/linter/rules/rules.go
+++ b/testing/matrix/linter/rules/rules.go
@@ -199,7 +199,8 @@ func containerImageDigestCheck(object storage.StoreObject, containers []v1.Conta
 			return errors.NewLintRuleError("CONTAINER003",
 				object.Identity()+"; container = "+c.Name,
 				nil,
-				"Cannot parse repository from image: "+c.Image,
+				"Cannot parse repository from image: %s",
+				c.Image,
 			)
 		}
 
@@ -207,7 +208,9 @@ func containerImageDigestCheck(object storage.StoreObject, containers []v1.Conta
 			return errors.NewLintRuleError("CONTAINER003",
 				object.Identity()+"; container = "+c.Name,
 				nil,
-				"All images must be deployed from the same default registry: "+defaultRegistry+" current:"+repo.RepositoryStr(),
+				"All images must be deployed from the same default registry: %s current: %s",
+				defaultRegistry,
+				repo.RepositoryStr(),
 			)
 		}
 	}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.22.8
+go 1.23.1
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible

--- a/werf.yaml
+++ b/werf.yaml
@@ -324,7 +324,7 @@ shell:
 
 ---
 artifact: golangci-lint-artifact
-from: {{ $.Images.BASE_GOLANG_23_ALPINE }}
+from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
 shell:
   install:
   # Use v1.60.1 - https://github.com/golangci/golangci-lint/issues/4837
@@ -889,6 +889,7 @@ args:
   BASE_GOLANG_22_ALPINE_DEV: {{ .Images.BASE_GOLANG_22_ALPINE_DEV }}
   BASE_GOLANG_22_BULLSEYE: {{ .Images.BASE_GOLANG_22_BULLSEYE }}
   BASE_GOLANG_23_ALPINE: {{ .Images.BASE_GOLANG_23_ALPINE }}
+  BASE_GOLANG_23_ALPINE_DEV: {{ .Images.BASE_GOLANG_23_ALPINE_DEV }}
   BASE_GOLANG_23_BULLSEYE: {{ .Images.BASE_GOLANG_23_BULLSEYE }}
   BASE_NGINX_ALPINE:  {{ .Images.BASE_NGINX_ALPINE }}
   BASE_NGINX_ALPINE_DEV:  {{ .Images.BASE_NGINX_ALPINE_DEV }}

--- a/werf.yaml
+++ b/werf.yaml
@@ -327,8 +327,9 @@ artifact: golangci-lint-artifact
 from: {{ $.Images.BASE_GOLANG_23_ALPINE }}
 shell:
   install:
+  # Use v1.60.1 - https://github.com/golangci/golangci-lint/issues/4837
   - export GOPROXY={{ .GOPROXY }}
-  - git clone --depth 1 {{ .SOURCE_REPO }}/golangci/golangci-lint --branch v1.58.0
+  - git clone --depth 1 {{ .SOURCE_REPO }}/golangci/golangci-lint --branch v1.60.1
   - cd golangci-lint/
   - CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w -extldflags "-static"' -o /usr/local/bin/golangci-lint cmd/golangci-lint/main.go
 

--- a/werf.yaml
+++ b/werf.yaml
@@ -324,8 +324,10 @@ shell:
 
 ---
 artifact: golangci-lint-artifact
-from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
+from: {{ $.Images.BASE_GOLANG_23_ALPINE }}
 shell:
+  beforeInstall:
+  - apk add --no-cache git
   install:
   # Use v1.60.1 - https://github.com/golangci/golangci-lint/issues/4837
   - export GOPROXY={{ .GOPROXY }}

--- a/werf.yaml
+++ b/werf.yaml
@@ -292,7 +292,7 @@ shell:
   beforeInstall:
 {{/*  TODO: Move it to the dev image */}}
   - rm -rf /usr/local/go
-  - curl -sSfL https://go.dev/dl/go1.22.2.linux-amd64.tar.gz -o - | tar -C /usr/local -zxvf -
+  - curl -sSfL https://go.dev/dl/go1.23.1.linux-amd64.tar.gz -o - | tar -C /usr/local -zxvf -
   {{- include "base components" . | nindent 2 }}
 
 ---
@@ -324,7 +324,7 @@ shell:
 
 ---
 artifact: golangci-lint-artifact
-from: {{ $.Images.BASE_GOLANG_22_ALPINE_DEV }}
+from: {{ $.Images.BASE_GOLANG_23_ALPINE }}
 shell:
   install:
   - export GOPROXY={{ .GOPROXY }}

--- a/werf.yaml
+++ b/werf.yaml
@@ -329,7 +329,7 @@ shell:
   beforeInstall:
   - apk add --no-cache git
   install:
-  # Use v1.60.1 - https://github.com/golangci/golangci-lint/issues/4837
+  # Use v1.60.1 for go1.23 - https://github.com/golangci/golangci-lint/issues/4837
   - export GOPROXY={{ .GOPROXY }}
   - git clone --depth 1 {{ .SOURCE_REPO }}/golangci/golangci-lint --branch v1.60.1
   - cd golangci-lint/


### PR DESCRIPTION
## Description
This PR updates the Go version to 1.23.
This update is necessary due to the addition of the dhctl dependency in the deckhouse-cli project, which requires Go 1.23 for compatibility.

Pipelines with Test Results:
https://github.com/deckhouse/deckhouse-test-2/actions/runs/11609963962
https://github.com/deckhouse/deckhouse-test-2/actions/runs/11610003870

After rebase(resolved conflicts by rebase):
https://github.com/deckhouse/deckhouse-test-2/actions/runs/11627516010

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: Use Go 1.23.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
