### PR TITLE
[testing] Fix automatic daily e2e test

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -345,7 +345,9 @@ check_e2e_labels:
     KUBERNETES_VERSION: "{!{ $ctx.kubernetesVersion }!}"
 {!{- end }!}
     EVENT_LABEL: ${{ github.event.label.name }}
+{!{- if coll.Has $ctx "manualRun" }!}
     WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+{!{- end }!}
   runs-on: [self-hosted, {!{ $runsOnLabel }!}]
   steps:
 {!{ tmpl.Exec "started_at_output" . | strings.Indent 4 }!}

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -151,7 +151,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -614,7 +613,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1085,7 +1083,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1544,7 +1541,6 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2011,7 +2007,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2470,7 +2465,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -2933,7 +2927,6 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3408,7 +3401,6 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
     runs-on: [self-hosted, e2e-common]
     steps:
 


### PR DESCRIPTION
## Description
Fix automatic daily e2e test.

## Why do we need it, and what problem does it solve?
Daily automatic e2e test currently fails as not all expected variables are passed on automated run.

## What is the expected result?
Working daily e2e test.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: fix
summary: Fix automatic daily e2e test.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
