### PR TITLE
[testing] Abandoned the use of yq in one place in the testing script in favor of python

### DIFF
--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -464,14 +464,6 @@ export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 export LANG=C
 set -Eeuo pipefail
 
->&2 echo "Download yq..."
-
-/opt/deckhouse/bin/d8-curl -sSLfk -o /opt/deckhouse/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
-
->&2 echo "chmod yq..."
-
-chmod +x /opt/deckhouse/bin/yq
-
 >&2 echo "Create release file ..."
 
 echo "$release" > /tmp/releaseFile.yaml
@@ -504,7 +496,15 @@ metadata:
 spec:
   version: v1.96.3
   requirements: {}
-' | /opt/deckhouse/bin/yq '. | load("/tmp/releaseFile.yaml") as \$d1 | .spec.requirements=\$d1.requirements' | kubectl apply -f -
+' | python3 -c "
+import yaml, sys
+
+data = yaml.safe_load(sys.stdin)
+with open('/tmp/releaseFile.yaml') as f:
+  d1 = yaml.safe_load(f)
+data['spec']['requirements'] = d1.get('requirements', {})
+print(yaml.dump(data))
+" | kubectl apply -f -
 
 >&2 echo "Remove release file ..."
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -466,7 +466,7 @@ set -Eeuo pipefail
 
 >&2 echo "Download yq..."
 
-/opt/deckhouse/bin/d8-curl -sSLf -o /opt/deckhouse/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+/opt/deckhouse/bin/d8-curl -sSLfk -o /opt/deckhouse/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
 
 >&2 echo "chmod yq..."
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -464,6 +464,19 @@ export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 export LANG=C
 set -Eeuo pipefail
 
+>&2 echo "Check python ..."
+function check_python() {
+  for pybin in python3 python2 python; do
+    if command -v "\$pybin" >/dev/null 2>&1; then
+      python_binary="\$pybin"
+      return 0
+    fi
+  done
+  echo "Python not found, exiting..."
+  return 1
+}
+check_python
+
 >&2 echo "Create release file ..."
 
 echo "$release" > /tmp/releaseFile.yaml
@@ -496,7 +509,7 @@ metadata:
 spec:
   version: v1.96.3
   requirements: {}
-' | python3 -c "
+' | $python_binary -c "
 import yaml, sys
 
 data = yaml.safe_load(sys.stdin)


### PR DESCRIPTION
## Description
Abandoned the use of yq in one place in the testing script in favor of python.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add ignoring certificate validity in tests
## Why do we need it, and what problem does it solve?
Reduced the number of downloadable files for the tests to work.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not related to release
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
e2e upgrade tests passed
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: Abandoned the use of yq in one place in the testing script in favor of python
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
