### PR TITLE
[deckhouse-controller] Increased CRDs Installer buffer size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/deckhouse/deckhouse/pkg/log v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
-	github.com/flant/addon-operator v1.5.2
+	github.com/flant/addon-operator v1.5.3-0.20241107133554-c4e1203a3b44
 	github.com/flant/kube-client v1.2.2
 	github.com/flant/shell-operator v1.5.1
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/deckhouse/deckhouse/pkg/log v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
-	github.com/flant/addon-operator v1.5.3-0.20241107133554-c4e1203a3b44
+	github.com/flant/addon-operator v1.5.3-0.20241107164507-a38325ae9db3
 	github.com/flant/kube-client v1.2.2
 	github.com/flant/shell-operator v1.5.1
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/flant/addon-operator v1.5.3-0.20241107113419-a62284231d16 h1:/gNTvm/p
 github.com/flant/addon-operator v1.5.3-0.20241107113419-a62284231d16/go.mod h1:G15JIgnzfTQiOjV0QxMJ3TkXUxpugsRcP3iw0jxi2vk=
 github.com/flant/addon-operator v1.5.3-0.20241107133554-c4e1203a3b44 h1:jWSpmuBoe/+jtlZp41cd5l/WPeww3WmbH028pfMNAxQ=
 github.com/flant/addon-operator v1.5.3-0.20241107133554-c4e1203a3b44/go.mod h1:G15JIgnzfTQiOjV0QxMJ3TkXUxpugsRcP3iw0jxi2vk=
+github.com/flant/addon-operator v1.5.3-0.20241107164507-a38325ae9db3 h1:vmH4IHi8NWtBOqgjQsN6rR5mPh+LklN0rGvPEeLNTg8=
+github.com/flant/addon-operator v1.5.3-0.20241107164507-a38325ae9db3/go.mod h1:G15JIgnzfTQiOjV0QxMJ3TkXUxpugsRcP3iw0jxi2vk=
 github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AWkndSY/+/5MX7ad1xJ/8A=
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.2.2 h1:27LBs+PKJEFnkQXjPU9eIps7a7iyI13AKcSYj897DCU=

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,10 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flant/addon-operator v1.5.2 h1:p2Djo3ZS41IJqbKOIZkvhj96tHpisvyarEL+hdqr3ws=
 github.com/flant/addon-operator v1.5.2/go.mod h1:G15JIgnzfTQiOjV0QxMJ3TkXUxpugsRcP3iw0jxi2vk=
+github.com/flant/addon-operator v1.5.3-0.20241107113419-a62284231d16 h1:/gNTvm/pDH8VN+wFYlOqR0F9widB89/jjurND33uYMY=
+github.com/flant/addon-operator v1.5.3-0.20241107113419-a62284231d16/go.mod h1:G15JIgnzfTQiOjV0QxMJ3TkXUxpugsRcP3iw0jxi2vk=
+github.com/flant/addon-operator v1.5.3-0.20241107133554-c4e1203a3b44 h1:jWSpmuBoe/+jtlZp41cd5l/WPeww3WmbH028pfMNAxQ=
+github.com/flant/addon-operator v1.5.3-0.20241107133554-c4e1203a3b44/go.mod h1:G15JIgnzfTQiOjV0QxMJ3TkXUxpugsRcP3iw0jxi2vk=
 github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AWkndSY/+/5MX7ad1xJ/8A=
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.2.2 h1:27LBs+PKJEFnkQXjPU9eIps7a7iyI13AKcSYj897DCU=

