### PR TITLE
[user-authn] Add ability to set custom labels on autogenerated DexClient secret (additional labels/annotations)

### DIFF
--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -75,11 +76,14 @@ func applyDexClientFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 		labels = make(map[string]string)
 	}
 	// Secrets with that label lead to D8CertmanagerOrphanSecretsChecksFailed alerts.
+	// argocd.argoproj.io is used by ArgoCD to identify secrets managed by it.
+	// app.kubernetes.io/managed-by is used by Helm to identify secrets managed by it.
 	delete(labels, "certmanager.k8s.io/certificate-name")
-
-	// Secrets with that labels lead to ArgoCD control over them.
 	delete(labels, "argocd.argoproj.io/instance")
 	delete(labels, "argocd.argoproj.io/secret-type")
+	if labels["app.kubernetes.io/managed-by"] == "Helm" {
+		delete(labels, "app.kubernetes.io/managed-by")
+	}
 
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
@@ -87,6 +91,13 @@ func applyDexClientFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 	}
 
 	delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
+	delete(annotations, "meta.helm.sh/release-name")
+	delete(annotations, "meta.helm.sh/release-namespace")
+	for key := range annotations {
+		if strings.Contains(key, "werf.io/") {
+			delete(annotations, key)
+		}
+	}
 
 	return DexClient{
 		ID:              id,

--- a/modules/150-user-authn/hooks/get_dex_client_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds_test.go
@@ -63,10 +63,22 @@ metadata:
     certmanager.k8s.io/certificate-name: test-cert-name
     argocd.argoproj.io/instance: test-instance
     argocd.argoproj.io/secret-type: secret-type
+    app.kubernetes.io/managed-by: Helm
   annotations:
     test-annotation: test-value
     new-annotation: test-new-value
     kubectl.kubernetes.io/last-applied-configuration: should-be-removed
+    meta.helm.sh/release-name: opendistro
+    meta.helm.sh/release-namespace: test
+    ci.werf.io/commit: 90we4affe93154c1200cd3db0f5ee3085c31def6
+    ci.werf.io/tag: v1
+    gitlab.ci.werf.io/job-url: https://gitlab.example.com/job-url
+    gitlab.ci.werf.io/pipeline-url: https://gitlab.example.com/pipeline-url
+    project.werf.io/env: test
+    project.werf.io/git: https://gitlab.example.com/
+    project.werf.io/name: opendistro
+    werf.io/release-channel: 1 alpha
+    werf.io/version: v1
 spec:
   redirectURIs:
   - https://opendistro.example.com/callback
@@ -213,10 +225,22 @@ metadata:
     certmanager.k8s.io/certificate-name: test-cert-name
     argocd.argoproj.io/instance: test-instance
     argocd.argoproj.io/secret-type: secret-type
+    app.kubernetes.io/managed-by: Helm
   annotations:
     test-annotation: test-value
     new-annotation: test-new-value
     kubectl.kubernetes.io/last-applied-configuration: should-be-removed
+    meta.helm.sh/release-name: opendistro
+    meta.helm.sh/release-namespace: test
+    ci.werf.io/commit: 90we4affe93154c1200cd3db0f5ee3085c31def6
+    ci.werf.io/tag: v1
+    gitlab.ci.werf.io/job-url: https://gitlab.example.com/job-url
+    gitlab.ci.werf.io/pipeline-url: https://gitlab.example.com/pipeline-url
+    project.werf.io/env: test
+    project.werf.io/git: https://gitlab.example.com/
+    project.werf.io/name: opendistro
+    werf.io/release-channel: 1 alpha
+    werf.io/version: v1
 spec:
   redirectURIs:
   - https://opendistro.example.com/callback


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Some additionals labels and annotations for exlude in [PR](https://github.com/deckhouse/deckhouse/pull/10536)
helm/werf.io exclude for transfer to secrets
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: feature
summary: helm/werf.io labels exclude for transfer to secrets
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
