### PR TITLE
[candi][bashible] Change selinux configuration requirements in step 004_install_mandatory_selinux_policies.sh

### DIFF
--- a/candi/bashible/bundles/centos/all/004_install_mandatory_selinux_policies.sh.tpl
+++ b/candi/bashible/bundles/centos/all/004_install_mandatory_selinux_policies.sh.tpl
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [[ "$(getenforce)" != "Enforcing" ]]; then
+# check that selinux exist in bundle
+if [[ ! "$(getenforce)" ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
## Description

In the current version of Deckhouse, in bashible step `004_install_mandatory_selinux_policies.sh`  which installs settings for selinux, there is a condition according to which the allowed installation only if at the time of installation the selinux mode was `Enforced`. 
There is a problem that in an already deployed cluster it is impossible to switch the mode. Bashible not starting after change selinux mode.

## Why do we need it, and what problem does it solve?
I suggest removing the selinux status check.
I would only keep the check that the status check command works. This is needed to determine that the selinux module is present in the current package.


## What is the expected result?

With this fix, the settings will always be created and it will be possible to switch the selinux mode in a deployed cluster

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: candi
type: fix 
summary: Change selinux configuration requirements 
impact_level: low
```