### PR TITLE
[cni-cilium] Fix nesting of the debugLogging parameter in the helm chart of the ciliumHubble module

### DIFF
--- a/modules/500-cilium-hubble/templates/relay/deployment.yaml
+++ b/modules/500-cilium-hubble/templates/relay/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - hubble-relay
           args:
             - serve
-          {{- if .Values.debugLogging }}
+          {{- if .Values.ciliumHubble.debugLogging }}
             - --debug
           {{- end }}
           ports:


### PR DESCRIPTION
## Description
Fixed nesting of the debugLogging parameter in the helm chart of the ciliumHubble module

## Why do we need it, and what problem does it solve?
In the current version, the debugLogging option is ignored in the helm chart due to incorrect nesting of values

## What is the expected result?
As a result, the debugLogging parameter in the cilium-hubble module settings will be included in helm chart render and enable debug logging mode for hubble

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Changes were tested in the Kubernetes cluster manually.

```
section: cni-cilium
type: fix
summary: Fixed nesting of the debugLogging parameter in the helm chart of the ciliumHubble module
impact_level: low
```