### PR TITLE
Permission to update StaticMachineTemplate.Spec for Deckhouse service account

### DIFF
--- a/modules/040-node-manager/images/caps-controller-manager/src/api/infrastructure/v1alpha1/staticmachinetemplate_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/infrastructure/v1alpha1/staticmachinetemplate_webhook.go
@@ -27,6 +27,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -37,11 +38,12 @@ type StaticMachineTemplateWebhook struct {
 	decoder *admission.Decoder
 }
 
-// +kubebuilder:webhook:path=/validate-infrastructure-cluster-x-k8s-io-v1alpha1-staticmachinetemplate,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=staticmachinetemplates,verbs=create;update;delete,versions=v1alpha1,name=validation.staticmachinetemplate.infrastructure.cluster.x-k8s.io
 func (r *StaticMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
-		Complete()
+	mw := &StaticMachineTemplateWebhook{}
+	dec := admission.NewDecoder(mgr.GetScheme())
+	mw.InjectDecoder(dec)
+	mgr.GetWebhookServer().Register("/validate-infrastructure-cluster-x-k8s-io-v1alpha1-staticmachinetemplate", &webhook.Admission{Handler: mw})
+	return nil
 }
 
 func (w *StaticMachineTemplateWebhook) InjectDecoder(d *admission.Decoder) error {

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/infrastructure/v1alpha1/staticmachinetemplate_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/infrastructure/v1alpha1/staticmachinetemplate_webhook.go
@@ -87,7 +87,7 @@ func isReqFromDeckhouse(userInfo authenticationv1.UserInfo) bool {
 func (w *StaticMachineTemplateWebhook) handleUpdate(newObj, oldObj StaticMachineTemplate, isDeckhouse bool) admission.Response {
 
 	if !reflect.DeepEqual(newObj.Spec, oldObj.Spec) && !isDeckhouse {
-		return admission.Denied("only deckhouse service account can update StaticMachineTemplate.Spec")
+		return admission.Denied("only deckhouse can update StaticMachineTemplate.Spec")
 	}
 	return admission.Allowed("update allowed")
 }

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/infrastructure/v1alpha1/staticmachinetemplate_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/infrastructure/v1alpha1/staticmachinetemplate_webhook.go
@@ -27,7 +27,6 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -38,10 +37,11 @@ type StaticMachineTemplateWebhook struct {
 	decoder *admission.Decoder
 }
 
+// +kubebuilder:webhook:path=/validate-infrastructure-cluster-x-k8s-io-v1alpha1-staticmachinetemplate,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=staticmachinetemplates,verbs=create;update;delete,versions=v1alpha1,name=validation.staticmachinetemplate.infrastructure.cluster.x-k8s.io
 func (r *StaticMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	mw := &StaticMachineTemplateWebhook{}
-	mgr.GetWebhookServer().Register("/validate-infrastructure-cluster-x-k8s-io-v1alpha1-staticmachinetemplate", &webhook.Admission{Handler: mw})
-	return nil
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
 }
 
 func (w *StaticMachineTemplateWebhook) InjectDecoder(d *admission.Decoder) error {


### PR DESCRIPTION
## Description

 Implemented custom validation in the StaticMachineTemplate webhook to allow only the Deckhouse service account to modify the `spec` field.

## Why do we need it, and what problem does it solve?

Previously, attempts by the Deckhouse to update `StaticMachineTemplate.spec` were denied, causing deckhouse queue freeze. This change allows Deckhouse to update `spec` while keeping it immutable for all other users.

## Why do we need it in the patch release (if we do)?


## What is the expected result?

Deckhouse  can successfully update the `spec` field in `StaticMachineTemplate`. All other attempts to modify `spec` will be denied by the webhook

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Allow Deckhouse  to modify spec in StaticMachineTemplate
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
