### PR TITLE
[cloud-provider-vcd] Fix getting `vcd_catalog_vapp_template` by `org` and `catalog_id`

### DIFF
--- a/ee/modules/040-terraform-manager/images/terraform-manager-vcd/patches/fix_getting_vcd_catalog_vapp_template_data_source_by_org_and_catalog_id.patch
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-vcd/patches/fix_getting_vcd_catalog_vapp_template_data_source_by_org_and_catalog_id.patch
@@ -7,16 +7,27 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/vcd/resource_vcd_catalog_vapp_template.go b/vcd/resource_vcd_catalog_vapp_template.go
 --- a/vcd/resource_vcd_catalog_vapp_template.go	(revision 2df7e589a92135093f3327e9d8698404bdf65bd0)
-+++ b/vcd/resource_vcd_catalog_vapp_template.go	(date 1727329211575)
-@@ -382,6 +382,32 @@
++++ b/vcd/resource_vcd_catalog_vapp_template.go	(date 1730884397001)
+@@ -382,6 +382,43 @@
  	// No filter: we continue with single item  GET
  
  	if isSearchedByCatalog {
 +		orgName, ok := d.GetOk("org")
 +		if ok {
-+			org, err := vcdClient.GetOrg(orgName.(string))
-+			if err != nil {
-+				return nil, fmt.Errorf("error retrieving org: %s", err)
++			var href string
++
++			org, err := vcdClient.GetOrgByName(orgName.(string))
++			if err == nil {
++				href = org.Org.HREF
++			} else {
++				util.Logger.Printf("[TRACE] error retrieving org: %s", err)
++
++				org, err := vcdClient.GetAdminOrgByName(orgName.(string))
++				if err != nil {
++					return nil, fmt.Errorf("error retrieving Admin Org: %s", err)
++				}
++
++				href = org.AdminOrg.HREF
 +			}
 +
 +			vAppTemplates, err := catalog.QueryVappTemplateList()
@@ -25,7 +36,7 @@ diff --git a/vcd/resource_vcd_catalog_vapp_template.go b/vcd/resource_vcd_catalo
 +			}
 +
 +			for _, vAppTemplate := range vAppTemplates {
-+				if vAppTemplate.Name == identifier && vAppTemplate.Org == org.Org.HREF {
++				if vAppTemplate.Name == identifier && vAppTemplate.Org == href {
 +					vAppTemplateHrefPrefix := vcdClient.Client.VCDHREF
 +					vAppTemplateHrefPrefix.Path += "/vAppTemplate/vappTemplate-"
 +


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
