### PR TITLE
[docs] Fix publicDomainTemplate in alert templates

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1640,10 +1640,10 @@ alerts:
       module: node-manager
       edition: ce
       description: |
-        The {{ $labels.node }} Node is not managed by the [node-manager](http://documentation.example.com/modules/040-node-manager/) module.
+        The {{ $labels.node }} Node is not managed by the [node-manager](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/040-node-manager/) module.
 
         The recommended actions are as follows:
-        - Follow these instructions to clean up the node and add it to the cluster: http://documentation.example.com/modules/040-node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster
+        - Follow these instructions to clean up the node and add it to the cluster: https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/040-node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster
       summary: |
         The {{ $labels.node }} Node is not managed by the node-manager module.
       severity: "9"
@@ -1818,7 +1818,7 @@ alerts:
         - reserved `metadata.labels` *node-role.deckhouse.io/* with ending not in `(system|frontend|monitoring|_deckhouse_module_name_)`
         - or reserved `spec.taints` *dedicated.deckhouse.io* with values not in `(system|frontend|monitoring|_deckhouse_module_name_)`
 
-        [Get instructions on how to fix it here](http://documentation.example.com/modules/040-node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).
+        [Get instructions on how to fix it here](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/040-node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).
       summary: |
         Node {{ $labels.name }} needs fixing up
       severity: "6"
@@ -2683,7 +2683,7 @@ alerts:
       module: ingress-nginx
       edition: ce
       description: |-
-        There is an IngressNginxController and/or an Ingress object that utilize(s) Nginx GeoIPv1 module's variables. The module is deprecated and its support is discontinued from Ingess Nginx Controller of version 1.10 and higher. It's recommend to upgrade your configuration to use [GeoIPv2 module](http://documentation.example.com/modules/402-ingress-nginx/cr.html#ingressnginxcontroller-v1-spec-geoip2).
+        There is an IngressNginxController and/or an Ingress object that utilize(s) Nginx GeoIPv1 module's variables. The module is deprecated and its support is discontinued from Ingess Nginx Controller of version 1.10 and higher. It's recommend to upgrade your configuration to use [GeoIPv2 module](https://deckhouse.io/documentation/v1/modules/402-ingress-nginx/cr.html#ingressnginxcontroller-v1-spec-geoip2).
         Use the following command to get the list of the IngressNginxControllers that contain GeoIPv1 variables:
         `kubectl  get ingressnginxcontrollers.deckhouse.io -o json | jq '.items[] | select(..|strings | test("\\$geoip_(country_(code3|code|name)|area_code|city_continent_code|city_country_(code3|code|name)|dma_code|latitude|longitude|region|region_name|city|postal_code|org)([^_a-zA-Z0-9]|$)+")) | .metadata.name'`
 
@@ -4522,9 +4522,6 @@ alerts:
       description: |-
         StorageClass having a cloud-provider provisioner shouldn't be deployed manually.
         They are managed by the cloud-provider module, you only need to change the module configuration to fit your needs.
-
-
-        [Find storage configuration documentation for your cloud-provider here](http://documentation.example.com/kubernetes.html).
       summary: |
         Manually deployed StorageClass {{ $labels.name }} found in the cluster
       severity: "6"
@@ -4537,9 +4534,6 @@ alerts:
       description: |-
         More than one StorageClass in the cluster annotated as a default.
         Probably manually deployed StorageClass exists, that overlaps with cloud-provider module default Storage configuration.
-
-
-        [Find storage configuration documentation for your cloud-provider here](http://documentation.example.com/kubernetes.html).
       summary: |
         Multiple default StorageClasses found in the cluster
       severity: "6"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1099,7 +1099,7 @@ alerts:
       description: |
         There is deprecated istio version `{{$labels.version}}` installed.
         Impact — version support will be removed in future deckhouse releases. The higher alert severity — the higher probability of support cancelling.
-        Upgrading instructions — https://deckhouse.io/documentation//modules/110-istio/examples.html#upgrading-istio.
+        Read [documentation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/110-istio/examples.html#upgrading-istio) on upgrading Istio.
       summary: |
         There is deprecated istio version installed
       severity: undefined
@@ -1240,7 +1240,7 @@ alerts:
       description: |
         The current istio version `{{$labels.istio_version}}` may not work properly with the current k8s version `{{$labels.k8s_version}}`, because it is unsupported officially.
         Please upgrade istio as soon as possible.
-        Upgrading instructions — https://deckhouse.io/documentation//modules/110-istio/examples.html#upgrading-istio.
+        Read [documentation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/110-istio/examples.html#upgrading-istio) on upgrading Istio.
       summary: |
         The installed istio version is incompatible with the k8s version
       severity: "3"

--- a/modules/040-node-manager/monitoring/prometheus-rules/early-oom.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/early-oom.tpl
@@ -21,9 +21,5 @@
         Possible actions to resolve the problem:
         * Upgrade kernel to version 4.20 or higher.
         * Enable [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).
-        {{ if .Values.global.modules.publicDomainTemplate }}
-        * [Disable]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/products/kubernetes-platform/documentation/v1/modules/040-node-manager/configuration.html#parameters-earlyoomenabled) early oom.
-        {{- else }}
-        * [Disable](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/040-node-manager/configuration.html#parameters-earlyoomenabled) early oom.
-        {{- end }}
+        * [Disable]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}{{- else }}https://deckhouse.io{{- end }}/products/kubernetes-platform/documentation/v1/modules/040-node-manager/configuration.html#parameters-earlyoomenabled) early oom.
 {{- end }}

--- a/modules/040-node-manager/monitoring/prometheus-rules/early-oom.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/early-oom.tpl
@@ -21,5 +21,9 @@
         Possible actions to resolve the problem:
         * Upgrade kernel to version 4.20 or higher.
         * Enable [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).
+        {{ if .Values.global.modules.publicDomainTemplate }}
+        * [Disable]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/products/kubernetes-platform/documentation/v1/modules/040-node-manager/configuration.html#parameters-earlyoomenabled) early oom.
+        {{- else }}
         * [Disable](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/040-node-manager/configuration.html#parameters-earlyoomenabled) early oom.
+        {{- end }}
 {{- end }}

--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.tpl
@@ -179,7 +179,11 @@
         To converge state of Kubernetes cluster, use `dhctl converge` command.
 
 {{- if (.Values.global.enabledModules | has "cloud-provider-aws") }}
+{{ if .Values.global.modules.publicDomainTemplate }}
+        Also, it can occur because of missing permissions for the following actions for the [Deckhouse IAM user]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/products/kubernetes-platform/documentation/v1/modules/030-cloud-provider-aws/environment.html#json-policy) in AWS (the new requirements in Deckhouse 1.45):
+{{- else }}
         Also, it can occur because of missing permissions for the following actions for the [Deckhouse IAM user](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/030-cloud-provider-aws/environment.html#json-policy) in AWS (the new requirements in Deckhouse 1.45):
+{{- end }}
         1. `ec2:DescribeInstanceTypes`,
         2. `ec2:DescribeSecurityGroupRules`.
 {{- end }}
@@ -207,7 +211,11 @@
         To converge state of Kubernetes cluster, use `dhctl converge` command.
 
 {{- if (.Values.global.enabledModules | has "cloud-provider-aws") }}
+{{ if .Values.global.modules.publicDomainTemplate }}
+        Also, it can occur because of missing permissions for the following actions for the [Deckhouse IAM user]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/products/kubernetes-platform/documentation/v1/modules/030-cloud-provider-aws/environment.html#json-policy) in AWS (the new requirements in Deckhouse 1.45):
+{{- else }}
         Also, it can occur because of missing permissions for the following actions for the [Deckhouse IAM user](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/030-cloud-provider-aws/environment.html#json-policy) in AWS (the new requirements in Deckhouse 1.45):
+{{- end }}
         1. `ec2:DescribeInstanceTypes`,
         2. `ec2:DescribeSecurityGroupRules`.
 {{- end }}

--- a/modules/110-istio/monitoring/prometheus-rules/versions.tpl
+++ b/modules/110-istio/monitoring/prometheus-rules/versions.tpl
@@ -5,7 +5,7 @@
         description: |
           There is deprecated istio version `{{"{{$labels.version}}"}}` installed.
           Impact — version support will be removed in future deckhouse releases. The higher alert severity — the higher probability of support cancelling.
-          Upgrading instructions — https://deckhouse.io/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio.
+          Read [documentation]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}{{- else }}https://deckhouse.io{{- end }}/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio) on upgrading Istio.
         plk_markup_format: markdown
         plk_labels_as_annotations: pod,instance
         plk_protocol_version: "1"
@@ -23,7 +23,7 @@
         description: |
           The current istio version `{{"{{$labels.istio_version}}"}}` may not work properly with the current k8s version `{{"{{$labels.k8s_version}}"}}`, because it is unsupported officially.
           Please upgrade istio as soon as possible.
-          Upgrading instructions — https://deckhouse.io/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio.
+          Read [documentation]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}{{- else }}https://deckhouse.io{{- end }}/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio) on upgrading Istio.
         plk_markup_format: markdown
         plk_labels_as_annotations: pod,instance
         plk_protocol_version: "1"

--- a/modules/110-istio/monitoring/prometheus-rules/versions.tpl
+++ b/modules/110-istio/monitoring/prometheus-rules/versions.tpl
@@ -5,11 +5,7 @@
         description: |
           There is deprecated istio version `{{"{{$labels.version}}"}}` installed.
           Impact — version support will be removed in future deckhouse releases. The higher alert severity — the higher probability of support cancelling.
-          {{ if .Values.global.modules.publicDomainTemplate }}
-          Upgrading instructions — {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio.
-          {{- else }}
           Upgrading instructions — https://deckhouse.io/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio.
-          {{- end }}
         plk_markup_format: markdown
         plk_labels_as_annotations: pod,instance
         plk_protocol_version: "1"
@@ -27,11 +23,7 @@
         description: |
           The current istio version `{{"{{$labels.istio_version}}"}}` may not work properly with the current k8s version `{{"{{$labels.k8s_version}}"}}`, because it is unsupported officially.
           Please upgrade istio as soon as possible.
-          {{ if .Values.global.modules.publicDomainTemplate }}
-          Upgrading instructions — {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio.
-          {{- else }}
           Upgrading instructions — https://deckhouse.io/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio.
-          {{- end }}
         plk_markup_format: markdown
         plk_labels_as_annotations: pod,instance
         plk_protocol_version: "1"

--- a/modules/110-istio/monitoring/prometheus-rules/versions.tpl
+++ b/modules/110-istio/monitoring/prometheus-rules/versions.tpl
@@ -5,7 +5,11 @@
         description: |
           There is deprecated istio version `{{"{{$labels.version}}"}}` installed.
           Impact — version support will be removed in future deckhouse releases. The higher alert severity — the higher probability of support cancelling.
+          {{ if .Values.global.modules.publicDomainTemplate }}
+          Upgrading instructions — {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio.
+          {{- else }}
           Upgrading instructions — https://deckhouse.io/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio.
+          {{- end }}
         plk_markup_format: markdown
         plk_labels_as_annotations: pod,instance
         plk_protocol_version: "1"
@@ -23,7 +27,11 @@
         description: |
           The current istio version `{{"{{$labels.istio_version}}"}}` may not work properly with the current k8s version `{{"{{$labels.k8s_version}}"}}`, because it is unsupported officially.
           Please upgrade istio as soon as possible.
+          {{ if .Values.global.modules.publicDomainTemplate }}
+          Upgrading instructions — {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio.
+          {{- else }}
           Upgrading instructions — https://deckhouse.io/documentation/{{ $.Values.global.deckhouseVersion }}/modules/110-istio/examples.html#upgrading-istio.
+          {{- end }}
         plk_markup_format: markdown
         plk_labels_as_annotations: pod,instance
         plk_protocol_version: "1"

--- a/modules/340-monitoring-custom/monitoring/prometheus-rules/reserved-domain.tpl
+++ b/modules/340-monitoring-custom/monitoring/prometheus-rules/reserved-domain.tpl
@@ -17,8 +17,5 @@
         Node {{`{{ $labels.name }}`}} uses:
         - reserved `metadata.labels` *node-role.deckhouse.io/* with ending not in `(system|frontend|monitoring|_deckhouse_module_name_)`
         - or reserved `spec.taints` *dedicated.deckhouse.io* with values not in `(system|frontend|monitoring|_deckhouse_module_name_)`
-{{ if .Values.global.modules.publicDomainTemplate }}
-        [Get instructions on how to fix it here]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/modules/040-node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).
-{{- else }}
-        [Get instructions on how to fix it here](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/040-node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).
-{{- end }}
+
+        [Get instructions on how to fix it here]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}{{- else }}https://deckhouse.io{{- end }}/products/kubernetes-platform/documentation/v1/modules/040-node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).

--- a/tools/helm_generate/runners/alert_templates/template_values/040-node-manager.yaml
+++ b/tools/helm_generate/runners/alert_templates/template_values/040-node-manager.yaml
@@ -1,6 +1,6 @@
 global:
   modules:
-    publicDomainTemplate: "%s.example.com"
+    publicDomainTemplate: ""
     https:
       mode: Disabled
 

--- a/tools/helm_generate/runners/alert_templates/template_values/110-istio.yaml
+++ b/tools/helm_generate/runners/alert_templates/template_values/110-istio.yaml
@@ -1,0 +1,6 @@
+global:
+  modules:
+    publicDomainTemplate: ""
+    https:
+      mode: Disabled
+  deckhouseVersion: v1

--- a/tools/helm_generate/runners/alert_templates/template_values/110-istio.yaml
+++ b/tools/helm_generate/runners/alert_templates/template_values/110-istio.yaml
@@ -1,0 +1,3 @@
+global:
+  modules:
+    publicDomainTemplate: ""

--- a/tools/helm_generate/runners/alert_templates/template_values/110-istio.yaml
+++ b/tools/helm_generate/runners/alert_templates/template_values/110-istio.yaml
@@ -1,3 +1,0 @@
-global:
-  modules:
-    publicDomainTemplate: ""

--- a/tools/helm_generate/runners/alert_templates/template_values/340-monitoring-custom.yaml
+++ b/tools/helm_generate/runners/alert_templates/template_values/340-monitoring-custom.yaml
@@ -1,5 +1,5 @@
 global:
   modules:
-    publicDomainTemplate: "%s.example.com"
+    publicDomainTemplate: ""
     https:
       mode: Disabled

--- a/tools/helm_generate/runners/alert_templates/template_values/340-monitoring-kubernetes.yaml
+++ b/tools/helm_generate/runners/alert_templates/template_values/340-monitoring-kubernetes.yaml
@@ -1,5 +1,5 @@
 global:
   modules:
-    publicDomainTemplate: "%s.example.com"
+    publicDomainTemplate: ""
     https:
       mode: Disabled

--- a/tools/helm_generate/runners/alert_templates/template_values/402-ingress-nginx.yaml
+++ b/tools/helm_generate/runners/alert_templates/template_values/402-ingress-nginx.yaml
@@ -1,5 +1,5 @@
 global:
   modules:
-    publicDomainTemplate: "%s.example.com"
+    publicDomainTemplate: ""
     https:
       mode: Disabled


### PR DESCRIPTION
## Description

Fix `publicDomainTemplate` in alert templates.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: fix
summary: |
  Fix `publicDomainTemplate` in alert templates.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
