### PR TITLE
[candi] Fix failed step reboot by bootstrap

### DIFF
--- a/candi/bashible/common-steps/all/099_reboot.sh.tpl
+++ b/candi/bashible/common-steps/all/099_reboot.sh.tpl
@@ -29,7 +29,7 @@ bb-flag-unset reboot
 # If it is first run bashible on bootstrap simple reboot node
 if [ "$FIRST_BASHIBLE_RUN" == "yes" ]; then
   bb-flag-unset disruption
-  shutdown -r now
+  shutdown -r -t 5
   exit 0
 fi
 
@@ -42,7 +42,7 @@ fi
 # We want bootstrap the node fully, reboot it and after reboot join the node into the cluster.
 if [ ! -f "/etc/kubernetes/kubelet.conf" ]; then
   bb-flag-unset disruption
-  shutdown -r now
+  shutdown -r -t 5
   exit 0
 fi
 
@@ -108,4 +108,4 @@ while true; do
 done
 
 bb-flag-unset disruption
-shutdown -r now
+shutdown -r -t 5


### PR DESCRIPTION
## Description
Switch `shutdown -r now` to delayed `shutdown -r -t 5` for able to correctly execute all scripts in bundle by bootstrap. 

## Why do we need it, and what problem does it solve?
Now we have failed reboot step and twice execute for execute bundle

```
┌ Execute bundle
│ ┌ ⛵ ~ Bootstrap: Checking bashible is ready
│ └ ⛵ ~ Bootstrap: Checking bashible is ready (0.49 seconds)
│
│ ┌ ⛵ ~ Bootstrap: Cleanup previous bashible run if need
│ │ Bashible instance not found. Start it!
│ └ ⛵ ~ Bootstrap: Cleanup previous bashible run if need (0.49 seconds)
│
│ ┌ Run step 000_add_node_users.sh
│ │ --- A lot of success log removed ---
│ └ Run step 098_set_permissions.sh (0.07 seconds)
│
│ ┌ Run step 099_reboot.sh
│ └ Run step 099_reboot.sh (0.17 seconds) FAILED
│
│ ️⛱️️ Attempt #1 of 30 |
│ 	Execute bundle failed, next attempt will be in 10s"
│ 	Error: bundle 'bashible' error: execute bundle: exit status 255
│ stderr: Warning: Permanently added '212.233.121.177' (ED25519) to the list of known hosts.
│ Connection to 212.233.121.177 closed by remote host.
│ Connection to 212.233.121.177 closed.
│
│
│ ┌ ⛵ ~ Bootstrap: Checking bashible is ready
│ └ ⛵ ~ Bootstrap: Checking bashible is ready (6.46 seconds) FAILED
│
│ ️⛱️️ Attempt #2 of 30 |
│ 	Execute bundle failed, next attempt will be in 10s"
│ 	Error: exit status 255
│
│ ┌ ⛵ ~ Bootstrap: Checking bashible is ready
│ └ ⛵ ~ Bootstrap: Checking bashible is ready (0.49 seconds)
│
│ ┌ ⛵ ~ Bootstrap: Cleanup previous bashible run if need
│ │ Bashible instance not found. Start it!
│ └ ⛵ ~ Bootstrap: Cleanup previous bashible run if need (0.51 seconds)
│
│ ┌ Run step 000_add_node_users.sh
│ │ --- A lot of success log removed ---
│ └ Run step 098_set_permissions.sh (0.06 seconds)
│
│ ┌ Run step 099_reboot.sh
│ └ Run step 099_reboot.sh (0.02 seconds)
│
│ ┌ Run step 099_upd_tfadm.sh
│ └ Run step 099_upd_tfadm.sh (0.04 seconds)
│
│ 🎉 Succeeded!
└ Execute bundle (140.93 seconds)
```
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
Not critical problem, but better bootstrap process. Less time (because we do not execute bundle twice).
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Execute bundle works by 1 attempt
```
┌ Execute bundle
│ ┌ ⛵ ~ Bootstrap: Checking bashible is ready
│ └ ⛵ ~ Bootstrap: Checking bashible is ready (0.47 seconds)
│
│ ┌ ⛵ ~ Bootstrap: Cleanup previous bashible run if need
│ │ Bashible instance not found. Start it!
│ └ ⛵ ~ Bootstrap: Cleanup previous bashible run if need (0.52 seconds)
│
│ ┌ Run step 000_add_node_users.sh
│ │ --- A lot of success log removed ---
│ └ Run step 098_set_permissions.sh (0.06 seconds)
│
│ ┌ Run step 099_reboot.sh
│ └ Run step 099_reboot.sh (0.04 seconds)
│
│ ┌ Run step 099_upd_tfadm.sh
│ └ Run step 099_upd_tfadm.sh (0.04 seconds)
│
│ 🎉 Succeeded!
└ Execute bundle (96.66 seconds)
```
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Switch immediately reboot to delayed reboot in reboot step for able to correctly execute all scripts in bundle by bootstrap.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
