### PR TITLE
[metallb] Extended pre-upgrade compatibility configuration check

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1512,7 +1512,7 @@ alerts:
         MetaLB module misconfiguration.
       severity: "4"
       markupFormat: markdown
-    - name: D8MetallbNotOnlyLayer2Pools
+    - name: D8MetallbBothBGPAndL2PoolsConfigured
       sourceFile: ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
       moduleUrl: 380-metallb
       module: metallb

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1529,7 +1529,7 @@ alerts:
       module: metallb
       edition: se
       description: |
-        The Service `{{$labels.name}}` is orphaned. A Service must have any of the following properties:
+        The Service `{{$labels.name}}` in `{{$labels.namespace}}` namespace is orphaned. A Service must have any of the following properties:
         - have the loadBalancerClass,
         - have the `metallb.universe.tf/address-pool` annotation,
         - have the `metallb.universe.tf/ip-allocated-from-pool` annotation.

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1449,6 +1449,17 @@ alerts:
         MetalLB BGP session down.
       severity: "4"
       markupFormat: markdown
+    - name: D8MetallbBothBGPAndL2PoolsConfigured
+      sourceFile: ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+      moduleUrl: 380-metallb
+      module: metallb
+      edition: se
+      description: |
+        There must not be `Layer2` and `BGP` IP pools configured at the same time in ModuleConfig version 1.
+      summary: |
+        MetaLB module misconfiguration.
+      severity: "4"
+      markupFormat: markdown
     - name: D8MetalLBConfigNotLoaded
       sourceFile: ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
       moduleUrl: 380-metallb
@@ -1508,17 +1519,6 @@ alerts:
       edition: se
       description: |
         L2Advertisement `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
-      summary: |
-        MetaLB module misconfiguration.
-      severity: "4"
-      markupFormat: markdown
-    - name: D8MetallbBothBGPAndL2PoolsConfigured
-      sourceFile: ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
-      moduleUrl: 380-metallb
-      module: metallb
-      edition: se
-      description: |
-        There must not be `Layer2` and `BGP` IP pools configured at the same time in ModuleConfig version 1.
       summary: |
         MetaLB module misconfiguration.
       severity: "4"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1487,7 +1487,7 @@ alerts:
       description: |
         IpAddressPool `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
       summary: |
-        MetalLB module misconfiguration.
+        Failure of MetalLB module update request verification.
       severity: "4"
       markupFormat: markdown
     - name: D8MetallbL2AdvertisementNodeSelectorsMismatch
@@ -1498,7 +1498,7 @@ alerts:
       description: |
         L2Advertisement `{{$labels.name}}`: there must only be one matchLabels (not matchExpressions) in the nodeSelectors.
       summary: |
-        MetalLB module misconfiguration.
+        Failure of MetalLB module update request verification.
       severity: "4"
       markupFormat: markdown
     - name: D8MetallbL2AdvertisementNSMismatch
@@ -1509,7 +1509,7 @@ alerts:
       description: |
         L2Advertisement `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
       summary: |
-        MetalLB module misconfiguration.
+        Failure of MetalLB module update request verification.
       severity: "4"
       markupFormat: markdown
     - name: D8MetallbNotOnlyLayer2Pools
@@ -1520,7 +1520,7 @@ alerts:
       description: |
         There must not be `layer2` and `bgp` IP pools type in the cluster at the same time.
       summary: |
-        MetalLB module misconfiguration.
+        Failure of MetalLB module update request verification.
       severity: "4"
       markupFormat: markdown
     - name: D8MetallbOrphanedLoadBalancerDetected
@@ -1534,7 +1534,7 @@ alerts:
         - have the `metallb.universe.tf/address-pool` annotation,
         - have the `metallb.universe.tf/ip-allocated-from-pool` annotation.
       summary: |
-        MetalLB module misconfiguration.
+        Failure of MetalLB module update request verification.
       severity: "4"
       markupFormat: markdown
     - name: D8NeedDecreaseEtcdQuotaBackendBytes

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1518,7 +1518,7 @@ alerts:
       module: metallb
       edition: se
       description: |
-        There must not be `layer2` and `bgp` IP pools type in the cluster at the same time.
+        There must not be `Layer2` and `BGP` IP pools configured at the same time in ModuleConfig version 1.
       summary: |
         MetaLB module misconfiguration.
       severity: "4"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1487,7 +1487,7 @@ alerts:
       description: |
         IpAddressPool `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
       summary: |
-        Failure of MetalLB module update request verification.
+        MetalLB module misconfiguration.
       severity: "4"
       markupFormat: markdown
     - name: D8MetallbL2AdvertisementNodeSelectorsMismatch
@@ -1498,7 +1498,7 @@ alerts:
       description: |
         L2Advertisement `{{$labels.name}}`: there must only be one matchLabels (not matchExpressions) in the nodeSelectors.
       summary: |
-        Failure of MetalLB module update request verification.
+        MetalLB module misconfiguration.
       severity: "4"
       markupFormat: markdown
     - name: D8MetallbL2AdvertisementNSMismatch
@@ -1509,7 +1509,7 @@ alerts:
       description: |
         L2Advertisement `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
       summary: |
-        Failure of MetalLB module update request verification.
+        MetalLB module misconfiguration.
       severity: "4"
       markupFormat: markdown
     - name: D8MetallbNotOnlyLayer2Pools
@@ -1520,7 +1520,7 @@ alerts:
       description: |
         There must not be `layer2` and `bgp` IP pools type in the cluster at the same time.
       summary: |
-        Failure of MetalLB module update request verification.
+        MetalLB module misconfiguration.
       severity: "4"
       markupFormat: markdown
     - name: D8MetallbOrphanedLoadBalancerDetected
@@ -1534,7 +1534,7 @@ alerts:
         - have the `metallb.universe.tf/address-pool` annotation,
         - have the `metallb.universe.tf/ip-allocated-from-pool` annotation.
       summary: |
-        Failure of MetalLB module update request verification.
+        MetalLB module misconfiguration.
       severity: "4"
       markupFormat: markdown
     - name: D8NeedDecreaseEtcdQuotaBackendBytes

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1479,6 +1479,64 @@ alerts:
         MetalLB running on a stale configuration, because the latest config failed to load.
       severity: "4"
       markupFormat: markdown
+    - name: D8MetallbIpAddressPoolNSMismatch
+      sourceFile: ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+      moduleUrl: 380-metallb
+      module: metallb
+      edition: se
+      description: |
+        IpAddressPool `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
+      summary: |
+        Failure of MetalLB module update request verification.
+      severity: "4"
+      markupFormat: markdown
+    - name: D8MetallbL2AdvertisementNodeSelectorsMismatch
+      sourceFile: ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+      moduleUrl: 380-metallb
+      module: metallb
+      edition: se
+      description: |
+        L2Advertisement `{{$labels.name}}`: there must only be one matchLabels (not matchExpressions) in the nodeSelectors.
+      summary: |
+        Failure of MetalLB module update request verification.
+      severity: "4"
+      markupFormat: markdown
+    - name: D8MetallbL2AdvertisementNSMismatch
+      sourceFile: ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+      moduleUrl: 380-metallb
+      module: metallb
+      edition: se
+      description: |
+        L2Advertisement `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
+      summary: |
+        Failure of MetalLB module update request verification.
+      severity: "4"
+      markupFormat: markdown
+    - name: D8MetallbNotOnlyLayer2Pools
+      sourceFile: ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+      moduleUrl: 380-metallb
+      module: metallb
+      edition: se
+      description: |
+        There must not be `layer2` and `bgp` IP pools type in the cluster at the same time.
+      summary: |
+        Failure of MetalLB module update request verification.
+      severity: "4"
+      markupFormat: markdown
+    - name: D8MetallbOrphanedLoadBalancerDetected
+      sourceFile: ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+      moduleUrl: 380-metallb
+      module: metallb
+      edition: se
+      description: |
+        The Service `{{$labels.name}}` is orphaned. A Service must have any of the following properties:
+        - have the loadBalancerClass,
+        - have the `metallb.universe.tf/address-pool` annotation,
+        - have the `metallb.universe.tf/ip-allocated-from-pool` annotation.
+      summary: |
+        Failure of MetalLB module update request verification.
+      severity: "4"
+      markupFormat: markdown
     - name: D8NeedDecreaseEtcdQuotaBackendBytes
       sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
       moduleUrl: 040-control-plane-manager

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1487,7 +1487,7 @@ alerts:
       description: |
         IpAddressPool `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
       summary: |
