### PR TITLE
[prometheus] Fix of properties prometheus remote write

### DIFF
--- a/modules/300-prometheus/crds/doc-ru-prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/doc-ru-prometheusremotewrite.yaml
@@ -26,7 +26,10 @@ spec:
                   description: Пользовательский токен, передаваемый в качестве заголовка `X-Auth-Token`.
                 headers:
                   description: |
-                    HTTP-заголовки, которые будут добавлены к запросу. Допустимые заголовки: X-Scope-OrgID
+                    HTTP-заголовки, которые будут добавлены к запросу.
+                  properties:
+                    description: |
+                      Допустимые заголовки: X-Scope-OrgID.
                 writeRelabelConfigs:
                   description: |
                     Параметры для relabel'инга данных для отправки.

--- a/modules/300-prometheus/crds/doc-ru-prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/doc-ru-prometheusremotewrite.yaml
@@ -26,11 +26,11 @@ spec:
                   description: Пользовательский токен, передаваемый в качестве заголовка `X-Auth-Token`.
                 headers:
                   description: |
-                    HTTP-заголовки, которые будут добавлены к запросу.
+                    HTTP-заголовки, добавляемые к запросу.
                   properties:
                     X-Scope-OrgID:
                       description: |
-                        Допустимые заголовки: X-Scope-OrgID.
+                        Заголовок `X-Scope-OrgID`, указывающий ID тенанта.
                 writeRelabelConfigs:
                   description: |
                     Параметры для relabel'инга данных для отправки.

--- a/modules/300-prometheus/crds/doc-ru-prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/doc-ru-prometheusremotewrite.yaml
@@ -28,8 +28,9 @@ spec:
                   description: |
                     HTTP-заголовки, которые будут добавлены к запросу.
                   properties:
-                    description: |
-                      Допустимые заголовки: X-Scope-OrgID.
+                    X-Scope-OrgID:
+                      description: |
+                        Допустимые заголовки: X-Scope-OrgID.
                 writeRelabelConfigs:
                   description: |
                     Параметры для relabel'инга данных для отправки.

--- a/modules/300-prometheus/crds/prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/prometheusremotewrite.yaml
@@ -61,10 +61,10 @@ spec:
                   description: |
                     Custom HTTP headers to be sent along with each remote write request. Allowed headers: X-scope-OrgID.
                   type: object
-                  patternProperties:
-                    "^X-Scope-OrgID$": 
+                  properties:
+                    X-Scope-OrgID: 
                       type: string
-                  additionalProperties: false
+                    required: ["X-Scope-OrgID"]
                 writeRelabelConfigs:
                   description: |
                     The list of remote write relabel configurations.

--- a/modules/300-prometheus/crds/prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/prometheusremotewrite.yaml
@@ -64,7 +64,7 @@ spec:
                   properties:
                     X-Scope-OrgID: 
                       type: string
-                    required: ["X-Scope-OrgID"]
+                  required: ["X-Scope-OrgID"]
                 writeRelabelConfigs:
                   description: |
                     The list of remote write relabel configurations.

--- a/modules/300-prometheus/crds/prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/prometheusremotewrite.yaml
@@ -59,9 +59,11 @@ spec:
                   description: Custom token sent as a value of the X-Auth-Token header.
                 headers:
                   description: |
-                    Custom HTTP headers to be sent along with each remote write request. Allowed headers: X-scope-OrgID.
+                    Custom HTTP headers to be sent along with each remote write request.
                   type: object
                   properties:
+                    description: |
+                      The only allowed header in this field is X-Scope-OrgID.
                     X-Scope-OrgID: 
                       type: string
                   required: ["X-Scope-OrgID"]

--- a/modules/300-prometheus/crds/prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/prometheusremotewrite.yaml
@@ -59,12 +59,12 @@ spec:
                   description: Custom token sent as a value of the X-Auth-Token header.
                 headers:
                   description: |
-                    Custom HTTP headers to be sent along with each remote write request.
+                    HTTP headers to include in the request.
                   type: object
                   properties:
                     X-Scope-OrgID:
                       description: |
-                        The only allowed header in this field is X-Scope-OrgID.
+                        The `X-Scope-OrgID` header specifying the tenant ID.
                       type: string
                   required: ["X-Scope-OrgID"]
                 writeRelabelConfigs:

--- a/modules/300-prometheus/crds/prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/prometheusremotewrite.yaml
@@ -62,9 +62,9 @@ spec:
                     Custom HTTP headers to be sent along with each remote write request.
                   type: object
                   properties:
-                    description: |
-                      The only allowed header in this field is X-Scope-OrgID.
-                    X-Scope-OrgID: 
+                    X-Scope-OrgID:
+                      description: |
+                        The only allowed header in this field is X-Scope-OrgID.
                       type: string
                   required: ["X-Scope-OrgID"]
                 writeRelabelConfigs:


### PR DESCRIPTION
## Description
The deckhouse controller does not seem to support `patternProperties` for built-in modules OpenAPI spec, thus the #10317 merged recently breaks the prometheus module and stuck the controller's queue.

This PR replaces `patternProperties` with a comprehensive list of properties that are allowed at the moment.

## Why do we need it, and what problem does it solve?
Fixes a regression introduced in ##10317 

## Why do we need it in the patch release (if we do)?
We don't, since the bug is not yet released, but we have to merge it ASAP to fix the main branch.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fix headers configuration for PrometheusRemoteWrite resource.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
