### PR TITLE
[docs][getting started] Add notices for for SpaceVM, Red, and Dynamix

### DIFF
--- a/docs/site/_includes/getting_started/dynamix/STEP_ENV.md
+++ b/docs/site/_includes/getting_started/dynamix/STEP_ENV.md
@@ -1,5 +1,0 @@
-{%- include getting_started/global/partials/NOTICES_ENVIRONMENT.liquid %}
-
-You need to create a service account so that Deckhouse Kubernetes Platform can manage resources in the {{ page.platform_name[page.lang] }}. The detailed instructions for creating a service account are available in the [documentation](/products/kubernetes-platform/documentation/v1/modules/030-cloud-provider-openstack/environment.html).
-
-Create the service account and download openrc file. The data from the openrc file will be required further to fill in the `provider` section in the Deckhouse Kubernetes Platform configuration.

--- a/docs/site/_includes/getting_started/dynamix/STEP_ENV_RU.md
+++ b/docs/site/_includes/getting_started/dynamix/STEP_ENV_RU.md
@@ -1,3 +1,4 @@
+{%- include getting_started/global/partials/NOTICES.liquid %}
 {%- include getting_started/global/partials/NOTICES_ENVIRONMENT.liquid %}
 
 ## Выбор образа ВМ

--- a/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
+++ b/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
@@ -1,4 +1,14 @@
 {%- if page.lang == "ru" %}
+{%- if page.platform_code == "spacevm" or  page.platform_code == "red" %}
+{%- alert level="warning" %}
+Доступно начиная с версии 1.65 Deckhouse Kubernetes Platform.
+{% endalert %}
+{%- endif %}
+{%- if page.platform_code == "dynamix" %}
+{%- alert level="warning" %}
+Доступно начиная с версии 1.66 Deckhouse Kubernetes Platform.
+{% endalert %}
+{%- endif %}
 {%- if page.platform_code == "azure" %}
 {% alert level="warning" %}
 Поддерживаются только [регионы](https://docs.microsoft.com/ru-ru/azure/availability-zones/az-region) в которых доступны `Availability Zones`.

--- a/docs/site/_plugins/gs_generator.rb
+++ b/docs/site/_plugins/gs_generator.rb
@@ -7,7 +7,7 @@ module GSGenerator
 
         next unless installTypeData['steps']
 
-        puts "Processing %s... (%s)" % [installTypeKey, installTypeData['name']]
+        puts "[GS] Generating for %s..." % [installTypeKey]
 
         installTypeData['steps'].each do |stepName, stepData|
           languages = installTypeData['languages'] ? installTypeData['languages'] : ['ru', 'en']


### PR DESCRIPTION
## Description
Add warnings for SpaceVM, Red, and Dynamix platforms in the getting started.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add warnings for SpaceVM, Red, and Dynamix platforms in the getting started.
impact_level: low
```
