### PR TITLE
[operator-trivy] add an option for disabling sbom generation

### DIFF
--- a/ee/modules/500-operator-trivy/hooks/sbom_reports_cleanup.go
+++ b/ee/modules/500-operator-trivy/hooks/sbom_reports_cleanup.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"context"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+)
+
+// Performs one-time cleanup of SBOM reports from the cluster if .Values.operatorTrivy.disableSBOMGeneration was set to true
+
+const (
+	operatorNs   = "d8-operator-trivy"
+	cleanUpLabel = "sbom-cleaned-up"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/operator-trivy/cleanup_sbom_reports",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "module_namespace",
+			ApiVersion: "v1",
+			Kind:       "Namespace",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{operatorNs},
+			},
+			ExecuteHookOnEvents:          ptr.To(false),
+			ExecuteHookOnSynchronization: ptr.To(false),
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					cleanUpLabel: "true",
+				},
+			},
+			FilterFunc: applyNamespaceFilter,
+		},
+		{
+			Name:       "module_config",
+			ApiVersion: "deckhouse.io/v1alpha1",
+			Kind:       "ModuleConfig",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"operator-trivy"},
+			},
+			ExecuteHookOnEvents:          ptr.To(true),
+			ExecuteHookOnSynchronization: ptr.To(false),
+			FilterFunc:                   applyConfigFilter,
+		},
+	},
+}, dependency.WithExternalDependencies(cleanUpReports))
+
+type moduleConfig struct {
+	Spec struct {
+		Settings struct {
+			DisableSBOMGeneration bool `json:"disableSBOMGeneration"`
+		} `json:"settings"`
+	} `json:"spec"`
+}
+
+func applyConfigFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var mc moduleConfig
+
+	err := sdk.FromUnstructured(obj, &mc)
+	if err != nil {
+		return nil, err
+	}
+
+	return mc.Spec.Settings.DisableSBOMGeneration, nil
+}
+
+func cleanUpReports(input *go_hook.HookInput, dc dependency.Container) error {
+	mc := input.Snapshots["module_config"]
+	if len(mc) > 0 {
+		disableSBOM := mc[0].(bool)
+		moduleNsPatch := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"labels": map[string]interface{}{
+					cleanUpLabel: nil,
+				},
+			},
+		}
+
+		// cleanup isn't required
+		if !disableSBOM {
+			// remove cleanup label from the namesapce
+			input.PatchCollector.MergePatch(moduleNsPatch, "v1", "Namespace", "", operatorNs)
+			return nil
+		}
+
+		// cleanup was already done
+		if len(input.Snapshots["module_namespace"]) > 0 {
+			return nil
+		}
+
+		k8sClient := dc.MustGetK8sClient()
+
+		list, err := k8sClient.Dynamic().Resource(sbomGVR).Namespace(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+
+		for _, item := range list.Items {
+			if err = k8sClient.Dynamic().Resource(sbomGVR).Namespace(item.GetNamespace()).Delete(context.Background(), item.GetName(), metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+		}
+
+		// set cleanup label to true
+		moduleNsPatch = map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"labels": map[string]interface{}{
+					cleanUpLabel: "true",
+				},
+			},
+		}
+		input.PatchCollector.MergePatch(moduleNsPatch, "v1", "Namespace", "", operatorNs)
+	}
+
+	return nil
+}

