### PR TITLE
fix provider bootstrap

### DIFF
--- a/ee/modules/015-admission-policy-engine/hooks/update_trivy_provider_config.go
+++ b/ee/modules/015-admission-policy-engine/hooks/update_trivy_provider_config.go
@@ -113,7 +113,7 @@ func updateConfig(input *go_hook.HookInput) error {
 		return nil
 	}
 
-	// either operator-trivy or trivy-provider is disabled, cclean up the configmap
+	// either operator-trivy or trivy-provider is disabled, clean up the configmap
 	input.Values.Remove("admissionPolicyEngine.internal.trivyConfigData")
 
 	return nil

--- a/ee/modules/015-admission-policy-engine/hooks/update_trivy_provider_config.go
+++ b/ee/modules/015-admission-policy-engine/hooks/update_trivy_provider_config.go
@@ -7,16 +7,11 @@ package hooks
 
 import (
 	"fmt"
-	"maps"
 	"strings"
-	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
-	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
 
@@ -26,7 +21,7 @@ import (
 const (
 	insecureRegistryPrefix = "trivy.insecureRegistry."
 	trivyProvider          = "trivy-provider"
-	trivyProviderNs        = "d8-admission-policy-engine"
+	apeNS                  = "d8-admission-policy-engine"
 	registryCAKey          = "TRIVY_REGISTRY_CA"
 	insecureKey            = "TRIVY_INSECURE"
 )
@@ -57,22 +52,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			FilterFunc:                   filterCM,
 			ExecuteHookOnSynchronization: ptr.To(true),
 			ExecuteHookOnEvents:          ptr.To(true),
-		},
-		{
-			Name:       "trivy_provider_config",
-			ApiVersion: "v1",
-			Kind:       "ConfigMap",
-			NameSelector: &types.NameSelector{
-				MatchNames: []string{trivyProvider},
-			},
-			NamespaceSelector: &types.NamespaceSelector{
-				NameSelector: &types.NameSelector{
-					MatchNames: []string{trivyProviderNs},
-				},
-			},
-			FilterFunc:                   filterCM,
-			ExecuteHookOnSynchronization: ptr.To(false),
-			ExecuteHookOnEvents:          ptr.To(false),
 		},
 	},
 }, updateConfig)
@@ -109,7 +88,6 @@ func filterCM(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 func updateConfig(input *go_hook.HookInput) error {
 	if set.NewFromValues(input.Values, "global.enabledModules").Has("operator-trivy") && input.ConfigValues.Get("admissionPolicyEngine.denyVulnerableImages.enabled").Bool() {
 		var (
-			restartRequired bool
 			// default settings
 			trivyConfig = trivySettings{
 				InsecureDbRegistry: "false",
@@ -119,71 +97,36 @@ func updateConfig(input *go_hook.HookInput) error {
 			trivyConfig = input.Snapshots["trivy_config"][0].(trivySettings)
 		}
 
-		resultingCm := &corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "ConfigMap",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      trivyProvider,
-				Namespace: trivyProviderNs,
-				Labels: map[string]string{
-					"heritage": "deckhouse",
-					"module":   "admission-policy-engine",
-				},
-			},
-			Data: make(map[string]string, 0),
-		}
+		trivyData := make(map[string]string, 0)
 		customCA := input.Values.Get("global.modulesImages.registry.CA").String()
 
 		if len(input.Snapshots["trivy_provider_config"]) == 0 {
-			restartRequired = true
 			if len(customCA) != 0 {
-				resultingCm.Data[registryCAKey] = customCA
+				trivyData[registryCAKey] = customCA
 			}
 
-			resultingCm.Data[insecureKey] = trivyConfig.InsecureDbRegistry
+			trivyData[insecureKey] = trivyConfig.InsecureDbRegistry
 
 			for k, v := range trivyConfig.InsecureRegistries {
-				resultingCm.Data[k] = v
+				trivyData[k] = v
 			}
 		} else {
-			providerConfig := input.Snapshots["trivy_provider_config"][0].(trivySettings)
-			if (customCA != providerConfig.CustomCA) || (trivyConfig.InsecureDbRegistry != providerConfig.InsecureDbRegistry) || !maps.Equal(trivyConfig.InsecureRegistries, providerConfig.InsecureRegistries) {
-				restartRequired = true
-			}
-
 			if len(customCA) != 0 {
-				resultingCm.Data[registryCAKey] = customCA
+				trivyData[registryCAKey] = customCA
 			}
-			resultingCm.Data[insecureKey] = trivyConfig.InsecureDbRegistry
+			trivyData[insecureKey] = trivyConfig.InsecureDbRegistry
 			for k, v := range trivyConfig.InsecureRegistries {
-				resultingCm.Data[k] = v
+				trivyData[k] = v
 			}
 		}
 
-		if restartRequired {
-			input.PatchCollector.Create(resultingCm, object_patch.UpdateIfExists())
-
-			templatePatch := map[string]interface{}{
-				"spec": map[string]interface{}{
-					"template": map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"annotations": map[string]string{
-								"restartedAt": time.Now().Format(time.RFC3339),
-							},
-						},
-					},
-				},
-			}
-			input.PatchCollector.MergePatch(templatePatch, "apps/v1", "StatefulSet", trivyProviderNs, trivyProvider, object_patch.IgnoreMissingObject())
-		}
+		input.Values.Set("admissionPolicyEngine.internal.trivyConfigData", trivyData)
 
 		return nil
 	}
 
