### PR TITLE
[ci] Improve autolabeling for backports

### DIFF
--- a/.github/actions/milestone-changelog/action.yml
+++ b/.github/actions/milestone-changelog/action.yml
@@ -93,6 +93,6 @@ runs:
           ${{ steps.changelog.outputs.release_markdown }}
 
           For more information, see the [changelog](https://github.com/deckhouse/deckhouse/blob/main/CHANGELOG/CHANGELOG-${{ steps.changelog.outputs.minor_version }}.md) and minor version [release changes](https://github.com/deckhouse/deckhouse/releases/tag/${{ steps.changelog.outputs.minor_version }}.0).
-        labels: changelog, auto
+        labels: changelog, auto, status/backport
         token: ${{ inputs.token }}
         delete-branch: true

--- a/.github/workflow_templates/on-pull-request-backport.yml
+++ b/.github/workflow_templates/on-pull-request-backport.yml
@@ -128,9 +128,16 @@ jobs:
           committer: "deckhouse-BOaTswain <89150800+deckhouse-boatswain@users.noreply.github.com>"
           branch: ${{ env.RELEASE_BRANCH }}
           commit: ${{ env.COMMIT_SHA }}
-          labels: auto,backported
+          labels: auto,status/backport/success
           automerge: true
           merge_method: squash
+      - name: Add success label
+        if: steps.cherry_pick_pr.conclusion == 'success'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          number: ${{ steps.prepare.outputs.pr_number }}
+          labels: "status/backport/success"
       - name: Add successful comment
         if: steps.cherry_pick_pr.conclusion == 'success'
         env:
@@ -144,20 +151,27 @@ jobs:
           reactions: hooray
           body: "Cherry pick PR [${{ env.cherry_pr_number }}](${{ env.cherry_pr_url }}) to the branch [${{ env.release_branch }}](https://github.com/${{github.repository}}/tree/${{ env.release_branch }}) successful!"
       - name: Remove backport label
-        if: steps.cherry_pick_pr.conclusion == 'success'
+        if: always()
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           github_token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
           number: ${{ steps.prepare.outputs.pr_number }}
           labels: "status/backport"
+      - name: Add error label
+        if: ${{ failure() && (steps.cherry_pick_pr.conclusion == 'failure' || steps.check_target_branch.conclusion == 'failure') }}
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          number: ${{ steps.prepare.outputs.pr_number }}
+          labels: "status/backport/failed"
       - name: Add error comment
         if: ${{ failure() && (steps.cherry_pick_pr.conclusion == 'failure' || steps.check_target_branch.conclusion == 'failure') }}
         uses: peter-evans/create-or-update-comment@v2
         env:
           error_message: ${{ steps.cherry_pick_pr.outputs.error_message }}
-          common_error: 'Backport failed. See [Job](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}) for details.'
+          common_error: "Backport failed. See [Job](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}) for details."
         with:
           token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
           issue-number: ${{ steps.prepare.outputs.pr_number }}
-          reactions: 'confused'
+          reactions: "confused"
           body: ${{ env.error_message || env.common_error }}

--- a/.github/workflows/on-pull-request-backport.yml
+++ b/.github/workflows/on-pull-request-backport.yml
@@ -132,9 +132,16 @@ jobs:
           committer: "deckhouse-BOaTswain <89150800+deckhouse-boatswain@users.noreply.github.com>"
           branch: ${{ env.RELEASE_BRANCH }}
           commit: ${{ env.COMMIT_SHA }}
-          labels: auto,backported
+          labels: auto,status/backport/success
           automerge: true
           merge_method: squash
+      - name: Add success label
+        if: steps.cherry_pick_pr.conclusion == 'success'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          number: ${{ steps.prepare.outputs.pr_number }}
+          labels: "status/backport/success"
       - name: Add successful comment
         if: steps.cherry_pick_pr.conclusion == 'success'
         env:
@@ -148,20 +155,27 @@ jobs:
           reactions: hooray
           body: "Cherry pick PR [${{ env.cherry_pr_number }}](${{ env.cherry_pr_url }}) to the branch [${{ env.release_branch }}](https://github.com/${{github.repository}}/tree/${{ env.release_branch }}) successful!"
       - name: Remove backport label
-        if: steps.cherry_pick_pr.conclusion == 'success'
+        if: always()
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           github_token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
           number: ${{ steps.prepare.outputs.pr_number }}
           labels: "status/backport"
+      - name: Add error label
+        if: ${{ failure() && (steps.cherry_pick_pr.conclusion == 'failure' || steps.check_target_branch.conclusion == 'failure') }}
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          number: ${{ steps.prepare.outputs.pr_number }}
+          labels: "status/backport/failed"
       - name: Add error comment
         if: ${{ failure() && (steps.cherry_pick_pr.conclusion == 'failure' || steps.check_target_branch.conclusion == 'failure') }}
         uses: peter-evans/create-or-update-comment@v2
         env:
           error_message: ${{ steps.cherry_pick_pr.outputs.error_message }}
-          common_error: 'Backport failed. See [Job](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}) for details.'
+          common_error: "Backport failed. See [Job](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}) for details."
         with:
           token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
           issue-number: ${{ steps.prepare.outputs.pr_number }}
-          reactions: 'confused'
+          reactions: "confused"
           body: ${{ env.error_message || env.common_error }}


### PR DESCRIPTION
## Description
Improve automatically set labels for backports.

## Why do we need it, and what problem does it solve?
This change allows for better readability of backport status.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: feature
summary:  Improve autolabeling for backports.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
