### PR TITLE
[operator-trivy]  Add extra fields to vulnerability reports.

### DIFF
--- a/ee/modules/500-operator-trivy/monitoring/grafana-dashboards/security/trivy.tpl
+++ b/ee/modules/500-operator-trivy/monitoring/grafana-dashboards/security/trivy.tpl
@@ -21,7 +21,7 @@
       }
     ]
   },
-  "description": "A dashboard to visualise trivy image vulnerabilities using metrics from trivy-operator.",
+  "description": "A dashboard to visualize trivy image vulnerabilities using metrics from trivy-operator.",
   "editable": false,
   "fiscalYearStartMonth": 0,
   "gnetId": 16742,
@@ -160,7 +160,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_vulnerability_id{severity=\"Critical\",namespace=~\"$namespace\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"})",
+          "expr": "sum(trivy_vulnerability_id{severity=\"Critical\",namespace=~\"$namespace\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"{{- range .Values.operatorTrivy.additionalVulnerabilityReportFields }},{{ . | lower}}=~\"${{ . | lower}}\"{{- end }}})",
           "instant": true,
           "legendFormat": "Critical",
           "range": false,
@@ -173,7 +173,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_vulnerability_id{severity=\"High\", namespace=~\"$namespace\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"})",
+          "expr": "sum(trivy_vulnerability_id{severity=\"High\", namespace=~\"$namespace\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"{{- range .Values.operatorTrivy.additionalVulnerabilityReportFields }},{{ . | lower}}=~\"${{ . | lower}}\"{{- end }}})",
           "hide": false,
           "instant": true,
           "legendFormat": "High",
@@ -187,7 +187,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_vulnerability_id{severity=\"Medium\", namespace=~\"$namespace\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"})",
+          "expr": "sum(trivy_vulnerability_id{severity=\"Medium\", namespace=~\"$namespace\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"{{- range .Values.operatorTrivy.additionalVulnerabilityReportFields }},{{ . | lower}}=~\"${{ . | lower}}\"{{- end }}})",
           "hide": false,
           "instant": true,
           "legendFormat": "Medium",
@@ -201,7 +201,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_vulnerability_id{severity=\"Low\", namespace=~\"$namespace\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"})",
+          "expr": "sum(trivy_vulnerability_id{severity=\"Low\", namespace=~\"$namespace\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"{{- range .Values.operatorTrivy.additionalVulnerabilityReportFields }},{{ . | lower}}=~\"${{ . | lower}}\"{{- end }}})",
           "hide": false,
           "instant": true,
           "legendFormat": "Low",
@@ -215,7 +215,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_vulnerability_id{severity=\"Unknown\", namespace=~\"$namespace\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"})",
+          "expr": "sum(trivy_vulnerability_id{severity=\"Unknown\", namespace=~\"$namespace\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"{{- range .Values.operatorTrivy.additionalVulnerabilityReportFields }},{{ . | lower}}=~\"${{ . | lower}}\"{{- end }}})",
           "hide": false,
           "instant": true,
           "legendFormat": "Unknown",
@@ -362,7 +362,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(trivy_vulnerability_id{namespace=~\"$namespace\",severity=~\"$severity\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"}) by (image_repository,image_tag,severity, vuln_id, namespace, resource_kind, resource, resource_name,vuln_title,vuln_url)",
+          "expr": "sum(trivy_vulnerability_id{namespace=~\"$namespace\",severity=~\"$severity\",vuln_id=~\"$vuln_id\",resource_name=~\"$resource_name\",resource=~\"$resource\"{{- range .Values.operatorTrivy.additionalVulnerabilityReportFields }},{{ . | lower}}=~\"${{ . | lower}}\"{{- end }}}) by (image_repository,image_tag,severity, vuln_id, installed_version, fixed_version, namespace, resource_kind, resource, resource_name,vuln_title,vuln_url{{- range .Values.operatorTrivy.additionalVulnerabilityReportFields }},{{ . | lower}}{{- end }})",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -388,6 +388,9 @@
               "resource": 3,
               "resource_kind": 9,
               "resource_name": 4,
+              "image_tag": 10,
+              "installed_version": 20,
+              "fixed_version": 21,
               "severity": 5,
               "vuln_id": 6,
               "vuln_title": 7
@@ -553,6 +556,40 @@
         "sort": 1,
         "type": "query"
       },
