### PR TITLE
[control-plane-manager] Update etcd restore docs

### DIFF
--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -584,28 +584,28 @@ The following steps will be described to restore to the previous state of the cl
 
 Follow these steps to restore a single-master cluster:
 
-1. - Find `etcdctl` utility on the master-node and copy the executable to `/usr/local/bin/`:
+1.  - Find `etcdctl` utility on the master-node and copy the executable to `/usr/local/bin/`:
 
-     ```shell
-     cp $(find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/ \
-     -name etcdctl -print | tail -n 1) /usr/local/bin/etcdctl
-     etcdctl version
-     ```
+      ```shell
+      cp $(find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/ \
+      -name etcdctl -print | tail -n 1) /usr/local/bin/etcdctl
+      etcdctl version
+      ```
 
-     The result must be a correct output of `etcdctl version` command without errors.
+      The result must be a correct output of `etcdctl version` command without errors.
 
-   - Alternatively, you can download [etcdctl](https://github.com/etcd-io/etcd/releases) executable to the node (preferably its version is the same as the etcd version in the cluster):
+    - Alternatively, you can download [etcdctl](https://github.com/etcd-io/etcd/releases) executable to the node (preferably its version is the same as the etcd version in the cluster):
 
-     ```shell
-     wget "https://github.com/etcd-io/etcd/releases/download/v3.5.16/etcd-v3.5.16-linux-amd64.tar.gz"
-     tar -xzvf etcd-v3.5.16-linux-amd64.tar.gz && mv etcd-v3.5.16-linux-amd64/etcdctl /usr/local/bin/etcdctl
-     ```
+      ```shell
+      wget "https://github.com/etcd-io/etcd/releases/download/v3.5.16/etcd-v3.5.16-linux-amd64.tar.gz"
+      tar -xzvf etcd-v3.5.16-linux-amd64.tar.gz && mv etcd-v3.5.16-linux-amd64/etcdctl /usr/local/bin/etcdctl
+      ```
 
-     You can check current `etcd` version using following command (might not work, if etcd and Kubernetes API are already unavailable):
+      You can check current `etcd` version using following command (might not work, if etcd and Kubernetes API are already unavailable):
 
-     ```shell
-     kubectl -n kube-system exec -ti etcd-$(hostname) -- etcdctl version
-     ```
+      ```shell
+      kubectl -n kube-system exec -ti etcd-$(hostname) -- etcdctl version
+      ```
 
 2. Stop the etcd.
 

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -585,6 +585,7 @@ The following steps will be described to restore to the previous state of the cl
 Follow these steps to restore a single-master cluster:
 
 1. - Find `etcdctl` utility on the master-node and copy the executable to `/usr/local/bin/`:
+
      ```shell
      cp $(find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/ \
      -name etcdctl -print | tail -n 1) /usr/local/bin/etcdctl

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -584,28 +584,28 @@ The following steps will be described to restore to the previous state of the cl
 
 Follow these steps to restore a single-master cluster:
 
-1.  - Find `etcdctl` utility on the master-node and copy the executable to `/usr/local/bin/`:
+1. - Find `etcdctl` utility on the master-node and copy the executable to `/usr/local/bin/`:
 
-      ```shell
-      cp $(find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/ \
-      -name etcdctl -print | tail -n 1) /usr/local/bin/etcdctl
-      etcdctl version
-      ```
+     ```shell
+     cp $(find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/ \
+     -name etcdctl -print | tail -n 1) /usr/local/bin/etcdctl
+     etcdctl version
+     ```
 
-      The result must be a correct output of `etcdctl version` command without errors.
+     The result must be a correct output of `etcdctl version` command without errors.
 
-    - Alternatively, you can download [etcdctl](https://github.com/etcd-io/etcd/releases) executable to the node (preferably its version is the same as the etcd version in the cluster):
+   - Alternatively, you can download [etcdctl](https://github.com/etcd-io/etcd/releases) executable to the node (preferably its version is the same as the etcd version in the cluster):
 
-      ```shell
-      wget "https://github.com/etcd-io/etcd/releases/download/v3.5.16/etcd-v3.5.16-linux-amd64.tar.gz"
-      tar -xzvf etcd-v3.5.16-linux-amd64.tar.gz && mv etcd-v3.5.16-linux-amd64/etcdctl /usr/local/bin/etcdctl
-      ```
+     ```shell
+     wget "https://github.com/etcd-io/etcd/releases/download/v3.5.16/etcd-v3.5.16-linux-amd64.tar.gz"
+     tar -xzvf etcd-v3.5.16-linux-amd64.tar.gz && mv etcd-v3.5.16-linux-amd64/etcdctl /usr/local/bin/etcdctl
+     ```
 
-      You can check current `etcd` version using following command (might not work, if etcd and Kubernetes API are already unavailable):
+     You can check current `etcd` version using following command (might not work, if etcd and Kubernetes API are already unavailable):
 
-      ```shell
-      kubectl -n kube-system exec -ti etcd-$(hostname) -- etcdctl version
-      ```
+     ```shell
+     kubectl -n kube-system exec -ti etcd-$(hostname) -- etcdctl version
+     ```
 
 2. Stop the etcd.
 

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -578,12 +578,13 @@ rm -r ./kubernetes ./etcd-backup.snapshot
 Для корректного восстановления кластера single-master выполните следующие шаги на master-узле:
 
 1. - Найдите утилиту `etcdctl` на мастер-узле и скопируйте исполняемый файл в `/usr/local/bin/`:
+
      ```shell
      cp $(find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/ \
      -name etcdctl -print | tail -n 1) /usr/local/bin/etcdctl
      etcdctl version
      ```
-   
+
      Должен отобразиться корректный вывод `etcdctl version` без ошибок.
 
    - Альтернативно, вы можете загрузить исполняемый файл [etcdctl](https://github.com/etcd-io/etcd/releases) на сервер (желательно чтобы её версия была такая же, как и версия etcd в кластере):
@@ -616,7 +617,7 @@ rm -r ./kubernetes ./etcd-backup.snapshot
    ```shell
    rm -rf /var/lib/etcd/member/
    ```
-   
+
 5. Перенесите и переименуйте резервную копию в `~/etcd-backup.snapshot`.
 
 6. Восстановите базу данных etcd.

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -577,28 +577,28 @@ rm -r ./kubernetes ./etcd-backup.snapshot
 
 Для корректного восстановления кластера single-master выполните следующие шаги на master-узле:
 
-1. - Найдите утилиту `etcdctl` на мастер-узле и скопируйте исполняемый файл в `/usr/local/bin/`:
+1.  - Найдите утилиту `etcdctl` на мастер-узле и скопируйте исполняемый файл в `/usr/local/bin/`:
 
-     ```shell
-     cp $(find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/ \
-     -name etcdctl -print | tail -n 1) /usr/local/bin/etcdctl
-     etcdctl version
-     ```
+      ```shell
+      cp $(find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/ \
+      -name etcdctl -print | tail -n 1) /usr/local/bin/etcdctl
+      etcdctl version
+      ``` 
 
-     Должен отобразиться корректный вывод `etcdctl version` без ошибок.
+      Должен отобразиться корректный вывод `etcdctl version` без ошибок.
 
-   - Альтернативно, вы можете загрузить исполняемый файл [etcdctl](https://github.com/etcd-io/etcd/releases) на сервер (желательно чтобы её версия была такая же, как и версия etcd в кластере):
+    - Альтернативно, вы можете загрузить исполняемый файл [etcdctl](https://github.com/etcd-io/etcd/releases) на сервер (желательно чтобы её версия была такая же, как и версия etcd в кластере):
 
-     ```shell
-     wget "https://github.com/etcd-io/etcd/releases/download/v3.5.16/etcd-v3.5.16-linux-amd64.tar.gz"
-     tar -xzvf etcd-v3.5.16-linux-amd64.tar.gz && mv etcd-v3.5.16-linux-amd64/etcdctl /usr/local/bin/etcdctl
-     ```
+      ```shell
+      wget "https://github.com/etcd-io/etcd/releases/download/v3.5.16/etcd-v3.5.16-linux-amd64.tar.gz"
+      tar -xzvf etcd-v3.5.16-linux-amd64.tar.gz && mv etcd-v3.5.16-linux-amd64/etcdctl /usr/local/bin/etcdctl
+      ```
   
-     Посмотреть версию etcd в кластере можно выполнив следующую команду (может не сработать, если etcd и Kubernetes API недоступны):
+      Посмотреть версию etcd в кластере можно выполнив следующую команду (может не сработать, если etcd и Kubernetes API недоступны):
   
-     ```shell
-     kubectl -n kube-system exec -ti etcd-$(hostname) -- etcdctl version
-     ```
+      ```shell
+      kubectl -n kube-system exec -ti etcd-$(hostname) -- etcdctl version
+      ```
 
 2. Остановите etcd.
 

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -577,28 +577,28 @@ rm -r ./kubernetes ./etcd-backup.snapshot
 
 Для корректного восстановления кластера single-master выполните следующие шаги на master-узле:
 
-1.  - Найдите утилиту `etcdctl` на мастер-узле и скопируйте исполняемый файл в `/usr/local/bin/`:
+1. - Найдите утилиту `etcdctl` на мастер-узле и скопируйте исполняемый файл в `/usr/local/bin/`:
 
-      ```shell
-      cp $(find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/ \
-      -name etcdctl -print | tail -n 1) /usr/local/bin/etcdctl
-      etcdctl version
-      ``` 
+     ```shell
+     cp $(find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/ \
+     -name etcdctl -print | tail -n 1) /usr/local/bin/etcdctl
+     etcdctl version
+     ```
 
-      Должен отобразиться корректный вывод `etcdctl version` без ошибок.
+     Должен отобразиться корректный вывод `etcdctl version` без ошибок.
 
-    - Альтернативно, вы можете загрузить исполняемый файл [etcdctl](https://github.com/etcd-io/etcd/releases) на сервер (желательно чтобы её версия была такая же, как и версия etcd в кластере):
+   - Альтернативно, вы можете загрузить исполняемый файл [etcdctl](https://github.com/etcd-io/etcd/releases) на сервер (желательно чтобы её версия была такая же, как и версия etcd в кластере):
 
-      ```shell
-      wget "https://github.com/etcd-io/etcd/releases/download/v3.5.16/etcd-v3.5.16-linux-amd64.tar.gz"
-      tar -xzvf etcd-v3.5.16-linux-amd64.tar.gz && mv etcd-v3.5.16-linux-amd64/etcdctl /usr/local/bin/etcdctl
-      ```
+     ```shell
+     wget "https://github.com/etcd-io/etcd/releases/download/v3.5.16/etcd-v3.5.16-linux-amd64.tar.gz"
+     tar -xzvf etcd-v3.5.16-linux-amd64.tar.gz && mv etcd-v3.5.16-linux-amd64/etcdctl /usr/local/bin/etcdctl
+     ```
   
-      Посмотреть версию etcd в кластере можно выполнив следующую команду (может не сработать, если etcd и Kubernetes API недоступны):
+     Посмотреть версию etcd в кластере можно выполнив следующую команду (может не сработать, если etcd и Kubernetes API недоступны):
   
-      ```shell
-      kubectl -n kube-system exec -ti etcd-$(hostname) -- etcdctl version
-      ```
+     ```shell
+     kubectl -n kube-system exec -ti etcd-$(hostname) -- etcdctl version
+     ```
 
 2. Остановите etcd.
 


### PR DESCRIPTION
## Description

Updated [How do perform a full recovery of the cluster state from an etcd backup?](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/040-control-plane-manager/faq.html#how-do-perform-a-full-recovery-of-the-cluster-state-from-an-etcd-backup) docs.

## Why do we need it, and what problem does it solve?

New version of the guide allow for higher chance of recovery if cluster does not have access to the internet, or `etcd` already has a corrupted db.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: Updated etcd db restore documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