-        Failure of MetalLB module update request verification.
+        MetaLB module misconfiguration.
       severity: "4"
       markupFormat: markdown
     - name: D8MetallbL2AdvertisementNodeSelectorsMismatch
@@ -1498,7 +1498,7 @@ alerts:
       description: |
         L2Advertisement `{{$labels.name}}`: there must only be one matchLabels (not matchExpressions) in the nodeSelectors.
       summary: |
-        Failure of MetalLB module update request verification.
+        MetaLB module misconfiguration.
       severity: "4"
       markupFormat: markdown
     - name: D8MetallbL2AdvertisementNSMismatch
@@ -1509,7 +1509,7 @@ alerts:
       description: |
         L2Advertisement `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
       summary: |
-        Failure of MetalLB module update request verification.
+        MetaLB module misconfiguration.
       severity: "4"
       markupFormat: markdown
     - name: D8MetallbNotOnlyLayer2Pools
@@ -1520,7 +1520,7 @@ alerts:
       description: |
         There must not be `layer2` and `bgp` IP pools type in the cluster at the same time.
       summary: |
-        Failure of MetalLB module update request verification.
+        MetaLB module misconfiguration.
       severity: "4"
       markupFormat: markdown
     - name: D8MetallbOrphanedLoadBalancerDetected
@@ -1534,7 +1534,7 @@ alerts:
         - have the `metallb.universe.tf/address-pool` annotation,
         - have the `metallb.universe.tf/ip-allocated-from-pool` annotation.
       summary: |
-        Failure of MetalLB module update request verification.
+        MetaLB module misconfiguration.
       severity: "4"
       markupFormat: markdown
     - name: D8NeedDecreaseEtcdQuotaBackendBytes

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
@@ -131,7 +131,7 @@ func checkAllRequirementsForUpgrade(input *go_hook.HookInput) error {
 		"D8MetallbL2AdvertisementNSMismatch",
 		"D8MetallbOrphanedLoadBalancerDetected",
 		"D8MetallbL2AdvertisementNodeSelectorsMismatch",
-		"D8MetallbNotOnlyLayer2Pools",
+		"D8MetallbBothBGPAndL2PoolsConfigured",
 	} {
 		input.MetricsCollector.Expire(alertGroup)
 	}
@@ -155,7 +155,7 @@ func checkAllRequirementsForUpgrade(input *go_hook.HookInput) error {
 		if protocols["bgp"] && (protocols["layer2"] || l2AdvertisementsCount > 0) {
 			requirements.SaveValue(metallbConfigurationStatusKey, "Misconfigured")
 			input.MetricsCollector.Set("d8_metallb_not_only_layer2_pools", 1,
-				map[string]string{}, metrics.WithGroup("D8MetallbNotOnlyLayer2Pools"))
+				map[string]string{}, metrics.WithGroup("D8MetallbBothBGPAndL2PoolsConfigured"))
 			break
 		}
 	}

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
@@ -152,7 +152,7 @@ func checkAllRequirementsForUpgrade(input *go_hook.HookInput) error {
 	l2AdvertisementsCount := len(input.Snapshots["l2_advertisements"])
 	for _, pool := range mc.Spec.Settings.AddressPools {
 		protocols[pool.Protocol] = true
-		if (protocols["layer2"] && protocols["bgp"]) || (protocols["bgp"] && l2AdvertisementsCount > 0) {
+		if (protocols["bgp"] && (protocols["layer2"] || l2AdvertisementsCount > 0)) {
 			requirements.SaveValue(metallbConfigurationStatusKey, "Misconfigured")
 			input.MetricsCollector.Set("d8_metallb_not_only_layer2_pools", 1,
 				map[string]string{}, metrics.WithGroup("D8MetallbNotOnlyLayer2Pools"))

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
@@ -152,7 +152,7 @@ func checkAllRequirementsForUpgrade(input *go_hook.HookInput) error {
 	l2AdvertisementsCount := len(input.Snapshots["l2_advertisements"])
 	for _, pool := range mc.Spec.Settings.AddressPools {
 		protocols[pool.Protocol] = true
-		if (protocols["bgp"] && (protocols["layer2"] || l2AdvertisementsCount > 0)) {
+		if protocols["bgp"] && (protocols["layer2"] || l2AdvertisementsCount > 0) {
 			requirements.SaveValue(metallbConfigurationStatusKey, "Misconfigured")
 			input.MetricsCollector.Set("d8_metallb_not_only_layer2_pools", 1,
 				map[string]string{}, metrics.WithGroup("D8MetallbNotOnlyLayer2Pools"))

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
@@ -203,7 +203,6 @@ func checkAllRequirementsForUpgrade(input *go_hook.HookInput) error {
 	}
 
 	// Search orphaned Services
-	// TODO add test
 	serviceNameSnaps := input.Snapshots["services"]
 	for _, serviceNameSnap := range serviceNameSnaps {
 		if serviceNameSnap != nil {

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade.go
@@ -1,70 +1,25 @@
 /*
 Copyright 2024 Flant JSC
-Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license.
+See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package hooks
 
 import (
+	"fmt"
 	"slices"
 	"sort"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 )
-
-type L2Advertisement struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec   L2AdvertisementSpec   `json:"spec,omitempty"`
-	Status L2AdvertisementStatus `json:"status,omitempty"`
-}
-
-type L2AdvertisementSpec struct {
-	IPAddressPools         []string               `json:"ipAddressPools,omitempty"`
-	IPAddressPoolSelectors []metav1.LabelSelector `json:"ipAddressPoolSelectors,omitempty"`
-	NodeSelectors          []metav1.LabelSelector `json:"nodeSelectors,omitempty"`
-	Interfaces             []string               `json:"interfaces,omitempty"`
-}
-
-type L2AdvertisementStatus struct {
-}
-
-type IPAddressPool struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec   IPAddressPoolSpec   `json:"spec"`
-	Status IPAddressPoolStatus `json:"status,omitempty"`
-}
-
-type IPAddressPoolSpec struct {
-	Addresses     []string           `json:"addresses"`
-	AutoAssign    *bool              `json:"autoAssign,omitempty"`
-	AvoidBuggyIPs bool               `json:"avoidBuggyIPs,omitempty"`
-	AllocateTo    *ServiceAllocation `json:"serviceAllocation,omitempty"`
-}
-
-type ServiceAllocation struct {
-	Priority           int                    `json:"priority,omitempty"`
-	Namespaces         []string               `json:"namespaces,omitempty"`
-	NamespaceSelectors []metav1.LabelSelector `json:"namespaceSelectors,omitempty"`
-	ServiceSelectors   []metav1.LabelSelector `json:"serviceSelectors,omitempty"`
-}
-
-type IPAddressPoolStatus struct {
-}
-
-type L2AdvertisementInfo struct {
-	IPAddressPools []string
-	NodeSelectors  []metav1.LabelSelector
-	Namespace      string
-}
 
 const (
 	metallbConfigurationStatusKey = "metallb:ConfigurationStatus"
@@ -73,16 +28,31 @@ const (
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:       "l2advertisements",
+			Name:       "l2_advertisements",
 			ApiVersion: "metallb.io/v1beta1",
 			Kind:       "L2Advertisement",
 			FilterFunc: applyL2AdvertisementFilter,
 		},
 		{
-			Name:       "ipaddresspools",
+			Name:       "ip_address_pools",
 			ApiVersion: "metallb.io/v1beta1",
 			Kind:       "IPAddressPool",
 			FilterFunc: applyIPAddressPoolFilter,
+		},
+		{
+			Name:       "services",
+			ApiVersion: "v1",
+			Kind:       "Service",
+			FilterFunc: applyServiceFilter,
+		},
+		{
+			Name:       "module_config",
+			ApiVersion: "deckhouse.io/v1alpha1",
+			Kind:       "ModuleConfig",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"metallb"},
+			},
+			FilterFunc: applyModuleConfigFilter,
 		},
 	},
 }, checkAllRequirementsForUpgrade)
@@ -94,14 +64,11 @@ func applyL2AdvertisementFilter(obj *unstructured.Unstructured) (go_hook.FilterR
 		return nil, err
 	}
 
-	if len(l2Advertisement.Spec.IPAddressPools) == 0 {
-		return nil, nil
-	}
-
 	return L2AdvertisementInfo{
 		IPAddressPools: l2Advertisement.Spec.IPAddressPools,
 		NodeSelectors:  l2Advertisement.Spec.NodeSelectors,
 		Namespace:      l2Advertisement.Namespace,
+		Name:           l2Advertisement.Name,
 	}, nil
 }
 
@@ -111,53 +78,144 @@ func applyIPAddressPoolFilter(obj *unstructured.Unstructured) (go_hook.FilterRes
 	if err != nil {
 		return nil, err
 	}
+	return IPAddressPoolInfo{
+		Name:      ipAddressPool.Name,
+		Namespace: ipAddressPool.Namespace,
+	}, nil
+}
 
-	return ipAddressPool.Name, err
+func applyModuleConfigFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	mc := &ModuleConfig{}
+	err := sdk.FromUnstructured(obj, mc)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert Metallb ModuleConfig: %v", err)
+	}
+	return mc.Spec.Version, nil
+}
+
+func applyServiceFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var service v1.Service
+
+	err := sdk.FromUnstructured(obj, &service)
+	if err != nil {
+		return nil, err
+	}
+
+	if service.Spec.Type != v1.ServiceTypeLoadBalancer {
+		return nil, nil
+	}
+	if service.Spec.LoadBalancerClass != nil {
+		if _, ok := service.Annotations["metallb.universe.tf/address-pool"]; ok {
+			if _, ok := service.Annotations["metallb.universe.tf/ip-allocated-from-pool"]; ok {
+				return nil, nil
+			}
+		}
+	}
+	return service.Name, nil
 }
 
 func checkAllRequirementsForUpgrade(input *go_hook.HookInput) error {
-	ipAddressPoolNamesFromL2A := make([]string, 0, 8)
-	l2AdvertisementSnaps := input.Snapshots["l2advertisements"]
-	for _, l2AdvertisementSnap := range l2AdvertisementSnaps {
-		l2Advertisement := l2AdvertisementSnap.(L2AdvertisementInfo)
-		// Check a namespace
-		if l2Advertisement.Namespace != "d8-metallb" {
-			requirements.SaveValue(metallbConfigurationStatusKey, "NSMismatch")
+	// Disable all alerts
+	for _, alertGroup := range []string{
+		"D8MetallbIpAddressPoolNSMismatch",
+		"D8MetallbL2AdvertisementNSMismatch",
+		"D8MetallbOrphanedLoadBalancerDetected",
+		"D8MetallbL2AdvertisementNodeSelectorsMismatch",
+		"D8MetallbNotOnlyLayer2Pools",
+	} {
+		input.MetricsCollector.Expire(alertGroup)
+	}
+	requirements.SaveValue(metallbConfigurationStatusKey, "OK")
+
+	// Check ModuleConfig version
+	mcSnaps := input.Snapshots["module_config"]
+	if len(mcSnaps) != 1 {
+		return nil
+	}
+	if version, ok := mcSnaps[0].(int); ok {
+		if version == 2 {
 			return nil
 		}
+	}
 
-		// There should only be one matchLabels (not matchExpressions) in nodeSelectors
-		if len(l2Advertisement.NodeSelectors) > 0 {
-			if len(l2Advertisement.NodeSelectors) != 1 {
-				requirements.SaveValue(metallbConfigurationStatusKey, "NodeSelectorsMismatch")
-				return nil
+	ipAddressPoolNamesFromL2A := make([]string, 0, 8)
+	l2AdvertisementSnaps := input.Snapshots["l2_advertisements"]
+	for _, l2AdvertisementSnap := range l2AdvertisementSnaps {
+		if l2Advertisement, ok := l2AdvertisementSnap.(L2AdvertisementInfo); ok {
+			// Check a namespace
+			if l2Advertisement.Namespace != "d8-metallb" {
+				requirements.SaveValue(metallbConfigurationStatusKey, "Misconfigured")
+				input.MetricsCollector.Set("d8_metallb_l2advertisement_ns_mismatch", 1,
+					map[string]string{
+						"namespace": l2Advertisement.Namespace,
+						"name":      l2Advertisement.Name,
+					}, metrics.WithGroup("D8MetallbL2AdvertisementNSMismatch"))
 			}
-			nodeSelector := l2Advertisement.NodeSelectors[0]
-			if len(nodeSelector.MatchExpressions) > 0 {
-				requirements.SaveValue(metallbConfigurationStatusKey, "NodeSelectorsMismatch")
-				return nil
+
+			// There should only be one matchLabels (not matchExpressions) in nodeSelectors
+			if len(l2Advertisement.NodeSelectors) > 0 {
+				if len(l2Advertisement.NodeSelectors) != 1 {
+					requirements.SaveValue(metallbConfigurationStatusKey, "Misconfigured")
+					input.MetricsCollector.Set("d8_metallb_l2advertisement_node_selectors_mismatch", 1,
+						map[string]string{
+							"name": l2Advertisement.Name,
+						}, metrics.WithGroup("D8MetallbL2AdvertisementNodeSelectorsMismatch"))
+				}
+				nodeSelector := l2Advertisement.NodeSelectors[0]
+				if len(nodeSelector.MatchExpressions) > 0 {
+					requirements.SaveValue(metallbConfigurationStatusKey, "Misconfigured")
+					input.MetricsCollector.Set("d8_metallb_l2advertisement_node_selectors_mismatch", 1,
+						map[string]string{
+							"name": l2Advertisement.Name,
+						}, metrics.WithGroup("D8MetallbL2AdvertisementNodeSelectorsMismatch"))
+				}
 			}
+			// Collect names of ipAddressPools from L2Advertisement
+			ipAddressPoolNamesFromL2A = append(ipAddressPoolNamesFromL2A, l2Advertisement.IPAddressPools...)
 		}
-
-		// Collect names of ipAddressPools from L2Advertisement
-		ipAddressPoolNamesFromL2A = append(ipAddressPoolNamesFromL2A, l2Advertisement.IPAddressPools...)
 	}
 
 	ipAddressPoolNamesFromIAP := make([]string, 0, 8)
-	ipAddressPoolSnaps := input.Snapshots["ipaddresspools"]
+	ipAddressPoolSnaps := input.Snapshots["ip_address_pools"]
 	for _, ipAddressPoolSnap := range ipAddressPoolSnaps {
-		ipAddressPoolName := ipAddressPoolSnap.(string)
-		// Collect names of ipAddressPools from IPAddressPools
-		ipAddressPoolNamesFromIAP = append(ipAddressPoolNamesFromIAP, ipAddressPoolName)
+		if ipAddressPool, ok := ipAddressPoolSnap.(IPAddressPoolInfo); ok {
+			// Check a namespace
+			if ipAddressPool.Namespace != "d8-metallb" {
+				requirements.SaveValue(metallbConfigurationStatusKey, "Misconfigured")
+				input.MetricsCollector.Set("d8_metallb_ipaddress_pool_ns_mismatch", 1,
+					map[string]string{
+						"namespace": ipAddressPool.Namespace,
+						"name":      ipAddressPool.Name,
+					}, metrics.WithGroup("D8MetallbIpAddressPoolNSMismatch"))
+			}
+			// Collect names of ipAddressPools from IPAddressPools
+			ipAddressPoolNamesFromIAP = append(ipAddressPoolNamesFromIAP, ipAddressPool.Name)
+		}
 	}
 
 	// Are only layer2 pools in the cluster?
 	sort.Strings(ipAddressPoolNamesFromL2A) // Only layer2 pools
 	sort.Strings(ipAddressPoolNamesFromIAP) // All pools of cluster
 	if !slices.Equal(ipAddressPoolNamesFromL2A, ipAddressPoolNamesFromIAP) {
-		requirements.SaveValue(metallbConfigurationStatusKey, "AddressPoolsMismatch")
-		return nil
+		requirements.SaveValue(metallbConfigurationStatusKey, "Misconfigured")
+		input.MetricsCollector.Set("d8_metallb_not_only_layer2_pools", 1,
+			map[string]string{}, metrics.WithGroup("D8MetallbNotOnlyLayer2Pools"))
 	}
-	requirements.SaveValue(metallbConfigurationStatusKey, "OK")
+
+	// Search orphaned Services
+	// TODO add test
+	serviceNameSnaps := input.Snapshots["services"]
+	for _, serviceNameSnap := range serviceNameSnaps {
+		if serviceNameSnap != nil {
+			if serviceName, ok := serviceNameSnap.(string); ok {
+				requirements.SaveValue(metallbConfigurationStatusKey, "Misconfigured")
+				input.MetricsCollector.Set("d8_metallb_orphaned_loadbalancer_detected", 1,
+					map[string]string{
+						"name": serviceName,
+					}, metrics.WithGroup("D8MetallbOrphanedLoadBalancerDetected"))
+			}
+		}
+	}
+
 	return nil
 }

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
@@ -131,11 +131,14 @@ spec:
 			Expect(configurationStatus).To(Equal("Misconfigured"))
 
 			metrics := f.MetricsCollector.CollectedMetrics()
+			found := false
 			for _, metric := range metrics {
 				if metric.Name == "d8_metallb_not_only_layer2_pools" {
+					found = true
 					Expect(*metric.Value).To(Equal(float64(1)))
 				}
 			}
+			Expect(found).To(BeTrue(), "Expected to find 'd8_metallb_not_only_layer2_pools' metric")
 		})
 	})
 
@@ -174,11 +177,14 @@ metadata:
 			Expect(configurationStatus).To(Equal("Misconfigured"))
 
 			metrics := f.MetricsCollector.CollectedMetrics()
+			found := false
 			for _, metric := range metrics {
 				if metric.Name == "d8_metallb_not_only_layer2_pools" {
+					found = true
 					Expect(*metric.Value).To(Equal(float64(1)))
 				}
 			}
+			Expect(found).To(BeTrue(), "Expected to find 'd8_metallb_not_only_layer2_pools' metric")
 		})
 	})
 
@@ -218,13 +224,16 @@ metadata:
 			Expect(configurationStatus).To(Equal("Misconfigured"))
 
 			metrics := f.MetricsCollector.CollectedMetrics()
+			found := false
 			for _, metric := range metrics {
 				if metric.Name == "d8_metallb_l2advertisement_ns_mismatch" {
+					found = true
 					Expect(*metric.Value).To(Equal(float64(1)))
 					Expect(metric.Labels["name"]).To(Equal("zone-b"))
 					Expect(metric.Labels["namespace"]).To(Equal("metallb"))
 				}
 			}
+			Expect(found).To(BeTrue(), "Expected to find 'd8_metallb_l2advertisement_ns_mismatch' metric")
 		})
 	})
 
@@ -264,13 +273,16 @@ metadata:
 			Expect(configurationStatus).To(Equal("Misconfigured"))
 
 			metrics := f.MetricsCollector.CollectedMetrics()
+			found := false
 			for _, metric := range metrics {
 				if metric.Name == "d8_metallb_ipaddress_pool_ns_mismatch" {
+					found = true
 					Expect(*metric.Value).To(Equal(float64(1)))
 					Expect(metric.Labels["name"]).To(Equal("pool-2"))
 					Expect(metric.Labels["namespace"]).To(Equal("metallb"))
 				}
 			}
+			Expect(found).To(BeTrue(), "Expected to find 'd8_metallb_ipaddress_pool_ns_mismatch' metric")
 		})
 	})
 
@@ -323,12 +335,15 @@ spec:
 			Expect(configurationStatus).To(Equal("Misconfigured"))
 
 			metrics := f.MetricsCollector.CollectedMetrics()
+			found := false
 			for _, metric := range metrics {
 				if metric.Name == "d8_metallb_l2advertisement_node_selectors_mismatch" {
+					found = true
 					Expect(*metric.Value).To(Equal(float64(1)))
 					Expect(metric.Labels["name"]).To(Equal("zone-b"))
 				}
 			}
+			Expect(found).To(BeTrue(), "Expected to find 'd8_metallb_l2advertisement_node_selectors_mismatch' metric")
 		})
 	})
 
@@ -414,12 +429,16 @@ spec:
 
 			metrics := f.MetricsCollector.CollectedMetrics()
 			var orphanedServiceNames []string
+			found := false
 			for _, metric := range metrics {
 				if metric.Name == "d8_metallb_orphaned_loadbalancer_detected" {
+					found = true
 					Expect(*metric.Value).To(Equal(float64(1)))
 					orphanedServiceNames = append(orphanedServiceNames, metric.Labels["name"])
 				}
 			}
+			Expect(found).To(BeTrue(), "Expected to find 'd8_metallb_orphaned_loadbalancer_detected' metric")
+
 			sort.Strings(orphanedServiceNames)
 			Expect(len(orphanedServiceNames)).To(Equal(1))
 			Expect(orphanedServiceNames).To(Equal([]string{"nginx1"}))

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
@@ -190,7 +190,7 @@ metadata:
   namespace: nginx3
   annotations:
     metallb.universe.tf/address-pool: "aaa"
-    metallb.universe.tf/ip-allocated-from-pool: "bbb"
+    metallb.universe.tf/ip-allocated-from-pool: "aaa"
 spec:
   clusterIP: 2.3.4.5
   ports:

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
@@ -7,16 +7,24 @@ See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 package hooks
 
 import (
+	"sort"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"sort"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-const (
-	config = `
+var _ = Describe("Metallb hooks :: check requirements for upgrade ::", func() {
+	f := HookExecutionConfigInit(`{}`, `{"global":{"discovery":{}}}`)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
+	f.RegisterCRD("metallb.io", "v1beta1", "L2Advertisement", true)
+	f.RegisterCRD("metallb.io", "v1beta1", "IPAddressPool", true)
+
+	Context("Cluster have correct configurations", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
@@ -25,9 +33,6 @@ metadata:
 spec:
   enabled: true
   version: 1
-  settings:
-`
-	l2Advertisement = `
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
@@ -41,8 +46,6 @@ spec:
   nodeSelectors:
   - matchLabels:
       zone: a
-`
-	ipAddressPools = `
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
@@ -61,42 +64,227 @@ metadata:
 spec:
   addresses:
   - 22.22.22.22/32
-`
-	ipAddressPools2 = `
+`))
+			f.RunHook()
+		})
+		It("ConfigurationStatus should be OK", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
+			Expect(exists).To(BeTrue())
+			configurationStatus := configurationStatusRaw.(string)
+			Expect(configurationStatus).To(Equal("OK"))
+		})
+	})
+
+	Context("Cluster have a ModuleConfig version 3", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: metallb
+spec:
+  enabled: true
+  version: 3
+`))
+			f.RunHook()
+		})
+		It("Should not proceed as ModuleConfig version is >= 2", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			mc := f.KubernetesResource("ModuleConfig", "", "metallb")
+			Expect(mc.Exists()).To(BeTrue(), "ModuleConfig resource should exist")
+			Expect(mc.Field("spec.version").Int()).To(BeNumerically(">=", 2))
+		})
+	})
+
+	Context("MC has pools with different types of pools", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: metallb
+spec:
+  enabled: true
+  version: 1
+  settings:
+    addressPools:
+      - addresses:
+        - 192.168.199.100-192.168.199.200
+        name: frontend-pool
+        protocol: layer2
+      - addresses:
+        - 192.168.198.100-192.168.198.200
+        name: frontend-pool-bgp
+        protocol: bgp
+`))
+			f.RunHook()
+		})
+		It(`ConfigurationStatus is Misconfigured and
+				the 'd8_metallb_not_only_layer2_pools' metric is 1`, func() {
+			Expect(f).To(ExecuteSuccessfully())
+			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
+			Expect(exists).To(BeTrue())
+			configurationStatus := configurationStatusRaw.(string)
+			Expect(configurationStatus).To(Equal("Misconfigured"))
+
+			metrics := f.MetricsCollector.CollectedMetrics()
+			for _, metric := range metrics {
+				if metric.Name == "d8_metallb_not_only_layer2_pools" {
+					Expect(*metric.Value).To(Equal(float64(1)))
+				}
+			}
+		})
+	})
+
+	Context("MC has pools `layer2` pool and L2Advertisement", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: metallb
+spec:
+  enabled: true
+  version: 1
+  settings:
+    addressPools:
+      - addresses:
+        - 192.168.199.100-192.168.199.200
+        name: frontend-pool
+        protocol: bgp
 ---
 apiVersion: metallb.io/v1beta1
-kind: IPAddressPool
+kind: L2Advertisement
 metadata:
-  name: pool-1
+  name: zone-a
   namespace: d8-metallb
-spec:
-  addresses:
-  - 11.11.11.11/32
+`))
+			f.RunHook()
+		})
+		It("ConfigurationStatus is Misconfigured and "+
+			"the 'd8_metallb_not_only_layer2_pools' metric is 1", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
+			Expect(exists).To(BeTrue())
+			configurationStatus := configurationStatusRaw.(string)
+			Expect(configurationStatus).To(Equal("Misconfigured"))
+
+			metrics := f.MetricsCollector.CollectedMetrics()
+			for _, metric := range metrics {
+				if metric.Name == "d8_metallb_not_only_layer2_pools" {
+					Expect(*metric.Value).To(Equal(float64(1)))
+				}
+			}
+		})
+	})
+
+	Context("Two L2Advertisement is located different namespaces", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
 ---
-apiVersion: metallb.io/v1beta1
-kind: IPAddressPool
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
 metadata:
-  name: pool-3
-  namespace: d8-metallb
+  name: metallb
 spec:
-  addresses:
-  - 33.33.33.33/32
-`
-	l2Advertisement2 = `
+  enabled: true
+  version: 1
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
   name: zone-b
   namespace: metallb
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: zone-a
+  namespace: d8-metallb
+`))
+			f.RunHook()
+		})
+
+		It("ConfigurationStatus is Misconfigured and "+
+			"the 'd8_metallb_l2advertisement_ns_mismatch' metric is 1", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
+			Expect(exists).To(BeTrue())
+			configurationStatus := configurationStatusRaw.(string)
+			Expect(configurationStatus).To(Equal("Misconfigured"))
+
+			metrics := f.MetricsCollector.CollectedMetrics()
+			for _, metric := range metrics {
+				if metric.Name == "d8_metallb_l2advertisement_ns_mismatch" {
+					Expect(*metric.Value).To(Equal(float64(1)))
+					Expect(metric.Labels["name"]).To(Equal("zone-b"))
+					Expect(metric.Labels["namespace"]).To(Equal("metallb"))
+				}
+			}
+		})
+	})
+
+	Context("Two IPAddressPool is located different namespaces", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: metallb
 spec:
-  ipAddressPools:
-  - pool-1
-  nodeSelectors:
-  - matchLabels:
-      zone: b
-`
-	l2Advertisement3 = `
+  enabled: true
+  version: 1
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: pool-1
+  namespace: d8-metallb
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: pool-2
+  namespace: metallb
+`))
+			f.RunHook()
+		})
+
+		It("ConfigurationStatus is Misconfigured and "+
+			"the 'd8_metallb_ipaddress_pool_ns_mismatch' metric is 1", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
+			Expect(exists).To(BeTrue())
+			configurationStatus := configurationStatusRaw.(string)
+			Expect(configurationStatus).To(Equal("Misconfigured"))
+
+			metrics := f.MetricsCollector.CollectedMetrics()
+			for _, metric := range metrics {
+				if metric.Name == "d8_metallb_ipaddress_pool_ns_mismatch" {
+					Expect(*metric.Value).To(Equal(float64(1)))
+					Expect(metric.Labels["name"]).To(Equal("pool-2"))
+					Expect(metric.Labels["namespace"]).To(Equal("metallb"))
+				}
+			}
+		})
+	})
+
+	Context("There is an L2Advertisement with matchExpressions in the cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: metallb
+spec:
+  enabled: true
+  version: 1
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
@@ -109,8 +297,6 @@ spec:
   nodeSelectors:
   - matchLabels:
       zone: a
-`
-	l2Advertisement4 = `
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
@@ -124,28 +310,39 @@ spec:
   - matchExpressions: []
   - matchLabels:
       zone: b
-`
-	ipAddressPools3 = `
+`))
+			f.RunHook()
+		})
+
+		It("ConfigurationStatus is Misconfigured and "+
+			"the 'd8_metallb_l2advertisement_node_selectors_mismatch' metric is 1", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
+			Expect(exists).To(BeTrue())
+			configurationStatus := configurationStatusRaw.(string)
+			Expect(configurationStatus).To(Equal("Misconfigured"))
+
+			metrics := f.MetricsCollector.CollectedMetrics()
+			for _, metric := range metrics {
+				if metric.Name == "d8_metallb_l2advertisement_node_selectors_mismatch" {
+					Expect(*metric.Value).To(Equal(float64(1)))
+					Expect(metric.Labels["name"]).To(Equal("zone-b"))
+				}
+			}
+		})
+	})
+
+	Context("There are several Services and among them one Orphaned Services", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
 ---
-apiVersion: metallb.io/v1beta1
-kind: IPAddressPool
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
 metadata:
-  name: pool-1
-  namespace: d8-metallb
+  name: metallb
 spec:
-  addresses:
-  - 11.11.11.11/32
----
-apiVersion: metallb.io/v1beta1
-kind: IPAddressPool
-metadata:
-  name: pool-3
-  namespace: metallb
-spec:
-  addresses:
-  - 33.33.33.33/32
-`
-	services = `
+  enabled: true
+  version: 1
 ---
 apiVersion: v1
 kind: Service
@@ -203,141 +400,12 @@ metadata:
 spec:
   type: LoadBalancer
   loadBalancerClass: nginx5
-`
-)
-
-var _ = Describe("Metallb hooks :: check requirements for upgrade ::", func() {
-	f := HookExecutionConfigInit(`{}`, `{"global":{"discovery":{}}}`)
-	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
-	f.RegisterCRD("metallb.io", "v1beta1", "L2Advertisement", true)
-	f.RegisterCRD("metallb.io", "v1beta1", "IPAddressPool", true)
-
-	Context("Check correct ModuleConfig version", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(config))
-			f.RunHook()
-		})
-		It("Check the set variable", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			mc := f.KubernetesResource("ModuleConfig", "", "metallb")
-			Expect(mc.Field("spec.version").String()).NotTo(Equal("2"))
-		})
-	})
-
-	Context("Check correct configurations", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(config + l2Advertisement + ipAddressPools))
-			f.RunHook()
-		})
-		It("Check the set variable", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
-			Expect(exists).To(BeTrue())
-			configurationStatus := configurationStatusRaw.(string)
-			Expect(configurationStatus).To(Equal("OK"))
-		})
-	})
-
-	Context("Check AddressPoolsMismatch error", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(config + l2Advertisement + ipAddressPools2))
+`))
 			f.RunHook()
 		})
 
-		It("Check the set variable", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
-			Expect(exists).To(BeTrue())
-			configurationStatus := configurationStatusRaw.(string)
-			Expect(configurationStatus).To(Equal("Misconfigured"))
-
-			metrics := f.MetricsCollector.CollectedMetrics()
-			for _, metric := range metrics {
-				if metric.Name == "d8_metallb_not_only_layer2_pools" {
-					Expect(*metric.Value).To(Equal(float64(1)))
-				}
-			}
-		})
-	})
-
-	Context("Check L2AdvertisementNSMismatch error", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(config + l2Advertisement2 + l2Advertisement3))
-			f.RunHook()
-		})
-
-		It("Check the set variable", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
-			Expect(exists).To(BeTrue())
-			configurationStatus := configurationStatusRaw.(string)
-			Expect(configurationStatus).To(Equal("Misconfigured"))
-
-			metrics := f.MetricsCollector.CollectedMetrics()
-			for _, metric := range metrics {
-				if metric.Name == "d8_metallb_l2advertisement_ns_mismatch" {
-					Expect(*metric.Value).To(Equal(float64(1)))
-					Expect(metric.Labels["name"]).To(Equal("zone-b"))
-					Expect(metric.Labels["namespace"]).To(Equal("metallb"))
-				}
-			}
-		})
-	})
-
-	Context("Check IpAddressPoolNSMismatch error", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(config + ipAddressPools3))
-			f.RunHook()
-		})
-
-		It("Check the set variable", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
-			Expect(exists).To(BeTrue())
-			configurationStatus := configurationStatusRaw.(string)
-			Expect(configurationStatus).To(Equal("Misconfigured"))
-
-			metrics := f.MetricsCollector.CollectedMetrics()
-			for _, metric := range metrics {
-				if metric.Name == "d8_metallb_ipaddress_pool_ns_mismatch" {
-					Expect(*metric.Value).To(Equal(float64(1)))
-					Expect(metric.Labels["name"]).To(Equal("pool-3"))
-					Expect(metric.Labels["namespace"]).To(Equal("metallb"))
-				}
-			}
-		})
-	})
-
-	Context("Check NodeSelectorsMismatch error", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(config + l2Advertisement3 + l2Advertisement4))
-			f.RunHook()
-		})
-
-		It("Check the set variable", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
-			Expect(exists).To(BeTrue())
-			configurationStatus := configurationStatusRaw.(string)
-			Expect(configurationStatus).To(Equal("Misconfigured"))
-
-			metrics := f.MetricsCollector.CollectedMetrics()
-			for _, metric := range metrics {
-				if metric.Name == "d8_metallb_l2advertisement_node_selectors_mismatch" {
-					Expect(*metric.Value).To(Equal(float64(1)))
-					Expect(metric.Labels["name"]).To(Equal("zone-b"))
-				}
-			}
-		})
-	})
-
-	Context("Check OrphanedServices error", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(config + services))
-			f.RunHook()
-		})
-
-		It("Check the set variable", func() {
+		It("ConfigurationStatus is Misconfigured and "+
+			"the 'd8_metallb_orphaned_loadbalancer_detected' metric is 1", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
 			Expect(exists).To(BeTrue())

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
@@ -122,8 +122,8 @@ spec:
 `))
 			f.RunHook()
 		})
