### PR TITLE
[control-plane-manager] Removed the removal of the old backup from etcd-backup

### DIFF
--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -29,8 +29,6 @@ tar -czvf "${archive}" "${etcd}"
 if [ $(df /var/lib/etcd/ | tail -1 | awk '{printf "%.0f\n", $4 - ($2 * 0.25)}') -ge $(du -k "${archive}" | awk '{print $1}') ]; then
     chmod 0600 "${archive}"
     mv "${archive}" "/var/lib/etcd/${archive}"
-    # remove after 1.66 Old version.
-    rm -f /var/lib/etcd/etcd-backup.snapshot
 else
     echo "Free space in /var/lib/etcd/ is too small for backup should be more than 25%"
     exit 1

--- a/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $binaries := "/bin/sh /bin/mv /bin/df /bin/du /bin/tail /bin/awk /bin/tar /bin/gzip /bin/rm /bin/chmod" }}
+{{- $binaries := "/bin/sh /bin/mv /bin/df /bin/du /bin/tail /bin/awk /bin/tar /bin/gzip /bin/chmod" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless


### PR DESCRIPTION
## Description
Removed the removal of the old backup from etcd-backup
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Code cleanup
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: Removed the removal of the old backup from etcd-backup
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
