### PR TITLE
[testing] add a handler to apply default values to CRs

### DIFF
--- a/modules/040-node-manager/hooks/create_master_node_group_test.go
+++ b/modules/040-node-manager/hooks/create_master_node_group_test.go
@@ -120,12 +120,7 @@ spec:
 			}
 
 			// TODO(miklezzzz): fix master ng template
-			var masterNgDefaultYAML = string(masterNgDefaultYAMLBBytes) +
-				`  kubelet:
-    containerLogMaxFiles: 4
-    containerLogMaxSize: 50Mi
-    resourceReservation:
-      mode: Auto`
+			var masterNgDefaultYAML = f.ApplyCRDefaults(string(masterNgDefaultYAMLBBytes))
 			assertDefaultMasterNodeGroupOnlyPresent := func(f *HookExecutionConfig) {
 				masterNg := f.KubernetesResource("NodeGroup", "", "master")
 				Expect(masterNg.ToYaml()).To(MatchYAML(masterNgDefaultYAML))

--- a/testing/hooks/init.go
+++ b/testing/hooks/init.go
@@ -480,6 +480,17 @@ func (hec *HookExecutionConfig) prepareCRDSchemas() (map[string]map[string]*spec
 	return schemas, nil
 }
 
+// ApplyCRDefaults applies default values to the provided resources.
+// In case of absent default schema or an error, it returns the original definition
+func (hec *HookExecutionConfig) ApplyCRDefaults(definition string) string {
+	result, err := hec.applyDefaults(definition)
+	if err != nil {
+		return definition
+	}
+
+	return result
+}
+
 func (hec *HookExecutionConfig) applyDefaults(newKubeState string) (string, error) {
 	yamls, err := kio.FromBytes([]byte(newKubeState))
 	if err != nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Provides `ApplyCRDefaults` method to the hook executor which can be used to enrich a CR with default values.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In some tests it may be desirable to create a CR definition from the scratch with default values to use it in tests.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Default values for a CR in the test environment can be set on demand.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: Add a handler to apply default values to CRs.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