-		It(`ConfigurationStatus is Misconfigured and
-				the 'd8_metallb_not_only_layer2_pools' metric is 1`, func() {
+		It("ConfigurationStatus is Misconfigured and "+
+			"the 'd8_metallb_not_only_layer2_pools' metric is 1", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			configurationStatusRaw, exists := requirements.GetValue(metallbConfigurationStatusKey)
 			Expect(exists).To(BeTrue())

--- a/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
+++ b/ee/se/modules/380-metallb/hooks/check_requirements_for_upgrade_test.go
@@ -181,7 +181,6 @@ spec:
   selector:
     app: nginx2
   type: LoadBalancer
-  loadBalancerClass: test
 ---
 apiVersion: v1
 kind: Service

--- a/ee/se/modules/380-metallb/hooks/common_test.go
+++ b/ee/se/modules/380-metallb/hooks/common_test.go
@@ -1,6 +1,7 @@
 /*
 Copyright 2024 Flant JSC
-Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license.
+See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package hooks

--- a/ee/se/modules/380-metallb/hooks/types.go
+++ b/ee/se/modules/380-metallb/hooks/types.go
@@ -101,7 +101,8 @@ type ModuleConfigStatus struct {
 	Message string `json:"message"`
 }
 
-type ServiceInfoForAlert struct {
-	Name      string `json:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
+type OrphanedLoadBalancerServiceInfo struct {
+	Name       string `json:"name,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	IsOrphaned bool   `json:"isOrphaned,omitempty"`
 }

--- a/ee/se/modules/380-metallb/hooks/types.go
+++ b/ee/se/modules/380-metallb/hooks/types.go
@@ -100,3 +100,8 @@ type ModuleConfigStatus struct {
 	Version string `json:"version"`
 	Message string `json:"message"`
 }
+
+type ServiceInfoForAlert struct {
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}

--- a/ee/se/modules/380-metallb/hooks/typos.go
+++ b/ee/se/modules/380-metallb/hooks/typos.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license.
+See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type L2Advertisement struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   L2AdvertisementSpec   `json:"spec,omitempty"`
+	Status L2AdvertisementStatus `json:"status,omitempty"`
+}
+
+type L2AdvertisementSpec struct {
+	IPAddressPools         []string               `json:"ipAddressPools,omitempty"`
+	IPAddressPoolSelectors []metav1.LabelSelector `json:"ipAddressPoolSelectors,omitempty"`
+	NodeSelectors          []metav1.LabelSelector `json:"nodeSelectors,omitempty"`
+	Interfaces             []string               `json:"interfaces,omitempty"`
+}
+
+type L2AdvertisementStatus struct {
+}
+
+type IPAddressPool struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   IPAddressPoolSpec   `json:"spec"`
+	Status IPAddressPoolStatus `json:"status,omitempty"`
+}
+
+type IPAddressPoolSpec struct {
+	Addresses     []string           `json:"addresses"`
+	AutoAssign    *bool              `json:"autoAssign,omitempty"`
+	AvoidBuggyIPs bool               `json:"avoidBuggyIPs,omitempty"`
+	AllocateTo    *ServiceAllocation `json:"serviceAllocation,omitempty"`
+}
+
+type ServiceAllocation struct {
+	Priority           int                    `json:"priority,omitempty"`
+	Namespaces         []string               `json:"namespaces,omitempty"`
+	NamespaceSelectors []metav1.LabelSelector `json:"namespaceSelectors,omitempty"`
+	ServiceSelectors   []metav1.LabelSelector `json:"serviceSelectors,omitempty"`
+}
+
+type IPAddressPoolStatus struct {
+}
+
+type L2AdvertisementInfo struct {
+	IPAddressPools []string               `json:"ipAddressPools,omitempty"`
+	NodeSelectors  []metav1.LabelSelector `json:"nodeSelectors,omitempty"`
+	Namespace      string                 `json:"namespace,omitempty"`
+	Name           string                 `json:"name,omitempty"`
+}
+
+type IPAddressPoolInfo struct {
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+type ModuleConfig struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ModuleConfigSpec   `json:"spec"`
+	Status ModuleConfigStatus `json:"status,omitempty"`
+}
+
+type ModuleConfigSpec struct {
+	Version  int            `json:"version,omitempty"`
+	Settings SettingsValues `json:"settings,omitempty"`
+	Enabled  bool           `json:"enabled,omitempty"`
+}
+
+type SettingsValues struct {
+	Speaker      Speaker       `json:"speaker" yaml:"speaker"`
+	AddressPools []AddressPool `json:"addressPools" yaml:"addressPools"`
+}
+
+type Speaker struct {
+	NodeSelector map[string]string `json:"nodeSelector" yaml:"nodeSelector"`
+	Tolerations  []v1.Toleration   `json:"tolerations" yaml:"tolerations"`
+}
+
+type AddressPool struct {
+	Name      string   `json:"name" yaml:"name"`
+	Protocol  string   `json:"protocol" yaml:"protocol"`
+	Addresses []string `json:"addresses" yaml:"addresses"`
+}
+
+type ModuleConfigStatus struct {
+	Version string `json:"version"`
+	Message string `json:"message"`
+}

--- a/ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+++ b/ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
@@ -72,7 +72,7 @@
         plk_grouped_by__d8_metallb_upgrade_failed: D8MetallbL2AdvertisementNSMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         description: |
           L2Advertisement `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
-        summary: Failure of MetalLB module update request verification.
+        summary: MetaLB module misconfiguration.
 
     - alert: D8MetallbL2AdvertisementNodeSelectorsMismatch
       expr: d8_metallb_l2advertisement_node_selectors_mismatch == 1
@@ -87,7 +87,7 @@
         plk_grouped_by__d8_metallb_upgrade_failed: D8MetallbL2AdvertisementNodeSelectorsMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         description: |
           L2Advertisement `{{$labels.name}}`: there must only be one matchLabels (not matchExpressions) in the nodeSelectors.
-        summary: Failure of MetalLB module update request verification.
+        summary: MetaLB module misconfiguration.
 
     - alert: D8MetallbIpAddressPoolNSMismatch
       expr: d8_metallb_ipaddress_pool_ns_mismatch == 1
@@ -102,7 +102,7 @@
         plk_grouped_by__d8_metallb_upgrade_failed: D8MetallbIpAddressPoolNSMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         description: |
           IpAddressPool `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
-        summary: Failure of MetalLB module update request verification.
+        summary: MetaLB module misconfiguration.
 
     - alert: D8MetallbNotOnlyLayer2Pools
       expr: d8_metallb_not_only_layer2_pools == 1
@@ -117,7 +117,7 @@
         plk_grouped_by__d8_metallb_upgrade_failed: D8MetallbNotOnlyLayer2PoolsGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         description: |
           There must not be `layer2` and `bgp` IP pools type in the cluster at the same time.
-        summary: Failure of MetalLB module update request verification.
+        summary: MetaLB module misconfiguration.
 
     - alert: D8MetallbOrphanedLoadBalancerDetected
       expr: d8_metallb_orphaned_loadbalancer_detected == 1
@@ -135,4 +135,4 @@
           - have the loadBalancerClass,
           - have the `metallb.universe.tf/address-pool` annotation,
           - have the `metallb.universe.tf/ip-allocated-from-pool` annotation.
-        summary: Failure of MetalLB module update request verification.
+        summary: MetaLB module misconfiguration.

--- a/ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+++ b/ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
@@ -104,7 +104,7 @@
           IpAddressPool `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
         summary: MetaLB module misconfiguration.
 
-    - alert: D8MetallbNotOnlyLayer2Pools
+    - alert: D8MetallbBothBGPAndL2PoolsConfigured
       expr: d8_metallb_not_only_layer2_pools == 1
       for: 5m
       labels:
@@ -113,10 +113,10 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_metallb_upgrade_failed: D8MetallbNotOnlyLayer2PoolsGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-        plk_grouped_by__d8_metallb_upgrade_failed: D8MetallbNotOnlyLayer2PoolsGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_create_group_if_not_exists__d8_metallb_upgrade_failed: D8MetallbBothBGPAndL2PoolsConfiguredGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_metallb_upgrade_failed: D8MetallbBothBGPAndL2PoolsConfiguredGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         description: |
-          There must not be `layer2` and `bgp` IP pools type in the cluster at the same time.
+          There must not be `Layer2` and `BGP` IP pools configured at the same time in ModuleConfig version 1.
         summary: MetaLB module misconfiguration.
 
     - alert: D8MetallbOrphanedLoadBalancerDetected

--- a/ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+++ b/ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
@@ -131,7 +131,7 @@
         plk_create_group_if_not_exists__d8_metallb_upgrade_failed: D8MetallbOrphanedLoadBalancerDetectedGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         plk_grouped_by__d8_metallb_upgrade_failed: D8MetallbOrphanedLoadBalancerDetectedGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         description: |
-          The Service `{{$labels.name}}` is orphaned. A Service must have any of the following properties:
+          The Service `{{$labels.name}}` in `{{$labels.namespace}}` namespace is orphaned. A Service must have any of the following properties:
           - have the loadBalancerClass,
           - have the `metallb.universe.tf/address-pool` annotation,
           - have the `metallb.universe.tf/ip-allocated-from-pool` annotation.

--- a/ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+++ b/ee/se/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
@@ -1,58 +1,138 @@
 - name: d8.metallb
   rules:
-  - alert: D8MetalLBConfigNotLoaded
-    expr: metallb_k8s_client_config_loaded_bool == 0
-    for: 5m
-    labels:
-      severity_level: "4"
-      tier: cluster
-    annotations:
-      plk_markup_format: "markdown"
-      plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBConfigNotLoaded,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBConfigNotLoaded,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      description: |
-        {{ $labels.job }} — MetalLB {{ $labels.container }} on {{ $labels.pod}} has not loaded.
-        To figure out the problem, check controller logs:
-        ```
-        kubectl -n d8-metallb logs deploy/controller -c controller
-        ```
-      summary: MetalLB config not loaded.
+    - alert: D8MetalLBConfigNotLoaded
+      expr: metallb_k8s_client_config_loaded_bool == 0
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBConfigNotLoaded,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBConfigNotLoaded,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        description: |
+          {{ $labels.job }} — MetalLB {{ $labels.container }} on {{ $labels.pod}} has not loaded.
+          To figure out the problem, check controller logs:
+          ```
+          kubectl -n d8-metallb logs deploy/controller -c controller
+          ```
+        summary: MetalLB config not loaded.
 
-  - alert: D8MetalLBConfigStale
-    expr: metallb_k8s_client_config_stale_bool == 1
-    for: 5m
-    labels:
-      severity_level: "4"
-      tier: cluster
-    annotations:
-      plk_markup_format: "markdown"
-      plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBConfigStales,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBConfigStales,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      description: |
-        {{ $labels.job }} — MetalLB {{ $labels.container }} on {{ $labels.pod}} has run on a stale configuration, because the latest config failed to load.
-        To figure out the problem, check controller logs:
-        ```
-        kubectl -n d8-metallb logs deploy/controller -c controller
-        ```
-      summary: MetalLB running on a stale configuration, because the latest config failed to load.
+    - alert: D8MetalLBConfigStale
+      expr: metallb_k8s_client_config_stale_bool == 1
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBConfigStales,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBConfigStales,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        description: |
+          {{ $labels.job }} — MetalLB {{ $labels.container }} on {{ $labels.pod}} has run on a stale configuration, because the latest config failed to load.
+          To figure out the problem, check controller logs:
+          ```
+          kubectl -n d8-metallb logs deploy/controller -c controller
+          ```
+        summary: MetalLB running on a stale configuration, because the latest config failed to load.
 
-  - alert: D8MetalLBBGPSessionDown
-    expr: metallb_bgp_session_up == 0
-    for: 5m
-    labels:
-      severity_level: "4"
-      tier: cluster
-    annotations:
-      plk_markup_format: "markdown"
-      plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBBGPSessionsDown,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBBGPSessionsDown,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      description: |
-        {{ $labels.job }} — MetalLB {{ $labels.container }} on {{ $labels.pod}} has BGP session {{ $labels.peer }} down.
-        Details are in logs:
-        ```
-        kubectl -n d8-metallb logs daemonset/speaker -c speaker
-        ```
-      summary: MetalLB BGP session down.
+    - alert: D8MetalLBBGPSessionDown
+      expr: metallb_bgp_session_up == 0
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_metallb_failed: ClusterHasD8MetalLBBGPSessionsDown,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_metallb_failed: ClusterHasD8MetalLBBGPSessionsDown,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        description: |
+          {{ $labels.job }} — MetalLB {{ $labels.container }} on {{ $labels.pod}} has BGP session {{ $labels.peer }} down.
+          Details are in logs:
+          ```
+          kubectl -n d8-metallb logs daemonset/speaker -c speaker
+          ```
+        summary: MetalLB BGP session down.
+
+- name: d8.metallb.upgrade_check
+  rules:
+    - alert: D8MetallbL2AdvertisementNSMismatch
+      expr: d8_metallb_l2advertisement_ns_mismatch == 1
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_metallb_upgrade_failed: D8MetallbL2AdvertisementNSMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_metallb_upgrade_failed: D8MetallbL2AdvertisementNSMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        description: |
+          L2Advertisement `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
+        summary: Failure of MetalLB module update request verification.
+
+    - alert: D8MetallbL2AdvertisementNodeSelectorsMismatch
+      expr: d8_metallb_l2advertisement_node_selectors_mismatch == 1
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_metallb_upgrade_failed: D8MetallbL2AdvertisementNodeSelectorsMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_metallb_upgrade_failed: D8MetallbL2AdvertisementNodeSelectorsMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        description: |
+          L2Advertisement `{{$labels.name}}`: there must only be one matchLabels (not matchExpressions) in the nodeSelectors.
+        summary: Failure of MetalLB module update request verification.
+
+    - alert: D8MetallbIpAddressPoolNSMismatch
+      expr: d8_metallb_ipaddress_pool_ns_mismatch == 1
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_metallb_upgrade_failed: D8MetallbIpAddressPoolNSMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_metallb_upgrade_failed: D8MetallbIpAddressPoolNSMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        description: |
+          IpAddressPool `{{$labels.name}}` is located in namespace `{{$labels.namespace}}`, but must be located in namespace `d8-metallb`.
+        summary: Failure of MetalLB module update request verification.
+
+    - alert: D8MetallbNotOnlyLayer2Pools
+      expr: d8_metallb_not_only_layer2_pools == 1
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_metallb_upgrade_failed: D8MetallbNotOnlyLayer2PoolsGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_metallb_upgrade_failed: D8MetallbNotOnlyLayer2PoolsGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        description: |
+          There must not be `layer2` and `bgp` IP pools type in the cluster at the same time.
+        summary: Failure of MetalLB module update request verification.
+
+    - alert: D8MetallbOrphanedLoadBalancerDetected
+      expr: d8_metallb_orphaned_loadbalancer_detected == 1
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_metallb_upgrade_failed: D8MetallbOrphanedLoadBalancerDetectedGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_metallb_upgrade_failed: D8MetallbOrphanedLoadBalancerDetectedGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        description: |
+          The Service `{{$labels.name}}` is orphaned. A Service must have any of the following properties:
+          - have the loadBalancerClass,
+          - have the `metallb.universe.tf/address-pool` annotation,
+          - have the `metallb.universe.tf/ip-allocated-from-pool` annotation.
+        summary: Failure of MetalLB module update request verification.

--- a/ee/se/modules/380-metallb/requirements/check.go
+++ b/ee/se/modules/380-metallb/requirements/check.go
@@ -1,6 +1,7 @@
 /*
 Copyright 2024 Flant JSC
-Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license.
+See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package requirements
@@ -23,20 +24,12 @@ func init() {
 			return true, nil
 		}
 
-		switch configurationStatus := configurationStatusRaw.(string); configurationStatus {
-		case "NSMismatch":
-			return false, errors.New(
-				"[metallb] all L2Advertisement must be in the d8-metallb namespace",
-			)
-		case "NodeSelectorsMismatch":
-			return false, errors.New(
-				"[metallb] nodeSelectors in L2Advertisement must contain only " +
-					"one matchLabels (not matchExpressions)",
-			)
-		case "AddressPoolsMismatch":
-			return false, errors.New(
-				"[metallb] there should not be layer2 and bgp pools in the cluster at the same time",
-			)
+		if configurationStatus, ok := configurationStatusRaw.(string); ok {
+			if configurationStatus == "Misconfigured" {
+				return false, errors.New(
+					"[metallb] cluster misconfigured, see ClusterAlerts for details",
+				)
+			}
 		}
 		return true, nil
 	}

--- a/ee/se/modules/380-metallb/requirements/check_test.go
+++ b/ee/se/modules/380-metallb/requirements/check_test.go
@@ -1,6 +1,7 @@
 /*
 Copyright 2024 Flant JSC
-Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license.
+See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package requirements
@@ -22,22 +23,8 @@ func TestKubernetesVersionRequirement(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("fail: NSMismatch", func(t *testing.T) {
-		requirements.SaveValue(metallbConfigurationStatusKey, "NSMismatch")
-		ok, err := requirements.CheckRequirement(metallbConfigurationStatusRequirementsKey, "")
-		assert.False(t, ok)
-		require.Error(t, err)
-	})
-
-	t.Run("fail: NodeSelectorsMismatch", func(t *testing.T) {
-		requirements.SaveValue(metallbConfigurationStatusKey, "NodeSelectorsMismatch")
-		ok, err := requirements.CheckRequirement(metallbConfigurationStatusRequirementsKey, "")
-		assert.False(t, ok)
-		require.Error(t, err)
-	})
-
-	t.Run("fail: AddressPoolsMismatch", func(t *testing.T) {
-		requirements.SaveValue(metallbConfigurationStatusKey, "AddressPoolsMismatch")
+	t.Run("fail: Misconfigured", func(t *testing.T) {
+		requirements.SaveValue(metallbConfigurationStatusKey, "Misconfigured")
 		ok, err := requirements.CheckRequirement(metallbConfigurationStatusRequirementsKey, "")
 		assert.False(t, ok)
 		require.Error(t, err)


### PR DESCRIPTION
## Description
Add a check of the settings of the `metallb` module and its resources for compliance with the requirements of the new version of the module.
This pr extends the [previous one](https://github.com/deckhouse/deckhouse/pull/10289).

## Why do we need it, and what problem does it solve?
We require the customer to change the settings in the cluster themselves before cluster upgrade.

## Why do de need it in patch release?
To handle [the new feature](https://github.com/deckhouse/deckhouse/pull/9658) in next release.

## What is the expected result?
`Deckhouse` can't be upgraded until the settings meet the new module version requirements:
- All custom IPAddressPools and L2Advertisements are in the `d8-metallb` namespace.
- There are no `layer2` and `bgp` pools in the cluster at the same time.
- In custom L2Advertisements, if there are nodeSelectors, there is an element and this element consists of matchLabels (not matchExpressions).
- There are orphaned Services in the cluster (no loadBalancerClass, no `metallb.universe.tf/address-pool` annotation, no `metallb.universe.tf/ip-allocated-from-pool` annotation).

An alert appears in the cluster for each violation.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: feature
summary: Added extended pre-upgrade compatibility check for metallb configuration.
impact_level: default
```