### PR TITLE
Clarify error message on bootstrap token expiration

### DIFF
--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -50,9 +50,10 @@ request = Request(sys.argv[1], headers={'Authorization': 'Bearer ' + sys.argv[2]
 try:
     response = urlopen(request, cafile='/var/lib/bashible/ca.crt')
 except HTTPError as e:
-    if e.getcode() >= 401:
+    if e.getcode() == 401:
         sys.stderr.write("Bootstrap-token compiled in this bootstrap.sh script is expired. Looks like more than 4 hours passed from the time it's been issued.\n")
         sys.exit(2)
+    print("Access to {} return HTTP Error {}: {}".format(sys.argv[2], e.getcode(), e.read()[:255]))
     sys.exit(1)
 data = json.loads(response.read())
 sys.stdout.write(data["bootstrap"])

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -41,13 +41,19 @@ import json
 import ssl
 
 try:
-    from urllib.request import urlopen, Request
+    from urllib.request import urlopen, Request, HTTPError
 except ImportError as e:
-    from urllib2 import urlopen, Request
+    from urllib2 import urlopen, Request, HTTPError
 
 ssl.match_hostname = lambda cert, hostname: True
 request = Request(sys.argv[1], headers={'Authorization': 'Bearer ' + sys.argv[2]})
-response = urlopen(request, cafile='/var/lib/bashible/ca.crt')
+try:
+    response = urlopen(request, cafile='/var/lib/bashible/ca.crt')
+except HTTPError as e:
+    if e.getcode() >= 401:
+        sys.stderr.write("Bootstrap-token compiled in this bootstrap.sh script is expired. Looks like more than 4 hours passed from the time it's been issued.\n")
+        sys.exit(2)
+    sys.exit(1)
 data = json.loads(response.read())
 sys.stdout.write(data["bootstrap"])
 EOF
@@ -62,6 +68,10 @@ function get_phase2() {
       url="https://${server}/apis/bashible.deckhouse.io/v1alpha1/bootstrap/${bootstrap_ng_name}"
       if eval "${python_binary}" - "${url}" "${token}" <<< "$(load_phase2_script)"; then
         return 0
+      else
+        if [ $? -eq 2 ]; then
+          return 1
+        fi
       fi
       >&2 echo "failed to get bootstrap ${bootstrap_ng_name} from $url"
     done


### PR DESCRIPTION
## Description

Change bootstrap.sh behavior: exit immediately by getting 401/403 from master node by bootstrapping node with human readable exception
 
## Why do we need it, and what problem does it solve?

Resolve issue #2847

## What is the expected result?

By using bootstrap.sh with expired token, exit immediately with human readable error message.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

```changes
section: node-manager
type: fix
summary: Fix bootstrap.sh behavior, exit with human readable message if it run with expired bootstrap token.
impact_level: low
```
