### PR TITLE
[extended-monitoring] Separate alert for standby-holder

### DIFF
--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -36,6 +36,8 @@
       (
         max by (namespace, deployment) (extended_monitoring_deployment_threshold{threshold="replicas-not-ready"})
       )
+      unless
+      (deployment == "standby-holder-worker-production")
     for: 5m
     labels:
       severity_level: "5"
@@ -186,3 +188,28 @@
         Count of ready replicas in StatefulSet {{$labels.namespace}}/{{$labels.statefulset}} at zero.
 
         List of unavailable Pod(s): {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"StatefulSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.deployment | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
+
+  - alert: StandbyHolderDeploymentUnavailable
+    expr: |
+      (
+        (kube_deployment_status_replicas_available == 0) * (kube_deployment_spec_replicas != 0)
+      )
+      * on (namespace, deployment)
+      (
+        max by (namespace, deployment) (extended_monitoring_deployment_threshold{threshold="replicas-not-ready"})
+      )
+      and (deployment == "standby-holder-worker-production")
+    for: 5m
+    labels:
+      severity_level: "5"
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,namespace={{ $labels.namespace }},kubernetes=~kubernetes"
+      plk_grouped_by__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,namespace={{ $labels.namespace }},kubernetes=~kubernetes"
+      summary: |-
+        Count of available replicas in Deployment {{$labels.namespace}}/standby-holder-worker-production is at zero.
+      description: |-
+        Count of available replicas in Deployment {{$labels.namespace}}/{{$labels.deployment}} is at zero.
+
+        List of unavailable Pod(s): {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"Deployment\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.deployment | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}


### PR DESCRIPTION
## Description
To fix [this](https://github.com/deckhouse/deckhouse/issues/4974) issue. 

## Why do we need it, and what problem does it solve?
When reaching max nodes in node group it triggers the KubernetesControllersMalfunctioningInNamespace alert for standby-holder. It is false positive alert.

## Why do we need it in the patch release (if we do)?
No we don't

## What is the expected result?
Reaching max nodes in node group doesn't trigger the alert anymore and there's a separate alert for this situation. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: fix
summary: separate alert for standby-holder
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
