### PR TITLE
[testing] Fix e2e tests on alternative editions for PRs

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -290,6 +290,7 @@ check_e2e_labels:
     {!{ printf "run_%s_%s: ${{ steps.check.outputs.run_%s_%s }}" $cri $kubernetesVersionSlug $cri $kubernetesVersionSlug }!}
 {!{- end -}!}
 {!{- end }!}
+    edition: ${{ steps.check.outputs.edition }}
     multimaster: ${{ steps.check.outputs.multimaster }}
   steps:
 {!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
@@ -346,7 +347,7 @@ check_e2e_labels:
 {!{- end }!}
     EVENT_LABEL: ${{ github.event.label.name }}
 {!{- if coll.Has $ctx "manualRun" }!}
-    WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+    WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
 {!{- end }!}
   runs-on: [self-hosted, {!{ $runsOnLabel }!}]
   steps:

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -478,10 +478,11 @@ const setCRIAndVersionsFromLabels = ({ core, labels, kubernetesDefaultVersion })
   let ver = [];
   let cri = [];
   let multimaster = e2eDefaults.multimaster;
+  let edition = "";
 
   for (const label of labels) {
     const info = knownLabels[label.name];
-    if (!info || info.type !== 'e2e-use') {
+    if (!info || (info.type !== 'e2e-use' && info.type !== 'edition')) {
       continue;
     }
     if (info.cri) {
@@ -491,6 +492,10 @@ const setCRIAndVersionsFromLabels = ({ core, labels, kubernetesDefaultVersion })
     if (info.ver) {
       core.info(`Detect '${label.name}': use Kubernetes version '${info.ver}'`);
       ver.push(info.ver.replace(/\./g, '_'));
+    }
+    if (info.edition) {
+      core.info(`Detect '${label.name}': use edition '${info.edition}'`);
+      edition = info.edition;
     }
     if (info.multimaster) {
       core.info(`Detect '${label.name}': use Kubernetes multimaster configuration`);
@@ -512,6 +517,7 @@ const setCRIAndVersionsFromLabels = ({ core, labels, kubernetesDefaultVersion })
 
   core.startGroup(`Set outputs`);
   core.setCommandEcho(true);
+  core.setOutput(`edition`, `${edition}`);
   core.setOutput(`multimaster`, `${multimaster}`);
   for (const out_cri of cri) {
     for (const out_ver of ver) {

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -51,11 +51,11 @@ const labels = {
   'e2e/use/multimaster': { type: 'e2e-use', multimaster: true },
 
   // E2E: edition
-  'e2e/use/edition/ce': { type: 'e2e-edition', edition: 'CE' },
-  'e2e/use/edition/ee': { type: 'e2e-edition', edition: 'EE' },
-  'e2e/use/edition/be': { type: 'e2e-edition', edition: 'BE' },
-  'e2e/use/edition/se': { type: 'e2e-edition', edition: 'SE' },
-  'e2e/use/edition/fe': { type: 'e2e-edition', edition: 'FE' },
+  'e2e/use/edition/ce': { type: 'e2e-use', edition: 'CE' },
+  'e2e/use/edition/ee': { type: 'e2e-use', edition: 'EE' },
+  'e2e/use/edition/be': { type: 'e2e-use', edition: 'BE' },
+  'e2e/use/edition/se': { type: 'e2e-use', edition: 'SE' },
+  'e2e/use/edition/fe': { type: 'e2e-use', edition: 'FE' },
 
   // Allow running workflows for external PRs.
   'status/ok-to-test': { type: 'ok-to-test' },

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -81,6 +81,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -81,6 +81,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -81,6 +81,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -81,6 +81,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -81,6 +81,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -81,6 +81,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -81,6 +81,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -81,6 +81,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -81,6 +81,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -172,6 +172,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 
@@ -216,7 +217,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -708,7 +709,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1200,7 +1201,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1692,7 +1693,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2184,7 +2185,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2676,7 +2677,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3168,7 +3169,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -172,6 +172,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 
@@ -216,7 +217,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -716,7 +717,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1216,7 +1217,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1716,7 +1717,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2216,7 +2217,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2716,7 +2717,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3216,7 +3217,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -172,6 +172,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 
@@ -216,7 +217,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -753,7 +754,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1290,7 +1291,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1827,7 +1828,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2364,7 +2365,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2901,7 +2902,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3438,7 +3439,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -172,6 +172,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 
@@ -216,7 +217,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -704,7 +705,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1192,7 +1193,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1680,7 +1681,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2168,7 +2169,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2656,7 +2657,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3144,7 +3145,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -172,6 +172,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 
@@ -216,7 +217,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -704,7 +705,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1192,7 +1193,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1680,7 +1681,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2168,7 +2169,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2656,7 +2657,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3144,7 +3145,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -172,6 +172,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 
@@ -216,7 +217,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -704,7 +705,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1192,7 +1193,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1680,7 +1681,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2168,7 +2169,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2656,7 +2657,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3144,7 +3145,7 @@ jobs:
       LAYOUT: Static
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -172,6 +172,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 
@@ -216,7 +217,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -720,7 +721,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1224,7 +1225,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1728,7 +1729,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2232,7 +2233,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2736,7 +2737,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3240,7 +3241,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -172,6 +172,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 
@@ -216,7 +217,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -708,7 +709,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -1200,7 +1201,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -1692,7 +1693,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -2184,7 +2185,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -2676,7 +2677,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 
@@ -3168,7 +3169,7 @@ jobs:
       LAYOUT: Standard
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
 

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -172,6 +172,7 @@ jobs:
       run_containerd_1_30: ${{ steps.check.outputs.run_containerd_1_30 }}
       run_containerd_1_31: ${{ steps.check.outputs.run_containerd_1_31 }}
       run_containerd_automatic: ${{ steps.check.outputs.run_containerd_automatic }}
+      edition: ${{ steps.check.outputs.edition }}
       multimaster: ${{ steps.check.outputs.multimaster }}
     steps:
 
@@ -216,7 +217,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.26"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -712,7 +713,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.27"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1208,7 +1209,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.28"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -1704,7 +1705,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.29"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2200,7 +2201,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.30"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -2696,7 +2697,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "1.31"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 
@@ -3192,7 +3193,7 @@ jobs:
       LAYOUT: WithoutNAT
       KUBERNETES_VERSION: "Automatic"
       EVENT_LABEL: ${{ github.event.label.name }}
-      WERF_ENV: "${{ fromJson(inputs.test_config).edition || 'FE'}}"
+      WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
 


### PR DESCRIPTION
## Description
Fix e2e tests on alternative editions (non-FE) for PRs

## Why do we need it, and what problem does it solve?
Previous change to e2e test logic (changed in #9769) did not work with different ways to set edition. Fixed.

## What is the expected result?
It should be possible to run e2e tests on alternative editions as was previously possible.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: fix
summary:  Fix e2e tests on alternative editions for PRs.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