-	// either operator-trivy or trivy-provider is disabled, clean up the configmap
-	input.PatchCollector.Delete("v1", "ConfigMap", "d8-admission-policy-engine", trivyProvider)
+	// either operator-trivy or trivy-provider is disabled, cclean up the configmap
+	input.Values.Remove("admissionPolicyEngine.internal.trivyConfigData")
 
 	return nil
 }

--- a/ee/modules/015-admission-policy-engine/hooks/update_trivy_provider_config.go
+++ b/ee/modules/015-admission-policy-engine/hooks/update_trivy_provider_config.go
@@ -20,8 +20,6 @@ import (
 
 const (
 	insecureRegistryPrefix = "trivy.insecureRegistry."
-	trivyProvider          = "trivy-provider"
-	apeNS                  = "d8-admission-policy-engine"
 	registryCAKey          = "TRIVY_REGISTRY_CA"
 	insecureKey            = "TRIVY_INSECURE"
 )

--- a/ee/modules/015-admission-policy-engine/hooks/update_trivy_provider_config.go
+++ b/ee/modules/015-admission-policy-engine/hooks/update_trivy_provider_config.go
@@ -100,24 +100,12 @@ func updateConfig(input *go_hook.HookInput) error {
 		trivyData := make(map[string]string, 0)
 		customCA := input.Values.Get("global.modulesImages.registry.CA").String()
 
-		if len(input.Snapshots["trivy_provider_config"]) == 0 {
-			if len(customCA) != 0 {
-				trivyData[registryCAKey] = customCA
-			}
-
-			trivyData[insecureKey] = trivyConfig.InsecureDbRegistry
-
-			for k, v := range trivyConfig.InsecureRegistries {
-				trivyData[k] = v
-			}
-		} else {
-			if len(customCA) != 0 {
-				trivyData[registryCAKey] = customCA
-			}
-			trivyData[insecureKey] = trivyConfig.InsecureDbRegistry
-			for k, v := range trivyConfig.InsecureRegistries {
-				trivyData[k] = v
-			}
+		if len(customCA) != 0 {
+			trivyData[registryCAKey] = customCA
+		}
+		trivyData[insecureKey] = trivyConfig.InsecureDbRegistry
+		for k, v := range trivyConfig.InsecureRegistries {
+			trivyData[k] = v
 		}
 
 		input.Values.Set("admissionPolicyEngine.internal.trivyConfigData", trivyData)

--- a/ee/modules/015-admission-policy-engine/hooks/update_trivy_provider_config_test.go
+++ b/ee/modules/015-admission-policy-engine/hooks/update_trivy_provider_config_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: trivy provider 
 		})
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(Equal(`{"TRIVY_INSECURE":"false"}`))
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(MatchJSON(`{"TRIVY_INSECURE":"false"}`))
 		})
 	})
 
