### PR TITLE
[operator-prometheus] Fix backup label value

### DIFF
--- a/modules/200-operator-prometheus/crds/podmonitors.yaml
+++ b/modules/200-operator-prometheus/crds/podmonitors.yaml
@@ -6,7 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   labels:
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
   name: podmonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/modules/200-operator-prometheus/crds/probes.yaml
+++ b/modules/200-operator-prometheus/crds/probes.yaml
@@ -6,7 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   labels:
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
   name: probes.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/modules/200-operator-prometheus/crds/prometheusrules.yaml
+++ b/modules/200-operator-prometheus/crds/prometheusrules.yaml
@@ -6,7 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   labels:
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
   name: prometheusrules.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/modules/200-operator-prometheus/crds/scrapeconfigs.yaml
+++ b/modules/200-operator-prometheus/crds/scrapeconfigs.yaml
@@ -6,7 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   labels:
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
   name: scrapeconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/modules/200-operator-prometheus/crds/servicemonitors.yaml
+++ b/modules/200-operator-prometheus/crds/servicemonitors.yaml
@@ -6,7 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   labels:
-    backup.deckhouse.io/cluster-config: ""
+    backup.deckhouse.io/cluster-config: "true"
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com


### PR DESCRIPTION
## Description
Fix value for label introduced in #10298 

## What is the expected result?
`d8 backup cluster-config` command backups all CRs for these CRDs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->
```changes
section: operator-prometheus
type: feature
summary: Fixed `backup.deckhouse.io/cluster-config` value.
impact_level: default
```
<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
