### PR TITLE
[cloud-provider-vcd] backport "remove pod mount path when NodeUnpublishVolume is called" patch to vcd-csi-plugin-legacy

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/patches/02-remove_pod_mount_path_when_NodeUnpublishVolume_is_called.patch
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/patches/02-remove_pod_mount_path_when_NodeUnpublishVolume_is_called.patch
@@ -1,0 +1,49 @@
+Subject: [PATCH] remove pod mount path when NodeUnpublishVolume is called (#251)
+---
+Index: pkg/csi/node.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/csi/node.go b/pkg/csi/node.go
+--- a/pkg/csi/node.go	(revision 89ff1aeab1be77cdf6536f1e1002bdc58dde63f2)
++++ b/pkg/csi/node.go	(revision fd88d99f7fcc4739990c403f1969728ae49c45f9)
+@@ -369,15 +369,18 @@
+ 	if err != nil {
+ 		return nil, fmt.Errorf("unable to check if pod mount dir [%s] is mounted: [%v]", podMountDir, err)
+ 	}
+-	if !isDirMounted {
+-		klog.Infof("Pod mount dir [%s] is not mounted. Assuming already unmounted.", podMountDir)
+-		return &csi.NodeUnpublishVolumeResponse{}, nil
+-	}
+ 
+ 	klog.Infof("Attempting to unmount pod mount dir [%s].", podMountDir)
+-	if err = gofsutil.Unmount(ctx, podMountDir); err != nil {
+-		return nil, fmt.Errorf("unable to unmount pod mount dir [%s]: [%v]", podMountDir, err)
++	if isDirMounted {
++		if err = gofsutil.Unmount(ctx, podMountDir); err != nil {
++			return nil, fmt.Errorf("unable to unmount pod mount dir [%s]: [%v]", podMountDir, err)
++		}
+ 	}
++
++	klog.Infof("Attempting to remove pod mount dir [%s].", podMountDir)
++	if err := ns.rmdir(podMountDir); err != nil {
++		return nil, fmt.Errorf("failed to remove pod mount dir %v", podMountDir)
++	}
+ 
+ 	klog.Infof("NodeUnpublishVolume successful for disk [%s] at mount dir [%s]", diskName, podMountDir)
+ 	return &csi.NodeUnpublishVolumeResponse{}, nil
+@@ -642,3 +645,13 @@
+ 
+ 	return nil
+ }
++
++func (ns *nodeService) rmdir(path string) error {
++	klog.Infof("Deleting path %s", path)
++	err := os.Remove(path)
++	if os.IsNotExist(err) {
++		klog.Infof("%s does not exist", path)
++		return nil
++	}
++	return err
++}

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/patches/README.md
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/patches/README.md
@@ -3,3 +3,8 @@
 ## Add IOPS calculation
 
 Added IOPS calculation on disk create in the case of iops limits are enabled. Upstream [patch](https://github.com/vmware/cloud-director-named-disk-csi-driver/pull/241).
+
+
+## remove pod mount path when NodeUnpublishVolume is called
+https://github.com/vmware/cloud-director-named-disk-csi-driver/commit/cfe7981efa821611c24e9973d547d156374cb586
+https://github.com/kubernetes/kubernetes/issues/122342


### PR DESCRIPTION
## Description
This PR backports [this fix from `cloud-director-named-disk-csi-driver v1.6.0`](https://github.com/vmware/cloud-director-named-disk-csi-driver/pull/251) to `vcd-csi-plugin-legacy` 

## Why do we need it, and what problem does it solve?
Fixes this issue: https://github.com/kubernetes/kubernetes/issues/122342

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: backport "remove pod mount path when NodeUnpublishVolume is called" patch to vcd-csi-plugin-legacy
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