@@ -161,7 +161,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: trivy provider 
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config").Exists()).To(BeTrue())
-			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(Equal(`{"TRIVY_INSECURE":"false"}`))
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(MatchJSON(`{"TRIVY_INSECURE": "false"}`))
 		})
 	})
 
@@ -175,7 +175,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: trivy provider 
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config").Exists()).To(BeTrue())
-			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(Equal(`{"TRIVY_INSECURE":"false"}`))
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(MatchJSON(`{"TRIVY_INSECURE": "false"}`))
 		})
 	})
 
@@ -189,7 +189,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: trivy provider 
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config").Exists()).To(BeTrue())
-			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(Equal(`{"TRIVY_INSECURE":"false"}`))
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(MatchJSON(`{"TRIVY_INSECURE": "false"}`))
 		})
 	})
 
@@ -203,7 +203,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: trivy provider 
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config").Exists()).To(BeTrue())
-			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(Equal(`{"TRIVY_INSECURE":"false","TRIVY_REGISTRY_CA":"123"}`))
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(MatchJSON(`{"TRIVY_INSECURE": "false", "TRIVY_REGISTRY_CA": "123"}`))
 		})
 	})
 
@@ -254,7 +254,7 @@ data:
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config").Exists()).To(BeTrue())
-			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(Equal(`{"TRIVY_INSECURE":"true","trivy.insecureRegistry.0": "nexus.com"}`))
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(MatchJSON(`{"TRIVY_INSECURE":"true","trivy.insecureRegistry.0": "nexus.com"}`))
 		})
 	})
 

