### PR TITLE
[testing] defaulting for CRs

### DIFF
--- a/modules/040-node-manager/hooks/create_master_node_group_test.go
+++ b/modules/040-node-manager/hooks/create_master_node_group_test.go
@@ -70,6 +70,11 @@ spec:
     labels:
       node.deckhouse.io/group: worker-big
   nodeType: CloudEphemeral
+  kubelet:
+    containerLogMaxFiles: 4
+    containerLogMaxSize: 50Mi
+    resourceReservation:
+      mode: Auto
 `
 		masterNgNoneDefault = `
 apiVersion: deckhouse.io/v1
@@ -87,6 +92,11 @@ spec:
       node-role.kubernetes.io/master: ""
       node-role.kubernetes.io/control-plane: ""
   nodeType: CloudStatic
+  kubelet:
+    containerLogMaxFiles: 4
+    containerLogMaxSize: 50Mi
+    resourceReservation:
+      mode: Auto
 `
 	)
 
@@ -98,7 +108,7 @@ spec:
 
 	for _, clType := range []string{"Cloud", "Static"} {
 		clusterType := clType
-		Context(fmt.Sprintf("%s cluster", clType), func() {
+		Context(fmt.Sprintf("%s cluster", clusterType), func() {
 			masterNgUnstructured, err := getDefaultMasterNg(clusterType)
 			if err != nil {
 				panic(err)
@@ -109,8 +119,13 @@ spec:
 				panic(err)
 			}
 
-			var masterNgDefaultYAML = string(masterNgDefaultYAMLBBytes)
-
+			// TODO(miklezzzz): fix master ng template
+			var masterNgDefaultYAML = string(masterNgDefaultYAMLBBytes) +
+				`  kubelet:
+    containerLogMaxFiles: 4
+    containerLogMaxSize: 50Mi
+    resourceReservation:
+      mode: Auto`
 			assertDefaultMasterNodeGroupOnlyPresent := func(f *HookExecutionConfig) {
 				masterNg := f.KubernetesResource("NodeGroup", "", "master")
 				Expect(masterNg.ToYaml()).To(MatchYAML(masterNgDefaultYAML))

--- a/modules/040-node-manager/hooks/get_crds_test.go
+++ b/modules/040-node-manager/hooks/get_crds_test.go
@@ -401,6 +401,14 @@ metadata:
 				      "zones": []
 				    },
                     "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.27",
 					"cri": {
@@ -422,6 +430,14 @@ metadata:
 				      ]
 				    },
                     "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.27",
 					"cri": {
@@ -471,6 +487,14 @@ metadata:
                       "type": "Containerd"
                     },
 					"manualRolloutID": "",
+		   "kubelet": {
+			"containerLogMaxSize": "50Mi",
+			"containerLogMaxFiles": 4,
+			"resourceReservation": {
+				"mode": "Auto"
+			},
+			"topologyManager": {}
+		    },
                     "name": "cp1",
                     "nodeType": "CloudPermanent",
                     "updateEpoch": "` + calculateEpoch("cp1", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
@@ -489,6 +513,14 @@ metadata:
 				      ]
 				    },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.27",
 					"cri": {
@@ -510,6 +542,14 @@ metadata:
 				      ]
 				    },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.27",
 					"cri": {
@@ -524,6 +564,14 @@ metadata:
                       "type": "Containerd"
                     },
                     "manualRolloutID": "",
+		   "kubelet": {
+			"containerLogMaxSize": "50Mi",
+			"containerLogMaxFiles": 4,
+			"resourceReservation": {
+				"mode": "Auto"
+			},
+			"topologyManager": {}
+		    },
                     "name": "static1",
                     "nodeType": "Static",
                     "updateEpoch": "` + calculateEpoch("static1", f.ValuesGet("global.discovery.clusterUUID").String()) + `",
@@ -561,6 +609,14 @@ metadata:
 					"cri": {
                       "type": "Containerd"
                     },
