### PR TITLE
[docs] fix: delete old module docs then upload new

### DIFF
--- a/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scaner/cache/cache.go
+++ b/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scaner/cache/cache.go
@@ -67,16 +67,16 @@ func (c *Cache) GetRange() (versions []backends.Version) {
 	defer c.m.RUnlock()
 
 	state := c.GetState()
-	for _, version := range state {
-		if !contain(c.stateSnap, version) {
-			version.ToDelete = false
+	for _, version := range c.stateSnap {
+		if !contain(state, version) {
+			version.ToDelete = true
 			versions = append(versions, version)
 		}
 	}
 
-	for _, version := range c.stateSnap {
-		if !contain(state, version) {
-			version.ToDelete = true
+	for _, version := range state {
+		if !contain(c.stateSnap, version) {
+			version.ToDelete = false
 			versions = append(versions, version)
 		}
 	}


### PR DESCRIPTION
## Description

In docs-builder, there was a problem in the logic of work. We check the modules for which we need to rebuild the documentation. Next, we define the modules that should be removed. And as a result, we get a complete removal of the documentation for the module.

To avoid such a situation, we need to reverse the sequence. That is, first we have to make a list of modules that need to be removed, and then add new modules that need to be rebuilt.

## Why do we need it, and what problem does it solve?

In order for module documentation to be collected and updated correctly. And at the same time, the documentation of modules that were removed from the register was deleted from the site.

## What is the expected result?

When updating the documentation of modules, they are reflected on the site. When a module is uninstalled, its documentation is deleted from the site.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: delete old module docs then upload new
impact_level: low
```
