### PR TITLE
[cloud-provider-yandex][docs] Remove obsolete info about resize pvc

### DIFF
--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION.md
@@ -19,16 +19,6 @@ The module automatically creates StorageClasses covering all available disks in 
 
 You can filter out the unnecessary StorageClasses via the [exclude](#parameters-storageclass-exclude) parameter.
 
-### Important information concerning the increase of the PVC size
-
-Due to the [nature](https://github.com/kubernetes-csi/external-resizer/issues/44) of volume-resizer, CSI, and Yandex Cloud API, you have to do the following after increasing the PVC size:
-
-1. On the node where the Pod is located, run the `kubectl cordon <node_name>` command.
-2. Delete the Pod.
-3. Make sure that the resize was successful. The PVC object *must not have* the `Resizing` state.
-   > The `FileSystemResizePending` state is OK.
-4. On the node where the Pod is located, run the `kubectl uncordon <node_name>` command.
-
 ## LoadBalancer
 
 The module subscribes to Service objects of the `LoadBalancer` type and creates the corresponding `NetworkLoadBalancer` and `TargetGroup` in Yandex Cloud.

--- a/modules/030-cloud-provider-yandex/docs/CONFIGURATION_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/CONFIGURATION_RU.md
@@ -19,16 +19,6 @@ title: "Cloud provider — Yandex Cloud: настройки"
 
 Вы можете отфильтровать ненужные StorageClass'ы с помощью параметра [exclude](#parameters-storageclass-exclude).
 
-### Важная информация об увеличении размера PVC
-
-Из-за [особенностей](https://github.com/kubernetes-csi/external-resizer/issues/44) работы volume-resizer, CSI и Yandex Cloud API после увеличения размера PVC необходимо:
-
-1. На узле, где находится под, выполнить команду `kubectl cordon <имя_узла>`.
-2. Удалить под.
-3. Убедиться, что увеличение размера произошло успешно. В объекте PVC *не будет* condition `Resizing`.
-   > Состояние `FileSystemResizePending` не является проблемой.
-4. На узле, где находится под, выполнить команду `kubectl uncordon <имя_узла>`.
-
 ## LoadBalancer
 
 Модуль подписывается на объекты Service с типом `LoadBalancer` и создает соответствующие `NetworkLoadBalancer` и `TargetGroup` в Yandex Cloud.


### PR DESCRIPTION
## Description
Information about resize PVC with cordon and delete pod not actual. Resize PVC goes online.

I just increase size in pvc and all works fine (without any manual operations like cordon node, delete pod)

```
~ $ kubectl get events -A | grep test-pvc
test-pvc     9m21s       Normal    FileSystemResizeSuccessful   pod/nginx-7d444d87dc-nz8vp                                     MountVolume.NodeExpandVolume succeeded for volume "pvc-1fdced6c-ba85-40ae-a5fa-0c690e1f4fa4" kovalkov-worker-59c3b116-5c8bd-nsv9b
test-pvc     9m53s       Normal    Resizing                     persistentvolumeclaim/nginx-pv-claim                           External resizer is resizing volume pvc-1fdced6c-ba85-40ae-a5fa-0c690e1f4fa4
test-pvc     9m53s       Warning   ExternalExpanding            persistentvolumeclaim/nginx-pv-claim                           waiting for an external controller to expand this PVC
test-pvc     9m34s       Normal    FileSystemResizeRequired     persistentvolumeclaim/nginx-pv-claim                           Require file system resize of volume on node
test-pvc     9m21s       Normal    FileSystemResizeSuccessful   persistentvolumeclaim/nginx-pv-claim                           MountVolume.NodeExpandVolume succeeded for volume "pvc-1fdced6c-ba85-40ae-a5fa-0c690e1f4fa4" kovalkov-worker-59c3b116-5c8bd-nsv9b
```

On node, where PVC was mounted in dmesg i also had event with resize (I resized PVC from 2G to 4G)
```
[10712.459638] virtio_blk virtio3: [vdb] new size: 8388608 512-byte logical blocks (4.29 GB/4.00 GiB)
[10712.459646] vdb: detected capacity change from 4194304 to 8388608
[10735.361518] EXT4-fs (vdb): resizing filesystem from 524288 to 1048576 blocks
[10735.490336] EXT4-fs (vdb): resized filesystem to 1048576
```

Also, in https://github.com/kubernetes-csi/external-resizer/issues/44#issuecomment-548766333 we have message, that this problem was solved.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: chore
summary: Remove obsolete info about resize pvc
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
