### PR TITLE
[prometheus] Upgrade Prometheus to version 2.53.2

### DIFF
--- a/modules/300-prometheus/images/prometheus/README.md
+++ b/modules/300-prometheus/images/prometheus/README.md
@@ -54,7 +54,7 @@ docker cp prometheus-deps:/prometheus/prometheus/web/ .
 docker rm -f prometheus-deps
 ```
 
-Before commiting your changes, remove the `.gitignore` files, so that all
+Before committing your changes, remove the `.gitignore` files, so that all
 changes made by `npm install` are included into the repository.
 
 ```shell

--- a/modules/300-prometheus/images/prometheus/README.md
+++ b/modules/300-prometheus/images/prometheus/README.md
@@ -16,7 +16,7 @@ Exports gauge metric with the count of successfully sent alerts.
 
 ### How-to build prometheus
 
-Current falco version is `PROMETHEUS_VERSION=v2.45.2`.
+Current falco version is `PROMETHEUS_VERSION=v2.53.2`.
 
 To build prometheus we need to repush used third-party libs to own registry. To do this we need to run specific Dockerfile:
 

--- a/modules/300-prometheus/images/prometheus/README.md
+++ b/modules/300-prometheus/images/prometheus/README.md
@@ -55,7 +55,7 @@ docker rm -f prometheus-deps
 ```
 
 Before commiting your changes, remove the `.gitignore` files, so that all
-changes made by `npm install` are included into the repostiory.
+changes made by `npm install` are included into the repository.
 
 ```shell
 find . -name ".gitignore" -type f -delete

--- a/modules/300-prometheus/images/prometheus/README.md
+++ b/modules/300-prometheus/images/prometheus/README.md
@@ -16,13 +16,13 @@ Exports gauge metric with the count of successfully sent alerts.
 
 ### How-to build prometheus
 
-Current falco version is `PROMETHEUS_VERSION=v2.53.2`.
+Current prometheus version is `PROMETHEUS_VERSION=v2.53.2`.
 
 To build prometheus we need to repush used third-party libs to own registry. To do this we need to run specific Dockerfile:
 
 ```dockerfile
-ARG BASE_GOLANG_21_BULLSEYE_DEV
-FROM $BASE_GOLANG_21_BULLSEYE_DEV
+ARG BASE_GOLANG_22_BULLSEYE_DEV
+FROM $BASE_GOLANG_22_BULLSEYE_DEV
 ARG PROMETHEUS_VERSION
 ARG SOURCE_REPO
 
@@ -38,16 +38,27 @@ RUN mkdir /prometheus && cd /prometheus &&\
 To run Dockerfile exec the command:
 
 ```shell
-docker build --build-arg SOURCE_REPO=https://github.com --build-arg BASE_GOLANG_21_BULLSEYE_DEV=registry.deckhouse.io/base_images/dev-golang:1.21.6-bullseye --build-arg PROMETHEUS_VERSION=${PROMETHEUS_VERSION} -t prometheus-deps .
+export PROMETHEUS_VERSION=v2.53.2
+# Check the image:tag used in the runner that will execute `npm run build`,
+# and for consistency, ensure they are the same.”
+export BASE_GOLANG_22_BULLSEYE_DEV=registry.deckhouse.io/base_images/dev-golang:1.22.8-bullseye@sha256:b79c06949dd2a4e19b900b1c29372219cfb0418109439c8b38fc485d26bbccdb
+docker build --build-arg SOURCE_REPO=https://github.com --build-arg BASE_GOLANG_22_BULLSEYE_DEV=${BASE_GOLANG_22_BULLSEYE_DEV} --build-arg PROMETHEUS_VERSION=${PROMETHEUS_VERSION} -t prometheus-deps . --progress=plain --no-cache
+
 ```
 
 Than copy folders from container:
 
 ```shell
-docker run --name prometheus-deps -d prometheus-deps bash
-docker cp prometheus-deps:/prometheus/prometheus/web/ui/node_modules node_modules
-docker cp prometheus-deps:/prometheus/prometheus/web/ui/package-lock.json package-lock.json
+docker run --name prometheus-deps -d prometheus-deps 
+docker cp prometheus-deps:/prometheus/prometheus/web/ . 
 docker rm -f prometheus-deps
