### PR TITLE
[multitenancy-manager] fix default and managed bundles

### DIFF
--- a/modules/values-default.yaml
+++ b/modules/values-default.yaml
@@ -25,7 +25,7 @@ monitoringDeckhouseEnabled: true
 monitoringKubernetesControlPlaneEnabled: true
 monitoringKubernetesEnabled: true
 monitoringPingEnabled: true
-multitenancyManager:Enabled: true
+multitenancyManagerEnabled: true
 namespaceConfiguratorEnabled: true
 registryPackagesProxyEnabled: true
 nodeManagerEnabled: true

--- a/modules/values-managed.yaml
+++ b/modules/values-managed.yaml
@@ -17,6 +17,7 @@ monitoringCustomEnabled: true
 monitoringDeckhouseEnabled: true
 monitoringKubernetesEnabled: true
 monitoringPingEnabled: true
+multitenancyManagerEnabled: true
 namespaceConfiguratorEnabled: true
 operatorPrometheusCrdEnabled: true
 operatorPrometheusEnabled: true


### PR DESCRIPTION
## Description
It provides fix for default and managed bundles to enable multitenancy-manager.

## Why do we need it, and what problem does it solve?
multitenancy-manager should be enabled by default.

## Why do we need it in the patch release (if we do)?
multitenancy-manager should be enabled by default.

## What is the expected result?
multitenancy-manager enabled by default.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: fix 
summary: Enable multitenancy-manager by default in default and managed bundles.
```
