### PR TITLE
[cloud-providers][aws] fixes for deploying a cluster in a local zone

### DIFF
--- a/candi/cloud-providers/aws/openapi/cloud_discovery_data.yaml
+++ b/candi/cloud-providers/aws/openapi/cloud_discovery_data.yaml
@@ -44,4 +44,4 @@ apiVersions:
         minItems: 1
         items:
           type: string
-          pattern: '^[a-z]+-[a-z]+-[0-9]+[a-z]+$'
+          pattern: '^[a-z]+-[a-z]+-[0-9]+(?:[a-z]|-[a-z]+-[0-9]+[a-z])$'

--- a/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
@@ -17,6 +17,10 @@ locals {
   az_count = length(data.aws_availability_zones.available.names)
 }
 
+data "aws_availability_zone" "master_az" {
+  name = aws_instance.master.availability_zone
+}
+
 data "aws_subnet" "kube" {
   count = local.az_count
   tags = {
@@ -104,6 +108,7 @@ resource "aws_instance" "master" {
 
 resource "aws_eip" "eip" {
   count = var.associate_public_ip_address ? 1 : 0
+  network_border_group = data.aws_availability_zone.master_az.group_name
   vpc = true
   tags = merge(var.tags, {
     Name = "${var.prefix}-master-${var.node_index}"

--- a/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
@@ -17,6 +17,12 @@ locals {
   az_count = length(data.aws_availability_zones.available.names)
 }
 
+data "aws_region" "current" {}
+
+locals {
+  network_border_group = data.aws_availability_zone.master_az.group_name != data.aws_region.current.name ? data.aws_availability_zone.master_az.group_name : null
+}
+
 data "aws_availability_zone" "master_az" {
   name = aws_instance.master.availability_zone
 }
@@ -108,7 +114,7 @@ resource "aws_instance" "master" {
 
 resource "aws_eip" "eip" {
   count = var.associate_public_ip_address ? 1 : 0
-  network_border_group = data.aws_availability_zone.master_az.group_name
+  network_border_group = local.network_border_group
   vpc = true
   tags = merge(var.tags, {
     Name = "${var.prefix}-master-${var.node_index}"

--- a/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
@@ -101,8 +101,7 @@ resource "aws_instance" "master" {
       user_data_replace_on_change,
       ebs_optimized,
       #TODO: remove ignore after we enable automatic converge for master nodes
-      volume_tags,
-      network_border_group
+      volume_tags
     ]
   }
 }
@@ -114,6 +113,9 @@ resource "aws_eip" "eip" {
   tags = merge(var.tags, {
     Name = "${var.prefix}-master-${var.node_index}"
   })
+  lifecycle {
+    ignore_changes = [network_border_group]
+  }
 }
 
 resource "aws_eip_association" "eip" {

--- a/candi/cloud-providers/aws/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/static-node/main.tf
@@ -77,7 +77,8 @@ resource "aws_instance" "node" {
       user_data_replace_on_change,
       ebs_optimized,
       #TODO: remove ignore after we enable automatic converge for master nodes
-      volume_tags
+      volume_tags,
+      network_border_group
     ]
   }
 }

--- a/candi/cloud-providers/aws/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/static-node/main.tf
@@ -77,8 +77,7 @@ resource "aws_instance" "node" {
       user_data_replace_on_change,
       ebs_optimized,
       #TODO: remove ignore after we enable automatic converge for master nodes
-      volume_tags,
-      network_border_group
+      volume_tags
     ]
   }
 }
@@ -90,6 +89,9 @@ resource "aws_eip" "eip" {
   tags = merge(var.tags, {
     Name = "${var.prefix}-${var.node_group.name}-${var.node_index}"
   })
+  lifecycle {
+    ignore_changes = [network_border_group]
+  }
 }
 
 resource "aws_eip_association" "eip" {

--- a/candi/cloud-providers/aws/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/static-node/main.tf
@@ -17,6 +17,10 @@ locals {
   az_count = length(data.aws_availability_zones.available.names)
 }
 
+data "aws_availability_zone" "node_az" {
+  name = aws_instance.node.availability_zone
+}
+
 data "aws_subnet" "kube" {
   count = local.az_count
   tags = {
@@ -80,6 +84,7 @@ resource "aws_instance" "node" {
 
 resource "aws_eip" "eip" {
   count = var.associate_public_ip_address ? 1 : 0
+  network_border_group = data.aws_availability_zone.node_az.group_name
   vpc = true
   tags = merge(var.tags, {
     Name = "${var.prefix}-${var.node_group.name}-${var.node_index}"

--- a/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
@@ -42,10 +42,6 @@ nodeGroups:
 nodeNetworkCIDR: "172.16.0.0/22"
 vpcNetworkCIDR: "172.16.0.0/16"
 sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSNdUmV2ekit0rFrQE9IoRsVqKTJfR8h+skMYjXHBv/nJN6J2eBvQlebnhfZngxTvHYYxl0XeRu3KEz5v23gIidT21o9x0+tD4b2PcyZ24o64GwnF/oFnQ9mYBJDRisZNdXYPadTp/RafQ0qNUX/6h8vZYlSPM77dhW7Oyf6hcbaniAmOD30bO89UM//VHbllGgfhlIbU382/EnPOfGvAHReATADBBHmxxtTCLbu48rN35DlOtMgPob3ZwOsJI3keRrIZOf5qxeF3VB0Ox4inoR6PUzWMFLCJyIMp7hzY+JLakO4dqfvRJZjgTZHQUvjDs+aeUcH8tD4Wd5NDzmxnHLtJup0lkHkqgjo6vqWIcQeDXuXsk3+YGw0PwMpwO2HMVPs2SnfT6cZ+Mo6Dmq0t1EjtSBXLMe5C5aac5w6NrXuypRQDoce7p3uZP2TVsxmpyvkd6RyiWr+wuOOB3h/k8q+kRh4LKzivJMEkZoZeCxkJiIWDknxEAU1sl25W4hEU="
-zones:
-  - eu-central-1a
-  - eu-central-1b
-  - eu-central-1c
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig

--- a/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
@@ -42,6 +42,10 @@ nodeGroups:
 nodeNetworkCIDR: "172.16.0.0/22"
 vpcNetworkCIDR: "172.16.0.0/16"
 sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSNdUmV2ekit0rFrQE9IoRsVqKTJfR8h+skMYjXHBv/nJN6J2eBvQlebnhfZngxTvHYYxl0XeRu3KEz5v23gIidT21o9x0+tD4b2PcyZ24o64GwnF/oFnQ9mYBJDRisZNdXYPadTp/RafQ0qNUX/6h8vZYlSPM77dhW7Oyf6hcbaniAmOD30bO89UM//VHbllGgfhlIbU382/EnPOfGvAHReATADBBHmxxtTCLbu48rN35DlOtMgPob3ZwOsJI3keRrIZOf5qxeF3VB0Ox4inoR6PUzWMFLCJyIMp7hzY+JLakO4dqfvRJZjgTZHQUvjDs+aeUcH8tD4Wd5NDzmxnHLtJup0lkHkqgjo6vqWIcQeDXuXsk3+YGw0PwMpwO2HMVPs2SnfT6cZ+Mo6Dmq0t1EjtSBXLMe5C5aac5w6NrXuypRQDoce7p3uZP2TVsxmpyvkd6RyiWr+wuOOB3h/k8q+kRh4LKzivJMEkZoZeCxkJiIWDknxEAU1sl25W4hEU="
+zones:
+  - eu-central-1a
+  - eu-central-1b
+  - eu-central-1c
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig


### PR DESCRIPTION
## Description

1. Cloud data discovery currently expects an AZ name in the format `ap-southeast-1a`. Updated regexp to support local AZs such as `ap-southeast-1-bkk-1a`.

2. If we create a master or static node in a local zone we must create an EIP in the network border group of that zone.

> If you have Local Zones or Wavelength Zones enabled, you can choose a network border group for AZs, Local Zones, or Wavelength Zones. Local Zones and Wavelength Zones may have different network border groups than the AZs in a Region to ensure minimum latency or physical distance between the AWS network and the customers accessing the resources in these Zones.

For example:

az: ap-southeast-1a - network border group: ap-southeast-1
az: ap-southeast-1b - network border group: ap-southeast-1

but

local az: ap-southeast-1-bkk-1a- network border group: ap-southeast-1-bkk-1a

Also about `group_names`:  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones#attribute-reference

## Why do we need it, and what problem does it solve?

Bootstrap to local AZ in AWS

## Why do we need it in the patch release (if we do)?

## What is the expected result?

This problem has been solved:
1. 
```
{"apiVersion":"deckhouse.io/v1","instances":{"additionalSecurityGroups":["sg-06523a45eaf14857f"],"ami":"ami-047126e50991d067b","associateP ↵
ublicIPAddress":true,"iamProfileName":"kube-th-prod-node"},"keyName":"kube-th-prod","kind":"AWSCloudDiscoveryData","loadBalancerSecurityGr ↵
oup":"sg-0101135956a6f322e","zoneToSubnetIdMap":{"ap-southeast-1-bkk-1a":"subnet-03665fe217cc18d9b","ap-southeast-1a":"subnet-033a7491b036 ↵
a91ed","ap-southeast-1b":"subnet-0f6bb12eccae57466","ap-southeast-1c":"subnet-0e141d26314267bea"},"zones":["ap-southeast-1-bkk-1a","ap-sou ↵
theast-1a","ap-southeast-1b","ap-southeast-1c"]}


1 error occurred:
    * zones should match '^[a-z]+-[a-z]+-[0-9]+[a-z]+$'
```

2. 
```

Error: creating EC2 EIP Association: OperationNotPermitted: Cannot associate addresses across network border groups
    status code: 400, request id: 8a69ff15-527d-43f2-8770-9b94cc75313c
```
How-To reproduce:

```yaml
apiVersion: deckhouse.io/v1
kind: AWSClusterConfiguration
layout: WithoutNAT
provider:
  providerAccessKeyId: ""
  providerSecretAccessKey: ""
  region: eu-north-1
masterNodeGroup:
  replicas: 3
  instanceClass:
    diskSizeGb: 50
    diskType: gp2
    instanceType: t3.medium
    ami: ami-08eb150f611ca277f
    etcdDisk:
      type: gp2
      sizeGb: 20
vpcNetworkCIDR: "10.243.0.0/16"
nodeNetworkCIDR: "10.243.32.0/20"
sshPublicKey: ""
zones:
  - eu-north-1-hel-1a
```


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: fix
summary: Fix for deploying a cluster in a local zone.
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
