### PR TITLE
[docs] Get rid of numeric prefixes in module URL on the site

### DIFF
--- a/docs/documentation/.helm/templates/_rewrites.tpl
+++ b/docs/documentation/.helm/templates/_rewrites.tpl
@@ -1,4 +1,5 @@
 {{- define "rewrites" }}
+rewrite ^/(.+/modules)/[0-9]+-([^/]+/.*)$ /$1/$2 permanent;
 rewrite ^/documentation/(.*)$ /products/kubernetes-platform/documentation/$1 permanent;
 rewrite ^/(.+)/modules/030-cloud-provider-openstack/usage.html$ /$1/modules/030-cloud-provider-openstack/examples.html redirect;
 rewrite ^/(.+)/modules/030-cloud-provider-vsphere/usage.html$ /$1/modules/030-cloud-provider-vsphere/docs/examples.html redirect;

--- a/docs/documentation/.werf/nginx.conf
+++ b/docs/documentation/.werf/nginx.conf
@@ -73,6 +73,9 @@ http {
             try_files /$2 =404;
         }
 
+        # Redirect old links with module priorities to the new links
+        rewrite ^/(.+)/[0-9]+-([^/]+/.*)$ /$1/$2 permanent;
+
         rewrite ^/(.+)/099-ceph-csi$ /$1/031-ceph-csi/ permanent;
         rewrite ^/(.+)/010-priority-class$ /$1/001-priority-class/ permanent;
         rewrite ^/(.+)/010-priority-class(/.*)$ /$1/001-priority-class$2 permanent;

--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -108,31 +108,31 @@ entries:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/002-deckhouse/
+                  url: /modules/deckhouse/
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/002-deckhouse/configuration.html
+                  url: /modules/deckhouse/configuration.html
                 - title:
                     en: Usage
                     ru: Примеры
-                  url: /modules/002-deckhouse/usage.html
+                  url: /modules/deckhouse/usage.html
                 - title: FAQ
-                  url: /modules/002-deckhouse/faq.html
+                  url: /modules/deckhouse/faq.html
             - title: documentation
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/810-documentation/
+                  url: /modules/documentation/
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/810-documentation/examples.html
+                  url: /modules/documentation/examples.html
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/810-documentation/configuration.html
+                  url: /modules/documentation/configuration.html
     - title:
         en: Kubernetes Cluster
         ru: Кластер Kubernetes
@@ -148,7 +148,7 @@ entries:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/030-cloud-provider-aws/
+                  url: /modules/cloud-provider-aws/
                 - title:
                     en: Installation
                     ru: Установка
@@ -156,15 +156,15 @@ entries:
                     - title:
                         en: Preparing environment
                         ru: Подготовка окружения
-                      url: /modules/030-cloud-provider-aws/environment.html
+                      url: /modules/cloud-provider-aws/environment.html
                     - title:
                         en: Layouts
                         ru: Схемы размещения
-                      url: /modules/030-cloud-provider-aws/layouts.html
+                      url: /modules/cloud-provider-aws/layouts.html
                     - title:
                         en: Provider configuration
                         ru: Настройка провайдера
-                      url: /modules/030-cloud-provider-aws/cluster_configuration.html
+                      url: /modules/cloud-provider-aws/cluster_configuration.html
                 - title:
                     en: Reference
                     ru: Справка
@@ -172,21 +172,21 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/030-cloud-provider-aws/configuration.html
+                      url: /modules/cloud-provider-aws/configuration.html
                     - title: Custom Resources
-                      url: /modules/030-cloud-provider-aws/cr.html
+                      url: /modules/cloud-provider-aws/cr.html
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/030-cloud-provider-aws/examples.html
+                  url: /modules/cloud-provider-aws/examples.html
                 - title: FAQ
-                  url: /modules/030-cloud-provider-aws/faq.html
+                  url: /modules/cloud-provider-aws/faq.html
             - title: Google Cloud Platform
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/030-cloud-provider-gcp/
+                  url: /modules/cloud-provider-gcp/
                 - title:
                     en: Installation
                     ru: Установка
@@ -194,15 +194,15 @@ entries:
                     - title:
                         en: Preparing environment
                         ru: Подготовка окружения
-                      url: /modules/030-cloud-provider-gcp/environment.html
+                      url: /modules/cloud-provider-gcp/environment.html
                     - title:
                         en: Layouts
                         ru: Схемы размещения
-                      url: /modules/030-cloud-provider-gcp/layouts.html
+                      url: /modules/cloud-provider-gcp/layouts.html
                     - title:
                         en: Provider configuration
                         ru: Настройка провайдера
-                      url: /modules/030-cloud-provider-gcp/cluster_configuration.html
+                      url: /modules/cloud-provider-gcp/cluster_configuration.html
                 - title:
                     en: Reference
                     ru: Справка
@@ -210,21 +210,21 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/030-cloud-provider-gcp/configuration.html
+                      url: /modules/cloud-provider-gcp/configuration.html
                     - title: Custom Resources
-                      url: /modules/030-cloud-provider-gcp/cr.html
+                      url: /modules/cloud-provider-gcp/cr.html
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/030-cloud-provider-gcp/examples.html
+                  url: /modules/cloud-provider-gcp/examples.html
                 - title: FAQ
-                  url: /modules/030-cloud-provider-gcp/faq.html
+                  url: /modules/cloud-provider-gcp/faq.html
             - title: Microsoft Azure
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/030-cloud-provider-azure/
+                  url: /modules/cloud-provider-azure/
                 - title:
                     en: Installation
                     ru: Установка
@@ -232,15 +232,15 @@ entries:
                     - title:
                         en: Preparing environment
                         ru: Подготовка окружения
-                      url: /modules/030-cloud-provider-azure/environment.html
+                      url: /modules/cloud-provider-azure/environment.html
                     - title:
                         en: Layouts
                         ru: Схемы размещения
-                      url: /modules/030-cloud-provider-azure/layouts.html
+                      url: /modules/cloud-provider-azure/layouts.html
                     - title:
                         en: Provider configuration
                         ru: Настройка провайдера
-                      url: /modules/030-cloud-provider-azure/cluster_configuration.html
+                      url: /modules/cloud-provider-azure/cluster_configuration.html
                 - title:
                     ru: Справка
                     en: Reference
@@ -248,20 +248,20 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/030-cloud-provider-azure/configuration.html
+                      url: /modules/cloud-provider-azure/configuration.html
                     - title: Custom Resources
-                      url: /modules/030-cloud-provider-azure/cr.html
+                      url: /modules/cloud-provider-azure/cr.html
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/030-cloud-provider-azure/examples.html
+                  url: /modules/cloud-provider-azure/examples.html
             - title: OpenStack
               d8Revision: ee
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/030-cloud-provider-openstack/
+                  url: /modules/cloud-provider-openstack/
                 - title:
                     en: Installation
                     ru: Установка
@@ -269,15 +269,15 @@ entries:
                     - title:
                         en: Preparing environment
                         ru: Подготовка окружения
-                      url: /modules/030-cloud-provider-openstack/environment.html
+                      url: /modules/cloud-provider-openstack/environment.html
                     - title:
                         en: Layouts
                         ru: Схемы размещения
-                      url: /modules/030-cloud-provider-openstack/layouts.html
+                      url: /modules/cloud-provider-openstack/layouts.html
                     - title:
                         en: Provider configuration
                         ru: Настройка провайдера
-                      url: /modules/030-cloud-provider-openstack/cluster_configuration.html
+                      url: /modules/cloud-provider-openstack/cluster_configuration.html
                 - title:
                     en: Reference
                     ru: Справка
