### PR TITLE
[dhctl] Add tasks for moduleconfigs routines for post bootstrap and creating with resources phases

### DIFF
--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -119,6 +119,11 @@ func PrepareDeckhouseInstallConfig(metaConfig *MetaConfig) (*DeckhouseInstaller,
 	if metaConfig == nil {
 		return nil, fmt.Errorf("Internal error. Metaconfig is nil")
 	}
+
+	if len(metaConfig.DeckhouseConfig.ConfigOverrides) > 0 {
+		return nil, fmt.Errorf("Support for 'configOverrides' was removed. Please use ModuleConfig's instead.")
+	}
+
 	clusterConfig, err := metaConfig.ClusterConfigYAML()
 	if err != nil {
 		return nil, fmt.Errorf("Marshal cluster config failed: %v", err)

--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -70,7 +70,6 @@ type DeckhouseInstaller struct {
 	KubeadmBootstrap   bool
 	MasterNodeSelector bool
 
-	ReleaseChannel   string
 	InstallerVersion string
 
 	CommanderMode bool
@@ -138,38 +137,7 @@ func PrepareDeckhouseInstallConfig(metaConfig *MetaConfig) (*DeckhouseInstaller,
 	bundle := DefaultBundle
 	logLevel := DefaultLogLevel
 
-	releaseChannel := ""
-
-	// todo after release 1.55 remove it and from openapi schema
-	deprecatedFields := make([]string, 0, 3)
-	deprecatedFieldsExamples := make([]string, 0, 3)
-	if metaConfig.DeckhouseConfig.ReleaseChannel != "" {
-		releaseChannel = metaConfig.DeckhouseConfig.ReleaseChannel
-		deprecatedFields = append(deprecatedFields, "releaseChannel")
-		deprecatedFieldsExamples = append(deprecatedFieldsExamples, "releaseChannel: Stable")
-	}
-
-	if metaConfig.DeckhouseConfig.Bundle != bundle {
-		bundle = metaConfig.DeckhouseConfig.Bundle
-		deprecatedFields = append(deprecatedFields, "bundle")
-		deprecatedFieldsExamples = append(deprecatedFieldsExamples, "bundle: Default")
-	}
-
-	if metaConfig.DeckhouseConfig.LogLevel != logLevel {
-		logLevel = metaConfig.DeckhouseConfig.LogLevel
-		deprecatedFields = append(deprecatedFields, "logLevel")
-		deprecatedFieldsExamples = append(deprecatedFieldsExamples, "logLevel: Info")
-	}
-
-	if len(deprecatedFields) > 0 {
-		log.WarnF(initConfigurationError, strings.Join(deprecatedFields, ","), strings.Join(deprecatedFieldsExamples, "\n    "))
-	}
-
 	schemasStore := NewSchemaStore()
-
-	if len(metaConfig.DeckhouseConfig.ConfigOverrides) > 0 {
-		return nil, fmt.Errorf("Support for 'configOverrides' was removed. Please use ModuleConfig's instead.")
-	}
 
 	var deckhouseCm *ModuleConfig
 	// find deckhouse module config for extract release
@@ -199,14 +167,6 @@ func PrepareDeckhouseInstallConfig(metaConfig *MetaConfig) (*DeckhouseInstaller,
 			return nil, fmt.Errorf("Cannot create ModuleConfig deckhouse: %s", err)
 		}
 		metaConfig.ModuleConfigs = append(metaConfig.ModuleConfigs, deckhouseCm)
-	} else {
-		releaseChannelRaw, hasReleaseChannelKey := deckhouseCm.Spec.Settings["releaseChannel"]
-		if rc, ok := releaseChannelRaw.(string); hasReleaseChannelKey && ok {
-			// we need set releaseChannel after bootstrapping process done
-			// to prevent update during bootstrap
-			delete(deckhouseCm.Spec.Settings, "releaseChannel")
-			releaseChannel = rc
-		}
 	}
 
 	installConfig := DeckhouseInstaller{
@@ -220,7 +180,6 @@ func PrepareDeckhouseInstallConfig(metaConfig *MetaConfig) (*DeckhouseInstaller,
 		StaticClusterConfig:   staticClusterConfig,
 		ClusterConfig:         clusterConfig,
 		ModuleConfigs:         metaConfig.ModuleConfigs,
-		ReleaseChannel:        releaseChannel,
 		InstallerVersion:      metaConfig.InstallerVersion,
 	}
 

--- a/dhctl/pkg/config/deckhouse_config_test.go
+++ b/dhctl/pkg/config/deckhouse_config_test.go
@@ -74,35 +74,6 @@ func generateMetaConfigForDeckhouseConfigTestWithErr(t *testing.T, data map[stri
 	return generateMetaConfig(t, configOverridesTemplate, data, true)
 }
 
-func TestDeckhouseReleaseChannelDeprecated(t *testing.T) {
-	metaConfig := generateMetaConfig(t, `
-apiVersion: deckhouse.io/v1
-kind: ClusterConfiguration
-clusterType: Static
-podSubnetCIDR: 10.111.0.0/16
-serviceSubnetCIDR: 10.222.0.0/16
-kubernetesVersion: "1.28"
-clusterDomain: "cluster.local"
----
-apiVersion: deckhouse.io/v1
-kind: InitConfiguration
-deckhouse:
-  devBranch: aaaa
-  releaseChannel: Beta
----
-apiVersion: deckhouse.io/v1alpha1
-# type of the configuration section
-kind: StaticClusterConfiguration
-# address space for the cluster's internal network
-internalNetworkCIDRs:
-- 192.168.199.0/24
-
-`, map[string]interface{}{}, false)
-	iCfg, err := PrepareDeckhouseInstallConfig(metaConfig)
-	require.NoError(t, err)
-	require.Equal(t, iCfg.ReleaseChannel, "Beta")
-}
-
 func TestModuleDeckhouseConfigOverridesAndMc(t *testing.T) {
 	t.Run("Use default bundle and logLevel", func(t *testing.T) {
 		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
@@ -155,33 +126,6 @@ spec:
 		require.Equal(t, iCfg.Bundle, "Minimal")
 
 		require.Len(t, iCfg.ModuleConfigs, 1)
-	})
-
-	t.Run("Remove releaseChannel from module config and set to installer cfg for adding after bootstrap", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
-			"moduleConfigs": `
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: deckhouse
-spec:
-  enabled: true
-  settings:
-    releaseChannel: RockSolid
-  version: 1
-`,
-		})
-
-		iCfg, err := PrepareDeckhouseInstallConfig(metaConfig)
-		require.NoError(t, err)
-
-		require.Equal(t, iCfg.LogLevel, "Info")
-		require.Equal(t, iCfg.Bundle, "Default")
-
-		require.Len(t, iCfg.ModuleConfigs, 1)
-
-		require.NotContains(t, iCfg.ModuleConfigs[0].Spec.Settings, "releaseChannel")
-		require.Equal(t, iCfg.ReleaseChannel, "RockSolid")
 	})
 
 	t.Run("Use bundle and logLevel from module config", func(t *testing.T) {

--- a/dhctl/pkg/config/deckhouse_config_test.go
+++ b/dhctl/pkg/config/deckhouse_config_test.go
@@ -128,19 +128,6 @@ spec:
 		require.Len(t, iCfg.ModuleConfigs, 1)
 	})
 
-	t.Run("Use bundle and logLevel from module config", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
-			"logLevel": "Debug",
-			"bundle":   "Minimal",
-		})
-
-		iCfg, err := PrepareDeckhouseInstallConfig(metaConfig)
-		require.NoError(t, err)
-
-		require.Equal(t, iCfg.LogLevel, "Debug")
-		require.Equal(t, iCfg.Bundle, "Minimal")
-	})
-
 	t.Run("Forbid to use configOverrides", func(t *testing.T) {
 		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
 			"configOverrides": `

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -30,7 +29,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/apis/v1alpha1"
@@ -159,64 +157,12 @@ func UnlockDeckhouseQueueAfterCreatingModuleConfigs(kubeCl *client.KubernetesCli
 	})
 }
 
-func ConfigureReleaseChannel(kubeCl *client.KubernetesClient, cfg *config.DeckhouseInstaller) error {
-	// if we have correct semver version we should create Deckhouse Release for prevent rollback on previous version
-	// if installer version > version in release channel
-	if tag, found := config.ReadVersionTagFromInstallerContainer(); found {
-		deckhouseRelease := unstructured.Unstructured{}
-		deckhouseRelease.SetUnstructuredContent(map[string]interface{}{
-			"apiVersion": "deckhouse.io/v1alpha1",
-			"kind":       "DeckhouseRelease",
-			"metadata": map[string]interface{}{
-				"name": tag,
-			},
-			"spec": map[string]interface{}{
-				"version": tag,
-			},
-		})
-
-		err := retry.NewLoop(fmt.Sprintf("Create deckhouse release for version %s", tag), 15, 5*time.Second).
-			BreakIf(apierrors.IsAlreadyExists).
-			Run(func() error {
-				_, err := kubeCl.Dynamic().Resource(v1alpha1.DeckhouseReleaseGVR).Create(context.TODO(), &deckhouseRelease, metav1.CreateOptions{})
-				if err != nil {
-					return err
-				}
-
-				return nil
-			})
-		if err != nil && !apierrors.IsAlreadyExists(err) {
-			return err
-		}
-	}
-
-	if cfg.ReleaseChannel == "" {
-		return nil
-	}
-	// save release channel into module config we do not set it in Deckhouse mc because we want to install deckhouse only one release
-	return retry.NewLoop("Set release channel to deckhouse module config", 15, 5*time.Second).
-		BreakIf(apierrors.IsNotFound).
-		Run(func() error {
-			cm, err := kubeCl.Dynamic().Resource(config.ModuleConfigGVR).Get(context.TODO(), "deckhouse", metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-
-			err = unstructured.SetNestedField(cm.Object, cfg.ReleaseChannel, "spec", "settings", "releaseChannel")
-			if err != nil {
-				return err
-			}
-
-			_, err = kubeCl.Dynamic().Resource(config.ModuleConfigGVR).Update(context.TODO(), cm, metav1.UpdateOptions{})
-			if err != nil {
-				return err
-			}
-
-			return nil
-		})
+type ManifestsResult struct {
+	WithResourcesMCTasks []actions.ModuleConfigTask
+	PostBootstrapMCTasks []actions.ModuleConfigTask
 }
 
-func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.DeckhouseInstaller) error {
+func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.DeckhouseInstaller) (*ManifestsResult, error) {
 	tasks := []actions.ManifestTask{
 		{
 			Name:     `Namespace "d8-system"`,
@@ -464,81 +410,24 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 
 	lockCmTask, err := LockDeckhouseQueueBeforeCreatingModuleConfigs(kubeCl)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
 	if lockCmTask != nil {
 		tasks = append(tasks, *lockCmTask)
 	}
 
 	tasks = append(tasks, controllerDeploymentTask(kubeCl, cfg))
 
+	result := &ManifestsResult{}
+
 	if len(cfg.ModuleConfigs) > 0 {
-		createTask := func(mc *config.ModuleConfig, createMsg string) actions.ManifestTask {
-			mcUnstructMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(mc)
-			if err != nil {
-				panic(err)
-			}
-			mcUnstruct := &unstructured.Unstructured{Object: mcUnstructMap}
-			return actions.ManifestTask{
-				Name: fmt.Sprintf(`ModuleConfig "%s"`, mc.GetName()),
-				Manifest: func() interface{} {
-					return mcUnstruct
-				},
-				CreateFunc: func(manifest interface{}) error {
-					if createMsg != "" {
-						log.InfoLn(createMsg)
-					}
-					// fake client does not support cache
-					if _, ok := os.LookupEnv("DHCTL_TEST"); !ok {
-						// need for invalidate cache
-						_, err := kubeCl.APIResource(config.ModuleConfigGroup+"/"+config.ModuleConfigVersion, config.ModuleConfigKind)
-						if err != nil {
-							log.DebugF("Error getting mc api resource: %v\n", err)
-						}
-					}
-
-					_, err = kubeCl.Dynamic().Resource(config.ModuleConfigGVR).
-						Create(context.TODO(), manifest.(*unstructured.Unstructured), metav1.CreateOptions{})
-					if err != nil {
-						log.DebugF("Do not create mc: %v\n", err)
-					}
-
-					return err
-				},
-				UpdateFunc: func(manifest interface{}) error {
-					// fake client does not support cache
-					if _, ok := os.LookupEnv("DHCTL_TEST"); !ok {
-						// need for invalidate cache
-						_, err := kubeCl.APIResource(config.ModuleConfigGroup+"/"+config.ModuleConfigVersion, config.ModuleConfigKind)
-						if err != nil {
-							log.DebugF("Error getting mc api resource: %v\n", err)
-						}
-					}
-
-					newManifest := manifest.(*unstructured.Unstructured)
-
-					oldManifest, err := kubeCl.Dynamic().Resource(config.ModuleConfigGVR).Get(context.TODO(), newManifest.GetName(), metav1.GetOptions{})
-					if err != nil && !apierrors.IsNotFound(err) {
-						log.DebugF("Error getting mc: %v\n", err)
-					} else {
-						newManifest.SetResourceVersion(oldManifest.GetResourceVersion())
-					}
-
-					_, err = kubeCl.Dynamic().Resource(config.ModuleConfigGVR).
-						Update(context.TODO(), newManifest, metav1.UpdateOptions{})
-					if err != nil {
-						log.InfoF("Do not updating mc: %v\n", err)
-					}
-
-					return err
-				},
-			}
-		}
-
-		tasks = append(tasks, createTask(cfg.ModuleConfigs[0], "Waiting for creating ModuleConfig CRD..."))
+		prepareModuleConfig(cfg.ModuleConfigs[0], result)
+		tasks = append(tasks, createModuleConfigManifestTask(kubeCl, cfg.ModuleConfigs[0], "Waiting for creating ModuleConfig CRD..."))
 
 		for i := 1; i < len(cfg.ModuleConfigs); i++ {
-			tasks = append(tasks, createTask(cfg.ModuleConfigs[i], ""))
+			prepareModuleConfig(cfg.ModuleConfigs[i], result)
+			tasks = append(tasks, createModuleConfigManifestTask(kubeCl, cfg.ModuleConfigs[i], ""))
 		}
 	}
 
@@ -551,12 +440,11 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 		}
 		return nil
 	})
-
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return UnlockDeckhouseQueueAfterCreatingModuleConfigs(kubeCl)
+	return result, UnlockDeckhouseQueueAfterCreatingModuleConfigs(kubeCl)
 }
 
 func WaitForReadiness(kubeCl *client.KubernetesClient) error {
@@ -628,4 +516,38 @@ func WaitForKubernetesAPI(kubeCl *client.KubernetesClient) error {
 		}
 		return fmt.Errorf("kubernetes API is not Ready: %w", err)
 	})
+}
+
+func ConfigureDeckhouseRelease(kubeCl *client.KubernetesClient) error {
+	// if we have correct semver version we should create Deckhouse Release for prevent rollback on previous version
+	// if installer version > version in release channel
+	if tag, found := config.ReadVersionTagFromInstallerContainer(); found {
+		deckhouseRelease := unstructured.Unstructured{}
+		deckhouseRelease.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "deckhouse.io/v1alpha1",
+			"kind":       "DeckhouseRelease",
+			"metadata": map[string]interface{}{
+				"name": tag,
+			},
+			"spec": map[string]interface{}{
+				"version": tag,
+			},
+		})
+
+		err := retry.NewLoop(fmt.Sprintf("Create deckhouse release for version %s", tag), 15, 5*time.Second).
+			BreakIf(apierrors.IsAlreadyExists).
+			Run(func() error {
+				_, err := kubeCl.Dynamic().Resource(v1alpha1.DeckhouseReleaseGVR).Create(context.TODO(), &deckhouseRelease, metav1.CreateOptions{})
+				if err != nil {
+					return err
+				}
+
+				return nil
+			})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
@@ -58,25 +58,27 @@ func TestDeckhouseInstall(t *testing.T) {
 		{
 			"Empty config",
 			func() error {
-				return CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{})
+				_, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{})
+				return err
 			},
 			false,
 		},
 		{
 			"Double install",
 			func() error {
-				err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{})
+				_, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{})
 				if err != nil {
 					return err
 				}
-				return CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{})
+				_, err = CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{})
+				return err
 			},
 			false,
 		},
 		{
 			"With docker cfg",
 			func() error {
-				err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+				_, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
 					Registry: config.RegistryData{DockerCfg: "YW55dGhpbmc="},
 				})
 				if err != nil {
@@ -103,7 +105,7 @@ func TestDeckhouseInstall(t *testing.T) {
 					ProviderClusterConfig: []byte(`test`),
 					TerraformState:        []byte(`test`),
 				}
-				err := CreateDeckhouseManifests(fakeClient, &conf)
+				_, err := CreateDeckhouseManifests(fakeClient, &conf)
 				if err != nil {
 					return err
 				}
@@ -114,6 +116,7 @@ func TestDeckhouseInstall(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		fmt.Printf("Running test case: %s\n", tc.name)
 		err := tc.test()
 
 		if err != nil && !tc.wantErr {
@@ -144,7 +147,7 @@ func TestDeckhouseInstallWithDevBranch(t *testing.T) {
 		os.Remove("/deckhouse/version")
 	}()
 
-	err = CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+	_, err = CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
 		DevBranch: "pr1111",
 	})
 
@@ -184,7 +187,7 @@ func TestDeckhouseInstallWithModuleConfig(t *testing.T) {
 		"ha": true,
 	})
 
-	err = CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+	_, err = CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
 		DevBranch:     "pr1111",
 		ModuleConfigs: []*config.ModuleConfig{mc1},
 	})
@@ -247,7 +250,7 @@ func TestDeckhouseInstallWithModuleConfigs(t *testing.T) {
 		"bundle": "Minimal",
 	})
 
-	err = CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+	_, err = CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
 		DevBranch:     "pr1111",
 		ModuleConfigs: []*config.ModuleConfig{mc1, mc2},
 	})
@@ -262,4 +265,201 @@ func TestDeckhouseInstallWithModuleConfigs(t *testing.T) {
 	// should be not found for unlock deckhouse queue
 	_, err = fakeClient.CoreV1().ConfigMaps("d8-system").Get(context.TODO(), "deckhouse-bootstrap-lock", metav1.GetOptions{})
 	require.True(t, errors.IsNotFound(err))
+}
+
+func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
+	err := os.Setenv("DHCTL_TEST", "yes")
+	require.NoError(t, err)
+	defer func() {
+		os.Unsetenv("DHCTL_TEST")
+	}()
+
+	err = os.WriteFile("/deckhouse/version", []byte("dev"), 0o666)
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		os.Remove("/deckhouse/version")
+	}()
+
+	t.Run("Only deckhouse mc", func(t *testing.T) {
+		t.Run("Should create only one post bootstrap mc task", func(t *testing.T) {
+			fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
+				config.ModuleConfigGVR: "ModuleConfigList",
+			})
+
+			mc := &config.ModuleConfig{}
+			mc.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   config.ModuleConfigGroup,
+				Version: config.ModuleConfigVersion,
+				Kind:    config.ModuleConfigKind,
+			})
+			mc.SetName("deckhouse")
+			mc.Spec.Enabled = ptr.To(true)
+			mc.Spec.Version = 1
+			mc.Spec.Settings = config.SettingsValues(map[string]interface{}{
+				"bundle":         "Minimal",
+				"logLevel":       "Debug",
+				"releaseChannel": "Alpha",
+			})
+
+			res, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+				DevBranch:     "pr1111",
+				ModuleConfigs: []*config.ModuleConfig{mc},
+			})
+			require.NoError(t, err)
+
+			require.Len(t, res.WithResourcesMCTasks, 0)
+			require.Len(t, res.PostBootstrapMCTasks, 1)
+			require.Equal(t, res.PostBootstrapMCTasks[0].Title, "Set release channel to deckhouse module config")
+
+			mcs, err := fakeClient.Dynamic().Resource(config.ModuleConfigGVR).List(context.TODO(), metav1.ListOptions{})
+			require.NoError(t, err)
+
+			require.Len(t, mcs.Items, 1)
+
+			require.NotContains(t, mcs.Items[0].Object["spec"].(map[string]interface{})["settings"], "releaseChannel")
+		})
+	})
+
+	t.Run("Only global mcs", func(t *testing.T) {
+		t.Run("Should create with resources tasks only one", func(t *testing.T) {
+			fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
+				config.ModuleConfigGVR: "ModuleConfigList",
+			})
+
+			mcGlobal := &config.ModuleConfig{}
+			mcGlobal.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   config.ModuleConfigGroup,
+				Version: config.ModuleConfigVersion,
+				Kind:    config.ModuleConfigKind,
+			})
+			mcGlobal.SetName("global")
+			mcGlobal.Spec.Enabled = ptr.To(true)
+			mcGlobal.Spec.Version = 1
+			mcGlobal.Spec.Settings = config.SettingsValues(map[string]interface{}{
+				"highAvailability": true,
+				"modules": map[string]interface{}{
+					"https": map[string]interface{}{
+						"customCertificate": map[string]interface{}{
+							"secretName": "secret",
+						},
+					},
+					"publicDomainTemplate": "template",
+				},
+			})
+
+			res, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+				DevBranch:     "pr1111",
+				ModuleConfigs: []*config.ModuleConfig{mcGlobal},
+			})
+			require.NoError(t, err)
+
+			require.Len(t, res.WithResourcesMCTasks, 1)
+			require.Len(t, res.PostBootstrapMCTasks, 0)
+			require.Equal(t, res.WithResourcesMCTasks[0].Title, "Set https setting to global module config")
+
+			mcs, err := fakeClient.Dynamic().Resource(config.ModuleConfigGVR).List(context.TODO(), metav1.ListOptions{})
+			require.NoError(t, err)
+
+			require.Len(t, mcs.Items, 1)
+
+			require.NotContains(t, mcs.Items[0].Object["spec"].(map[string]interface{})["settings"].(map[string]interface{})["modules"], "https")
+		})
+	})
+
+	t.Run("Without global and deckhouse mcs", func(t *testing.T) {
+		t.Run("Should create with resources tasks only one", func(t *testing.T) {
+			fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
+				config.ModuleConfigGVR: "ModuleConfigList",
+			})
+
+			mcGlobal := &config.ModuleConfig{}
+			mcGlobal.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   config.ModuleConfigGroup,
+				Version: config.ModuleConfigVersion,
+				Kind:    config.ModuleConfigKind,
+			})
+			mcGlobal.SetName("prometheus")
+			mcGlobal.Spec.Enabled = ptr.To(true)
+			mcGlobal.Spec.Version = 1
+			mcGlobal.Spec.Settings = config.SettingsValues(map[string]interface{}{
+				"highAvailability": true,
+			})
+
+			res, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+				DevBranch:     "pr1111",
+				ModuleConfigs: []*config.ModuleConfig{mcGlobal},
+			})
+			require.NoError(t, err)
+
+			require.Len(t, res.WithResourcesMCTasks, 0)
+			require.Len(t, res.PostBootstrapMCTasks, 0)
+
+			mcs, err := fakeClient.Dynamic().Resource(config.ModuleConfigGVR).List(context.TODO(), metav1.ListOptions{})
+			require.NoError(t, err)
+
+			require.Len(t, mcs.Items, 1)
+		})
+	})
+
+	t.Run("Deckhouse + global mcs", func(t *testing.T) {
+		t.Run("Should create post bootstrap and with resources mc task", func(t *testing.T) {
+			fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
+				config.ModuleConfigGVR: "ModuleConfigList",
+			})
+
+			mcDeckhouse := &config.ModuleConfig{}
+			mcDeckhouse.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   config.ModuleConfigGroup,
+				Version: config.ModuleConfigVersion,
+				Kind:    config.ModuleConfigKind,
+			})
+			mcDeckhouse.SetName("deckhouse")
+			mcDeckhouse.Spec.Enabled = ptr.To(true)
+			mcDeckhouse.Spec.Version = 1
+			mcDeckhouse.Spec.Settings = config.SettingsValues(map[string]interface{}{
+				"bundle":         "Minimal",
+				"logLevel":       "Debug",
+				"releaseChannel": "Alpha",
+			})
+
+			mcGlobal := &config.ModuleConfig{}
+			mcGlobal.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   config.ModuleConfigGroup,
+				Version: config.ModuleConfigVersion,
+				Kind:    config.ModuleConfigKind,
+			})
+			mcGlobal.SetName("global")
+			mcGlobal.Spec.Enabled = ptr.To(true)
+			mcGlobal.Spec.Version = 1
+			mcGlobal.Spec.Settings = config.SettingsValues(map[string]interface{}{
+				"highAvailability": true,
+				"modules": map[string]interface{}{
+					"https": map[string]interface{}{
+						"customCertificate": map[string]interface{}{
+							"secretName": "secret",
+						},
+					},
+				},
+			})
+
+			res, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+				DevBranch:     "pr1111",
+				ModuleConfigs: []*config.ModuleConfig{mcDeckhouse, mcGlobal},
+			})
+			require.NoError(t, err)
+
+			require.Len(t, res.WithResourcesMCTasks, 1)
+			require.Len(t, res.PostBootstrapMCTasks, 1)
+			require.Equal(t, res.PostBootstrapMCTasks[0].Title, "Set release channel to deckhouse module config")
+			require.Equal(t, res.WithResourcesMCTasks[0].Title, "Set https setting to global module config")
+
+			mcs, err := fakeClient.Dynamic().Resource(config.ModuleConfigGVR).List(context.TODO(), metav1.ListOptions{})
+			require.NoError(t, err)
+
+			require.Len(t, mcs.Items, 2)
+		})
+	})
 }

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
@@ -289,16 +289,7 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 				config.ModuleConfigGVR: "ModuleConfigList",
 			})
 
-			mc := &config.ModuleConfig{}
-			mc.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   config.ModuleConfigGroup,
-				Version: config.ModuleConfigVersion,
-				Kind:    config.ModuleConfigKind,
-			})
-			mc.SetName("deckhouse")
-			mc.Spec.Enabled = ptr.To(true)
-			mc.Spec.Version = 1
-			mc.Spec.Settings = config.SettingsValues(map[string]interface{}{
+			mc := createMC("deckhouse", map[string]interface{}{
 				"bundle":         "Minimal",
 				"logLevel":       "Debug",
 				"releaseChannel": "Alpha",
@@ -329,16 +320,7 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 				config.ModuleConfigGVR: "ModuleConfigList",
 			})
 
-			mcGlobal := &config.ModuleConfig{}
-			mcGlobal.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   config.ModuleConfigGroup,
-				Version: config.ModuleConfigVersion,
-				Kind:    config.ModuleConfigKind,
-			})
-			mcGlobal.SetName("global")
-			mcGlobal.Spec.Enabled = ptr.To(true)
-			mcGlobal.Spec.Version = 1
-			mcGlobal.Spec.Settings = config.SettingsValues(map[string]interface{}{
+			mc := createMC("global", map[string]interface{}{
 				"highAvailability": true,
 				"modules": map[string]interface{}{
 					"https": map[string]interface{}{
@@ -352,7 +334,7 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 
 			res, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
 				DevBranch:     "pr1111",
-				ModuleConfigs: []*config.ModuleConfig{mcGlobal},
+				ModuleConfigs: []*config.ModuleConfig{mc},
 			})
 			require.NoError(t, err)
 
@@ -375,22 +357,13 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 				config.ModuleConfigGVR: "ModuleConfigList",
 			})
 
-			mcGlobal := &config.ModuleConfig{}
-			mcGlobal.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   config.ModuleConfigGroup,
-				Version: config.ModuleConfigVersion,
-				Kind:    config.ModuleConfigKind,
-			})
-			mcGlobal.SetName("prometheus")
-			mcGlobal.Spec.Enabled = ptr.To(true)
-			mcGlobal.Spec.Version = 1
-			mcGlobal.Spec.Settings = config.SettingsValues(map[string]interface{}{
+			mc := createMC("prometheus", map[string]interface{}{
 				"highAvailability": true,
 			})
 
 			res, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
 				DevBranch:     "pr1111",
-				ModuleConfigs: []*config.ModuleConfig{mcGlobal},
+				ModuleConfigs: []*config.ModuleConfig{mc},
 			})
 			require.NoError(t, err)
 
@@ -410,31 +383,13 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 				config.ModuleConfigGVR: "ModuleConfigList",
 			})
 
-			mcDeckhouse := &config.ModuleConfig{}
-			mcDeckhouse.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   config.ModuleConfigGroup,
-				Version: config.ModuleConfigVersion,
-				Kind:    config.ModuleConfigKind,
-			})
-			mcDeckhouse.SetName("deckhouse")
-			mcDeckhouse.Spec.Enabled = ptr.To(true)
-			mcDeckhouse.Spec.Version = 1
-			mcDeckhouse.Spec.Settings = config.SettingsValues(map[string]interface{}{
+			mcDeckhouse := createMC("deckhouse", map[string]interface{}{
 				"bundle":         "Minimal",
 				"logLevel":       "Debug",
 				"releaseChannel": "Alpha",
 			})
 
-			mcGlobal := &config.ModuleConfig{}
-			mcGlobal.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   config.ModuleConfigGroup,
-				Version: config.ModuleConfigVersion,
-				Kind:    config.ModuleConfigKind,
-			})
-			mcGlobal.SetName("global")
-			mcGlobal.Spec.Enabled = ptr.To(true)
-			mcGlobal.Spec.Version = 1
-			mcGlobal.Spec.Settings = config.SettingsValues(map[string]interface{}{
+			mcGlobal := createMC("global", map[string]interface{}{
 				"highAvailability": true,
 				"modules": map[string]interface{}{
 					"https": map[string]interface{}{

--- a/dhctl/pkg/kubernetes/actions/deckhouse/module_config.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/module_config.go
@@ -79,6 +79,9 @@ func createModuleConfigManifestTask(kubeCl *client.KubernetesClient, mc *config.
 }
 
 func prepareModuleConfig(mc *config.ModuleConfig, res *ManifestsResult) {
+	// we need apply some settings after bootstrap and with creating resources
+	// but not apply when we are creating module configs into cluster
+	// see description for functions
 	switch mc.GetName() {
 	case "deckhouse":
 		prepareDeckhouseMC(mc, res)
@@ -111,6 +114,10 @@ func setSettingToModuleConfig(kubeCl *client.KubernetesClient, mcName string, va
 }
 
 func prepareDeckhouseMC(mc *config.ModuleConfig, res *ManifestsResult) {
+	// we should apply releaseChannel setting after bootstrap cluster
+	// for preventing an updating deckhouse during bootstrap process
+	// for example, we are installing v1.66 tag but in release channel we have v1.67 tag
+
 	log.DebugLn("Found deckhouse mc. Try to prepare...")
 
 	releaseChannel := ""
@@ -138,6 +145,12 @@ func prepareDeckhouseMC(mc *config.ModuleConfig, res *ManifestsResult) {
 }
 
 func prepareGlobalMC(mc *config.ModuleConfig, res *ManifestsResult) {
+	// we should apply setting only after bootstrap cloud permanent node
+	// imagine, we have https custom certificate setting
+	// if we apply with this, we will have deckhouse in error state because secret will be created in resource
+	// and deckhouse cannot found this secret and cloud permanent nodes will not bootstrap
+	// because deckhouse stuck in error and it cannot create manual-for-bootstrap secrets
+
 	log.DebugLn("Found global mc. Try to prepare...")
 
 	var httpsSettings map[string]interface{}

--- a/dhctl/pkg/kubernetes/actions/deckhouse/module_config.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/module_config.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deckhouse
 
 import (

--- a/dhctl/pkg/kubernetes/actions/deckhouse/module_config_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/module_config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Flant JSC
+// Copyright 2024 Flant JSC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dhctl/pkg/kubernetes/actions/deckhouse/module_config_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/module_config_test.go
@@ -30,6 +30,21 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
+func createMC(name string, settings map[string]interface{}) *config.ModuleConfig {
+	mc := &config.ModuleConfig{}
+	mc.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   config.ModuleConfigGroup,
+		Version: config.ModuleConfigVersion,
+		Kind:    config.ModuleConfigKind,
+	})
+	mc.SetName(name)
+	mc.Spec.Enabled = ptr.To(true)
+	mc.Spec.Version = 1
+	mc.Spec.Settings = config.SettingsValues(settings)
+
+	return mc
+}
+
 func TestPrepareDeckhouseModuleConfig(t *testing.T) {
 	log.InitLogger("simple")
 
@@ -38,33 +53,25 @@ func TestPrepareDeckhouseModuleConfig(t *testing.T) {
 			config.ModuleConfigGVR: "ModuleConfigList",
 		})
 
-		mcWithReleaseChannel := &config.ModuleConfig{}
-		mcWithReleaseChannel.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   config.ModuleConfigGroup,
-			Version: config.ModuleConfigVersion,
-			Kind:    config.ModuleConfigKind,
-		})
-		mcWithReleaseChannel.SetName("deckhouse")
-		mcWithReleaseChannel.Spec.Enabled = ptr.To(true)
-		mcWithReleaseChannel.Spec.Version = 1
-		mcWithReleaseChannel.Spec.Settings = config.SettingsValues(map[string]interface{}{
+		mc := createMC("deckhouse", map[string]interface{}{
 			"bundle":         "Minimal",
 			"logLevel":       "Debug",
 			"releaseChannel": "Alpha",
 		})
-		res := &ManifestsResult{}
-		prepareModuleConfig(mcWithReleaseChannel, res)
 
-		require.NotContains(t, mcWithReleaseChannel.Spec.Settings, "releaseChannel")
-		require.Contains(t, mcWithReleaseChannel.Spec.Settings, "bundle")
-		require.Contains(t, mcWithReleaseChannel.Spec.Settings, "logLevel")
-		require.Equal(t, mcWithReleaseChannel.Spec.Settings["bundle"], "Minimal")
-		require.Equal(t, mcWithReleaseChannel.Spec.Settings["logLevel"], "Debug")
+		res := &ManifestsResult{}
+		prepareModuleConfig(mc, res)
+
+		require.NotContains(t, mc.Spec.Settings, "releaseChannel")
+		require.Contains(t, mc.Spec.Settings, "bundle")
+		require.Contains(t, mc.Spec.Settings, "logLevel")
+		require.Equal(t, mc.Spec.Settings["bundle"], "Minimal")
+		require.Equal(t, mc.Spec.Settings["logLevel"], "Debug")
 
 		require.Len(t, res.WithResourcesMCTasks, 0)
 		require.Len(t, res.PostBootstrapMCTasks, 1)
 
-		u, err := sdk.ToUnstructured(mcWithReleaseChannel)
+		u, err := sdk.ToUnstructured(mc)
 		require.NoError(t, err)
 		_, err = fakeClient.Dynamic().Resource(config.ModuleConfigGVR).Create(context.TODO(), u, metav1.CreateOptions{})
 		require.NoError(t, err)
@@ -99,27 +106,18 @@ func TestPrepareDeckhouseModuleConfig(t *testing.T) {
 			config.ModuleConfigGVR: "ModuleConfigList",
 		})
 
-		mcWithoutReleaseChannel := &config.ModuleConfig{}
-		mcWithoutReleaseChannel.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   config.ModuleConfigGroup,
-			Version: config.ModuleConfigVersion,
-			Kind:    config.ModuleConfigKind,
-		})
-		mcWithoutReleaseChannel.SetName("deckhouse")
-		mcWithoutReleaseChannel.Spec.Enabled = ptr.To(true)
-		mcWithoutReleaseChannel.Spec.Version = 1
-		mcWithoutReleaseChannel.Spec.Settings = config.SettingsValues(map[string]interface{}{
+		mc := createMC("deckhouse", map[string]interface{}{
 			"bundle": "Minimal",
 		})
 
 		res := &ManifestsResult{}
-		prepareModuleConfig(mcWithoutReleaseChannel, res)
+		prepareModuleConfig(mc, res)
 
-		require.NotContains(t, mcWithoutReleaseChannel.Spec.Settings, "releaseChannel")
-		require.Contains(t, mcWithoutReleaseChannel.Spec.Settings, "bundle")
-		require.Equal(t, mcWithoutReleaseChannel.Spec.Settings["bundle"], "Minimal")
+		require.NotContains(t, mc.Spec.Settings, "releaseChannel")
+		require.Contains(t, mc.Spec.Settings, "bundle")
+		require.Equal(t, mc.Spec.Settings["bundle"], "Minimal")
 
-		u, err := sdk.ToUnstructured(mcWithoutReleaseChannel)
+		u, err := sdk.ToUnstructured(mc)
 		require.NoError(t, err)
 		_, err = fakeClient.Dynamic().Resource(config.ModuleConfigGVR).Create(context.TODO(), u, metav1.CreateOptions{})
 		require.NoError(t, err)
@@ -132,22 +130,50 @@ func TestPrepareDeckhouseModuleConfig(t *testing.T) {
 func TestPrepareGlobalModuleConfig(t *testing.T) {
 	log.InitLogger("simple")
 
+	assertSaveAnotherFields := func(t *testing.T, mc *unstructured.Unstructured, publicDomainTemplateFound bool) {
+		// does not change another fields
+		ha, found, err := unstructured.NestedBool(mc.Object, "spec", "settings", "highAvailability")
+		require.NoError(t, err)
+		require.True(t, found)
+		require.True(t, ha)
+
+		tmpl, found, err := unstructured.NestedString(mc.Object, "spec", "settings", "modules", "publicDomainTemplate")
+		require.NoError(t, err)
+
+		if publicDomainTemplateFound {
+			require.True(t, found)
+			require.Equal(t, "template", tmpl)
+			return
+		}
+
+		require.False(t, found)
+	}
+
+	assertHTTPSSettings := func(t *testing.T, mc *unstructured.Unstructured) {
+		https, found, err := unstructured.NestedMap(mc.Object, "spec", "settings", "modules", "https")
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, https, map[string]interface{}{
+			"customCertificate": map[string]interface{}{
+				"secretName": "secret",
+			},
+		})
+	}
+
+	assertMCAfterPrepare := func(t *testing.T, mc *config.ModuleConfig) {
+		require.Contains(t, mc.Spec.Settings, "modules")
+		require.NotContains(t, mc.Spec.Settings["modules"], "https")
+		require.True(t, mc.Spec.Settings["highAvailability"].(bool))
+		require.Equal(t, mc.Spec.Settings["modules"].(map[string]interface{})["publicDomainTemplate"], "template")
+	}
+
 	t.Run("ModuleConfig global with https setting and another modules settings should remove https from mc and adds to result task with returning https to with resources tasks", func(t *testing.T) {
 		t.Run("And keeps another modules settings", func(t *testing.T) {
 			fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
 				config.ModuleConfigGVR: "ModuleConfigList",
 			})
 
-			mc := &config.ModuleConfig{}
-			mc.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   config.ModuleConfigGroup,
-				Version: config.ModuleConfigVersion,
-				Kind:    config.ModuleConfigKind,
-			})
-			mc.SetName("global")
-			mc.Spec.Enabled = ptr.To(true)
-			mc.Spec.Version = 1
-			mc.Spec.Settings = config.SettingsValues(map[string]interface{}{
+			mc := createMC("global", map[string]interface{}{
 				"highAvailability": true,
 				"modules": map[string]interface{}{
 					"https": map[string]interface{}{
@@ -158,13 +184,11 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 					"publicDomainTemplate": "template",
 				},
 			})
+
 			res := &ManifestsResult{}
 			prepareModuleConfig(mc, res)
 
-			require.Contains(t, mc.Spec.Settings, "modules")
-			require.NotContains(t, mc.Spec.Settings["modules"], "https")
-			require.True(t, mc.Spec.Settings["highAvailability"].(bool))
-			require.Equal(t, mc.Spec.Settings["modules"].(map[string]interface{})["publicDomainTemplate"], "template")
+			assertMCAfterPrepare(t, mc)
 
 			require.Len(t, res.WithResourcesMCTasks, 1)
 			require.Len(t, res.PostBootstrapMCTasks, 0)
@@ -182,25 +206,9 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 			resMC, err := fakeClient.Dynamic().Resource(config.ModuleConfigGVR).Get(context.TODO(), "global", metav1.GetOptions{})
 			require.NoError(t, err)
 
-			https, found, err := unstructured.NestedMap(resMC.Object, "spec", "settings", "modules", "https")
-			require.NoError(t, err)
-			require.True(t, found)
-			require.Equal(t, https, map[string]interface{}{
-				"customCertificate": map[string]interface{}{
-					"secretName": "secret",
-				},
-			})
+			assertHTTPSSettings(t, resMC)
 
-			// does not change another fields
-			tmpl, found, err := unstructured.NestedString(resMC.Object, "spec", "settings", "modules", "publicDomainTemplate")
-			require.NoError(t, err)
-			require.True(t, found)
-			require.Equal(t, "template", tmpl)
-
-			ha, found, err := unstructured.NestedBool(resMC.Object, "spec", "settings", "highAvailability")
-			require.NoError(t, err)
-			require.True(t, found)
-			require.True(t, ha)
+			assertSaveAnotherFields(t, resMC, true)
 		})
 	})
 
@@ -210,16 +218,7 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 				config.ModuleConfigGVR: "ModuleConfigList",
 			})
 
-			mc := &config.ModuleConfig{}
-			mc.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   config.ModuleConfigGroup,
-				Version: config.ModuleConfigVersion,
-				Kind:    config.ModuleConfigKind,
-			})
-			mc.SetName("global")
-			mc.Spec.Enabled = ptr.To(true)
-			mc.Spec.Version = 1
-			mc.Spec.Settings = config.SettingsValues(map[string]interface{}{
+			mc := createMC("global", map[string]interface{}{
 				"highAvailability": true,
 				"modules": map[string]interface{}{
 					"https": map[string]interface{}{
@@ -229,6 +228,7 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 					},
 				},
 			})
+
 			res := &ManifestsResult{}
 			prepareModuleConfig(mc, res)
 
@@ -251,24 +251,9 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 			resMC, err := fakeClient.Dynamic().Resource(config.ModuleConfigGVR).Get(context.TODO(), "global", metav1.GetOptions{})
 			require.NoError(t, err)
 
-			https, found, err := unstructured.NestedMap(resMC.Object, "spec", "settings", "modules", "https")
-			require.NoError(t, err)
-			require.True(t, found)
-			require.Equal(t, https, map[string]interface{}{
-				"customCertificate": map[string]interface{}{
-					"secretName": "secret",
-				},
-			})
+			assertHTTPSSettings(t, resMC)
 
-			// does not change another fields
-			_, found, err = unstructured.NestedString(resMC.Object, "spec", "settings", "modules", "publicDomainTemplate")
-			require.NoError(t, err)
-			require.False(t, found)
-
-			ha, found, err := unstructured.NestedBool(resMC.Object, "spec", "settings", "highAvailability")
-			require.NoError(t, err)
-			require.True(t, found)
-			require.True(t, ha)
+			assertSaveAnotherFields(t, resMC, false)
 		})
 	})
 
@@ -277,28 +262,17 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 			config.ModuleConfigGVR: "ModuleConfigList",
 		})
 
-		mc := &config.ModuleConfig{}
-		mc.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   config.ModuleConfigGroup,
-			Version: config.ModuleConfigVersion,
-			Kind:    config.ModuleConfigKind,
-		})
-		mc.SetName("global")
-		mc.Spec.Enabled = ptr.To(true)
-		mc.Spec.Version = 1
-		mc.Spec.Settings = config.SettingsValues(map[string]interface{}{
+		mc := createMC("global", map[string]interface{}{
 			"highAvailability": true,
 			"modules": map[string]interface{}{
 				"publicDomainTemplate": "template",
 			},
 		})
+
 		res := &ManifestsResult{}
 		prepareModuleConfig(mc, res)
 
-		require.Contains(t, mc.Spec.Settings, "modules")
-		require.NotContains(t, mc.Spec.Settings["modules"], "https")
-		require.True(t, mc.Spec.Settings["highAvailability"].(bool))
-		require.Equal(t, mc.Spec.Settings["modules"].(map[string]interface{})["publicDomainTemplate"], "template")
+		assertMCAfterPrepare(t, mc)
 
 		require.Len(t, res.WithResourcesMCTasks, 0)
 		require.Len(t, res.PostBootstrapMCTasks, 0)

--- a/dhctl/pkg/kubernetes/actions/deckhouse/module_config_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/module_config_test.go
@@ -1,0 +1,311 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deckhouse
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flant/addon-operator/sdk"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+func TestPrepareDeckhouseModuleConfig(t *testing.T) {
+	log.InitLogger("simple")
+
+	t.Run("ModuleConfig deckhouse with releaseChannel should remove releaseChannel from mc and adds to result task with returning releaseChannel to post bootstrap tasks", func(t *testing.T) {
+		fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
+			config.ModuleConfigGVR: "ModuleConfigList",
+		})
+
+		mcWithReleaseChannel := &config.ModuleConfig{}
+		mcWithReleaseChannel.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   config.ModuleConfigGroup,
+			Version: config.ModuleConfigVersion,
+			Kind:    config.ModuleConfigKind,
+		})
+		mcWithReleaseChannel.SetName("deckhouse")
+		mcWithReleaseChannel.Spec.Enabled = ptr.To(true)
+		mcWithReleaseChannel.Spec.Version = 1
+		mcWithReleaseChannel.Spec.Settings = config.SettingsValues(map[string]interface{}{
+			"bundle":         "Minimal",
+			"logLevel":       "Debug",
+			"releaseChannel": "Alpha",
+		})
+		res := &ManifestsResult{}
+		prepareModuleConfig(mcWithReleaseChannel, res)
+
+		require.NotContains(t, mcWithReleaseChannel.Spec.Settings, "releaseChannel")
+		require.Contains(t, mcWithReleaseChannel.Spec.Settings, "bundle")
+		require.Contains(t, mcWithReleaseChannel.Spec.Settings, "logLevel")
+		require.Equal(t, mcWithReleaseChannel.Spec.Settings["bundle"], "Minimal")
+		require.Equal(t, mcWithReleaseChannel.Spec.Settings["logLevel"], "Debug")
+
+		require.Len(t, res.WithResourcesMCTasks, 0)
+		require.Len(t, res.PostBootstrapMCTasks, 1)
+
+		u, err := sdk.ToUnstructured(mcWithReleaseChannel)
+		require.NoError(t, err)
+		_, err = fakeClient.Dynamic().Resource(config.ModuleConfigGVR).Create(context.TODO(), u, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		require.Equal(t, res.PostBootstrapMCTasks[0].Title, "Set release channel to deckhouse module config")
+
+		err = res.PostBootstrapMCTasks[0].Do(fakeClient)
+		require.NoError(t, err)
+
+		resMC, err := fakeClient.Dynamic().Resource(config.ModuleConfigGVR).Get(context.TODO(), "deckhouse", metav1.GetOptions{})
+		require.NoError(t, err)
+
+		rc, found, err := unstructured.NestedString(resMC.Object, "spec", "settings", "releaseChannel")
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, "Alpha", rc)
+
+		// does not change another fields
+		lg, found, err := unstructured.NestedString(resMC.Object, "spec", "settings", "logLevel")
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, "Debug", lg)
+
+		bundle, found, err := unstructured.NestedString(resMC.Object, "spec", "settings", "bundle")
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, "Minimal", bundle)
+	})
+
+	t.Run("ModuleConfig deckhouse without releaseChannel should keep as is mc and should not add tasks", func(t *testing.T) {
+		fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
+			config.ModuleConfigGVR: "ModuleConfigList",
+		})
+
+		mcWithoutReleaseChannel := &config.ModuleConfig{}
+		mcWithoutReleaseChannel.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   config.ModuleConfigGroup,
+			Version: config.ModuleConfigVersion,
+			Kind:    config.ModuleConfigKind,
+		})
+		mcWithoutReleaseChannel.SetName("deckhouse")
+		mcWithoutReleaseChannel.Spec.Enabled = ptr.To(true)
+		mcWithoutReleaseChannel.Spec.Version = 1
+		mcWithoutReleaseChannel.Spec.Settings = config.SettingsValues(map[string]interface{}{
+			"bundle": "Minimal",
+		})
+
+		res := &ManifestsResult{}
+		prepareModuleConfig(mcWithoutReleaseChannel, res)
+
+		require.NotContains(t, mcWithoutReleaseChannel.Spec.Settings, "releaseChannel")
+		require.Contains(t, mcWithoutReleaseChannel.Spec.Settings, "bundle")
+		require.Equal(t, mcWithoutReleaseChannel.Spec.Settings["bundle"], "Minimal")
+
+		u, err := sdk.ToUnstructured(mcWithoutReleaseChannel)
+		require.NoError(t, err)
+		_, err = fakeClient.Dynamic().Resource(config.ModuleConfigGVR).Create(context.TODO(), u, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		require.Len(t, res.WithResourcesMCTasks, 0)
+		require.Len(t, res.PostBootstrapMCTasks, 0)
+	})
+}
+
+func TestPrepareGlobalModuleConfig(t *testing.T) {
+	log.InitLogger("simple")
+
+	t.Run("ModuleConfig global with https setting and another modules settings should remove https from mc and adds to result task with returning https to with resources tasks", func(t *testing.T) {
+		t.Run("And keeps another modules settings", func(t *testing.T) {
+			fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
+				config.ModuleConfigGVR: "ModuleConfigList",
+			})
+
+			mc := &config.ModuleConfig{}
+			mc.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   config.ModuleConfigGroup,
+				Version: config.ModuleConfigVersion,
+				Kind:    config.ModuleConfigKind,
+			})
+			mc.SetName("global")
+			mc.Spec.Enabled = ptr.To(true)
+			mc.Spec.Version = 1
+			mc.Spec.Settings = config.SettingsValues(map[string]interface{}{
+				"highAvailability": true,
+				"modules": map[string]interface{}{
+					"https": map[string]interface{}{
+						"customCertificate": map[string]interface{}{
+							"secretName": "secret",
+						},
+					},
+					"publicDomainTemplate": "template",
+				},
+			})
+			res := &ManifestsResult{}
+			prepareModuleConfig(mc, res)
+
+			require.Contains(t, mc.Spec.Settings, "modules")
+			require.NotContains(t, mc.Spec.Settings["modules"], "https")
+			require.True(t, mc.Spec.Settings["highAvailability"].(bool))
+			require.Equal(t, mc.Spec.Settings["modules"].(map[string]interface{})["publicDomainTemplate"], "template")
+
+			require.Len(t, res.WithResourcesMCTasks, 1)
+			require.Len(t, res.PostBootstrapMCTasks, 0)
+
+			u, err := sdk.ToUnstructured(mc)
+			require.NoError(t, err)
+			_, err = fakeClient.Dynamic().Resource(config.ModuleConfigGVR).Create(context.TODO(), u, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			require.Equal(t, res.WithResourcesMCTasks[0].Title, "Set https setting to global module config")
+
+			err = res.WithResourcesMCTasks[0].Do(fakeClient)
+			require.NoError(t, err)
+
+			resMC, err := fakeClient.Dynamic().Resource(config.ModuleConfigGVR).Get(context.TODO(), "global", metav1.GetOptions{})
+			require.NoError(t, err)
+
+			https, found, err := unstructured.NestedMap(resMC.Object, "spec", "settings", "modules", "https")
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, https, map[string]interface{}{
+				"customCertificate": map[string]interface{}{
+					"secretName": "secret",
+				},
+			})
+
+			// does not change another fields
+			tmpl, found, err := unstructured.NestedString(resMC.Object, "spec", "settings", "modules", "publicDomainTemplate")
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, "template", tmpl)
+
+			ha, found, err := unstructured.NestedBool(resMC.Object, "spec", "settings", "highAvailability")
+			require.NoError(t, err)
+			require.True(t, found)
+			require.True(t, ha)
+		})
+	})
+
+	t.Run("ModuleConfig global with https setting and without another modules settings should remove https from mc and adds to result task with returning https to with resources tasks", func(t *testing.T) {
+		t.Run("And removes modules from settings and keeps another settings", func(t *testing.T) {
+			fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
+				config.ModuleConfigGVR: "ModuleConfigList",
+			})
+
+			mc := &config.ModuleConfig{}
+			mc.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   config.ModuleConfigGroup,
+				Version: config.ModuleConfigVersion,
+				Kind:    config.ModuleConfigKind,
+			})
+			mc.SetName("global")
+			mc.Spec.Enabled = ptr.To(true)
+			mc.Spec.Version = 1
+			mc.Spec.Settings = config.SettingsValues(map[string]interface{}{
+				"highAvailability": true,
+				"modules": map[string]interface{}{
+					"https": map[string]interface{}{
+						"customCertificate": map[string]interface{}{
+							"secretName": "secret",
+						},
+					},
+				},
+			})
+			res := &ManifestsResult{}
+			prepareModuleConfig(mc, res)
+
+			require.NotContains(t, mc.Spec.Settings, "modules")
+			require.True(t, mc.Spec.Settings["highAvailability"].(bool))
+
+			require.Len(t, res.WithResourcesMCTasks, 1)
+			require.Len(t, res.PostBootstrapMCTasks, 0)
+
+			u, err := sdk.ToUnstructured(mc)
+			require.NoError(t, err)
+			_, err = fakeClient.Dynamic().Resource(config.ModuleConfigGVR).Create(context.TODO(), u, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			require.Equal(t, res.WithResourcesMCTasks[0].Title, "Set https setting to global module config")
+
+			err = res.WithResourcesMCTasks[0].Do(fakeClient)
+			require.NoError(t, err)
+
+			resMC, err := fakeClient.Dynamic().Resource(config.ModuleConfigGVR).Get(context.TODO(), "global", metav1.GetOptions{})
+			require.NoError(t, err)
+
+			https, found, err := unstructured.NestedMap(resMC.Object, "spec", "settings", "modules", "https")
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, https, map[string]interface{}{
+				"customCertificate": map[string]interface{}{
+					"secretName": "secret",
+				},
+			})
+
+			// does not change another fields
+			_, found, err = unstructured.NestedString(resMC.Object, "spec", "settings", "modules", "publicDomainTemplate")
+			require.NoError(t, err)
+			require.False(t, found)
+
+			ha, found, err := unstructured.NestedBool(resMC.Object, "spec", "settings", "highAvailability")
+			require.NoError(t, err)
+			require.True(t, found)
+			require.True(t, ha)
+		})
+	})
+
+	t.Run("ModuleConfig global without https setting and another modules settings should keep another settings and should not add result task to with resources tasks", func(t *testing.T) {
+		fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
+			config.ModuleConfigGVR: "ModuleConfigList",
+		})
+
+		mc := &config.ModuleConfig{}
+		mc.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   config.ModuleConfigGroup,
+			Version: config.ModuleConfigVersion,
+			Kind:    config.ModuleConfigKind,
+		})
+		mc.SetName("global")
+		mc.Spec.Enabled = ptr.To(true)
+		mc.Spec.Version = 1
+		mc.Spec.Settings = config.SettingsValues(map[string]interface{}{
+			"highAvailability": true,
+			"modules": map[string]interface{}{
+				"publicDomainTemplate": "template",
+			},
+		})
+		res := &ManifestsResult{}
+		prepareModuleConfig(mc, res)
+
+		require.Contains(t, mc.Spec.Settings, "modules")
+		require.NotContains(t, mc.Spec.Settings["modules"], "https")
+		require.True(t, mc.Spec.Settings["highAvailability"].(bool))
+		require.Equal(t, mc.Spec.Settings["modules"].(map[string]interface{})["publicDomainTemplate"], "template")
+
+		require.Len(t, res.WithResourcesMCTasks, 0)
+		require.Len(t, res.PostBootstrapMCTasks, 0)
+
+		u, err := sdk.ToUnstructured(mc)
+		require.NoError(t, err)
+		_, err = fakeClient.Dynamic().Resource(config.ModuleConfigGVR).Create(context.TODO(), u, metav1.CreateOptions{})
+		require.NoError(t, err)
+	})
+}

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -62,6 +62,14 @@ type DeckhouseDeploymentParams struct {
 type imagesDigests map[string]map[string]interface{}
 
 func loadImagesDigests(filename string) (imagesDigests, error) {
+	if val, ok := os.LookupEnv("DHCTL_TEST"); ok && val == "yes" {
+		return map[string]map[string]interface{}{
+			"common": {
+				"init": "sha256:4c5064aa2864e7650e4f2dd5548a4a6a4aaa065b4f8779f01023f73132cde882",
+			},
+		}, nil
+	}
+
 	var imagesDigestsDict imagesDigests
 
 	imagesDigestsJSONFile, err := os.ReadFile(filename)

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests_test.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests_test.go
@@ -16,6 +16,7 @@ package manifests
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -79,6 +80,21 @@ func compareDeployments(t *testing.T, depl1, depl2 *appsv1.Deployment) {
 }
 
 func Test_struct_vs_unmarshal(t *testing.T) {
+	err := os.Setenv("DHCTL_TEST", "yes")
+	require.NoError(t, err)
+	defer func() {
+		os.Unsetenv("DHCTL_TEST")
+	}()
+
+	err = os.WriteFile("/deckhouse/version", []byte("dev"), 0o666)
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		os.Remove("/deckhouse/version")
+	}()
+
 	params := DeckhouseDeploymentParams{
 		Registry:         "registry.example.com/deckhouse:master",
 		LogLevel:         "debug",
@@ -94,6 +110,21 @@ func Test_struct_vs_unmarshal(t *testing.T) {
 }
 
 func Test_DeployTime(t *testing.T) {
+	err := os.Setenv("DHCTL_TEST", "yes")
+	require.NoError(t, err)
+	defer func() {
+		os.Unsetenv("DHCTL_TEST")
+	}()
+
+	err = os.WriteFile("/deckhouse/version", []byte("dev"), 0o666)
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		os.Remove("/deckhouse/version")
+	}()
+
 	paramsGet := func() DeckhouseDeploymentParams {
 		return DeckhouseDeploymentParams{
 			Registry:         "registry.example.com/deckhouse:master",
@@ -127,6 +158,21 @@ func Test_DeployTime(t *testing.T) {
 }
 
 func Test_DoNotMutateDeployment(t *testing.T) {
+	err := os.Setenv("DHCTL_TEST", "yes")
+	require.NoError(t, err)
+	defer func() {
+		os.Unsetenv("DHCTL_TEST")
+	}()
+
+	err = os.WriteFile("/deckhouse/version", []byte("dev"), 0o666)
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		os.Remove("/deckhouse/version")
+	}()
+
 	tc := []struct {
 		name   string
 		params DeckhouseDeploymentParams

--- a/dhctl/pkg/kubernetes/actions/resources/resouce_ready.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resouce_ready.go
@@ -41,7 +41,7 @@ type resourceReadinessChecker struct {
 // kind should be in lower case!
 var kindsToAttempts = map[string]int{
 	// in some cases deckhouse controller doesn't have time for set status field, and we have Ready nodegroup whe it is not Ready
-	"nodegroup": 3,
+	"nodegroup": 5,
 }
 
 func (c *resourceReadinessChecker) IsReady() (bool, error) {

--- a/dhctl/pkg/kubernetes/actions/resources/resouce_ready.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resouce_ready.go
@@ -17,6 +17,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +38,12 @@ type resourceReadinessChecker struct {
 	attempt int
 }
 
+// kind should be in lower case!
+var kindsToAttempts = map[string]int{
+	// in some cases deckhouse controller doesn't have time for set status field, and we have Ready nodegroup whe it is not Ready
+	"nodegroup": 3,
+}
+
 func (c *resourceReadinessChecker) IsReady() (bool, error) {
 	defer func() {
 		c.attempt++
@@ -52,8 +59,15 @@ func (c *resourceReadinessChecker) IsReady() (bool, error) {
 
 	c.logger.LogInfoF("Checking if resource %s is ready...\n", name)
 
+	expectedAttempts := 1
+	kind := strings.ToLower(c.resource.GVK.Kind)
+	if attempts, ok := kindsToAttempts[kind]; ok {
+		log.DebugF("Found custom attempts %d for kind\n", attempts, c.resource.GVK.Kind)
+		expectedAttempts = attempts
+	}
+
 	// wait some attempts for set statuses in the resources
-	if c.attempt < 3 {
+	if c.attempt < expectedAttempts {
 		logNotReadyYet()
 		c.logger.LogDebugF("Skip resource % readiness checking for waiting set status\n", name)
 		return false, nil

--- a/dhctl/pkg/kubernetes/actions/resources/resouce_ready.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resouce_ready.go
@@ -53,7 +53,7 @@ func (c *resourceReadinessChecker) IsReady() (bool, error) {
 	c.logger.LogInfoF("Checking if resource %s is ready...\n", name)
 
 	// wait some attempts for set statuses in the resources
-	if c.attempt < 1 {
+	if c.attempt < 3 {
 		logNotReadyYet()
 		c.logger.LogDebugF("Skip resource % readiness checking for waiting set status\n", name)
 		return false, nil

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -144,13 +144,6 @@ func (c *Creator) createAll() error {
 		}
 	}
 
-	for _, task := range c.mcTasks {
-		err = c.runSingleMCTask(task)
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -228,6 +221,20 @@ func (c *Creator) TryToCreate() error {
 			gvks[key] = struct{}{}
 			resourcesToCreate = append(resourcesToCreate, key)
 		}
+	}
+
+	for _, task := range c.mcTasks {
+		err := c.runSingleMCTask(task)
+		if err != nil {
+			return err
+		}
+	}
+
+	// we do not want to support same creation logic for module config tasks as for resources
+	// if task was failed we return error.
+	// thus, all tasks were done here, just remove tasks for prevent multiple applying
+	if len(c.mcTasks) > 0 {
+		c.mcTasks = make([]actions.ModuleConfigTask, 0)
 	}
 
 	if len(c.resources) > 0 {

--- a/dhctl/pkg/kubernetes/actions/task.go
+++ b/dhctl/pkg/kubernetes/actions/task.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -96,4 +98,11 @@ func (task *ManifestTask) PatchOrCreate() error {
 		return fmt.Errorf("Create '%s': %v", task.Name, err)
 	}
 	return nil
+}
+
+type ModuleConfigTask struct {
+	// task without attempts inside, client must retry all tasks by itself
+	Do    func(kubeCl *client.KubernetesClient) error
+	Title string
+	Name  string
 }

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
@@ -16,6 +16,7 @@ package bootstrap
 
 import (
 	"fmt"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
@@ -68,5 +69,6 @@ func (b *ClusterBootstrapper) InstallDeckhouse() error {
 		return err
 	}
 
-	return InstallDeckhouse(kubeCl, installConfig)
+	_, err = InstallDeckhouse(kubeCl, installConfig)
+	return err
 }

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
@@ -86,6 +86,6 @@ func (b *ClusterBootstrapper) CreateResources() error {
 			return err
 		}
 
-		return resources.CreateResourcesLoop(kubeCl, resourcesToCreate, checkers)
+		return resources.CreateResourcesLoop(kubeCl, resourcesToCreate, checkers, nil)
 	})
 }

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -38,10 +38,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions"
-
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/converge"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -38,6 +38,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/converge"
@@ -684,17 +686,24 @@ func WaitForSSHConnectionOnMaster(sshClient *ssh.Client) error {
 	})
 }
 
-func InstallDeckhouse(kubeCl *client.KubernetesClient, config *config.DeckhouseInstaller) error {
-	return log.Process("bootstrap", "Install Deckhouse", func() error {
+type InstallDeckhouseResult struct {
+	ManifestResult *deckhouse.ManifestsResult
+}
+
+func InstallDeckhouse(kubeCl *client.KubernetesClient, config *config.DeckhouseInstaller) (*InstallDeckhouseResult, error) {
+	res := &InstallDeckhouseResult{}
+	err := log.Process("bootstrap", "Install Deckhouse", func() error {
 		err := CheckPreventBreakAnotherBootstrappedCluster(kubeCl, config)
 		if err != nil {
 			return err
 		}
 
-		err = deckhouse.CreateDeckhouseManifests(kubeCl, config)
+		resManifests, err := deckhouse.CreateDeckhouseManifests(kubeCl, config)
 		if err != nil {
 			return fmt.Errorf("deckhouse create manifests: %v", err)
 		}
+
+		res.ManifestResult = resManifests
 
 		err = cache.Global().Save(ManifestCreatedInClusterCacheKey, []byte("yes"))
 		if err != nil {
@@ -708,6 +717,11 @@ func InstallDeckhouse(kubeCl *client.KubernetesClient, config *config.DeckhouseI
 
 		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }
 
 func BootstrapTerraNodes(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, terraNodeGroups []config.TerraNodeGroupSpec, terraformContext *terraform.TerraformContext) error {
@@ -846,4 +860,34 @@ func BootstrapGetNodesFromCache(metaConfig *config.MetaConfig, stateCache state.
 		return nil
 	})
 	return nodesFromCache, err
+}
+
+func applyPostBootstrapModuleConfigs(kubeCl *client.KubernetesClient, tasks []actions.ModuleConfigTask) error {
+	for _, task := range tasks {
+		err := retry.NewLoop(task.Title, 15, 5*time.Second).
+			Run(func() error {
+				return task.Do(kubeCl)
+			})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func RunPostInstallTasks(kubeCl *client.KubernetesClient, result *InstallDeckhouseResult) error {
+	if result == nil {
+		log.DebugF("Skip post install tasks because result is nil\n")
+		return nil
+	}
+
+	return log.Process("bootstrap", "Run post bootstrap actions", func() error {
+		err := deckhouse.ConfigureDeckhouseRelease(kubeCl)
+		if err != nil {
+			return err
+		}
+
+		return applyPostBootstrapModuleConfigs(kubeCl, result.ManifestResult.PostBootstrapMCTasks)
+	})
 }

--- a/dhctl/pkg/operations/bootstrap/steps_test.go
+++ b/dhctl/pkg/operations/bootstrap/steps_test.go
@@ -114,6 +114,21 @@ func TestBootstrapGetNodesFromCache(t *testing.T) {
 }
 
 func TestInstallDeckhouse(t *testing.T) {
+	err := os.Setenv("DHCTL_TEST", "yes")
+	require.NoError(t, err)
+	defer func() {
+		os.Unsetenv("DHCTL_TEST")
+	}()
+
+	err = os.WriteFile("/deckhouse/version", []byte("dev"), 0o666)
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		os.Remove("/deckhouse/version")
+	}()
+
 	createReadyDeckhousePod := func(fakeClient *client.KubernetesClient) {
 		pod := &v1.Pod{
 			TypeMeta: metav1.TypeMeta{
@@ -195,7 +210,7 @@ func TestInstallDeckhouse(t *testing.T) {
 			fakeClient := client.NewFakeKubernetesClient()
 			createReadyDeckhousePod(fakeClient)
 
-			err := InstallDeckhouse(fakeClient, conf)
+			_, err := InstallDeckhouse(fakeClient, conf)
 
 			require.NoError(t, err, "Should install Deckhouse")
 
@@ -212,7 +227,7 @@ func TestInstallDeckhouse(t *testing.T) {
 				createReadyDeckhousePod(fakeClient)
 				createUUIDConfigMap(fakeClient, curUUID)
 
-				err := InstallDeckhouse(fakeClient, conf)
+				_, err := InstallDeckhouse(fakeClient, conf)
 
 				require.Error(t, err, "Should not install Deckhouse")
 
@@ -229,7 +244,7 @@ func TestInstallDeckhouse(t *testing.T) {
 				createReadyDeckhousePod(fakeClient)
 				createUUIDConfigMap(fakeClient, curUUID)
 
-				err := InstallDeckhouse(fakeClient, conf)
+				_, err := InstallDeckhouse(fakeClient, conf)
 
 				require.Error(t, err, "Should not install Deckhouse")
 
@@ -243,7 +258,7 @@ func TestInstallDeckhouse(t *testing.T) {
 				createReadyDeckhousePod(fakeClient)
 				createUUIDConfigMap(fakeClient, clusterUUID)
 
-				err := InstallDeckhouse(fakeClient, conf)
+				_, err := InstallDeckhouse(fakeClient, conf)
 
 				require.NoError(t, err, "Should install Deckhouse")
 

--- a/dhctl/pkg/operations/commander/attach/attacher.go
+++ b/dhctl/pkg/operations/commander/attach/attacher.go
@@ -299,7 +299,7 @@ func (i *Attacher) capture(
 			return fmt.Errorf("unable to get resource checkers: %w", err)
 		}
 
-		err = resources.CreateResourcesLoop(kubeClient, attachResources, checkers)
+		err = resources.CreateResourcesLoop(kubeClient, attachResources, checkers, nil)
 		if err != nil {
 			return fmt.Errorf("unable to create resources: %w", err)
 		}

--- a/dhctl/pkg/operations/commander/detach/detacher.go
+++ b/dhctl/pkg/operations/commander/detach/detacher.go
@@ -91,7 +91,7 @@ func (op *Detacher) Detach(ctx context.Context) error {
 			return fmt.Errorf("unable to get resource checkers: %w", err)
 		}
 
-		err = resources.CreateResourcesLoop(kubeClient, detachResources, checkers)
+		err = resources.CreateResourcesLoop(kubeClient, detachResources, checkers, nil)
 		if err != nil {
 			return fmt.Errorf("unable to create resources: %w", err)
 		}

--- a/dhctl/pkg/template/resources_test.go
+++ b/dhctl/pkg/template/resources_test.go
@@ -37,6 +37,7 @@ func fromUnstructured(unstructuredObj unstructured.Unstructured, obj interface{}
 
 func TestResourcesOrder(t *testing.T) {
 	unknownAdditionalOrder := []string{
+		"IngressNginxController",
 		"ClusterAuthorizationRule",
 		"YandexInstanceClass",
 		"NodeGroup",

--- a/dhctl/pkg/template/testdata/resources/order.yaml
+++ b/dhctl/pkg/template/testdata/resources/order.yaml
@@ -1,4 +1,25 @@
 apiVersion: deckhouse.io/v1
+kind: IngressNginxController
+metadata:
+  name: main
+spec:
+  chaosMonkey: false
+  disableHTTP2: false
+  hsts: false
+  ingressClass: nginx
+  inlet: LoadBalancer
+  maxReplicas: 1
+  minReplicas: 1
+  nodeSelector:
+    node-role.deckhouse.io/system: ""
+  tolerations:
+    - key: dedicated.deckhouse.io
+      operator: Equal
+      value: system
+  underscoresInHeaders: false
+  validationEnabled: true
+---
+apiVersion: deckhouse.io/v1
 kind: ClusterAuthorizationRule
 metadata:
   name: admin


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

There is a situation where the cluster bootstrap terminates with an error. For this, we need to add module config `global` with parameter `modules.https.mode` `CustomCertificate` and CloudPermanent nodegroup `system` and for example `worker` with at least one replica. We have the following sequence:
- creating module configs
- cloud permanent node creation
- creating resources (such as the secret for `CustomCertificate` mode)

After applying module configs `global` with the `modules.https.mode` `CustomCertificate` parameter and creating nodegroup system, deckhouse hangs with the error

```
Queue 'main': length 30, status: 'sleep after fail for 32s (17s left of 32s delay)'
 1. ModuleHookRun:main:kubernetes:150-user-authn/hooks/https/copy_custom_certificate.go:custom_certificates:OperatorStartup:failures 7602:module hook '150-user-authn/hooks/https/copy_custom_certificate.go' failed: custom certificate secret name is configured, but secret with this name doesn't exis
```

To prevent this behaviour, dhctl introduced three types of specialised actions with module configs: preparing module config before applying it to the cluster, post action with moduleconfig at the stage of
resource creation and installation completion (the second case is needed to apply `releaseChannel` to module config deckhouse).
Now in the preparation phase for moduleconfig deckhouse `releaseChannel` is removed and remembered, for moduleconfig global `modules.https` is removed and remembered.
At the resource creation stage, `modules.https` is returned to moduleconfig global. Why is this necessary exactly at the resource creation stage? So that once the secret is created, the settings are immediately applied.
At the finalisation stage of the deployment, `releaseChannel` is returned to moduleconfig deckhouse. This is to ensure that deckhouse is not updated during the installation process. This mechanism was already implemented, but rewritten to the new approach for a better Developer Experience.

Also, the following has been done in this  pull request:
- the logic for populating deckhouse module config from configOverrides was removed, this method was removed and dead code remained
- some tests were crashing locally with panic because the /deckhouse/version and /deckhouse/candi/images_digests.json files were not created. This has been fixed
- also added a custom number of wait attempts for NodeGroup kind resources, as deckhouse-controller does not have time to set `status` in 1 attempt

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Cluster bottstrap can failed in some cases.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Add tasks for moduleconfigs routines for post bootstrap and creating with resources phases.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
