### PR TITLE
[operator-trivy] add insecure db registry and non-ssl registries

### DIFF
--- a/ee/modules/500-operator-trivy/openapi/config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/config-values.yaml
@@ -17,7 +17,9 @@ properties:
     type: boolean
     default: false
     description: |
-      Allows Trivy to download the database using insecure and unencrypted connections (non-ssl).
+      Allows Trivy to download vulnerability databases using insecure HTTPS connections (not passed TLS certificate verification) or HTTP connections.
+
+      The list of addresses to which such connections are allowed must be specified in the [insecureRegistries](#parameters-insecureregistries) parameter.
 
     x-doc-default: false
     x-examples: [true, false]
@@ -112,6 +114,10 @@ properties:
 
   insecureRegistries:
     type: array
+    description: |
+      List of container registry addresses to which insecure HTTPS connections (not passed TLS certificate verification) or HTTP connections are allowed.
+
+      > The parameter [insecureDbRegistry](#parameters-insecuredbregistry) must be enabled.
     x-examples:
     -
       - my.registry.com

--- a/ee/modules/500-operator-trivy/openapi/config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/config-values.yaml
@@ -13,6 +13,14 @@ properties:
       **Warning.** Specifying a value different from the one currently used (in the existing PVC) will result in disk re-provisioning and all data will be deleted.
       
       If `false` is specified, `emptyDir` will be forced to be used.
+  insecureDbRegistry:
+    type: boolean
+    default: false
+    description: |
+      Allows Trivy to download the database using insecure and unencrypted connections (non-ssl).
+
+    x-doc-default: false
+    x-examples: [true, false]
   additionalVulnerabilityReportFields:
     type: array
     description: |
@@ -101,10 +109,25 @@ properties:
     -
       - app
       - env
+
   insecureRegistries:
     type: array
-    x-doc-example: [["my.registry.com", "http-only.registry.io"]]
+    x-examples:
+    -
+      - my.registry.com
+      - http-only.registry.io
     items:
       type: string
     description: |
       Container registries to which insecure connections are allowed.
+
+  nonSslRegistries:
+    type: array
+    x-examples:
+    -
+      - my.registry.com
+      - http-only.registry.io
+    items:
+      type: string
+    description: |
+      Container registries to which unencrypted (non-ssl) connections are allowed.

--- a/ee/modules/500-operator-trivy/openapi/config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/config-values.yaml
@@ -120,14 +120,3 @@ properties:
       type: string
     description: |
       Container registries to which insecure connections are allowed.
-
-  nonSslRegistries:
-    type: array
-    x-examples:
-    -
-      - my.registry.com
-      - http-only.registry.io
-    items:
-      type: string
-    description: |
-      Container registries to which unencrypted (non-ssl) connections are allowed.

--- a/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
@@ -3,19 +3,19 @@ properties:
   storageClass:
     description: |-
       Имя StorageClass, который будет использоваться по умолчанию в кластере.
-      
+
       Если значение не указано, то будет использоваться StorageClass, согласно настройке [глобального параметра storageClass](../../deckhouse-configure-global.html#parameters-storageclass).
-      
+
       Настройка глобального параметра `storageClass` учитывается только при включении модуля. Изменение глобального параметра `storageClass` при включенном модуле не приведет к перезаказу диска.
-      
+
       **Внимание.** Если указать значение, отличное от текущего (используемого в существующей PVC), диск будет перезаказан, и все данные удалятся.
-      
+
       Если указать `false`, будет принудительно использоваться `emptyDir`.
 
   insecureDbRegistry:
     description: |
       Разрешает Trivy скачивать базы данных уязвимостей используя недоверенные HTTPS-подключения (не прошедшие проверку TLS-сертификата) или подключения по HTTP.
-      
+
       Список адресов, к которым разрешены такие подключения, необходимо указать в параметре [insecureRegistries](#parameters-insecureregistries).
 
   additionalVulnerabilityReportFields:
@@ -53,4 +53,6 @@ properties:
 
   insecureRegistries:
     description: |
-      Хранилище образов контейнеров (container registry), к которым разрешены незащищённые соединения.
+      Список адресов хранилищ образов контейнеров (container registry), к которым разрешены недоверенные HTTPS-подключения (не прошедшие проверку TLS-сертификата) и подключения по HTTP.
+
+      > Для работы необходимо включение параметра [insecureDbRegistry](#parameters-insecuredbregistry).

--- a/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
@@ -52,7 +52,3 @@ properties:
   insecureRegistries:
     description: |
       Хранилище образов контейнеров (container registry), к которым разрешены незащищённые соединения.
-
-  nonSslRegistries:
-    description: |
-      Хранилище образов контейнеров (container registry), к которым разрешены незашифрованные (non-ssl) подключения.

--- a/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
@@ -14,7 +14,9 @@ properties:
 
   insecureDbRegistry:
     description: |
-      Разрешает Trivy использовать незащищенные и незашифрованные (non-ssl) подключения для скачивания базы данных уязвимостей.
+      Разрешает Trivy скачивать базы данных уязвимостей используя недоверенные HTTPS-подключения (не прошедшие проверку TLS-сертификата) или подключения по HTTP.
+      
+      Список адресов, к которым разрешены такие подключения, необходимо указать в параметре [insecureRegistries](#parameters-insecureregistries).
 
   additionalVulnerabilityReportFields:
     description: |

--- a/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
@@ -12,6 +12,10 @@ properties:
       
       Если указать `false`, будет принудительно использоваться `emptyDir`.
 
+  insecureDbRegistry:
+    description: |
+      Разрешает Trivy использовать незащищенные и незашифрованные (non-ssl) подключения для скачивания базы данных уязвимостей.
+
   additionalVulnerabilityReportFields:
     description: |
       Список дополнительных полей из базы уязвимостей, добавляемых к отчетам об уязвимостях (VulnerabilityReport).
@@ -48,3 +52,7 @@ properties:
   insecureRegistries:
     description: |
       Хранилище образов контейнеров (container registry), к которым разрешены незащищённые соединения.
+
+  nonSslRegistries:
+    description: |
+      Хранилище образов контейнеров (container registry), к которым разрешены незашифрованные (non-ssl) подключения.

--- a/ee/modules/500-operator-trivy/template_tests/template_test.go
+++ b/ee/modules/500-operator-trivy/template_tests/template_test.go
@@ -174,26 +174,6 @@ insecureRegistries:
 			Expect(cm.Exists()).To(BeTrue())
 			Expect(cm.Field(`data`).Map()["trivy.insecureRegistry.0"].String()).To(Equal("example.com"))
 			Expect(cm.Field(`data`).Map()["trivy.insecureRegistry.1"].String()).To(Equal("test.example.com:8080"))
-		})
-	})
-
-	Context("Operator trivy with non-ssl registry set", func() {
-		BeforeEach(func() {
-			f.ValuesSetFromYaml("operatorTrivy", `
-nonSslRegistries:
-- example.com
-- test.example.com:8080`)
-
-			f.HelmRender()
-		})
-
-		It("Everything must render properly for cluster", func() {
-			Expect(f.RenderError).ShouldNot(HaveOccurred())
-		})
-
-		It("Operator trivy has proper nonSslRegistry.[id] set", func() {
-			cm := f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config")
-			Expect(cm.Exists()).To(BeTrue())
 			Expect(cm.Field(`data`).Map()["trivy.nonSslRegistry.0"].String()).To(Equal("example.com"))
 			Expect(cm.Field(`data`).Map()["trivy.nonSslRegistry.1"].String()).To(Equal("test.example.com:8080"))
 		})

--- a/ee/modules/500-operator-trivy/template_tests/template_test.go
+++ b/ee/modules/500-operator-trivy/template_tests/template_test.go
@@ -134,6 +134,107 @@ var _ = Describe("Module :: operator-trivy :: helm template :: custom-certificat
 		})
 	})
 
+	Context("Operator trivy with additional vulnerability report fields set", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("operatorTrivy", `
+additionalVulnerabilityReportFields:
+- Class
+- Target`)
+
+			f.HelmRender()
+		})
+
+		It("Everything must render properly for cluster", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+		})
+
+		It("Operator trivy has proper additionalVulnerabilityReportFields set", func() {
+			cm := f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config")
+			Expect(cm.Exists()).To(BeTrue())
+			Expect(cm.Field(`data`).Map()["trivy.additionalVulnerabilityReportFields"].String()).To(Equal("Class,Target"))
+		})
+	})
+
+	Context("Operator trivy with insecure registry set", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("operatorTrivy", `
+insecureRegistries:
+- example.com
+- test.example.com:8080`)
+
+			f.HelmRender()
+		})
+
+		It("Everything must render properly for cluster", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+		})
+
+		It("Operator trivy has proper insecureRegistry.[id] set", func() {
+			cm := f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config")
+			Expect(cm.Exists()).To(BeTrue())
+			Expect(cm.Field(`data`).Map()["trivy.insecureRegistry.0"].String()).To(Equal("example.com"))
+			Expect(cm.Field(`data`).Map()["trivy.insecureRegistry.1"].String()).To(Equal("test.example.com:8080"))
+		})
+	})
+
+	Context("Operator trivy with non-ssl registry set", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("operatorTrivy", `
+nonSslRegistries:
+- example.com
+- test.example.com:8080`)
+
+			f.HelmRender()
+		})
+
+		It("Everything must render properly for cluster", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+		})
+
+		It("Operator trivy has proper nonSslRegistry.[id] set", func() {
+			cm := f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config")
+			Expect(cm.Exists()).To(BeTrue())
+			Expect(cm.Field(`data`).Map()["trivy.nonSslRegistry.0"].String()).To(Equal("example.com"))
+			Expect(cm.Field(`data`).Map()["trivy.nonSslRegistry.1"].String()).To(Equal("test.example.com:8080"))
+		})
+	})
+
+	Context("Operator trivy with insecure database registry set", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("operatorTrivy", `
+insecureDbRegistry: true`)
+			f.HelmRender()
+		})
+
+		It("Everything must render properly for cluster", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+		})
+
+		It("Operator trivy has proper TRIVY_INSECURE and dbRepositoryInsecure set", func() {
+			cm := f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config")
+			Expect(cm.Exists()).To(BeTrue())
+			Expect(cm.Field(`data`).Map()["trivy.dbRepositoryInsecure"].String()).To(Equal("true"))
+			Expect(cm.Field(`data`).Map()["TRIVY_INSECURE"].String()).To(Equal("true"))
+		})
+	})
+
+	Context("Operator trivy without insecure database registry set", func() {
+		BeforeEach(func() {
+			f.HelmRender()
+		})
+
+		It("Everything must render properly for cluster", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+		})
+
+		It("Operator trivy has proper TRIVY_INSECURE and dbRepositoryInsecure set", func() {
+			cm := f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config")
+			Expect(cm.Exists()).To(BeTrue())
+			Expect(cm.Field(`data`).Map()["trivy.dbRepositoryInsecure"].String()).To(Equal("false"))
+			Expect(cm.Field(`data`).Map()["TRIVY_INSECURE"].String()).To(Equal("false"))
+		})
+	})
+
 	Context("Operator trivy with no value in enabledNamespaces", func() {
 		BeforeEach(func() {
 			f.HelmRender()

--- a/ee/modules/500-operator-trivy/templates/configmap.yaml
+++ b/ee/modules/500-operator-trivy/templates/configmap.yaml
@@ -62,11 +62,20 @@ data:
   {{- range $idx, $registry := .Values.operatorTrivy.insecureRegistries }}
   trivy.insecureRegistry.{{ $idx }}: {{ $registry | quote }}
   {{- end }}
+  {{- range $idx, $registry := .Values.operatorTrivy.nonSslRegistries }}
+  trivy.nonSslRegistry.{{ $idx }}: {{ $registry | quote }}
+  {{- end }}
   trivy.slow: "true"
   trivy.dbRepository: {{ $dbRepository }}
   trivy.javaDbRepository: {{ $javaDbRepository }}
   trivy.command: "image"
+  {{- if .Values.operatorTrivy.insecureDbRegistry }}
+  TRIVY_INSECURE: {{ .Values.operatorTrivy.insecureDbRegistry | quote }}
+  trivy.dbRepositoryInsecure: {{ .Values.operatorTrivy.insecureDbRegistry | quote }}
+  {{- else }}
+  TRIVY_INSECURE: "false"
   trivy.dbRepositoryInsecure: "false"
+  {{- end }}
   trivy.useBuiltinRegoPolicies: "true"
   trivy.supportedConfigAuditKinds: "Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"
   trivy.timeout: "5m0s"

--- a/ee/modules/500-operator-trivy/templates/configmap.yaml
+++ b/ee/modules/500-operator-trivy/templates/configmap.yaml
@@ -61,8 +61,6 @@ data:
   {{- end }}
   {{- range $idx, $registry := .Values.operatorTrivy.insecureRegistries }}
   trivy.insecureRegistry.{{ $idx }}: {{ $registry | quote }}
-  {{- end }}
-  {{- range $idx, $registry := .Values.operatorTrivy.nonSslRegistries }}
   trivy.nonSslRegistry.{{ $idx }}: {{ $registry | quote }}
   {{- end }}
   trivy.slow: "true"


### PR DESCRIPTION
## Description
Provides a new setting that allows downloading databases from insecure registries.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Some users may want to use the operator in an air-gapped environment, hosting images and databases in insecure registries.
Closes #10471 
Closes #6608 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

## What is the expected result?
Trivy-server is able to download databases/images from insecure registries.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: chore
summary: Add a setting for downloading images from insecure registries.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