+		    "kubelet": {
+			"containerLogMaxSize": "50Mi",
+			"containerLogMaxFiles": 4,
+			"resourceReservation": {
+				"mode": "Auto"
+			},
+			"topologyManager": {}
+		    },
                     "manualRolloutID": "",
                     "name": "cp1",
                     "nodeType": "CloudPermanent",
@@ -580,6 +636,14 @@ metadata:
 				      ]
 				    },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.27",
 					"cri": {
@@ -601,6 +665,14 @@ metadata:
 				      ]
 				    },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.27",
 					"cri": {
@@ -614,6 +686,14 @@ metadata:
 					"cri": {
                       "type": "Containerd"
                     },
+		    "kubelet": {
+			"containerLogMaxSize": "50Mi",
+			"containerLogMaxFiles": 4,
+			"resourceReservation": {
+				"mode": "Auto"
+			},
+			"topologyManager": {}
+		    },
                     "manualRolloutID": "",
                     "name": "static1",
                     "nodeType": "Static",
@@ -659,6 +739,14 @@ metadata:
 				      ]
 				    },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.27",
 					"cri": {
@@ -680,6 +768,14 @@ metadata:
 				      ]
 				    },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.27",
 					"cri": {
@@ -732,6 +828,14 @@ metadata:
                       "type": "Containerd"
                     },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
                     "updateEpoch": "` + calculateEpoch("proper1", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  },
 				  {
@@ -753,6 +857,14 @@ metadata:
                       "type": "Containerd"
                     },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
                     "updateEpoch": "` + calculateEpoch("proper2", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  }
 				]
@@ -817,6 +929,14 @@ metadata:
                       "type": "Containerd"
                     },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
                     "updateEpoch": "` + calculateEpoch("proper1", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  },
 				  {
@@ -838,6 +958,14 @@ metadata:
                       "type": "Containerd"
                     },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
                     "updateEpoch": "` + calculateEpoch("proper2", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  }
 				]
@@ -887,6 +1015,14 @@ metadata:
                       "type": "Containerd"
                     },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
                     "updateEpoch": "` + calculateEpoch("proper1", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  },
 				  {
@@ -908,6 +1044,14 @@ metadata:
                       "type": "Containerd"
                     },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
                     "updateEpoch": "` + calculateEpoch("proper2", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  }
 				]
@@ -957,6 +1101,14 @@ metadata:
                       "type": "Containerd"
                     },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
                     "updateEpoch": "` + calculateEpoch("proper1", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  },
 				  {
@@ -978,6 +1130,14 @@ metadata:
                       "type": "Containerd"
                     },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
                     "updateEpoch": "` + calculateEpoch("proper2", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  }
 				]
@@ -1042,6 +1202,14 @@ metadata:
                       "type": "Containerd"
                     },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
                     "updateEpoch": "` + calculateEpoch("proper1", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  },
 				  {
@@ -1063,6 +1231,14 @@ metadata:
                       "type": "Containerd"
                     },
 				    "instanceClass": null,
+				    "kubelet": {
+					"containerLogMaxSize": "50Mi",
+					"containerLogMaxFiles": 4,
+					"resourceReservation": {
+						"mode": "Auto"
+					},
+					"topologyManager": {}
+				    },
                     "updateEpoch": "` + calculateEpoch("proper2", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  }
 				]

--- a/modules/140-user-authz/hooks/handle_authorization_rules_test.go
+++ b/modules/140-user-authz/hooks/handle_authorization_rules_test.go
@@ -74,7 +74,7 @@ var _ = Describe("User Authz hooks :: handle authorization rules ::", func() {
 
 		It("ARs must be stored in values", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("userAuthz.internal.authRuleCrds").String()).To(MatchJSON(`[{"name":"ar0","namespace":"test","spec":{"accessLevel":"User", "subjects":[{"kind":"Group", "name":"NotEveryone"}]}},{"name":"ar1","namespace":"test","spec":{"accessLevel":"Admin", "subjects":[{"kind":"Group", "name":"Everyone"}]}}]`))
+			Expect(f.ValuesGet("userAuthz.internal.authRuleCrds").String()).To(MatchJSON(`[{"name":"ar0","namespace":"test","spec":{"accessLevel":"User", "allowScale": false, "portForwarding": false, "subjects":[{"kind":"Group", "name":"NotEveryone"}]}},{"name":"ar1","namespace":"test","spec":{"accessLevel":"Admin", "allowScale": false, "portForwarding": false, "subjects":[{"kind":"Group", "name":"Everyone"}]}}]`))
 		})
 	})
 })

