### PR TITLE
[control-plane-manager][docs] update etcd backup instructions in the FAQ

### DIFF
--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -615,7 +615,7 @@ Follow these steps to restore a single-master cluster:
    rm -rf /var/lib/etcd/member/
    ```
 
-1. Transfer and rename the backup to `~/etcd-backup.snapshot`.
+1. Put the etcd backup to `~/etcd-backup.snapshot` file.
 
 1. Restore the etcd database.
 

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -608,7 +608,7 @@ rm -r ./kubernetes ./etcd-backup.snapshot
    rm -rf /var/lib/etcd/member/
    ```
 
-1. Перенесите и переименуйте резервную копию в `~/etcd-backup.snapshot`.
+1. Положите резервную копию etcd в файл `~/etcd-backup.snapshot`.
 
 1. Восстановите базу данных etcd.
 


### PR DESCRIPTION
## Description

Update etcd backup instructions in the FAQ.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: control-plane-manager
type: chore
summary: Update etcd backup instructions in the FAQ.
impact_level: low
```
