### PR TITLE
[ci] Prevent SE edition from being built if SE-plus was requested

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -351,11 +351,6 @@ check_e2e_labels:
 {!{- end }!}
   runs-on: [self-hosted, {!{ $runsOnLabel }!}]
   steps:
-    - name: Print data
-      run: |
-        echo "WERF_ENV is ${WERF_ENV}"
-        echo "test_config is ${{ inputs.test_config }}"
-        echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 {!{ tmpl.Exec "started_at_output" . | strings.Indent 4 }!}
 {!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 4 }!}
 

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -57,6 +57,37 @@ jobs:
 
 {!{ tmpl.Exec "git_info_job" $ctx | strings.Indent 2 }!}
 
+  detect_editions:
+    name: Detect editions
+    runs-on: ubuntu-latest
+    outputs:
+      BUILD_CE: ${{steps.detect_editions.outputs.BUILD_CE}}
+      BUILD_EE: ${{steps.detect_editions.outputs.BUILD_EE}}
+      BUILD_BE: ${{steps.detect_editions.outputs.BUILD_BE}}
+      BUILD_SE: ${{steps.detect_editions.outputs.BUILD_SE}}
+      BUILD_SE-plus: ${{steps.detect_editions.outputs.BUILD_SE-plus}}
+    steps:
+      - name: Detect editions
+        id: detect_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          EMPTY_EDITIONS=yes
+
+          for edition in CE EE BE SE SE-plus ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable build of ${edition} edition."
+              echo "BUILD_${edition}=true" >> $GITHUB_OUTPUT
+              EMPTY_EDITIONS=no
+            fi
+          done
+
+          if [[ $EMPTY_EDITIONS == "yes" ]] ; then
+            echo "No editions requested. Building only FE."
+          fi
+
   comment_on_start:
     name: Update issue comment
     runs-on: ubuntu-latest
@@ -100,7 +131,8 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'ee') }}
+      - detect_editions
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (needs.detect_editions.outputs.BUILD_EE == 'true') }}
     env:
       WERF_ENV: "EE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -114,7 +146,8 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'se') }}
+      - detect_editions
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (needs.detect_editions.outputs.BUILD_SE == 'true') }}
     env:
       WERF_ENV: "SE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -128,7 +161,8 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'se-plus') }}
+      - detect_editions
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (needs.detect_editions.outputs.BUILD_SE-plus == 'true') }}
     env:
       WERF_ENV: "SE-plus"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -142,7 +176,8 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'be') }}
+      - detect_editions
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (needs.detect_editions.outputs.BUILD_BE == 'true') }}
     env:
       WERF_ENV: "BE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -156,7 +191,8 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'ce') }}
+      - detect_editions
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (needs.detect_editions.outputs.BUILD_CE == 'true') }}
     env:
       WERF_ENV: "CE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -100,7 +100,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'ee') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'ee') }}
     env:
       WERF_ENV: "EE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -114,7 +114,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'se') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'se') }}
     env:
       WERF_ENV: "SE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -128,7 +128,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'se-plus') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'se-plus') }}
     env:
       WERF_ENV: "SE-plus"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -142,7 +142,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'be') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'be') }}
     env:
       WERF_ENV: "BE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -156,7 +156,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'ce') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'ce') }}
     env:
       WERF_ENV: "CE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -159,6 +159,37 @@ jobs:
 
   # </template: git_info_job>
 
+  detect_editions:
+    name: Detect editions
+    runs-on: ubuntu-latest
+    outputs:
+      BUILD_CE: ${{steps.detect_editions.outputs.BUILD_CE}}
+      BUILD_EE: ${{steps.detect_editions.outputs.BUILD_EE}}
+      BUILD_BE: ${{steps.detect_editions.outputs.BUILD_BE}}
+      BUILD_SE: ${{steps.detect_editions.outputs.BUILD_SE}}
+      BUILD_SE-plus: ${{steps.detect_editions.outputs.BUILD_SE-plus}}
+    steps:
+      - name: Detect editions
+        id: detect_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          EMPTY_EDITIONS=yes
+
+          for edition in CE EE BE SE SE-plus ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable build of ${edition} edition."
+              echo "BUILD_${edition}=true" >> $GITHUB_OUTPUT
+              EMPTY_EDITIONS=no
+            fi
+          done
+
+          if [[ $EMPTY_EDITIONS == "yes" ]] ; then
+            echo "No editions requested. Building only FE."
+          fi
+
   comment_on_start:
     name: Update issue comment
     runs-on: ubuntu-latest