--- a/modules/140-user-authz/hooks/handle_cluster_authorization_rules_test.go
+++ b/modules/140-user-authz/hooks/handle_cluster_authorization_rules_test.go
@@ -72,7 +72,7 @@ var _ = Describe("User Authz hooks :: handle cluster authorization rules ::", fu
 
 		It("CARs must be stored in values", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("userAuthz.internal.clusterAuthRuleCrds").String()).To(MatchJSON(`[{"name":"car0","spec":{"accessLevel":"ClusterEditor", "subjects":[{"kind":"Group", "name":"NotEveryone"}]}},{"name":"car1","spec":{"accessLevel":"ClusterAdmin", "subjects":[{"kind":"Group", "name":"Everyone"}]}}]`))
+			Expect(f.ValuesGet("userAuthz.internal.clusterAuthRuleCrds").String()).To(MatchJSON(`[{"name":"car0","spec":{"accessLevel":"ClusterEditor", "allowScale": false, "portForwarding": false, "subjects":[{"kind":"Group", "name":"NotEveryone"}]}},{"name":"car1","spec":{"accessLevel":"ClusterAdmin", "allowScale": false, "portForwarding": false, "subjects":[{"kind":"Group", "name":"Everyone"}]}}]`))
 		})
 	})
 })

--- a/modules/150-user-authn/hooks/get_dex_providers_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_providers_crds_test.go
@@ -88,17 +88,18 @@ spec:
 
 				Expect(f.ValuesGet("userAuthn.internal.providers").String()).To(MatchJSON(`
 [{
-  "type": "BitbucketCloud",
-  "displayName": "bitbucket",
   "bitbucketCloud": {
     "clientID": "plainstring",
     "clientSecret": "plainstring",
+    "includeTeamGroups": false,
     "teams": [
       "only",
       "team"
     ]
   },
-  "id": "bitbucket"
+  "displayName": "bitbucket",
+  "id": "bitbucket",
+  "type": "BitbucketCloud"
 }]`))
 			})
 
@@ -124,34 +125,42 @@ spec:
 					Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
 
 					Expect(f.ValuesGet("userAuthn.internal.providers").String()).To(MatchUnorderedJSON(`
-[{
-  "type": "OIDC",
-  "displayName": "google",
-  "oidc": {
-    "basicAuthUnsupported": true,
-    "clientID": "plainstring",
-    "clientSecret": "plainstring",
-    "getUserInfo": true,
-    "insecureSkipEmailVerified": true,
-    "issuer": "https://issue.example.com",
-    "scopes": [
-      "profile",
-      "email"
-    ]
-  },
-  "id": "oidc-notslu-gif-ed"
-}, {
-  "type": "BitbucketCloud",
-  "displayName": "bitbucket",
+[
+{
   "bitbucketCloud": {
     "clientID": "plainstring",
     "clientSecret": "plainstring",
+    "includeTeamGroups": false,
     "teams": [
       "only",
       "team"
     ]
   },
-  "id": "bitbucket"
+  "displayName": "bitbucket",
+  "id": "bitbucket",
+  "type": "BitbucketCloud"
+},
+{
+  "displayName": "google",
+  "id": "oidc-notslu-gif-ed",
+  "oidc": {
+    "basicAuthUnsupported": true,
+    "claimMappingOverride": false,
+    "clientID": "plainstring",
+    "clientSecret": "plainstring",
+    "getUserInfo": true,
+    "insecureSkipEmailVerified": true,
+    "insecureSkipVerify": false,
+    "issuer": "https://issue.example.com",
+    "promptType": "consent",
+    "scopes": [
+      "profile",
+      "email"
+    ],
+    "userIDKey": "sub",
+    "userNameKey": "name"
+  },
+  "type": "OIDC"
 }]`))
 				})
 			})