+{{- range .Values.operatorTrivy.additionalVulnerabilityReportFields }}
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${ds_prometheus}"
+        },
+        "definition": "label_values(trivy_vulnerability_id, {{ . | lower }})",
+        "hide": 0,
+        "includeAll": true,
+        "label": {{ . | quote }},
+        "multi": true,
+        "name": {{ . | lower | quote }},
+        "options": [],
+        "query": {
+          "query": "label_values(trivy_vulnerability_id, {{ . | lower }})",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+{{- end }}
       {
         "current": {
           "selected": false,

--- a/ee/modules/500-operator-trivy/openapi/config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/config-values.yaml
@@ -20,10 +20,11 @@ properties:
 
     items:
       type: string
-    x-example:
-      additionalVulnerabilityReportFields
-        - Class
-        - Target
+    x-examples:
+    -
+      additionalVulnerabilityReportFields:
+      - Class
+      - Target
   severities:
     type: array
     description: |
@@ -37,10 +38,11 @@ properties:
         - MEDIUM
         - HIGH
         - CRITICAL
-    x-example:
+    x-examples:
+    -
       severities:
-        - UNKNOWN
-        - CRITICAl
+      - UNKNOWN
+      - CRITICAl
   linkCVEtoBDU:
     type: boolean
     default: false
@@ -98,7 +100,8 @@ properties:
       The values of these labels will correspond to the values of the scanned resources' labels.
     items:
       type: string
-    x-example:
+    x-examples:
+    -
       - app
       - env
   insecureRegistries:

--- a/ee/modules/500-operator-trivy/openapi/config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/config-values.yaml
@@ -22,7 +22,6 @@ properties:
       type: string
     x-examples:
     -
-      additionalVulnerabilityReportFields:
       - Class
       - Target
   severities:
@@ -40,7 +39,6 @@ properties:
         - CRITICAL
     x-examples:
     -
-      severities:
       - UNKNOWN
       - CRITICAl
   linkCVEtoBDU:

--- a/ee/modules/500-operator-trivy/openapi/config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/config-values.yaml
@@ -17,7 +17,6 @@ properties:
     type: array
     description: |
       A list of additional fields from the vulnerability database to add to the VulnerabilityReport.
-
     items:
       type: string
     x-examples:

--- a/ee/modules/500-operator-trivy/openapi/config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/config-values.yaml
@@ -13,6 +13,17 @@ properties:
       **Warning.** Specifying a value different from the one currently used (in the existing PVC) will result in disk re-provisioning and all data will be deleted.
       
       If `false` is specified, `emptyDir` will be forced to be used.
+  additionalVulnerabilityReportFields:
+    type: array
+    description: |
+      A list of additional fields from the vulnerability database to add to the VulnerabilityReport.
+
+    items:
+      type: string
+    x-example:
+      additionalVulnerabilityReportFields
+        - Class
+        - Target
   severities:
     type: array
     description: |

--- a/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
@@ -14,7 +14,7 @@ properties:
 
   additionalVulnerabilityReportFields:
     description: |
-      Список дополнительных полей из базы уязвимостей, добавляемых к отчетам уязвимостей (VulnerabilityReport).
+      Список дополнительных полей из базы уязвимостей, добавляемых к отчетам об уязвимостях (VulnerabilityReport).
 
   severities:
     description: |

--- a/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
@@ -12,6 +12,10 @@ properties:
       
       Если указать `false`, будет принудительно использоваться `emptyDir`.
 
+  additionalVulnerabilityReportFields:
+    description: |
+      Список дополнительных полей из базы уязвимостей, добавляемых к отчетам уязвимостей (VulnerabilityReport).
+
   severities:
     description: |
       Фильтрация отчетов уязвимостей по уровню их критичности.

--- a/ee/modules/500-operator-trivy/templates/configmap.yaml
+++ b/ee/modules/500-operator-trivy/templates/configmap.yaml
@@ -49,9 +49,13 @@ data:
   {{- $image := (include "helm_lib_module_image" (list . "trivy")) | splitn ":" 2 }}
   trivy.repository: {{ $image._0 }}
   trivy.tag: {{ $image._1 }}
+  {{- if .Values.operatorTrivy.additionalVulnerabilityReportFields }}
+  trivy.additionalVulnerabilityReportFields: {{ .Values.operatorTrivy.additionalVulnerabilityReportFields | join "," | quote }}
+  {{- else }}
   trivy.additionalVulnerabilityReportFields: ""
+  {{- end }}
   {{- if .Values.operatorTrivy.severities }}
-  trivy.severity: {{ .Values.operatorTrivy.severities | join "," }}
+  trivy.severity: {{ .Values.operatorTrivy.severities | join "," | quote }}
   {{- else }}
   trivy.severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   {{- end }}

--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.33.0
-digest: sha256:132c1ceb38ea342daf06eba90660a5b232f4b54d8b88edc124cf1dc74c3efc7b
-generated: "2024-10-22T10:08:42.016830949+04:00"
+  version: 1.35.2
+digest: sha256:19914d541553e4774579d6b3885d9ccfb0095eb612c2560521b3bfddab61ac25
+generated: "2024-11-05T16:51:56.723514231+03:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: "Helm helpers"
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.33.0"
+    version: "1.35.2"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.33.0
+version: 1.35.2

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
@@ -22,6 +22,7 @@ memory: 25Mi
   {{- $additionalNodeVolumes := $config.additionalNodeVolumes }}
   {{- $additionalNodeVolumeMounts := $config.additionalNodeVolumeMounts }}
   {{- $additionalNodeLivenessProbesCmd := $config.additionalNodeLivenessProbesCmd }}
+  {{- $additionalNodeSelectorTerms := $config.additionalNodeSelectorTerms }}
   {{- $initContainerCommand := $config.initContainerCommand }}
   {{- $initContainerImage := $config.initContainerImage }}
   {{- $initContainerVolumeMounts := $config.initContainerVolumeMounts }}
@@ -93,6 +94,9 @@ spec:
                 {{- if or (eq $fullname "csi-node-rbd") (eq $fullname "csi-node-cephfs") (eq $fullname "csi-nfs") (eq $fullname "csi-yadro") }}
                 - Static
                 {{- end }}
+              {{- if $additionalNodeSelectorTerms }}
+              {{- $additionalNodeSelectorTerms | toYaml | nindent 14 }}
+              {{- end }}
       imagePullSecrets:
       - name: deckhouse-registry
       {{- include "helm_lib_priority_class" (tuple $context "system-node-critical") | nindent 6 }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_monitoring_grafana_dashboards.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_monitoring_grafana_dashboards.tpl
@@ -26,8 +26,25 @@
 {{ include "helm_lib_single_dashboard" (list $context $resourceName $folder $definition) }}
   {{- end }}
 
+  {{- range $path, $_ := $context.Files.Glob (print $currentDir "/*.tpl") }}
+    {{- $fileName := ($path | splitList "/" | last ) }}
+    {{- $definition := tpl ($context.Files.Get $path) $context }}
+
+    {{- $folder := (index ($currentDir | splitList "/") $folderNamesIndex | replace "-" " " | title) }}
+    {{- $resourceName := (regexReplaceAllLiteral "\\.tpl$" $path "") }}
+    {{- $resourceName = ($resourceName | replace " " "-" | replace "." "-" | replace "_" "-") }}
+    {{- $resourceName = (slice ($resourceName | splitList "/") $folderNamesIndex | join "-") }}
+    {{- $resourceName = (printf "%s-%s" $context.Chart.Name $resourceName) }}
+
+{{ include "helm_lib_single_dashboard" (list $context $resourceName $folder $definition) }}
+  {{- end }}
+
   {{- $subDirs := list }}
   {{- range $path, $_ := ($context.Files.Glob (print $currentDir "/**.json")) }}
+    {{- $pathSlice := ($path | splitList "/") }}
+    {{- $subDirs = append $subDirs (slice $pathSlice 0 (add $currentDirIndex 2) | join "/") }}
+  {{- end }}
+  {{- range $path, $_ := ($context.Files.Glob (print $currentDir "/**.tpl")) }}
     {{- $pathSlice := ($path | splitList "/") }}
     {{- $subDirs = append $subDirs (slice $pathSlice 0 (add $currentDirIndex 2) | join "/") }}
   {{- end }}
@@ -35,6 +52,7 @@
   {{- range $subDir := ($subDirs | uniq) }}
 {{ include "helm_lib_grafana_dashboard_definitions_recursion" (list $context $rootDir $subDir) }}
   {{- end }}
+
 {{- end }}
 
 

--- a/tools/validation/grafana_dashboard.go
+++ b/tools/validation/grafana_dashboard.go
@@ -69,10 +69,11 @@ func RunGrafanaDashboardValidation(info *DiffInfo) (exitCode int) {
 func isGrafanaDashboard(fileName string) bool {
 	fileName = strings.ToLower(fileName)
 	return strings.Contains(fileName, "grafana-dashboards") &&
-		strings.HasSuffix(fileName, ".json")
+		(strings.HasSuffix(fileName, ".json") || strings.HasSuffix(fileName, ".tpl"))
 }
 
 func validateGrafanaDashboardFile(fileName string, fileContent []byte) *Messages {
+	fmt.Printf("Validating %s grafana dashboard definition\n", fileName)
 	msgs := NewMessages()
 
 	dashboard := gjson.ParseBytes(fileContent)


### PR DESCRIPTION
## Description
This pr updates `operator-trivy` module with new configuration setting - `additionalVulnerabilityReportFields` which can be used to enrich trivy vulnerability reports with additional fields from trivy db.

Also, it updates Grafana dashboard delivery procedure with possibility to define a dashboard via go templates, fully or partially, - *.tpl files in `<module_name>/monitoring/grafana-dashboards/` directories are rendered before making their way to the resulting chart. 

The dashboard validation is also updated to check `*.tpl` files.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It allows users to add extra fields to Trivy vulnerability reports and these defined fields get automatically added to the Trivy Image Vulnerability Overview dashboard for filtering.
Closes #10427 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
It's possible to define additional fields for vulnerability reports and these fields can be used for filtering data on Trivy Image Vulnerability Overview dashboard.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: feature
summary: Add extra fields to vulnerability reports.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
