### PR TITLE
[docs] Use data for DVP topnav from the API

### DIFF
--- a/docs/site/werf.yaml
+++ b/docs/site/werf.yaml
@@ -62,11 +62,7 @@ shell:
     - |
       jq '.header | if ( ( .en | length) < 1 ) or ( ( .ru | length) < 1 ) then error("Got empty header array!") else ( . | {"topnav": { "en": [{"items": .en}], "ru": [ {"items": .ru}  ]}}) end ' /tmp/menus.json > /data/topnav.json
     - |
-      # REVERT ! TODO
-      # jq '."header-products" | if ( ( .ru | length) < 1 ) then error("Got empty header array!") else . end' /tmp/menus.json > /data/topnav-l2-products.json
-      jq '."header-products" | if ( ( .ru | length) < 1 ) then error("Got empty header array!") else . end| (.ru[]| select(.url=="/products/virtualization-platform/").items |= .+ [{"title": "Быстрый старт", "url": "/products/virtualization-platform/gs/bm/", "target": "", "rel": ""},{"title": "Подготовка к Production", "url": "/products/virtualization-platform/guides/production.html", "target": "", "rel": ""}])' /tmp/menus.json | jq -s '{"ru": .}' > /data/topnav-l2-products.json
-      #  REMOVE! TODO
-      sed -i 's#products/kubernetes-platform/modules/virtualization/stable/#products/virtualization-platform/documentation/#' /data/topnav-l2-products.json
+      jq '."header-products" | if ( ( .ru | length) < 1 ) then error("Got empty header array!") else . end' /tmp/menus.json > /data/topnav-l2-products.json
     - |
       jq '.footer | if ( ( .en | length) < 1 ) or ( ( .ru | length) < 1 ) then error("Got empty footer array!") else ( . | {"columns": . }) end ' /tmp/menus.json > /data/footer.json
     - |


### PR DESCRIPTION
## Description
Use data for DVP topnav from the API and remove the stub.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Use data for DVP topnav from the API.
impact_level: low
```
