### PR TITLE
Backport Prom++ to 1.65

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -5,6 +5,7 @@ import (
 	_ "github.com/flant/addon-operator/sdk"
 
 	_ "github.com/deckhouse/deckhouse/ee/be/modules/350-node-local-dns/hooks"
+	_ "github.com/deckhouse/deckhouse/ee/fe/modules/300-prometheus/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/fe/modules/340-monitoring-applications/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/fe/modules/500-basic-auth/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/fe/modules/500-okmeter/hooks"

--- a/ee/fe/modules/300-prometheus/.build.yaml
+++ b/ee/fe/modules/300-prometheus/.build.yaml
@@ -1,0 +1,4 @@
+openapi/*
+templates/prometheus/pp
+images/*
+hooks/*

--- a/ee/fe/modules/300-prometheus/hooks/cm_check.go
+++ b/ee/fe/modules/300-prometheus/hooks/cm_check.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 5},
+	Queue:        "/modules/prometheus/cm_check",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "prometheus_config_map",
+			ApiVersion: "v1",
+			Kind:       "ConfigMap",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{MatchNames: []string{
+					"d8-monitoring",
+				}},
+			},
+			NameSelector: &types.NameSelector{MatchNames: []string{
+				"prometheus-pp-envs",
+			}},
+			FilterFunc: filterPrometheusConfigMap,
+		},
+	},
+}, handleConfigMaps)
+
+func filterPrometheusConfigMap(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return obj.GetName(), nil
+}
+
+func handleConfigMaps(input *go_hook.HookInput) error {
+	prometheusConfigMapSnapshots := input.Snapshots["prometheus_config_map"]
+
+	input.Values.Set("prometheus.internal.prometheusPlusPlus.enabled", len(prometheusConfigMapSnapshots) > 0)
+
+	return nil
+}

--- a/ee/fe/modules/300-prometheus/images/prometheuspp/werf.inc.yaml
+++ b/ee/fe/modules/300-prometheus/images/prometheuspp/werf.inc.yaml
@@ -1,0 +1,110 @@
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-promu-artifact
+from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+shell:
+  install:
+  - export GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+  - git clone --depth 1 --branch v0.14.0 {{ $.SOURCE_REPO }}/prometheus/promu.git /promu
+  - cd /promu
+  - go build -ldflags="-s -w" -o promu ./main.go
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+import:
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-promu-artifact
+  add: /promu/promu
+  to: /bin/promu
+  before: install
+git:
+- add: /{{ $.ModulePath }}modules/300-{{ $.ModuleName }}/images/{{ $.ImageName }}
+  to: /patches
+shell:
+  install:
+  - apk update && apk add --no-cache gcc g++ nodejs npm
+  - export GOPROXY={{ $.GOPROXY }} CGO_ENABLED=1 GOOS=linux GOARCH=amd64 PROMETHEUS_DEPS_VERSION=v2.53.2 PROMETHEUS_VERSION=v2.53.2-0.0.2
+  - git clone -b "${PROMETHEUS_DEPS_VERSION}" --single-branch {{ $.SOURCE_REPO }}/prometheus/prometheus-deps
+  - mkdir /prometheus && cd /prometheus
+  - git clone -b "${PROMETHEUS_VERSION}" --single-branch {{ $.OBSERVABILITY_SOURCE_REPO }}/prometheus-plus-plus prometheus
+  - cd /prometheus/prometheus/web/ui
+  - rm -rf ./* && mv /prometheus-deps/web/ui/* .
+  - npm run build
+  - cd /prometheus/prometheus
+  - scripts/compress_assets.sh
+  - go mod tidy
+  - go generate -tags plugins ./plugins
+  - /bin/promu build --prefix /prometheus/prometheus
+  - mkdir -p /consoles
+  - cp /prometheus/prometheus/consoles/* /consoles
+  - cp /prometheus/prometheus/console_libraries/* /consoles
+  - mkdir -p /etc
+  - cp /prometheus/prometheus/documentation/examples/prometheus.yml /etc
+  - cp /prometheus/prometheus/console_libraries/* /etc
+  - mkdir /empty
+  - chown -R 64535:64535 /empty
+  - chown -R 64535:64535 /prometheus/
+  - chown -R 64535:64535 /etc/
+  - chown -R 64535:64535 /consoles/
+  - chmod 0700 /prometheus/prometheus/prometheus
+  - chmod 0700 /prometheus/prometheus/promtool
+---
+{{ $binariesList := "/usr/bin/curl /bin/sh /bin/df" }}
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+from: {{ $.Images.BASE_ALT_DEV }}
+shell:
+  install:
+    - /binary_replace.sh -i "{{ $binariesList }}" -o /relocate
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}
+fromImage: common/distroless
+fromCacheVersion: 2024022701
+import:
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  add: /prometheus/prometheus/prometheus
+  to: /bin/prometheus
+  before: setup
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  add: /prometheus/prometheus/promtool
+  to: /bin/promtool
+  before: setup
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  add: /prometheus/prometheus/console_libraries/
+  to: /usr/share/prometheus/console_libraries
+  before: setup
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  add: /consoles/
+  to: /usr/share/prometheus/consoles
+  before: setup
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  add: /etc/
+  to: /etc/prometheus
+  before: setup
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  add: /empty/
+  to: /prometheus
+  before: setup
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  add: /relocate
+  to: /
+  before: install
+  includePaths:
+  - '**/*'
+docker:
+  EXPOSE:
+  - "9090"
+  VOLUME:
+  - "/prometheus"
+  WORKDIR: "/prometheus"
+  ENTRYPOINT:
+  - "/bin/prometheus"
+  CMD:
+  - "--config.file=/etc/prometheus/prometheus.yml"
+  - "--storage.tsdb.path=/prometheus"
+  - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+  - "--web.console.templates=/usr/share/prometheus/consoles"

--- a/ee/fe/modules/300-prometheus/openapi/openapi-case-tests.yaml
+++ b/ee/fe/modules/300-prometheus/openapi/openapi-case-tests.yaml
@@ -1,0 +1,107 @@
+positive:
+  values:
+  - internal:
+      prometheusPlusPlus:
+        prometheusToken: "example-token"
+        enabled: true
+  - internal:
+      prometheusPlusPlus:
+        prometheusToken: ""
+        enabled: false
+  - internal:
+      vpa:
+        maxCPU: 4096
+        maxMemory: 0.1
+  - internal:
+      vpa:
+        maxCPU: "1400m"
+        maxMemory: "100"
+  - internal:
+      vpa:
+        maxCPU: "1400m"
+        maxMemory: "1.5Gi"
+  - internal:
+      vpa:
+        longtermMaxCPU: "1m"
+        longtermMaxMemory: "100Mi"
+  - internal:
+      vpa:
+        longtermMaxCPU: "1m"
+        longtermMaxMemory: "1.5Gi"
+  - internal:
+      vpa:
+        longtermMaxCPU: 4096
+        longtermMaxMemory: 1000
+  - internal:
+      prometheusLongterm:
+        retentionGigabytes: 25
+  - internal:
+      prometheusAPIClientTLS:
+        certificate: somecertstring
+        key: somekeystring
+        certificate_updated: false
+  - internal:
+      prometheusAPIClientTLS:
+        certificate: somecertstring
+        key: somekeystring
+        certificate_updated: true
+      grafana:
+        additionalDatasources:
+        - access: proxy
+          basicAuth: false
+          editable: false
+          isDefault: false
+          jsonData:
+            timeInterval: 30s
+            integer: 1
+          name: loki
+          orgId: 1
+          type: loki
+          url: http://loki.loki:3100
+          uuid: loki
+          version: 1
+        - access: proxy
+          basicAuth: false
+          editable: false
+          isDefault: false
+          jsonData:
+            httpMethod: POST
+            timeInterval: 30s
+          name: promscale-production
+          orgId: 1
+          type: prometheus
+          url: http://my.domain.com:9091
+          uuid: promscale-production
+          version: 1
+        - access: proxy
+          basicAuth: true
+          basicAuthUser: metric
+          editable: false
+          isDefault: false
+          jsonData:
+            timeInterval: 30s
+          name: external-prometheus
+          orgId: 1
+          secureJsonData:
+            basicAuthPassword: secret
+          type: prometheus
+          url: http://my.domain.com/prometheus/
+          uuid: external-prometheus
+          version: 1
+negative:
+  values:
+  - internal:
+      prometheusPlusPlus:
+        prometheusToken: 12345
+        enabled: "yes"
+  - internal:
+      prometheusPlusPlus:
+        unexpectedField: "value"
+  - internal:
+      vpa:
+        maxCPU: "123Hz"
+        maxMemory: "3445J"
+  - internal:
+      vpa:
+        maxCPU: "123Pz"
+        maxMemory: "3.Gi"

--- a/ee/fe/modules/300-prometheus/openapi/values.yaml
+++ b/ee/fe/modules/300-prometheus/openapi/values.yaml
@@ -1,0 +1,435 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties:
+  internal:
+    type: object
+    default: {}
+    properties:
+      vpa:
+        type: object
+        default: {}
+        x-examples:
+          - longtermMaxCPU: "220m"
+            longtermMaxMemory: "1650Mi"
+            maxCPU: "6600m"
+            maxMemory: "4950Mi"
+        properties:
+          maxCPU:
+            oneOf:
+              - type: string
+                pattern: "^[0-9]+m?$"
+              - type: number
+            x-examples: ["1000m"]
+          maxMemory:
+            oneOf:
+              - type: string
+                pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+              - type: number
+            x-examples: ["1500Mi"]
+          longtermMaxCPU:
+            oneOf:
+              - type: string
+                pattern: "^[0-9]+m?$"
+              - type: number
+            x-examples: ["220", 2.24]
+          longtermMaxMemory:
+            oneOf:
+              - type: string
+                pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+              - type: number
+            x-examples: ["1500Gi"]
+      prometheusMain:
+        type: object
+        default: {}
+        x-examples:
+          - effectiveStorageClass: "ceph-ssd"
+          - effectiveStorageClass: false
+        properties:
+          effectiveStorageClass:
+            oneOf:
+              - type: string
+              - type: boolean
+          retentionGigabytes:
+            type: integer
+          diskSizeGigabytes:
+            type: integer
+          diskFilesystemSize:
+            type: number
+          diskUsage:
+            type: number
+      prometheusPlusPlus:
+        type: object
+        default: {}
+        x-examples:
+          - prometheusToken: "aaa111bbb"
+            enabled: true
+        properties:
+          prometheusToken:
+            type: string
+            default: ""
+          enabled:
+            type: boolean
+            default: false
+      prometheusLongterm:
+        type: object
+        default: {}
+        x-examples:
+          - effectiveStorageClass: "ceph-ssd"
+            retentionGigabytes: 30
+        properties:
+          effectiveStorageClass:
+            oneOf:
+              - type: string
+              - type: boolean
+          retentionGigabytes:
+            type: integer
+          diskSizeGigabytes:
+            type: integer
+          diskFilesystemSize:
+            type: number
+          diskUsage:
+            type: number
+      grafana:
+        type: object
+        default: {}
+        properties:
+          alertsChannelsConfig:
+            type: object
+            default: {}
+            properties:
+              notifiers:
+                default: []
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  - type
+                  - uid
+                  - org_id
+                  - is_default
+                  - disable_resolve_message
+                  - settings
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                      enum: ["prometheus-alertmanager"]
+                    uid:
+                      type: string
+                    org_id:
+                      type: number
+                      enum: [1]
+                    is_default:
+                      type: boolean
+                      default: false
+                    send_reminder:
+                      type: boolean
+                      default: false
+                    frequency:
+                      type: string
+                    disable_resolve_message:
+                      type: boolean
+                      default: false
+                    settings:
+                      type: object
+                      required:
+                      - url
+                      properties:
+                        url:
+                          type: string
+                        basicAuthUser:
+                          type: string
+                    secure_settings:
+                      type: object
+                      default: {}
+                      properties:
+                        basicAuthPassword:
+                          type: string
+          additionalDatasources:
+            type: array
+            items:
+              type: object
+              properties:
+                type:
+                  type: string
+                access:
+                  type: string
+                url:
+                  type: string
+                user:
+                  type: string
+                database:
+                  type: string
+                withCredentials:
+                  type: boolean
+                name:
+                  type: string
+                uuid:
+                  type: string
+                orgId:
+                  type: integer
+                editable:
+                  type: boolean
+                version:
+                  type: integer
+                isDefault:
+                  type: boolean
+                basicAuth:
+                  type: boolean
+                basicAuthUser:
+                  type: string
+                jsonData:
+                  type: object
+                  additionalProperties: true
+                secureJsonData:
+                  type: object
+                  additionalProperties: true
+          customLogo:
+            type: object
+            default: {}
+            properties:
+              enabled:
+                type: boolean
+                default: false
+              checksum:
+                type: string
+        x-examples:
+          - additionalDatasources:
+              - type: graphite
+                access: proxy
+                url: /graphite-1
+                name: testtesttest
+                uuid: testtesttest
+                orgId: 1
+                editable: false
+                version: 1
+                isDefault: false
+                jsonData:
+                  anything: 1
+                  nothing: special
+            alertsChannelsConfig:
+              notifiers:
+                - org_id: 1
+                  type: prometheus-alertmanager
+                  name: "test"
+                  uid: "test"
+                  is_default: false
+                  disable_resolve_message: false
+                  send_reminder: false
+                  settings:
+                    basicAuthUser: user
+                    url: "http://test-alert-manager-url"
+                  secure_settings:
+                    basicAuthPassword: "password"
+      remoteWrite:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            spec:
+              type: object
+              properties:
+                url:
+                  type: string
+                basicAuth:
+                  type: object
+                  properties:
+                    username:
+                      type: string
+                    password:
+                      type: string
+                      format: password
+                bearerToken:
+                  type: string
+                customAuthToken:
+                  type: string
+                writeRelabelConfigs:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      action:
+                        type: string
+                        default: "replace"
+                      separator:
+                        type: string
+                        default: ";"
+                      targetLabel:
+                        type: string
+                      regex:
+                        type: string
+                        default: ".*"
+                      modulus:
+                        type: integer
+                      replacement:
+                        type: string
+                        default: "$1"
+                      sourceLabels:
+                        type: array
+                        items:
+                          type: string
+                tlsConfig:
+                  type: object
+                  properties:
+                    insecureSkipVerify:
+                      type: boolean
+                    ca:
+                      type: string
+        default: []
+        x-examples:
+          -
+            - name: test-remote-write
+              spec:
+                basicAuth:
+                  password: password
+                  username: username
+                customAuthToken: test
+                url: https://test-victoriametrics.domain.com/api/v1/write
+                writeRelabelConfigs:
+                - action: keep
+                  regex: "prometheus_build_.*"
+                  sourceLabels: [ "__name__" ]
+      alertmanagers:
+        type: object
+        default: {}
+        properties:
+          byService:
+            additionalProperties:
+              type: array
+          byAddress:
+            type: array
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                scheme:
+                  type: string
+                target:
+                  type: string
+                path:
+                  type: string
+                  default: "/"
+                basicAuth:
+                  type: object
+                  properties:
+                    username:
+                      type: string
+                    password:
+                      type: string
+                bearerToken:
+                  type: string
+                tlsConfig:
+                  type: object
+                  properties:
+                    ca:
+                      type: string
+                    cert:
+                      type: string
+                    key:
+                      type: string
+                    insecureSkipVerify:
+                      type: boolean
+          internal:
+            additionalProperties:
+              type: array
+        x-examples:
+          - byService:
+            - name: mysvc1
+              namespace: myns1
+              pathPrefix: /myprefix/
+              port: 81
+            - name: mysvc2
+              namespace: myns1
+              pathPrefix: /myprefix/
+              port: test
+          - byAddress:
+            - name: myaddress11
+              scheme: http
+              target: 1.2.3.4
+              path: metrics
+          - internal:
+            - name: wechat
+              receivers:
+              - name: wechat-example
+                wechatConfigs:
+                - apiSecret:
+                    key: apiSecret
+                    name: wechat-config
+                  apiURL: http://wechatserver:8080/
+                  corpID: wechat-corpid
+              route:
+                groupBy:
+                - job
+                groupInterval: 5m
+                groupWait: 30s
+                receiver: wechat-example
+                repeatInterval: 12h
+      customCertificateData:
+        type: object
+        default: {}
+        x-examples:
+          - tls.crt: plainstring
+            tls.key: plainstring
+            ca.crt: plainstring
+        properties:
+          ca.crt:
+            type: string
+          tls.key:
+            type: string
+          tls.crt:
+            type: string
+      deployDexAuthenticator:
+        type: boolean
+        x-examples: [true]
+      prometheusAPIClientTLS:
+        type: object
+        default: {}
+        x-examples:
+          - certificate: somestring
+            key: somestring
+            certificate_updated: false
+        properties:
+          certificate:
+            type: string
+          key:
+            type: string
+          certificate_updated:
+            type: boolean
+      prometheusScraperTLS:
+        type: object
+        default: {}
+        x-examples:
+          - certificate: somestring
+            key: somestring
+            certificate_updated: false
+        properties:
+          certificate:
+            type: string
+          key:
+            type: string
+          certificate_updated:
+            type: boolean
+      prometheusScraperIstioMTLS:
+        type: object
+        default: {}
+        x-examples:
+          - certificate: somestring
+            key: somestring
+        properties:
+          certificate:
+            type: string
+          key:
+            type: string
+      auth:
+        type: object
+        default: {}
+        properties:
+          password:
+            type: string
+            x-examples: ["p4ssw0rd"]

--- a/ee/fe/modules/300-prometheus/templates/prometheus/pp/grafana-additional-ds.yaml
+++ b/ee/fe/modules/300-prometheus/templates/prometheus/pp/grafana-additional-ds.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.prometheus.internal.prometheusPlusPlus.enabled }}
+---
+apiVersion: deckhouse.io/v1
+kind: GrafanaAdditionalDatasource
+metadata:
+  name: prometheus-pp
+  namespace: d8-monitoring
+spec:
+  access: Proxy
+  jsonData:
+    httpHeaderName1: Authorization
+    tlsSkipVerify: true
+    timeInterval: 30s
+  secureJsonData:
+    httpHeaderValue1: 'Bearer $PROMETHEUS_TOKEN' 
+  type: prometheus
+  url: https://prometheus-pp.d8-monitoring.svc.cluster.local:9090
+{{- end }}

