### PR TITLE
[dhctl] fix data race in local NodeInterface command executor

### DIFF
--- a/dhctl/pkg/system/node/local/command.go
+++ b/dhctl/pkg/system/node/local/command.go
@@ -66,17 +66,16 @@ func (c *Command) Run() error {
 	wg := &sync.WaitGroup{}
 	stdoutBuf := &bytes.Buffer{}
 	stderrBuf := &bytes.Buffer{}
-
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("stdout pipe failed: %v", err)
 	}
-	go c.scanLines(stdout, stdoutBuf, wg, c.stdoutLineHandler)
-
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		return fmt.Errorf("stderr pipe failed: %v", err)
 	}
+	wg.Add(2)
+	go c.scanLines(stdout, stdoutBuf, wg, c.stdoutLineHandler)
 	go c.scanLines(stderr, stderrBuf, wg, c.stderrLineHandler)
 
 	if err = cmd.Start(); err != nil {
@@ -98,7 +97,6 @@ func (c *Command) scanLines(
 	wg *sync.WaitGroup,
 	handler func(string),
 ) {
-	wg.Add(1)
 	defer wg.Done()
 
 	scan := bufio.NewScanner(stream)

--- a/dhctl/pkg/system/node/local/command_test.go
+++ b/dhctl/pkg/system/node/local/command_test.go
@@ -59,8 +59,6 @@ func TestCommandCombinedOutput(t *testing.T) {
 }
 
 func TestCommandRun(t *testing.T) {
-	t.SkipNow()
-
 	s := require.New(t)
 	testFilePath := filepath.Join(os.TempDir(), "test")
 	tmpFile, err := os.Create(testFilePath)
@@ -80,8 +78,6 @@ func TestCommandRun(t *testing.T) {
 }
 
 func TestCommandPipe(t *testing.T) {
-	t.SkipNow()
-
 	s := require.New(t)
 
 	cmd := NewCommand("bash", "-c", `echo "Goodbye world" | sed "s/Goodbye/Hello/g"`)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed a data race that occured during calls to `*Command.Run()` in local cmd executions. The reason for race has been the `sync.WaitGroup`'s `Wait()` method was called before the `scanLines()` would start in a separate goroutine and call `Add(1)` on that same `WaitGroup`. This resulted in a race between reading stdout buffer and writing into it.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This fixes a bug that could potentially break installation process in standalone mode.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix data race in local NodeInterface command executor
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