@@ -700,7 +731,8 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'ee') }}
+      - detect_editions
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (needs.detect_editions.outputs.BUILD_EE == 'true') }}
     env:
       WERF_ENV: "EE"
     # <template: build_template>
@@ -1025,7 +1057,8 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'se') }}
+      - detect_editions
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (needs.detect_editions.outputs.BUILD_SE == 'true') }}
     env:
       WERF_ENV: "SE"
     # <template: build_template>
@@ -1350,7 +1383,8 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'se-plus') }}
+      - detect_editions
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (needs.detect_editions.outputs.BUILD_SE-plus == 'true') }}
     env:
       WERF_ENV: "SE-plus"
     # <template: build_template>
@@ -1675,7 +1709,8 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'be') }}
+      - detect_editions
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (needs.detect_editions.outputs.BUILD_BE == 'true') }}
     env:
       WERF_ENV: "BE"
     # <template: build_template>
@@ -2000,7 +2035,8 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'ce') }}
+      - detect_editions
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (needs.detect_editions.outputs.BUILD_CE == 'true') }}
     env:
       WERF_ENV: "CE"
     # <template: build_template>

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -700,7 +700,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'ee') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'ee') }}
     env:
       WERF_ENV: "EE"
     # <template: build_template>
@@ -1025,7 +1025,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'se') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'se') }}
     env:
       WERF_ENV: "SE"
     # <template: build_template>
@@ -1350,7 +1350,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'se-plus') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'se-plus') }}
     env:
       WERF_ENV: "SE-plus"
     # <template: build_template>
@@ -1675,7 +1675,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'be') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'be') }}
     env:
       WERF_ENV: "BE"
     # <template: build_template>
@@ -2000,7 +2000,7 @@ jobs:
       - go_generate
       - workflow_render
       - build_fe
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || contains(github.event.inputs.editions, 'ce') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event.inputs.editions == 'ce') }}
     env:
       WERF_ENV: "CE"
     # <template: build_template>

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -220,11 +220,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -717,11 +712,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1214,11 +1204,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1711,11 +1696,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2208,11 +2188,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2705,11 +2680,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -3202,11 +3172,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -220,11 +220,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -725,11 +720,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1230,11 +1220,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1735,11 +1720,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2240,11 +2220,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2745,11 +2720,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -3250,11 +3220,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -153,11 +153,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -620,11 +615,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1132,11 +1122,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1607,11 +1592,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2070,11 +2050,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2541,11 +2516,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -3004,11 +2974,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -3471,11 +3436,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -3950,11 +3910,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -220,11 +220,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -762,11 +757,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1304,11 +1294,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1846,11 +1831,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2388,11 +2368,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2930,11 +2905,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -3472,11 +3442,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -220,11 +220,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -713,11 +708,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1206,11 +1196,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1699,11 +1684,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2192,11 +2172,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2685,11 +2660,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -3178,11 +3148,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -220,11 +220,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -713,11 +708,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1206,11 +1196,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1699,11 +1684,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2192,11 +2172,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2685,11 +2660,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -3178,11 +3148,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -220,11 +220,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -713,11 +708,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1206,11 +1196,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1699,11 +1684,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2192,11 +2172,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2685,11 +2660,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -3178,11 +3148,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -220,11 +220,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -729,11 +724,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1238,11 +1228,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1747,11 +1732,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2256,11 +2236,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2765,11 +2740,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -3274,11 +3244,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -220,11 +220,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -717,11 +712,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1214,11 +1204,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1711,11 +1696,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2208,11 +2188,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2705,11 +2680,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -3202,11 +3172,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -220,11 +220,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -721,11 +716,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1222,11 +1212,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -1723,11 +1708,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2224,11 +2204,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -2725,11 +2700,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -3226,11 +3196,6 @@ jobs:
       WERF_ENV: "${{ needs.check_e2e_labels.outputs.edition || fromJson(inputs.test_config).edition }}"
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Print data
-        run: |
-          echo "WERF_ENV is ${WERF_ENV}"
-          echo "test_config is ${{ inputs.test_config }}"
-          echo "output edition is ${{ needs.check_e2e_labels.outputs.edition }}"
 
       # <template: started_at_output>
       - name: Job started timestamp


### PR DESCRIPTION
## Description
Prevent SE edition from being built if SE-plus was requested.

## Why do we need it, and what problem does it solve?
Current implementation for triggers of different editions tests inclusion rather than equality of edition names, causing build of different but similarily-named edition. Fixed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Prevent SE edition from being built if SE-plus was requested.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
