### PR TITLE
[deckhouse-controller] DeckhouseRelease without annotations is not reconciled (#9838)

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
@@ -24,18 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var (
-	DeckhouseReleaseGVR = schema.GroupVersionResource{
-		Group:    SchemeGroupVersion.Group,
-		Version:  SchemeGroupVersion.Version,
-		Resource: "deckhousereleases",
-	}
-	DeckhouseReleaseGVK = schema.GroupVersionKind{
-		Group:   SchemeGroupVersion.Group,
-		Version: SchemeGroupVersion.Version,
-		Kind:    "DeckhouseRelease",
-	}
-)
+var DeckhouseReleaseGVK = schema.GroupVersionKind{
+	Group:   SchemeGroupVersion.Group,
+	Version: SchemeGroupVersion.Version,
+	Kind:    DeckhouseReleaseKind,
+}
 
 // +genclient
 // +genclient:nonNamespaced

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/register.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/register.go
@@ -22,8 +22,13 @@ import (
 	deckhouse_io "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io"
 )
 
+const (
+	Version              = "v1alpha1"
+	DeckhouseReleaseKind = "DeckhouseRelease"
+)
+
 // SchemeGroupVersion is group version used to register these objects
-var SchemeGroupVersion = schema.GroupVersion{Group: deckhouse_io.GroupName, Version: "v1alpha1"}
+var SchemeGroupVersion = schema.GroupVersion{Group: deckhouse_io.GroupName, Version: Version}
 
 // Resource takes an unqualified resource and returns a Group qualified GroupResource
 func Resource(resource string) schema.GroupResource {

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -100,18 +100,6 @@ func NewDeckhouseController(ctx context.Context, config *rest.Config, mm *module
 	}
 
 	dc := dependency.NewDependencyContainer()
-	// create a default policy, it'll be filled in with relevant settings from the deckhouse moduleConfig, see runDeckhouseConfigObserver method
-	embeddedDeckhousePolicy := v1alpha1.NewModuleUpdatePolicySpecContainer(&v1alpha1.ModuleUpdatePolicySpec{
-		Update: v1alpha1.ModuleUpdatePolicySpecUpdate{
-			Mode: "Auto",
-		},
-		ReleaseChannel: "Stable",
-	})
-	ds := &helpers.DeckhouseSettings{ReleaseChannel: ""}
-	ds.Update.DisruptionApprovalMode = "Auto"
-	ds.Update.Mode = "Auto"
-	dsContainer := helpers.NewDeckhouseSettingsContainer(ds)
-
 	scheme := runtime.NewScheme()
 
 	for _, add := range []func(s *runtime.Scheme) error{corev1.AddToScheme, coordv1.AddToScheme, v1alpha1.AddToScheme, appsv1.AddToScheme} {
@@ -177,6 +165,15 @@ func NewDeckhouseController(ctx context.Context, config *rest.Config, mm *module
 	if err != nil {
 		return nil, err
 	}
+
+	// create a default policy, it'll be filled in with relevant settings from the deckhouse moduleConfig, see runDeckhouseConfigObserver method
+	embeddedDeckhousePolicy := helpers.NewModuleUpdatePolicySpecContainer(&v1alpha1.ModuleUpdatePolicySpec{
+		Update: v1alpha1.ModuleUpdatePolicySpecUpdate{
+			Mode: "Auto",
+		},
+		ReleaseChannel: "Stable",
+	})
+	dsContainer := helpers.NewDeckhouseSettingsContainer(nil)
 
 	err = deckhouse_release.NewDeckhouseReleaseController(ctx, mgr, dc, mm, dsContainer, metricStorage)
 	if err != nil {

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -167,7 +167,7 @@ func NewDeckhouseController(ctx context.Context, config *rest.Config, mm *module
 	}
 
 	// create a default policy, it'll be filled in with relevant settings from the deckhouse moduleConfig, see runDeckhouseConfigObserver method
-	embeddedDeckhousePolicy := helpers.NewModuleUpdatePolicySpecContainer(&v1alpha1.ModuleUpdatePolicySpec{
+	embeddedDeckhousePolicy := v1alpha1.NewModuleUpdatePolicySpecContainer(&v1alpha1.ModuleUpdatePolicySpec{
 		Update: v1alpha1.ModuleUpdatePolicySpecUpdate{
 			Mode: "Auto",
 		},

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -41,7 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	d8updater "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/deckhouse-release/updater"
@@ -338,14 +337,8 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 		windows = r.updateSettings.Get().Update.Windows
 	}
 
-	err = deckhouseUpdater.ApplyPredictedRelease(windows)
-
-	if err != nil {
-		if errors.Is(err, updater.ErrNotReadyForDeploy) || errors.Is(err, updater.ErrRequirementsNotMet) {
-			// TODO: create custom error type with additional fields like reason end requeueAfter
-			return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
-		}
-		return ctrl.Result{}, fmt.Errorf("apply predicted release: %w", err)
+	if !deckhouseUpdater.ApplyPredictedRelease(windows) {
+		r.logger.Errorln("apply predicted release failed")
 	}
 
 	return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -40,9 +40,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	d8updater "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/deckhouse-release/updater"
@@ -73,7 +72,8 @@ type deckhouseReleaseReconciler struct {
 }
 
 func NewDeckhouseReleaseController(ctx context.Context, mgr manager.Manager, dc dependency.Container,
-	moduleManager moduleManager, updateSettings *helpers.DeckhouseSettingsContainer, metricStorage *metric_storage.MetricStorage) error {
+	moduleManager moduleManager, updateSettings *helpers.DeckhouseSettingsContainer, metricStorage *metric_storage.MetricStorage,
+) error {
 	lg := log.WithField("component", "DeckhouseRelease")
 
 	r := &deckhouseReleaseReconciler{
@@ -105,54 +105,29 @@ func NewDeckhouseReleaseController(ctx context.Context, mgr manager.Manager, dc 
 		return err
 	}
 
+	lg.Info("Controller started")
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.DeckhouseRelease{}).
-		WithEventFilter(predicate.And(
-			predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}),
-			releasePhasePredicate{},
-		)).
+		WithEventFilter(logWrapper{lg, newEventFilter()}).
 		Complete(ctr)
 }
 
-type releasePhasePredicate struct{}
+func (r *deckhouseReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
+	r.logger.Debugf("%s release processing started", req.Name)
+	defer func() { r.logger.Debugf("%s release processing complete: %+v", req.Name, result) }()
 
-func (rp releasePhasePredicate) Create(ev event.CreateEvent) bool {
-	switch ev.Object.(*v1alpha1.DeckhouseRelease).Status.Phase {
-	case v1alpha1.PhaseSkipped, v1alpha1.PhaseSuperseded, v1alpha1.PhaseSuspended, v1alpha1.PhaseDeployed:
-		return false
-	}
-	return true
-}
-
-// Delete returns true if the Delete event should be processed
-func (rp releasePhasePredicate) Delete(_ event.DeleteEvent) bool {
-	return false
-}
-
-// Update returns true if the Update event should be processed
-func (rp releasePhasePredicate) Update(ev event.UpdateEvent) bool {
-	switch ev.ObjectNew.(*v1alpha1.DeckhouseRelease).Status.Phase {
-	case v1alpha1.PhaseSkipped, v1alpha1.PhaseSuperseded, v1alpha1.PhaseSuspended, v1alpha1.PhaseDeployed:
-		return false
-	}
-	return true
-}
-
-// Generic returns true if the Generic event should be processed
-func (rp releasePhasePredicate) Generic(_ event.GenericEvent) bool {
-	return true
-}
-
-func (r *deckhouseReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	if r.updateSettings.Get().ReleaseChannel == "" {
+		r.logger.Debug("release channel not set")
 		return ctrl.Result{}, nil
 	}
 
 	r.metricStorage.GroupedVault.ExpireGroupMetrics(metricReleasesGroup)
 
 	release := new(v1alpha1.DeckhouseRelease)
-	err := r.client.Get(ctx, req.NamespacedName, release)
+	err = r.client.Get(ctx, req.NamespacedName, release)
 	if err != nil {
+		r.logger.Debug("get release: %s", err.Error())
 		// The DeckhouseRelease resource may no longer exist, in which case we stop
 		// processing.
 		if apierrors.IsNotFound(err) {
@@ -163,6 +138,7 @@ func (r *deckhouseReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	if !release.DeletionTimestamp.IsZero() {
+		r.logger.Debug("release deletion timestamp: %s", release.DeletionTimestamp.String())
 		return ctrl.Result{}, nil
 	}
 
@@ -184,6 +160,7 @@ func (r *deckhouseReleaseReconciler) createOrUpdateReconcile(ctx context.Context
 		return ctrl.Result{Requeue: true}, nil // process to the next phase
 
 	case v1alpha1.PhaseSkipped, v1alpha1.PhaseSuperseded, v1alpha1.PhaseSuspended:
+		r.logger.Debug("release phase: %s", dr.Status.Phase)
 		return ctrl.Result{}, nil
 
 	case v1alpha1.PhaseDeployed:
@@ -282,7 +259,6 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 		r.logger, r.client, r.dc, dus, releaseData, r.metricStorage, podReady,
 		clusterBootstrapping, imagesRegistry, r.moduleManager.GetEnabledModuleNames(),
 	)
-
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("initializing deckhouse updater: %w", err)
 	}
@@ -313,6 +289,7 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 	deckhouseUpdater.SetReleases(pointerReleases)
 
 	if deckhouseUpdater.ReleasesCount() == 0 {
+		r.logger.Debug("releases count is zero")
 		return ctrl.Result{}, nil
 	}
 
@@ -321,6 +298,7 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 
 	// has already Deployed the latest release
 	if deckhouseUpdater.LastReleaseDeployed() {
+		r.logger.Debug("latest release is deployed")
 		return ctrl.Result{}, nil
 	}
 
@@ -339,6 +317,7 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 	if rel := deckhouseUpdater.GetPredictedRelease(); rel != nil {
 		if rel.GetName() != dr.GetName() {
 			// don't requeue releases other than predicted one
+			r.logger.Debugf("processing wrong release (current: %s, predicted: %s)", dr.Name, rel.Name)
 			return ctrl.Result{}, nil
 		}
 	}
@@ -359,8 +338,14 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 		windows = r.updateSettings.Get().Update.Windows
 	}
 
-	if deckhouseUpdater.ApplyPredictedRelease(windows) {
-		return ctrl.Result{}, nil
+	err = deckhouseUpdater.ApplyPredictedRelease(windows)
+
+	if err != nil {
+		if errors.Is(err, updater.ErrNotReadyForDeploy) || errors.Is(err, updater.ErrRequirementsNotMet) {
+			// TODO: create custom error type with additional fields like reason end requeueAfter
+			return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("apply predicted release: %w", err)
 	}
 
 	return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -30,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tidwall/sjson"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
@@ -115,7 +115,7 @@ func (suite *ControllerTestSuite) TearDownSubTest() {
 	got := suite.fetchResults()
 
 	if golden {
-		err := os.WriteFile(goldenFile, got, 0666)
+		err := os.WriteFile(goldenFile, gotB, 0o666)
 		require.NoError(suite.T(), err)
 	} else {
 		exp, err := os.ReadFile(goldenFile)
@@ -123,6 +123,7 @@ func (suite *ControllerTestSuite) TearDownSubTest() {
 		assert.YAMLEq(suite.T(), string(exp), string(got))
 	}
 }
+
 func (suite *ControllerTestSuite) setupController(
 	filename string,
 	initValues string,
@@ -524,9 +525,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 	})
 
 	suite.Run("Notification: bearer token auth", func() {
-		var (
-			headerValue string
-		)
+		var headerValue string
 		svr := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			headerValue = r.Header.Get("Authorization")
 		}))

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -29,7 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tidwall/sjson"
@@ -111,11 +111,15 @@ func (suite *ControllerTestSuite) SetupSubTest() {
 }
 
 func (suite *ControllerTestSuite) TearDownSubTest() {
+	if suite.T().Skipped() {
+		return
+	}
+
 	goldenFile := filepath.Join("./testdata", "golden", suite.testDataFileName)
 	got := suite.fetchResults()
 
 	if golden {
-		err := os.WriteFile(goldenFile, gotB, 0o666)
+		err := os.WriteFile(goldenFile, got, 0o666)
 		require.NoError(suite.T(), err)
 	} else {
 		exp, err := os.ReadFile(goldenFile)

--- a/deckhouse-controller/pkg/controller/deckhouse-release/event.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/event.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deckhouse_release
+
+import (
+	"runtime/debug"
+
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+)
+
+func newEventFilter() predicate.Predicate {
+	return predicate.And(
+		predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}),
+		releasePhasePredicate{},
+	)
+}
+
+type logWrapper struct {
+	l *logrus.Entry
+	p predicate.Predicate
+}
+
+func (w logWrapper) Create(createEvent event.CreateEvent) bool {
+	logEntry := w.l.WithField("event", createEvent)
+	defer w.recover(logEntry)
+
+	result := w.p.Create(createEvent)
+	logEntry.
+		WithField("result", result).
+		Debugln("processed create event")
+
+	return result
+}
+
+func (w logWrapper) Delete(deleteEvent event.DeleteEvent) bool {
+	logEntry := w.l.WithField("event", deleteEvent)
+	defer w.recover(logEntry)
+
+	result := w.p.Delete(deleteEvent)
+	logEntry.
+		WithField("result", result).
+		Debugln("processed delete event")
+
+	return result
+}
+
+func (w logWrapper) Update(updateEvent event.UpdateEvent) bool {
+	logEntry := w.l.WithField("event", updateEvent)
+	defer w.recover(logEntry)
+
+	result := w.p.Update(updateEvent)
+	logEntry.
+		WithField("result", result).
+		Debugln("processed update event")
+
+	return result
+}
+
+func (w logWrapper) Generic(genericEvent event.GenericEvent) bool {
+	logEntry := w.l.WithField("event", genericEvent)
+	defer w.recover(logEntry)
+
+	result := w.p.Generic(genericEvent)
+	logEntry.
+		WithField("result", result).
+		Debugln("processed generic event")
+
+	return result
+}
+
+func (w logWrapper) recover(logEntry *logrus.Entry) {
+	r := recover()
+	if r == nil {
+		return
+	}
+
+	logEntry.
+		WithField("panic", r).
+		WithField("stack", debug.Stack()).
+		Errorln("recovered from panic")
+}
+
+type releasePhasePredicate struct{}
+
+func (rp releasePhasePredicate) Create(ev event.CreateEvent) bool {
+	if ev.Object == nil {
+		return false
+	}
+
+	switch ev.Object.(*v1alpha1.DeckhouseRelease).Status.Phase {
+	case v1alpha1.PhaseSkipped, v1alpha1.PhaseSuperseded, v1alpha1.PhaseSuspended, v1alpha1.PhaseDeployed:
+		return false
+	}
+	return true
+}
+
+// Delete returns true if the Delete event should be processed
+func (rp releasePhasePredicate) Delete(_ event.DeleteEvent) bool {
+	return false
+}
+
+// Update returns true if the Update event should be processed
+func (rp releasePhasePredicate) Update(ev event.UpdateEvent) bool {
+	if ev.ObjectNew == nil {
+		return false
+	}
+
+	switch ev.ObjectNew.(*v1alpha1.DeckhouseRelease).Status.Phase {
+	case v1alpha1.PhaseSkipped, v1alpha1.PhaseSuperseded, v1alpha1.PhaseSuspended, v1alpha1.PhaseDeployed:
+		return false
+	}
+	return true
+}
+
+// Generic returns true if the Generic event should be processed
+func (rp releasePhasePredicate) Generic(_ event.GenericEvent) bool {
+	return true
+}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/event_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/event_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deckhouse_release
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+)
+
+func TestEventFilter(t *testing.T) {
+	eventFilter := newEventFilter()
+
+	t.Run("Create Event", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			arg      event.CreateEvent
+			expected bool
+		}{
+			{
+				name: "Release without annotations",
+				arg: event.CreateEvent{
+					Object: &v1alpha1.DeckhouseRelease{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       v1alpha1.DeckhouseReleaseKind,
+							APIVersion: v1alpha1.DeckhouseReleaseGVK.GroupVersion().String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "v1.63.9",
+						},
+						Spec: v1alpha1.DeckhouseReleaseSpec{
+							Version: "v1.63.9",
+						},
+					},
+				},
+				expected: true,
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				got := eventFilter.Create(test.arg)
+				if got != test.expected {
+					t.Errorf("Event:\n%v\ngot %t\nexpected %t", string(must(yaml.Marshal(test.arg))), got, test.expected)
+				}
+			})
+		}
+	})
+}
+
+func must[T any](val T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+
+	return val
+}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/apply-now-deckhouse-previous-release-is-not-ready.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/apply-now-deckhouse-previous-release-is-not-ready.yaml
@@ -24,11 +24,11 @@ metadata:
     release.deckhouse.io/notified: "true"
   creationTimestamp: null
   name: v1.26.0
-  resourceVersion: "1002"
+  resourceVersion: "1001"
 spec:
   version: v1.26.0
 status:
-  approved: true
+  approved: false
   message: Waiting for Deckhouse pod to be ready
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/apply-now-manual-approval-mode-is-set.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/apply-now-manual-approval-mode-is-set.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   version: v1.26.0
 status:
-  approved: true
+  approved: false
   message: ""
   phase: Deployed
   transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-deploy-patch-release-in-manual-mode.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-deploy-patch-release-in-manual-mode.yaml
@@ -26,7 +26,7 @@ metadata:
   resourceVersion: "1002"
 spec:
   version: v1.25.1
-status:v1.26.0
+status:
   approved: false
   message: ""
   phase: Deployed

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/manual-approval-mode-with-canary-process.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/manual-approval-mode-with-canary-process.yaml
@@ -23,7 +23,7 @@ metadata:
     release.deckhouse.io/notified: "true"
   creationTimestamp: null
   name: v1.36.0
-  resourceVersion: "1001"
+  resourceVersion: "1002"
 spec:
   applyAfter: "2222-11-11T23:23:23Z"
   version: v1.36.0

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/no-update-windows-configured.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/no-update-windows-configured.yaml
@@ -23,11 +23,11 @@ metadata:
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   name: v1.26.0
-  resourceVersion: "1004"
+  resourceVersion: "1003"
 spec:
   version: v1.26.0
 status:
-  approved: true
+  approved: false
   message: ""
   phase: Deployed
   transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-out-of-update-window.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-out-of-update-window.yaml
@@ -23,11 +23,11 @@ metadata:
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   name: v1.25.1
-  resourceVersion: "1002"
+  resourceVersion: "1001"
 spec:
   version: v1.25.1
 status:
-  approved: true
+  approved: false
   message: ""
   phase: Deployed
   transitionTime: "2019-10-17T15:33:00Z"
@@ -38,14 +38,14 @@ kind: DeckhouseRelease
 metadata:
   creationTimestamp: null
   name: v1.26.0
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   version: v1.26.0
 status:
-  approved: true
+  approved: false
   message: ""
   phase: Pending
-  transitionTime: "2019-10-17T15:33:00Z"
+  transitionTime: null
 ---
 apiVersion: v1
 kind: Pod

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/pending-manual-release-on-cluster-bootstrap.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/pending-manual-release-on-cluster-bootstrap.yaml
@@ -23,14 +23,14 @@ metadata:
     release.deckhouse.io/notified: "true"
   creationTimestamp: null
   name: v1.46.0
-  resourceVersion: "1000"
+  resourceVersion: "1001"
 spec:
   version: v1.46.0
 status:
   approved: false
   message: Waiting for manual approval
   phase: Pending
-  transitionTime: "2023-05-20T10:10:10Z"
+  transitionTime: "2019-10-17T15:33:00Z"
 ---
 apiVersion: v1
 kind: Pod

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-apply-now-annotation-out-of-window.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-apply-now-annotation-out-of-window.yaml
@@ -23,11 +23,11 @@ metadata:
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   name: v1.26.0
-  resourceVersion: "1005"
+  resourceVersion: "1004"
 spec:
   version: v1.26.0
 status:
-  approved: true
+  approved: false
   message: ""
   phase: Deployed
   transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-notification-settings.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-notification-settings.yaml
@@ -24,15 +24,15 @@ metadata:
     release.deckhouse.io/notified: "true"
   creationTimestamp: null
   name: v1.26.0
-  resourceVersion: "1002"
+  resourceVersion: "1001"
 spec:
   applyAfter: "2021-01-01T14:30:00Z"
   version: v1.26.0
 status:
-  approved: true
+  approved: false
   message: ""
   phase: Pending
-  transitionTime: "2019-10-17T15:33:00Z"
+  transitionTime: null
 ---
 apiVersion: v1
 kind: Pod

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/shutdown-and-evicted-pods.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/shutdown-and-evicted-pods.yaml
@@ -23,11 +23,11 @@ metadata:
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   name: v1.26.0
-  resourceVersion: "1004"
+  resourceVersion: "1003"
 spec:
   version: v1.26.0
 status:
-  approved: true
+  approved: false
   message: ""
   phase: Deployed
   transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/suspend-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/suspend-release.yaml
@@ -18,15 +18,17 @@ apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
+  annotations:
+    release.deckhouse.io/suspended: "true"
   creationTimestamp: null
   name: v1.25.1
-  resourceVersion: "1001"
+  resourceVersion: "1000"
 spec:
   version: v1.25.1
 status:
   approved: false
   message: ""
-  phase: Suspended
+  phase: Skipped
   transitionTime: "2019-10-17T15:33:00Z"
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/update-in-day-window.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/update-in-day-window.yaml
@@ -23,11 +23,11 @@ metadata:
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   name: v1.26.0
-  resourceVersion: "1004"
+  resourceVersion: "1003"
 spec:
   version: v1.26.0
 status:
-  approved: true
+  approved: false
   message: ""
   phase: Deployed
   transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/update-minimal-notification-time-without-configuring-notification-webhook.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/update-minimal-notification-time-without-configuring-notification-webhook.yaml
@@ -24,15 +24,15 @@ metadata:
     release.deckhouse.io/notified: "true"
   creationTimestamp: null
   name: v1.26.0
-  resourceVersion: "1002"
+  resourceVersion: "1001"
 spec:
   applyAfter: "2021-01-01T15:30:00Z"
   version: v1.26.0
 status:
-  approved: true
+  approved: false
   message: ""
   phase: Pending
-  transitionTime: "2019-10-17T15:33:00Z"
+  transitionTime: null
 ---
 apiVersion: v1
 kind: Pod

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/update-out-of-day-window.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/update-out-of-day-window.yaml
@@ -23,11 +23,11 @@ metadata:
     release.deckhouse.io/notified: "true"
   creationTimestamp: null
   name: v1.26.0
-  resourceVersion: "1002"
+  resourceVersion: "1001"
 spec:
   version: v1.26.0
 status:
-  approved: true
+  approved: false
   message: 'Release is waiting for the update window: 04 Jan 21 08:00 UTC'
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/update-out-of-window.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/update-out-of-window.yaml
@@ -23,11 +23,11 @@ metadata:
     release.deckhouse.io/notified: "true"
   creationTimestamp: null
   name: v1.26.0
-  resourceVersion: "1002"
+  resourceVersion: "1001"
 spec:
   version: v1.26.0
 status:
-  approved: true
+  approved: false
   message: 'Release is waiting for the update window: 02 Jan 21 08:00 UTC'
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/update-release-is-deployed.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/update-release-is-deployed.yaml
@@ -61,13 +61,11 @@ status: {}
 ---
 apiVersion: v1
 data:
-  isUpdating: "false"
+  isUpdating: "true"
   notified: "false"
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: d8-release-data
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -93,7 +93,7 @@ func (suite *ControllerTestSuite) TearDownSubTest() {
 	got := suite.fetchResults()
 
 	if golden {
-		err := os.WriteFile(goldenFile, got, 0666)
+		err := os.WriteFile(goldenFile, got, 0o666)
 		require.NoError(suite.T(), err)
 	} else {
 		exp, err := os.ReadFile(goldenFile)
@@ -427,7 +427,7 @@ spec:
 func (suite *ControllerTestSuite) setupController(yamlDoc string) {
 	manifests := releaseutil.SplitManifests(yamlDoc)
 
-	var initObjects = make([]client.Object, 0, len(manifests))
+	initObjects := make([]client.Object, 0, len(manifests))
 	for _, manifest := range manifests {
 		obj := suite.assembleInitObject(manifest)
 		initObjects = append(initObjects, obj)

--- a/deckhouse-controller/pkg/helpers/deckhouse_settings.go
+++ b/deckhouse-controller/pkg/helpers/deckhouse_settings.go
@@ -35,29 +35,55 @@ type DeckhouseSettings struct {
 	ReleaseChannel string `json:"releaseChannel"`
 }
 
+func DefaultDeckhouseSettings() *DeckhouseSettings {
+	settings := &DeckhouseSettings{
+		ReleaseChannel: "",
+	}
+	settings.Update.Mode = "Auto"
+	settings.Update.DisruptionApprovalMode = "Auto"
+
+	return settings
+}
+
 func NewDeckhouseSettingsContainer(spec *DeckhouseSettings) *DeckhouseSettingsContainer {
-	return &DeckhouseSettingsContainer{spec: spec}
+	return &DeckhouseSettingsContainer{settings: spec, inited: make(chan struct{})}
 }
 
 type DeckhouseSettingsContainer struct {
-	spec *DeckhouseSettings
-	lock sync.Mutex
+	settings *DeckhouseSettings
+	lock     sync.Mutex
+	inited   chan struct{}
 }
 
 func (c *DeckhouseSettingsContainer) Set(settings *DeckhouseSettings) {
+	if settings == nil {
+		panic("argument should be defined")
+	}
+
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	c.spec.ReleaseChannel = settings.ReleaseChannel
-	c.spec.Update.Mode = settings.Update.Mode
-	c.spec.Update.Windows = settings.Update.Windows
-	c.spec.Update.DisruptionApprovalMode = settings.Update.DisruptionApprovalMode
-	c.spec.Update.NotificationConfig = settings.Update.NotificationConfig
+	if c.settings == nil {
+		c.settings = DefaultDeckhouseSettings()
+		close(c.inited)
+	}
+
+	c.settings.ReleaseChannel = settings.ReleaseChannel
+	c.settings.Update.Mode = settings.Update.Mode
+	c.settings.Update.Windows = settings.Update.Windows
+	c.settings.Update.DisruptionApprovalMode = settings.Update.DisruptionApprovalMode
+	c.settings.Update.NotificationConfig = settings.Update.NotificationConfig
 }
 
 func (c *DeckhouseSettingsContainer) Get() *DeckhouseSettings {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	return c.spec
+	if c.settings == nil {
+		c.lock.Unlock()
+		<-c.inited
+		c.lock.Lock()
+	}
+
+	return c.settings
 }


### PR DESCRIPTION
## Description

## Description
Fixed a bug related to the fact that the state of the release object was not updated

(cherry picked from commit f482a320027e19cc154a53c20cf3c8bb524169ee)

## Why do we need it, and what problem does it solve?
Close https://github.com/deckhouse/deckhouse/issues/9823

## Why do we need it in the patch release (if we do)?
The issue is relevant for the current production
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fixed a bug related to the fact that the state of the release object was not updated.
impact_level: default
```