--- a/ee/modules/500-operator-trivy/hooks/sbom_reports_cleanup_test.go
+++ b/ee/modules/500-operator-trivy/hooks/sbom_reports_cleanup_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var (
+	nsDefault = `
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+`
+	nsOperatorTrivy = `
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d8-operator-trivy
+  annotations:
+    meta.helm.sh/release-name: operator-trivy
+    meta.helm.sh/release-namespace: d8-system
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    extended-monitoring.deckhouse.io/enabled: ""
+    heritage: deckhouse
+    kubernetes.io/metadata.name: d8-operator-trivy
+    module: operator-trivy
+    prometheus.deckhouse.io/rules-watcher-enabled: "true"
+`
+
+	nsOperatorTrivyCleanedUp = nsOperatorTrivy + `
+    sbom-cleaned-up: "true"
+`
+
+	sbom1Yaml = `
+---
+apiVersion: aquasecurity.github.io/v1alpha1
+kind: SbomReport
+metadata:
+  name: job-echo
+  namespace: default
+report:
+  artifact:
+    digest: sha256:6013ae1a63c2ee58a8949f03c6366a3ef6a2f386a7db27d86de2de965e9f450b
+    repository: library/ubuntu
+    tag: "20.04"
+`
+
+	sbom2Yaml = `
+---
+apiVersion: aquasecurity.github.io/v1alpha1
+kind: SbomReport
+metadata:
+  name: job-alpha
+  namespace: default
+report:
+  artifact:
+    digest: sha256:6013ae1a63c2ee58a8949f03c6366a3ef6a2f386a7db27d86de2de965e9f450b
+    repository: library/ubuntu
+    tag: "20.04"
+`
+
+	moduleConfigSBOMDisabled = `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: operator-trivy
+spec:
+  enabled: true
+  settings:
+    disableSBOMGeneration: true
+`
+
+	moduleConfigSBOMEnabled = `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: operator-trivy
+spec:
+  enabled: true
+  settings:
+    disableSBOMGeneration: false
+`
+)
+
+var _ = Describe("Modules :: operator-trivy :: hooks :: sbom reports cleanup ::", func() {
+
+	f := HookExecutionConfigInit("", "")
+	f.RegisterCRD("aquasecurity.github.io", "v1alpha1", "SbomReport", false)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
+
+	Context(":: empty cluster", func() {
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context(":: empty cluster with ns", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(nsDefault + nsOperatorTrivy)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Namespace unchanged", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ns := f.KubernetesResource("Namespace", "", "d8-operator-trivy")
+			Expect(ns.Exists()).To(BeTrue())
+			Expect(ns.ToYaml()).To(MatchYAML(nsOperatorTrivy))
+		})
+
+	})
+	Context(":: ns plus sboms", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(nsDefault + nsOperatorTrivy + sbom1Yaml + sbom2Yaml)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Namespace unchanged, sboms in place", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ns := f.KubernetesResource("Namespace", "", "d8-operator-trivy")
+			Expect(ns.Exists()).To(BeTrue())
+			Expect(ns.ToYaml()).To(MatchYAML(nsOperatorTrivy))
+			_, err := f.KubeClient().Dynamic().Resource(sbomGVR).Namespace("default").Get(context.TODO(), "job-echo", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			_, err = f.KubeClient().Dynamic().Resource(sbomGVR).Namespace("default").Get(context.TODO(), "job-alpha", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context(":: ns plus sboms and module config set to disable sboms", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(nsDefault + nsOperatorTrivy + sbom1Yaml + sbom2Yaml + moduleConfigSBOMDisabled)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Namespace labeled, sboms deleted", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ns := f.KubernetesResource("Namespace", "", "d8-operator-trivy")
+			Expect(ns.Exists()).To(BeTrue())
+			Expect(ns.ToYaml()).To(MatchYAML(nsOperatorTrivyCleanedUp))
+			_, err := f.KubeClient().Dynamic().Resource(sbomGVR).Namespace("default").Get(context.TODO(), "job-echo", metav1.GetOptions{})
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			_, err = f.KubeClient().Dynamic().Resource(sbomGVR).Namespace("default").Get(context.TODO(), "job-alpha", metav1.GetOptions{})
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	Context(":: labeled ns plus sboms and module config set to disable sboms", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(nsDefault + nsOperatorTrivyCleanedUp + sbom1Yaml + sbom2Yaml + moduleConfigSBOMDisabled)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Namespace labeled, sboms unchanged", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ns := f.KubernetesResource("Namespace", "", "d8-operator-trivy")
+			Expect(ns.Exists()).To(BeTrue())
+			Expect(ns.ToYaml()).To(MatchYAML(nsOperatorTrivyCleanedUp))
+			_, err := f.KubeClient().Dynamic().Resource(sbomGVR).Namespace("default").Get(context.TODO(), "job-echo", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			_, err = f.KubeClient().Dynamic().Resource(sbomGVR).Namespace("default").Get(context.TODO(), "job-alpha", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context(":: labeled ns plus sboms and module config set to enable sboms", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(nsDefault + nsOperatorTrivyCleanedUp + sbom1Yaml + sbom2Yaml + moduleConfigSBOMEnabled)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Namespace unlabeled, sboms unchanged", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ns := f.KubernetesResource("Namespace", "", "d8-operator-trivy")
+			Expect(ns.Exists()).To(BeTrue())
+			Expect(ns.ToYaml()).To(MatchYAML(nsOperatorTrivy))
+			_, err := f.KubeClient().Dynamic().Resource(sbomGVR).Namespace("default").Get(context.TODO(), "job-echo", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			_, err = f.KubeClient().Dynamic().Resource(sbomGVR).Namespace("default").Get(context.TODO(), "job-alpha", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+		})
+	})
+
+})

--- a/ee/modules/500-operator-trivy/openapi/config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/config-values.yaml
@@ -96,6 +96,16 @@ properties:
       The same as `spec.nodeSelector` for the Kubernetes pod.
 
       If the parameter is omitted or `false`, it will be determined [automatically](https://deckhouse.io/products/kubernetes-platform/documentation/v1/#advanced-scheduling).
+  disableSBOMGeneration:
+    type: boolean
+    default: false
+    description: |
+      Disables SBOM reports generation.
+
+      **Warning.** When this options is set to true, all current SBOM reports are deleted from the cluster (the cleanup is executed only once).
+
+    x-doc-default: false
+    x-examples: [true, false]
   reportResourceLabels:
     type: array
     description: |

--- a/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/500-operator-trivy/openapi/doc-ru-config-values.yaml
@@ -42,6 +42,11 @@ properties:
       Структура, аналогичная `spec.nodeSelector` пода Kubernetes.
 
       Если значение не указано или указано `false`, будет использоваться [автоматика](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
+  disableSBOMGeneration:
+    description: |
+      Отключает генерацию отчетов SBOM.
+
+      **Внимание.** При установке значения "true", все текущие отчеты SBOM в кластере удаляются (очистка выполняется один раз).
 
   reportResourceLabels:
     description: |

--- a/ee/modules/500-operator-trivy/templates/deployment.yaml
+++ b/ee/modules/500-operator-trivy/templates/deployment.yaml
@@ -106,7 +106,11 @@ spec:
           - name: OPERATOR_VULNERABILITY_SCANNER_ENABLED
             value: "true"
           - name: OPERATOR_SBOM_GENERATION_ENABLED
+          {{- if .Values.operatorTrivy.disableSBOMGeneration }}
+            value: "false"
+          {{- else }}
             value: "true"
+          {{- end }}
           - name: OPERATOR_CLUSTER_SBOM_CACHE_ENABLED
             value: "false"
           - name: OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS


### PR DESCRIPTION
## Description
Adds yet another setting for the module  - `disableSBOMGeneration`, which controls if the operator should generate SBOM reports when scanning images. By default it's set to `false`. Also, if `disableSBOMGeneration` transitions from `false` to `true`, `sbom_reports_cleanup` hook is executed once deleting current sbom reports from the cluster.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Having generation SBOM reports turned on in a cluster doesn't look like a good default setting as quite often these reports are left unrequested. Moreover, had a number of incidents related to having dozens of sbom reports in a cluster, which eventually would put some extra load on the cluster's kube api.
Closes #10090
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

## What is the expected result?
There is a way provided for disabling SBOM generation functionality through the module's settings.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: feature
summary: An option for disabling sbom generation.
impact: Once set to true, ALL current SBOM reports are deleted (one-time operation).
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
