### PR TITLE
[user-authn] Fix offline session updates

### DIFF
--- a/modules/150-user-authn/images/dex/Dockerfile
+++ b/modules/150-user-authn/images/dex/Dockerfile
@@ -6,12 +6,14 @@ ENV GOPROXY=${GOPROXY}
 ARG SOURCE_REPO
 ENV SOURCE_REPO=${SOURCE_REPO}
 WORKDIR /dex
-COPY patches/client-groups.patch patches/static-user-groups.patch patches/gitlab-refresh-context.patch patches/bytes-and-string-certificates.patch /
+COPY patches/client-groups.patch patches/static-user-groups.patch patches/gitlab-refresh-context.patch patches/bytes-and-string-certificates.patch patches/fix-offline-session-updates.patch /
 RUN git clone --branch v2.41.1 --depth 1 ${SOURCE_REPO}/dexidp/dex.git . \
   && git apply /client-groups.patch \
-  && git apply /static-user-groups.patch \
   && git apply /gitlab-refresh-context.patch \
+  && git apply /fix-offline-session-updates.patch \
+  && git apply /static-user-groups.patch \
   && git apply /bytes-and-string-certificates.patch
+
 
 RUN CGO_ENABLED=1 GOOS=linux go build -ldflags '-s -w' -ldflags "-linkmode external -extldflags -static" -tags netgo ./cmd/dex
 

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -18,3 +18,9 @@ This problem is not solved in upstream, and our patch will not be accepted.
 Refresh can be called only one. By propagating a context of the user request, refresh can accidentally canceled.
 
 To avoid this, this patch makes refresh requests to declare and utilize their own contexts.
+
+### Fix offline session creation
+
+Offline session is not created if the skip approval option is toggled. In this case Dex looses connector data and cannot refresh tokens.
+
+Upstream PR: https://github.com/dexidp/dex/pull/3828

