### PR TITLE
[secret-copier] Allow secret-copier secrets deletion by user

### DIFF
--- a/modules/600-secret-copier/templates/validation.yml
+++ b/modules/600-secret-copier/templates/validation.yml
@@ -9,7 +9,7 @@ spec:
   auditAnnotations:
     - key: source-user
       valueExpression: '''User: '' + string(request.userInfo.username) + '' tries to
-      create secret with `secret-copier.deckhouse.io/enabled` label outside of `default` namespace'''
+      create or update secret with `secret-copier.deckhouse.io/enabled` label outside of `default` namespace'''
   failurePolicy: Fail
   matchConstraints:
     matchPolicy: Equivalent
@@ -23,7 +23,6 @@ spec:
         operations:
           - CREATE
           - UPDATE
-          - DELETE
         resources:
           - 'secrets'
         scope: 'Namespaced'
@@ -31,7 +30,7 @@ spec:
   - expression: request.userInfo.username == "system:serviceaccount:d8-system:deckhouse"
     reason: Forbidden
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
-    messageExpression: '''Creating secrets with `secret-copier.deckhouse.io/enabled` label outside of `default` namespace is forbidden'''
+    messageExpression: '''Creating or updating secrets with `secret-copier.deckhouse.io/enabled` label outside of `default` namespace is forbidden'''
 {{- end }}
 ---
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}


### PR DESCRIPTION
## Description
Allow deletion of secrets copied by `secret-copier` in the `ValidatingAdmissionPolicy`. It's needed e.g. when deleting a namespace.

## Why do we need it, and what problem does it solve?
Fix after PR https://github.com/deckhouse/deckhouse/pull/10066

Valid deletion of a secret in a namespace due to delete was throwing an error:
```
$ k -n network-policy delete secrets registrysecret
Error from server (Forbidden): secrets "registrysecret" is forbidden: ValidatingAdmissionPolicy 'secret-copier-label.deckhouse.io' with binding 'secret-copier-label.deckhouse.io' denied request: Creating secrets with `secret-copier.deckhouse.io/enabled` label outside of `default` namespace is forbidden
```

## Why do we need it in the patch release (if we do)?

It fixes a bug (not a breaking one, but still)

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: secret-copier
type: chore
summary: Allow deletion by user of secrets created by secret-copier
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
