### PR TITLE
[dhctl] Add root user check for ssh-become-pass flag

### DIFF
--- a/dhctl/pkg/app/ssh.go
+++ b/dhctl/pkg/app/ssh.go
@@ -160,6 +160,7 @@ func DefineBecomeFlags(cmd *kingpin.CmdClause) {
 		_ = fmt.Errorf("flag --ssh-become-pass cannot be set for --ssh-user=root")
 		os.Exit(1)
 	}
+
 }
 
 func processConnectionConfigFile(sshFlagSetByUser bool, parser connectionConfigParser) error {


### PR DESCRIPTION
## Description
Added user check for `--ask-become-pass` flag. If the user is root, the parameter value is set to false

## Why do we need it, and what problem does it solve?
When setting up a cluster as the root user and with the `--ssh-become-pass` parameter set, the preflight check fails, and the utility cannot check sudo availability.

## What is the expected result?
Now the installer will not try to execute sudo as root and the installation will not fail with both the `--ask-become-pass` parameter and the --ssh-user=root parameter set simultaneously.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```
section: dhctl
type: fix
summary: Added root user check when reading --ask-become-pass flag
impact_level: low
```