@@ -169,17 +178,18 @@ spec:
 
 			Expect(f.ValuesGet("userAuthn.internal.providers").String()).To(MatchJSON(`
 [{
-  "type": "BitbucketCloud",
-  "displayName": "bitbucket",
-  "bitbucketCloud": {
-    "clientID": "plainstring",
-    "clientSecret": "plainstring",
-    "teams": [
-      "only",
-      "team"
-    ]
-  },
-  "id": "bitbucket"
+"bitbucketCloud": {
+  "clientID": "plainstring",
+  "clientSecret": "plainstring",
+  "includeTeamGroups": false,
+  "teams": [
+    "only",
+    "team"
+  ]
+},
+"displayName": "bitbucket",
+"id": "bitbucket",
+"type": "BitbucketCloud"
 }]`))
 		})
 	})

--- a/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
+++ b/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
@@ -63,13 +63,28 @@ spec:
 				Expect(f.ValuesGet("ingressNginx.internal.ingressControllers").String()).To(MatchJSON(`[{
 "name": "test",
 "spec": {
+  "acceptRequestsFrom": [
+    "127.0.0.1/32",
+    "192.168.0.0/24"
+  ],
+  "annotationValidationEnabled": false,
+  "chaosMonkey": false,
   "config": {},
-  "ingressClass": "nginx",
   "controllerVersion": "1.9",
+  "disableHTTP2": false,
+  "enableHTTP3": false,
+  "geoIP2": {},
+  "hostPort": {},
+  "hostPortWithProxyProtocol": {},
+  "hostWithFailover": {},
+  "hsts": false,
+  "hstsOptions": {},
+  "ingressClass": "nginx",
   "inlet": "LoadBalancer",
   "loadBalancer": {},
-  "hstsOptions": {},
-  "geoIP2": {},
+  "loadBalancerWithProxyProtocol": {},
+  "maxReplicas": 1,
+  "minReplicas": 1,
   "resourcesRequests": {
     "mode": "VPA",
     "static": {},
@@ -78,14 +93,8 @@ spec:
       "memory": {}
     }
   },
-  "hostPortWithProxyProtocol": {},
-  "hostPort": {},
-  "hostWithFailover": {},
-  "loadBalancerWithProxyProtocol": {},
-  "acceptRequestsFrom": [
-    "127.0.0.1/32",
-    "192.168.0.0/24"
-  ]
+  "underscoresInHeaders": false,
+  "validationEnabled": true
 }
 }]`))
 			})
@@ -166,59 +175,105 @@ spec:
 
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers.0.name").String()).To(Equal("test"))
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers.0.spec").String()).To(MatchJSON(`{
+"annotationValidationEnabled": false,
+"chaosMonkey": false,
 "config": {},
+"disableHTTP2": false,
+"enableHTTP3": false,
+"geoIP2": {},
+"hostPort": {},
+"hostPortWithProxyProtocol": {},
+"hostWithFailover": {},
+"hsts": false,
+"hstsOptions": {},
 "ingressClass": "nginx",
 "inlet": "LoadBalancer",
-"hstsOptions": {},
-"geoIP2": {},
+"loadBalancer": {},
+"loadBalancerWithProxyProtocol": {},
+"maxReplicas": 1,
+"minReplicas": 1,
 "resourcesRequests": {
   "mode": "Static",
   "static": {},
-  "vpa": {"cpu": {}, "memory": {}}
+  "vpa": {
+    "cpu": {},
+    "memory": {}
+  }
 },
