### PR TITLE
[rbacv2] replace use admin with use user for manage manager role

### DIFF
--- a/modules/140-user-authz/hooks/handle_manage_bindings.go
+++ b/modules/140-user-authz/hooks/handle_manage_bindings.go
@@ -136,7 +136,7 @@ func syncBindings(input *go_hook.HookInput) error {
 	for _, snap := range input.Snapshots["manageBindings"] {
 		binding := snap.(*filteredManageBinding)
 		role, namespaces := roleAndNamespacesByBinding(input.Snapshots["manageRoles"], binding.RoleName)
-		useBindingName := fmt.Sprintf("d8:use:binding:%s", binding.Name)
+		useBindingName := fmt.Sprintf("d8:use:%s:binding:%s", role, binding.Name)
 		for namespace := range namespaces {
 			input.PatchCollector.Create(createBinding(binding, role, namespace), object_patch.UpdateIfExists())
 			expected[useBindingName] = true
@@ -228,7 +228,7 @@ func createBinding(binding *filteredManageBinding, useRoleName string, namespace
 			APIVersion: "rbac.authorization.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("d8:use:binding:%s", binding.Name),
+			Name:      fmt.Sprintf("d8:use:%s:binding:%s", useRoleName, binding.Name),
 			Namespace: namespace,
 			Labels: map[string]string{
 				"heritage":                       "deckhouse",

--- a/modules/140-user-authz/hooks/handle_manage_bindings_test.go
+++ b/modules/140-user-authz/hooks/handle_manage_bindings_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = Describe("Modules :: user-authz :: hooks :: handle-scope-bindings ::", func() {
+var _ = Describe("Modules :: user-authz :: hooks :: handle-manage-bindings ::", func() {
 	f := HookExecutionConfigInit(`{"userAuthz":{"internal": {}}}`, "")
 
 	Context("There`s ManageScopeBinding", func() {
@@ -50,13 +50,13 @@ var _ = Describe("Modules :: user-authz :: hooks :: handle-scope-bindings ::", f
 
 		It("Should create RoleBinding", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			roleBinding := f.KubernetesResource("RoleBinding", "test-ns", "d8:use:binding:test")
-			Expect(roleBinding.Field("metadata.name").Str).To(Equal("d8:use:binding:test"))
-			roleBinding = f.KubernetesResource("RoleBinding", "test2-ns", "d8:use:binding:test")
-			Expect(roleBinding.Field("metadata.name").Str).To(Equal("d8:use:binding:test"))
+			roleBinding := f.KubernetesResource("RoleBinding", "test-ns", "d8:use:admin:binding:test")
+			Expect(roleBinding.Field("metadata.name").Str).To(Equal("d8:use:admin:binding:test"))
+			roleBinding = f.KubernetesResource("RoleBinding", "test2-ns", "d8:use:admin:binding:test")
+			Expect(roleBinding.Field("metadata.name").Str).To(Equal("d8:use:admin:binding:test"))
 
-			roleBinding = f.KubernetesResource("RoleBinding", "test2-ns", "d8:use:binding:test2")
-			Expect(roleBinding.Field("metadata.name").Str).To(Equal("d8:use:binding:test2"))
+			roleBinding = f.KubernetesResource("RoleBinding", "test2-ns", "d8:use:admin:binding:test2")
+			Expect(roleBinding.Field("metadata.name").Str).To(Equal("d8:use:admin:binding:test2"))
 		})
 	})
 
@@ -75,10 +75,10 @@ var _ = Describe("Modules :: user-authz :: hooks :: handle-scope-bindings ::", f
 
 		It("Should create RoleBinding", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			roleBinding := f.KubernetesResource("RoleBinding", "test-ns", "d8:use:binding:test")
-			Expect(roleBinding.Field("metadata.name").Str).To(Equal("d8:use:binding:test"))
-			roleBinding = f.KubernetesResource("RoleBinding", "test2-ns", "d8:use:binding:test")
-			Expect(roleBinding.Field("metadata.name").Str).To(Equal("d8:use:binding:test"))
+			roleBinding := f.KubernetesResource("RoleBinding", "test-ns", "d8:use:admin:binding:test")
+			Expect(roleBinding.Field("metadata.name").Str).To(Equal("d8:use:admin:binding:test"))
+			roleBinding = f.KubernetesResource("RoleBinding", "test2-ns", "d8:use:admin:binding:test")
+			Expect(roleBinding.Field("metadata.name").Str).To(Equal("d8:use:admin:binding:test"))
 		})
 	})
 
@@ -96,13 +96,13 @@ var _ = Describe("Modules :: user-authz :: hooks :: handle-scope-bindings ::", f
 
 		It("Should delete RoleBinding", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			roleBinding := f.KubernetesResource("RoleBinding", "test-ns", "d8:use:binding:test")
+			roleBinding := f.KubernetesResource("RoleBinding", "test-ns", "d8:use:admin:binding:test")
 			Expect(roleBinding).To(BeEmpty())
-			roleBinding = f.KubernetesResource("RoleBinding", "test-ns", "d8:use:binding:test2")
+			roleBinding = f.KubernetesResource("RoleBinding", "test-ns", "d8:use:admin:binding:test2")
 			Expect(roleBinding).To(BeEmpty())
-			roleBinding = f.KubernetesResource("RoleBinding", "test-ns2", "d8:use:binding:test3")
+			roleBinding = f.KubernetesResource("RoleBinding", "test-ns2", "d8:use:admin:binding:test3")
 			Expect(roleBinding).To(BeEmpty())
-			roleBinding = f.KubernetesResource("RoleBinding", "test-ns2", "d8:use:binding:test4")
+			roleBinding = f.KubernetesResource("RoleBinding", "test-ns2", "d8:use:admin:binding:test4")
 			Expect(roleBinding).To(BeEmpty())
 		})
 	})

--- a/modules/140-user-authz/templates/rbacv2/global/manage/roles/all/manager.yaml
+++ b/modules/140-user-authz/templates/rbacv2/global/manage/roles/all/manager.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authz
-    rbac.deckhouse.io/use-role: admin
+    rbac.deckhouse.io/use-role: user
     rbac.deckhouse.io/kind: manage
     rbac.deckhouse.io/level: all
 aggregationRule:

--- a/modules/140-user-authz/templates/rbacv2/global/manage/roles/deckhouse/manager.yaml
+++ b/modules/140-user-authz/templates/rbacv2/global/manage/roles/deckhouse/manager.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authz
-    rbac.deckhouse.io/use-role: admin
+    rbac.deckhouse.io/use-role: user
     rbac.deckhouse.io/kind: manage
     rbac.deckhouse.io/level: scope
     rbac.deckhouse.io/scope: deckhouse

--- a/modules/140-user-authz/templates/rbacv2/global/manage/roles/infrastructure/manager.yaml
+++ b/modules/140-user-authz/templates/rbacv2/global/manage/roles/infrastructure/manager.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authz
-    rbac.deckhouse.io/use-role: admin
+    rbac.deckhouse.io/use-role: user
     rbac.deckhouse.io/kind: manage
     rbac.deckhouse.io/level: scope
     rbac.deckhouse.io/scope: infrastructure

--- a/modules/140-user-authz/templates/rbacv2/global/manage/roles/kubernetes/manager.yaml
+++ b/modules/140-user-authz/templates/rbacv2/global/manage/roles/kubernetes/manager.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authz
-    rbac.deckhouse.io/use-role: admin
+    rbac.deckhouse.io/use-role: user
     rbac.deckhouse.io/kind: manage
     rbac.deckhouse.io/level: scope
     rbac.deckhouse.io/scope: kubernetes

--- a/modules/140-user-authz/templates/rbacv2/global/manage/roles/networking/manager.yaml
+++ b/modules/140-user-authz/templates/rbacv2/global/manage/roles/networking/manager.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authz
-    rbac.deckhouse.io/use-role: admin
+    rbac.deckhouse.io/use-role: user
     rbac.deckhouse.io/kind: manage
     rbac.deckhouse.io/level: scope
     rbac.deckhouse.io/scope: networking

--- a/modules/140-user-authz/templates/rbacv2/global/manage/roles/observability/manager.yaml
+++ b/modules/140-user-authz/templates/rbacv2/global/manage/roles/observability/manager.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authz
-    rbac.deckhouse.io/use-role: admin
+    rbac.deckhouse.io/use-role: user
     rbac.deckhouse.io/kind: manage
     rbac.deckhouse.io/level: scope
     rbac.deckhouse.io/scope: observability

--- a/modules/140-user-authz/templates/rbacv2/global/manage/roles/security/manager.yaml
+++ b/modules/140-user-authz/templates/rbacv2/global/manage/roles/security/manager.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authz
-    rbac.deckhouse.io/use-role: admin
+    rbac.deckhouse.io/use-role: user
     rbac.deckhouse.io/kind: manage
     rbac.deckhouse.io/level: scope
     rbac.deckhouse.io/scope: security

--- a/modules/140-user-authz/templates/rbacv2/global/manage/roles/storage/manager.yaml
+++ b/modules/140-user-authz/templates/rbacv2/global/manage/roles/storage/manager.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     heritage: deckhouse
     module: user-authz
-    rbac.deckhouse.io/use-role: admin
+    rbac.deckhouse.io/use-role: user
     rbac.deckhouse.io/kind: manage
     rbac.deckhouse.io/level: scope
     rbac.deckhouse.io/scope: storage


### PR DESCRIPTION
## Description
It replaces use admin role with use user role for manage manager roles.

## Why do we need it, and what problem does it solve?
It reduces rights for manage manager roles.

## What is the expected result?
Use user roles are created in system namespaces when manage manager roles are created.

Use roles for manage:all:manager:
<img width="781" alt="Screenshot 2024-11-20 at 2 28 05 PM" src="https://github.com/user-attachments/assets/f20c3db2-d07d-4652-82ab-177f5b8f9498">

Use roles for manage:security:manager:
<img width="809" alt="Screenshot 2024-11-20 at 2 26 42 PM" src="https://github.com/user-attachments/assets/ec937f94-fba1-429d-847f-f21a76a22f4d">

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: feature
summary: Replace use admin roles with use user roles for manage manager roles.
impact: Reducing rights for manage manager roles.
impact_level: default
```