### PR TITLE
[control-plane-manager] Fixed free space sufficiency detection for etcd-backup

### DIFF
--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -536,7 +536,7 @@ When deciding on the appropriate threshold values, consider resources consumed b
 
 ### What is done automatically
 
-CronJob `kube-system/d8-etcd-backup-*` is automatically started at 00:00 UTC+0. The result is saved in `/var/lib/etcd/etcd-backup.snapshot` on all nodes with `control-plane` in the cluster (master nodes).
+CronJob `kube-system/d8-etcd-backup-*` is automatically started at 00:00 UTC+0. The result is saved in `/var/lib/etcd/etcd-backup.tar.gz` on all nodes with `control-plane` in the cluster (master nodes).
 
 ### How to manually backup etcd
 
@@ -563,7 +563,7 @@ tar -cvzf kube-backup.tar.gz ./etcd-backup.snapshot ./kubernetes/
 rm -r ./kubernetes ./etcd-backup.snapshot
 ```
 
-In the current directory etcd snapshot file `etcd-backup.snapshot` will be created from one of an etcd cluster members.
+In the current directory etcd snapshot file `kube-backup.tar.gz` will be created from one of an etcd cluster members.
 From this file, you can restore the previous etcd cluster state in the future.
 
 Also, we recommend making a backup of the `/etc/kubernetes` directory, which contains:

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -554,6 +554,7 @@ Login into any control-plane node with `root` user and use next script:
 
 ```bash
 #!/usr/bin/env bash
