### PR TITLE
[operator-trivy] fix description for `insecureDbRegistry` and   `insecureRegistries`

### DIFF
--- a/ee/modules/500-operator-trivy/openapi/config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/config-values.yaml
@@ -5,22 +5,19 @@ properties:
     x-examples: [ "ceph-ssd", "false" ]
     description: |-
       The name of StorageClass that will be used in the cluster by default.
-      
+
       If the value is not specified, the StorageClass will be used according to the [global storageClass parameter](../../deckhouse-configure-global.html#parameters-storageclass) setting.
-      
+
       The global `storageClass` parameter is only considered when the module is enabled. Changing the global `storageClass` parameter while the module is enabled will not trigger disk re-provisioning.
-      
+
       **Warning.** Specifying a value different from the one currently used (in the existing PVC) will result in disk re-provisioning and all data will be deleted.
-      
+
       If `false` is specified, `emptyDir` will be forced to be used.
   insecureDbRegistry:
     type: boolean
     default: false
     description: |
       Allows Trivy to download vulnerability databases using insecure HTTPS connections (not passed TLS certificate verification) or HTTP connections.
-
-      The list of addresses to which such connections are allowed must be specified in the [insecureRegistries](#parameters-insecureregistries) parameter.
-
     x-doc-default: false
     x-examples: [true, false]
   additionalVulnerabilityReportFields:
@@ -116,8 +113,6 @@ properties:
     type: array
     description: |
       List of container registry addresses to which insecure HTTPS connections (not passed TLS certificate verification) or HTTP connections are allowed.
-
-      > The parameter [insecureDbRegistry](#parameters-insecuredbregistry) must be enabled.
     x-examples:
     -
       - my.registry.com

--- a/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
@@ -16,8 +16,6 @@ properties:
     description: |
       Разрешает Trivy скачивать базы данных уязвимостей используя недоверенные HTTPS-подключения (не прошедшие проверку TLS-сертификата) или подключения по HTTP.
 
-      Список адресов, к которым разрешены такие подключения, необходимо указать в параметре [insecureRegistries](#parameters-insecureregistries).
-
   additionalVulnerabilityReportFields:
     description: |
       Список дополнительных полей из базы уязвимостей, добавляемых к отчетам об уязвимостях (VulnerabilityReport).
@@ -54,5 +52,3 @@ properties:
   insecureRegistries:
     description: |
       Список адресов хранилищ образов контейнеров (container registry), к которым разрешены недоверенные HTTPS-подключения (не прошедшие проверку TLS-сертификата) и подключения по HTTP.
-
-      > Для работы необходимо включение параметра [insecureDbRegistry](#parameters-insecuredbregistry).


### PR DESCRIPTION
## Description
Fix description for  `insecureDbRegistry` and   `insecureRegistries` of the operator-trivy module.

Ref: https://github.com/deckhouse/deckhouse/pull/10559

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix description for  `insecureDbRegistry` and   `insecureRegistries` of the operator-trivy module.
impact_level: low
```
