### PR TITLE
[dhctl] add terraform resource management timeout option

### DIFF
--- a/candi/cloud-providers/aws/layouts/standard/master-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/standard/master-node/main.tf
@@ -24,4 +24,5 @@ module "master-node" {
   cloud_config = var.cloudConfig
   zones = local.zones
   tags = local.tags
+  resourceManagementTimeout = var.resourceManagementTimeout
 }

--- a/candi/cloud-providers/aws/layouts/standard/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/standard/master-node/variables.tf
@@ -33,6 +33,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 data "aws_availability_zones" "available" {}
 
 locals {

--- a/candi/cloud-providers/aws/layouts/standard/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/standard/master-node/variables.tf
@@ -35,7 +35,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 data "aws_availability_zones" "available" {}

--- a/candi/cloud-providers/aws/layouts/standard/static-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/standard/static-node/main.tf
@@ -24,4 +24,5 @@ module "static-node" {
   cloud_config = var.cloudConfig
   zones = local.zones
   tags = local.tags
+  resourceManagementTimeout = var.resourceManagementTimeout
 }

--- a/candi/cloud-providers/aws/layouts/standard/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/standard/static-node/variables.tf
@@ -37,6 +37,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 data "aws_availability_zones" "available" {}
 
 locals {

--- a/candi/cloud-providers/aws/layouts/standard/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/standard/static-node/variables.tf
@@ -39,7 +39,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 data "aws_availability_zones" "available" {}

--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
@@ -251,6 +251,12 @@ resource "aws_instance" "bastion" {
       ebs_optimized
     ]
   }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }
 
 resource "aws_eip" "bastion" {

--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/variables.tf
@@ -34,6 +34,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   with_nat                 = lookup(var.providerClusterConfiguration, "withNAT", {})
   bastion_instance         = lookup(local.with_nat, "bastionInstance", {})

--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/variables.tf
@@ -36,7 +36,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/candi/cloud-providers/aws/layouts/with-nat/master-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/master-node/main.tf
@@ -25,4 +25,5 @@ module "master-node" {
   zones = local.zones
   tags = local.tags
   associate_ssh_accessible_sg = local.bastion_instance != {} ? false : true
+  resourceManagementTimeout = var.resourceManagementTimeout
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/master-node/variables.tf
@@ -33,6 +33,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 data "aws_availability_zones" "available" {}
 
 locals {

--- a/candi/cloud-providers/aws/layouts/with-nat/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/master-node/variables.tf
@@ -35,7 +35,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 data "aws_availability_zones" "available" {}

--- a/candi/cloud-providers/aws/layouts/with-nat/static-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/static-node/main.tf
@@ -24,4 +24,5 @@ module "static-node" {
   cloud_config = var.cloudConfig
   zones = local.zones
   tags = local.tags
+  resourceManagementTimeout = var.resourceManagementTimeout
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/static-node/variables.tf
@@ -37,6 +37,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 data "aws_availability_zones" "available" {}
 
 locals {

--- a/candi/cloud-providers/aws/layouts/with-nat/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/static-node/variables.tf
@@ -39,7 +39,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 data "aws_availability_zones" "available" {}

--- a/candi/cloud-providers/aws/layouts/without-nat/master-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/master-node/main.tf
@@ -25,4 +25,5 @@ module "master-node" {
   cloud_config = var.cloudConfig
   zones = local.zones
   tags = local.tags
+  resourceManagementTimeout = var.resourceManagementTimeout
 }

--- a/candi/cloud-providers/aws/layouts/without-nat/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/master-node/variables.tf
@@ -33,6 +33,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 data "aws_availability_zones" "available" {}
 
 locals {

--- a/candi/cloud-providers/aws/layouts/without-nat/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/master-node/variables.tf
@@ -35,7 +35,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 data "aws_availability_zones" "available" {}

--- a/candi/cloud-providers/aws/layouts/without-nat/static-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/static-node/main.tf
@@ -25,4 +25,5 @@ module "static-node" {
   cloud_config = var.cloudConfig
   zones = local.zones
   tags = local.tags
+  resourceManagementTimeout = var.resourceManagementTimeout
 }

--- a/candi/cloud-providers/aws/layouts/without-nat/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/static-node/variables.tf
@@ -37,6 +37,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 data "aws_availability_zones" "available" {}
 
 locals {

--- a/candi/cloud-providers/aws/layouts/without-nat/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/static-node/variables.tf
@@ -39,7 +39,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 data "aws_availability_zones" "available" {}

--- a/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
@@ -43,6 +43,12 @@ resource "aws_ebs_volume" "kubernetes_data" {
     Name = "${var.prefix}-kubernetes-data-${var.node_index}"
   })
   availability_zone = local.zone
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }
 
 resource "aws_volume_attachment" "kubernetes_data" {
@@ -103,6 +109,12 @@ resource "aws_instance" "master" {
       #TODO: remove ignore after we enable automatic converge for master nodes
       volume_tags
     ]
+  }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
   }
 }
 

--- a/candi/cloud-providers/aws/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/aws/terraform-modules/master-node/variables.tf
@@ -69,5 +69,5 @@ locals {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }

--- a/candi/cloud-providers/aws/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/aws/terraform-modules/master-node/variables.tf
@@ -66,3 +66,8 @@ variable "tags" {
 locals {
   zones = sort(distinct(var.zones))
 }
+
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}

--- a/candi/cloud-providers/aws/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/static-node/main.tf
@@ -80,6 +80,12 @@ resource "aws_instance" "node" {
       volume_tags
     ]
   }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }
 
 resource "aws_eip" "eip" {

--- a/candi/cloud-providers/aws/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/aws/terraform-modules/static-node/variables.tf
@@ -61,3 +61,8 @@ variable "tags" {
 locals {
   zones = sort(distinct(var.zones))
 }
+
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}

--- a/candi/cloud-providers/aws/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/aws/terraform-modules/static-node/variables.tf
@@ -64,5 +64,5 @@ locals {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }

--- a/candi/cloud-providers/azure/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/azure/terraform-modules/master-node/main.tf
@@ -99,6 +99,12 @@ resource "azurerm_linux_virtual_machine" "master" {
       custom_data
     ]
   }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }
 
 resource "azurerm_managed_disk" "kubernetes_data" {
@@ -110,6 +116,12 @@ resource "azurerm_managed_disk" "kubernetes_data" {
   create_option        = "Empty"
   disk_size_gb         = local.etcd_disk_size_gb
   tags                 = local.additional_tags
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "kubernetes_data" {

--- a/candi/cloud-providers/azure/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/azure/terraform-modules/master-node/variables.tf
@@ -39,6 +39,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix                 = var.clusterConfiguration.cloud.prefix
   admin_username         = "azureuser"

--- a/candi/cloud-providers/azure/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/azure/terraform-modules/master-node/variables.tf
@@ -41,7 +41,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/candi/cloud-providers/azure/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/azure/terraform-modules/static-node/main.tf
@@ -97,4 +97,10 @@ resource "azurerm_linux_virtual_machine" "node" {
       custom_data
     ]
   }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }

--- a/candi/cloud-providers/azure/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/azure/terraform-modules/static-node/variables.tf
@@ -40,7 +40,7 @@ variable "nodeGroupName" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/candi/cloud-providers/azure/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/azure/terraform-modules/static-node/variables.tf
@@ -38,6 +38,11 @@ variable "nodeGroupName" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix                 = var.clusterConfiguration.cloud.prefix
   admin_username         = "azureuser"

--- a/candi/cloud-providers/gcp/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/gcp/terraform-modules/master-node/main.tf
@@ -33,6 +33,12 @@ resource "google_compute_disk" "kubernetes_data" {
   type   = "pd-ssd"
   size   = local.etcd_disk_size_gb
   labels = local.additional_labels
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }
 
 resource "google_compute_instance" "master" {
@@ -67,10 +73,17 @@ resource "google_compute_instance" "master" {
     ssh-keys  = "${local.ssh_user}:${local.ssh_key}"
     user-data = base64decode(var.cloudConfig)
   }
+
   lifecycle {
     ignore_changes = [
       attached_disk,
       metadata["user-data"]
     ]
+  }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
   }
 }

