### PR TITLE
[1.64] [dhctl] fix(dhctl-for-commander): fix nil CommonOptions handling

### DIFF
--- a/dhctl/pkg/server/rpc/dhctl/abort.go
+++ b/dhctl/pkg/server/rpc/dhctl/abort.go
@@ -193,7 +193,7 @@ func (s *Service) abort(
 	app.ResourcesTimeout = request.Options.ResourcesTimeout.AsDuration()
 	app.DeckhouseTimeout = request.Options.DeckhouseTimeout.AsDuration()
 	app.CacheDir = s.cacheDir
-	app.ApplyPreflightSkips(request.Options.CommonOptions.SkipPreflightChecks)
+	applyPreflightSkips(request.Options.CommonOptions)
 
 	log.InfoF("Task is running by DHCTL Server pod/%s\n", s.podName)
 	defer func() {

--- a/dhctl/pkg/server/rpc/dhctl/bootstrap.go
+++ b/dhctl/pkg/server/rpc/dhctl/bootstrap.go
@@ -192,7 +192,7 @@ func (s *Service) bootstrap(
 	app.SanityCheck = true
 	app.UseTfCache = app.UseStateCacheYes
 	app.CacheDir = s.cacheDir
-	app.ApplyPreflightSkips(request.Options.CommonOptions.SkipPreflightChecks)
+	applyPreflightSkips(request.Options.CommonOptions)
 
 	log.InfoF("Task is running by DHCTL Server pod/%s\n", s.podName)
 	defer func() {

--- a/dhctl/pkg/server/rpc/dhctl/check.go
+++ b/dhctl/pkg/server/rpc/dhctl/check.go
@@ -169,7 +169,7 @@ func (s *Service) check(
 	app.ResourcesTimeout = request.Options.ResourcesTimeout.AsDuration()
 	app.DeckhouseTimeout = request.Options.DeckhouseTimeout.AsDuration()
 	app.CacheDir = s.cacheDir
-	app.ApplyPreflightSkips(request.Options.CommonOptions.SkipPreflightChecks)
+	applyPreflightSkips(request.Options.CommonOptions)
 
 	log.InfoF("Task is running by DHCTL Server pod/%s\n", s.podName)
 	defer func() {

--- a/dhctl/pkg/server/rpc/dhctl/commander_attach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_attach.go
@@ -192,7 +192,7 @@ func (s *Service) CommanderAttachCluster(
 	app.ResourcesTimeout = request.Options.ResourcesTimeout.AsDuration()
 	app.DeckhouseTimeout = request.Options.DeckhouseTimeout.AsDuration()
 	app.CacheDir = s.cacheDir
-	app.ApplyPreflightSkips(request.Options.CommonOptions.SkipPreflightChecks)
+	applyPreflightSkips(request.Options.CommonOptions)
 
 	log.InfoF("Task is running by DHCTL Server pod/%s\n", s.podName)
 	defer func() {

--- a/dhctl/pkg/server/rpc/dhctl/commander_detach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_detach.go
@@ -170,7 +170,7 @@ func (s *Service) CommanderDetachCluster(
 	app.ResourcesTimeout = request.Options.ResourcesTimeout.AsDuration()
 	app.DeckhouseTimeout = request.Options.DeckhouseTimeout.AsDuration()
 	app.CacheDir = s.cacheDir
-	app.ApplyPreflightSkips(request.Options.CommonOptions.SkipPreflightChecks)
+	applyPreflightSkips(request.Options.CommonOptions)
 
 	log.InfoF("Task is running by DHCTL Server pod/%s\n", s.podName)
 	defer func() {

--- a/dhctl/pkg/server/rpc/dhctl/converge.go
+++ b/dhctl/pkg/server/rpc/dhctl/converge.go
@@ -195,7 +195,7 @@ func (s *Service) converge(
 	app.ResourcesTimeout = request.Options.ResourcesTimeout.AsDuration()
 	app.DeckhouseTimeout = request.Options.DeckhouseTimeout.AsDuration()
 	app.CacheDir = s.cacheDir
-	app.ApplyPreflightSkips(request.Options.CommonOptions.SkipPreflightChecks)
+	applyPreflightSkips(request.Options.CommonOptions)
 
 	log.InfoF("Task is running by DHCTL Server pod/%s\n", s.podName)
 	defer func() {

--- a/dhctl/pkg/server/rpc/dhctl/destroy.go
+++ b/dhctl/pkg/server/rpc/dhctl/destroy.go
@@ -194,7 +194,7 @@ func (s *Service) destroy(
 	app.ResourcesTimeout = request.Options.ResourcesTimeout.AsDuration()
 	app.DeckhouseTimeout = request.Options.DeckhouseTimeout.AsDuration()
 	app.CacheDir = s.cacheDir
-	app.ApplyPreflightSkips(request.Options.CommonOptions.SkipPreflightChecks)
+	applyPreflightSkips(request.Options.CommonOptions)
 
 	log.InfoF("Task is running by DHCTL Server pod/%s\n", s.podName)
 	defer func() {

--- a/dhctl/pkg/server/rpc/dhctl/service.go
+++ b/dhctl/pkg/server/rpc/dhctl/service.go
@@ -184,6 +184,12 @@ func onCheckResult(checkRes *check.CheckResult) error {
 	return nil
 }
 
+func applyPreflightSkips(operationOptions *pb.OperationOptions) {
+	if operationOptions != nil {
+		app.ApplyPreflightSkips(operationOptions.SkipPreflightChecks)
+	}
+}
+
 func portToString(p *int32) string {
 	if p == nil {
 		return ""


### PR DESCRIPTION
## Description

Fixed the panic occurring with Commander version 1.5 and dhctl version 1.64. Added a check for the existence of the field.

## Why do we need it in the patch release (if we do)?

There are still users on Commander version 1.5, so the panic needs to be fixed for them.

```changes
section: dhctl
type: fix 
summary: Fix panic if commander version is 1.5
impact: Users will be able to perform operations on the cluster without errors
impact_level: high
```
