### PR TITLE
[user-authn] Add ability to set custom labels on autogenerated DexClient secret

### DIFF
--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -70,6 +70,16 @@ func applyDexClientFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 	id := fmt.Sprintf("dex-client-%s@%s", name, namespace)
 	legacyID := fmt.Sprintf("dex-client-%s:%s", name, namespace)
 
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
 	return DexClient{
 		ID:              id,
 		LegacyID:        legacyID,
@@ -78,8 +88,8 @@ func applyDexClientFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 		Name:            name,
 		Namespace:       namespace,
 		Spec:            spec,
-		Labels:          obj.GetLabels(),
-		Annotations:     obj.GetAnnotations(),
+		Labels:          labels,
+		Annotations:     annotations,
 	}, nil
 }
 

--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -43,6 +43,9 @@ type DexClient struct {
 	//   basic auth credentials part
 	LegacyID        string `json:"legacyID"`
 	LegacyEncodedID string `json:"legacyEncodedID"`
+
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
 }
 
 type DexClientSecret struct {
@@ -75,6 +78,8 @@ func applyDexClientFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 		Name:            name,
 		Namespace:       namespace,
 		Spec:            spec,
+		Labels:          obj.GetLabels(),
+		Annotations:     obj.GetAnnotations(),
 	}, nil
 }
 

--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -74,11 +74,19 @@ func applyDexClientFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 	if labels == nil {
 		labels = make(map[string]string)
 	}
+	// Secrets with that label lead to D8CertmanagerOrphanSecretsChecksFailed alerts.
+	delete(labels, "certmanager.k8s.io/certificate-name")
+
+	// Secrets with that labels lead to ArgoCD control over them.
+	delete(labels, "argocd.argoproj.io/instance")
+	delete(labels, "argocd.argoproj.io/secret-type")
 
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
+
+	delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
 
 	return DexClient{
 		ID:              id,

--- a/modules/150-user-authn/hooks/get_dex_client_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds_test.go
@@ -60,8 +60,13 @@ metadata:
   namespace: test
   labels:
     test-label: test-value
+    certmanager.k8s.io/certificate-name: test-cert-name
+    argocd.argoproj.io/instance: test-instance
+    argocd.argoproj.io/secret-type: secret-type
   annotations:
     test-annotation: test-value
+    new-annotation: test-new-value
+    kubectl.kubernetes.io/last-applied-configuration: should-be-removed
 spec:
   redirectURIs:
   - https://opendistro.example.com/callback
@@ -102,7 +107,8 @@ spec:
     "test-label": "test-value"
   },
   "annotations": {
-    "test-annotation": "test-value"
+    "test-annotation": "test-value",
+    "new-annotation": "test-new-value"
   }
 }]`))
 			})
@@ -202,6 +208,15 @@ kind: DexClient
 metadata:
   name: opendistro
   namespace: test
+  labels:
+    test-label: test-value
+    certmanager.k8s.io/certificate-name: test-cert-name
+    argocd.argoproj.io/instance: test-instance
+    argocd.argoproj.io/secret-type: secret-type
+  annotations:
+    test-annotation: test-value
+    new-annotation: test-new-value
+    kubectl.kubernetes.io/last-applied-configuration: should-be-removed
 spec:
   redirectURIs:
   - https://opendistro.example.com/callback
@@ -240,8 +255,13 @@ spec:
   "namespace": "test",
   "spec": {"redirectURIs": ["https://opendistro.example.com/callback"]},
   "clientSecret": "test",
-  "labels": {},
-  "annotations": {}
+  "labels": {
+    "test-label": "test-value"
+  },
+  "annotations": {
+    "test-annotation": "test-value",
+    "new-annotation": "test-new-value"
+  }
 }]`))
 		})
 	})

--- a/modules/150-user-authn/hooks/get_dex_client_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds_test.go
@@ -58,6 +58,10 @@ kind: DexClient
 metadata:
   name: opendistro
   namespace: test
+  labels:
+    test-label: test-value
+  annotations:
+    test-annotation: test-value
 spec:
   redirectURIs:
   - https://opendistro.example.com/callback
@@ -93,7 +97,13 @@ spec:
   },
   "legacyID": "dex-client-opendistro:test",
   "legacyEncodedID": "mrsxqlldnruwk3tufvxxazlomruxg5dsn45hizltotf7fhheqqrcgji",
-  "clientSecret": "test"
+  "clientSecret": "test",
+  "labels": {
+    "test-label": "test-value"
+  },
+  "annotations": {
+    "test-annotation": "test-value"
+  }
 }]`))
 			})
 
@@ -152,7 +162,9 @@ spec:
   },
   "clientSecret": "test",
   "legacyID": "dex-client-opendistro:test",
-  "legacyEncodedID": "mrsxqlldnruwk3tufvxxazlomruxg5dsn45hizltotf7fhheqqrcgji"
+  "legacyEncodedID": "mrsxqlldnruwk3tufvxxazlomruxg5dsn45hizltotf7fhheqqrcgji",
+  "labels": {},
+  "annotations": {}
 }]`))
 				})
 			})
@@ -215,7 +227,9 @@ spec:
   "name": "grafana",
   "namespace": "test-grafana",
   "spec": {"redirectURIs": ["https://grafana.example.com/callback"]},
-  "clientSecret": "test"
+  "clientSecret": "test",
+  "labels": {},
+  "annotations": {}
 },
 {
   "id": "dex-client-opendistro@test",
@@ -225,7 +239,9 @@ spec:
   "name": "opendistro",
   "namespace": "test",
   "spec": {"redirectURIs": ["https://opendistro.example.com/callback"]},
-  "clientSecret": "test"
+  "clientSecret": "test",
+  "labels": {},
+  "annotations": {}
 }]`))
 		})
 	})

--- a/modules/150-user-authn/openapi/values.yaml
+++ b/modules/150-user-authn/openapi/values.yaml
@@ -149,6 +149,14 @@ properties:
               type: string
             legacyEncodedID:
               type: string
+            labels:
+              type: object
+              additionalProperties:
+                type: string
+            annotations:
+              type: object
+              additionalProperties:
+                type: string
             spec:
               # clients spec is copied from custom resources as is and validated by its spec
               type: object

--- a/modules/150-user-authn/openapi/values.yaml
+++ b/modules/150-user-authn/openapi/values.yaml
@@ -151,10 +151,12 @@ properties:
               type: string
             labels:
               type: object
+              default: {}
               additionalProperties:
                 type: string
             annotations:
               type: object
+              default: {}
               additionalProperties:
                 type: string
             spec:

--- a/modules/150-user-authn/templates/dex-client/secret.yaml
+++ b/modules/150-user-authn/templates/dex-client/secret.yaml
@@ -7,6 +7,14 @@ metadata:
   name: dex-client-{{ $crd.name }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-client" "name" "credentials")) | nindent 2 }}
+  {{- with $crd.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $crd.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   clientSecret: {{ $crd.clientSecret | b64enc }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix [issue](https://github.com/deckhouse/deckhouse/issues/10172)

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: feature
summary: Add ability to set custom labels on autogenerated DexClient secret
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
