### PR TITLE
[extended-monitoring] Add namespace-scoped overrides for threshold labels

### DIFF
--- a/modules/340-extended-monitoring/docs/CONFIGURATION.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION.md
@@ -18,6 +18,10 @@ Any of the methods above would result in the emergence of the default metrics (+
 You can also add custom labels with the specified value to `threshold.extended-monitoring.deckhouse.io/something` Kubernetes objects, e.g., `kubectl label pod test threshold.extended-monitoring.deckhouse.io/disk-inodes-warning=30`.
 In this case, the label value will replace the default one.
 
+If you want to override the default thresholds for all objects in a namespace, you can set the `threshold.extended-monitoring.deckhouse.io/` label at the namespace level. For example:
+`kubectl label namespace my-app-production threshold.extended-monitoring.deckhouse.io/disk-inodes-warning=30`
+This will replace the default value for all objects in the namespace that do not already have this label set.
+
 You can disable monitoring on a per-object basis by adding the `extended-monitoring.deckhouse.io/enabled=false` label to it. Thus, the default labels will also be disabled (as well as label-based alerts).
 
 ### Standard labels and supported Kubernetes objects

--- a/modules/340-extended-monitoring/docs/CONFIGURATION.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION.md
@@ -19,7 +19,7 @@ You can also add custom labels with the specified value to `threshold.extended-m
 In this case, the label value will replace the default one.
 
 If you want to override the default thresholds for all objects in a namespace, you can set the `threshold.extended-monitoring.deckhouse.io/` label at the namespace level. For example:
-`kubectl label namespace my-app-production threshold.extended-monitoring.deckhouse.io/disk-inodes-warning=30`
+`kubectl label namespace my-app-production threshold.extended-monitoring.deckhouse.io/5xx-warning=20`
 This will replace the default value for all objects in the namespace that do not already have this label set.
 
 You can disable monitoring on a per-object basis by adding the `extended-monitoring.deckhouse.io/enabled=false` label to it. Thus, the default labels will also be disabled (as well as label-based alerts).

--- a/modules/340-extended-monitoring/docs/CONFIGURATION.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION.md
@@ -3,8 +3,6 @@ title: "The extended-monitoring module: configuration"
 force_searchable: true
 ---
 
-<!-- SCHEMA -->
-
 ## How to use `extended-monitoring-exporter`
 
 Attach the `extended-monitoring.deckhouse.io/enabled` label to the Namespace to enable the export of extended monitoring metrics. You can do it by:
@@ -122,3 +120,5 @@ After:
   max by (namespace, statefulset) (extended_monitoring_statefulset_threshold{threshold="replicas-not-ready"})
 )
 ```
+
+<!-- SCHEMA -->

--- a/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
@@ -18,7 +18,7 @@ force_searchable: true
 К Kubernetes-объектам `threshold.extended-monitoring.deckhouse.io/что-то свое` можно добавить любые другие лейблы с указанным значением. Пример: `kubectl label pod test threshold.extended-monitoring.deckhouse.io/disk-inodes-warning=30`.
 В таком случае значение из лейбла заменит значение по умолчанию.
 
-Если вы хотите переопределить значения threshold для всех объектов в определенном namespace, вы можете установить лейбл `threshold.extended-monitoring.deckhouse.io/` на уровне namespace. Например: `kubectl label namespace my-app-production threshold.extended-monitoring.deckhouse.io/disk-inodes-warning=30`.
+Если вы хотите переопределить значения threshold для всех объектов в определенном namespace, вы можете установить лейбл `threshold.extended-monitoring.deckhouse.io/` на уровне namespace. Например: `kubectl label namespace my-app-production threshold.extended-monitoring.deckhouse.io/5xx-warning=20`.
 Это заменит значение по умолчанию для всех объектов namespace, для которых еще не установлен этот лейбл.
 
 Слежение за объектом можно отключить индивидуально, поставив на него лейбл `extended-monitoring.deckhouse.io/enabled=false`. Соответственно, отключатся и лейблы по умолчанию, а также все алерты, привязанные к лейблам.

--- a/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
@@ -18,7 +18,7 @@ force_searchable: true
 К Kubernetes-объектам `threshold.extended-monitoring.deckhouse.io/что-то свое` можно добавить любые другие лейблы с указанным значением. Пример: `kubectl label pod test threshold.extended-monitoring.deckhouse.io/disk-inodes-warning=30`.
 В таком случае значение из лейбла заменит значение по умолчанию.
 
-Если вы хотите переопределить значения threshold для всех объектов в определенном namespace, вы можете установить лейбл `threshold.extended-monitoring.deckhouse.io/` на уровне namespace. Например: `kubectl label namespace my-app-production threshold.extended-monitoring.deckhouse.io/5xx-warning=20`.
+Если вы хотите переопределить значения threshold для всех объектов в определенном пространстве имен, вы можете установить лейбл `threshold.extended-monitoring.deckhouse.io/` на уровне namespace. Например: `kubectl label namespace my-app-production threshold.extended-monitoring.deckhouse.io/5xx-warning=20`.
 Это заменит значение по умолчанию для всех объектов namespace, для которых еще не установлен этот лейбл.
 
 Слежение за объектом можно отключить индивидуально, поставив на него лейбл `extended-monitoring.deckhouse.io/enabled=false`. Соответственно, отключатся и лейблы по умолчанию, а также все алерты, привязанные к лейблам.

--- a/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
@@ -18,6 +18,9 @@ force_searchable: true
 К Kubernetes-объектам `threshold.extended-monitoring.deckhouse.io/что-то свое` можно добавить любые другие лейблы с указанным значением. Пример: `kubectl label pod test threshold.extended-monitoring.deckhouse.io/disk-inodes-warning=30`.
 В таком случае значение из лейбла заменит значение по умолчанию.
 
+Если вы хотите переопределить значения threshold для всех объектов в определенном namespace, вы можете установить лейбл `threshold.extended-monitoring.deckhouse.io/` на уровне namespace. Например: `kubectl label namespace my-app-production threshold.extended-monitoring.deckhouse.io/disk-inodes-warning=30`.
+Это заменит значение по умолчанию для всех объектов namespace, для которых еще не установлен этот лейбл.
+
 Слежение за объектом можно отключить индивидуально, поставив на него лейбл `extended-monitoring.deckhouse.io/enabled=false`. Соответственно, отключатся и лейблы по умолчанию, а также все алерты, привязанные к лейблам.
 
 ### Стандартные лейблы и поддерживаемые Kubernetes-объекты

--- a/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
+++ b/modules/340-extended-monitoring/docs/CONFIGURATION_RU.md
@@ -3,17 +3,15 @@ title: "Модуль extended-monitoring: настройки"
 force_searchable: true
 ---
 
-<!-- SCHEMA -->
-
 ## Как использовать `extended-monitoring-exporter`
 
-Чтобы включить экспортирование extended-monitoring метрик, нужно навесить на namespace лейбл `extended-monitoring.deckhouse.io/enabled` любым удобным способом, например:
+Чтобы включить экспортирование extended-monitoring метрик, нужно указать в пространстве имён лейбл `extended-monitoring.deckhouse.io/enabled` любым удобным способом, например:
 - добавить в проект соответствующий helm-чарт (рекомендуемый);
 - добавить в описание `.gitlab-ci.yml` (kubectl patch/create);
-- поставить руками (`kubectl label namespace my-app-production extended-monitoring.deckhouse.io/enabled=""`);
+- добавить вручную (`kubectl label namespace my-app-production extended-monitoring.deckhouse.io/enabled=""`);
 - настроить через [namespace-configurator](../namespace-configurator/) модуль.
 
-Сразу же после этого для всех поддерживаемых Kubernetes-объектов в данном namespace в Prometheus появятся default-метрики + любые кастомные с префиксом `threshold.extended-monitoring.deckhouse.io/`. Для ряда [non-namespaced](#non-namespaced-kubernetes-объекты) Kubernetes-объектов, описанных ниже, мониторинг включается автоматически.
+Сразу же после этого для всех поддерживаемых Kubernetes-объектов в данном пространстве имён в Prometheus появятся default-метрики + любые кастомные с префиксом `threshold.extended-monitoring.deckhouse.io/`. Для ряда [non-namespaced](#non-namespaced-kubernetes-объекты) Kubernetes-объектов, описанных ниже, мониторинг включается автоматически.
 
 К Kubernetes-объектам `threshold.extended-monitoring.deckhouse.io/что-то свое` можно добавить любые другие лейблы с указанным значением. Пример: `kubectl label pod test threshold.extended-monitoring.deckhouse.io/disk-inodes-warning=30`.
 В таком случае значение из лейбла заменит значение по умолчанию.
@@ -33,62 +31,62 @@ force_searchable: true
 
 #### Non-namespaced Kubernetes-объекты
 
-Non-namespaced Kubernetes-объекты не нуждаются в лейблах на namespace и мониторинг на них включается по умолчанию при включении модуля.
+Non-namespaced Kubernetes-объекты, то есть объекты вне пространств имён, не нуждаются в лейблах на этих пространствах и мониторинг на них включается по умолчанию при включении модуля.
 
-##### Node
+##### Узел
 
-| Label                                   | Type          | Default value  |
-|-----------------------------------------|---------------|----------------|
-| disk-bytes-warning                      | int (percent) | 70             |
-| disk-bytes-critical                     | int (percent) | 80             |
-| disk-inodes-warning                     | int (percent) | 90             |
-| disk-inodes-critical                    | int (percent) | 95             |
-| load-average-per-core-warning           | int           | 3              |
-| load-average-per-core-critical          | int           | 10             |
+| Лейбл                          | Тип           | Значение по умолчанию |
+|--------------------------------|---------------|-----------------------|
+| disk-bytes-warning             | int (percent) | 70                    |
+| disk-bytes-critical            | int (percent) | 80                    |
+| disk-inodes-warning            | int (percent) | 90                    |
+| disk-inodes-critical           | int (percent) | 95                    |
+| load-average-per-core-warning  | int           | 3                     |
+| load-average-per-core-critical | int           | 10                    |
 
 > **Важно!** Эти лейблы **не** действуют для тех разделов, в которых расположены `imagefs` (по умолчанию — `/var/lib/docker`) и `nodefs` (по умолчанию — `/var/lib/kubelet`).
 Для этих разделов пороги настраиваются полностью автоматически согласно [eviction thresholds в kubelet](https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/).
-Значения по умолчанию см. [тут](https://github.com/kubernetes/kubernetes/blob/743e4fba6339237cc8d5c11413f76ea54b4cc3e8/pkg/kubelet/apis/config/v1beta1/defaults_linux.go#L22-L27), подробнее см. [экспортер](https://github.com/deckhouse/deckhouse/blob/main/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/).
+Значения по умолчанию указаны в документации [Kubernetes](https://github.com/kubernetes/kubernetes/blob/743e4fba6339237cc8d5c11413f76ea54b4cc3e8/pkg/kubelet/apis/config/v1beta1/defaults_linux.go#L22-L27), в описании [экспортера](https://github.com/deckhouse/deckhouse/blob/main/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/).
 
 #### Namespaced Kubernetes-объекты
 
 ##### Под
 
-| Label                                   | Type          | Default value  |
-|-----------------------------------------|---------------|----------------|
-| disk-bytes-warning                      | int (percent) | 85             |
-| disk-bytes-critical                     | int (percent) | 95             |
-| disk-inodes-warning                     | int (percent) | 85             |
-| disk-inodes-critical                    | int (percent) | 90             |
+| Лейбл                | Тип           | Значение по умолчанию |
+|----------------------|---------------|-----------------------|
+| disk-bytes-warning   | int (percent) | 85                    |
+| disk-bytes-critical  | int (percent) | 95                    |
+| disk-inodes-warning  | int (percent) | 85                    |
+| disk-inodes-critical | int (percent) | 90                    |
 
 ##### Ingress
 
-| Label                  | Type          | Default value |
-|------------------------|---------------|---------------|
-| 5xx-warning            | int (percent) | 10            |
-| 5xx-critical           | int (percent) | 20            |
+| Лейбл        | Тип           | Значение по умолчанию |
+|--------------|---------------|-----------------------|
+| 5xx-warning  | int (percent) | 10                    |
+| 5xx-critical | int (percent) | 20                    |
 
 ##### Deployment
 
-| Label                  | Type          | Default value |
-|------------------------|---------------|---------------|
-| replicas-not-ready     | int (count)   | 0             |
+| Лейбл              | Тип         | Значение по умолчанию |
+|--------------------|-------------|-----------------------|
+| replicas-not-ready | int (count) | 0                     |
 
-Порог подразумевает количество недоступных реплик **сверх** [maxUnavailable](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable). Сработает, если недоступно реплик больше на указанное значение, чем разрешено в `maxUnavailable`. То есть при нуле сработает, если недоступно больше, чем указано в `maxUnavailable`, а при единице сработает, если недоступно больше, чем указано в `maxUnavailable`, плюс 1. Таким образом, у конкретных Deployment, которые находятся в namespace со включенным расширенным мониторингом и которым допустимо быть недоступными, можно подкрутить этот параметр, чтобы не получать ненужные алерты.
+Порог подразумевает количество недоступных реплик **сверх** [maxUnavailable](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable). Сработает, если недоступно реплик больше на указанное значение, чем разрешено в `maxUnavailable`. То есть при нуле сработает, если недоступно больше, чем указано в `maxUnavailable`, а при единице сработает, если недоступно больше, чем указано в `maxUnavailable`, плюс 1. Таким образом, у конкретных Deployment, которые находятся в пространстве имён со включенным расширенным мониторингом и которым допустимо быть недоступными, можно установить этот параметр, чтобы не получать ненужные алерты.
 
 ##### StatefulSet
 
-| Label                  | Type          | Default value |
-|------------------------|---------------|---------------|
-| replicas-not-ready     | int (count)   | 0             |
+| Лейбл              | Тип         | Значение по умолчанию |
+|--------------------|-------------|-----------------------|
+| replicas-not-ready | int (count) | 0                     |
 
 Порог подразумевает количество недоступных реплик **сверх** [maxUnavailable](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable) (см. комментарии к [Deployment](#deployment)).
 
 ##### DaemonSet
 
-| Label                  | Type          | Default value |
-|------------------------|---------------|---------------|
-| replicas-not-ready     | int (count)   | 0             |
+| Лейбл              | Тип         | Значение по умолчанию |
+|--------------------|-------------|-----------------------|
+| replicas-not-ready | int (count) | 0                     |
 
 Порог подразумевает количество недоступных реплик **сверх** [maxUnavailable](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable) (см. комментарии к [Deployment](#deployment)).
 
@@ -121,3 +119,5 @@ Non-namespaced Kubernetes-объекты не нуждаются в лейбла
   max by (namespace, statefulset) (extended_monitoring_statefulset_threshold{threshold="replicas-not-ready"})
 )
 ```
+
+<!-- SCHEMA -->

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
@@ -58,17 +58,12 @@ def is_monitoring_enabled(labels, annotations):
 
 
 def parse_thresholds(labels, annotations, default_thresholds, namespace=None):
-    """
-    Parses and returns thresholds by overriding default values with those from
-    namespace labels, annotations, and object labels.
-    """
     thresholds = copy.deepcopy(default_thresholds)
     if namespace:
         for name, value in corev1.read_namespace(namespace).metadata.labels.items():
             if name.startswith(EXTENDED_MONITORING_LABEL_THRESHOLD_PREFIX):
                 unprefixed_name = name.replace(EXTENDED_MONITORING_LABEL_THRESHOLD_PREFIX, "")
                 thresholds[unprefixed_name] = value
-                logging.info('Overiding defaults with namespace values: {}/{}'.format(name, value))
     if annotations:
         for name, value in annotations.items():
             if name.startswith(DEPRECATED_EXTENDED_MONITORING_ANNOTATION_THRESHOLD_PREFIX):

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
@@ -63,7 +63,8 @@ def parse_thresholds(labels, annotations, default_thresholds, namespace=None):
         for name, value in corev1.read_namespace(namespace).metadata.labels.items():
             if name.startswith(EXTENDED_MONITORING_LABEL_THRESHOLD_PREFIX):
                 unprefixed_name = name.replace(EXTENDED_MONITORING_LABEL_THRESHOLD_PREFIX, "")
-                thresholds[unprefixed_name] = value
+                if unprefixed_name in thresholds:
+                    thresholds[unprefixed_name] = value
     if annotations:
         for name, value in annotations.items():
             if name.startswith(DEPRECATED_EXTENDED_MONITORING_ANNOTATION_THRESHOLD_PREFIX):


### PR DESCRIPTION
Add namespace-scoped overrides for threshold.extended-monitoring.flant.com labels

## Description
- Enable overriding default thresholds using `threshold.extended-monitoring.flant.com` labels at the namespace level.
- Small indention fixes for /metrics output.

## Why do we need it, and what problem does it solve?
- It enables applying diffirent threshold values for resources in a namespace without modifying each resources individually. Closes https://github.com/deckhouse/deckhouse/issues/8352  

## Why do we need it in the patch release (if we do)?

-->

## What is the expected result?
Namespace-level labels `threshold.extended-monitoring.flant.com`  will override the default thresholds.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: feature
summary: Namespace-level `threshold.extended-monitoring.flant.com` labels now override default threshold values for objects lacking the label.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