@@ -285,22 +285,22 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/030-cloud-provider-openstack/configuration.html
+                      url: /modules/cloud-provider-openstack/configuration.html
                     - title: Custom Resources
-                      url: /modules/030-cloud-provider-openstack/cr.html
+                      url: /modules/cloud-provider-openstack/cr.html
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/030-cloud-provider-openstack/examples.html
+                  url: /modules/cloud-provider-openstack/examples.html
                 - title: FAQ
-                  url: /modules/030-cloud-provider-openstack/faq.html
+                  url: /modules/cloud-provider-openstack/faq.html
             - title: VMware vSphere
               d8Revision: ee
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/030-cloud-provider-vsphere/
+                  url: /modules/cloud-provider-vsphere/
                 - title:
                     en: Installation
                     ru: Установка
@@ -308,15 +308,15 @@ entries:
                     - title:
                         en: Preparing environment
                         ru: Подготовка окружения
-                      url: /modules/030-cloud-provider-vsphere/environment.html
+                      url: /modules/cloud-provider-vsphere/environment.html
                     - title:
                         en: Layouts
                         ru: Схемы размещения
-                      url: /modules/030-cloud-provider-vsphere/layouts.html
+                      url: /modules/cloud-provider-vsphere/layouts.html
                     - title:
                         en: Provider configuration
                         ru: Настройка провайдера
-                      url: /modules/030-cloud-provider-vsphere/cluster_configuration.html
+                      url: /modules/cloud-provider-vsphere/cluster_configuration.html
                 - title:
                     en: Reference
                     ru: Справка
@@ -324,15 +324,15 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/030-cloud-provider-vsphere/configuration.html
+                      url: /modules/cloud-provider-vsphere/configuration.html
                     - title: Custom Resources
-                      url: /modules/030-cloud-provider-vsphere/cr.html
+                      url: /modules/cloud-provider-vsphere/cr.html
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/030-cloud-provider-vsphere/examples.html
+                  url: /modules/cloud-provider-vsphere/examples.html
                 - title: FAQ
-                  url: /modules/030-cloud-provider-vsphere/faq.html
+                  url: /modules/cloud-provider-vsphere/faq.html
             - title: Dynamix
               d8Revision: ee
               featureStatus: experimental
@@ -340,7 +340,7 @@ entries:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/030-cloud-provider-dynamix/
+                  url: /modules/cloud-provider-dynamix/
                 - title:
                     en: Installation
                     ru: Установка
@@ -348,15 +348,15 @@ entries:
                     - title:
                         en: Preparing environment
                         ru: Подготовка окружения
-                      url: /modules/030-cloud-provider-dynamix/environment.html
+                      url: /modules/cloud-provider-dynamix/environment.html
                     - title:
                         en: Layouts
                         ru: Схемы размещения
-                      url: /modules/030-cloud-provider-dynamix/layouts.html
+                      url: /modules/cloud-provider-dynamix/layouts.html
                     - title:
                         en: Provider configuration
                         ru: Настройка провайдера
-                      url: /modules/030-cloud-provider-dynamix/cluster_configuration.html
+                      url: /modules/cloud-provider-dynamix/cluster_configuration.html
                 - title:
                     en: Reference
                     ru: Справка
@@ -364,9 +364,9 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/030-cloud-provider-dynamix/configuration.html
+                      url: /modules/cloud-provider-dynamix/configuration.html
                     - title: Custom Resources
-                      url: /modules/030-cloud-provider-dynamix/cr.html
+                      url: /modules/cloud-provider-dynamix/cr.html
             - title: VMware Cloud Director
               d8Revision: ee
               featureStatus: experimental
@@ -374,7 +374,7 @@ entries:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/030-cloud-provider-vcd/
+                  url: /modules/cloud-provider-vcd/
                 - title:
                     en: Installation
                     ru: Установка
@@ -382,15 +382,15 @@ entries:
                     - title:
                         en: Preparing environment
                         ru: Подготовка окружения
-                      url: /modules/030-cloud-provider-vcd/environment.html
+                      url: /modules/cloud-provider-vcd/environment.html
                     - title:
                         en: Layouts
                         ru: Схемы размещения
-                      url: /modules/030-cloud-provider-vcd/layouts.html
+                      url: /modules/cloud-provider-vcd/layouts.html
                     - title:
                         en: Provider configuration
                         ru: Настройка провайдера
-                      url: /modules/030-cloud-provider-vcd/cluster_configuration.html
+                      url: /modules/cloud-provider-vcd/cluster_configuration.html
                 - title:
                     en: Reference
                     ru: Справка
@@ -398,21 +398,21 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/030-cloud-provider-vcd/configuration.html
+                      url: /modules/cloud-provider-vcd/configuration.html
                     - title: Custom Resources
-                      url: /modules/030-cloud-provider-vcd/cr.html
+                      url: /modules/cloud-provider-vcd/cr.html
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/030-cloud-provider-vcd/examples.html
+                  url: /modules/cloud-provider-vcd/examples.html
                 - title: FAQ
-                  url: /modules/030-cloud-provider-vcd/faq.html
+                  url: /modules/cloud-provider-vcd/faq.html
             - title: Yandex Cloud
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/030-cloud-provider-yandex/
+                  url: /modules/cloud-provider-yandex/
                 - title:
                     en: Installation
                     ru: Установка
@@ -420,15 +420,15 @@ entries:
                     - title:
                         en: Preparing environment
                         ru: Подготовка окружения
-                      url: /modules/030-cloud-provider-yandex/environment.html
+                      url: /modules/cloud-provider-yandex/environment.html
                     - title:
                         en: Layouts
                         ru: Схемы размещения
-                      url: /modules/030-cloud-provider-yandex/layouts.html
+                      url: /modules/cloud-provider-yandex/layouts.html
                     - title:
                         en: Provider configuration
                         ru: Настройка провайдера
-                      url: /modules/030-cloud-provider-yandex/cluster_configuration.html
+                      url: /modules/cloud-provider-yandex/cluster_configuration.html
                 - title:
                     en: Reference
                     ru: Справка
@@ -436,15 +436,15 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/030-cloud-provider-yandex/configuration.html
+                      url: /modules/cloud-provider-yandex/configuration.html
                     - title: Custom Resources
-                      url: /modules/030-cloud-provider-yandex/cr.html
+                      url: /modules/cloud-provider-yandex/cr.html
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/030-cloud-provider-yandex/examples.html
+                  url: /modules/cloud-provider-yandex/examples.html
                 - title: FAQ
-                  url: /modules/030-cloud-provider-yandex/faq.html
+                  url: /modules/cloud-provider-yandex/faq.html
             - title: zVirt
               d8Revision: ee
               featureStatus: experimental
@@ -452,7 +452,7 @@ entries:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/030-cloud-provider-zvirt/
+                  url: /modules/cloud-provider-zvirt/
                 - title:
                     en: Installation
                     ru: Установка
@@ -460,15 +460,15 @@ entries:
                     - title:
                         en: Preparing environment
                         ru: Подготовка окружения
-                      url: /modules/030-cloud-provider-zvirt/environment.html
+                      url: /modules/cloud-provider-zvirt/environment.html
                     - title:
                         en: Layouts
                         ru: Схемы размещения
-                      url: /modules/030-cloud-provider-zvirt/layouts.html
+                      url: /modules/cloud-provider-zvirt/layouts.html
                     - title:
                         en: Provider configuration
                         ru: Настройка провайдера
