### PR TITLE
[multitenancy-manager] add retry on startup

### DIFF
--- a/modules/160-multitenancy-manager/images/multitenancy-manager/cmd/main.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/cmd/main.go
@@ -61,7 +61,7 @@ var (
 )
 
 const (
-	haModeEnv    = "HA_MODE"
+	haModeEnv      = "HA_MODE"
 	controllerName = "multitenancy-manager"
 )
 

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/project/utils.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/pkg/manager/project/utils.go
@@ -18,6 +18,7 @@ package project
 
 import (
 	"context"
+	"fmt"
 	"slices"
 
 	"controller/pkg/apis/deckhouse.io/v1alpha1"
@@ -95,8 +96,7 @@ func (m *Manager) ensureProject(ctx context.Context, project *v1alpha2.Project) 
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				existingProject := new(v1alpha2.Project)
 				if err = m.client.Get(ctx, types.NamespacedName{Name: project.Name}, existingProject); err != nil {
-					m.log.Error(err, "failed to fetch the project")
-					return err
+					return fmt.Errorf("failed to fetch the project: %w", err)
 				}
 
 				existingProject.Spec = project.Spec
@@ -106,12 +106,10 @@ func (m *Manager) ensureProject(ctx context.Context, project *v1alpha2.Project) 
 				return m.client.Update(ctx, existingProject)
 			})
 			if err != nil {
-				m.log.Error(err, "failed to update the project")
-				return err
+				return fmt.Errorf("failed to update the project: %w", err)
 			}
 		} else {
-			m.log.Error(err, "failed to create the project", "project", project.Name)
-			return err
+			return fmt.Errorf("failed to create the '%s' project: %w", project.Name, err)
 		}
 	}
 	m.log.Info("successfully ensured the project", "project", project.Name)


### PR DESCRIPTION
## Description
Improves the controller's bootstrap sequence by leveraging `retry.OnError` function to retry Init steps in case the controller's webhooks haven't started yet.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
The controller starts smoothly, without multiple restarts.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
The controller starts smoothly, without multiple restarts.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: multitenancy-manager
type: chore
summary: Add retry on startup.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
