### PR TITLE
[node-local-dns] Fix iptables-loop container exit in non-cilium installations

### DIFF
--- a/ee/be/modules/350-node-local-dns/images/iptables-loop/iptables-loop.sh
+++ b/ee/be/modules/350-node-local-dns/images/iptables-loop/iptables-loop.sh
@@ -37,7 +37,6 @@ function check_readiness() {
     fi
   else
     echo "Unknown state in file \"$readiness_file_path\": \"$(< "$readiness_file_path")\""
-    exit 1
   fi
 }
 


### PR DESCRIPTION
## Description
In the current version of DKP there is a bug in the nodelocaldns module in configurations where iptables is used (if CNI not cillium).

## Why do we need it, and what problem does it solve?

The bug is that the `iptables-loop` script checks the file.
If an unknown string is written to the file, but the script exits with code 1.
However, healthcheck is not implemented for this container (the pod only has healthcheck for the `coredns` container) and after exiting the pod is not restarted. In this case, file monitoring and making changes to iptables are disabled, which after a while leads to the failure of the service (requests go directly to kube-dns).
Tested on two clusters


## What is the expected result?

After removing the exit command, the `iptables-loop` container should continue to monitor the file for changes (in the hope that the output will normalize)

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section:  node-local-dns
type: fix  
summary: Fix iptables-loop container exit in non-cilium installations
impact_level: low
```
