### PR TITLE
[control-plane-manager] fix kubeadm template when changing ServiceAcciount Issuer

### DIFF
--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -45,6 +45,7 @@ apiServer:
 {{- if .apiserver.serviceAccount }}
     {{- $defaultAud := printf "https://kubernetes.default.svc.%s" .clusterConfiguration.clusterDomain }}
     {{- $uniqueAdditionalAuds := .apiserver.serviceAccount.additionalAPIAudiences | uniq }}
+    # {{- $uniqueAdditionalAuds := (default (list) .apiserver.serviceAccount.additionalAPIAudiences) | uniq }}
     {{- $filteredAuds := list }}
     {{- range $uniqueAdditionalAuds }}
       {{- if ne . $defaultAud }}

--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -44,8 +44,7 @@ apiServer:
   extraArgs:
 {{- if .apiserver.serviceAccount }}
     {{- $defaultAud := printf "https://kubernetes.default.svc.%s" .clusterConfiguration.clusterDomain }}
-    {{- $uniqueAdditionalAuds := .apiserver.serviceAccount.additionalAPIAudiences | uniq }}
-    # {{- $uniqueAdditionalAuds := (default (list) .apiserver.serviceAccount.additionalAPIAudiences) | uniq }}
+    {{- $uniqueAdditionalAuds := (default (list) .apiserver.serviceAccount.additionalAPIAudiences) | uniq }}
     {{- $filteredAuds := list }}
     {{- range $uniqueAdditionalAuds }}
       {{- if ne . $defaultAud }}


### PR DESCRIPTION
## Description

Fix kubeadm template. Error occurs if serviceAccount.issuer is added to mc control-plane-manager but additionalAPIAudiences is not specified

## Why do we need it, and what problem does it solve?

This fixes a bug in the kubeadm template

## Why do we need it in the patch release (if we do)?


## What is the expected result?

ServiceAccount Issuer has been successfully updated, no additionalAPIAudiences need to be specified

Test case 1:

only issuer

```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: control-plane-manager
spec:
  version: 1
  enabled: true
  settings:
    apiserver:
      serviceAccount:
        issuer: https://api.example.com
```

```bash
cat /etc/kubernetes/manifests/kube-apiserver.yaml | grep -iE "issue|audience"
    - --api-audiences=https://kubernetes.default.svc.cluster.local
    - --service-account-issuer=https://api.example.com

```

Test case 2:

issuer + additionalAPIAudiences

```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: control-plane-manager
spec:
  version: 1
  enabled: true
  settings:
    apiserver:
      serviceAccount:
        issuer: https://api.example.com
        additionalAPIAudiences:
          - https://api.example.com
          - https://bob.com
```

```bash
cat /etc/kubernetes/manifests/kube-apiserver.yaml | grep -iE "issue|audience"
    - --api-audiences=https://kubernetes.default.svc.cluster.local,https://api.example.com,https://bob.com
    - --service-account-issuer=https://api.example.com

```

Test case 3:

only additionalAPIAudiences

```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: control-plane-manager
spec:
  version: 1
  enabled: true
  settings:
    apiserver:
      serviceAccount:
        additionalAPIAudiences:
          - https://api.example.com
          - https://bob.com
```

```bash
cat /etc/kubernetes/manifests/kube-apiserver.yaml | grep -iE "issuer=|audience"
    - --api-audiences=https://kubernetes.default.svc.cluster.local,https://api.example.com,https://bob.com
    - --service-account-issuer=https://kubernetes.default.svc.cluster.local

```


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix 
summary: Fix kubeadm template when changing ServiceAcciount Issuer
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