--- a/modules/150-user-authn/images/dex/patches/fix-offline-session-updates.patch
+++ b/modules/150-user-authn/images/dex/patches/fix-offline-session-updates.patch
@@ -1,0 +1,115 @@
+diff --git a/server/handlers.go b/server/handlers.go
+index 63cb6122..51a75bbf 100644
+--- a/server/handlers.go
++++ b/server/handlers.go
+@@ -529,23 +529,6 @@ func (s *Server) finalizeLogin(ctx context.Context, identity connector.Identity,
+ 		"connector_id", authReq.ConnectorID, "username", claims.Username,
+ 		"preferred_username", claims.PreferredUsername, "email", email, "groups", claims.Groups)
+ 
+-	// we can skip the redirect to /approval and go ahead and send code if it's not required
+-	if s.skipApproval && !authReq.ForceApprovalPrompt {
+-		return "", true, nil
+-	}
+-
+-	// an HMAC is used here to ensure that the request ID is unpredictable, ensuring that an attacker who intercepted the original
+-	// flow would be unable to poll for the result at the /approval endpoint
+-	h := hmac.New(sha256.New, authReq.HMACKey)
+-	h.Write([]byte(authReq.ID))
+-	mac := h.Sum(nil)
+-
+-	returnURL := path.Join(s.issuerURL.Path, "/approval") + "?req=" + authReq.ID + "&hmac=" + base64.RawURLEncoding.EncodeToString(mac)
+-	_, ok := conn.(connector.RefreshConnector)
+-	if !ok {
+-		return returnURL, false, nil
+-	}
+-
+ 	offlineAccessRequested := false
+ 	for _, scope := range authReq.Scopes {
+ 		if scope == scopeOfflineAccess {
+@@ -553,45 +536,55 @@ func (s *Server) finalizeLogin(ctx context.Context, identity connector.Identity,
+ 			break
+ 		}
+ 	}
+-	if !offlineAccessRequested {
+-		return returnURL, false, nil
+-	}
++	_, canRefresh := conn.(connector.RefreshConnector)
+ 
+-	// Try to retrieve an existing OfflineSession object for the corresponding user.
+-	session, err := s.storage.GetOfflineSessions(identity.UserID, authReq.ConnectorID)
+-	if err != nil {
+-		if err != storage.ErrNotFound {
+-			s.logger.ErrorContext(ctx, "failed to get offline session", "err", err)
+-			return "", false, err
+-		}
+-		offlineSessions := storage.OfflineSessions{
+-			UserID:        identity.UserID,
+-			ConnID:        authReq.ConnectorID,
+-			Refresh:       make(map[string]*storage.RefreshTokenRef),
+-			ConnectorData: identity.ConnectorData,
+-		}
++	if offlineAccessRequested && canRefresh {
++		// Try to retrieve an existing OfflineSession object for the corresponding user.
++		session, err := s.storage.GetOfflineSessions(identity.UserID, authReq.ConnectorID)
++		switch {
++		case err != nil && err == storage.ErrNotFound:
++			offlineSessions := storage.OfflineSessions{
++				UserID:        identity.UserID,
++				ConnID:        authReq.ConnectorID,
++				Refresh:       make(map[string]*storage.RefreshTokenRef),
++				ConnectorData: identity.ConnectorData,
++			}
+ 
+-		// Create a new OfflineSession object for the user and add a reference object for
+-		// the newly received refreshtoken.
+-		if err := s.storage.CreateOfflineSessions(ctx, offlineSessions); err != nil {
+-			s.logger.ErrorContext(ctx, "failed to create offline session", "err", err)
++			// Create a new OfflineSession object for the user and add a reference object for
++			// the newly received refreshtoken.
++			if err := s.storage.CreateOfflineSessions(ctx, offlineSessions); err != nil {
++				s.logger.ErrorContext(ctx, "failed to create offline session", "err", err)
++				return "", false, err
++			}
++		case err == nil:
++			// Update existing OfflineSession obj with new RefreshTokenRef.
++			if err := s.storage.UpdateOfflineSessions(session.UserID, session.ConnID, func(old storage.OfflineSessions) (storage.OfflineSessions, error) {
++				if len(identity.ConnectorData) > 0 {
++					old.ConnectorData = identity.ConnectorData
++				}
++				return old, nil
++			}); err != nil {
++				s.logger.ErrorContext(ctx, "failed to update offline session", "err", err)
++				return "", false, err
++			}
++		default:
++			s.logger.ErrorContext(ctx, "failed to get offline session", "err", err)
+ 			return "", false, err
+ 		}
+-
+-		return returnURL, false, nil
+ 	}
+ 
+-	// Update existing OfflineSession obj with new RefreshTokenRef.
+-	if err := s.storage.UpdateOfflineSessions(session.UserID, session.ConnID, func(old storage.OfflineSessions) (storage.OfflineSessions, error) {
+-		if len(identity.ConnectorData) > 0 {
+-			old.ConnectorData = identity.ConnectorData
+-		}
+-		return old, nil
+-	}); err != nil {
+-		s.logger.ErrorContext(ctx, "failed to update offline session", "err", err)
+-		return "", false, err
++	// we can skip the redirect to /approval and go ahead and send code if it's not required
++	if s.skipApproval && !authReq.ForceApprovalPrompt {
++		return "", true, nil
+ 	}
+ 
++	// an HMAC is used here to ensure that the request ID is unpredictable, ensuring that an attacker who intercepted the original
++	// flow would be unable to poll for the result at the /approval endpoint
++	h := hmac.New(sha256.New, authReq.HMACKey)
++	h.Write([]byte(authReq.ID))
++	mac := h.Sum(nil)
++
++	returnURL := path.Join(s.issuerURL.Path, "/approval") + "?req=" + authReq.ID + "&hmac=" + base64.RawURLEncoding.EncodeToString(mac)
+ 	return returnURL, false, nil
+ }
+ 


### PR DESCRIPTION
## Description
Add a patch to fix the problem with offline sessions that are not created/updated properly, which causes random refresh problems.

## Why do we need it, and what problem does it solve?
https://github.com/dexidp/dex/pull/3828

## Why do we need it in the patch release (if we do)?
It affects token refreshing in all clusters.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Add a patch to fix the problem with offline sessions that are not created/updated properly, which causes random refresh problems.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