--- a/candi/cloud-providers/gcp/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/gcp/terraform-modules/master-node/variables.tf
@@ -40,7 +40,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/candi/cloud-providers/gcp/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/gcp/terraform-modules/master-node/variables.tf
@@ -38,6 +38,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix                       = var.clusterConfiguration.cloud.prefix
   machine_type                 = var.providerClusterConfiguration.masterNodeGroup.instanceClass.machineType

--- a/candi/cloud-providers/gcp/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/gcp/terraform-modules/static-node/main.tf
@@ -55,10 +55,17 @@ resource "google_compute_instance" "static" {
     ssh-keys  = "${local.ssh_user}:${local.ssh_key}"
     user-data = base64decode(var.cloudConfig)
   }
+
   lifecycle {
     ignore_changes = [
       attached_disk,
       metadata["user-data"]
     ]
+  }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
   }
 }

--- a/candi/cloud-providers/gcp/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/gcp/terraform-modules/static-node/variables.tf
@@ -44,7 +44,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/candi/cloud-providers/gcp/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/gcp/terraform-modules/static-node/variables.tf
@@ -42,6 +42,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix                       = var.clusterConfiguration.cloud.prefix
   node_groups                  = lookup(var.providerClusterConfiguration, "nodeGroups", [])

--- a/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
@@ -90,6 +90,12 @@ resource "yandex_compute_disk" "kubernetes_data" {
   type        = local.disk_type
 
   labels = local.additional_labels
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }
 
 resource "yandex_compute_instance" "master" {
@@ -144,6 +150,12 @@ resource "yandex_compute_instance" "master" {
       metadata,
       secondary_disk,
     ]
+  }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
   }
 
   metadata = {

--- a/candi/cloud-providers/yandex/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/master-node/variables.tf
@@ -44,7 +44,7 @@ variable "network_types" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/candi/cloud-providers/yandex/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/master-node/variables.tf
@@ -42,6 +42,11 @@ variable "network_types" {
   }
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix                = var.clusterConfiguration.cloud.prefix
   mng                   = var.providerClusterConfiguration.masterNodeGroup

--- a/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
@@ -117,6 +117,12 @@ resource "yandex_compute_instance" "static" {
     ]
   }
 
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
+
   metadata = {
     ssh-keys          = "user:${local.ssh_public_key}"
     user-data         = base64decode(var.cloudConfig)

--- a/candi/cloud-providers/yandex/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/static-node/variables.tf
@@ -45,6 +45,11 @@ variable "network_types" {
   }
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix            = var.clusterConfiguration.cloud.prefix
   ng                = [for i in var.providerClusterConfiguration.nodeGroups : i if i.name == var.nodeGroupName][0]

--- a/candi/cloud-providers/yandex/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/static-node/variables.tf
@@ -47,7 +47,7 @@ variable "network_types" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -151,6 +151,12 @@ resource "yandex_compute_instance" "nat_instance" {
     ]
   }
 
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
+
   metadata = {
     user-data = local.user_data
   }

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
@@ -85,5 +85,5 @@ variable "labels" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
@@ -82,3 +82,8 @@ variable "nat_instance_ssh_key" {
 variable "labels" {
   type = map
 }
+
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}

