### PR TITLE
[cni-cilium] ebpf-powered dhcp server for pods

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/005-ebpf-dhcp-server.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/005-ebpf-dhcp-server.patch
@@ -1,16 +1,19 @@
 diff --git a/bpf/bpf_lxc.c b/bpf/bpf_lxc.c
-index e5653ec9f9..b288b5c29e 100644
+index e5653ec9f9..cd72247c4b 100644
 --- a/bpf/bpf_lxc.c
 +++ b/bpf/bpf_lxc.c
-@@ -37,6 +37,7 @@
- #include "lib/lxc.h"
+@@ -38,6 +38,10 @@
  #include "lib/identity.h"
  #include "lib/policy.h"
-+#include "lib/dhcp.h"
  
++#ifdef ENABLE_DHCPD
++#include "lib/dhcp.h"
++#endif
++
  /* Override LB_SELECTION initially defined in node_config.h to force bpf_lxc to use the random backend selection
   * algorithm for in-cluster traffic. Otherwise, it will fail with the Maglev hash algorithm because Cilium doesn't provision
-@@ -58,6 +59,7 @@
+  * the Maglev table for ClusterIP unless bpf.lbExternalClusterIP is set to true.
+@@ -58,6 +62,7 @@
  #include "lib/nodeport.h"
  #include "lib/policy_log.h"
  
@@ -18,21 +21,23 @@ index e5653ec9f9..b288b5c29e 100644
  /* Per-packet LB is needed if all LB cases can not be handled in bpf_sock.
   * Most services with L7 LB flag can not be redirected to their proxy port
   * in bpf_sock, so we must check for those via per packet LB as well.
-@@ -1396,6 +1398,8 @@ int cil_from_container(struct __ctx_buff *ctx)
+@@ -1396,6 +1401,10 @@ int cil_from_container(struct __ctx_buff *ctx)
  #endif /* ENABLE_IPV6 */
  #ifdef ENABLE_IPV4
  	case bpf_htons(ETH_P_IP):
++#ifdef ENABLE_DHCPD
 +		if (unlikely(handle_dhcp_request(ctx, &ret)))
 +			break;
++#endif
  		edt_set_aggregate(ctx, LXC_ID);
  		ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_LXC);
  		ret = DROP_MISSED_TAIL_CALL;
 diff --git a/bpf/lib/dhcp.h b/bpf/lib/dhcp.h
 new file mode 100644
-index 0000000000..4454e2f735
+index 0000000000..83b64e78e2
 --- /dev/null
 +++ b/bpf/lib/dhcp.h
-@@ -0,0 +1,391 @@
+@@ -0,0 +1,392 @@
 +/*
 +Copyright 2024 Flant JSC
 +
@@ -171,6 +176,18 @@ index 0000000000..4454e2f735
 +#define DHCP_VEND_SIZE                       60
 +#define DHCP_LEASE_TIME              0x7FFFFFFE
 +
++#ifndef IPV4_DNS_SERVER
++	#define IPV4_DNS_SERVER          0x0ADE0001
++#endif
++
++#define COPY_DATA_IF_SAFE(data_dst, data_src, data_end)   \
++	do {                                                   \
++		if ((data_dst) + sizeof(data_src) > (data_end))     \
++			return false;                                   \
++		memcpy((data_dst), &(data_src), sizeof(data_src));  \
++		(data_dst) += sizeof(data_src);                     \
++	} while (0)
++
 +struct dhcp_opt {
 +	__u8 type;
 +	__u8 len;
@@ -194,6 +211,12 @@ index 0000000000..4454e2f735
 +	char file[128];
 +	char cookies[4];
 +};
++
++#ifndef DOMAIN_SEARCH_LIST_VALUE
++	#define DOMAIN_SEARCH_LIST_VALUE { 119, 15, 7, 'c', 'l', 'u', 's', 't', 'e', 'r', 5, 'l', 'o', 'c', 'a', 'l', 0 }
++#endif
++/* DHCP Option 119 */
++static __u8 domain_search_list[] = DOMAIN_SEARCH_LIST_VALUE;
 +
 +static __always_inline bool
 +dhcp_prepare_options(__u8 request_type, void *options, void *data_end)
@@ -219,42 +242,25 @@ index 0000000000..4454e2f735
 +		.len = 4,
 +		.data = IPV4_GATEWAY,
 +	};
-+
++	struct dhcp_opt dns_srv = {
++		.type = DHO_DOMAIN_NAME_SERVERS,
++		.len = 4,
++		.data = bpf_htonl(IPV4_DNS_SERVER),
++	};
 +	__u8 msg_type[] = {
 +		DHO_DHCP_MESSAGE_TYPE,
 +		1,
 +		request_type == DHCP_REQUEST ? DHCP_ACK : DHCP_OFFER
 +	};
 +
-+	if (options + sizeof(msg_type) > data_end)
-+		return false;
-+
-+	memcpy(options, &msg_type, sizeof(msg_type));
-+	options += sizeof(msg_type);
-+	if (options + sizeof(srv_id) > data_end)
-+		return false;
-+
-+	memcpy(options, &srv_id, sizeof(srv_id));
-+	options += sizeof(srv_id);
-+
-+	if (options + sizeof(lease_time) > data_end)
-+		return false;
-+	memcpy(options, &lease_time, sizeof(lease_time));
-+	options += sizeof(lease_time);
-+
-+	if (options + sizeof(subnet_mask) > data_end)
-+		return false;
-+	memcpy(options, &subnet_mask, sizeof(subnet_mask));
-+	options += sizeof(subnet_mask);
-+
-+	if (options + sizeof(router) > data_end)
-+		return false;
-+	memcpy(options, &router, sizeof(router));
-+	options += sizeof(router);
-+
-+	if (options + sizeof(end) > data_end)
-+		return false;
-+	memcpy(options, &end, sizeof(end));
++	COPY_DATA_IF_SAFE(options, msg_type, data_end);
++	COPY_DATA_IF_SAFE(options, srv_id, data_end);
++	COPY_DATA_IF_SAFE(options, lease_time, data_end);
++	COPY_DATA_IF_SAFE(options, subnet_mask, data_end);
++	COPY_DATA_IF_SAFE(options, router, data_end);
++	COPY_DATA_IF_SAFE(options, dns_srv, data_end);
++	COPY_DATA_IF_SAFE(options, domain_search_list, data_end);
++	COPY_DATA_IF_SAFE(options, end, data_end);
 +
 +	return true;
 +}
