### PR TITLE
[docs] Add fixed width for cells with icon

### DIFF
--- a/docs/documentation/_includes/revision_comparison_detail_table.liquid
+++ b/docs/documentation/_includes/revision_comparison_detail_table.liquid
@@ -8,7 +8,17 @@
   {%- assign siteD8Edition = site.d8Revision | downcase %}
 {%- endif %}
 
-<table markdown="0">
+<table markdown="0" style="table-layout: fixed">
+  <colgroup>
+    <col width="225px">
+    <col width="68px">
+    <col width="68px">
+    <col width="68px">
+    <col width="68px">
+    <col width="68px">
+    <col width="90px">
+    <col width="90px">
+  </colgroup>
   <thead>
   <tr>
     <th style="text-align: center"></th>
@@ -86,7 +96,7 @@
         {%- endif %}
         {%- if skip %}{% continue %}{% endif %}
 
-        <td style="text-align: center; width: 170px;">
+        <td style="text-align: center;">
           {%- if editionsWeight[moduleEdition] <= editionsWeight[currentEdition] or module[1].editionRestrictions contains currentEdition %}
 
             {%- if site.data.editions[currentEdition].excludeModules contains moduleName %}


### PR DESCRIPTION
## Description
Add fixed width for cells with icon for the comparison table.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add fixed width for cells with icon for the comparison table.
impact_level: low
```