+```
+
+Before commiting your changes, remove the `.gitignore` files, so that all
+changes made by `npm install` are included into the repostiory.
+
+```shell
+find . -name ".gitignore" -type f -delete
 ```
 
 Then commit content to `fox.flant.com/deckhouse/3p/prometheus/prometheus-deps` to the branch `${PROMETHEUS_VERSION}`.

--- a/modules/300-prometheus/images/prometheus/sample_limit_annotation.patch
+++ b/modules/300-prometheus/images/prometheus/sample_limit_annotation.patch
@@ -1,8 +1,8 @@
 diff --git a/discovery/kubernetes/pod.go b/discovery/kubernetes/pod.go
-index 732cf52ad..3080f013b 100644
+index 02990e415..69aba7e25 100644
 --- a/discovery/kubernetes/pod.go
 +++ b/discovery/kubernetes/pod.go
-@@ -299,6 +299,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
+@@ -284,6 +284,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
  			// The user has to add a port manually.
  			tg.Targets = append(tg.Targets, model.LabelSet{
  				model.AddressLabel:     lv(pod.Status.PodIP),
@@ -10,8 +10,8 @@ index 732cf52ad..3080f013b 100644
  				podContainerNameLabel:  lv(c.Name),
  				podContainerIDLabel:    lv(cID),
  				podContainerImageLabel: lv(c.Image),
-@@ -313,6 +314,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
-
+@@ -298,6 +299,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
+ 
  			tg.Targets = append(tg.Targets, model.LabelSet{
  				model.AddressLabel:            lv(addr),
 +				"__sample_limit__":            lv(""),
@@ -19,11 +19,11 @@ index 732cf52ad..3080f013b 100644
  				podContainerIDLabel:           lv(cID),
  				podContainerImageLabel:        lv(c.Image),
 diff --git a/discovery/kubernetes/service.go b/discovery/kubernetes/service.go
-index 40e17679e..32e3ea46c 100644
+index 51204a5a1..31a8df2ce 100644
 --- a/discovery/kubernetes/service.go
 +++ b/discovery/kubernetes/service.go
-@@ -193,6 +193,7 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
-
+@@ -180,6 +180,7 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
+ 
  		labelSet := model.LabelSet{
  			model.AddressLabel:       lv(addr),
 +			"__sample_limit__":       lv(""),
@@ -31,13 +31,13 @@ index 40e17679e..32e3ea46c 100644
  			servicePortNumberLabel:   lv(strconv.FormatInt(int64(port.Port), 10)),
  			servicePortProtocolLabel: lv(string(port.Protocol)),
 diff --git a/scrape/scrape.go b/scrape/scrape.go
-index 8c4cc51e7..e7bff4dcb 100644
+index c285f05e3..97f57252d 100644
 --- a/scrape/scrape.go
 +++ b/scrape/scrape.go
-@@ -314,6 +314,11 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed
+@@ -155,6 +155,11 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed
  		}
  		opts.target.SetMetadataStore(cache)
-
+ 
 +		limit := opts.target.SampleLimit()
 +		if limit == 0 {
 +			limit = opts.sampleLimit
@@ -46,20 +46,20 @@ index 8c4cc51e7..e7bff4dcb 100644
  		return newScrapeLoop(
  			ctx,
  			opts.scraper,
-@@ -327,7 +332,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed
- 			cache,
- 			offsetSeed,
+@@ -171,7 +176,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed
  			opts.honorTimestamps,
+ 			opts.trackTimestampsStaleness,
+ 			opts.enableCompression,
 -			opts.sampleLimit,
 +			limit,
  			opts.bucketLimit,
+ 			opts.maxSchema,
  			opts.labelLimits,
- 			opts.interval,
 diff --git a/scrape/target.go b/scrape/target.go
-index a655e8541..fbd437e01 100644
+index ad4b4f685..c58bf6c2f 100644
 --- a/scrape/target.go
 +++ b/scrape/target.go
-@@ -18,6 +18,7 @@ import (
+@@ -19,6 +19,7 @@ import (
  	"hash/fnv"
  	"net"
  	"net/url"
@@ -67,7 +67,7 @@ index a655e8541..fbd437e01 100644
  	"strings"
  	"sync"
  	"time"
-@@ -546,3 +547,15 @@ func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig, noDefault
+@@ -578,3 +579,15 @@ func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig, noDefault
  	}
  	return targets, failures
  }

--- a/modules/300-prometheus/images/prometheus/successfully_sent_metric.patch
+++ b/modules/300-prometheus/images/prometheus/successfully_sent_metric.patch
@@ -1,8 +1,8 @@
 diff --git a/notifier/notifier.go b/notifier/notifier.go
-index 3d2ee5949..aa000dcf9 100644
+index 4cf376aa0..2725a4d72 100644
 --- a/notifier/notifier.go
 +++ b/notifier/notifier.go
-@@ -135,6 +135,7 @@ type alertMetrics struct {
+@@ -134,6 +134,7 @@ type alertMetrics struct {
  	latency                 *prometheus.SummaryVec
  	errors                  *prometheus.CounterVec
  	sent                    *prometheus.CounterVec
@@ -10,10 +10,11 @@ index 3d2ee5949..aa000dcf9 100644
  	dropped                 prometheus.Counter
  	queueLength             prometheus.GaugeFunc
  	queueCapacity           prometheus.Gauge
-@@ -168,6 +169,12 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
+@@ -167,6 +168,13 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
  		},
  			[]string{alertmanagerLabel},
  		),
++
 +		successfullySent: prometheus.NewCounterVec(prometheus.CounterOpts{
 +			Namespace: namespace,
 +			Subsystem: subsystem,
@@ -23,7 +24,7 @@ index 3d2ee5949..aa000dcf9 100644
  		dropped: prometheus.NewCounter(prometheus.CounterOpts{
  			Namespace: namespace,
  			Subsystem: subsystem,
-@@ -199,6 +206,7 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
+@@ -198,6 +206,7 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
  			m.latency,
  			m.errors,
  			m.sent,
@@ -31,19 +32,19 @@ index 3d2ee5949..aa000dcf9 100644
  			m.dropped,
  			m.queueLength,
  			m.queueCapacity,
-@@ -535,6 +543,7 @@ func (n *Manager) sendAll(alerts ...*Alert) bool {
+@@ -550,6 +559,7 @@ func (n *Manager) sendAll(alerts ...*Alert) bool {
  					n.metrics.errors.WithLabelValues(url).Inc()
  				} else {
  					numSuccess.Inc()
 +					n.metrics.successfullySent.WithLabelValues(url).Add(float64(len(alerts)))
  				}
  				n.metrics.latency.WithLabelValues(url).Observe(time.Since(begin).Seconds())
- 				n.metrics.sent.WithLabelValues(url).Add(float64(len(alerts)))
-@@ -687,6 +696,7 @@ func (s *alertmanagerSet) sync(tgs []*targetgroup.Group) {
+ 				n.metrics.sent.WithLabelValues(url).Add(float64(len(amAlerts)))
+@@ -713,6 +723,7 @@ func (s *alertmanagerSet) sync(tgs []*targetgroup.Group) {
  		// This will initialize the Counters for the AM to 0.
  		s.metrics.sent.WithLabelValues(us)
  		s.metrics.errors.WithLabelValues(us)
 +		s.metrics.successfullySent.WithLabelValues(us)
-
+ 
  		seen[us] = struct{}{}
  		s.ams = append(s.ams, am)

--- a/modules/300-prometheus/images/prometheus/werf.inc.yaml
+++ b/modules/300-prometheus/images/prometheus/werf.inc.yaml
@@ -12,8 +12,7 @@ shell:
   - go build -ldflags="-s -w" -o promu ./main.go
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ $.Images.BASE_GOLANG_21_BULLSEYE_DEV }}
-fromCacheVersion: 2024022701
+from: {{ $.Images.BASE_GOLANG_22_BULLSEYE_DEV }}
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
@@ -32,14 +31,13 @@ git:
     - '**/*'
 shell:
   install:
-  - export NODE_MAJOR=20
-  - export GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 PROMETHEUS_VERSION=v2.45.2
+  - export GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 PROMETHEUS_VERSION=v2.53.2
   - git clone -b "${PROMETHEUS_VERSION}" --single-branch {{ $.SOURCE_REPO }}/prometheus/prometheus-deps
   - mkdir /prometheus && cd /prometheus
   - git clone -b "${PROMETHEUS_VERSION}" --single-branch {{ $.SOURCE_REPO }}/prometheus/prometheus
-  - cd /prometheus/prometheus/web/ui
-  - mv /prometheus-deps/* .
-  - npm run build
+  - cd /prometheus/prometheus
+  - rm -rf web && cp -r /prometheus-deps/web .
+  - cd web/ui && npm run build
   - cd /prometheus/prometheus
   - scripts/compress_assets.sh
   - go mod tidy

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -52,7 +52,7 @@ spec:
   retention: {{ .Values.prometheus.longtermRetentionDays }}d
   retentionSize: {{ .Values.prometheus.internal.prometheusLongterm.retentionGigabytes }}GB
   image: {{ include "helm_lib_module_image" (list . "prometheus") }}
-  version: v2.45.2
+  version: v2.53.2
   imagePullSecrets:
   - name: deckhouse-registry
   listenLocal: true

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -51,7 +51,7 @@ spec:
   retention: {{ .Values.prometheus.retentionDays }}d
   retentionSize: {{ .Values.prometheus.internal.prometheusMain.retentionGigabytes }}GB
   image: {{ include "helm_lib_module_image" (list . "prometheus") }}
-  version: v2.45.2
+  version: v2.53.2
   enableRemoteWriteReceiver: true
   enableFeatures:
   - memory-snapshot-on-shutdown # https://ganeshvernekar.com/blog/prometheus-tsdb-snapshot-on-shutdown/


### PR DESCRIPTION
## Description
- Upgrade Prometheus to version 2.53.2 

## Why do we need it, and what problem does it solve?
- Upgrades Prometheus to LTS version (improves stability and security).
- Closes https://github.com/deckhouse/deckhouse/issues/7438


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: chore
summary: Upgrade Prometheus version from `v2.45.2` to `v2.53.2`
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
