### PR TITLE
[ci] Fix autolabeling on backport

### DIFF
--- a/.github/workflow_templates/on-pull-request-backport.yml
+++ b/.github/workflow_templates/on-pull-request-backport.yml
@@ -128,9 +128,16 @@ jobs:
           committer: "deckhouse-BOaTswain <89150800+deckhouse-boatswain@users.noreply.github.com>"
           branch: ${{ env.RELEASE_BRANCH }}
           commit: ${{ env.COMMIT_SHA }}
-          labels: auto,status/backport/success
+          labels: auto,backported
           automerge: true
           merge_method: squash
+      - name: Remove backport label
+        if: always()
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          number: ${{ steps.prepare.outputs.pr_number }}
+          labels: "status/backport"
       - name: Add success label
         if: steps.cherry_pick_pr.conclusion == 'success'
         uses: actions-ecosystem/action-add-labels@v1
@@ -150,13 +157,6 @@ jobs:
           issue-number: ${{ steps.prepare.outputs.pr_number }}
           reactions: hooray
           body: "Cherry pick PR [${{ env.cherry_pr_number }}](${{ env.cherry_pr_url }}) to the branch [${{ env.release_branch }}](https://github.com/${{github.repository}}/tree/${{ env.release_branch }}) successful!"
-      - name: Remove backport label
-        if: always()
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          github_token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
-          number: ${{ steps.prepare.outputs.pr_number }}
-          labels: "status/backport"
       - name: Add error label
         if: ${{ failure() && (steps.cherry_pick_pr.conclusion == 'failure' || steps.check_target_branch.conclusion == 'failure') }}
         uses: actions-ecosystem/action-add-labels@v1

--- a/.github/workflows/on-pull-request-backport.yml
+++ b/.github/workflows/on-pull-request-backport.yml
@@ -132,9 +132,16 @@ jobs:
           committer: "deckhouse-BOaTswain <89150800+deckhouse-boatswain@users.noreply.github.com>"
           branch: ${{ env.RELEASE_BRANCH }}
           commit: ${{ env.COMMIT_SHA }}
-          labels: auto,status/backport/success
+          labels: auto,backported
           automerge: true
           merge_method: squash
+      - name: Remove backport label
+        if: always()
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          number: ${{ steps.prepare.outputs.pr_number }}
+          labels: "status/backport"
       - name: Add success label
         if: steps.cherry_pick_pr.conclusion == 'success'
         uses: actions-ecosystem/action-add-labels@v1
@@ -154,13 +161,6 @@ jobs:
           issue-number: ${{ steps.prepare.outputs.pr_number }}
           reactions: hooray
           body: "Cherry pick PR [${{ env.cherry_pr_number }}](${{ env.cherry_pr_url }}) to the branch [${{ env.release_branch }}](https://github.com/${{github.repository}}/tree/${{ env.release_branch }}) successful!"
-      - name: Remove backport label
-        if: always()
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          github_token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
-          number: ${{ steps.prepare.outputs.pr_number }}
-          labels: "status/backport"
       - name: Add error label
         if: ${{ failure() && (steps.cherry_pick_pr.conclusion == 'failure' || steps.check_target_branch.conclusion == 'failure') }}
         uses: actions-ecosystem/action-add-labels@v1


### PR DESCRIPTION
## Description
Fix problems with backport autolabeling.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix autolabeling on backport.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
