### PR TITLE
[tools] implement src-artifact usage linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,9 @@ lint-markdown-fix: ## Run markdown linter and fix problems automatically.
 	@docker run --rm -v ${PWD}:/workdir ${MDLINTER_IMAGE} \
 		--config testing/markdownlint.yaml -p testing/.markdownlintignore "**/*.md" --fix && (echo 'Fixed successfully.')
 
+lint-src-artifact: set-build-envs ## Run src-artifact stapel linter
+	@werf config render | awk 'NR!=1 {print}' | go run ./tools/lint-src-artifact/lint-src-artifact.go
+
 ##@ Generate
 
 .PHONY: generate render-workflow

--- a/modules/500-dashboard/images/dashboard/werf.inc.yaml
+++ b/modules/500-dashboard/images/dashboard/werf.inc.yaml
@@ -25,6 +25,7 @@ shell:
   - git checkout v2.7.0
     # Use batch/v1 for fetching cronjob jobs https://github.com/kubernetes/dashboard/pull/7465
   - git cherry-pick f79f3a5e25df152df6164ddfaf2ffc1f09e5058f
+  - rm -rf .git
 ---
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}

--- a/modules/500-openvpn/images/openvpn/werf.inc.yaml
+++ b/modules/500-openvpn/images/openvpn/werf.inc.yaml
@@ -48,10 +48,9 @@ git:
     - 'go.sum'
 shell:
   install:
-  - cd /src
-  - git clone --depth 1 -b openssl-{{ $opensslVersion }} {{ .SOURCE_REPO }}/openssl/openssl.git ./openssl
-  - git clone --depth 1 -b v{{ $libcapNgVersion }} {{ .SOURCE_REPO }}/stevegrubb/libcap-ng.git ./libcap-ng
-  - git clone --depth 1 -b v{{ $openvpnVersion }} {{ .SOURCE_REPO }}/OpenVPN/openvpn.git ./openvpn
+  - git clone --depth 1 -b openssl-{{ $opensslVersion }} {{ .SOURCE_REPO }}/openssl/openssl.git /src/openssl && cd /src/openssl && rm -rf .git
+  - git clone --depth 1 -b v{{ $libcapNgVersion }} {{ .SOURCE_REPO }}/stevegrubb/libcap-ng.git /src/libcap-ng && cd /src/libcap-ng && rm -rf .git
+  - git clone --depth 1 -b v{{ $openvpnVersion }} {{ .SOURCE_REPO }}/OpenVPN/openvpn.git /src/openvpn && cd /src/openvpn && rm -rf .git
 ---
 artifact: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}

--- a/modules/500-openvpn/images/ovpn-admin/werf.inc.yaml
+++ b/modules/500-openvpn/images/ovpn-admin/werf.inc.yaml
@@ -49,6 +49,7 @@ shell:
   - git clone {{ .SOURCE_REPO }}/flant/ovpn-admin.git .
   - git checkout {{ $gitCommit }}
   - git apply /patches/*.patch --verbose
+  - rm -rf .git
   - echo {{ $gitCommit }} > version
 ---
 artifact: {{ .ModuleName }}/{{ .ImageName }}-backend-artifact

--- a/modules/500-openvpn/images/pmacct/werf.inc.yaml
+++ b/modules/500-openvpn/images/pmacct/werf.inc.yaml
@@ -22,6 +22,7 @@ shell:
       url = {{ .SOURCE_REPO }}/msune/libcdada.git
     EOF
   - git submodule update --init
+  - rm -rf /src/.git
 ---
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 fromArtifact: common/relocate-artifact

--- a/tools/lint-src-artifact/lint-src-artifact.go
+++ b/tools/lint-src-artifact/lint-src-artifact.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type stapelManifest struct {
+	Artifact     string `yaml:"artifact"`
+	FromArtifact string `yaml:"fromArtifact"`
+	Shell        struct {
+		BeforeInstall []string `yaml:"beforeInstall"`
+		Install       []string `yaml:"install"`
+		BeforeSetup   []string `yaml:"beforeSetup"`
+		Setup         []string `yaml:"setup"`
+	} `yaml:"shell"`
+}
+
+var (
+	cloneRegexp = regexp.MustCompile(`git clone.*(([&><|]){1,2}|<<<|$)`)
+	rmGitRegexp = regexp.MustCompile(`rm -rf.* (\/src\/)?\.git(.*)*`)
+)
+
+func main() {
+	log.SetFlags(0)
+	yamlDecoder := yaml.NewDecoder(os.Stdin)
+	stapel := stapelManifest{}
+
+	exitCode := 0
+	for {
+		stapel = stapelManifest{}
+		if err := yamlDecoder.Decode(&stapel); err != nil {
+			if err == io.EOF {
+				break
+			}
+			log.Fatalln("invalid yaml:", err)
+		}
+		if stapel.FromArtifact != "common/src-artifact" {
+			continue
+		}
+
+		validators := []func(manifest *stapelManifest) error{
+			validateSrcArtifactSuffix, validateDotGitRemoval,
+		}
+
+		for _, validator := range validators {
+			if err := validator(&stapel); err != nil {
+				exitCode = 1
+				log.Println(err)
+			}
+		}
+	}
+	os.Exit(exitCode)
+}
+
+func validateSrcArtifactSuffix(stapel *stapelManifest) error {
+	if !strings.HasSuffix(stapel.Artifact, "-src-artifact") {
+		return fmt.Errorf(
+			"[SRC-M1] %s: Artifact is based on common/src-artifact but does not have a -src-artifact suffix",
+			stapel.Artifact)
+	}
+	return nil
+}
+
+func validateDotGitRemoval(stapel *stapelManifest) error {
+	commands := append(stapel.Shell.BeforeInstall,
+		append(stapel.Shell.Install,
+			append(stapel.Shell.BeforeSetup, stapel.Shell.Setup...)...)...,
+	)
+
+	seenClones, seenRemovals := 0, 0
+	for _, cmd := range commands {
+		if cloneRegexp.MatchString(cmd) {
+			seenClones += 1
+		}
+		if rmGitRegexp.MatchString(cmd) {
+			seenRemovals += 1
+		}
+	}
+
+	if seenClones > seenRemovals {
+		return fmt.Errorf(
+			"[SRC-M2] %s: .git is not removed from image layer after git clone",
+			stapel.Artifact)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added a simple linting of src-artifact stapel build script via `make lint-src-artifact`. It will check that everything based on the `common/src-artifact` has `-src-artifact` suffix in the name and that it explicitly deletes `.git` dirs from everything that it clones. Also fixed a few src-artifact builds that were not removing `.git`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We want to enforce some rules regarding `src-artifact` usage. This will lay the groundwork for it.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: chore
summary: implement src-artifact usage linter
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
