### PR TITLE
[user-authn] Fix dexclient secret recreate and add labelKeysToIgnore

### DIFF
--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -91,10 +91,8 @@ func applyDexClientFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 	}
 
 	delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
-	delete(annotations, "meta.helm.sh/release-name")
-	delete(annotations, "meta.helm.sh/release-namespace")
 	for key := range annotations {
-		if strings.Contains(key, "werf.io/") {
+		if strings.Contains(key, "werf.io/") || strings.Contains(key, "meta.helm.sh/") {
 			delete(annotations, key)
 		}
 	}

--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -78,11 +78,19 @@ func applyDexClientFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 	// Secrets with that label lead to D8CertmanagerOrphanSecretsChecksFailed alerts.
 	// argocd.argoproj.io is used by ArgoCD to identify secrets managed by it.
 	// app.kubernetes.io/managed-by is used by Helm to identify secrets managed by it.
-	delete(labels, "certmanager.k8s.io/certificate-name")
-	delete(labels, "argocd.argoproj.io/instance")
-	delete(labels, "argocd.argoproj.io/secret-type")
-	if labels["app.kubernetes.io/managed-by"] == "Helm" {
-		delete(labels, "app.kubernetes.io/managed-by")
+	// Delete labels that should not be transferred to the secret
+	labelKeysToIgnore := []string{
+		"app",
+		"heritage",
+		"module",
+		"name",
+		"app.kubernetes.io/managed-by",
+		"argocd.argoproj.io/secret-type",
+		"argocd.argoproj.io/instance",
+		"certmanager.k8s.io/certificate-name",
+	}
+	for _, key := range labelKeysToIgnore {
+		delete(labels, key)
 	}
 
 	annotations := obj.GetAnnotations()

--- a/modules/150-user-authn/hooks/get_dex_client_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds_test.go
@@ -64,6 +64,10 @@ metadata:
     argocd.argoproj.io/instance: test-instance
     argocd.argoproj.io/secret-type: secret-type
     app.kubernetes.io/managed-by: Helm
+    app: should-be-removed
+    heritage: should-be-removed
+    module: should-be-removed
+    name: should-be-removed
   annotations:
     test-annotation: test-value
     new-annotation: test-new-value
@@ -226,6 +230,10 @@ metadata:
     argocd.argoproj.io/instance: test-instance
     argocd.argoproj.io/secret-type: secret-type
     app.kubernetes.io/managed-by: Helm
+    app: should-be-removed
+    heritage: should-be-removed
+    module: should-be-removed
+    name: should-be-removed
   annotations:
     test-annotation: test-value
     new-annotation: test-new-value

--- a/modules/150-user-authn/templates/dex-client/secret.yaml
+++ b/modules/150-user-authn/templates/dex-client/secret.yaml
@@ -6,11 +6,13 @@ kind: Secret
 metadata:
   name: dex-client-{{ $crd.name }}
   namespace: {{ $crd.namespace }}
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-client" "name" "credentials")) | nindent 2 }}
-  {{- with $crd.labels }}
-  labels:
-    {{- toYaml . | nindent 4 }}
+  {{- $defaultLabels := dict "app" "dex-client" "name" "credentials" }}
+  {{- if $crd.labels }}
+    {{- range $key, $value := $crd.labels }}
+      {{- $_ := set $defaultLabels $key $value }}
+    {{- end }}
   {{- end }}
+  {{- include "helm_lib_module_labels" (list $context $defaultLabels) | nindent 2 }}
   {{- with $crd.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
fix [pr](https://github.com/deckhouse/deckhouse/pull/10536)
Disable transfer some label keys from dexclient to dexclient secret
```
		"app",
		"heritage",
		"module",
		"name",
		"app.kubernetes.io/managed-by",
		"argocd.argoproj.io/secret-type",
		"argocd.argoproj.io/instance",
		"certmanager.k8s.io/certificate-name",
```