-                      url: /modules/030-cloud-provider-zvirt/cluster_configuration.html
+                      url: /modules/cloud-provider-zvirt/cluster_configuration.html
                 - title:
                     en: Reference
                     ru: Справка
@@ -476,11 +476,11 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/030-cloud-provider-zvirt/configuration.html
+                      url: /modules/cloud-provider-zvirt/configuration.html
                     - title: Custom Resources
-                      url: /modules/030-cloud-provider-zvirt/cr.html
+                      url: /modules/cloud-provider-zvirt/cr.html
                 - title: FAQ
-                  url: /modules/030-cloud-provider-zvirt/faq.html
+                  url: /modules/cloud-provider-zvirt/faq.html
         - title:
             en: Control plane management
             ru: Управление control plane
@@ -488,7 +488,7 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/040-control-plane-manager/
+              url: /modules/control-plane-manager/
             - title:
                 en: Reference
                 ru: Справка
@@ -496,15 +496,15 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/040-control-plane-manager/configuration.html
+                  url: /modules/control-plane-manager/configuration.html
                 - title: Custom Resources
-                  url: /modules/040-control-plane-manager/cr.html
+                  url: /modules/control-plane-manager/cr.html
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/040-control-plane-manager/examples.html
+              url: /modules/control-plane-manager/examples.html
             - title: FAQ
-              url: /modules/040-control-plane-manager/faq.html
+              url: /modules/control-plane-manager/faq.html
         - title:
             en: Node management
             ru: Управление узлами
@@ -512,11 +512,11 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/040-node-manager/
+              url: /modules/node-manager/
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/040-node-manager/examples.html
+              url: /modules/node-manager/examples.html
             - title:
                 en: Reference
                 ru: Справка
@@ -524,11 +524,11 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/040-node-manager/configuration.html
+                  url: /modules/node-manager/configuration.html
                 - title: Custom Resources
-                  url: /modules/040-node-manager/cr.html
+                  url: /modules/node-manager/cr.html
             - title: FAQ
-              url: /modules/040-node-manager/faq.html
+              url: /modules/node-manager/faq.html
         - title:
             en: Other modules
             ru: Другие модули
@@ -538,87 +538,87 @@ entries:
                 - title:
                     ru: Описание
                     en: Description
-                  url: /modules/500-cilium-hubble/
+                  url: /modules/cilium-hubble/
                 - title:
                     ru: Настройки
                     en: Configuration
-                  url: /modules/500-cilium-hubble/configuration.html
+                  url: /modules/cilium-hubble/configuration.html
             - title: cni-cilium
               folders:
                 - title:
                     ru: Описание
                     en: Description
-                  url: /modules/021-cni-cilium/
+                  url: /modules/cni-cilium/
                 - title:
                     ru: Настройки
                     en: Configuration
-                  url: /modules/021-cni-cilium/configuration.html
+                  url: /modules/cni-cilium/configuration.html
                 - title: Custom Resources
-                  url: /modules/021-cni-cilium/cr.html
+                  url: /modules/cni-cilium/cr.html
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/021-cni-cilium/examples.html
+                  url: /modules/cni-cilium/examples.html
             - title: cni-flannel
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/035-cni-flannel/
+                  url: /modules/cni-flannel/
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/035-cni-flannel/configuration.html
+                  url: /modules/cni-flannel/configuration.html
             - title: cni-simple-bridge
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/035-cni-simple-bridge/
+                  url: /modules/cni-simple-bridge/
             - title: kube-dns
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/042-kube-dns/
+                  url: /modules/kube-dns/
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/042-kube-dns/configuration.html
+                  url: /modules/kube-dns/configuration.html
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/042-kube-dns/examples.html
+                  url: /modules/kube-dns/examples.html
                 - title: FAQ
-                  url: /modules/042-kube-dns/faq.html
+                  url: /modules/kube-dns/faq.html
             - title: kube-proxy
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/036-kube-proxy/
+                  url: /modules/kube-proxy/
             - title: node-local-dns
               d8Revision: ee
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/350-node-local-dns/
+                  url: /modules/node-local-dns/
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/350-node-local-dns/examples.html
+                  url: /modules/node-local-dns/examples.html
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/350-node-local-dns/configuration.html
+                  url: /modules/node-local-dns/configuration.html
             - title: static-routing-manager
               d8Revision: ee
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/025-static-routing-manager/
+                  url: /modules/static-routing-manager/
                 - title:
                     en: Reference
                     ru: Справка
@@ -626,23 +626,23 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/025-static-routing-manager/configuration.html
+                      url: /modules/static-routing-manager/configuration.html
                     - title: Custom Resources
-                      url: /modules/025-static-routing-manager/cr.html
+                      url: /modules/static-routing-manager/cr.html
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/025-static-routing-manager/examples.html
+                  url: /modules/static-routing-manager/examples.html
             - title: terraform-manager
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/040-terraform-manager/
+                  url: /modules/terraform-manager/
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/040-terraform-manager/configuration.html
+                  url: /modules/terraform-manager/configuration.html
     - title:
         en: Accessing cluster
         ru: Доступ к кластеру
@@ -652,30 +652,30 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/500-dashboard/
+              url: /modules/dashboard/
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/500-dashboard/examples.html
+              url: /modules/dashboard/examples.html
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/500-dashboard/configuration.html
+              url: /modules/dashboard/configuration.html
         - title: openvpn
           featureStatus: experimental
           folders:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/500-openvpn/
+              url: /modules/openvpn/
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/500-openvpn/examples.html
+              url: /modules/openvpn/examples.html
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/500-openvpn/configuration.html
+              url: /modules/openvpn/configuration.html
     - title:
         en: Network Load Balancing
         ru: Балансировка трафика
@@ -685,11 +685,11 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/402-ingress-nginx/
+              url: /modules/ingress-nginx/
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/402-ingress-nginx/examples.html
+              url: /modules/ingress-nginx/examples.html
             - title:
                 en: Reference
                 ru: Справка
@@ -697,17 +697,17 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/402-ingress-nginx/configuration.html
+                  url: /modules/ingress-nginx/configuration.html
                 - title: Custom Resources
-                  url: /modules/402-ingress-nginx/cr.html
+                  url: /modules/ingress-nginx/cr.html
             - title: FAQ
-              url: /modules/402-ingress-nginx/faq.html
+              url: /modules/ingress-nginx/faq.html
         - title: istio
           folders:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/110-istio/
+              url: /modules/istio/
             - title:
                 en: Reference
                 ru: Справка
@@ -715,32 +715,32 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/110-istio/configuration.html
+                  url: /modules/istio/configuration.html
                 - title: Custom Resources
-                  url: /modules/110-istio/cr.html
+                  url: /modules/istio/cr.html
                 - title:
                     en: "Custom Resources (by istio.io)"
                     ru: "Custom Resources (от istio.io)"
-                  url: /modules/110-istio/istio-cr.html
+                  url: /modules/istio/istio-cr.html
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/110-istio/examples.html
+              url: /modules/istio/examples.html
     - title:
         en: Monitoring
         ru: Мониторинг
       folders:
         - title: Prometheus & Grafana
-          url: /modules/300-prometheus/
+          url: /modules/prometheus/
           folders:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/300-prometheus/
+              url: /modules/prometheus/
             - title:
                 en: Usage
                 ru: Примеры
-              url: /modules/300-prometheus/usage.html
+              url: /modules/prometheus/usage.html
             - title:
                 en: Reference
                 ru: Справка
@@ -748,11 +748,11 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/300-prometheus/configuration.html
+                  url: /modules/prometheus/configuration.html
                 - title: Custom Resources
