### PR TITLE
[deckhouse] add update policies validation

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
@@ -39,14 +39,9 @@ type moduleManager interface {
 }
 
 // RegisterAdmissionHandlers registers validation webhook handlers for admission server built-in in addon-operator
-func RegisterAdmissionHandlers(
-	registerer registerer,
-	client client.Client,
-	mm moduleManager,
-	configValidator *configtools.Validator,
-	storage moduleStorage,
-	metricStorage *metricstorage.MetricStorage) {
-	registerer.RegisterHandler("/validate/v1alpha1/module-configs", moduleConfigValidationHandler(client, storage, metricStorage, configValidator))
-	registerer.RegisterHandler("/validate/v1alpha1/modules", moduleValidationHandler())
-	registerer.RegisterHandler("/validate/v1/configuration-secret", kubernetesVersionHandler(mm))
+func RegisterAdmissionHandlers(reg registerer, cli client.Client, mm moduleManager, validator *configtools.Validator, storage moduleStorage, metricStorage *metricstorage.MetricStorage) {
+	reg.RegisterHandler("/validate/v1alpha1/module-configs", moduleConfigValidationHandler(cli, storage, metricStorage, validator))
+	reg.RegisterHandler("/validate/v1alpha1/modules", moduleValidationHandler())
+	reg.RegisterHandler("/validate/v1/configuration-secret", kubernetesVersionHandler(mm))
+	reg.RegisterHandler("/validate/v1alpha1/update-policies", updatePolicyHandler(cli))
 }

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
@@ -39,7 +39,14 @@ type moduleManager interface {
 }
 
 // RegisterAdmissionHandlers registers validation webhook handlers for admission server built-in in addon-operator
-func RegisterAdmissionHandlers(reg registerer, cli client.Client, mm moduleManager, validator *configtools.Validator, storage moduleStorage, metricStorage *metricstorage.MetricStorage) {
+func RegisterAdmissionHandlers(
+	reg registerer,
+	cli client.Client,
+	mm moduleManager,
+	validator *configtools.Validator,
+	storage moduleStorage,
+	metricStorage *metricstorage.MetricStorage,
+) {
 	reg.RegisterHandler("/validate/v1alpha1/module-configs", moduleConfigValidationHandler(cli, storage, metricStorage, validator))
 	reg.RegisterHandler("/validate/v1alpha1/modules", moduleValidationHandler())
 	reg.RegisterHandler("/validate/v1/configuration-secret", kubernetesVersionHandler(mm))

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_kubernetes_version.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_kubernetes_version.go
@@ -67,7 +67,7 @@ func kubernetesVersionHandler(mm moduleManager) http.Handler {
 				return rejectResult(err.Error())
 			}
 			if mm.IsModuleEnabled(moduleName) {
-				log.Debugf("the '%s' module has unsatisfied requierements", moduleName)
+				log.Debugf("the module %q has unsatisfied requirements", moduleName)
 				return rejectResult(err.Error())
 			}
 		}

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_kubernetes_version.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_kubernetes_version.go
@@ -54,7 +54,7 @@ func kubernetesVersionHandler(mm moduleManager) http.Handler {
 		clusterConf := new(clusterConfig)
 		if err := yaml.Unmarshal(clusterConfigurationRaw, clusterConf); err != nil {
 			log.Debugf("failed to unmarshal cluster configuration: %v", err)
-			return nil, err
+			return nil, fmt.Errorf("unmarshal cluster configuration: %w", err)
 		}
 
 		if clusterConf.KubernetesVersion == "Automatic" {
@@ -67,7 +67,7 @@ func kubernetesVersionHandler(mm moduleManager) http.Handler {
 				return rejectResult(err.Error())
 			}
 			if mm.IsModuleEnabled(moduleName) {
-				log.Debugf("module %s has unsatisfied requierements", moduleName)
+				log.Debugf("the '%s' module has unsatisfied requierements", moduleName)
 				return rejectResult(err.Error())
 			}
 		}

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -148,8 +148,6 @@ func moduleConfigValidationHandler(cli client.Client, moduleStorage moduleStorag
 			return rejectResult(fmt.Sprintf("the '%s' module source is an unavailable source for the '%s' module, available sources: %v", cfg.Spec.Source, cfg.Name, module.Properties.AvailableSources))
 		}
 
-		var warning string
-
 		// empty policy means module uses deckhouse embedded policy
 		if cfg.Spec.UpdatePolicy != "" {
 			tmp := new(v1alpha1.ModuleUpdatePolicy)
@@ -157,9 +155,11 @@ func moduleConfigValidationHandler(cli client.Client, moduleStorage moduleStorag
 				if !apierrors.IsNotFound(err) {
 					return nil, fmt.Errorf("get the '%s' module policy: %w", cfg.Spec.UpdatePolicy, err)
 				}
-				warning = fmt.Sprintf("the '%s' module policy not found, the policy from the deckhouse settings will be used instead", cfg.Spec.UpdatePolicy)
+				return rejectResult(fmt.Sprintf("the '%s' module policy does not exist", cfg.Spec.UpdatePolicy))
 			}
 		}
+
+		var warning string
 
 		// check if spec.version value is valid and the version is the latest.
 		if res := configValidator.Validate(cfg); res.HasError() {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_update_policy.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_update_policy.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	kwhhttp "github.com/slok/kubewebhook/v2/pkg/http"
+	"github.com/slok/kubewebhook/v2/pkg/model"
+	kwhvalidating "github.com/slok/kubewebhook/v2/pkg/webhook/validating"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+func updatePolicyHandler(cli client.Client) http.Handler {
+	validator := kwhvalidating.ValidatorFunc(func(_ context.Context, _ *model.AdmissionReview, obj metav1.Object) (*kwhvalidating.ValidatorResult, error) {
+		policy, ok := obj.(*v1alpha2.ModuleUpdatePolicy)
+		if !ok {
+			log.Debugf("unexpected type, expected %T, got %T", v1alpha2.ModuleUpdatePolicy{}, obj)
+			return nil, fmt.Errorf("expect Secret as unstructured, got %T", obj)
+		}
+
+		configs := new(v1alpha1.ModuleConfigList)
+		if err := cli.List(context.Background(), configs); err != nil {
+			return nil, fmt.Errorf("list configs: %w", err)
+		}
+
+		for _, config := range configs.Items {
+			if config.Spec.UpdatePolicy == policy.Name {
+				return rejectResult(fmt.Sprintf("the '%s' update policy used in the '%s' module config", policy.Name, config.Name))
+			}
+		}
+
+		return allowResult("")
+	})
+
+	// Create webhook.
+	wh, _ := kwhvalidating.NewWebhook(kwhvalidating.WebhookConfig{
+		ID:        "update-policy-validator",
+		Validator: validator,
+		Logger:    nil,
+		Obj:       &v1alpha2.ModuleUpdatePolicy{},
+	})
+
+	return kwhhttp.MustHandlerFor(kwhhttp.HandlerConfig{Webhook: wh, Logger: nil})
+}

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_update_policy.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_update_policy.go
@@ -47,7 +47,7 @@ func updatePolicyHandler(cli client.Client) http.Handler {
 
 		for _, config := range configs.Items {
 			if config.Spec.UpdatePolicy == policy.Name {
-				return rejectResult(fmt.Sprintf("the '%s' update policy used in the '%s' module config", policy.Name, config.Name))
+				return rejectResult(fmt.Sprintf("the '%s' update policy is used by the '%s' module config", policy.Name, config.Name))
 			}
 		}
 

--- a/modules/002-deckhouse/templates/admission/validation.yaml
+++ b/modules/002-deckhouse/templates/admission/validation.yaml
@@ -56,6 +56,28 @@ webhooks:
         namespace: d8-system
         port: 4223
         path: /validate/v1alpha1/module-configs
+  - name: update-policies.deckhouse-webhook.deckhouse.io
+    rules:
+      - apiGroups:
+          - "deckhouse.io"
+        apiVersions:
+          - "v1alpha2"
+        resources:
+          - "moduleupdatepolicies"
+        operations:
+          - DELETE
+    admissionReviewVersions:
+      - v1
+    matchPolicy: Equivalent
+    failurePolicy: Fail
+    sideEffects: None
+    clientConfig:
+      caBundle: {{ .Values.deckhouse.internal.admissionWebhookCert.ca | b64enc }}
+      service:
+        name: deckhouse
+        namespace: d8-system
+        port: 4223
+        path: /validate/v1alpha1/update-policies
   - name: kubernetes-version.deckhouse-webhook.deckhouse.io
     rules:
       - apiGroups:


### PR DESCRIPTION
## Description
It provides update policy validation.

## Why do we need it, and what problem does it solve?
We need to prohibit creating module configs with non existing update policy, and prohibit deleting update policy that used by a  module config.

## What is the expected result?

- delete update policy that used by a module config.
```
root@dev-master-0:~# k delete -f mup.yaml 
Error from server: error when deleting "mup.yaml": admission webhook "update-policies.deckhouse-webhook.deckhouse.io" denied the request: the 'test-alpha' update policy used in the 'test' module config
```

- create module configs with non existing update policy
```
root@dev-master-0:~# kubectl edit mc test 
error: moduleconfigs.deckhouse.io "test" could not be patched: admission webhook "module-configs.deckhouse-webhook.deckhouse.io" denied the request: the 'test1' module policy does not exist
```


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Add update policy validation.
impact_level: low
```
