### PR TITLE
[istio] delete legacy roles and rolebindings created by istio-operator

### DIFF
--- a/modules/110-istio/hooks/migration_delete_legacy_roles.go
+++ b/modules/110-istio/hooks/migration_delete_legacy_roles.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+)
+
+// This hook deletes legacy roles and rolebindings created by operator (not DH) in both scopes
+// TODO: Remove this hook after 1.67
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 20},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "role_for_delete",
+			ApiVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+			FilterFunc: applyRoleFilter,
+			LabelSelector: &v1.LabelSelector{
+				MatchLabels: map[string]string{
+					"release": "istio",
+				},
+			},
+			NamespaceSelector: lib.NsSelector(),
+		},
+		{
+			Name:       "rolebinding_for_delete",
+			ApiVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+			FilterFunc: applyRoleBindingFilter,
+			LabelSelector: &v1.LabelSelector{
+				MatchLabels: map[string]string{
+					"release": "istio",
+				},
+			},
+			NamespaceSelector: lib.NsSelector(),
+		},
+		{
+			Name:       "clusterrole_for_delete",
+			ApiVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRole",
+			FilterFunc: applyClusterRoleFilter,
+			LabelSelector: &v1.LabelSelector{
+				MatchLabels: map[string]string{
+					"release": "istio",
+				},
+			},
+		},
+		{
+			Name:       "clusterrolebinding_for_delete",
+			ApiVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRoleBinding",
+			FilterFunc: applyClusterRoleBindingFilter,
+			LabelSelector: &v1.LabelSelector{
+				MatchLabels: map[string]string{
+					"release": "istio",
+				},
+			},
+		},
+	},
+}, deleteLegacyRBACs)
+
+func applyRoleFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return objectInfo{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}, nil
+}
+
+func applyRoleBindingFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return objectInfo{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}, nil
+}
+
+func applyClusterRoleFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return obj.GetName(), nil
+}
+
+func applyClusterRoleBindingFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return obj.GetName(), nil
+}
+
+func deleteLegacyRBACs(input *go_hook.HookInput) error {
+	// remove legacy Roles
+	for _, resource := range input.Snapshots["role_for_delete"] {
+		role := resource.(objectInfo)
+		input.Logger.Info("remove legacy Role %s in %s namespace", role.Name, role.Namespace)
+		input.PatchCollector.Delete("rbac.authorization.k8s.io/v1", "Role", role.Namespace, role.Name)
+	}
+
+	// remove legacy RoleBindings
+	for _, resource := range input.Snapshots["rolebinding_for_delete"] {
+		roleBinding := resource.(objectInfo)
+		input.Logger.Info("remove legacy RoleBinding %s in %s namespace", roleBinding.Name, roleBinding.Namespace)
+		input.PatchCollector.Delete("rbac.authorization.k8s.io/v1", "RoleBinding", roleBinding.Namespace, roleBinding.Name)
+	}
+
+	// remove legacy ClusterRoles
+	for _, resource := range input.Snapshots["clusterrole_for_delete"] {
+		clusterRoleName := resource.(string)
+		input.Logger.Info("remove legacy ClusterRole %s", clusterRoleName)
+		input.PatchCollector.Delete("rbac.authorization.k8s.io/v1", "ClusterRole", "", clusterRoleName)
+	}
+
+	// remove legacy ClusterRoleBindings
+	for _, resource := range input.Snapshots["clusterrolebinding_for_delete"] {
+		clusterRoleBindingName := resource.(string)
+		input.Logger.Info("remove legacy ClusterRoleBinding %s", clusterRoleBindingName)
+		input.PatchCollector.Delete("rbac.authorization.k8s.io/v1", "ClusterRoleBinding", "", clusterRoleBindingName)
+	}
+
+	return nil
+}
+
+type objectInfo struct {
+	Name      string
+	Namespace string
+}