--- a/ee/modules/015-admission-policy-engine/hooks/update_trivy_provider_config_test.go
+++ b/ee/modules/015-admission-policy-engine/hooks/update_trivy_provider_config_test.go
@@ -97,7 +97,7 @@ spec:
 var _ = Describe("Modules :: admission-policy-engine :: hooks :: trivy provider config ::", func() {
 
 	Context(":: empty cluster", func() {
-		f := HookExecutionConfigInit("", "")
+		f := HookExecutionConfigInit(`{"admissionPolicyEngine": { "internal": {} }}`, "")
 		BeforeEach(func() {
 			f.KubeStateSet("")
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -111,7 +111,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: trivy provider 
 	})
 
 	Context(":: empty cluster with operator-trivy module enabled", func() {
-		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["operator-trivy", "foo-bar"]}}`, "")
+		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["operator-trivy", "foo-bar"]}, "admissionPolicyEngine": { "internal": {} }}`, "")
 		BeforeEach(func() {
 			f.KubeStateSet("")
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -125,7 +125,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: trivy provider 
 	})
 
 	Context(":: empty cluster with provider enabled", func() {
-		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["foo-bar"]}}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
+		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["foo-bar"]}, "admissionPolicyEngine": { "internal": {} }}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
 		BeforeEach(func() {
 			f.KubeStateSet("")
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -139,7 +139,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: trivy provider 
 	})
 
 	Context(":: empty cluster with operator-trivy enabled and provider enabled", func() {
-		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["operator-trivy", "foo-bar"]}}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
+		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["operator-trivy", "foo-bar"]}, "admissionPolicyEngine": { "internal": {} }}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
 		BeforeEach(func() {
 			f.KubeStateSet("")
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -147,26 +147,12 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: trivy provider 
 		})
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			provCm := f.KubernetesResource("ConfigMap", "d8-admission-policy-engine", "trivy-provider")
-			Expect(provCm.Exists()).To(BeTrue())
-			Expect(provCm.ToYaml()).To(MatchYAML(`
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    heritage: deckhouse
-    module: admission-policy-engine
-  name: trivy-provider
-  namespace: d8-admission-policy-engine
-data:
-  TRIVY_INSECURE: "false"
-`))
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(Equal(`{"TRIVY_INSECURE":"false"}`))
 		})
 	})
 
 	Context(":: cluster with trivy configmap, but no provider statefulset", func() {
-		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["operator-trivy", "foo-bar"]}}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
+		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["operator-trivy", "foo-bar"]}, "admissionPolicyEngine": { "internal": {} }}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
 		BeforeEach(func() {
 			f.KubeStateSet(trivyAndProviderNs + trivyCmInsecureFalse)
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -174,27 +160,13 @@ data:
 		})
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			provCm := f.KubernetesResource("ConfigMap", "d8-admission-policy-engine", "trivy-provider")
 			Expect(f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config").Exists()).To(BeTrue())
-			Expect(provCm.Exists()).To(BeTrue())
-			Expect(provCm.ToYaml()).To(MatchYAML(`
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    heritage: deckhouse
-    module: admission-policy-engine
-  name: trivy-provider
-  namespace: d8-admission-policy-engine
-data:
-  TRIVY_INSECURE: "false"
-`))
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(Equal(`{"TRIVY_INSECURE":"false"}`))
 		})
 	})
 
 	Context(":: cluster with trivy configmap and provider statefulset", func() {
-		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["operator-trivy", "foo-bar"]}}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
+		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["operator-trivy", "foo-bar"]}, "admissionPolicyEngine": { "internal": {} }}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
 		BeforeEach(func() {
 			f.KubeStateSet(trivyAndProviderNs + trivyCmInsecureFalse + providerSts)
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -202,30 +174,13 @@ data:
 		})
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			provCm := f.KubernetesResource("ConfigMap", "d8-admission-policy-engine", "trivy-provider")
 			Expect(f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config").Exists()).To(BeTrue())
-			Expect(provCm.Exists()).To(BeTrue())
-			Expect(provCm.ToYaml()).To(MatchYAML(`
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    heritage: deckhouse
-    module: admission-policy-engine
-  name: trivy-provider
-  namespace: d8-admission-policy-engine
-data:
-  TRIVY_INSECURE: "false"
-`))
-			providerSts := f.KubernetesResource("StatefulSet", "d8-admission-policy-engine", "trivy-provider")
-			Expect(providerSts.Exists()).To(BeTrue())
-			Expect(providerSts.Field("spec.template.metadata.annotations.restartedAt").String()).NotTo(Equal(""))
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(Equal(`{"TRIVY_INSECURE":"false"}`))
 		})
 	})
 
 	Context(":: cluster with equal trivy and provider configmaps, and provider statefulset", func() {
-		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["operator-trivy", "foo-bar"]}}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
+		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["operator-trivy", "foo-bar"]}, "admissionPolicyEngine": { "internal": {} }}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
 		BeforeEach(func() {
 			f.KubeStateSet(trivyAndProviderNs + trivyCmInsecureFalse + providerSts + providerCm)
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -233,18 +188,13 @@ data:
 		})
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			provCm := f.KubernetesResource("ConfigMap", "d8-admission-policy-engine", "trivy-provider")
 			Expect(f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config").Exists()).To(BeTrue())
-			Expect(provCm.Exists()).To(BeTrue())
-			Expect(provCm.ToYaml()).To(MatchYAML(providerCm))
-			providerSts := f.KubernetesResource("StatefulSet", "d8-admission-policy-engine", "trivy-provider")
-			Expect(providerSts.Exists()).To(BeTrue())
-			Expect(providerSts.Field("spec.template.metadata.annotations.restartedAt").Exists()).To(BeFalse())
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(Equal(`{"TRIVY_INSECURE":"false"}`))
 		})
 	})
 
 	Context(":: cluster with equal trivy and provider configmaps, provider statefulset and custom CA set", func() {
-		f := HookExecutionConfigInit(`{"global": {"modulesImages": {"registry": {"CA": "123"}}, "enabledModules": ["operator-trivy", "foo-bar"]}}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
+		f := HookExecutionConfigInit(`{"global": {"modulesImages": {"registry": {"CA": "123"}}, "enabledModules": ["operator-trivy", "foo-bar"]}, "admissionPolicyEngine": { "internal": {} }}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
 		BeforeEach(func() {
 			f.KubeStateSet(trivyAndProviderNs + trivyCmInsecureFalse + providerSts + providerCm)
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -252,31 +202,13 @@ data:
 		})
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			provCm := f.KubernetesResource("ConfigMap", "d8-admission-policy-engine", "trivy-provider")
 			Expect(f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config").Exists()).To(BeTrue())
-			Expect(provCm.Exists()).To(BeTrue())
-			Expect(provCm.ToYaml()).To(MatchYAML(`
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    heritage: deckhouse
-    module: admission-policy-engine
-  name: trivy-provider
-  namespace: d8-admission-policy-engine
-data:
-  TRIVY_INSECURE: "false"
-  TRIVY_REGISTRY_CA: "123"
-`))
-			providerSts := f.KubernetesResource("StatefulSet", "d8-admission-policy-engine", "trivy-provider")
-			Expect(providerSts.Exists()).To(BeTrue())
-			Expect(providerSts.Field("spec.template.metadata.annotations.restartedAt").Exists()).To(BeTrue())
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(Equal(`{"TRIVY_INSECURE":"false","TRIVY_REGISTRY_CA":"123"}`))
 		})
 	})
 
 	Context(":: cluster with different trivy and provider configmaps, provider statefulset and no custom CA set", func() {
-		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["operator-trivy", "foo-bar"]}}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
+		f := HookExecutionConfigInit(`{"global": {"enabledModules": ["operator-trivy", "foo-bar"]}, "admissionPolicyEngine": { "internal": {} }}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
 		BeforeEach(func() {
 			f.KubeStateSet(trivyAndProviderNs + `
 ---
@@ -321,31 +253,13 @@ data:
 		})
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			provCm := f.KubernetesResource("ConfigMap", "d8-admission-policy-engine", "trivy-provider")
 			Expect(f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config").Exists()).To(BeTrue())
-			Expect(provCm.Exists()).To(BeTrue())
-			Expect(provCm.ToYaml()).To(MatchYAML(`
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    heritage: deckhouse
-    module: admission-policy-engine
-  name: trivy-provider
-  namespace: d8-admission-policy-engine
-data:
-  TRIVY_INSECURE: "true"
-  trivy.insecureRegistry.0: "nexus.com"
-`))
-			providerSts := f.KubernetesResource("StatefulSet", "d8-admission-policy-engine", "trivy-provider")
-			Expect(providerSts.Exists()).To(BeTrue())
-			Expect(providerSts.Field("spec.template.metadata.annotations.restartedAt").Exists()).To(BeTrue())
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").String()).To(Equal(`{"TRIVY_INSECURE":"true","trivy.insecureRegistry.0": "nexus.com"}`))
 		})
 	})
 
 	Context(":: cluster with operator-trivy disabled, but provider configmap exists", func() {
-		f := HookExecutionConfigInit(`{"global": {"modulesImages": {"registry": {"CA": "123"}}, "enabledModules": ["foo-bar"]}}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
+		f := HookExecutionConfigInit(`{"global": {"modulesImages": {"registry": {"CA": "123"}}, "enabledModules": ["foo-bar"]}, "admissionPolicyEngine": { "internal": {} }}`, `{"admissionPolicyEngine": {"denyVulnerableImages": {"enabled": true}}}`)
 		BeforeEach(func() {
 			f.KubeStateSet(trivyAndProviderNs + providerCm)
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -353,9 +267,8 @@ data:
 		})
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			provCm := f.KubernetesResource("ConfigMap", "d8-admission-policy-engine", "trivy-provider")
 			Expect(f.KubernetesResource("ConfigMap", "d8-operator-trivy", "trivy-operator-trivy-config").Exists()).To(BeFalse())
-			Expect(provCm.Exists()).To(BeFalse())
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trivyConfigData").Exists()).To(BeFalse())
 		})
 	})
 })

--- a/ee/modules/015-admission-policy-engine/templates/trivy-provider/configmap.yaml
+++ b/ee/modules/015-admission-policy-engine/templates/trivy-provider/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if include "trivy.provider.enabled" $ }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trivy-provider
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "trivy-provider" "app.kubernetes.io/part-of" "gatekeeper")) | nindent 2 }}
+data:
+  {{- .Values.admissionPolicyEngine.internal.trivyConfigData | toYaml | nindent 2 }}
+{{- end }}

--- a/ee/modules/015-admission-policy-engine/templates/trivy-provider/configmap.yaml
+++ b/ee/modules/015-admission-policy-engine/templates/trivy-provider/configmap.yaml
@@ -1,4 +1,5 @@
 {{- if include "trivy.provider.enabled" $ }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/ee/modules/015-admission-policy-engine/templates/trivy-provider/statefulset.yaml
+++ b/ee/modules/015-admission-policy-engine/templates/trivy-provider/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: { { include (print $.Template.BasePath "/configmap.yaml") . | sha256sum } }
+        checksum/config: { { include (print $.Template.BasePath "/trivy-provider/configmap.yaml") . | sha256sum } }
       labels:
         app: trivy-provider
         app.kubernetes.io/part-of: gatekeeper

--- a/ee/modules/015-admission-policy-engine/templates/trivy-provider/statefulset.yaml
+++ b/ee/modules/015-admission-policy-engine/templates/trivy-provider/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: { { include (print $.Template.BasePath "/trivy-provider/configmap.yaml") . | sha256sum } }
+        checksum/config: {{ include (print $.Template.BasePath "/trivy-provider/configmap.yaml") . | sha256sum }}
       labels:
         app: trivy-provider
         app.kubernetes.io/part-of: gatekeeper

--- a/ee/modules/015-admission-policy-engine/templates/trivy-provider/statefulset.yaml
+++ b/ee/modules/015-admission-policy-engine/templates/trivy-provider/statefulset.yaml
@@ -43,6 +43,8 @@ spec:
       app.kubernetes.io/part-of: gatekeeper
   template:
     metadata:
+      annotations:
+        checksum/config: { { include (print $.Template.BasePath "/configmap.yaml") . | sha256sum } }
       labels:
         app: trivy-provider
         app.kubernetes.io/part-of: gatekeeper

--- a/modules/015-admission-policy-engine/openapi/values.yaml
+++ b/modules/015-admission-policy-engine/openapi/values.yaml
@@ -124,3 +124,9 @@ properties:
                     type: string
                   registrytoken:
                     type: string
+      trivyConfigData:
+        type: object
+        additionalProperties:
+          type: string
+        description: |
+          Configuration for trivy. Fetched from the trivy config map.


### PR DESCRIPTION
## Description
Fix trivy-provider configuration

## Why do we need it, and what problem does it solve?
Admission-policy-engine can stuck on bootstrap.
Because of BeforeHelm it generates the error:
```
    * Create object: v1/ConfigMap/d8-admission-policy-engine/trivy-provider: namespaces "d8-admission-policy-engine" not found
```
and we can't run trivy-provider pod without the cm

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
```
# kubectl -n d8-admission-policy-engine  get cm
NAME                     DATA   AGE
constraint-exporter      2      377d
istio-ca-root-cert       1      20d
kube-rbac-proxy-ca.crt   1      377d
kube-root-ca.crt         1      377d
```

enable the flag
```
spec:
  enabled: true
  settings:
    denyVulnerableImages:
      enabled: true
```

after
```
# kubectl -n d8-admission-policy-engine  get cm trivy-provider  -o yaml
apiVersion: v1
data:
  TRIVY_INSECURE: "false"
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: admission-policy-engine
    meta.helm.sh/release-namespace: d8-system
  creationTimestamp: "2024-11-28T15:01:28Z"
  labels:
    app: trivy-provider
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: gatekeeper
    heritage: deckhouse
    module: admission-policy-engine
  name: trivy-provider
  namespace: d8-admission-policy-engine
  resourceVersion: "350952439"
  uid: 06706113-6920-430d-a51e-d6e3ea2bbf84
```

On trivy-operator cm change:
```
apiVersion: v1
data:
  TRIVY_INSECURE: "true"
  trivy.insecureRegistry.0: nexus.com
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: admission-policy-engine
    meta.helm.sh/release-namespace: d8-system
  creationTimestamp: "2024-11-28T15:01:28Z"
  labels:
    app: trivy-provider
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: gatekeeper
    heritage: deckhouse
    module: admission-policy-engine
  name: trivy-provider
  namespace: d8-admission-policy-engine
  resourceVersion: "350962269"
  uid: 06706113-6920-430d-a51e-d6e3ea2bbf84
```
and pod restarted
```
trivy-provider-0                                1/1     Running   0          4s
```


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: fix
summary: Fix trivy-provider bootstrap process.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
