### PR TITLE
[prometheus-metrics-adapter] Review wildcard RBAC

### DIFF
--- a/modules/301-prometheus-metrics-adapter/templates/rbac-for-us.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/rbac-for-us.yaml
@@ -97,7 +97,7 @@ rules:
 - apiGroups:
   - external.metrics.k8s.io
   resources:
-  - '*'
+  - '*' # In this case "resource" is the arbitrary metric name, so we have to use a wildcard
   verbs:
   - get
   - list

--- a/testing/matrix/linter/rules/roles/wildcards.go
+++ b/testing/matrix/linter/rules/roles/wildcards.go
@@ -43,6 +43,10 @@ var skipCheckWildcards = map[string][]string{
 		// We read all resources from the `deckhouse.io` api group
 		"d8:deckhouse:webhook-handler",
 	},
+	"prometheus-metrics-adapter/templates/rbac-for-us.yaml": {
+		// In the case of external.metrics.k8s.io, the "resource" is a metric with an arbitrary name, so we have to use a wildcard.
+		"d8:prometheus-metrics-adapter:horizontal-pod-autoscaler-external-metrics",
+	},
 	"vertical-pod-autoscaler/templates/rbac-for-us.yaml": {
 		// VPA can scale CR and must have access to */scale subresources.
 		"d8:vertical-pod-autoscaler:controllers-reader",
@@ -64,9 +68,6 @@ var skipCheckWildcards = map[string][]string{
 	},
 	"operator-prometheus/templates/rbac-for-us.yaml": {
 		"d8:operator-prometheus",
-	},
-	"prometheus-metrics-adapter/templates/rbac-for-us.yaml": {
-		"d8:prometheus-metrics-adapter:horizontal-pod-autoscaler-external-metrics",
 	},
 	"ingress-nginx/templates/kruise/rbac-for-us.yaml": {
 		"d8:ingress-nginx:kruise-role",


### PR DESCRIPTION
## Description
Review the wildcards in the `prometheus-metrics-adapter` module

## Why do we need it, and what problem does it solve?
Clarify the necessity of the wildcard in the module RBACs.

## Why do we need it in the patch release (if we do)?
We don't

## What is the expected result?
No functional changes. This PR adds few comments about the issue

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