-                  url: /modules/300-prometheus/cr.html
+                  url: /modules/prometheus/cr.html
             - title: FAQ
-              url: /modules/300-prometheus/faq.html
+              url: /modules/prometheus/faq.html
         - title:
             en: Monitoring your applications
             ru: Мониторинг вашего приложения
@@ -760,11 +760,11 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/340-monitoring-custom/
+              url: /modules/monitoring-custom/
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/340-monitoring-custom/configuration.html
+              url: /modules/monitoring-custom/configuration.html
         - title:
             en: Network monitoring
             ru: Мониторинг сети
@@ -772,15 +772,15 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/340-monitoring-ping/
+              url: /modules/monitoring-ping/
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/340-monitoring-ping/configuration.html
+              url: /modules/monitoring-ping/configuration.html
             - title:
                 en: Usage
                 ru: Примеры
-              url: /modules/340-monitoring-ping/usage.html
+              url: /modules/monitoring-ping/usage.html
         - title:
             ru: Мониторинг кластера
             en: Cluster monitoring
@@ -788,11 +788,11 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/340-monitoring-kubernetes/
+              url: /modules/monitoring-kubernetes/
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/340-monitoring-kubernetes/configuration.html
+              url: /modules/monitoring-kubernetes/configuration.html
         - title:
             en: Control plane monitoring
             ru: Мониторинг control plane
@@ -800,11 +800,11 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/340-monitoring-kubernetes-control-plane/
+              url: /modules/monitoring-kubernetes-control-plane/
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/340-monitoring-kubernetes-control-plane/configuration.html
+              url: /modules/monitoring-kubernetes-control-plane/configuration.html
         - title:
             ru: Расширенный мониторинг
             en: Extended monitoring
@@ -812,11 +812,11 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/340-extended-monitoring/
+              url: /modules/extended-monitoring/
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/340-extended-monitoring/configuration.html
+              url: /modules/extended-monitoring/configuration.html
         - title:
             en: Logs
             ru: Логи
@@ -828,15 +828,15 @@ entries:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/460-log-shipper/
+                  url: /modules/log-shipper/
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/460-log-shipper/examples.html
+                  url: /modules/log-shipper/examples.html
                 - title:
                     en: Advanced Usage
                     ru: Расширенная конфигурация
-                  url: /modules/460-log-shipper/advanced_usage.html
+                  url: /modules/log-shipper/advanced_usage.html
                 - title:
                     en: Reference
                     ru: Справка
@@ -844,11 +844,11 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/460-log-shipper/configuration.html
+                      url: /modules/log-shipper/configuration.html
                     - title: Custom Resources
-                      url: /modules/460-log-shipper/cr.html
+                      url: /modules/log-shipper/cr.html
                 - title: FAQ
-                  url: /modules/460-log-shipper/faq.html
+                  url: /modules/log-shipper/faq.html
 
             - title:
                 en: Short-term storage
@@ -858,15 +858,15 @@ entries:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/462-loki/
+                  url: /modules/loki/
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/462-loki/examples.html
+                  url: /modules/loki/examples.html
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/462-loki/configuration.html
+                  url: /modules/loki/configuration.html
         - title:
             en: Other modules
             ru: Другие модули
@@ -876,52 +876,52 @@ entries:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/200-operator-prometheus/
+                  url: /modules/operator-prometheus/
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/200-operator-prometheus/configuration.html
+                  url: /modules/operator-prometheus/configuration.html
                 - title: FAQ
-                  url: /modules/200-operator-prometheus/faq.html
+                  url: /modules/operator-prometheus/faq.html
             - title: okmeter
               featureStatus: proprietaryOkmeter
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/500-okmeter/
+                  url: /modules/okmeter/
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/500-okmeter/examples.html
+                  url: /modules/okmeter/examples.html
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/500-okmeter/configuration.html
+                  url: /modules/okmeter/configuration.html
             - title: prometheus-pushgateway
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/303-prometheus-pushgateway/
+                  url: /modules/prometheus-pushgateway/
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/303-prometheus-pushgateway/examples.html
+                  url: /modules/prometheus-pushgateway/examples.html
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/303-prometheus-pushgateway/configuration.html
+                  url: /modules/prometheus-pushgateway/configuration.html
             - title: upmeter
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/500-upmeter/
+                  url: /modules/upmeter/
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/500-upmeter/examples.html
+                  url: /modules/upmeter/examples.html
                 - title:
                     en: Configuration
                     ru: Настройки
@@ -929,9 +929,9 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/500-upmeter/configuration.html
+                      url: /modules/upmeter/configuration.html
                     - title: Custom Resources
-                      url: /modules/500-upmeter/cr.html
+                      url: /modules/upmeter/cr.html
     - title:
         en: Autoscaling & Managing resources
         ru: Масштабирование и управление ресурсами
@@ -941,11 +941,11 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/001-priority-class/
+              url: /modules/priority-class/
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/001-priority-class/configuration.html
+              url: /modules/priority-class/configuration.html
         - title:
             en: Scaling by any metric
             ru: Масштабирование по метрикам
@@ -953,11 +953,11 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/301-prometheus-metrics-adapter/
+              url: /modules/prometheus-metrics-adapter/
             - title:
                 en: Usage
                 ru: Примеры
-              url: /modules/301-prometheus-metrics-adapter/usage.html
+              url: /modules/prometheus-metrics-adapter/usage.html
             - title:
                 en: Reference
                 ru: Справка
@@ -965,9 +965,9 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/301-prometheus-metrics-adapter/configuration.html
+                  url: /modules/prometheus-metrics-adapter/configuration.html
                 - title: Custom Resources
-                  url: /modules/301-prometheus-metrics-adapter/cr.html
+                  url: /modules/prometheus-metrics-adapter/cr.html
         - title:
             en: Vertical Pod autoscaler
             ru: Вертикальное масштабирование
@@ -975,11 +975,11 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/302-vertical-pod-autoscaler/
+              url: /modules/vertical-pod-autoscaler/
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/302-vertical-pod-autoscaler/examples.html
+              url: /modules/vertical-pod-autoscaler/examples.html
             - title:
                 en: Reference
                 ru: Справка
@@ -987,11 +987,11 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/302-vertical-pod-autoscaler/configuration.html
+                  url: /modules/vertical-pod-autoscaler/configuration.html
                 - title: Custom Resources
-                  url: /modules/302-vertical-pod-autoscaler/cr.html
+                  url: /modules/vertical-pod-autoscaler/cr.html
             - title: FAQ
-              url: /modules/302-vertical-pod-autoscaler/faq.html
+              url: /modules/vertical-pod-autoscaler/faq.html
         - title:
             en: Other modules
             ru: Другие модули
@@ -1002,11 +1002,11 @@ entries:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/400-descheduler/
+                  url: /modules/descheduler/
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/400-descheduler/examples.html
+                  url: /modules/descheduler/examples.html
                 - title:
                     en: Reference
                     ru: Справка
@@ -1014,35 +1014,35 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/400-descheduler/configuration.html
+                      url: /modules/descheduler/configuration.html
                     - title: Custom Resources
-                      url: /modules/400-descheduler/cr.html
+                      url: /modules/descheduler/cr.html
             - title: flow-schema
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/011-flow-schema/
+                  url: /modules/flow-schema/
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/011-flow-schema/configuration.html
+                  url: /modules/flow-schema/configuration.html
                 - title: FAQ
-                  url: /modules/011-flow-schema/faq.html
+                  url: /modules/flow-schema/faq.html
             - title: pod-reloader
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/465-pod-reloader/
+                  url: /modules/pod-reloader/
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/465-pod-reloader/examples.html
+                  url: /modules/pod-reloader/examples.html
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/465-pod-reloader/configuration.html
+                  url: /modules/pod-reloader/configuration.html
     - title:
         en: Security
         ru: Безопасность
