### PR TITLE
[cni-cilium] fix template test

### DIFF
--- a/modules/021-cni-cilium/template_tests/module_test.go
+++ b/modules/021-cni-cilium/template_tests/module_test.go
@@ -166,7 +166,9 @@ var _ = Describe("Module :: cniCilium :: helm template ::", func() {
 			cegp := f.KubernetesGlobalResource("CiliumEgressGatewayPolicy", "d8.myeg")
 			Expect(cegp.Exists()).To(BeTrue())
 
-			Expect(cegp.Field("spec.excludedCIDRs").String()).To(MatchJSON(`["192.168.0.0/16"]`))
+			Expect(cegp.Field("spec.destinationCIDRs").String()).To(MatchJSON(`["192.168.0.0/16"]`))
+
+			Expect(cegp.Field("spec.excludedCIDRs").String()).To(MatchJSON(`["192.168.3.0/24"]`))
 
 			Expect(cegp.Field("spec.selectors").String()).To(MatchJSON(`[{"podSelector": {"matchLabels": {"app": "nginx"}}}]`))
 


### PR DESCRIPTION
## Description
We have merged [the PR](https://github.com/deckhouse/deckhouse/pull/10493) with broken tests on carelessness and broke the release branch :(.

## Why do we need it, and what problem does it solve?
It will fix the release and main branches.

## Why do we need it in the patch release (if we do)?
It will fix the release branch.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: fix
summary: fix for templates test
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
