### PR TITLE
[deckhouse-controller] add error wrapping

### DIFF
--- a/deckhouse-controller/pkg/addon-operator/kube-config/backend/module_config.go
+++ b/deckhouse-controller/pkg/addon-operator/kube-config/backend/module_config.go
@@ -17,6 +17,7 @@ package backend
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -166,13 +167,13 @@ func (mc ModuleConfigBackend) LoadConfig(ctx context.Context, _ ...string) (*con
 
 	list, err := mc.mcKubeClient.DeckhouseV1alpha1().ModuleConfigs().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list module configs: %w", err)
 	}
 
 	for _, item := range list.Items {
 		values, err := mc.fetchValuesFromModuleConfig(&item)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("fetch values: %w", err)
 		}
 
 		if item.Name == "global" {
@@ -210,7 +211,7 @@ func (mc ModuleConfigBackend) fetchValuesFromModuleConfig(item *v1alpha1.ModuleC
 
 	newVersion, newSettings, err := converter.ConvertToLatest(item.Spec.Version, item.Spec.Settings)
 	if err != nil {
-		return utils.Values{}, err
+		return utils.Values{}, fmt.Errorf("convert: %w", err)
 	}
 
 	item.Spec.Version = newVersion

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -100,7 +100,7 @@ type DeckhouseController struct {
 func NewDeckhouseController(ctx context.Context, config *rest.Config, mm *module_manager.ModuleManager, metricStorage *metric_storage.MetricStorage, logger *log.Logger) (*DeckhouseController, error) {
 	mcClient, err := versioned.NewForConfig(config)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("versioned client creating: %w", err)
 	}
 
 	dc := dependency.NewDependencyContainer()
@@ -109,7 +109,7 @@ func NewDeckhouseController(ctx context.Context, config *rest.Config, mm *module
 	for _, add := range []func(s *runtime.Scheme) error{corev1.AddToScheme, coordv1.AddToScheme, v1alpha1.AddToScheme, appsv1.AddToScheme} {
 		err = add(scheme)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("add to scheme: %w", err)
 		}
 	}
 
@@ -179,13 +179,13 @@ func NewDeckhouseController(ctx context.Context, config *rest.Config, mm *module
 		},
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("controller runtime manager creating: %w", err)
 	}
 
 	// register extenders
 	for _, extender := range extenders.Extenders() {
 		if err = mm.AddExtender(extender); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("add extender: %w", err)
 		}
 	}
 
@@ -263,7 +263,7 @@ func (dml *DeckhouseController) DiscoverDeckhouseModules(ctx context.Context, mo
 	// we have to get all source module for deployed releases
 	err = dml.setupSourceModules(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("setup source modules: %w", err)
 	}
 
 	go dml.runEventLoop(moduleEventC)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