@@ -1052,11 +1052,11 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/150-user-authn/
+              url: /modules/user-authn/
             - title:
                 en: Usage
                 ru: Примеры
-              url: /modules/150-user-authn/usage.html
+              url: /modules/user-authn/usage.html
             - title:
                 en: Reference
                 ru: Справка
@@ -1064,21 +1064,21 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/150-user-authn/configuration.html
+                  url: /modules/user-authn/configuration.html
                 - title: Custom Resources
-                  url: /modules/150-user-authn/cr.html
+                  url: /modules/user-authn/cr.html
             - title: FAQ
-              url: /modules/150-user-authn/faq.html
+              url: /modules/user-authn/faq.html
         - title: User authorization
           folders:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/140-user-authz/
+              url: /modules/user-authz/
             - title:
                 en: Usage
                 ru: Примеры
-              url: /modules/140-user-authz/usage.html
+              url: /modules/user-authz/usage.html
             - title:
                 en: Reference
                 ru: Справка
@@ -1086,22 +1086,22 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/140-user-authz/configuration.html
+                  url: /modules/user-authz/configuration.html
                 - title: Custom Resources
-                  url: /modules/140-user-authz/cr.html
+                  url: /modules/user-authz/cr.html
             - title: FAQ
-              url: /modules/140-user-authz/faq.html
+              url: /modules/user-authz/faq.html
         - title: Multitenancy
           moduleName: multitenancy-manager
           folders:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/160-multitenancy-manager/
+              url: /modules/multitenancy-manager/
             - title:
                 en: Usage
                 ru: Примеры
-              url: /modules/160-multitenancy-manager/usage.html
+              url: /modules/multitenancy-manager/usage.html
             - title:
                 en: Reference
                 ru: Справка
@@ -1109,9 +1109,9 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/160-multitenancy-manager/configuration.html
+                  url: /modules/multitenancy-manager/configuration.html
                 - title: Custom Resources
-                  url: /modules/160-multitenancy-manager/cr.html
+                  url: /modules/multitenancy-manager/cr.html
         - title:
             en: Admission Policy
             ru: Политики безопасности
@@ -1119,7 +1119,7 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/015-admission-policy-engine/
+              url: /modules/admission-policy-engine/
             - title:
                 ru: Справка
                 en: Reference
@@ -1127,11 +1127,11 @@ entries:
                 - title:
                     ru: Настройки
                     en: Configuration
-                  url: /modules/015-admission-policy-engine/configuration.html
+                  url: /modules/admission-policy-engine/configuration.html
                 - title: Custom Resources
-                  url: /modules/015-admission-policy-engine/cr.html
+                  url: /modules/admission-policy-engine/cr.html
             - title: FAQ
-              url: /modules/015-admission-policy-engine/faq.html
+              url: /modules/admission-policy-engine/faq.html
         - title:
             en: Audit
             ru: Аудит
@@ -1142,7 +1142,7 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/650-runtime-audit-engine/
+              url: /modules/runtime-audit-engine/
             - title:
                 ru: Справка
                 en: Reference
@@ -1150,19 +1150,19 @@ entries:
                 - title:
                     ru: Настройки
                     en: Configuration
-                  url: /modules/650-runtime-audit-engine/configuration.html
+                  url: /modules/runtime-audit-engine/configuration.html
                 - title: Custom Resources
-                  url: /modules/650-runtime-audit-engine/cr.html
+                  url: /modules/runtime-audit-engine/cr.html
             - title:
                 en: Advanced Usage
                 ru: Расширенная конфигурация
-              url: /modules/650-runtime-audit-engine/advanced_usage.html
+              url: /modules/runtime-audit-engine/advanced_usage.html
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/650-runtime-audit-engine/examples.html
+              url: /modules/runtime-audit-engine/examples.html
             - title: FAQ
-              url: /modules/650-runtime-audit-engine/faq.html
+              url: /modules/runtime-audit-engine/faq.html
         - title:
             en: Other modules
             ru: Другие модули
@@ -1172,11 +1172,11 @@ entries:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/101-cert-manager/
+                  url: /modules/cert-manager/
                 - title:
                     en: Usage
                     ru: Примеры
-                  url: /modules/101-cert-manager/usage.html
+                  url: /modules/cert-manager/usage.html
                 - title:
                     en: Reference
                     ru: Справка
@@ -1184,25 +1184,25 @@ entries:
                     - title:
                         en: Configuration
                         ru: Настройки
-                      url: /modules/101-cert-manager/configuration.html
+                      url: /modules/cert-manager/configuration.html
                     - title: Custom Resources
-                      url: /modules/101-cert-manager/cr.html
+                      url: /modules/cert-manager/cr.html
                 - title: FAQ
-                  url: /modules/101-cert-manager/faq.html
+                  url: /modules/cert-manager/faq.html
             - title: network-policy-engine
               folders:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/050-network-policy-engine/
+                  url: /modules/network-policy-engine/
                 - title:
                     en: Examples
                     ru: Примеры
-                  url: /modules/050-network-policy-engine/examples.html
+                  url: /modules/network-policy-engine/examples.html
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/050-network-policy-engine/configuration.html
+                  url: /modules/network-policy-engine/configuration.html
             - title: operator-trivy
               d8Revision: ee
               featureStatus: experimental
@@ -1210,13 +1210,13 @@ entries:
                 - title:
                     en: Description
                     ru: Описание
-                  url: /modules/500-operator-trivy/
+                  url: /modules/operator-trivy/
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/500-operator-trivy/configuration.html
+                  url: /modules/operator-trivy/configuration.html
                 - title: FAQ
-                  url: /modules/500-operator-trivy/faq.html
+                  url: /modules/operator-trivy/faq.html
     - title:
         en: Storage
         ru: Хранилище
@@ -1227,11 +1227,11 @@ entries:
             - title:
                 ru: Описание
                 en: Description
-              url: /modules/031-ceph-csi/
+              url: /modules/ceph-csi/
             - title:
                 ru: Примеры
                 en: Examples
-              url: /modules/031-ceph-csi/examples.html
+              url: /modules/ceph-csi/examples.html
             - title:
                 ru: Справка
                 en: Reference
@@ -1239,21 +1239,21 @@ entries:
                 - title:
                     ru: Настройки
                     en: Configuration
-                  url: /modules/031-ceph-csi/configuration.html
+                  url: /modules/ceph-csi/configuration.html
                 - title: Custom Resources
-                  url: /modules/031-ceph-csi/cr.html
+                  url: /modules/ceph-csi/cr.html
             - title: FAQ
-              url: /modules/031-ceph-csi/faq.html
+              url: /modules/ceph-csi/faq.html
         - title: local-path-provisioner
           folders:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/031-local-path-provisioner/
+              url: /modules/local-path-provisioner/
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/031-local-path-provisioner/examples.html
+              url: /modules/local-path-provisioner/examples.html
             - title:
                 en: Reference
                 ru: Справка
@@ -1261,25 +1261,25 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/031-local-path-provisioner/configuration.html
+                  url: /modules/local-path-provisioner/configuration.html
                 - title: Custom Resources
-                  url: /modules/031-local-path-provisioner/cr.html
+                  url: /modules/local-path-provisioner/cr.html
             - title: FAQ
-              url: /modules/031-local-path-provisioner/faq.html
+              url: /modules/local-path-provisioner/faq.html
         - title: snapshot-controller
           folders:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/045-snapshot-controller/
