### PR TITLE
[docs] Rework recomendations for Quay

### DIFF
--- a/docs/documentation/_data/supported_versions.yml
+++ b/docs/documentation/_data/supported_versions.yml
@@ -115,26 +115,28 @@ registries:
     url: https://quay.io/
     additionalInfo:
       ru: |
-        <em>Требуется добавить поддержку <a href="https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/use_red_hat_quay/oci-intro#other-oci-artifacts-with-quay" target="_blank">дополнительных типов артефактов OCI.</a></em>
+        <em>Требуется добавить поддержку дополнительных типов артефактов OCI.</em>
+        <em>Подробнее можно ознакомиться <a href="https://docs.redhat.com/en/documentation/red_hat_quay/3/html/manage_red_hat_quay/supported-oci-media-types#configuring-additional-oci-media-types-proc" target="_blank">тут</a> или <a href="https://docs.projectquay.io/manage_quay.html#configuring-additional-oci-media-types-proc" target="_blank">тут</a></em>
         <pre>
         FEATURE_GENERAL_OCI_SUPPORT: true
         ALLOWED_OCI_ARTIFACT_TYPES:
-          "application/vnd.aquasec.trivy.config.v1+json":
-            - "application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
-          "application/octet-stream":
-            - "application/deckhouse.io.bdu.layer.v1.tar+gzip"
-          "application/vnd.oci.empty.v1+json":
-            - "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"
+          application/octet-stream:
+            - application/deckhouse.io.bdu.layer.v1.tar+gzip
+            - application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip
+          application/vnd.aquasec.trivy.config.v1+json:
+            - application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
+            - application/vnd.aquasec.trivy.db.layer.v1.tar+gzip
         </pre>
       en: |
-        <em>It is required to add support for <a href="https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/use_red_hat_quay/oci-intro#other-oci-artifacts-with-quay" target="_blank">additional types of OCI artifacts.</a></em>
+        <em>It is required to add support for additional types of OCI artifacts.</em>
+        <em>More information you can get <a href="https://docs.redhat.com/en/documentation/red_hat_quay/3/html/manage_red_hat_quay/supported-oci-media-types#configuring-additional-oci-media-types-proc" target="_blank">here</a> or <a href="https://docs.projectquay.io/manage_quay.html#configuring-additional-oci-media-types-proc" target="_blank">here</a></em>
         <pre>
         FEATURE_GENERAL_OCI_SUPPORT: true
         ALLOWED_OCI_ARTIFACT_TYPES:
-          "application/vnd.aquasec.trivy.config.v1+json":
-            - "application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
-          "application/octet-stream":
-            - "application/deckhouse.io.bdu.layer.v1.tar+gzip"
-          "application/vnd.oci.empty.v1+json":
-            - "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"
+          application/octet-stream:
+            - application/deckhouse.io.bdu.layer.v1.tar+gzip
+            - application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip
+          application/vnd.aquasec.trivy.config.v1+json:
+            - application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
+            - application/vnd.aquasec.trivy.db.layer.v1.tar+gzip
         </pre>

--- a/docs/documentation/_data/supported_versions.yml
+++ b/docs/documentation/_data/supported_versions.yml
@@ -116,7 +116,7 @@ registries:
     additionalInfo:
       ru: |
         <em>Требуется добавить поддержку дополнительных типов артефактов OCI.</em>
-        <em>Подробнее можно ознакомиться <a href="https://docs.redhat.com/en/documentation/red_hat_quay/3/html/manage_red_hat_quay/supported-oci-media-types#configuring-additional-oci-media-types-proc" target="_blank">тут</a> или <a href="https://docs.projectquay.io/manage_quay.html#configuring-additional-oci-media-types-proc" target="_blank">тут</a></em>
+        <em>Подробнее можно ознакомиться <a href="https://docs.redhat.com/en/documentation/red_hat_quay/3/html/manage_red_hat_quay/supported-oci-media-types#configuring-additional-oci-media-types-proc" target="_blank">в документации Red Hat Quay</a> или <a href="https://docs.projectquay.io/manage_quay.html#configuring-additional-oci-media-types-proc" target="_blank">документации Project Quay</a></em>
         <pre>
         FEATURE_GENERAL_OCI_SUPPORT: true
         ALLOWED_OCI_ARTIFACT_TYPES:
@@ -129,7 +129,7 @@ registries:
         </pre>
       en: |
         <em>It is required to add support for additional types of OCI artifacts.</em>
