### PR TITLE
[docs] Updated text for the EOL version of Kubernetes in DKP

### DIFF
--- a/docs/documentation/_data/supported_versions.yml
+++ b/docs/documentation/_data/supported_versions.yml
@@ -49,8 +49,8 @@ osDistributions:
 
 k8s_statuses:
   end-of-life:
-    en: Version with limited support, which is unavailable for new installations.
-    ru: Версия с ограниченной поддержкой, недоступная для новых установок.
+    en: The version is not recommended for use. It is planned for removal in future releases.
+    ru: Версия не рекомендуется для использования. Запланирована для удаления в будущих релизах.
   intermediate:
     en: An intermediate version that is only available to perform rolling Kubernetes updates.
     ru: Промежуточная версия, доступная только для плавных обновлений Kubernetes.


### PR DESCRIPTION
## Description
Updated  text for the EOL version of Kubernetes in DKP.



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix 
summary: Updated  text for the EOL version of Kubernetes in DKP.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
