### PR TITLE
[dhctl] Converge. Skip remove labels if node was not found

### DIFF
--- a/dhctl/pkg/kubernetes/actions/converge/converge.go
+++ b/dhctl/pkg/kubernetes/actions/converge/converge.go
@@ -144,6 +144,8 @@ func (r *Runner) RunConverge() error {
 		if err != nil {
 			return fmt.Errorf("failed to start lock runner: %w", err)
 		}
+
+		return nil
 	}
 
 	return r.converge()

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/drain.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/drain.go
@@ -40,6 +40,7 @@ func drainNode(kubeCl *client.KubernetesClient, nodeName string) error {
 	node, err := kubeCl.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
+			log.InfoF("Node '%s' has been deleted. Skip\n", nodeName)
 			return nil
 		}
 

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	flantkubeclient "github.com/flant/kube-client/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -102,6 +104,10 @@ func removeLabelsFromNode(kubeCl *client.KubernetesClient, nodeName string, labe
 	return retry.NewLoop(fmt.Sprintf("Remove labels from node %s", nodeName), 45, 5*time.Second).Run(func() error {
 		node, err := kubeCl.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 		if err != nil {
+			if errors.IsNotFound(err) {
+				log.InfoF("Node '%s' has been deleted. Skip\n", nodeName)
+				return nil
+			}
 			return err
 		}
 

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
@@ -21,9 +21,8 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-
 	flantkubeclient "github.com/flant/kube-client/client"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 


### PR DESCRIPTION
## Description
Skip remove labels if node was not found during converge.
Remove second converge operation.

## Why do we need it, and what problem does it solve?
Manual instruction for remove master does not work because in the instruction we delete node object and converge fail if node does not exist.

Mistake in the code run converge two times and second time without lock

## Why do we need it in the patch release (if we do)?

Documentation does not work

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Skip remove labels if node was not found during converge.
impact_level: default
---
section: dhctl
type: fix
summary: Do not run converge second time.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
