### PR TITLE
[dhctl] Forbid to use `logLevel` `bundle` and `releaseChannel` from deckhouse init configuration

### DIFF
--- a/candi/openapi/init_configuration.yaml
+++ b/candi/openapi/init_configuration.yaml
@@ -58,32 +58,8 @@ apiVersions:
             description: Registry access scheme (HTTP or HTTPS).
             enum: [HTTP, HTTPS]
             default: HTTPS
-          releaseChannel:
-            type: string
-            deprecated: true
-            description: |
-              Instead of this parameter, use the [releaseChannel](../modules/002-deckhouse/configuration.html#parameters-releasechannel) parameter of the ModuleConfig 'deckhouse'.
-
-              The release channel to use in the cluster.
-            enum: [Alpha, Beta, EarlyAccess, Stable, RockSolid]
           devBranch:
             type: string
             deprecated: true
             description: |
               The parameter is used for development needs. Will be replaced with the CLI-tools.
-          bundle:
-            type: string
-            deprecated: true
-            description: |
-              Instead of this parameter, use the [bundle](../modules/002-deckhouse/configuration.html#parameters-bundle) parameter of the ModuleConfig 'deckhouse'.
-
-              The Deckhouse bundle to use in the cluster.
-            enum: [Minimal, Managed, Default]
-          logLevel:
-            type: string
-            deprecated: true
-            description: |
-              Instead of this parameter, use the [logLevel](../modules/002-deckhouse/configuration.html#parameters-loglevel) parameter of the ModuleConfig 'deckhouse'.
-
-              Deckhouse logging Level.
-            enum: [Debug, Info, Error]

--- a/candi/openapi/init_configuration.yaml
+++ b/candi/openapi/init_configuration.yaml
@@ -79,7 +79,6 @@ apiVersions:
 
               The Deckhouse bundle to use in the cluster.
             enum: [Minimal, Managed, Default]
-            default: Default
           logLevel:
             type: string
             deprecated: true
@@ -88,4 +87,3 @@ apiVersions:
 
               Deckhouse logging Level.
             enum: [Debug, Info, Error]
-            default: Info

--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -117,7 +117,7 @@ func PrepareDeckhouseInstallConfig(metaConfig *MetaConfig) (*DeckhouseInstaller,
 	}
 
 	if metaConfig.DeckhouseConfig.LogLevel != "" {
-		return nil, fmt.Errorf("Support for 'logLevel' was removed. Please use 'deckhouse' ModuleConfig's settings instead.")
+		return nil, fmt.Errorf("Support for 'logLevel' in InitConfiguration was removed. Please use 'deckhouse' ModuleConfig's settings instead.")
 	}
 
 	clusterConfig, err := metaConfig.ClusterConfigYAML()

--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -29,25 +29,6 @@ import (
 )
 
 const (
-	initConfigurationError = `%s fields in InitConfiguration are deprecated.
-Please use ModuleConfig 'deckhouse' section in configuration. Example:
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ClusterConfiguration
-...
-apiVersion: deckhouse.io/v1alpha1
-kind: InitConfiguration
-...
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: deckhouse
-spec:
-  settings:
-    %s
-`
-
 	DefaultBundle   = "Default"
 	DefaultLogLevel = "Info"
 )
@@ -125,6 +106,18 @@ func PrepareDeckhouseInstallConfig(metaConfig *MetaConfig) (*DeckhouseInstaller,
 
 	if len(metaConfig.DeckhouseConfig.ConfigOverrides) > 0 {
 		return nil, fmt.Errorf("Support for 'configOverrides' was removed. Please use ModuleConfig's instead.")
+	}
+
+	if metaConfig.DeckhouseConfig.ReleaseChannel != "" {
+		return nil, fmt.Errorf("Support for 'releaseChannel' was removed. Please use 'deckhouse' ModuleConfig's settings instead.")
+	}
+
+	if metaConfig.DeckhouseConfig.Bundle != "" {
+		return nil, fmt.Errorf("Support for 'bundle' was removed. Please use 'deckhouse' ModuleConfig's settings instead.")
+	}
+
+	if metaConfig.DeckhouseConfig.LogLevel != "" {
+		return nil, fmt.Errorf("Support for 'logLevel' was removed. Please use 'deckhouse' ModuleConfig's settings instead.")
 	}
 
 	clusterConfig, err := metaConfig.ClusterConfigYAML()

--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -113,7 +113,7 @@ func PrepareDeckhouseInstallConfig(metaConfig *MetaConfig) (*DeckhouseInstaller,
 	}
 
 	if metaConfig.DeckhouseConfig.Bundle != "" {
-		return nil, fmt.Errorf("Support for 'bundle' was removed. Please use 'deckhouse' ModuleConfig's settings instead.")
+		return nil, fmt.Errorf("Support for 'bundle' in InitConfiguration was removed. Please use 'deckhouse' ModuleConfig's settings instead.")
 	}
 
 	if metaConfig.DeckhouseConfig.LogLevel != "" {

--- a/dhctl/pkg/config/deckhouse_config_test.go
+++ b/dhctl/pkg/config/deckhouse_config_test.go
@@ -39,6 +39,10 @@ deckhouse:
   bundle: {{ .bundle }}
 {{- end }}
 
+{{- if .releaseChannel }}
+  releaseChannel: {{ .releaseChannel }}
+{{- end }}
+
 {{- if .logLevel }}
   logLevel: {{ .logLevel }}
 {{- end }}
@@ -142,6 +146,33 @@ configOverrides:
   common:
     testString: aaaaa
 `,
+		})
+
+		_, err := PrepareDeckhouseInstallConfig(metaConfig)
+		require.Error(t, err)
+	})
+
+	t.Run("Forbid to use releaseChannel", func(t *testing.T) {
+		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
+			"releaseChannel": "Beta",
+		})
+
+		_, err := PrepareDeckhouseInstallConfig(metaConfig)
+		require.Error(t, err)
+	})
+
+	t.Run("Forbid to use bundle", func(t *testing.T) {
+		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
+			"bundle": "Default",
+		})
+
+		_, err := PrepareDeckhouseInstallConfig(metaConfig)
+		require.Error(t, err)
+	})
+
+	t.Run("Forbid to use logLevel", func(t *testing.T) {
+		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
+			"logLevel": "Info",
 		})
 
 		_, err := PrepareDeckhouseInstallConfig(metaConfig)

--- a/dhctl/pkg/config/types.go
+++ b/dhctl/pkg/config/types.go
@@ -75,10 +75,10 @@ type TerraNodeGroupSpec struct {
 }
 
 type DeckhouseClusterConfig struct {
-	ReleaseChannel    string                 `json:"releaseChannel,omitempty"`
+	ReleaseChannel    string                 `json:"releaseChannel,omitempty"` // Deprecated
 	DevBranch         string                 `json:"devBranch,omitempty"`
-	Bundle            string                 `json:"bundle,omitempty"`
-	LogLevel          string                 `json:"logLevel,omitempty"`
+	Bundle            string                 `json:"bundle,omitempty"`   // Deprecated
+	LogLevel          string                 `json:"logLevel,omitempty"` // Deprecated
 	ImagesRepo        string                 `json:"imagesRepo"`
 	RegistryDockerCfg string                 `json:"registryDockerCfg,omitempty"`
 	RegistryCA        string                 `json:"registryCA,omitempty"`

--- a/docs/site/pages/virtualization-platform/documentation/admin/install/steps/INSTALL.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/install/steps/INSTALL.md
@@ -39,10 +39,17 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: cluster.local
 ---
-apiVersion: deckhouse.io/v1
-kind: InitConfiguration
-deckhouse:
-  releaseChannel: Stable
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  enabled: true
+  settings:
+    releaseChannel: Stable
+    bundle: Default
+    logLevel: Info
+  version: 1
 ---
 apiVersion: deckhouse.io/v1
 kind: AzureClusterConfiguration

--- a/docs/site/pages/virtualization-platform/documentation/admin/install/steps/INSTALL_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/install/steps/INSTALL_RU.md
@@ -38,10 +38,17 @@ serviceSubnetCIDR: 10.99.0.0/16
 kubernetesVersion: "Automatic"
 clusterDomain: "cluster.local"
 ---
-apiVersion: deckhouse.io/v1
-kind: InitConfiguration
-deckhouse:
-  releaseChannel: Stable
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  enabled: true
+  settings:
+    releaseChannel: Stable
+    bundle: Default
+    logLevel: Info
+  version: 1
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig

--- a/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
@@ -20,6 +20,17 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
+  name: deckhouse
+spec:
+  enabled: true
+  version: 1
+  settings:
+    bundle: Minimal
+    logLevel: Info
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
   name: cert-manager
 spec:
   enabled: true
@@ -78,13 +89,6 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: monitoring-kubernetes
-spec:
-  enabled: true
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: vertical-pod-autoscaler
 spec:
   enabled: true
 ---


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

In release 1.55 we deprecate next parameters of deckhouse init configuration
```
apiVersion: deckhouse.io/v1alpha1
kind: InitConfiguration
deckhouse:
  releaseChannel: 'Beta'
  bundle: "Default"
  logLevel: "Info"
```
in exchange for use `deckhouse` ModuleConfig settings.

We showed warnings about replacing, now we will return error and stop bootstrapping.

## Why do we need it, and what problem does it solve?
Remove deprecates

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fchore
summary: Forbid to use logLevel bundle and releaseChannel from deckhouse init configuration
impact: |
  Please use deckhouse ModuleConfig settings for set releaseChannel and/or bundle and/or logLevel settings instead of use  InitConfiguration deckhouse section
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
