### PR TITLE
[docs][getting-started] Refactor description generation in GS pages

### DIFF
--- a/docs/site/_data/i18n.yaml
+++ b/docs/site/_data/i18n.yaml
@@ -179,6 +179,9 @@ common:
   includes_rules_from:
     en: includes all rules from the role
     ru: включает все правила из роли
+  gs_description:
+    en: Getting Started. <TITLE>. <STEP>
+    ru: Быстрый старт. <TITLE>. <STEP>
 
 comparison:
   except_parameters:

--- a/docs/site/_includes/head.html
+++ b/docs/site/_includes/head.html
@@ -37,12 +37,14 @@
 <title>{{ generated_title }} | {{ site.site_title }}</title>
 {%- if page.description %}
     {%- assign description = page.description | strip_html | strip_newlines | strip | truncate: 200 %}
-{%- else %}
+{% else %}
     {%- assign pageCommonName = page.name | replace: '_RU.md', '' | replace: '.md', '' | downcase %}
     {%- if pageCommonName == "configuration" or pageCommonName == "cr" or pageCommonName == "examples" or pageCommonName == "usage" or pageCommonName == "faq"  %}
         {%- assign i18nKey = 'description_' | append: pageCommonName %}
         {%- assign description = site.data.i18n.common[i18nKey][page.lang] | replace: '<MODULENAME>', page['module-kebab-name'] %}
-    {%- else %}
+    {%- elsif page.platform_type %}
+        {%- assign description = site.data.i18n.common['gs_description'][page.lang] | replace: '<TITLE>', page.title_main | replace: '<STEP>', page.step_name %}
+    {% else %}
         {%- assign description = page.content | markdownify | strip_html | normalizeSearchContent | strip_newlines | strip | truncate: 200 %}
     {%- endif %}
 {%- endif %}

--- a/docs/site/_includes/head.html
+++ b/docs/site/_includes/head.html
@@ -37,14 +37,14 @@
 <title>{{ generated_title }} | {{ site.site_title }}</title>
 {%- if page.description %}
     {%- assign description = page.description | strip_html | strip_newlines | strip | truncate: 200 %}
-{% else %}
+{%- else %}
     {%- assign pageCommonName = page.name | replace: '_RU.md', '' | replace: '.md', '' | downcase %}
     {%- if pageCommonName == "configuration" or pageCommonName == "cr" or pageCommonName == "examples" or pageCommonName == "usage" or pageCommonName == "faq"  %}
         {%- assign i18nKey = 'description_' | append: pageCommonName %}
         {%- assign description = site.data.i18n.common[i18nKey][page.lang] | replace: '<MODULENAME>', page['module-kebab-name'] %}
     {%- elsif page.platform_type %}
         {%- assign description = site.data.i18n.common['gs_description'][page.lang] | replace: '<TITLE>', page.title_main | replace: '<STEP>', page.step_name %}
-    {% else %}
+    {%- else %}
         {%- assign description = page.content | markdownify | strip_html | normalizeSearchContent | strip_newlines | strip | truncate: 200 %}
     {%- endif %}
 {%- endif %}

--- a/docs/site/pages/guides/PRODUCTION.md
+++ b/docs/site/pages/guides/PRODUCTION.md
@@ -1,6 +1,7 @@
 ---
 title: Going to Production
 permalink: en/guides/production.html
+description: Recommendations for preparing Deckhouse Kubernetes Platform cluster for production environment.
 ---
 
 The following recommendations may be of less importance for a test or development cluster, but they may be critical for a production one.

--- a/docs/site/pages/guides/PRODUCTION_RU.md
+++ b/docs/site/pages/guides/PRODUCTION_RU.md
@@ -1,6 +1,7 @@
 ---
 title: Подготовка к production
 permalink: ru/guides/production.html
+description: Рекомендации по подготовке Deckhouse Kubernetes Platform для работы в продуктивной среде.
 lang: ru
 ---
 

--- a/docs/site/pages/guides/PRODUCTION_RU.md
+++ b/docs/site/pages/guides/PRODUCTION_RU.md
@@ -1,7 +1,7 @@
 ---
 title: Подготовка к production
 permalink: ru/guides/production.html
-description: Рекомендации по подготовке Deckhouse Kubernetes Platform для работы в продуктивной среде.
+description: Рекомендации по подготовке кластера Deckhouse Kubernetes Platform для работы в продуктивной среде.
 lang: ru
 ---
 


### PR DESCRIPTION
## Description

- Fix description generation on Getting Started pages
- Add the description for the guide.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fix description generation on Getting Started pages. Add the description for the guide.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
