### PR TITLE
Add locale package to install image

### DIFF
--- a/.werf/werf-dev-install.yaml
+++ b/.werf/werf-dev-install.yaml
@@ -76,7 +76,9 @@ docker:
     EDITOR: vim
 shell:
   beforeInstall:
-  - apt-get update && apt-get install -y locale && apt-get clean
+  - |
+    apt-get update && apt-get install -y locale && apt-get clean
+    find /var/lib/apt/ /var/cache/apt/ -type f -delete
   setup:
   - |
     ln -fs /dhctl /usr/bin/dhctl

--- a/.werf/werf-dev-install.yaml
+++ b/.werf/werf-dev-install.yaml
@@ -75,6 +75,8 @@ docker:
   ENV:
     EDITOR: vim
 shell:
+  beforeInstall:
+  - apt-get update && apt-get install -y locale && apt-get clean
   setup:
   - |
     ln -fs /dhctl /usr/bin/dhctl
@@ -103,5 +105,3 @@ shell:
 
     echo 'eval "$(dhctl --completion-script-bash)"' >> /etc/bashrc
     echo '{{- env "CI_COMMIT_TAG" | default "dev" }}' > /deckhouse/version
-
-    apt-get update && apt-get install -y locale && apt-get clean

--- a/.werf/werf-dev-install.yaml
+++ b/.werf/werf-dev-install.yaml
@@ -103,3 +103,5 @@ shell:
 
     echo 'eval "$(dhctl --completion-script-bash)"' >> /etc/bashrc
     echo '{{- env "CI_COMMIT_TAG" | default "dev" }}' > /deckhouse/version
+
+    apt-get update && apt-get install -y locale && apt-get clean


### PR DESCRIPTION
## Description
Added locale package to install image

## Why do we need it, and what problem does it solve?
Resolve issue #10713

## What is the expected result?
Using install image, users won't see a warning about locale

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Add locale package to install image, to fix warning about locale.
impact_level: low
```