-"loadBalancer": {},
-"loadBalancerWithProxyProtocol": {},
-"hostPortWithProxyProtocol": {},
-"hostWithFailover": {},
-"hostPort": {}
+"underscoresInHeaders": false,
+"validationEnabled": true
 }`))
 
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers.1.name").String()).To(Equal("test-2"))
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers.1.spec").String()).To(MatchJSON(`{
+"annotationValidationEnabled": false,
+"chaosMonkey": false,
 "config": {},
+"disableHTTP2": false,
+"enableHTTP3": false,
+"geoIP2": {},
+"hostPort": {},
+"hostPortWithProxyProtocol": {
+  "httpPort": 80,
+  "httpsPort": 443
+},
+"hostWithFailover": {},
+"hsts": false,
+"hstsOptions": {},
 "ingressClass": "test",
 "inlet": "HostPortWithProxyProtocol",
-"hstsOptions": {},
-"geoIP2": {},
+"loadBalancer": {},
+"loadBalancerWithProxyProtocol": {},
+"maxReplicas": 1,
+"minReplicas": 1,
 "resourcesRequests": {
   "mode": "VPA",
   "static": {},
-  "vpa": {"cpu": {"max": "100m"}, "memory": {"max": "200Mi"}, "mode": "Auto"}
+  "vpa": {
+    "cpu": {
+      "max": "100m",
+      "min": "10m"
+    },
+    "memory": {
+      "max": "200Mi",
+      "min": "50Mi"
+    },
+    "mode": "Auto"
+  }
 },
-"loadBalancer": {},
-"loadBalancerWithProxyProtocol": {},
-"hostPortWithProxyProtocol": {"httpPort": 80, "httpsPort": 443},
-"hostWithFailover": {},
-"hostPort": {}
+"underscoresInHeaders": false,
+"validationEnabled": true
 }`))
 
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers.2.name").String()).To(Equal("test-3"))
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers.2.spec").String()).To(MatchJSON(`{
+"annotationValidationEnabled": false,
+"chaosMonkey": false,
 "config": {},
+"disableHTTP2": false,
+"enableHTTP3": false,
+"geoIP2": {},
+"hostPort": {},
+"hostPortWithProxyProtocol": {},
+"hostWithFailover": {},
+"hsts": false,
+"hstsOptions": {},
 "ingressClass": "test",
 "inlet": "LoadBalancerWithProxyProtocol",
-"hstsOptions": {},
-"geoIP2": {},
+"loadBalancer": {},
+"loadBalancerWithProxyProtocol": {},
+"maxReplicas": 1,
+"minReplicas": 1,
 "resourcesRequests": {
   "mode": "VPA",
   "static": {},
-  "vpa": {"cpu": {}, "memory": {}}
+  "vpa": {
+    "cpu": {},
+    "memory": {}
+  }
 },
-"loadBalancer": {},
-"loadBalancerWithProxyProtocol": {},
-"hostPortWithProxyProtocol": {},
-"hostWithFailover": {},
-"hostPort": {}
+"underscoresInHeaders": false,
+"validationEnabled": true
 }`))
 		})
 	})

--- a/testing/hooks/init.go
+++ b/testing/hooks/init.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/models/hooks"
 	"github.com/flant/addon-operator/pkg/module_manager/models/hooks/kind"
 	addonutils "github.com/flant/addon-operator/pkg/utils"
+	"github.com/flant/addon-operator/pkg/values/validation"
 	"github.com/flant/addon-operator/sdk"
 	klient "github.com/flant/kube-client/client"
 	"github.com/flant/kube-client/fake"
@@ -42,13 +44,19 @@ import (
 	"github.com/flant/shell-operator/pkg/metric_storage/operation"
 	utils "github.com/flant/shell-operator/pkg/utils/file"
 	hookcontext "github.com/flant/shell-operator/test/hook/context"
+	"github.com/go-openapi/spec"
+	"github.com/go-openapi/swag"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sdynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/testing"
+	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
@@ -126,6 +134,24 @@ type ShellOperatorHookConfig struct {
 	Schedule      interface{} `json:"schedule,omitempty"`
 }
 
+type crdDoc struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Spec       struct {
+		Names struct {
+			Kind string `yaml:"kind"`
+		} `yaml:"names"`
+		Versions []struct {
+			Name   string `yaml:"name"`
+			Schema struct {
+				OpenAPIV3Schema struct {
+					Properties interface{} `yaml:"properties"`
+				} `yaml:"openAPIV3Schema"`
+			} `yaml:"schema"`
+		} `yaml:"versions"`
+	} `yaml:"spec"`
+}
+
 type CustomCRD struct {
 	Group      string
 	Version    string
@@ -145,6 +171,7 @@ type HookExecutionConfig struct {
 	configValues             *values_store.ValuesStore
 	hookConfig               string // <hook> --config output
 	KubeExtraCRDs            []CustomCRD
+	CRDSchemas               map[string]map[string]*spec.Schema
 	IsKubeStateInited        bool
 	BindingContexts          BindingContextsSlice
 	BindingContextController *hookcontext.BindingContextController
@@ -290,6 +317,10 @@ func HookExecutionConfigInit(initValues, initConfigValues string, k8sVersion ...
 	}
 
 	hec.KubeExtraCRDs = []CustomCRD{}
+	hec.CRDSchemas, err = hec.prepareCRDSchemas()
+	if err != nil {
+		panic(fmt.Errorf("failed to prepare CRD schemas: %v", err))
+	}
 
 	BeforeEach(func() {
 		defaultConfigValues := addonutils.Values{
@@ -368,14 +399,144 @@ func (hec *HookExecutionConfig) KubeStateSetAndWaitForBindingContexts(newKubeSta
 	return hec.KubeStateSet(newKubeState)
 }
 
+func (hec *HookExecutionConfig) prepareCRDSchemas() (map[string]map[string]*spec.Schema, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	crdPath, err := filepath.Abs(cwd + "/../crds/")
+	if err != nil {
+		return nil, err
+	}
+
+	crdFilesPaths := make([]string, 0)
+	err = filepath.Walk(
+		crdPath,
+		func(path string, _ os.FileInfo, err error) error {
+			if err != nil && !os.IsNotExist(err) {
+				return err
+			}
+
+			if filepath.Ext(path) == ".yaml" && !strings.HasPrefix(filepath.Base(path), "doc-ru-") {
+				crdFilesPaths = append(crdFilesPaths, path)
+			}
+
+			return nil
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	schemas := make(map[string]map[string]*spec.Schema, 0)
+	manifestDelimiter := regexp.MustCompile("(?m)^---$")
+
+	// range over files
+	for _, crdFile := range crdFilesPaths {
+		bytes, err := os.ReadFile(crdFile)
+		if err != nil {
+			return nil, err
+		}
+		yamlDocs := manifestDelimiter.Split(string(bytes), -1)
+
+		// range over yaml docs
+		for _, doc := range yamlDocs {
+			crd := new(crdDoc)
+			err := yaml.Unmarshal([]byte(doc), crd)
+			if err != nil {
+				return nil, fmt.Errorf("yaml unmarashal: %w", err)
+			}
+
+			if crd.Kind != "CustomResourceDefinition" || crd.APIVersion != "apiextensions.k8s.io/v1" {
+				continue
+			}
+
+			// range over cr versions
+			for _, version := range crd.Spec.Versions {
+				if _, ok := schemas[crd.Spec.Names.Kind]; !ok {
+					schemas[crd.Spec.Names.Kind] = make(map[string]*spec.Schema, 0)
+				}
+
+				rawJSON, err := swag.YAMLToJSON(version.Schema.OpenAPIV3Schema)
+				if err != nil {
+					return nil, fmt.Errorf("yaml to json: %w", err)
+				}
+
+				s := new(spec.Schema)
+				if err := json.Unmarshal(rawJSON, s); err != nil {
+					return nil, fmt.Errorf("json unmarshal: %v", err)
+				}
+
+				err = spec.ExpandSchema(s, s, nil)
+				if err != nil {
+					return nil, fmt.Errorf("expand schema: %v", err)
+				}
+
+				schemas[crd.Spec.Names.Kind][version.Name] = s
+			}
+		}
+	}
+
+	return schemas, nil
+}
+
+func (hec *HookExecutionConfig) applyDefaults(newKubeState string) (string, error) {
+	yamls, err := kio.FromBytes([]byte(newKubeState))
+	if err != nil {
+		return "", err
+	}
+
+	defaultedKubeState := new(strings.Builder)
+
+	for _, yamlDoc := range yamls {
+		defaulted := false
+		// defaulting
+		if versions, ok := hec.CRDSchemas[yamlDoc.GetKind()]; ok {
+			split := strings.Split(yamlDoc.GetApiVersion(), "/")
+			version := split[len(split)-1]
+			if sc, ok := versions[version]; ok {
+				doc, err := yamlDoc.Map()
+				if err != nil {
+					return "", err
+				}
+				if defaulted = validation.ApplyDefaults(doc, sc); defaulted {
+					defaultedDoc, err := yaml.Marshal(doc)
+					if err != nil {
+						return "", err
+					}
+					defaultedKubeState.WriteString("---\n" + string(defaultedDoc))
+				}
+			}
+		}
+		if !defaulted {
+			originalDoc, err := yamlDoc.String()
+			if err != nil {
+				return "", err
+			}
+			defaultedKubeState.WriteString("---\n" + originalDoc)
+		}
+	}
+
+	return defaultedKubeState.String(), nil
+}
+
 func (hec *HookExecutionConfig) KubeStateSet(newKubeState string) hookcontext.GeneratedBindingContexts {
-	var contexts hookcontext.GeneratedBindingContexts
-	var err error
+	var (
+		contexts hookcontext.GeneratedBindingContexts
+		err      error
+	)
+
+	if len(hec.CRDSchemas) > 0 {
+		newKubeStateWithDefaults, err := hec.applyDefaults(newKubeState)
+		if err != nil {
+			fmt.Printf("Warning: failed to apply default values to the kube state: %s\n", err.Error())
+		} else {
+			newKubeState = newKubeStateWithDefaults
+		}
+	}
+
 	if !hec.IsKubeStateInited {
 		hec.BindingContextController = hookcontext.NewBindingContextController(hec.hookConfig, hec.logger, hec.fakeClusterVersion)
-		if err != nil {
-			panic(err)
-		}
 		hec.fakeCluster = hec.BindingContextController.FakeCluster()
 		hec.fakeCluster.Client.WithServer("fake-test")
 		dependency.TestDC.K8sClient = hec.fakeCluster.Client
@@ -396,6 +557,26 @@ func (hec *HookExecutionConfig) KubeStateSet(newKubeState string) hookcontext.Ge
 		if len(hec.KubeExtraCRDs) > 0 {
 			for _, crd := range hec.KubeExtraCRDs {
 				hec.BindingContextController.RegisterCRD(crd.Group, crd.Version, crd.Kind, crd.Namespaced)
+
+				// defaulting reactor (an entity of fake k8s client, that resembles kind of middleware that is invoked for each defined action) is prepended for each custom resource defined
+				if fc, ok := hec.fakeCluster.Client.Dynamic().(*k8sdynamicfake.FakeDynamicClient); ok {
+					// prepending is required so that the defaulting reactor is executed before the default one
+					fc.PrependReactor("create", hec.fakeCluster.MustFindGVR(fmt.Sprintf("%s/%s", crd.Group, crd.Version), crd.Kind).Resource, func(action testing.Action) (bool, k8sruntime.Object, error) {
+						obj := action.(testing.CreateAction).GetObject()
+						if versions, ok := hec.CRDSchemas[obj.GetObjectKind().GroupVersionKind().Kind]; ok {
+							if sc, ok := versions[obj.GetObjectKind().GroupVersionKind().Version]; ok {
+								unstructuredObj, err := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(obj)
+								if err != nil {
+									panic(err)
+								}
+								// object defaulting
+								validation.ApplyDefaults(unstructuredObj, sc)
+							}
+						}
+						// returns false so as not to stop the ReactionChain (by default, the ReactionChain for each action contains a reactor that implements create/update/patch/etc actions
+						return false, nil, nil
+					})
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description
Provides defaulting for objects created in test environments via `KubeStateSet`/patch collector or kube client.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Closes #10459 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
When an object is defined in a test environment, it's empty fields are filled with default values, in accordance with the object's Custom Resource Definition.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tests
type: chore
summary: Provide defaulting for Custom Resource in test environments.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
