### PR TITLE
[docs][module-builder] Improve error handling

### DIFF
--- a/docs/documentation/_data/supported_versions.yml
+++ b/docs/documentation/_data/supported_versions.yml
@@ -115,26 +115,28 @@ registries:
     url: https://quay.io/
     additionalInfo:
       ru: |
-        <em>Требуется добавить поддержку <a href="https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/use_red_hat_quay/oci-intro#other-oci-artifacts-with-quay" target="_blank">дополнительных типов артефактов OCI.</a></em>
+        <em>Требуется добавить поддержку дополнительных типов артефактов OCI.</em>
+        <em>Подробнее можно ознакомиться <a href="https://docs.redhat.com/en/documentation/red_hat_quay/3/html/manage_red_hat_quay/supported-oci-media-types#configuring-additional-oci-media-types-proc" target="_blank">в документации Red Hat Quay</a> или <a href="https://docs.projectquay.io/manage_quay.html#configuring-additional-oci-media-types-proc" target="_blank">документации Project Quay</a></em>
         <pre>
         FEATURE_GENERAL_OCI_SUPPORT: true
         ALLOWED_OCI_ARTIFACT_TYPES:
-          "application/vnd.aquasec.trivy.config.v1+json":
-            - "application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
-          "application/octet-stream":
-            - "application/deckhouse.io.bdu.layer.v1.tar+gzip"
-          "application/vnd.oci.empty.v1+json":
-            - "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"
+          application/octet-stream:
+            - application/deckhouse.io.bdu.layer.v1.tar+gzip
+            - application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip
+          application/vnd.aquasec.trivy.config.v1+json:
+            - application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
+            - application/vnd.aquasec.trivy.db.layer.v1.tar+gzip
         </pre>
       en: |
-        <em>It is required to add support for <a href="https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/use_red_hat_quay/oci-intro#other-oci-artifacts-with-quay" target="_blank">additional types of OCI artifacts.</a></em>
+        <em>It is required to add support for additional types of OCI artifacts.</em>
+        <em>More information you can get in the <a href="https://docs.redhat.com/en/documentation/red_hat_quay/3/html/manage_red_hat_quay/supported-oci-media-types#configuring-additional-oci-media-types-proc" target="_blank">Red Hat Quay documentation</a> or <a href="https://docs.projectquay.io/manage_quay.html#configuring-additional-oci-media-types-proc" target="_blank">Project Quay documentation</a></em>
         <pre>
         FEATURE_GENERAL_OCI_SUPPORT: true
         ALLOWED_OCI_ARTIFACT_TYPES:
-          "application/vnd.aquasec.trivy.config.v1+json":
-            - "application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
-          "application/octet-stream":
-            - "application/deckhouse.io.bdu.layer.v1.tar+gzip"
-          "application/vnd.oci.empty.v1+json":
-            - "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"
+          application/octet-stream:
+            - application/deckhouse.io.bdu.layer.v1.tar+gzip
+            - application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip
+          application/vnd.aquasec.trivy.config.v1+json:
+            - application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
+            - application/vnd.aquasec.trivy.db.layer.v1.tar+gzip
         </pre>

--- a/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-schema.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-schema.html
@@ -51,7 +51,7 @@
     <span id="{{ $linkAnchor }}" data-anchor-id="{{ $linkAnchor }}" class="resources__prop_name anchored">
       <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
       <span class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-      <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div><span title="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span>
+      <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div><title="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span>
     </div>
   {{- else }}
     <div class="resources__prop_name anchored" data-anchor-id="{{ $linkAnchor }}"  id="{{ $linkAnchor }}">

--- a/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-schema.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-schema.html
@@ -51,7 +51,7 @@
     <span id="{{ $linkAnchor }}" data-anchor-id="{{ $linkAnchor }}" class="resources__prop_name anchored">
       <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
       <span class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-      <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div><title="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span>
+      <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div><span title="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span>
     </div>
   {{- else }}
     <div class="resources__prop_name anchored" data-anchor-id="{{ $linkAnchor }}"  id="{{ $linkAnchor }}">


### PR DESCRIPTION
## Description
There is a error.  When docs-builder can't render templates, not all containers of the frontend deployment are ready, but something bad happens.  Investigating the issue.

## Why do we need it, and what problem does it solve?
If we have a global build error (affect all site), we need to mark readiness check to false, to respond with only good site

* global build error - our site has error when build default platform documentation
* module build error - will skip module build and try to rebuild all other site pages

## What is the expected result?
### Before
Documentation site show result with errors and pods are still running in cluster
```
documentation-b5dbff57c-9rj95                        2/2     Running
```

### After
Documentation site show 503 Service Temporarily Unavailable nginx page and pods are not ready in cluster
```
documentation-b5dbff57c-9rj95                        1/2     Running
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: |
  Improve readiness probe for the `docs-builder` component. Set pods as *not ready* If we have global build error.
impact_level: low
```
