### PR TITLE
[candi] del quotes for primary_mac value in bootstrap-network

### DIFF
--- a/candi/cloud-providers/yandex/bashible/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/yandex/bashible/bootstrap-networks.sh.tpl
@@ -52,7 +52,7 @@ function netplan_configure(){
     exit 1
   fi
 
-  primary_mac="$(grep -m 1 -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml || test $? = 1;)"
+  primary_mac="$(grep -m 1 -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml | sed 's/"//g' || test $? = 1;)"
 
   if [ -z "$primary_mac" ]; then
     primary_ifname=$(grep -Po '(ens|eth|eno|enp)[0-9]+(?=:)' /etc/netplan/50-cloud-init.yaml | head -n1)

--- a/ee/candi/cloud-providers/openstack/bashible/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/openstack/bashible/bootstrap-networks.sh.tpl
@@ -25,7 +25,7 @@ function netplan_configure(){
   count_default_routes=$(ip -4 route show default | wc -l)
   if [[ "$count_default_routes" -gt "1" ]]; then
     CLOUD_INIT_NETPLAN_CFG="/etc/netplan/50-cloud-init.yaml"
-    configured_macs="$(grep -Po '(?<=macaddress: ).+' $CLOUD_INIT_NETPLAN_CFG || test $? = 1;)"
+    configured_macs="$(grep -Po '(?<=macaddress: ).+' $CLOUD_INIT_NETPLAN_CFG | sed 's/"//g' || test $? = 1;)"
     for configured_mac in $configured_macs; do
       ifname="$( (ip -o link show | grep "link/ether $configured_mac" | cut -d ":" -f2 | tr -d " ") || test $? = 1;)"
       if [[ "$ifname" != "" ]]; then

--- a/ee/candi/cloud-providers/vcd/bashible/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/vcd/bashible/bootstrap-networks.sh.tpl
@@ -6,7 +6,7 @@
 shopt -s extglob
 
 function netplan_configure(){
-  primary_mac="$(grep -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml || test $? = 1;)"
+  primary_mac="$(grep -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml | sed 's/"//g' || test $? = 1;)"
 
   if [ -z "$primary_mac" ]; then
     primary_ifname=$(grep -Po '(ens|eth|eno|enp)[0-9]+(?=:)' /etc/netplan/50-cloud-init.yaml | head -n1)

--- a/ee/candi/cloud-providers/vsphere/bashible/bootstrap-networks.sh.tpl
+++ b/ee/candi/cloud-providers/vsphere/bashible/bootstrap-networks.sh.tpl
@@ -6,7 +6,7 @@
 shopt -s extglob
 
 function netplan_configure(){
-  primary_mac="$(grep -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml || test $? = 1;)"
+  primary_mac="$(grep -Po '(?<=macaddress: ).+' /etc/netplan/50-cloud-init.yaml | sed 's/"//g' || test $? = 1;)"
 
   if [ -z "$primary_mac" ]; then
     primary_ifname=$(grep -Po '(ens|eth|eno|enp)[0-9]+(?=:)' /etc/netplan/50-cloud-init.yaml | head -n1)


### PR DESCRIPTION
## Description

Delete quotes for `primary_mac` value in bootstrap-network.  

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Sometimes `primary_mac` value in `50-cloud-init.yaml` is wrapped in quotes, sometimes not.  This is a problem for correct execution bootstrap-network script.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

This problem can affect the addition of new nodes to the cluster.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?

Correct execution of bootstrap-network script.

<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Delete quotes for `primary_mac` value in bootstrap-network script.  
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