--- a/modules/110-istio/hooks/migration_delete_legacy_roles_test.go
+++ b/modules/110-istio/hooks/migration_delete_legacy_roles_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Istio hooks :: delete_legacy_RBACs ::", func() {
+	f := HookExecutionConfigInit(`{"global":{"discovery":{"clusterDomain":"cluster.flomaster"}},"istio":{"internal":{}}}`, "")
+
+	Context("Legacy RBACs are deleted by platform", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: istio-reader
+    release: istio
+  name: istio-reader-clusterrole-v1x16-d8-istio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: istio-reader
+    release: istio
+  name: istio-reader-clusterrole-v1x16-d8-istio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: istio-reader-custom
+    release: istio-custom
+  name: istio-reader-clusterrole-dont-delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: istiod
+    release: istio
+  name: istiod-v1x16
+  namespace: d8-istio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: istiod
+    release: istio
+  name: istiod-v1x16
+  namespace: d8-istio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: istiod
+    release: istio
+  name: istiod-binding-dont-delete
+  namespace: istio-system
+`))
+			f.RunHook()
+		})
+
+		It("Legacy roles and rolebindings are removed", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+			cr := f.KubernetesGlobalResource("ClusterRole", "istio-reader-clusterrole-v1x16-d8-istio")
+			Expect(cr.Exists()).To(BeFalse())
+
+			crb := f.KubernetesGlobalResource("ClusterRoleBinding", "istio-reader-clusterrole-v1x16")
+			Expect(crb.Exists()).To(BeFalse())
+
+			crNotForDeletion := f.KubernetesGlobalResource("ClusterRole", "istio-reader-clusterrole-dont-delete")
+			Expect(crNotForDeletion.Exists()).To(BeTrue())
+
+			r := f.KubernetesResource("Role", "d8-istio", "istiod-v1x16")
+			Expect(r.Exists()).To(BeFalse())
+
+			rb := f.KubernetesResource("RoleBinding", "d8-istio", "istiod-v1x16")
+			Expect(rb.Exists()).To(BeFalse())
+
+			rbNotForDeletion := f.KubernetesResource("RoleBinding", "istio-system", "istiod-binding-dont-delete")
+			Expect(rbNotForDeletion.Exists()).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
## Description
The removal of legacy RBACs from the cluster created by the Istio operator before we switched to creating RBACs through the platform.

## Why do we need it, and what problem does it solve?
Legacy RBACs interfere with the operation of the IstioOperator reconcile in the cluster. There are errors in operator logs:
```
2024-11-20T18:01:33.652832Z     error   installer       Failed to delete resources with helm reconciler: rolebindings.rbac.authorization.k8s.io "istiod-v1x16" is forbidden: User "system:serviceaccount:d8-istio:operator" cannot delete resource "rolebindings" in API group "rbac.authorization.k8s.io" in the namespace "d8-istio", roles.rbac.authorization.k8s.io "istiod-v1x16" is forbidden: User "system:serviceaccount:d8-istio:operator" cannot delete resource "roles" in API group "rbac.authorization.k8s.io" in the namespace "d8-istio", clusterroles.rbac.authorization.k8s.io "istio-reader-clusterrole-v1x16-d8-istio" is forbidden: User "system:serviceaccount:d8-istio:operator" cannot delete resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope, clusterroles.rbac.authorization.k8s.io "istiod-clusterrole-v1x16-d8-istio" is forbidden: User "system:serviceaccount:d8-istio:operator" cannot delete resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope, clusterroles.rbac.authorization.k8s.io "istiod-gateway-controller-v1x16-d8-istio" is forbidden: User "system:serviceaccount:d8-istio:operator" cannot delete resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope, clusterrolebindings.rbac.authorization.k8s.io "istio-reader-clusterrole-v1x16-d8-istio" is forbidden: User "system:serviceaccount:d8-istio:operator" cannot delete resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope, clusterrolebindings.rbac.authorization.k8s.io "istiod-clusterrole-v1x16-d8-istio" is forbidden: User "system:serviceaccount:d8-istio:operator" cannot delete resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope, clusterrolebindings.rbac.authorization.k8s.io "istiod-gateway-controller-v1x16-d8-istio" is forbidden: User "system:serviceaccount:d8-istio:operator" cannot delete resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope.
```

## What is the expected result?
There aren't any errors related to RBAC deletion in istio-operator.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Got rid of legacy RBACs created by istio-operator.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