--- a/ee/fe/modules/300-prometheus/templates/prometheus/pp/ingress.yaml
+++ b/ee/fe/modules/300-prometheus/templates/prometheus/pp/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if and .Values.prometheus.internal.prometheusPlusPlus.enabled .Values.global.modules.publicDomainTemplate }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus-pp
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus-pp" "prometheus" "pp")) | nindent 2 }}
+  annotations:
+    web.deckhouse.io/export-name: "prometheus"
+    web.deckhouse.io/export-icon: "/public/img/prometheus.ico"
+  {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.prometheus.auth.externalAuthentication }}
+    nginx.ingress.kubernetes.io/auth-signin: {{ .Values.prometheus.auth.externalAuthentication.authSignInURL | quote }}
+    nginx.ingress.kubernetes.io/auth-url: {{ .Values.prometheus.auth.externalAuthentication.authURL | quote }}
+    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email
+  {{- else }}
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: basic-auth
+    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
+  {{- end }}
+  {{- if .Values.prometheus.auth.whitelistSourceRanges }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.prometheus.auth.whitelistSourceRanges | join "," }}
+  {{- end }}
+  {{- if .Values.prometheus.auth.satisfyAny }}
+    nginx.ingress.kubernetes.io/satisfy: "any"
+  {{- end }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_ssl_certificate /etc/nginx/ssl/client.crt;
+      proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
+      proxy_ssl_protocols TLSv1.2;
+      proxy_ssl_session_reuse on;
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+spec:
+  ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
+  {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
+  tls:
+  - hosts:
+    - {{ include "helm_lib_module_public_domain" (list . "grafana") }}
+    secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  {{- end }}
+  rules:
+  - host: {{ include "helm_lib_module_public_domain" (list . "grafana") }}
+    http:
+      paths:
+      - path: /prometheus/pp(/|$)(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: prometheus-pp
+            port:
+              name: https
+{{- end }}

--- a/ee/fe/modules/300-prometheus/templates/prometheus/pp/pdb.yaml
+++ b/ee/fe/modules/300-prometheus/templates/prometheus/pp/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.prometheus.internal.prometheusPlusPlus.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: prometheus-pp
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus-pp" "prometheus" "pp")) | nindent 2 }}
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      prometheus: pp
+{{- end }}

--- a/ee/fe/modules/300-prometheus/templates/prometheus/pp/prometheus.yaml
+++ b/ee/fe/modules/300-prometheus/templates/prometheus/pp/prometheus.yaml
@@ -1,0 +1,243 @@
+{{- define "prometheus_resources" }} # for reference see modules/300-prometheus/hooks/detect_vpa_max.go
+cpu: 200m
+memory: 1000Mi
+{{- end }}
+
+{{- define "config_reloader_resources" }}
+cpu: 10m
+memory: 25Mi
+{{- end }}
+
+{{- if .Values.prometheus.internal.prometheusPlusPlus.enabled }}
+{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: prometheus-pp
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus")) | nindent 2 }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: StatefulSet
+    name: prometheus-pp
+  updatePolicy:
+    updateMode: {{ .Values.prometheus.vpa.updateMode | quote }}
+  resourcePolicy:
+    containerPolicies:
+    - containerName: "prometheus"
+      minAllowed:
+        {{- include "prometheus_resources" . | nindent 8 }}
+      maxAllowed:
+        cpu: {{ .Values.prometheus.vpa.maxCPU | default .Values.prometheus.internal.vpa.maxCPU | quote }}
+        memory: {{ .Values.prometheus.vpa.maxMemory | default .Values.prometheus.internal.vpa.maxMemory | quote }}
+    - containerName: config-reloader
+      minAllowed:
+        {{- include "config_reloader_resources" . | nindent 8 }}
+      maxAllowed:
+        cpu: 20m
+        memory: 50Mi
+    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
+{{- end }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: pp
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus-pp" "prometheus" "pp")) | nindent 2 }}
+spec:
+  replicas: 1
+  retention: {{ .Values.prometheus.retentionDays }}d
+  retentionSize: {{ .Values.prometheus.internal.prometheusMain.retentionGigabytes }}GB
+  image: {{ include "helm_lib_module_image" (list $ "prometheuspp") }}
+  version: v2.53.2
+  enableRemoteWriteReceiver: true
+  enableFeatures:
+  - memory-snapshot-on-shutdown # https://ganeshvernekar.com/blog/prometheus-tsdb-snapshot-on-shutdown/
+  - extra-scrape-metrics # https://prometheus.io/docs/prometheus/2.44/feature_flags/#extra-scrape-metrics usage scrape_sample_limit
+  imagePullSecrets:
+  - name: deckhouse-registry
+  listenLocal: true
+  query:
+    maxSamples: 100000000
+    lookbackDelta: {{ mul (.Values.global.discovery.prometheusScrapeInterval | default 30) 2 }}s
+  additionalArgs:
+    - name: scrape.timestamp-tolerance
+      value: 10ms
+  containers:
+  - name: prometheus
+    startupProbe:
+      failureThreshold: 300
+    envFrom:
+      - configMapRef:
+          name: prometheus-pp-envs
+    env:
+    - name: PROMETHEUS_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: prometheus-token
+          key: token
+          optional: false
+  - name: kube-rbac-proxy
+    {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 4 }}
+    image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
+    args:
+    - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):9090"
+    - "--client-ca-file=/etc/kube-rbac-proxy/ca.crt"
+    - "--v=2"
+    - "--logtostderr=true"
+    - "--stale-cache-interval=1h30m"
+    ports:
+    - containerPort: 9090
+      name: https
+    env:
+    - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: KUBE_RBAC_PROXY_CONFIG
+      value: |
+        upstreams:
+        - upstream: http://127.0.0.1:9090/
+          path: /
+          authorization:
+            resourceAttributes:
+              namespace: d8-monitoring
+              apiGroup: monitoring.coreos.com
+              apiVersion: v1
+              resource: prometheuses
+              subresource: http
+              name: main
+    resources:
+      requests:
+        {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 8 }}
+{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+        {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 8 }}
+{{- end }}
+    volumeMounts:
+    - name: kube-rbac-proxy-ca
+      mountPath: /etc/kube-rbac-proxy
+  - name: config-reloader
+    resources:
+      requests:
+        {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 20 | nindent 8 }}
+{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+        {{- include "config_reloader_resources" . | nindent 8 }}
+{{- end }}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+              prometheus: longterm
+          topologyKey: kubernetes.io/hostname
+  scrapeInterval: {{ .Values.prometheus.scrapeInterval | default "30s"}}
+  evaluationInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
+  prometheusExternalLabelName: ""
+  replicaExternalLabelName: ""
+  serviceAccountName: prometheus
+  podMonitorNamespaceSelector:
+    matchLabels:
+      prometheus.deckhouse.io/monitor-watcher-enabled: "true"
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      prometheus.deckhouse.io/monitor-watcher-enabled: "true"
+  ruleNamespaceSelector:
+    matchLabels:
+      prometheus.deckhouse.io/rules-watcher-enabled: "true"
+  scrapeConfigNamespaceSelector:
+    matchLabels:
+      prometheus.deckhouse.io/scrape-configs-watcher-enabled: "true"
+  probeNamespaceSelector:
+    matchLabels:
+      prometheus.deckhouse.io/probe-watcher-enabled: "true"
+  podMetadata:
+    labels:
+      threshold.extended-monitoring.deckhouse.io/disk-bytes-warning: "94"
+      threshold.extended-monitoring.deckhouse.io/disk-bytes-critical: "96"
+    annotations:
+      checksum/kube-rbac-proxy: {{ include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "") | sha256sum }}
+  serviceMonitorSelector:
+    matchLabels:
+      prometheus: main
+  podMonitorSelector:
+    matchLabels:
+      prometheus: main
+  probeSelector:
+    matchLabels:
+      prometheus: main
+  scrapeConfigSelector:
+    matchLabels:
+      prometheus: main
+  secrets:
+  - alertmanagers-tls-config
+  rules:
+    alert:
+      resendDelay: 29s
+  ruleSelector:
+    matchLabels:
+      prometheus: main
+      component: rules
+  remoteWrite: []
+  additionalScrapeConfigs:
+    name: prometheus-main-additional-configs
+    key: scrapes.yaml
+  additionalAlertRelabelConfigs:
+    name: prometheus-main-additional-configs
+    key: alert-relabels.yaml
+  additionalAlertManagerConfigs:
+    name: prometheus-main-additional-configs
+    key: alert-managers.yaml
+{{- $alertmanagers_byservice := false }}
+{{- $alertmanagers_internal := false }}
+{{- if hasKey .Values.prometheus.internal.alertmanagers "byService" }}
+  {{- if len .Values.prometheus.internal.alertmanagers.byService }}
+    {{- $alertmanagers_byservice = true }}
+  {{- end }}
+{{- end }}
+{{- if hasKey .Values.prometheus.internal.alertmanagers "internal" }}
+  {{- if len .Values.prometheus.internal.alertmanagers.internal }}
+    {{- $alertmanagers_internal = true }}
+  {{- end }}
+{{- end }}
+{{- if or $alertmanagers_byservice $alertmanagers_internal }}
+  alerting:
+    alertmanagers: []
+{{- end }}
+{{- if .Values.global.modules.publicDomainTemplate }}
+  externalUrl: {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "grafana") }}/prometheus/
+{{- end }}
+  {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 2 }}
+    fsGroup: 64535
+  {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 2 }}
+  {{- include "helm_lib_tolerations" (tuple . "monitoring" "without-storage-problems") | nindent 2 }}
+  {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 2 }}
+{{- $storageClass := .Values.prometheus.internal.prometheusMain.effectiveStorageClass }}
+{{- if $storageClass }}
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.prometheus.internal.prometheusMain.diskSizeGigabytes }}Gi
+        storageClassName: {{ $storageClass }}
+{{- end }}
+  resources:
+    requests:
+      {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 100 | nindent 6 }}
+{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+      {{- include "prometheus_resources" . | nindent 6 }}
+{{- end }}
+  volumes:
+  - name: kube-rbac-proxy-ca
+    configMap:
+      defaultMode: 420
+      name: kube-rbac-proxy-ca.crt
+{{- end }}

--- a/ee/fe/modules/300-prometheus/templates/prometheus/pp/service.yaml
+++ b/ee/fe/modules/300-prometheus/templates/prometheus/pp/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.prometheus.internal.prometheusPlusPlus.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-pp
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus" "prometheus" "pp")) | nindent 2 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: https
+    port: 9090
+    protocol: TCP
+    targetPort: https
+  selector:
+    prometheus: pp
+{{- end }}

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -352,6 +352,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"memcachedExporter":           "imageHash-prometheus-memcachedExporter",
 		"mimir":                       "imageHash-prometheus-mimir",
 		"prometheus":                  "imageHash-prometheus-prometheus",
+		"prometheuspp":                "imageHash-prometheus-prometheuspp",
 		"promxy":                      "imageHash-prometheus-promxy",
 		"trickster":                   "imageHash-prometheus-trickster",
 	},