-        <em>More information you can get <a href="https://docs.redhat.com/en/documentation/red_hat_quay/3/html/manage_red_hat_quay/supported-oci-media-types#configuring-additional-oci-media-types-proc" target="_blank">here</a> or <a href="https://docs.projectquay.io/manage_quay.html#configuring-additional-oci-media-types-proc" target="_blank">here</a></em>
+        <em>More information you can get in the <a href="https://docs.redhat.com/en/documentation/red_hat_quay/3/html/manage_red_hat_quay/supported-oci-media-types#configuring-additional-oci-media-types-proc" target="_blank">Red Hat Quay documentation</a> or <a href="https://docs.projectquay.io/manage_quay.html#configuring-additional-oci-media-types-proc" target="_blank">Project Quay documentation</a></em>
         <pre>
         FEATURE_GENERAL_OCI_SUPPORT: true
         ALLOWED_OCI_ARTIFACT_TYPES:


### PR DESCRIPTION
## Description
Rework recommendations for Quay registry.

## Why do we need it, and what problem does it solve?
`trivy-checks` cannot be pushed with error like this:
```
Nov 14 22:16:32.881 INFO  ║ [1 / 1] Pushing image kovalkov-quay.ru-central1.internal/user/dkp/security/trivy-checks:0
Nov 14 22:16:33.284 WARN  ║ It looks like you are using Project Quay registry and it is not configured correctly for hosting Deckhouse.
See the docs at https://deckhouse.io/documentation/v1/supported_versions.html#container-registry for more details.

TL;DR: You should retry push after allowing some additional types of OCI artifacts in your config.yaml as follows:
FEATURE_GENERAL_OCI_SUPPORT: true
ALLOWED_OCI_ARTIFACT_TYPES:
  "application/vnd.aquasec.trivy.config.v1+json":
    - "application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
  "application/octet-stream":
    - "application/deckhouse.io.bdu.layer.v1.tar+gzip"
  "application/vnd.oci.empty.v1+json":
    - "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"
```

But this recomendations does not help.
```
gunicorn-registry stdout | During handling of the above exception, another exception occurred:
gunicorn-registry stdout | Traceback (most recent call last):
gunicorn-registry stdout |   File "/quay-registry/endpoints/v2/manifest.py", line 325, in _parse_manifest
gunicorn-registry stdout |     return parse_manifest_from_bytes(
gunicorn-registry stdout |   File "/quay-registry/image/shared/schemas.py", line 47, in parse_manifest_from_bytes
gunicorn-registry stdout |     return OCIManifest(manifest_bytes, ignore_unknown_mediatypes=ignore_unknown_mediatypes)
gunicorn-registry stdout |   File "/quay-registry/image/oci/manifest.py", line 158, in __init__
gunicorn-registry stdout |     raise MalformedOCIManifest("manifest data does not match schema: %s" % ve)
gunicorn-registry stdout | image.oci.manifest.MalformedOCIManifest: manifest data does not match schema: 'application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip' is not one of ['application/vnd.oci.image.layer.v1.tar', 'application/vnd.oci.image.layer.v1.tar+gzip', 'application/vnd.oci.image.layer.v1.tar+zstd', 'application/vnd.oci.image.layer.nondistributable.v1.tar', 'application/vnd.oci.image.layer.nondistributable.v1.tar+gzip', 'application/vnd.oci.image.layer.v1.tar+zstd', 'application/vnd.sylabs.sif.layer.v1+tar', 'application/deckhouse.io.bdu.layer.v1.tar+gzip', 'application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip', 'application/vnd.aquasec.trivy.db.layer.v1.tar+gzip', 'application/tar+gzip', 'application/vnd.cncf.helm.chart.content.v1.tar+gzip']
gunicorn-registry stdout | Failed validating 'enum' in schema['properties']['layers']['items']['properties']['mediaType']:
gunicorn-registry stdout |     {'description': 'The MIME type of the referenced manifest',
gunicorn-registry stdout |      'enum': ['application/vnd.oci.image.layer.v1.tar',
gunicorn-registry stdout |               'application/vnd.oci.image.layer.v1.tar+gzip',
gunicorn-registry stdout |               'application/vnd.oci.image.layer.v1.tar+zstd',
gunicorn-registry stdout |               'application/vnd.oci.image.layer.nondistributable.v1.tar',
gunicorn-registry stdout |               'application/vnd.oci.image.layer.nondistributable.v1.tar+gzip',
gunicorn-registry stdout |               'application/vnd.oci.image.layer.v1.tar+zstd',
gunicorn-registry stdout |               'application/vnd.sylabs.sif.layer.v1+tar',
gunicorn-registry stdout |               'application/deckhouse.io.bdu.layer.v1.tar+gzip',
gunicorn-registry stdout |               'application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip',
gunicorn-registry stdout |               'application/vnd.aquasec.trivy.db.layer.v1.tar+gzip',
gunicorn-registry stdout |               'application/tar+gzip',
gunicorn-registry stdout |               'application/vnd.cncf.helm.chart.content.v1.tar+gzip'],
gunicorn-registry stdout |      'pattern': '\\w+/[-.\\w]+(?:\\+[-.\\w]+)?',
gunicorn-registry stdout |      'type': 'string'}
gunicorn-registry stdout | On instance['layers'][0]['mediaType']:
gunicorn-registry stdout |     'application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip'
```

