### PR TITLE
[cloud-provider-aws] bump version aws-node-termination-handler

### DIFF
--- a/modules/030-cloud-provider-aws/images/node-termination-handler/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/node-termination-handler/werf.inc.yaml
@@ -9,23 +9,34 @@ import:
 docker:
   ENTRYPOINT: ["/node-termination-handler"]
 ---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+final: false
+fromImage: common/src-artifact
+shell:
+  install:
+  - git clone --depth 1 --branch v1.23.1 {{ $.SOURCE_REPO }}/aws/aws-node-termination-handler.git /src
+  - cd /src
+  - rm -rf .git
+---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ .Images.BASE_GOLANG_20_ALPINE }}
+from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  add: /src
+  to: /src
+  before: install
 shell:
   beforeInstall:
   - |
     apk upgrade --available --no-cache && \
-    apk add --no-cache ca-certificates git make openssh-client
+    apk add --no-cache ca-certificates make
   install:
   - export GO_VERSION=${GOLANG_VERSION}
   - export GOPROXY={{ $.GOPROXY }}
-  - mkdir -p /src
-  - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
-  - git clone --depth 1 --branch v1.5.0 {{ $.SOURCE_REPO }}/aws/aws-node-termination-handler.git /src
   - cd /src
   - make build
   - chown 64535:64535 /src/build/node-termination-handler

--- a/modules/030-cloud-provider-aws/templates/node-termination-handler/daemonset.yaml
+++ b/modules/030-cloud-provider-aws/templates/node-termination-handler/daemonset.yaml
@@ -65,6 +65,9 @@ spec:
       - name: node-termination-handler
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "nodeTerminationHandler") }}
+        args:
+        - --enable-rebalance-monitoring=true
+        - --enable-rebalance-draining=true
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
## Description
bump version aws-node-termination-handler to v1.22.1
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Added support new event "Instance Rebalance Recommendation" 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
aws-node-termination-handler reacts to the event "Instance Rebalance Recommendation" 
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: feature
summary: bump version aws-node-termination-handler to v1.22.1
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
