### PR TITLE
[istio] Fix SA token path in api-proxy container

### DIFF
--- a/ee/modules/110-istio/images/api-proxy/main.go
+++ b/ee/modules/110-istio/images/api-proxy/main.go
@@ -179,7 +179,7 @@ func httpHandlerApiProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// impersonate as current ServiceAccount
-	saToken, _ := os.ReadFile("/run/secrets/kubernetes.io/serviceaccount/token")
+	saToken, _ := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	proxyDirector := func(req *http.Request) {
 		req.Header.Del("Authorization")
 		req.Header.Add("Authorization", "Bearer "+string(saToken))


### PR DESCRIPTION
## Description
Fix SA token path in api-proxy container.

## Why do we need it, and what problem does it solve?
api-proxy can't authenticate to apiserver, so it can't handle remote requests.
Multiclusters malfunctioning.

## Why do we need it in the patch release (if we do)?
Istio multiclusters don't work.

## What is the expected result?
There aren't 401 messages in api-proxy's logs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: fix
summary: SA token path in api-proxy container fixed.
impact_level: default
```