### PR TITLE
[admission-policy-engine] fix jqfilter

### DIFF
--- a/modules/015-admission-policy-engine/webhooks/validating/security_policy.py
+++ b/modules/015-admission-policy-engine/webhooks/validating/security_policy.py
@@ -32,7 +32,7 @@ kubernetes:
     jqFilter: |
       {
         "name": .metadata.name,
-        "references": [.spec.policies.verifyImageSignatures[].reference]
+        "references": [.spec.policies.verifyImageSignatures[]?.reference]
       }
 kubernetesValidating:
 - name: securitypolicies.deckhouse.io


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixes 
```
bash-5.2$ ./shell-operator queue list
Queue 'main': length 12, status: 'sleep after fail for 32s (29s left of 32s delay)'

 1. EnableKubernetesBindings:::015-admission-policy-engine/webhooks/validating/security_policy.py:EnableKubernetesBindings:failures 172:run monitor: jqFilter: libjq filter '{
  "name": .metadata.name,
  "references": [.spec.policies.verifyImageSignatures[].reference]
}
': 'Cannot iterate over null (null)'
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
See above.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Hooks doesn't fail if there are no security policies without `.verifyImageSignatures` parameter.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: chore
summary: Fix security-policy validation hook.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