--- a/tools/build_includes/modules-FE.yaml
+++ b/tools/build_includes/modules-FE.yaml
@@ -264,6 +264,31 @@
   stageDependencies:
     setup:
         - '**/*.go'
+- add: /ee/fe/modules/300-prometheus/openapi/openapi-case-tests.yaml
+  to: /deckhouse/modules/300-prometheus/openapi/openapi-case-tests.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
+- add: /ee/fe/modules/300-prometheus/openapi/values.yaml
+  to: /deckhouse/modules/300-prometheus/openapi/values.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
+- add: /ee/fe/modules/300-prometheus/templates/prometheus/pp
+  to: /deckhouse/modules/300-prometheus/templates/prometheus/pp
+  stageDependencies:
+    setup:
+        - '**/*.go'
+- add: /ee/fe/modules/300-prometheus/images/prometheuspp
+  to: /deckhouse/modules/300-prometheus/images/prometheuspp
+  stageDependencies:
+    setup:
+        - '**/*.go'
+- add: /ee/fe/modules/300-prometheus/hooks/cm_check.go
+  to: /deckhouse/modules/300-prometheus/hooks/cm_check.go
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/fe/modules/340-monitoring-applications
   to: /deckhouse/modules/340-monitoring-applications
   stageDependencies:

--- a/tools/build_includes/modules-with-dependencies-FE.yaml
+++ b/tools/build_includes/modules-with-dependencies-FE.yaml
@@ -1218,6 +1218,67 @@
   stageDependencies:
     setup:
         - '**/*.go'
