### PR TITLE
[candi] nodeUser creation fix

### DIFF
--- a/candi/bashible/common-steps/node-group/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/node-group/000_add_node_users.sh.tpl
@@ -203,7 +203,7 @@ function main() {
     if [ $uid -le 1000 ]; then
       bb-log-error "Uid for user $user_name must be > 1000"
       nodeuser_add_error "${user_name}" "Uid for user $user_name must be > 1000"
-      return
+      continue
     fi
 
     # Check user existence
@@ -213,52 +213,57 @@ function main() {
       if [[ "$(cut -d ":" -f5 <<< "$user_info")" != "$comment" ]]; then
         bb-log-error "User with UID $uid was created before by someone else"
         nodeuser_add_error "${user_name}" "User with UID $uid was created before by someone else"
-        return
+        continue
       fi
       # check username
       if [[ "$(cut -d ":" -f1 <<< "$user_info")" != "$user_name" ]]; then
         bb-log-error "Username of user with UID $uid was changed by someone else"
         nodeuser_add_error "${user_name}" "Username of user with UID $uid was changed by someone else"
-        return
+        continue
       fi
       # check mainGroup
       if [[ "$(cut -d ":" -f4 <<< "$user_info")" != "$main_group" ]]; then
         bb-log-error "User GID of user with UID $uid was changed by someone else"
         nodeuser_add_error "${user_name}" "User GID of user with UID $uid was changed by someone else"
-        return
+        continue
       fi
       # check homeDir
       if [[ "$(cut -d ":" -f6 <<< "$user_info")" != "$home_base_path/$user_name" ]]; then
         bb-log-error "User home dir of user with UID $uid was changed by someone else"
         nodeuser_add_error "${user_name}" "User home dir of user with UID $uid was changed by someone else"
-        return
+        continue
       fi
       # All ok, modify user
       error_message=$(modify_user "$user_name" "$extra_groups" "$password_hash" 2>&1)
       if bb-error?
       then
         nodeuser_add_error "${user_name}" "${error_message}"
-        return
+        continue
       fi
       error_message=$(put_user_ssh_key "$user_name" "$home_base_path" "$main_group" "$ssh_public_keys" 2>&1)
       if bb-error?
       then
         nodeuser_add_error "${user_name}" "${error_message}"
-        return
+        continue
       fi
+    elif id "$user_name" >/dev/null 2>&1; then
+      existing_uid=$(id -u "$user_name")
+      bb-log-error "User $user_name already exists with UID $existing_uid, expected UID $uid"
+      nodeuser_add_error "${user_name}" "User $user_name already exists with UID $existing_uid, expected UID $uid"
+      continue
     else
       # Adding user
       error_message=$(useradd -b "$home_base_path" -g "$main_group" -G "$extra_groups" -p "$password_hash" -s "$default_shell" -u "$uid" -c "$comment" -m "$user_name" 2>&1)
       if bb-error?
       then
         nodeuser_add_error "${user_name}" "${error_message}"
-        return
+        continue
       fi
       error_message=$(put_user_ssh_key "$user_name" "$home_base_path" "$main_group" "$ssh_public_keys" 2>&1)
       if bb-error?
       then
         nodeuser_add_error "${user_name}" "${error_message}"
-        return
+        continue
       fi
     fi
     nodeuser_clear_error "${user_name}"

--- a/candi/bashible/common-steps/node-group/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/node-group/000_add_node_users.sh.tpl
@@ -184,12 +184,12 @@ function main() {
   default_shell="/bin/bash"
   comment="created by deckhouse"
 
-	if [ -d "$home_base_path" ]; then
-		chmod -c 755  $home_base_path
-		chown -c root:root $home_base_path
-	else
-		mkdir -p $home_base_path
-	fi
+  if [ -d "$home_base_path" ]; then
+    chmod -c 755  $home_base_path
+    chown -c root:root $home_base_path
+  else
+    mkdir -p $home_base_path
+  fi
 
   for uid in $(jq -rc '.[].spec.uid' <<< "$node_users_json"); do
     user_name="$(jq --arg uid $uid -rc '.[] | select(.spec.uid==($uid | tonumber)) | .name' <<< "$node_users_json")"
@@ -237,12 +237,14 @@ function main() {
       error_message=$(modify_user "$user_name" "$extra_groups" "$password_hash" 2>&1)
       if bb-error?
       then
+        bb-log-error "Error modifying user '$user_name': ${error_message}"
         nodeuser_add_error "${user_name}" "${error_message}"
         continue
       fi
       error_message=$(put_user_ssh_key "$user_name" "$home_base_path" "$main_group" "$ssh_public_keys" 2>&1)
       if bb-error?
       then
+        bb-log-error "Error updating SSH keys for user '$user_name': ${error_message}"
         nodeuser_add_error "${user_name}" "${error_message}"
         continue
       fi
@@ -256,12 +258,14 @@ function main() {
       error_message=$(useradd -b "$home_base_path" -g "$main_group" -G "$extra_groups" -p "$password_hash" -s "$default_shell" -u "$uid" -c "$comment" -m "$user_name" 2>&1)
       if bb-error?
       then
+        bb-log-error "Error adding user '$user_name': ${error_message}"
         nodeuser_add_error "${user_name}" "${error_message}"
         continue
       fi
       error_message=$(put_user_ssh_key "$user_name" "$home_base_path" "$main_group" "$ssh_public_keys" 2>&1)
       if bb-error?
       then
+        bb-log-error "Error updating SSH keys for user '$user_name': ${error_message}"
         nodeuser_add_error "${user_name}" "${error_message}"
         continue
       fi

--- a/candi/bashible/common-steps/node-group/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/node-group/000_add_node_users.sh.tpl
@@ -293,7 +293,7 @@ function main() {
         done
       else
         bb-log-error "Strange user with UID: $local_user_id, cannot delete it"
-        return
+        continue
       fi
     fi
   done


### PR DESCRIPTION
## Description

Fix for creating system users through the NodeUser mechanism:

1. `candi` iterates over all `nodeUser` entries in alphabetical order. Currently, if an unexpected error occurs while creating one of the users, the creation of subsequent users is halted. After the fix, an error will be returned for the failed user, and the system will attempt to create the next user in the list.

2. If a user with the same username but a different UID already exists in the system, an error will be returned:

```shell
 kubectl get nodeuser ansible
NAME      UID      ISSUDOER   EXTRAGROUPS   NODEGROUPS   ERRORS                                                                                            AGE
ansible   100099   true                     ["master"]   {"yc-10676-tt-master-0":"User ansible already exists with UID 1002, expected UID 100099"}   107m
```

## Why do we need it, and what problem does it solve?

This fixes a bug in the user creation mechanism

## Why do we need it in the patch release (if we do)?


## What is the expected result?

NodeUser will create all users, and if some cannot be created, an error will be returned.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: nodeUser creation fix
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