--- a/go_lib/hooks/ensure_crds/hook.go
+++ b/go_lib/hooks/ensure_crds/hook.go
@@ -27,7 +27,6 @@ import (
 	addonoperator "github.com/flant/addon-operator/pkg/addon-operator"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
-	klient "github.com/flant/kube-client/client"
 	"github.com/hashicorp/go-multierror"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -200,11 +199,6 @@ func (cp *CRDsInstaller) getCRDFromCluster(ctx context.Context, crdName string) 
 // NewCRDsInstaller creates new installer for CRDs
 // crdsGlob example: "/deckhouse/modules/002-deckhouse/crds/*.yaml"
 func NewCRDsInstaller(client k8s.Client, crdsGlob string) (*CRDsInstaller, error) {
-	kClient, ok := client.(*klient.Client)
-	if !ok {
-		return nil, fmt.Errorf("TODO: add installer support for %T", client)
-	}
-
 	crds, err := filepath.Glob(crdsGlob)
 	if err != nil {
 		return nil, fmt.Errorf("glob %q: %w", crdsGlob, err)
@@ -213,7 +207,7 @@ func NewCRDsInstaller(client k8s.Client, crdsGlob string) (*CRDsInstaller, error
 	return &CRDsInstaller{
 		k8sClient: client,
 		installer: addonoperator.NewCRDsInstaller(
-			kClient,
+			client,
 			crds,
 			addonoperator.WithExtraLabels(defaultLabels),
 			addonoperator.WithFileFilter(func(crdFilePath string) bool {

--- a/go_lib/hooks/ensure_crds/hook.go
+++ b/go_lib/hooks/ensure_crds/hook.go
@@ -17,37 +17,37 @@ limitations under the License.
 package ensure_crds
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 
+	addonoperator "github.com/flant/addon-operator/pkg/addon-operator"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	klient "github.com/flant/kube-client/client"
 	"github.com/hashicorp/go-multierror"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	apimachineryYaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
 )
 
-var (
-	crdGVR = schema.GroupVersionResource{
-		Group:    "apiextensions.k8s.io",
-		Version:  "v1",
-		Resource: "customresourcedefinitions",
-	}
-)
+var crdGVR = schema.GroupVersionResource{
+	Group:    "apiextensions.k8s.io",
+	Version:  "v1",
+	Resource: "customresourcedefinitions",
+}
+
+var defaultLabels = map[string]string{
+	"heritage": "deckhouse",
+}
 
 func RegisterEnsureCRDsHook(crdsGlob string) bool {
 	return sdk.RegisterFunc(&go_hook.HookConfig{
@@ -89,7 +89,7 @@ func EnsureCRDs(crdsGlob string, dc dependency.Container) *multierror.Error {
 type CRDsInstaller struct {
 	k8sClient    k8s.Client
 	crdFilesPath []string
-	buffer       []byte
+	installer    *addonoperator.CRDsInstaller
 
 	// concurrent tasks to create resource in a k8s cluster
 	k8sTasks *multierror.Group
@@ -136,90 +136,7 @@ func (cp *CRDsInstaller) DeleteCRDs(ctx context.Context, crdsToDelete []string) 
 }
 
 func (cp *CRDsInstaller) Run(ctx context.Context) *multierror.Error {
-	result := new(multierror.Error)
-
-	for _, crdFilePath := range cp.crdFilesPath {
-		if match := strings.HasPrefix(filepath.Base(crdFilePath), "doc-"); match {
-			continue
-		}
-
-		err := cp.processCRD(ctx, crdFilePath)
-		if err != nil {
-			err = fmt.Errorf("error occurred during processing %q file: %w", crdFilePath, err)
-			result = multierror.Append(result, err)
-			continue
-		}
-	}
-
-	errs := cp.k8sTasks.Wait()
-	if errs.ErrorOrNil() != nil {
-		result = multierror.Append(result, errs.Errors...)
-	}
-
-	return result
-}
-
-func (cp *CRDsInstaller) processCRD(ctx context.Context, crdFilePath string) error {
-	crdFileReader, err := os.Open(crdFilePath)
-	if err != nil {
-		return err
-	}
-	defer crdFileReader.Close()
-
-	crdReader := apimachineryYaml.NewDocumentDecoder(crdFileReader)
-
-	for {
-		n, err := crdReader.Read(cp.buffer)
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-
-			return err
-		}
-
-		data := cp.buffer[:n]
-		if len(data) == 0 {
-			// some empty yaml document, or empty string before separator
-			continue
-		}
-		rd := bytes.NewReader(data)
-		err = cp.putCRDToCluster(ctx, rd, n)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reader, bufferSize int) error {
-	var crd *v1.CustomResourceDefinition
-
-	err := apimachineryYaml.NewYAMLOrJSONDecoder(crdReader, bufferSize).Decode(&crd)
-	if err != nil {
-		return err
-	}
-
-	// it could be a comment or some other peace of yaml file, skip it
-	if crd == nil {
-		return nil
-	}
-
-	if crd.APIVersion != v1.SchemeGroupVersion.String() && crd.Kind != "CustomResourceDefinition" {
-		return fmt.Errorf("invalid CRD document apiversion/kind: '%s/%s'", crd.APIVersion, crd.Kind)
-	}
-
-	if len(crd.ObjectMeta.Labels) == 0 {
-		crd.ObjectMeta.Labels = make(map[string]string, 1)
-	}
-	crd.ObjectMeta.Labels["heritage"] = "deckhouse"
-
-	cp.k8sTasks.Go(func() error {
-		return cp.updateOrInsertCRD(ctx, crd)
-	})
-
-	return nil
+	return cp.installer.Run(ctx)
 }
 
 func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *v1.CustomResourceDefinition) error {
@@ -283,18 +200,27 @@ func (cp *CRDsInstaller) getCRDFromCluster(ctx context.Context, crdName string) 
 // NewCRDsInstaller creates new installer for CRDs
 // crdsGlob example: "/deckhouse/modules/002-deckhouse/crds/*.yaml"
 func NewCRDsInstaller(client k8s.Client, crdsGlob string) (*CRDsInstaller, error) {
+	kClient, ok := client.(*klient.Client)
+	if !ok {
+		return nil, fmt.Errorf("TODO: add installer support for %T", client)
+	}
+
 	crds, err := filepath.Glob(crdsGlob)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("glob %q: %w", crdsGlob, err)
 	}
 
 	return &CRDsInstaller{
-		k8sClient:    client,
+		k8sClient: client,
+		installer: addonoperator.NewCRDsInstaller(
+			kClient,
+			crds,
+			addonoperator.WithExtraLabels(defaultLabels),
+			addonoperator.WithFileFilter(func(crdFilePath string) bool {
+				return !strings.HasPrefix(filepath.Base(crdFilePath), "doc-")
+			}),
+		),
 		crdFilesPath: crds,
-		// 1Mb - maximum size of kubernetes object
-		// if we take less, we have to handle io.ErrShortBuffer error and increase the buffer
-		// take more does not make any sense due to kubernetes limitations
-		buffer:   make([]byte, 1*1024*1024),
-		k8sTasks: &multierror.Group{},
+		k8sTasks:     new(multierror.Group),
 	}, nil
 }

--- a/go_lib/hooks/ensure_crds/test_data/heritage.crd
+++ b/go_lib/hooks/ensure_crds/test_data/heritage.crd
@@ -11,3 +11,5 @@ spec:
     plural: deschedulers
     singular: descheduler
   scope: Cluster
+  versions:
+    - name: v1

--- a/modules/000-common/crds/doc-ru-test-crd.yaml
+++ b/modules/000-common/crds/doc-ru-test-crd.yaml
@@ -1,3 +1,9 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: testcrds.deckhouse.io
+  labels:
+    heritage: deckhouse
 spec:
   group: deckhouse.io
   scope: Cluster

--- a/modules/110-istio/_crds/istio/0.990/test-crd.yaml
+++ b/modules/110-istio/_crds/istio/0.990/test-crd.yaml
@@ -6,3 +6,10 @@ metadata:
     heritage: deckhouse
 spec:
   scope: "0.990"
+  group: networking.istio.io
+  names:
+    plural: testcrds
+    singular: testcrd
+    kind: TestCrd
+  versions:
+    - name: v1

--- a/modules/110-istio/_crds/istio/0.991/test-crd.yaml
+++ b/modules/110-istio/_crds/istio/0.991/test-crd.yaml
@@ -6,3 +6,10 @@ metadata:
     heritage: deckhouse
 spec:
   scope: "0.991"
+  group: networking.istio.io
+  names:
+    plural: testcrds
+    singular: testcrd
+    kind: TestCrd
+  versions:
+    - name: v1

--- a/modules/110-istio/_crds/istio/0.992/test-crd.yaml
+++ b/modules/110-istio/_crds/istio/0.992/test-crd.yaml
@@ -6,3 +6,10 @@ metadata:
     heritage: deckhouse
 spec:
   scope: "0.992"
+  group: networking.istio.io
+  names:
+    plural: testcrds
+    singular: testcrd
+    kind: TestCrd
+  versions:
+    - name: v1


### PR DESCRIPTION
## Description
Considering that etcd has a default value of 1.5Mb, it was decided to set it to 2Mb, so that in most cases we would get a more informative error from Kubernetes, not just "short buffer"
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Increased internal module CRD buffer
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