+- add: /ee/fe/modules/300-prometheus/openapi/openapi-case-tests.yaml
+  to: /deckhouse/modules/300-prometheus/openapi/openapi-case-tests.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
+- add: /ee/fe/modules/300-prometheus/openapi/values.yaml
+  to: /deckhouse/modules/300-prometheus/openapi/values.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
+- add: /ee/fe/modules/300-prometheus/templates/prometheus/pp
+  to: /deckhouse/modules/300-prometheus/templates/prometheus/pp
+  excludePaths:
+    - images
+    - templates
+    - charts
+    - crds
+    - docs
+    - monitoring
+    - openapi
+    - oss.yaml
+    - cloud-instance-manager
+    - values_matrix_test.yaml
+    - values.yaml
+    - .helmignore
+    - candi
+    - Chart.yaml
+    - .namespace
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    setup:
+        - '**/*.go'
+- add: /ee/fe/modules/300-prometheus/images/prometheuspp
+  to: /deckhouse/modules/300-prometheus/images/prometheuspp
+  excludePaths:
+    - images
+    - templates
+    - charts
+    - crds
+    - docs
+    - monitoring
+    - openapi
+    - oss.yaml
+    - cloud-instance-manager
+    - values_matrix_test.yaml
+    - values.yaml
+    - .helmignore
+    - candi
+    - Chart.yaml
+    - .namespace
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    setup:
+        - '**/*.go'
+- add: /ee/fe/modules/300-prometheus/hooks/cm_check.go
+  to: /deckhouse/modules/300-prometheus/hooks/cm_check.go
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/fe/modules/340-monitoring-applications
   to: /deckhouse/modules/340-monitoring-applications
   excludePaths:

