### PR TITLE
[dhctl] fix(dhctl-for-commander): add operations panic handler

### DIFF
--- a/dhctl/pkg/server/pkg/interceptors/interceptors.go
+++ b/dhctl/pkg/server/pkg/interceptors/interceptors.go
@@ -37,7 +37,7 @@ func PanicRecoveryHandler() func(ctx context.Context, p any) error {
 		logger.L(ctx).Error(
 			"recovered from panic",
 			slog.Any("panic", p),
-			slog.Any("stack", string(debug.Stack())),
+			slog.String("stack", string(debug.Stack())),
 		)
 		return status.Errorf(codes.Internal, "%s", p)
 	}

--- a/dhctl/pkg/server/rpc/dhctl/commander_attach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_attach.go
@@ -89,7 +89,7 @@ connectionProcessor:
 					continue connectionProcessor
 				}
 				go func() {
-					result := s.commanderAttach(ctx, message.Start, phaseSwitcher.switchPhase, logWriter)
+					result := s.commanderAttachSafe(ctx, message.Start, phaseSwitcher.switchPhase, logWriter)
 					sendCh <- &pb.CommanderAttachResponse{Message: &pb.CommanderAttachResponse_Result{Result: result}}
 				}()
 
@@ -118,6 +118,21 @@ connectionProcessor:
 			}
 		}
 	}
+}
+
+func (s *Service) commanderAttachSafe(
+	ctx context.Context,
+	request *pb.CommanderAttachStart,
+	switchPhase phases.OnPhaseFunc[attach.PhaseData],
+	logWriter io.Writer,
+) (result *pb.CommanderAttachResult) {
+	defer func() {
+		if r := recover(); r != nil {
+			result = &pb.CommanderAttachResult{Err: panicMessage(ctx, r)}
+		}
+	}()
+
+	return s.commanderAttach(ctx, request, switchPhase, logWriter)
 }
 
 func (s *Service) commanderAttach(

--- a/dhctl/pkg/server/rpc/dhctl/commander_detach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_detach.go
@@ -90,7 +90,7 @@ connectionProcessor:
 					continue connectionProcessor
 				}
 				go func() {
-					result := s.commanderDetach(ctx, message.Start, logWriter)
+					result := s.commanderDetachSafe(ctx, message.Start, logWriter)
 					sendCh <- &pb.CommanderDetachResponse{Message: &pb.CommanderDetachResponse_Result{Result: result}}
 				}()
 
@@ -101,6 +101,20 @@ connectionProcessor:
 			}
 		}
 	}
+}
+
+func (s *Service) commanderDetachSafe(
+	ctx context.Context,
+	request *pb.CommanderDetachStart,
+	logWriter io.Writer,
+) (result *pb.CommanderDetachResult) {
+	defer func() {
+		if r := recover(); r != nil {
+			result = &pb.CommanderDetachResult{Err: panicMessage(ctx, r)}
+		}
+	}()
+
+	return s.commanderDetach(ctx, request, logWriter)
 }
 
 func (s *Service) commanderDetach(

--- a/dhctl/pkg/server/server/proxy.go
+++ b/dhctl/pkg/server/server/proxy.go
@@ -177,7 +177,7 @@ func writeLogs(log *slog.Logger, reader io.ReadCloser, writer io.Writer, mx *syn
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		mx.Lock()
-		_, err := fmt.Fprintf(writer, scanner.Text())
+		_, err := fmt.Fprintf(writer, scanner.Text()+"\n")
 		mx.Unlock()
 		if err != nil {
 			log.Error("failed to write dhctl instance logs", logger.Err(err))


### PR DESCRIPTION
## Description

Improve grpc-server panic handling. Fixed line breaks in logs.

## What is the expected result?

It is not expected to change behaviour of any dhctl operation not in commander-mode. 

```changes
section: dhctl
type: feature
summary: Improve panic handling. Fixed line breaks in logs.
impact_level: default
```