@@ -275,7 +281,7 @@ index 0000000000..4454e2f735
 +	union macaddr node_mac = NODE_MAC;
 +	__u32 yiaddr = LXC_IPV4;
 +	/* manually calculated, based on dhcp_prepare_options implementation */
-+	__u16 dhcp_options_len = 3 + 6 + 6 + 6 + 6 + 1;
++	__u16 dhcp_options_len = 3 + 6 + 6 + 6 + 6 + 6 + sizeof(domain_search_list) + 1;
 +	__u16 dhcp_padding_len = dhcp_options_len < DHCP_VEND_SIZE ?
 +		DHCP_VEND_SIZE - dhcp_options_len : 0;
 +	__u16 dhcp_options_with_pad_len = dhcp_options_len + dhcp_padding_len;
@@ -424,3 +430,128 @@ index 0000000000..4454e2f735
 +
 +
 +#endif /* __LIB_DHCP__ */
+diff --git a/pkg/datapath/linux/config/config.go b/pkg/datapath/linux/config/config.go
+index 333076b2ff..a195e611ef 100644
+--- a/pkg/datapath/linux/config/config.go
++++ b/pkg/datapath/linux/config/config.go
+@@ -80,6 +80,41 @@ func writeIncludes(w io.Writer) (int, error) {
+ 	return fmt.Fprintf(w, "#include \"lib/utils.h\"\n\n")
+ }
+ 
++func IPv4ToHex(ipString string) (string, error) {
++	ip := net.ParseIP(ipString)
++	if ip == nil {
++		return "", fmt.Errorf("invalid IPv4 address: %s", ipString)
++	}
++
++	ipBytes := ip.To4()
++	if ipBytes == nil {
++		return "", fmt.Errorf("not an IPv4 address: %s", ipString)
++	}
++
++	hexString := fmt.Sprintf("0x%02X%02X%02X%02X", ipBytes[0], ipBytes[1], ipBytes[2], ipBytes[3])
++	return hexString, nil
++}
++
++// now implemented only single domain
++func GenerateDomainSearchList(domain string) string {
++	labels := strings.Split(domain, ".")
++	var result []string
++	result = append(result, "119") // Option code
++	result = append(result, "0") // total length
++	totalLength := 1
++	for _, label := range labels {
++		labelLength := len(label)
++		result = append(result, fmt.Sprintf("%d", labelLength))
++		for _, c := range label {
++			result = append(result, fmt.Sprintf("'%c'", c))
++		}
++		totalLength += 1 + labelLength
++	}
++	result = append(result, "0")
++	result[1] = fmt.Sprintf("%d", totalLength)
++	return fmt.Sprintf("{ %s }", strings.Join(result, ", "))
++}
++
+ // WriteNodeConfig writes the local node configuration to the specified writer.
+ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeConfiguration) error {
+ 	extraMacrosMap := make(map[string]string)
+@@ -129,6 +164,16 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
+ 			cDefinesMap["IPV4_FRAG_DATAGRAMS_MAP"] = fragmap.MapName
+ 			cDefinesMap["CILIUM_IPV4_FRAG_MAP_MAX_ENTRIES"] = fmt.Sprintf("%d", option.Config.FragmentsMapEntries)
+ 		}
++
++		if option.Config.DhcpdEnabled {
++			cDefinesMap["ENABLE_DHCPD"] = "1"
++			ipv4Dns, err := IPv4ToHex(option.Config.DhcpdClusterDns)
++			if err != nil {
++				return err
++			}
++			cDefinesMap["IPV4_DNS_SERVER"] = ipv4Dns
++			cDefinesMap["DOMAIN_SEARCH_LIST_VALUE"] = GenerateDomainSearchList(option.Config.DhcpdClusterDomain)
++		}
+ 	}
+ 
+ 	if option.Config.EnableIPv6 {
+diff --git a/pkg/defaults/defaults.go b/pkg/defaults/defaults.go
+index c9f89257a5..927b680afa 100644
+--- a/pkg/defaults/defaults.go
++++ b/pkg/defaults/defaults.go
+@@ -559,6 +559,10 @@ const (
+ 
+ 	// EnableEnvoyConfig is the default value for option.EnableEnvoyConfig
+ 	EnableEnvoyConfig = false
++
++	DhcpdEnabled = false
++	DhcpdClusterDns = ""
++	DhcpdClusterDomain = ""
+ )
+ 
+ var (
+diff --git a/pkg/option/config.go b/pkg/option/config.go
+index e891a60a3d..280d5e2930 100644
+--- a/pkg/option/config.go
++++ b/pkg/option/config.go
+@@ -379,6 +379,11 @@ const (
+ 	// EnableIPMasqAgent enables BPF ip-masq-agent
+ 	EnableIPMasqAgent = "enable-ip-masq-agent"
+ 
++	// DdhcpdEnabled enables BPF dhcp server
++	DhcpdEnabled = "dhcpd-enabled"
++	DhcpdClusterDns = "dhcpd-cluster-dns"
++	DhcpdClusterDomain = "dhcpd-cluster-domain"
++
+ 	// EnableIPv4EgressGateway enables the IPv4 egress gateway
+ 	EnableIPv4EgressGateway = "enable-ipv4-egress-gateway"
+ 
+@@ -1820,6 +1825,9 @@ type DaemonConfig struct {
+ 	DeriveMasqIPAddrFromDevice string
+ 	EnableBPFClockProbe        bool
+ 	EnableIPMasqAgent          bool
++	DhcpdEnabled               bool
++	DhcpdClusterDns            string
++	DhcpdClusterDomain         string
+ 	EnableIPv4EgressGateway    bool
+ 	EnableEnvoyConfig          bool
+ 	EnableIngressController    bool
+@@ -2513,6 +2521,7 @@ var (
+ 		EnableBGPControlPlane:  defaults.EnableBGPControlPlane,
+ 		EnableK8sNetworkPolicy: defaults.EnableK8sNetworkPolicy,
+ 		EnableEnvoyConfig:      defaults.EnableEnvoyConfig,
++		DhcpdEnabled:           defaults.DhcpdEnabled,
+ 	}
+ )
+ 
+@@ -3166,6 +3175,9 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
+ 	c.LocalRouterIPv6 = vp.GetString(LocalRouterIPv6)
+ 	c.EnableBPFClockProbe = vp.GetBool(EnableBPFClockProbe)
+ 	c.EnableIPMasqAgent = vp.GetBool(EnableIPMasqAgent)
++	c.DhcpdEnabled = vp.GetBool(DhcpdEnabled)
++	c.DhcpdClusterDns = vp.GetString(DhcpdClusterDns)
++	c.DhcpdClusterDomain = vp.GetString(DhcpdClusterDomain)
+ 	c.EnableIPv4EgressGateway = vp.GetBool(EnableIPv4EgressGateway)
+ 	c.EnableEnvoyConfig = vp.GetBool(EnableEnvoyConfig)
+ 	c.EnableIngressController = vp.GetBool(EnableIngressController)
+-- 
+2.34.1
+

--- a/modules/021-cni-cilium/images/bin-cilium/patches/005-ebpf-dhcp-server.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/005-ebpf-dhcp-server.patch
@@ -1,0 +1,426 @@
+diff --git a/bpf/bpf_lxc.c b/bpf/bpf_lxc.c
+index e5653ec9f9..b288b5c29e 100644
+--- a/bpf/bpf_lxc.c
++++ b/bpf/bpf_lxc.c
+@@ -37,6 +37,7 @@
+ #include "lib/lxc.h"
+ #include "lib/identity.h"
+ #include "lib/policy.h"
++#include "lib/dhcp.h"
+ 
+ /* Override LB_SELECTION initially defined in node_config.h to force bpf_lxc to use the random backend selection
+  * algorithm for in-cluster traffic. Otherwise, it will fail with the Maglev hash algorithm because Cilium doesn't provision
+@@ -58,6 +59,7 @@
+ #include "lib/nodeport.h"
+ #include "lib/policy_log.h"
+ 
++
+ /* Per-packet LB is needed if all LB cases can not be handled in bpf_sock.
+  * Most services with L7 LB flag can not be redirected to their proxy port
+  * in bpf_sock, so we must check for those via per packet LB as well.
+@@ -1396,6 +1398,8 @@ int cil_from_container(struct __ctx_buff *ctx)
+ #endif /* ENABLE_IPV6 */
+ #ifdef ENABLE_IPV4
+ 	case bpf_htons(ETH_P_IP):
++		if (unlikely(handle_dhcp_request(ctx, &ret)))
++			break;
+ 		edt_set_aggregate(ctx, LXC_ID);
+ 		ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_LXC);
+ 		ret = DROP_MISSED_TAIL_CALL;
+diff --git a/bpf/lib/dhcp.h b/bpf/lib/dhcp.h
+new file mode 100644
+index 0000000000..4454e2f735
+--- /dev/null
++++ b/bpf/lib/dhcp.h
+@@ -0,0 +1,391 @@
++/*
++Copyright 2024 Flant JSC
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++	http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++/* - this module used as replacement for kubevirt embedded dhcp server
++ * https://github.com/kubevirt/kubevirt/blob/main/pkg/network/dhcp/server/server.go
++ * - server implement very restricted part of dhcp protocol,
++ * only offer/ack responses on discover/request
++ * - server is stateless
++ */
++
++#ifndef __LIB_DHCP__
++#define __LIB_DHCP__
++
++#define BOOT_REQUEST                          1
++#define BOOT_REPLY                            2
++
++/* DHCP HTYPE CODE */
++#define HTYPE_ETHER                           1
++#define HTYPE_IEEE802                         6
++#define HTYPE_FDDI                            8
++#define HTYPE_IEEE1394                       24
++
++/* DHCP MESSAGE CODES */
++#define DHCP_DISCOVER                         1
++#define DHCP_OFFER                            2
++#define DHCP_REQUEST                          3
++#define DHCP_ACK                              5
++
++#define DHO_PAD                               0
++#define DHO_SUBNET                            1
++#define DHO_TIME_OFFSET                       2
++#define DHO_ROUTERS                           3
++#define DHO_TIME_SERVERS                      4
++#define DHO_NAME_SERVERS                      5
++#define DHO_DOMAIN_NAME_SERVERS               6
++#define DHO_LOG_SERVER                        7
++#define DHO_COOKIE_SERVERS                    8
++#define DHO_LPR_SERVERS                       9
++#define DHO_IMPRESS_SERVER                   10
++#define DHO_RESOURCE_LOCATION_SERVERS        11
++#define DHO_HOST_NAME                        12
++#define DHO_BOOT_SIZE                        13
++#define DHO_MERIT_DUMP                       14
++#define DHO_DOMAIN_NAME                      15
++#define DHO_SWAP_SERVER                      16
++#define DHO_ROOT_PATH                        17
++#define DHO_EXTENSIONS_PATH                  18
++#define DHO_IP_FORWARDING                    19
++#define DHO_NON_LOCAL_SOURCE_ROUTING         20
++#define DHO_POLICY_FILTER                    21
++#define DHO_MAX_DGRAM_REASSEMBLY             22
++#define DHO_DEFAULT_IP_TTL                   23
++#define DHO_PATH_MTU_AGING_TIMEOUT           24
++#define DHO_PATH_MTU_PLATEAU_TABLE           25
++#define DHO_INTERFACE_MTU                    26
++#define DHO_ALL_SUBNETS_LOCAL                27
++#define DHO_BROADCAST_ADDRESS                28
++#define DHO_PERFORM_MASK_DISCOVERY           29
++#define DHO_MASK_SUPPLIER                    30
++#define DHO_ROUTER_DISCOVERY                 31
++#define DHO_ROUTER_SOLICITATION_ADDRESS      32
++#define DHO_STATIC_ROUTES                    33
++#define DHO_TRAILER_ENCAPSULATION            34
++#define DHO_ARP_CACHE_TIMEOUT                35
++#define DHO_IEEE802_3_ENCAPSULATION          36
++#define DHO_DEFAULT_TCP_TTL                  37
++#define DHO_TCP_KEEPALIVE_INTERVAL           38
++#define DHO_TCP_KEEPALIVE_GARBAGE            39
++#define DHO_NIS_SERVERS                      41
++#define DHO_NTP_SERVERS                      42
++#define DHO_VENDOR_ENCAPSULATED_OPTIONS      43
++#define DHO_NETBIOS_NAME_SERVERS             44
++#define DHO_NETBIOS_DD_SERVER                45
++#define DHO_NETBIOS_NODE_TYPE                46
++#define DHO_NETBIOS_SCOPE                    47
++#define DHO_FONT_SERVERS                     48
++#define DHO_X_DISPLAY_MANAGER                49
++#define DHO_DHCP_REQUESTED_ADDRESS           50
++#define DHO_DHCP_LEASE_TIME                  51
++#define DHO_DHCP_OPTION_OVERLOAD             52
++#define DHO_DHCP_MESSAGE_TYPE                53
++#define DHO_DHCP_SERVER_IDENTIFIER           54
++#define DHO_DHCP_PARAMETER_REQUEST_LIST      55
++#define DHO_DHCP_MESSAGE                     56
++#define DHO_DHCP_MAX_MESSAGE_SIZE            57
++#define DHO_DHCP_RENEWAL_TIME                58
++#define DHO_DHCP_REBINDING_TIME              59
++#define DHO_VENDOR_CLASS_IDENTIFIER          60
++#define DHO_DHCP_CLIENT_IDENTIFIER           61
++#define DHO_NWIP_DOMAIN_NAME                 62
++#define DHO_NWIP_SUBOPTIONS                  63
++#define DHO_NISPLUS_DOMAIN                   64
++#define DHO_NISPLUS_SERVER                   65
++#define DHO_TFTP_SERVER                      66
++#define DHO_BOOTFILE                         67
++#define DHO_MOBILE_IP_HOME_AGENT             68
++#define DHO_SMTP_SERVER                      69
++#define DHO_POP3_SERVER                      70
++#define DHO_NNTP_SERVER                      71
++#define DHO_WWW_SERVER                       72
++#define DHO_FINGER_SERVER                    73
++#define DHO_IRC_SERVER                       74
++#define DHO_STREETTALK_SERVER                75
++#define DHO_STDA_SERVER                      76
++#define DHO_USER_CLASS                       77
++#define DHO_FQDN                             81
++#define DHO_DHCP_AGENT_OPTIONS               82
++#define DHO_NDS_SERVERS                      85
++#define DHO_NDS_TREE_NAME                    86
++#define DHO_NDS_CONTEXT                      87
++#define DHO_CLIENT_LAST_TRANSACTION_TIME     91
++#define DHO_ASSOCIATED_IP                    92
++#define DHO_USER_AUTHENTICATION_PROTOCOL     98
++#define DHO_AUTO_CONFIGURE                  116
++#define DHO_NAME_SERVICE_SEARCH             117
++#define DHO_SUBNET_SELECTION                118
++#define DHO_DOMAIN_SEARCH                   119
++#define DHO_CLASSLESS_ROUTE                 121
++#define DHO_END                             255
++
++#define DHO_DHCP_MESSAGE_TYPE_LEN             3
++#define BOOTP_ABSOLUTE_MIN_LEN              240
++#define DHCP_VEND_SIZE                       60
++#define DHCP_LEASE_TIME              0x7FFFFFFE
++
++struct dhcp_opt {
++	__u8 type;
++	__u8 len;
++	__u32 data;
++} __packed;
++
++struct dhcp_packet {
++	char op;
++	char htype;
++	char hlen;
++	char hops;
++	char xid[4];
++	char secs[2];
++	char flags[2];
++	char ciaddr[4];
++	char yiaddr[4];
++	char siaddr[4];
++	char giaddr[4];
++	char chaddr[16];
++	char sname[64];
++	char file[128];
++	char cookies[4];
++};
++
++static __always_inline bool
++dhcp_prepare_options(__u8 request_type, void *options, void *data_end)
++{
++	__u8 end = DHO_END;
++	struct dhcp_opt srv_id = {
++		.type = DHO_DHCP_SERVER_IDENTIFIER,
++		.len = 4,
++		.data = IPV4_GATEWAY,
++	};
++	struct dhcp_opt lease_time = {
++		.type = DHO_DHCP_LEASE_TIME,
++		.len = 4,
++		.data = bpf_htonl(DHCP_LEASE_TIME),
++	};
++	struct dhcp_opt subnet_mask = {
++		.type = DHO_SUBNET,
++		.len = 4,
++		.data = bpf_htonl(0xFFFFFFFF),
++	};
++	struct dhcp_opt router = {
++		.type = DHO_ROUTERS,
++		.len = 4,
++		.data = IPV4_GATEWAY,
++	};
++
++	__u8 msg_type[] = {
++		DHO_DHCP_MESSAGE_TYPE,
++		1,
++		request_type == DHCP_REQUEST ? DHCP_ACK : DHCP_OFFER
++	};
++
++	if (options + sizeof(msg_type) > data_end)
++		return false;
++
++	memcpy(options, &msg_type, sizeof(msg_type));
++	options += sizeof(msg_type);
++	if (options + sizeof(srv_id) > data_end)
++		return false;
++
++	memcpy(options, &srv_id, sizeof(srv_id));
++	options += sizeof(srv_id);
++
++	if (options + sizeof(lease_time) > data_end)
++		return false;
++	memcpy(options, &lease_time, sizeof(lease_time));
++	options += sizeof(lease_time);
++
++	if (options + sizeof(subnet_mask) > data_end)
++		return false;
++	memcpy(options, &subnet_mask, sizeof(subnet_mask));
++	options += sizeof(subnet_mask);
++
++	if (options + sizeof(router) > data_end)
++		return false;
++	memcpy(options, &router, sizeof(router));
++	options += sizeof(router);
++
++	if (options + sizeof(end) > data_end)
++		return false;
++	memcpy(options, &end, sizeof(end));
++
++	return true;
++}
++
++static __always_inline bool
++dhcp_prepare_response(struct __ctx_buff *ctx, __u8 request_type)
++{
++	__u8 tmp_mac[ETH_ALEN];
++
++	struct ethhdr *eth;
++	struct iphdr *ip;
++	struct udphdr *udp;
++	struct dhcp_packet *dhcp;
++
++	void *dhcp_options;
++	void *data, *data_end;
++
++	union macaddr node_mac = NODE_MAC;
++	__u32 yiaddr = LXC_IPV4;
++	/* manually calculated, based on dhcp_prepare_options implementation */
++	__u16 dhcp_options_len = 3 + 6 + 6 + 6 + 6 + 1;
++	__u16 dhcp_padding_len = dhcp_options_len < DHCP_VEND_SIZE ?
++		DHCP_VEND_SIZE - dhcp_options_len : 0;
++	__u16 dhcp_options_with_pad_len = dhcp_options_len + dhcp_padding_len;
++
++	__u16 udp_len = sizeof(*udp) + sizeof(*dhcp) + dhcp_options_with_pad_len;
++	__u16 ip_len = sizeof(*ip) + udp_len;
++
++	__u32 len_new = sizeof(*eth) + ip_len;
++	__u32 len_old = ctx_full_len(ctx);
++	__s32 len_diff = -(len_old - len_new);
++	if (ctx_adjust_troom(ctx, len_diff) < 0)
++		return false;
++
++	if (!revalidate_data_pull(ctx, &data, &data_end, &ip))
++		return false;
++
++	if (data + len_new > data_end)
++		return false;
++
++	eth = data;
++	udp = (struct udphdr *)(ip + 1);
++	dhcp = (struct dhcp_packet *)(udp + 1);
++
++	dhcp->op = BOOT_REPLY;
++	dhcp->hops = 1;
++	memcpy(&dhcp->yiaddr, &yiaddr, sizeof(yiaddr));
++
++	dhcp_options = dhcp + 1;
++	if (!dhcp_prepare_options(request_type, dhcp_options, data_end))
++		return false;
++
++	if (dhcp_padding_len > 0) {
++		void *start_pad = dhcp_options + dhcp_options_len;
++		__bpf_memset_builtin(start_pad, 0, dhcp_padding_len);
++	}
++
++	udp->source = bpf_htons(67);
++	udp->dest = bpf_htons(68);
++	udp->len = bpf_htons(udp_len);
++	udp->check = 0;
++
++	ip->ihl = 5;
++	ip->version = IPVERSION;
++	ip->ttl = IPDEFTTL;
++	ip->protocol = IPPROTO_UDP;
++	ip->frag_off = bpf_htons(IP_DF);
++	ip->id = 0;
++	ip->tos = 0;
++	ip->tot_len = bpf_htons(ip_len);
++	ip->saddr = IPV4_GATEWAY;
++	ip->daddr = yiaddr;
++	ip->check = 0;
++	ip->check = csum_fold(csum_diff(NULL, 0, ip, sizeof(*ip), 0));
++
++	memcpy(tmp_mac, eth->h_source, ETH_ALEN);
++	memcpy(eth->h_source, &node_mac, ETH_ALEN);
++	memcpy(eth->h_dest, tmp_mac, ETH_ALEN);
++
++	return true;
++}
++
++static __always_inline bool
++is_valid_dhcp_request(__u8 type)
++{
++	return type == DHCP_DISCOVER || type == DHCP_REQUEST;
++}
++
++static __always_inline bool
++is_dhcp_request(struct __ctx_buff *ctx, __u8 *request_type)
++{
++	bool is_dhcp_flow;
++	struct iphdr *ip;
++	struct udphdr *udp;
++	struct dhcp_packet *dhcp;
++	__u32 dhcp_len;
++	__u8 *dhcp_options;
++
++	char dhcp_magic_cookie[4] = {0x63, 0x82, 0x53, 0x63};
++	void *data_end = ctx_data_end(ctx);
++	void *data = ctx_data(ctx);
++	/* skip eth check - it is already done in cil_from_container */
++	ip = (struct iphdr *) (data + ETH_HLEN);
++	if ((void *)(ip + 1) > data_end)
++		return false;
++
++	if (unlikely(ip->version != 4))
++		return false;
++
++	if (ip->protocol != IPPROTO_UDP)
++		return false;
++
++	udp = (struct udphdr *)(ip + 1);
++	if ((void *)(udp + 1) > data_end)
++		return false;
++
++	is_dhcp_flow = bpf_ntohs(udp->dest) == 67 && bpf_ntohs(udp->source) == 68;
++	if (likely(!is_dhcp_flow))
++		return false;
++
++	dhcp_len = sizeof(struct ethhdr) + sizeof(*ip) + sizeof(*udp) + sizeof(*dhcp);
++	if (data + dhcp_len > data_end)
++		return false;
++
++	dhcp = (struct dhcp_packet *)(udp + 1);
++	if (dhcp->op != BOOT_REQUEST)
++		return false;
++
++	if (memcmp(dhcp_magic_cookie, &dhcp->cookies, sizeof(dhcp->cookies)) != 0)
++		return false;
++
++	dhcp_options = (__u8 *)(dhcp + 1);
++	if ((void*)dhcp_options + DHO_DHCP_MESSAGE_TYPE_LEN > data_end)
++		return false;
++
++	if (dhcp_options[0] != DHO_DHCP_MESSAGE_TYPE && dhcp_options[1] != 1)
++		return false;
++
++	*request_type = dhcp_options[2];
++
++	return true;
++}
++
++static __always_inline bool
++handle_dhcp_request(struct __ctx_buff *ctx, int *ret)
++{
++	__u8 request_type;
++
++	if (likely(!is_dhcp_request(ctx, &request_type)))
++		return false;
++
++	if (!is_valid_dhcp_request(request_type)) {
++		/* drop unsupported request types: release, inform */
++		*ret = CTX_ACT_DROP;
++		return true;
++	}
++
++	if (!dhcp_prepare_response(ctx, request_type)) {
++		/* drop malformed packet */
++		*ret = CTX_ACT_DROP;
++		return true;
++	}
++
++	*ret = redirect_self(ctx);
++	return true;
++}
++
++
++#endif /* __LIB_DHCP__ */

--- a/modules/021-cni-cilium/images/bin-cilium/patches/005-ebpf-dhcp-server.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/005-ebpf-dhcp-server.patch
@@ -1,19 +1,5 @@
-From a16962752ba60e7d9fe184723a68ce22efd92a4d Mon Sep 17 00:00:00 2001
-From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
-Date: Wed, 13 Nov 2024 16:30:54 +0300
-Subject: [PATCH] add: dhcp server for pods(kubevirt replacement)
-
----
- bpf/bpf_lxc.c                       |   9 +
- bpf/lib/dhcp.h                      | 394 ++++++++++++++++++++++++++++
- pkg/datapath/linux/config/config.go |  45 ++++
- pkg/defaults/defaults.go            |   4 +
- pkg/option/config.go                |  12 +
- 5 files changed, 464 insertions(+)
- create mode 100644 bpf/lib/dhcp.h
-
 diff --git a/bpf/bpf_lxc.c b/bpf/bpf_lxc.c
-index e5653ec9f9..cd72247c4b 100644
+index e5653ec9f9..5ecc4c68f4 100644
 --- a/bpf/bpf_lxc.c
 +++ b/bpf/bpf_lxc.c
 @@ -38,6 +38,10 @@
@@ -27,15 +13,7 @@ index e5653ec9f9..cd72247c4b 100644
  /* Override LB_SELECTION initially defined in node_config.h to force bpf_lxc to use the random backend selection
   * algorithm for in-cluster traffic. Otherwise, it will fail with the Maglev hash algorithm because Cilium doesn't provision
   * the Maglev table for ClusterIP unless bpf.lbExternalClusterIP is set to true.
-@@ -58,6 +62,7 @@
- #include "lib/nodeport.h"
- #include "lib/policy_log.h"
- 
-+
- /* Per-packet LB is needed if all LB cases can not be handled in bpf_sock.
-  * Most services with L7 LB flag can not be redirected to their proxy port
-  * in bpf_sock, so we must check for those via per packet LB as well.
-@@ -1396,6 +1401,10 @@ int cil_from_container(struct __ctx_buff *ctx)
+@@ -1396,6 +1400,10 @@ int cil_from_container(struct __ctx_buff *ctx)
  #endif /* ENABLE_IPV6 */
  #ifdef ENABLE_IPV4
  	case bpf_htons(ETH_P_IP):
@@ -48,7 +26,7 @@ index e5653ec9f9..cd72247c4b 100644
  		ret = DROP_MISSED_TAIL_CALL;
 diff --git a/bpf/lib/dhcp.h b/bpf/lib/dhcp.h
 new file mode 100644
-index 0000000000..387d215056
+index 0000000000..682fc7e4c6
 --- /dev/null
 +++ b/bpf/lib/dhcp.h
 @@ -0,0 +1,394 @@
@@ -68,7 +46,7 @@ index 0000000000..387d215056
 +limitations under the License.
 +*/
 +
-+/* - this module used as replacement for kubevirt embedded dhcp server
++/* - this module is a replacement for kubevirt embedded dhcp server
 + * https://github.com/kubevirt/kubevirt/blob/main/pkg/network/dhcp/server/server.go
 + * - server implement very restricted part of dhcp protocol,
 + * only offer/ack responses on discover/request

--- a/modules/021-cni-cilium/images/bin-cilium/patches/005-ebpf-dhcp-server.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/005-ebpf-dhcp-server.patch
@@ -1,3 +1,17 @@
+From a16962752ba60e7d9fe184723a68ce22efd92a4d Mon Sep 17 00:00:00 2001
+From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
+Date: Wed, 13 Nov 2024 16:30:54 +0300
+Subject: [PATCH] add: dhcp server for pods(kubevirt replacement)
+
+---
+ bpf/bpf_lxc.c                       |   9 +
+ bpf/lib/dhcp.h                      | 394 ++++++++++++++++++++++++++++
+ pkg/datapath/linux/config/config.go |  45 ++++
+ pkg/defaults/defaults.go            |   4 +
+ pkg/option/config.go                |  12 +
+ 5 files changed, 464 insertions(+)
+ create mode 100644 bpf/lib/dhcp.h
+
 diff --git a/bpf/bpf_lxc.c b/bpf/bpf_lxc.c
 index e5653ec9f9..cd72247c4b 100644
 --- a/bpf/bpf_lxc.c
@@ -34,10 +48,10 @@ index e5653ec9f9..cd72247c4b 100644
  		ret = DROP_MISSED_TAIL_CALL;
 diff --git a/bpf/lib/dhcp.h b/bpf/lib/dhcp.h
 new file mode 100644
-index 0000000000..83b64e78e2
+index 0000000000..387d215056
 --- /dev/null
 +++ b/bpf/lib/dhcp.h
-@@ -0,0 +1,392 @@
+@@ -0,0 +1,394 @@
 +/*
 +Copyright 2024 Flant JSC
 +
@@ -177,7 +191,8 @@ index 0000000000..83b64e78e2
 +#define DHCP_LEASE_TIME              0x7FFFFFFE
 +
 +#ifndef IPV4_DNS_SERVER
-+	#define IPV4_DNS_SERVER          0x0ADE0001
++	/* default DNS address in cluster: 10.222.0.10 */
++	#define IPV4_DNS_SERVER          0x0ADE000a
 +#endif
 +
 +#define COPY_DATA_IF_SAFE(data_dst, data_src, data_end)   \
@@ -213,6 +228,7 @@ index 0000000000..83b64e78e2
 +};
 +
 +#ifndef DOMAIN_SEARCH_LIST_VALUE
++	/* default domain in cluster: cluster.local */
 +	#define DOMAIN_SEARCH_LIST_VALUE { 119, 15, 7, 'c', 'l', 'u', 's', 't', 'e', 'r', 5, 'l', 'o', 'c', 'a', 'l', 0 }
 +#endif
 +/* DHCP Option 119 */
@@ -431,14 +447,14 @@ index 0000000000..83b64e78e2
 +
 +#endif /* __LIB_DHCP__ */
 diff --git a/pkg/datapath/linux/config/config.go b/pkg/datapath/linux/config/config.go
-index 333076b2ff..a195e611ef 100644
+index 333076b2ff..11b6dc35e5 100644
 --- a/pkg/datapath/linux/config/config.go
 +++ b/pkg/datapath/linux/config/config.go
 @@ -80,6 +80,41 @@ func writeIncludes(w io.Writer) (int, error) {
  	return fmt.Fprintf(w, "#include \"lib/utils.h\"\n\n")
  }
  
-+func IPv4ToHex(ipString string) (string, error) {
++func ipv4ToHex(ipString string) (string, error) {
 +	ip := net.ParseIP(ipString)
 +	if ip == nil {
 +		return "", fmt.Errorf("invalid IPv4 address: %s", ipString)
@@ -453,11 +469,11 @@ index 333076b2ff..a195e611ef 100644
 +	return hexString, nil
 +}
 +
-+// now implemented only single domain
-+func GenerateDomainSearchList(domain string) string {
++// implemented only single domain
++func generateDomainSearchList(domain string) string {
 +	labels := strings.Split(domain, ".")
 +	var result []string
-+	result = append(result, "119") // Option code
++	result = append(result, "119") // option code
 +	result = append(result, "0") // total length
 +	totalLength := 1
 +	for _, label := range labels {
@@ -483,18 +499,18 @@ index 333076b2ff..a195e611ef 100644
 +
 +		if option.Config.DhcpdEnabled {
 +			cDefinesMap["ENABLE_DHCPD"] = "1"
-+			ipv4Dns, err := IPv4ToHex(option.Config.DhcpdClusterDns)
++			ipv4DNS, err := ipv4ToHex(option.Config.DhcpdClusterDNS)
 +			if err != nil {
 +				return err
 +			}
-+			cDefinesMap["IPV4_DNS_SERVER"] = ipv4Dns
-+			cDefinesMap["DOMAIN_SEARCH_LIST_VALUE"] = GenerateDomainSearchList(option.Config.DhcpdClusterDomain)
++			cDefinesMap["IPV4_DNS_SERVER"] = ipv4DNS
++			cDefinesMap["DOMAIN_SEARCH_LIST_VALUE"] = generateDomainSearchList(option.Config.DhcpdClusterDomain)
 +		}
  	}
  
  	if option.Config.EnableIPv6 {
 diff --git a/pkg/defaults/defaults.go b/pkg/defaults/defaults.go
-index c9f89257a5..927b680afa 100644
+index c9f89257a5..72b3cc610f 100644
 --- a/pkg/defaults/defaults.go
 +++ b/pkg/defaults/defaults.go
 @@ -559,6 +559,10 @@ const (
@@ -503,13 +519,13 @@ index c9f89257a5..927b680afa 100644
  	EnableEnvoyConfig = false
 +
 +	DhcpdEnabled = false
-+	DhcpdClusterDns = ""
++	DhcpdClusterDNS = ""
 +	DhcpdClusterDomain = ""
  )
  
  var (
 diff --git a/pkg/option/config.go b/pkg/option/config.go
-index e891a60a3d..280d5e2930 100644
+index e891a60a3d..fc581d083a 100644
 --- a/pkg/option/config.go
 +++ b/pkg/option/config.go
 @@ -379,6 +379,11 @@ const (
@@ -518,7 +534,7 @@ index e891a60a3d..280d5e2930 100644
  
 +	// DdhcpdEnabled enables BPF dhcp server
 +	DhcpdEnabled = "dhcpd-enabled"
-+	DhcpdClusterDns = "dhcpd-cluster-dns"
++	DhcpdClusterDNS = "dhcpd-cluster-dns"
 +	DhcpdClusterDomain = "dhcpd-cluster-domain"
 +
  	// EnableIPv4EgressGateway enables the IPv4 egress gateway
@@ -529,7 +545,7 @@ index e891a60a3d..280d5e2930 100644
  	EnableBPFClockProbe        bool
  	EnableIPMasqAgent          bool
 +	DhcpdEnabled               bool
-+	DhcpdClusterDns            string
++	DhcpdClusterDNS            string
 +	DhcpdClusterDomain         string
  	EnableIPv4EgressGateway    bool
  	EnableEnvoyConfig          bool
@@ -547,7 +563,7 @@ index e891a60a3d..280d5e2930 100644
  	c.EnableBPFClockProbe = vp.GetBool(EnableBPFClockProbe)
  	c.EnableIPMasqAgent = vp.GetBool(EnableIPMasqAgent)
 +	c.DhcpdEnabled = vp.GetBool(DhcpdEnabled)
-+	c.DhcpdClusterDns = vp.GetString(DhcpdClusterDns)
++	c.DhcpdClusterDNS = vp.GetString(DhcpdClusterDNS)
 +	c.DhcpdClusterDomain = vp.GetString(DhcpdClusterDomain)
  	c.EnableIPv4EgressGateway = vp.GetBool(EnableIPv4EgressGateway)
  	c.EnableEnvoyConfig = vp.GetBool(EnableEnvoyConfig)

--- a/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
@@ -52,6 +52,8 @@ shell:
   - cd /go/src/github.com/cilium/cilium
   - find /patches -name '*.patch' | xargs git apply --verbose
   - go mod tidy && go mod vendor && go mod verify
+  # it is hack for adding file from patch to installing proccess of cilium build
+  - git add bpf/lib/dhcp.h 
   - make PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/tmp/install build-container install-container-binary
   - make PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/tmp/install install-bash-completion licenses-all
   - mv LICENSE.all /tmp/install/LICENSE.all

--- a/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
@@ -5,7 +5,7 @@
 # Based on https://github.com/cilium/cilium/blob/v1.14.14/images/cilium/Dockerfile (builder stage)
 ---
 artifact: {{ $.ModuleName }}/cilium-artifact
-fromCacheVersion: "2024-11-15.0"
+fromCacheVersion: "2024-11-20.0"
 fromImage: {{ $.ModuleName }}/base-cilium-dev
 git:
 - add: /{{ $.ModulePath }}modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches

--- a/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
@@ -5,7 +5,7 @@
 # Based on https://github.com/cilium/cilium/blob/v1.14.14/images/cilium/Dockerfile (builder stage)
 ---
 artifact: {{ $.ModuleName }}/cilium-artifact
-fromCacheVersion: "2024-11-20.0"
+fromCacheVersion: "2024-11-21.0"
 fromImage: {{ $.ModuleName }}/base-cilium-dev
 git:
 - add: /{{ $.ModulePath }}modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches

--- a/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
@@ -5,7 +5,7 @@
 # Based on https://github.com/cilium/cilium/blob/v1.14.14/images/cilium/Dockerfile (builder stage)
 ---
 artifact: {{ $.ModuleName }}/cilium-artifact
-fromCacheVersion: 4
+fromCacheVersion: "2024-11-15.0"
 fromImage: {{ $.ModuleName }}/base-cilium-dev
 git:
 - add: /{{ $.ModulePath }}modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -52,7 +52,7 @@ shell:
   - cd /go/src/github.com/cilium/cilium
   - find /patches -name '*.patch' | xargs git apply --verbose
   - go mod tidy && go mod vendor && go mod verify
-  # it is hack for adding file from patch to installing proccess of cilium build
+  # git-adding files from patches to force build script take them into account
   - git add bpf/lib/dhcp.h 
   - make PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/tmp/install build-container install-container-binary
   - make PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/tmp/install install-bash-completion licenses-all

--- a/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
@@ -5,6 +5,7 @@
 # Based on https://github.com/cilium/cilium/blob/v1.14.14/images/cilium/Dockerfile (builder stage)
 ---
 artifact: {{ $.ModuleName }}/cilium-artifact
+fromCacheVersion: 4
 fromImage: {{ $.ModuleName }}/base-cilium-dev
 git:
 - add: /{{ $.ModulePath }}modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches

--- a/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
@@ -53,7 +53,7 @@ shell:
   - find /patches -name '*.patch' | xargs git apply --verbose
   - go mod tidy && go mod vendor && go mod verify
   # git-adding files from patches to force build script take them into account
-  - git add bpf/lib/dhcp.h 
+  - git add .
   - make PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/tmp/install build-container install-container-binary
   - make PKG_BUILD=1 SKIP_DOCS=true DESTDIR=/tmp/install install-bash-completion licenses-all
   - mv LICENSE.all /tmp/install/LICENSE.all

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -53,6 +53,9 @@ data:
   # Use stable MAC addresses for pods
   endpoint-interface-host-mac: "f6:e1:74:94:b8:1b"
   endpoint-interface-mac: "f6:e1:74:94:b8:1a"
+  dhcpd-enabled: "true"
+  dhcpd-cluster-dns: {{ .Values.global.discovery.clusterDNSAddress | quote }}
+  dhcpd-cluster-domain: {{ .Values.global.discovery.clusterDomain | quote }}
   {{- end }}
 
   {{- if eq .Values.cniCilium.internal.masqueradeMode "BPF" }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add dhcp server for pods implemented in cilium agent traffic control ebpf hook of lxc interfaces.

This dhcp server has fewer options than the virt-launcher dhcp server. List of not implemented options:
- 26 Interface MTU
- 121 Classless Static Route
- 119 Domain Search(only one basic fqdn cluster.local)
- 12 Host Name
- 15 Domain Name

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
DVP uses the DHCP for configuring guest network interfaces. It is now implemented by embedded to virt-launcher dhcp server which is linked to internal bridge in VM Pod. 
For optimizing purposes we need to redesign the in-Pod VM network scheme and get rid of internal bridge. So, we won't be able to use embedded dhcp server.


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Every Pod in cluster will be able to request it's IP via dhcp:

```
root@nginx-77b4fdf86c-bxz5w:/# dhclient eth0 -v
...
Listening on LPF/eth0/9e:56:fa:66:b5:bd
Sending on   LPF/eth0/9e:56:fa:66:b5:bd
Sending on   Socket/fallback
DHCPREQUEST for 10.111.1.157 on eth0 to 255.255.255.255 port 67
DHCPACK of 10.111.1.157 from 10.111.1.46
bound to 10.111.1.157 -- renewal in 1073741824 seconds.
```

After disabling kubevirt dhcp server QEMU/virtual machine will receive network settings from cilium dhcp server.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: feature
summary: Added ebpf-powered dhcp server for Pods.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
