### PR TITLE
[docs] Removed experimental status of multitenancy-manager module

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -1092,7 +1092,6 @@ entries:
             - title: FAQ
               url: /modules/140-user-authz/faq.html
         - title: Multitenancy
-          featureStatus: experimental
           moduleName: multitenancy-manager
           folders:
             - title:

--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -191,6 +191,5 @@ defaults:
       path: "*/160-multitenancy-manager"
       type: "pages"
     values:
-      featureStatus: experimental
 timezone: Europe/Moscow
 


### PR DESCRIPTION
## Description
Removed experimental status of multitenancy-manager module.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?


## What is the expected result?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Removed experimental status of multitenancy-manager module.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