--- a/tools/build_includes/modules-with-exclude-FE.yaml
+++ b/tools/build_includes/modules-with-exclude-FE.yaml
@@ -584,6 +584,43 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+
+- add: /ee/fe/modules/300-prometheus/openapi/openapi-case-tests.yaml
+  to: /deckhouse/modules/300-prometheus/openapi/openapi-case-tests.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
+- add: /ee/fe/modules/300-prometheus/openapi/values.yaml
+  to: /deckhouse/modules/300-prometheus/openapi/values.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
+- add: /ee/fe/modules/300-prometheus/templates/prometheus/pp
+  to: /deckhouse/modules/300-prometheus/templates/prometheus/pp
+  excludePaths:
+    - docs
+    - README.md
+    - images
+    - hooks/**/*.go
+    - hooks/*.go
+    - hack
+    - template_tests
+    - .namespace
+    - values_matrix_test.yaml
+    - .build.yaml
+- add: /ee/fe/modules/300-prometheus/images/prometheuspp
+  to: /deckhouse/modules/300-prometheus/images/prometheuspp
+  excludePaths:
+    - docs
+    - README.md
+    - images
+    - hooks/**/*.go
+    - hooks/*.go
+    - hack
+    - template_tests
+    - .namespace
+    - values_matrix_test.yaml
+    - .build.yaml
 - add: /ee/fe/modules/340-monitoring-applications
   to: /deckhouse/modules/340-monitoring-applications
   excludePaths:


### PR DESCRIPTION
* [prometheus] Add Prom++ to prometheus module

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