--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -31,6 +31,7 @@ func DefineBootstrapCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 	app.DefineCacheFlags(cmd)
 	app.DefineDropCacheFlags(cmd)
 	app.DefineResourcesFlags(cmd, false)
+	app.DefineTFResourceManagementTimeout(cmd)
 	app.DefineDeckhouseFlags(cmd)
 	app.DefineDontUsePublicImagesFlags(cmd)
 	app.DefinePostBootstrapScriptFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -31,6 +31,7 @@ func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause) *kingpin.
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)
+	app.DefineTFResourceManagementTimeout(cmd)
 	app.DefineKubeFlags(cmd)
 	app.DefineDeckhouseFlags(cmd)
 	app.DefineDeckhouseInstallFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -49,6 +49,7 @@ func DefineDestroyCommand(parent *kingpin.Application) *kingpin.CmdClause {
 	app.DefineCacheFlags(cmd)
 	app.DefineSanityFlags(cmd)
 	app.DefineDestroyResourcesFlags(cmd)
+	app.DefineTFResourceManagmentTimeout(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		if !app.SanityCheck {

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -49,7 +49,7 @@ func DefineDestroyCommand(parent *kingpin.Application) *kingpin.CmdClause {
 	app.DefineCacheFlags(cmd)
 	app.DefineSanityFlags(cmd)
 	app.DefineDestroyResourcesFlags(cmd)
-	app.DefineTFResourceManagmentTimeout(cmd)
+	app.DefineTFResourceManagementTimeout(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		if !app.SanityCheck {

--- a/dhctl/pkg/app/terraform.go
+++ b/dhctl/pkg/app/terraform.go
@@ -41,7 +41,7 @@ var (
 	CacheKubeName            = ""
 	CacheKubeLabels          = make(map[string]string)
 
-	ResourceManagmentTimeout = ""
+	ResourceManagementTimeout = ""
 )
 
 func DefineCacheFlags(cmd *kingpin.CmdClause) {
@@ -84,8 +84,8 @@ func DefineDropCacheFlags(cmd *kingpin.CmdClause) {
 		BoolVar(&DropCache)
 }
 
-func DefineTFResourceManagmentTimeout(cmd *kingpin.CmdClause) {
+func DefineTFResourceManagementTimeout(cmd *kingpin.CmdClause) {
 	cmd.Flag("tf-resource-managment-timeout", "Redefine terraform resource management timeouts").
 		Envar(configEnvName("DHCTL_TF_RESOURCE_MANAGMENT_TIMEOUT")).
-		StringVar(&ResourceManagmentTimeout)
+		StringVar(&ResourceManagementTimeout)
 }

--- a/dhctl/pkg/app/terraform.go
+++ b/dhctl/pkg/app/terraform.go
@@ -85,7 +85,7 @@ func DefineDropCacheFlags(cmd *kingpin.CmdClause) {
 }
 
 func DefineTFResourceManagementTimeout(cmd *kingpin.CmdClause) {
-	cmd.Flag("tf-resource-managment-timeout", "Redefine terraform resource management timeouts").
-		Envar(configEnvName("DHCTL_TF_RESOURCE_MANAGMENT_TIMEOUT")).
+	cmd.Flag("tf-resource-management-timeout", "Redefine terraform resource management timeouts").
+		Envar(configEnvName("DHCTL_TF_RESOURCE_MANAGEMENT_TIMEOUT")).
 		StringVar(&ResourceManagementTimeout)
 }

--- a/dhctl/pkg/app/terraform.go
+++ b/dhctl/pkg/app/terraform.go
@@ -40,6 +40,8 @@ var (
 	CacheKubeNamespace       = ""
 	CacheKubeName            = ""
 	CacheKubeLabels          = make(map[string]string)
+
+	ResourceManagmentTimeout = ""
 )
 
 func DefineCacheFlags(cmd *kingpin.CmdClause) {
@@ -80,4 +82,10 @@ func DefineDropCacheFlags(cmd *kingpin.CmdClause) {
 	cmd.Flag("yes-i-want-to-drop-cache", "All cached information will be deleted from your local cache.").
 		Default("false").
 		BoolVar(&DropCache)
+}
+
+func DefineTFResourceManagmentTimeout(cmd *kingpin.CmdClause) {
+	cmd.Flag("tf-resource-managment-timeout", "Redefine terraform resource management timeouts").
+		Envar(configEnvName("DHCTL_TF_RESOURCE_MANAGMENT_TIMEOUT")).
+		StringVar(&ResourceManagmentTimeout)
 }

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -49,12 +49,13 @@ type MetaConfig struct {
 	ProviderClusterConfig map[string]json.RawMessage `json:"providerClusterConfiguration,omitempty"`
 	StaticClusterConfig   map[string]json.RawMessage `json:"staticClusterConfiguration,omitempty"`
 
-	VersionMap       map[string]interface{} `json:"-"`
-	Images           imagesDigests          `json:"-"`
-	Registry         RegistryData           `json:"-"`
-	UUID             string                 `json:"clusterUUID,omitempty"`
-	InstallerVersion string                 `json:"-"`
-	ResourcesYAML    string                 `json:"-"`
+	VersionMap                map[string]interface{} `json:"-"`
+	Images                    imagesDigests          `json:"-"`
+	Registry                  RegistryData           `json:"-"`
+	UUID                      string                 `json:"clusterUUID,omitempty"`
+	InstallerVersion          string                 `json:"-"`
+	ResourcesYAML             string                 `json:"-"`
+	ResourceManagementTimeout string                 `json:"resourceManagementTimeout,omitempty"`
 }
 
 type imagesDigests map[string]map[string]interface{}
@@ -462,6 +463,10 @@ func (m *MetaConfig) NodeGroupConfig(nodeGroupName string, nodeIndex int, cloudC
 		result["clusterUUID"] = m.UUID
 	}
 
+	if len(m.ResourceManagementTimeout) > 0 {
+		result["resourceManagementTimeout"] = m.ResourceManagementTimeout
+	}
+
 	data, _ := json.Marshal(result)
 	return data
 }
@@ -529,6 +534,10 @@ func (m *MetaConfig) DeepCopy() *MetaConfig {
 
 	if m.UUID != "" {
 		out.UUID = m.UUID
+	}
+
+	if m.ResourceManagementTimeout != "" {
+		out.ResourceManagementTimeout = m.ResourceManagementTimeout
 	}
 
 	return out

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -242,6 +242,8 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 	}
 	metaConfig.UUID = clusterUUID
 
+	metaConfig.ResourceManagementTimeout = app.ResourceManagementTimeout
+
 	deckhouseInstallConfig, err := config.PrepareDeckhouseInstallConfig(metaConfig)
 	if err != nil {
 		return err

--- a/ee/candi/cloud-providers/dynamix/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/dynamix/terraform-modules/master-node/main.tf
@@ -42,6 +42,12 @@ resource "decort_disk" "kubernetes_data_disk" {
   type       = "D" # disk type, always use "D" for extra disks
   sep_id     = local.storage_endpoint_id
   pool       = local.pool
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }
 
 resource "decort_kvmvm" "master_vm" {
@@ -74,5 +80,10 @@ resource "decort_kvmvm" "master_vm" {
       cloud_init,
     ]
   }
-}
 
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
+}

--- a/ee/candi/cloud-providers/dynamix/terraform-modules/master-node/variables.tf
+++ b/ee/candi/cloud-providers/dynamix/terraform-modules/master-node/variables.tf
@@ -21,7 +21,7 @@ variable "cloudConfig" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals{

--- a/ee/candi/cloud-providers/dynamix/terraform-modules/master-node/variables.tf
+++ b/ee/candi/cloud-providers/dynamix/terraform-modules/master-node/variables.tf
@@ -19,6 +19,11 @@ variable "cloudConfig" {
   default = ""
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals{
   resource_name_prefix = var.clusterConfiguration.cloud.prefix
   master_node_name = join("-", [local.resource_name_prefix, "master", var.nodeIndex])

--- a/ee/candi/cloud-providers/dynamix/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/dynamix/terraform-modules/static-node/main.tf
@@ -51,5 +51,10 @@ resource "decort_kvmvm" "node_vm" {
       cloud_init,
     ]
   }
-}
 
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
+}

--- a/ee/candi/cloud-providers/dynamix/terraform-modules/static-node/variables.tf
+++ b/ee/candi/cloud-providers/dynamix/terraform-modules/static-node/variables.tf
@@ -25,7 +25,7 @@ variable "nodeGroupName" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/ee/candi/cloud-providers/dynamix/terraform-modules/static-node/variables.tf
+++ b/ee/candi/cloud-providers/dynamix/terraform-modules/static-node/variables.tf
@@ -23,6 +23,11 @@ variable "nodeGroupName" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   resource_name_prefix = var.clusterConfiguration.cloud.prefix
   ng             = [for i in var.providerClusterConfiguration.nodeGroups : i if i.name == var.nodeGroupName][0]

--- a/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/variables.tf
@@ -25,7 +25,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/variables.tf
@@ -23,6 +23,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix                = var.clusterConfiguration.cloud.prefix
   pod_subnet_cidr       = var.clusterConfiguration.podSubnetCIDR

--- a/ee/candi/cloud-providers/openstack/layouts/simple/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple/master-node/main.tf
@@ -62,11 +62,18 @@ resource "openstack_blockstorage_volume_v3" "master" {
   volume_type = local.volume_type
   availability_zone = module.volume_zone.zone
   enable_online_resize = true
+
   lifecycle {
     ignore_changes = [
       metadata,
       availability_zone,
     ]
+  }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
   }
 }
 
@@ -99,6 +106,12 @@ resource "openstack_compute_instance_v2" "master" {
     ignore_changes = [
       user_data,
     ]
+  }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
   }
 
   metadata = local.metadata_tags

--- a/ee/candi/cloud-providers/openstack/layouts/simple/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple/master-node/main.tf
@@ -73,7 +73,6 @@ resource "openstack_blockstorage_volume_v3" "master" {
   timeouts {
     create = var.resourceManagementTimeout
     delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
   }
 }
 

--- a/ee/candi/cloud-providers/openstack/layouts/simple/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple/variables.tf
@@ -25,7 +25,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/ee/candi/cloud-providers/openstack/layouts/simple/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple/variables.tf
@@ -23,6 +23,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix                = var.clusterConfiguration.cloud.prefix
   pod_subnet_cidr       = var.clusterConfiguration.podSubnetCIDR

--- a/ee/candi/cloud-providers/openstack/layouts/standard-with-no-router/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard-with-no-router/variables.tf
@@ -29,7 +29,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/ee/candi/cloud-providers/openstack/layouts/standard-with-no-router/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard-with-no-router/variables.tf
@@ -27,6 +27,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix                = var.clusterConfiguration.cloud.prefix
   pod_subnet_cidr       = var.clusterConfiguration.podSubnetCIDR

--- a/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
@@ -96,11 +96,18 @@ resource "openstack_blockstorage_volume_v3" "root" {
   volume_type = local.volume_type
   availability_zone = module.volume_zone.zone
   enable_online_resize = true
+
   lifecycle {
     ignore_changes = [
       metadata,
       availability_zone,
     ]
+  }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
   }
 }
 
@@ -123,6 +130,12 @@ resource "openstack_compute_instance_v2" "bastion" {
     source_type           = "volume"
     destination_type      = "volume"
     delete_on_termination = true
+  }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
   }
 
   metadata = local.metadata_tags

--- a/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
@@ -107,7 +107,6 @@ resource "openstack_blockstorage_volume_v3" "root" {
   timeouts {
     create = var.resourceManagementTimeout
     delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
   }
 }
 

--- a/ee/candi/cloud-providers/openstack/layouts/standard/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/variables.tf
@@ -27,6 +27,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix                = var.clusterConfiguration.cloud.prefix
   standard              = lookup(var.providerClusterConfiguration, "standard", {})

--- a/ee/candi/cloud-providers/openstack/layouts/standard/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/variables.tf
@@ -29,7 +29,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/main.tf
@@ -20,7 +20,6 @@ resource "openstack_blockstorage_volume_v3" "kubernetes_data" {
   timeouts {
     create = var.resourceManagementTimeout
     delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
   }
 }
 

--- a/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/main.tf
@@ -9,11 +9,18 @@ resource "openstack_blockstorage_volume_v3" "kubernetes_data" {
   availability_zone = var.volume_zone
   enable_online_resize = true
   metadata = var.tags
+
   lifecycle {
     ignore_changes = [
       metadata,
       availability_zone,
     ]
+  }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
   }
 }
 

--- a/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/variables.tf
@@ -28,3 +28,8 @@ variable "volume_zone" {
 variable "tags" {
   type = map(string)
 }
+
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}

--- a/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/variables.tf
@@ -31,5 +31,5 @@ variable "tags" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
@@ -19,11 +19,18 @@ resource "openstack_blockstorage_volume_v3" "master" {
   volume_type          = var.volume_type
   availability_zone    = var.volume_zone
   enable_online_resize = true
+
   lifecycle {
     ignore_changes = [
       metadata,
       availability_zone,
     ]
+  }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
   }
 }
 
@@ -64,6 +71,12 @@ resource "openstack_compute_instance_v2" "master" {
     ignore_changes = [
       user_data,
     ]
+  }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
   }
 
   metadata = local.metadata_tags

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
@@ -30,7 +30,6 @@ resource "openstack_blockstorage_volume_v3" "master" {
   timeouts {
     create = var.resourceManagementTimeout
     delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
   }
 }
 

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/variables.tf
@@ -70,3 +70,8 @@ variable "zone" {
 variable "server_group" {
   type = any
 }
+
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/variables.tf
@@ -73,5 +73,5 @@ variable "server_group" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }

--- a/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
@@ -66,7 +66,6 @@ resource "openstack_blockstorage_volume_v3" "volume" {
   timeouts {
     create = var.resourceManagementTimeout
     delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
   }
 }
 

--- a/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
@@ -55,11 +55,18 @@ resource "openstack_blockstorage_volume_v3" "volume" {
   volume_type       = local.volume_type
   availability_zone = module.volume_zone.zone
   enable_online_resize = true
+
   lifecycle {
     ignore_changes = [
       metadata,
       availability_zone,
     ]
+  }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
   }
 }
 
@@ -97,6 +104,12 @@ resource "openstack_compute_instance_v2" "node" {
     ]
   }
 
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
+
   metadata = local.metadata_tags
 }
 
@@ -117,4 +130,3 @@ resource "openstack_compute_floatingip_associate_v2" "node" {
     ]
   }
 }
-

--- a/ee/candi/cloud-providers/openstack/terraform-modules/static-node/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/static-node/variables.tf
@@ -25,6 +25,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 # SimpleWithInternalNetwork only
 data "openstack_networking_subnet_v2" "internal" {
   count = local.layout == "simpleWithInternalNetwork" ? 1 : 0

--- a/ee/candi/cloud-providers/openstack/terraform-modules/static-node/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/static-node/variables.tf
@@ -27,7 +27,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 # SimpleWithInternalNetwork only

--- a/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
@@ -51,6 +51,12 @@ resource "vcd_vm_internal_disk" "kubernetes_data"{
   bus_number      = 0
   unit_number     = 1
   bus_type        = "paravirtual"
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }
 
 resource "vcd_vapp_vm" "master" {
@@ -94,6 +100,12 @@ resource "vcd_vapp_vm" "master" {
     ]
   }
 
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
+
   guest_properties = merge({
     "instance-id"         = join("-", [local.prefix, "master", var.nodeIndex])
     "local-hostname"      = join("-", [local.prefix, "master", var.nodeIndex])
@@ -101,4 +113,3 @@ resource "vcd_vapp_vm" "master" {
     "disk.EnableUUID"     = "1"
   }, length(var.cloudConfig) > 0 ? {"user-data" = var.cloudConfig} : {} )
 }
-

--- a/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
@@ -100,12 +100,6 @@ resource "vcd_vapp_vm" "master" {
     ]
   }
 