Also, we have this mediaType:
```
~$ crane manifest registry.deckhouse.io/deckhouse/ee/security/trivy-checks:0 | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/octet-stream",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2
  },
  "layers": [
    {
      "mediaType": "application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip",
      "digest": "sha256:35ca4b9bd8dc2a5f560c0186c387881d95034317fa4894dc538e3f84099975b4",
      "size": 74904,
      "annotations": {
        "org.opencontainers.image.title": "bundle.tar.gz"
      }
    }
  ],
  "annotations": {
    "org.opencontainers.image.created": "2024-11-14T12:21:56Z"
  }
}

~$ crane manifest registry.deckhouse.io/deckhouse/ee/security/trivy-db:2 | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.aquasec.trivy.config.v1+json",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2
  },
  "layers": [
    {
      "mediaType": "application/vnd.aquasec.trivy.db.layer.v1.tar+gzip",
      "digest": "sha256:ba31b67fed6353c4e4772354f564e2e027de370560f80a9a5aefc5b9161df549",
      "size": 152116085,
      "annotations": {
        "org.opencontainers.image.title": "db.tar.gz"
      }
    }
  ],
  "annotations": {
    "org.opencontainers.image.created": "2024-11-14T12:21:46Z"
  }
}

~$ crane manifest registry.deckhouse.io/deckhouse/ee/security/trivy-bdu:1 | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/octet-stream",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2
  },
  "layers": [
    {
      "mediaType": "application/deckhouse.io.bdu.layer.v1.tar+gzip",
      "digest": "sha256:1d02e67f8d33ed4c9fb106575680e89fbd5151507d83c736b3eac049270eabd0",
      "size": 455943,
      "annotations": {
        "org.opencontainers.image.title": "export.tar.gz"
      }
    }
  ],
  "annotations": {
    "org.opencontainers.image.created": "2024-11-14T12:22:29Z"
  }
}

~$ crane manifest registry.deckhouse.io/deckhouse/ee/security/trivy-java-db:1 | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.aquasec.trivy.config.v1+json",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2
  },
  "layers": [
    {
      "mediaType": "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip",
      "digest": "sha256:e0f42193fefbfaa79c6a550a76a527557fe36a480643849d8ed21e98ccb5575d",
      "size": 693127787,
      "annotations": {
        "org.opencontainers.image.title": "javadb.tar.gz"
      }
    }
  ],
  "annotations": {
    "org.opencontainers.image.created": "2024-11-14T12:22:40Z"
  }
}
```

Little helper:
```
for image in "registry.deckhouse.io/deckhouse/ee/security/trivy-bdu:1" "registry.deckhouse.io/deckhouse/ee/security/trivy-checks:0" "registry.deckhouse.io/deckhouse/ee/security/trivy-db:2" "registry.deckhouse.io/deckhouse/ee/security/trivy-java-db:1"; do echo $image; crane manifest $image | jq -r '"\(.config.mediaType) \(.layers[].mediaType)"'; done
registry.deckhouse.io/deckhouse/ee/security/trivy-bdu:1
application/octet-stream application/deckhouse.io.bdu.layer.v1.tar+gzip
registry.deckhouse.io/deckhouse/ee/security/trivy-checks:0
application/octet-stream application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip
registry.deckhouse.io/deckhouse/ee/security/trivy-db:2
application/vnd.aquasec.trivy.config.v1+json application/vnd.aquasec.trivy.db.layer.v1.tar+gzip
registry.deckhouse.io/deckhouse/ee/security/trivy-java-db:1
application/vnd.aquasec.trivy.config.v1+json application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
```

## Why do we need it in the patch release (if we do)?

Correct documentation for mirroring to Quay registry.

## What is the expected result?

Mirror works correctly
```
Nov 14 22:27:33.000 INFO  ╚ Push Deckhouse images to registry succeeded in 4m31.325803667s
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Rework recomendations for Quay registry.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