+set -e
 
 pod=etcd-`hostname`
 kubectl -n kube-system exec "$pod" -- /usr/bin/etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ snapshot save /var/lib/etcd/${pod##*/}.snapshot && \

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -529,7 +529,7 @@ spec:
 
 ### Что делается автоматически
 
-Автоматически запускаются CronJob `kube-system/d8-etcd-backup-*` в 00:00 по UTC+0. Результат сохраняется в `/var/lib/etcd/etcd-backup.snapshot` на всех узлах с `control-plane` в кластере (мастер-узлы).
+Автоматически запускаются CronJob `kube-system/d8-etcd-backup-*` в 00:00 по UTC+0. Результат сохраняется в `/var/lib/etcd/etcd-backup.tar.gz` на всех узлах с `control-plane` в кластере (мастер-узлы).
 
 ### Как сделать бэкап etcd вручную
 
@@ -556,7 +556,7 @@ tar -cvzf kube-backup.tar.gz ./etcd-backup.snapshot ./kubernetes/
 rm -r ./kubernetes ./etcd-backup.snapshot
 ```
 
-В текущей директории будет создан файл `etcd-backup.snapshot` со снимком базы etcd одного из членов etcd-кластера.
+В текущей директории будет создан файл `kube-backup.tar.gz` со снимком базы etcd одного из членов etcd-кластера.
 Из полученного снимка можно будет восстановить состояние кластера etcd.
 
 Также рекомендуем сделать бэкап директории `/etc/kubernetes`, в которой находятся:

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -547,6 +547,7 @@ d8 backup etcd --kubeconfig $KUBECONFIG ./etcd.db
 
 ```bash
 #!/usr/bin/env bash
+set -e
 
 pod=etcd-`hostname`
 kubectl -n kube-system exec "$pod" -- /usr/bin/etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ snapshot save /var/lib/etcd/${pod##*/}.snapshot && \

--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -5,10 +5,10 @@ etcd=etcd-backup.snapshot
 archive=etcd-backup.tar.gz
 etcdctl --endpoints=https://127.0.0.1:2379 --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt --key=/etc/kubernetes/pki/etcd/healthcheck-client.key snapshot save "${etcd}"
 tar -czvf "${archive}" "${etcd}"
-# Check that there will be 30% free space left after adding the file.
+# Check that there will be 30% free space left after adding the file
 if [ $(df /var/lib/etcd/ | tail -1 | awk '{printf "%.0f\n", $4 - ($2 * 0.3)}') -ge $(du -k "${archive}" | awk '{print $1}') ]; then
     cp "${archive}" "/var/lib/etcd/${archive}"
 else
-    echo "Free space in /var/lib/etcd/ is too small for backup should be more than 30%."
+    echo "Free space in /var/lib/etcd/ is too small for backup should be more than 30%"
     exit 1
 fi

--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -27,7 +27,7 @@ etcdctl \
 tar -czvf "${archive}" "${etcd}"
 # Check that there will be 25% free space left after adding the file
 if [ $(df /var/lib/etcd/ | tail -1 | awk '{printf "%.0f\n", $4 - ($2 * 0.25)}') -ge $(du -k "${archive}" | awk '{print $1}') ]; then
-    chmod 0500 "${archive}"
+    chmod 0600 "${archive}"
     mv "${archive}" "/var/lib/etcd/${archive}"
     # remove after 1.66 Old version.
     rm -f /var/lib/etcd/etcd-backup.snapshot

--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
+
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -xe
 cd /tmp/
 etcd=etcd-backup.snapshot

--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -28,6 +28,8 @@ tar -czvf "${archive}" "${etcd}"
 # Check that there will be 25% free space left after adding the file
 if [ $(df /var/lib/etcd/ | tail -1 | awk '{printf "%.0f\n", $4 - ($2 * 0.25)}') -ge $(du -k "${archive}" | awk '{print $1}') ]; then
     cp "${archive}" "/var/lib/etcd/${archive}"
+    # remove after 1.66 Old version.
+    rm -f /var/lib/etcd/etcd-backup.snapshot
 else
     echo "Free space in /var/lib/etcd/ is too small for backup should be more than 25%"
     exit 1

--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -27,7 +27,8 @@ etcdctl \
 tar -czvf "${archive}" "${etcd}"
 # Check that there will be 25% free space left after adding the file
 if [ $(df /var/lib/etcd/ | tail -1 | awk '{printf "%.0f\n", $4 - ($2 * 0.25)}') -ge $(du -k "${archive}" | awk '{print $1}') ]; then
-    cp "${archive}" "/var/lib/etcd/${archive}"
+    chmod 0500 "${archive}"
+    mv "${archive}" "/var/lib/etcd/${archive}"
     # remove after 1.66 Old version.
     rm -f /var/lib/etcd/etcd-backup.snapshot
 else

--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -10,10 +10,10 @@ etcdctl \
     --key=/etc/kubernetes/pki/etcd/healthcheck-client.key \
     snapshot save "${etcd}"
 tar -czvf "${archive}" "${etcd}"
-# Check that there will be 30% free space left after adding the file
-if [ $(df /var/lib/etcd/ | tail -1 | awk '{printf "%.0f\n", $4 - ($2 * 0.3)}') -ge $(du -k "${archive}" | awk '{print $1}') ]; then
+# Check that there will be 25% free space left after adding the file
+if [ $(df /var/lib/etcd/ | tail -1 | awk '{printf "%.0f\n", $4 - ($2 * 0.25)}') -ge $(du -k "${archive}" | awk '{print $1}') ]; then
     cp "${archive}" "/var/lib/etcd/${archive}"
 else
-    echo "Free space in /var/lib/etcd/ is too small for backup should be more than 30%"
+    echo "Free space in /var/lib/etcd/ is too small for backup should be more than 25%"
     exit 1
 fi

--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -xe
+cd /tmp/
+etcd=etcd-backup.snapshot
+archive=etcd-backup.tar.gz
+etcdctl --endpoints=https://127.0.0.1:2379 --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt --key=/etc/kubernetes/pki/etcd/healthcheck-client.key snapshot save "${etcd}"
+tar -czvf "${archive}" "${etcd}"
+# Check that there will be 30% free space left after adding the file.
+if [ $(df /var/lib/etcd/ | tail -1 | awk '{printf "%.0f\n", $4 - ($2 * 0.3)}') -ge $(du -k "${archive}" | awk '{print $1}') ]; then
+    cp "${archive}" "/var/lib/etcd/${archive}"
+else
+    echo "Free space in /var/lib/etcd/ is too small for backup should be more than 30%."
+    exit 1
+fi

--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -3,7 +3,12 @@ set -xe
 cd /tmp/
 etcd=etcd-backup.snapshot
 archive=etcd-backup.tar.gz
-etcdctl --endpoints=https://127.0.0.1:2379 --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt --key=/etc/kubernetes/pki/etcd/healthcheck-client.key snapshot save "${etcd}"
+etcdctl \
+    --endpoints=https://127.0.0.1:2379 \
+    --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+    --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt \
+    --key=/etc/kubernetes/pki/etcd/healthcheck-client.key \
+    snapshot save "${etcd}"
 tar -czvf "${archive}" "${etcd}"
 # Check that there will be 30% free space left after adding the file
 if [ $(df /var/lib/etcd/ | tail -1 | awk '{printf "%.0f\n", $4 - ($2 * 0.3)}') -ge $(du -k "${archive}" | awk '{print $1}') ]; then

--- a/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
@@ -1,7 +1,13 @@
-{{- $binaries := "/bin/sh /bin/cp /bin/df /bin/du /bin/tail /bin/awk" }}
+{{- $binaries := "/bin/sh /bin/cp /bin/df /bin/du /bin/tail /bin/awk /bin/tar" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
+git:
+- add: /{{ $.ModulePath }}/modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/entrypoint.sh
+  to: /entrypoint.sh
+  stageDependencies:
+    setup:
+    - '**/*'
 import:
 - artifact: {{ .ModuleName }}/etcd-artifact
   add: /etcdctl
@@ -11,6 +17,8 @@ import:
   add: /relocate
   to: /
   before: setup
+docker:
+  ENTRYPOINT: ["/entrypoint.sh"]
 ---
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ .Images.BASE_ALT_P11 }}

--- a/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $binaries := "/bin/sh /bin/cp /bin/df /bin/du /bin/tail /bin/awk /bin/tar /bin/gzip" }}
+{{- $binaries := "/bin/sh /bin/mv /bin/df /bin/du /bin/tail /bin/awk /bin/tar /bin/gzip /bin/rm /bin/chmod" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless

--- a/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $binaries := "/bin/sh /bin/cp /bin/df /bin/du /bin/tail /bin/awk /bin/tar" }}
+{{- $binaries := "/bin/sh /bin/cp /bin/df /bin/du /bin/tail /bin/awk /bin/tar /bin/gzip" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless

--- a/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
+++ b/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
@@ -37,11 +37,6 @@ spec:
             {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" $ | nindent 12 }}
             image: {{ include "helm_lib_module_image" (list $ "etcdBackup") }}
             imagePullPolicy: IfNotPresent
-            command:
-            - /bin/sh
-            - -c
-            - --
-            - set -x; etcdctl --endpoints=https://127.0.0.1:2379 --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt --key=/etc/kubernetes/pki/etcd/healthcheck-client.key snapshot save /tmp/etcd-backup.snapshot && [ $(df /var/lib/etcd/ | tail -1 | awk '{print $4}') -ge $(du -k /tmp/etcd-backup.snapshot | awk '{print $1}') ] && cp /tmp/etcd-backup.snapshot /var/lib/etcd/etcd-backup.snapshot || exit 1
             resources:
               requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 50 | nindent 16 }}


### PR DESCRIPTION
## Description
Corrected the check of sufficient free space it should remain more than 25% after copying the archive.
Added etcd dump compression.
Corrected documentation.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
The past check was not safe for etcd and may have depleted the free disk space under etcd.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
The change should go to the branch where it was added to avoid future problems.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix 
summary: Fixed free space sufficiency detection for etcd-backup
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