+              url: /modules/snapshot-controller/
             - title:
                 en: Usage
                 ru: Примеры
-              url: /modules/045-snapshot-controller/usage.html
+              url: /modules/snapshot-controller/usage.html
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/045-snapshot-controller/configuration.html
+              url: /modules/snapshot-controller/configuration.html
     - title:
         en: Little things
         ru: Приятные мелочи
@@ -1289,43 +1289,43 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/470-chrony/
+              url: /modules/chrony/
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/470-chrony/configuration.html
+              url: /modules/chrony/configuration.html
             - title: FAQ
-              url: /modules/470-chrony/faq.html
+              url: /modules/chrony/faq.html
         - title: namespace-configurator
           folders:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/600-namespace-configurator/
+              url: /modules/namespace-configurator/
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/600-namespace-configurator/configuration.html
+              url: /modules/namespace-configurator/configuration.html
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/600-namespace-configurator/examples.html
+              url: /modules/namespace-configurator/examples.html
         - title: secret-copier
           folders:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/600-secret-copier/
+              url: /modules/secret-copier/
         - title: deckhouse-tools
           folders:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/800-deckhouse-tools/
+              url: /modules/deckhouse-tools/
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/800-deckhouse-tools/configuration.html
+              url: /modules/deckhouse-tools/configuration.html
     - title:
         en: Bare Metal
         ru: Bare Metal
@@ -1336,11 +1336,11 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/450-keepalived/
+              url: /modules/keepalived/
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/450-keepalived/examples.html
+              url: /modules/keepalived/examples.html
             - title:
                 en: Reference
                 ru: Справка
@@ -1348,11 +1348,11 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/450-keepalived/configuration.html
+                  url: /modules/keepalived/configuration.html
                 - title: Custom Resources
-                  url: /modules/450-keepalived/cr.html
+                  url: /modules/keepalived/cr.html
             - title: FAQ
-              url: /modules/450-keepalived/faq.html
+              url: /modules/keepalived/faq.html
         - title: l2-load-balancer
           d8Revision: ee
           featureStatus: deprecated
@@ -1360,11 +1360,11 @@ entries:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/381-l2-load-balancer/
+              url: /modules/l2-load-balancer/
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/381-l2-load-balancer/examples.html
+              url: /modules/l2-load-balancer/examples.html
             - title:
                 en: Reference
                 ru: Справка
@@ -1372,35 +1372,35 @@ entries:
                 - title:
                     en: Configuration
                     ru: Настройки
-                  url: /modules/381-l2-load-balancer/configuration.html
+                  url: /modules/l2-load-balancer/configuration.html
                 - title: Custom Resources
-                  url: /modules/381-l2-load-balancer/cr.html
+                  url: /modules/l2-load-balancer/cr.html
         - title: metallb
           d8Revision: ee
           folders:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/380-metallb/
+              url: /modules/metallb/
             - title:
                 en: Examples
                 ru: Примеры
-              url: /modules/380-metallb/examples.html
+              url: /modules/metallb/examples.html
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/380-metallb/configuration.html
+              url: /modules/metallb/configuration.html
         - title: network-gateway
           d8Revision: ee
           folders:
             - title:
                 en: Description
                 ru: Описание
-              url: /modules/450-network-gateway/
+              url: /modules/network-gateway/
             - title:
                 en: Configuration
                 ru: Настройки
-              url: /modules/450-network-gateway/configuration.html
+              url: /modules/network-gateway/configuration.html
     - title:
         en: Deckhouse CLI
         ru: Deckhouse CLI

--- a/docs/documentation/_includes/revision_comparison_detail_table.liquid
+++ b/docs/documentation/_includes/revision_comparison_detail_table.liquid
@@ -20,7 +20,6 @@
   </thead>
   <tbody>
   {%- for module in modules %}
-    {%- assign modulePath = module[1].path %}
     {%- assign moduleName = module[0] %}
     {%- assign moduleEdition = module[1].edition %}
     {%- assign moduleIsExternal = false %}
@@ -43,6 +42,8 @@
 
     {%- if moduleIsExternal %}
       {%- assign modulePath = module[1].path | prepend: '/products/kubernetes-platform/documentation/v1/' | prepend: site.urls[page.lang] %}
+    {%- else %}
+      {%- assign modulePath = module[1].path %}
     {%- endif %}
 
     <tr>

--- a/docs/documentation/_plugins/custom_hooks.rb
+++ b/docs/documentation/_plugins/custom_hooks.rb
@@ -73,9 +73,9 @@ Jekyll::Hooks.register :site, :post_read do |site|
   ]
 
   site.pages.each do |page|
-    if page.url.match?(%r{/modules/[0-9]+-[^/]+/$}) || pageSuffixes.any? { |suffix| page.name.end_with?(suffix) }
+    if page.url.match?(%r{/modules/([0-9]+-)?[^/]+/$}) || pageSuffixes.any? { |suffix| page.name.end_with?(suffix) }
     then
-      moduleKebabCase = page.url.sub(%r{(.*)?/modules/[0-9]+-([^/]+)/.*$},'\2')
+      moduleKebabCase = page.url.sub(%r{(.*)?/modules/([0-9]+-)?([^/]+)/.*$},'\3')
       moduleSnakeCase = moduleKebabCase.gsub(/-[a-z]/,&:upcase).gsub(/-/,'')
       page.data['module-kebab-name'] = moduleKebabCase
       page.data['module-snake-name'] = moduleSnakeCase

--- a/docs/documentation/generate_cluster_configuration.sh
+++ b/docs/documentation/generate_cluster_configuration.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
 
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Update configuration.html page for modules from the corresponding module openapi schema
 #
 
 for schema_path in $(find $MODULES_DIR -regex '^.*/openapi/cluster_configuration.yaml$' -print); do
   module_path=$(echo $schema_path | cut -d\/ -f-2 )
-  module_name=$(echo $schema_path | cut -d\/ -f2 | cut -d- -f2-)
+  module_name=$(echo $schema_path | cut -d\/ -f2 )
   mkdir -p _data/schemas/${module_name}
   cp -f $schema_path _data/schemas/${module_name}/
   if [ -f $module_path/openapi/doc-ru-cluster_configuration.yaml ]; then