-  timeouts {
-    create = var.resourceManagementTimeout
-    delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
-  }
-
   guest_properties = merge({
     "instance-id"         = join("-", [local.prefix, "master", var.nodeIndex])
     "local-hostname"      = join("-", [local.prefix, "master", var.nodeIndex])

--- a/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
@@ -51,12 +51,6 @@ resource "vcd_vm_internal_disk" "kubernetes_data"{
   bus_number      = 0
   unit_number     = 1
   bus_type        = "paravirtual"
-
-  timeouts {
-    create = var.resourceManagementTimeout
-    delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
-  }
 }
 
 resource "vcd_vapp_vm" "master" {

--- a/ee/candi/cloud-providers/vcd/terraform-modules/master-node/variables.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/master-node/variables.tf
@@ -36,7 +36,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/ee/candi/cloud-providers/vcd/terraform-modules/master-node/variables.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/master-node/variables.tf
@@ -34,6 +34,11 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix = var.clusterConfiguration.cloud.prefix
   vapp_name = var.providerClusterConfiguration.virtualApplicationName

--- a/ee/candi/cloud-providers/vcd/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/static-node/main.tf
@@ -81,6 +81,12 @@ resource "vcd_vapp_vm" "node" {
     ]
   }
 
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
+
   guest_properties = {
     "instance-id"         = join("-", [local.prefix, local.node_group_name, var.nodeIndex])
     "local-hostname"      = join("-", [local.prefix, local.node_group_name, var.nodeIndex])

--- a/ee/candi/cloud-providers/vcd/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/static-node/main.tf
@@ -81,12 +81,6 @@ resource "vcd_vapp_vm" "node" {
     ]
   }
 
-  timeouts {
-    create = var.resourceManagementTimeout
-    delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
-  }
-
   guest_properties = {
     "instance-id"         = join("-", [local.prefix, local.node_group_name, var.nodeIndex])
     "local-hostname"      = join("-", [local.prefix, local.node_group_name, var.nodeIndex])

--- a/ee/candi/cloud-providers/vcd/terraform-modules/static-node/variables.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/static-node/variables.tf
@@ -37,6 +37,11 @@ variable "nodeGroupName" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix = var.clusterConfiguration.cloud.prefix
   vapp_name = var.providerClusterConfiguration.virtualApplicationName

--- a/ee/candi/cloud-providers/vcd/terraform-modules/static-node/variables.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/static-node/variables.tf
@@ -39,7 +39,7 @@ variable "nodeGroupName" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
@@ -127,6 +127,12 @@ resource "vsphere_virtual_disk" "kubernetes_data" {
   type               = "eagerZeroedThick"
   vmdk_path          = "deckhouse/${join("-", [var.clusterUUID, "kubernetes-data", var.nodeIndex])}.vmdk"
   create_directories = true
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }
 
 resource "vsphere_virtual_machine" "master" {
@@ -201,5 +207,12 @@ resource "vsphere_virtual_machine" "master" {
       firmware,
     ]
   }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
+
   wait_for_guest_net_routable = false
 }

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
@@ -202,11 +202,5 @@ resource "vsphere_virtual_machine" "master" {
     ]
   }
 
-  timeouts {
-    create = var.resourceManagementTimeout
-    delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
-  }
-
   wait_for_guest_net_routable = false
 }

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
@@ -127,12 +127,6 @@ resource "vsphere_virtual_disk" "kubernetes_data" {
   type               = "eagerZeroedThick"
   vmdk_path          = "deckhouse/${join("-", [var.clusterUUID, "kubernetes-data", var.nodeIndex])}.vmdk"
   create_directories = true
-
-  timeouts {
-    create = var.resourceManagementTimeout
-    delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
-  }
 }
 
 resource "vsphere_virtual_machine" "master" {

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/variables.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/variables.tf
@@ -34,6 +34,10 @@ variable "clusterUUID" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
 
 locals {
   prefix = var.clusterConfiguration.cloud.prefix

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/variables.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/variables.tf
@@ -36,7 +36,7 @@ variable "clusterUUID" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
@@ -165,12 +165,6 @@ resource "vsphere_virtual_machine" "node" {
     client_device = true
   }
 
-  timeouts {
-    create = var.resourceManagementTimeout
-    delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
-  }
-
   lifecycle {
     ignore_changes = [
       extra_config,

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
@@ -165,6 +165,12 @@ resource "vsphere_virtual_machine" "node" {
     client_device = true
   }
 
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
+
   lifecycle {
     ignore_changes = [
       extra_config,

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/static-node/variables.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/static-node/variables.tf
@@ -37,6 +37,11 @@ variable "nodeGroupName" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   prefix = var.clusterConfiguration.cloud.prefix
 

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/static-node/variables.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/static-node/variables.tf
@@ -39,7 +39,7 @@ variable "nodeGroupName" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/master-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/master-node/main.tf
@@ -32,6 +32,12 @@ resource "ovirt_vm" "master_vm" {
       placement_policy_host_ids
     ]
   }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }
 
 data "ovirt_disk_attachments" "master-vm-boot-disk-attachment" {

--- a/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/master-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/master-node/main.tf
@@ -32,12 +32,6 @@ resource "ovirt_vm" "master_vm" {
       placement_policy_host_ids
     ]
   }
-
-  timeouts {
-    create = var.resourceManagementTimeout
-    delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
-  }
 }
 
 data "ovirt_disk_attachments" "master-vm-boot-disk-attachment" {

--- a/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/master-node/variables.tf
+++ b/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/master-node/variables.tf
@@ -19,6 +19,11 @@ variable "cloudConfig" {
   default = ""
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   resource_name_prefix = var.clusterConfiguration.cloud.prefix
   vnic_profile_id = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "vnicProfileID", [])

--- a/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/master-node/variables.tf
+++ b/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/master-node/variables.tf
@@ -21,7 +21,7 @@ variable "cloudConfig" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/static-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/static-node/main.tf
@@ -32,6 +32,12 @@ resource "ovirt_vm" "node_vm" {
       placement_policy_host_ids
     ]
   }
+
+  timeouts {
+    create = var.resourceManagementTimeout
+    delete = var.resourceManagementTimeout
+    update = var.resourceManagementTimeout
+  }
 }
 
 data "ovirt_disk_attachments" "node-vm-boot-disk-attachment" {

--- a/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/static-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/static-node/main.tf
@@ -32,12 +32,6 @@ resource "ovirt_vm" "node_vm" {
       placement_policy_host_ids
     ]
   }
-
-  timeouts {
-    create = var.resourceManagementTimeout
-    delete = var.resourceManagementTimeout
-    update = var.resourceManagementTimeout
-  }
 }
 
 data "ovirt_disk_attachments" "node-vm-boot-disk-attachment" {

--- a/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/static-node/variables.tf
+++ b/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/static-node/variables.tf
@@ -25,7 +25,7 @@ variable "nodeGroupName" {
 
 variable "resourceManagementTimeout" {
   type = string
-  default = "20m"
+  default = "10m"
 }
 
 locals {

--- a/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/static-node/variables.tf
+++ b/ee/se-plus/candi/cloud-providers/zvirt/terraform-modules/static-node/variables.tf
@@ -23,6 +23,11 @@ variable "nodeGroupName" {
   type = string
 }
 
+variable "resourceManagementTimeout" {
+  type = string
+  default = "20m"
+}
+
 locals {
   resource_name_prefix = var.clusterConfiguration.cloud.prefix
   ng             = [for i in var.providerClusterConfiguration.nodeGroups : i if i.name == var.nodeGroupName][0]


### PR DESCRIPTION
## Description
This PR adds `--tf-resource-management-timeout` (`DHCTL_TF_RESOURCE_MANAGEMENT_TIMEOUT`) flag and sets default terraform resource operations timeout to 10 min

Supported providers:
- AWS
- Azure
- GCP
- Yandex
- OpenStack
- Dynamix

## Why do we need it, and what problem does it solve?
In some cases, the default timeout value is not enough to create some resources.

## What is the expected result?
Terraform will use user-defined timeout on resource management operations.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: new --tf-resource-management-timeout flag,  TF default timeout set to 10min
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
