### PR TITLE
[deckhouse-controller] Improved CRDs Installer

### DIFF
--- a/deckhouse-controller/pkg/apis/ensure_crds.go
+++ b/deckhouse-controller/pkg/apis/ensure_crds.go
@@ -24,12 +24,10 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-var (
-	deprecatedCRDs = []string{
-		"externalmodulesources.deckhouse.io",
-		"externalmodulereleases.deckhouse.io",
-	}
-)
+var deprecatedCRDs = []string{
+	"externalmodulesources.deckhouse.io",
+	"externalmodulereleases.deckhouse.io",
+}
 
 type kubeClient interface {
 	kubernetes.Interface

--- a/deckhouse-controller/pkg/apis/ensure_crds.go
+++ b/deckhouse-controller/pkg/apis/ensure_crds.go
@@ -24,10 +24,8 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-var deprecatedCRDs = []string{
-	"externalmodulesources.deckhouse.io",
-	"externalmodulereleases.deckhouse.io",
-}
+// list of CRDs to delete, like "externalmodulesources.deckhouse.io"
+var deprecatedCRDs = []string{}
 
 type kubeClient interface {
 	kubernetes.Interface

--- a/go_lib/hooks/ensure_crds/hook_test.go
+++ b/go_lib/hooks/ensure_crds/hook_test.go
@@ -64,6 +64,7 @@ func TestDeleteCRDs(t *testing.T) {
 	cluster := fake.NewFakeCluster(fake.ClusterVersionV125)
 	cluster.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleSource", true)
 
+	client := cluster.Client.Dynamic()
 	inst, err := NewCRDsInstaller(cluster.Client, "./test_data/single.crd")
 	require.NoError(t, err)
 
@@ -86,11 +87,11 @@ func TestDeleteCRDs(t *testing.T) {
 		},
 	}
 
-	_, err = inst.k8sClient.Dynamic().Resource(gvr).Create(context.TODO(), msObject, apimachineryv1.CreateOptions{})
+	_, err = client.Resource(gvr).Create(context.TODO(), msObject, apimachineryv1.CreateOptions{})
 	require.NoError(t, err)
 
 	// one cr is in the cluster
-	list, err := cluster.Client.Dynamic().Resource(crdGVR).List(context.TODO(), apimachineryv1.ListOptions{})
+	list, err := client.Resource(crdGVR).List(context.TODO(), apimachineryv1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, list.Items, 1)
 
@@ -99,7 +100,7 @@ func TestDeleteCRDs(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, deleted, 0)
 
-	list, err = cluster.Client.Dynamic().Resource(crdGVR).List(context.TODO(), apimachineryv1.ListOptions{})
+	list, err = client.Resource(crdGVR).List(context.TODO(), apimachineryv1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, list.Items, 1)
 
@@ -115,7 +116,7 @@ func TestDeleteCRDs(t *testing.T) {
 	assert.Equal(t, expected, result)
 
 	// no cr in the cluster
-	err = inst.k8sClient.Dynamic().Resource(gvr).Delete(context.TODO(), msObject.GetName(), apimachineryv1.DeleteOptions{})
+	err = client.Resource(gvr).Delete(context.TODO(), msObject.GetName(), apimachineryv1.DeleteOptions{})
 	require.NoError(t, err)
 
 	// one crd should be deleted
@@ -129,7 +130,7 @@ func TestDeleteCRDs(t *testing.T) {
 	assert.Equal(t, expected, deleted)
 
 	// no crds left
-	list, err = cluster.Client.Dynamic().Resource(crdGVR).List(context.TODO(), apimachineryv1.ListOptions{})
+	list, err = client.Resource(crdGVR).List(context.TODO(), apimachineryv1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, list.Items, 0)
 }


### PR DESCRIPTION
## Description
Abstracted the kubernetes client for use in tests
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
