### PR TITLE
[ingress-class] Fix ingress class validation rule

### DIFF
--- a/modules/402-ingress-nginx/templates/controller/admission.yaml
+++ b/modules/402-ingress-nginx/templates/controller/admission.yaml
@@ -35,7 +35,7 @@ webhooks:
     {{- if semverCompare ">= 1.27" $kubernetesVersion }}
     matchConditions:
       - name: 'exclude-ingress-class-name'
-        expression: (has(object.spec.ingressClassName) && object.spec.ingressClassName == '{{ $crd.spec.ingressClass }}') || (('kubernetes.io/ingress.class' in object.metadata.annotations) && object.metadata.annotations['kubernetes.io/ingress.class'] == '{{ $crd.spec.ingressClass }}')
+        expression: (has(object.spec.ingressClassName) && object.spec.ingressClassName == '{{ $crd.spec.ingressClass }}') || (has(object.metadata.annotations) && ('kubernetes.io/ingress.class' in object.metadata.annotations) && object.metadata.annotations['kubernetes.io/ingress.class'] == '{{ $crd.spec.ingressClass }}')
     {{- end }}
     failurePolicy: Fail
     sideEffects: None
@@ -70,7 +70,7 @@ webhooks:
     {{- if semverCompare ">= 1.27" $kubernetesVersion }}
     matchConditions:
       - name: 'exclude-ingress-class-name'
-        expression: (has(object.spec.ingressClassName) && object.spec.ingressClassName == '{{ $crd.spec.ingressClass }}') || (('kubernetes.io/ingress.class' in object.metadata.annotations) && object.metadata.annotations['kubernetes.io/ingress.class'] == '{{ $crd.spec.ingressClass }}')
+        expression: (has(object.spec.ingressClassName) && object.spec.ingressClassName == '{{ $crd.spec.ingressClass }}') || (has(object.metadata.annotations) && ('kubernetes.io/ingress.class' in object.metadata.annotations) && object.metadata.annotations['kubernetes.io/ingress.class'] == '{{ $crd.spec.ingressClass }}')
     {{- end }}
     failurePolicy: Ignore
     sideEffects: None

--- a/modules/402-ingress-nginx/templates/validation.yaml
+++ b/modules/402-ingress-nginx/templates/validation.yaml
@@ -22,7 +22,7 @@ spec:
     - expression: '!(has(object.spec.{{ $spec }} ) && object.spec.inlet != "{{ $inlet }}" )'
       reason: Forbidden
 {{- if semverCompare ">= 1.27" $kubernetesVersion }}
-      messageExpression: '''parameters "spec.{{ $spec }}" avalible only for inlet "{{ $inlet }}"'''
+      messageExpression: '''parameters "spec.{{ $spec }}" available only for inlet "{{ $inlet }}"'''
 {{- end }}
 {{- end }}
 ---


### PR DESCRIPTION
## Description
Fix validation rule

## Why do we need it, and what problem does it solve?
For multiply controllers we can have an error during the Ingress creation if we use `kubectl create` because it does not fille the `metadata.annotations` field with an empty object

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
```test-ingress.yaml
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test-spec
spec:
  ingressClassName: nginx
  rules:
  - host: test-spec.apps.lmru.tech
    http:
      paths:
      - backend:
          service:
            name: documentation
            port:
              name: http
        path: /
        pathType: ImplementationSpecific
```

```shell
# kubectl -n default create -f test-ingress.yaml
ingress.networking.k8s.io/test-spec created
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Fix ingress validation rule for multiply ingress-controllers.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