@@ -19,9 +33,9 @@ for schema_path in $(find $MODULES_DIR -regex '^.*/openapi/cluster_configuration
   grep -q '<!-- SCHEMA -->' ${module_path}/docs/CLUSTER_CONFIGURATION.md
   if [ $? -eq 0 ]; then
     # Apply schema
-    echo "Generating schema ${schema_path} for ${module_path}/docs/CLUSTER_CONFIGURATION.md"
+    echo "   ...${module_name}"
     sed -i "/<!-- SCHEMA -->/i\{\{ site.data.schemas.${module_name}.cluster_configuration \| format_cluster_configuration: \"${module_name}\" \}\}" ${module_path}/docs/CLUSTER_CONFIGURATION.md
   else
-    echo "WARNING: Schema ${schema_path} found but there is no '<!-- SCHEMA -->' placeholder in the ${module_path}/docs/CLUSTER_CONFIGURATION.md"
+    echo "WARN: Found schema for ${module_name} module, but there is no '<!-- SCHEMA -->' placeholder in the CLUSTER_CONFIGURATION.md file."
   fi
 done

--- a/docs/documentation/modules_generate_configuration.sh
+++ b/docs/documentation/modules_generate_configuration.sh
@@ -1,12 +1,27 @@
 #!/bin/bash
 
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Update configuration.html page for modules from the corresponding module openapi schema
 #
 
 for schema_path in $(find $MODULES_DIR -regex '^.*/openapi/config-values.yaml$' -print); do
   module_path=$(echo $schema_path | cut -d\/ -f-2 )
-  module_name=$(echo $schema_path | cut -d\/ -f2 | cut -d- -f2-)
+  module_name=$(echo $schema_path | cut -d\/ -f2 )
+
   mkdir -p _data/schemas/${module_name}
   cp -f $schema_path _data/schemas/${module_name}/
   if [ -f $module_path/openapi/doc-ru-config-values.yaml ]; then
@@ -16,13 +31,19 @@ for schema_path in $(find $MODULES_DIR -regex '^.*/openapi/config-values.yaml$' 
   if [ ! -f ${module_path}/docs/CONFIGURATION.md ]; then
       continue
   fi
-  grep -q '<!-- SCHEMA -->' ${module_path}/docs/CONFIGURATION.md
-  if [ $? -eq 0 ]; then
+
+  if grep -q '<!-- SCHEMA -->' ${module_path}/docs/CONFIGURATION.md; then
     # Apply schema
-    echo "Generating schema ${schema_path} for ${module_path}/docs/CONFIGURATION.md"
+    echo "   ...${module_name}"
     sed -i "/<!-- SCHEMA -->/i\{\% include module-configuration.liquid \%\}" ${module_path}/docs/CONFIGURATION.md
+  elif grep -q 'module-settings.liquid' ${module_path}/docs/CONFIGURATION.md; then
+    # It is a normal case. Manually configured schema rendering.
+    continue
   else
-    echo "WARNING: Schema ${schema_path} found but there is no '<!-- SCHEMA -->' placeholder in the ${module_path}/docs/CONFIGURATION.md"
+    PARAMETERS_COUNT=$(cat $schema_path | yq eval '.properties| length' - )
+    if [ $PARAMETERS_COUNT -gt 0 ]; then
+      echo "WARN: Found schema for ${module_name} module, but there is no '<!-- SCHEMA -->' placeholder in the CONFIGURATION.md file."
+    fi
   fi
 done
 

--- a/docs/documentation/modules_generate_cr.sh
+++ b/docs/documentation/modules_generate_cr.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Update CR.md page for modules according to CR's used in module
 #
@@ -7,7 +21,7 @@
 for schema_path in $(find $MODULES_DIR -regex '^.*/crds/.*.yaml$' -print | grep -v '/crds/doc-ru-'| sort); do
   module_path=$(echo $schema_path | cut -d\/ -f-2 )
   module_file_name=$(echo $schema_path | awk -F\/ '{print $NF}')
-  module_name=$(echo $schema_path | cut -d\/ -f2 | cut -d- -f2-)
+  module_name=$(echo $schema_path | cut -d\/ -f2 )
   schema_path_relative=$(echo $schema_path | cut -d\/ -f3- | sed "s#\.yaml##; s#\.##g; s#\/#\.#g")
   mkdir -p _data/schemas/${module_name}/crds
   cp -f $schema_path _data/schemas/${module_name}/crds/
@@ -18,9 +32,9 @@ for schema_path in $(find $MODULES_DIR -regex '^.*/crds/.*.yaml$' -print | grep 
   grep -q '<!-- SCHEMA -->' ${module_path}/docs/CR.md &> /dev/null
   if [ $? -eq 0 ]; then
     # Apply schema
-    echo "OK: Generating schema ${schema_path} for ${module_path}/docs/CR.md"
+    echo "   ...${module_name}/${module_file_name}"
     sed -i "/<!-- SCHEMA -->/i\{\{ site.data.schemas.${module_name}.${schema_path_relative} \| format_crd: \"${module_name}\" \}\}" ${module_path}/docs/CR.md
   else
-    echo "WARNING: Schema ${schema_path} found but there is no '<!-- SCHEMA -->' placeholder in the ${module_path}/docs/CR.md"
+    echo "WARN: Found ${module_file_name} for ${module_name} module, but there is no '<!-- SCHEMA -->' placeholder in the CR.md file."
   fi
 done

--- a/docs/documentation/modules_generate_ossinfo.sh
+++ b/docs/documentation/modules_generate_ossinfo.sh
@@ -1,14 +1,27 @@
 #!/bin/bash
 
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Copy files with information about the licenses used in modules to _data/ossinfo folder (jekyll will construct an array with this data)
 
 mkdir -p _data/ossinfo/
 
-for path in $(find $MODULES_DIR -regex '^.*/[0-9]*-[^/]*/oss.yaml$' -print); do
+for path in $(find $MODULES_DIR -iname oss.yaml -print); do
   module_short_name=$(echo $path | sed -E 's#.+/(.+/[^/]+)$#\1#' | cut -d\/ -f-1 | cut -d- -f2-)
   module_full_name=$(echo $path | sed -E 's#.+/(.+/[^/]+)$#\1#' | cut -d\/ -f-1)
   cp -f $path _data/ossinfo/${module_short_name}.yaml
   cat $path >> _data/ossinfo-cumulative.yaml
-  echo "copied $path to _data/ossinfo/${module_short_name}.yaml"
 done

--- a/docs/documentation/modules_list.sh
+++ b/docs/documentation/modules_list.sh
@@ -1,16 +1,31 @@
 #!/bin/bash
 
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This script outputs alphabetically sorted modules list including path and revision in the YAML format.
 # Example:
 # ...
 # modules:
-#   admission-policy-engine:
-#     path: modules/015-admission-policy-engine/
-#     revision: ce
-#   ceph-csi:
-#     path: modules/031-ceph-csi/
-#     revision: ce
-#     parameters-ee:
+#   network-gateway:
+#     folder_name: modules/450-network-gateway/
+#     path: modules/network-gateway/
+#     edition: ee
+#   network-policy-engine:
+#     folder_name: modules/050-network-policy-engine/
+#     path: modules/network-policy-engine/
+#     edition: ce
 #
 
 if [[ -z ${MODULES_DIR} ]]; then
@@ -19,22 +34,19 @@ fi
 
 echo "modules:"
 
-if [ -f modules_menu_skip ]; then
-  modules_skip_list=$(cat modules_menu_skip)
-fi
-
 for module_edition_path in $(find ${MODULES_DIR} -regex '.*/docs/README.md' -print | sed -E "s#^${MODULES_DIR}/modules/#${MODULES_DIR}/ce/modules/#" | sed -E "s#^${MODULES_DIR}/(ce/|be/|se/|ee/|fe/)?modules/([^/]+)/.*\$#\1\2#" | sort -t/ -k 2.4 ); do
-  skip=false
-  module_path=$(echo $module_edition_path | sed -E 's#ce/|be/|se/|ee/|fe/##')
-  # Skip unnecessary modules
-  for skip_item in $modules_skip_list ; do
-    if [[ $skip_item == $module_path ]] ; then skip=true; break; fi
-  done
-  if [[ "$skip" == 'true' ]]; then continue; fi
+  module_repo_folder_name=$(echo $module_edition_path | sed -E 's#ce/|be/|se/|ee/|fe/##')
+  module_name=$(echo $module_repo_folder_name | sed -E 's#^[0-9]+-##')
+
+  # Skip modules, which are listed in modules_menu_skip file
+  if grep -Fxq "$module_name" modules_menu_skip; then
+      continue
+  fi
 
   cat << YAML
-  $(echo $module_path | cut -d- -f2-):
-    path: modules/${module_path}/
+  $module_name:
+    repo_folder_name: modules/${module_repo_folder_name}/
+    path: modules/${module_name}/
     edition: $(echo $module_edition_path | cut -d/ -f1)
 YAML
 done

--- a/docs/documentation/modules_menu_skip
+++ b/docs/documentation/modules_menu_skip
@@ -1,5 +1,5 @@
-000-common
-010-cloud-data-crd
-340-monitoring-applications
-340-prometheus-madison-integration
-500-basic-auth
+common
+cloud-data-crd
+monitoring-applications
+prometheus-madison-integration
+basic-auth

--- a/docs/documentation/pages/DECKHOUSE_CONFIGURE.md
+++ b/docs/documentation/pages/DECKHOUSE_CONFIGURE.md
@@ -145,10 +145,8 @@ Depending on the [bundle used](./modules/002-deckhouse/configuration.html#parame
 <td>
 <ul style="columns: 3">
 {%- for moduleName in site.data.bundles.bundleModules[bundle] %}
-{%- assign isExcluded = site.data.exclude.module_names | where: "name", moduleName %}
-{%- if isExcluded.size > 0 %}{% continue %}{% endif %}
-<li>
-{{ moduleName }}</li>
+{%- if site.data.excludedModules contains moduleName %}{% continue %}{% endif %}
+<li>{{ moduleName }}</li>
 {%- endfor %}
 </ul>
 </td>

--- a/docs/documentation/pages/DECKHOUSE_CONFIGURE_RU.md
+++ b/docs/documentation/pages/DECKHOUSE_CONFIGURE_RU.md
@@ -146,10 +146,8 @@ user-authn   false     1         12h
 <td>
 <ul style="columns: 3">
 {%- for moduleName in site.data.bundles.bundleModules[bundle] %}
-{%- assign isExcluded = site.data.exclude.module_names | where: "name", moduleName %}
-{%- if isExcluded.size > 0 %}{% continue %}{% endif %}
-<li>
-{{ moduleName }}</li>
+{%- if site.data.excludedModules contains moduleName %}{% continue %}{% endif %}
+<li>{{ moduleName }}</li>
 {%- endfor %}
 </ul>
 </td>

--- a/docs/documentation/werf-web.inc.yaml
+++ b/docs/documentation/werf-web.inc.yaml
@@ -41,24 +41,24 @@ shell:
         echo "Gem: $(gem --version)"
         bundle --version
 
-        # "Create modules.yml"
+        echo '[] Creating modules.yml ...'
         cd /srv/jekyll-data/documentation/
 {{ if ne .ModuleName "docs" }}
         export MODULES_DIR=/comparison
 {{ end }}
         ./modules_list.sh 1>_data/modules.yaml
-        cat modules_menu_skip  | cut -d\- -f 2-  | jq -nRc '[inputs] | map({"name":.}) | {module_names:.}' > _data/exclude.json
+        cat modules_menu_skip  | sed -E 's/^[0-9]+-//'  | jq -nRc '[inputs]' > _data/excludedModules.json
 
-        # "Edition: {{ .Edition }}. Merging modules of different editions"
+        echo '[] Edition - {{ .Edition }}. Merging modules of different editions...'
         for dir in {be,se,ee,fe}; do if [ -d /src/$dir/modules ];then cp -rf /src/$dir/modules /src >& /dev/null; fi; done
 
-        # "Preparing modules structure"
+        echo '[] Preparing modules structure...'
         export MODULES_SRC_DIR=/src/modules
         export MODULES_DST_EN=/srv/jekyll-data/documentation/modules_en
         export MODULES_DST_RU=/srv/jekyll-data/documentation/modules_ru
         bash ./modules_prepare.sh
 
-        # "Adding permalinks..."
+        echo '[] Adding permalinks...'
         for i in $(find . -regex '.*.md' -print); do
           if ! grep -q "^---" "$i"; then continue; fi
           if cat $i | tr -d '\n' | grep -qv "^---.*permalink: .*---"; then
@@ -68,36 +68,39 @@ shell:
           fi
         done
 
-        # "Generating configuration schemas..."
+        echo '[] Generating configuration schemas...'
         export MODULES_DIR=modules_en
         bash ./modules_generate_configuration.sh
         export MODULES_DIR=modules_ru MODULES_LANG=ru
         bash ./modules_generate_configuration.sh
 
-        # "Generating cluster configuration schemas..."
+        echo
+        echo '[] Generating cluster configuration schemas...'
         export MODULES_DIR=modules_en
         bash ./generate_cluster_configuration.sh
         export MODULES_DIR=modules_ru MODULES_LANG=ru
         bash ./generate_cluster_configuration.sh
 
-        # "Generating CR schemas..."
+        echo
+        echo "[] Generating CR schemas..."
         export MODULES_DIR=modules_en
         bash ./modules_generate_cr.sh
         export MODULES_DIR=modules_ru
         bash ./modules_generate_cr.sh
 
-        # "Preparing OSS license info..."
+        echo
+        echo '[] Preparing OSS license info...'
         export MODULES_DIR=/src/modules
         bash ./modules_generate_ossinfo.sh
 
-        # "Extracting the default Kubernetes version..."
+        echo '[] Extracting the default Kubernetes version...'
         echo "default: \"$(grep "DefaultKubernetesVersion" -m 1 _data/dhctl-base.go | grep -Eo '[0-9.]+')\"" > _data/version_kubernetes.yml
 
-        # "Filling in the array of supported OS & K8S versions..."
+        echo '[] Filling in the array of supported OS & K8S versions...'
         cd _data
         sed '/^bashible:/r version_map_addition.yml' version_map.yml >> supported_versions.yml
 
-        # "Convert editions structure"
+        echo '[] Converting editions structure...'
         yq e -j editions-source.yaml | jq -M 'reduce .editions[] as $item ({}; .[$item.name | ascii_downcase] = $item)' > editions.json
 
 {{ if ne .ModuleName "docs" }}
@@ -122,7 +125,7 @@ shell:
         echo -e "\nd8Revision: {{ .Edition }}" >> /tmp/_config_additional.yml
 {{ end }}
 
-        # "Generating static files of the documentation part..."
+        echo '[] Generating static files of the documentation part...'
         cd ..
         mkdir -m 777 -p /app/_site/
 {{ if eq .ModuleName "docs" }}
@@ -134,7 +137,7 @@ shell:
 {{ else }}
         JEKYLL_ENV=production jekyll build -d /app/_site/documentation/ --config _config.yml,/tmp/_config_additional.yml
 
-        # "Generating static file's of the main part..."
+        echo '[] Generating static files of the main part...'
         cd /srv/jekyll-data/site/
         JEKYLL_ENV=production jekyll build -d /app/_site/site/ --config _config.yml,/tmp/_config_additional.yml
 

--- a/modules/810-documentation/templates/ingress.yaml
+++ b/modules/810-documentation/templates/ingress.yaml
@@ -24,6 +24,7 @@ metadata:
       proxy_ssl_session_reuse on;
   {{- end }}
       rewrite ^/$ /en/platform/ permanent;
+      rewrite ^/((ru|en)/(.+)/modules)/[0-9]+-([^/]+/.*)$ /$1/$4 permanent;
       rewrite ^/(en|ru)/$ /$1/platform/ permanent;
       rewrite ^/modules/(.+) /en/modules/$1 permanent;
       rewrite ^/platform/(.+) /en/platform/$1 permanent;


### PR DESCRIPTION
## Description

- Adjust module naming to remove numeric prefixes in module URL on the site and in the `documentation` module.
- Build refactoring to improve efficiency.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs, documentation
type: chore
summary: Get rid of numeric prefixes in module URL.
impact_level: default
```
