### PR TITLE
[cni-cilium] Fix egressGatewayPolicies

### DIFF
--- a/ee/modules/021-cni-cilium/templates/egress-policy/cilium-egress-policies.yaml
+++ b/ee/modules/021-cni-cilium/templates/egress-policy/cilium-egress-policies.yaml
@@ -14,7 +14,7 @@ spec:
     {{- $egp.destinationCIDRs | toYaml | nindent 2 }}
   {{- if $egp.excludedCIDRs }}
   excludedCIDRs:
-    {{- $egp.destinationCIDRs | toYaml | nindent 2 }}
+    {{- $egp.excludedCIDRs | toYaml | nindent 2 }}
   {{- end }}
   egressGateway:
     nodeSelector:


### PR DESCRIPTION
## Description

Fixed an issue with the "CiliumEgressGatewayPolicy" resource generation.

## Why do we need it, and what problem does it solve?

If we specify `excludedCIDRs` in resource `EgressGatewayPolicy`, in resulting `CiliumEgressGatewayPolicy` resource in the field `excludedCIDRs` added items from field `destinationCIDRs`.
Because of this, the `excludedCIDRs` field cannot be used.

## Why do we need it in the patch release (if we do)?

This feature is used by clients in clusters.

## What is the expected result?

We can use field `excludedCIDRs` in `EgressGatewayPolicy`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: cni-ciliim
type: fix
summary: Fixed `excludedCIDRs` option in EgressGatewayPolicies
impact_level: default
```

