### PR TITLE
[deckhouse] add update policy migration

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -117,6 +117,12 @@ func (l *Loader) Sync(ctx context.Context) error {
 		return fmt.Errorf("delete modules with absent releases: %w", err)
 	}
 
+	// TODO(ipaqsa): delete it after 1.68
+	l.log.Debugf("migrate update policies")
+	if err := l.migrateUpdatePolicies(ctx); err != nil {
+		return fmt.Errorf("migrate update policies: %w", err)
+	}
+
 	l.log.Debug("module loader initialized")
 
 	return nil


### PR DESCRIPTION
## Description
It provides migration for update policy.

## Why do we need it, and what problem does it solve?
v1alpha is deprecated. We no longer have label selector, now update policy is selected by module config, but we need to migrate outdated update policy by setting in module properties.

## What is the expected result?

Module without policy:
```
root@dev-master-0:~# k get module echo -oyaml
apiVersion: deckhouse.io/v1alpha1
kind: Module
metadata:
  creationTimestamp: "2024-11-18T15:34:15Z"
  generation: 24
  labels:
    deckhouse.io/epoch: "1326105356"
  name: echo
  resourceVersion: "232874852"
  uid: 7111cee7-50cd-4ecf-ba20-d691b13b0f59
properties:
  availableSources:
  - losev-test
  releaseChannel: Stable
  requirements:
    deckhouse: '> v1.63.0'
    kubernetes: '> v1.25.0'
  source: losev-test
  weight: 910
status:
  conditions:
  - lastProbeTime: "2024-12-05T14:30:55Z"
    lastTransitionTime: "2024-12-05T14:30:55Z"
    status: "True"
    type: EnabledByModuleConfig
  - lastProbeTime: "2024-12-06T13:53:06Z"
    lastTransitionTime: "2024-12-03T15:57:26Z"
    status: "True"
    type: EnabledByModuleManager
  - lastProbeTime: "2024-12-06T13:53:06Z"
    lastTransitionTime: "2024-12-06T13:53:05Z"
    status: "True"
    type: IsReady
  - lastProbeTime: "2024-12-06T10:42:49Z"
    lastTransitionTime: "2024-12-06T10:42:49Z"
    status: "False"
    type: IsOverridden
  hooksState: 'v0.7.24/hooks/moduleVersion.py: ok'
  phase: Ready
```

Outdated policy:

```
root@dev-master-0:~# kubectl get moduleupdatepolicies.v1alpha1.deckhouse.io test-alpha -oyaml 
Warning: deckhouse.io/v1alpha1 ModuleUpdatePolicy is deprecated; use deckhouse.io/v1alpha2 ModuleUpdatePolicy
apiVersion: deckhouse.io/v1alpha1
kind: ModuleUpdatePolicy
metadata:
  creationTimestamp: "2024-12-06T14:46:33Z"
  generation: 1
  name: test-alpha
  resourceVersion: "232907679"
  uid: 68b2f064-f8d7-418d-9f40-49a9f83f41b4
spec:
  moduleReleaseSelector:
    labelSelector:
      matchLabels:
        module: test
        source: losev-test
  releaseChannel: Alpha
  update:
    mode: Auto
```

Logs after restart:
```
r/moduleloader/sync.go:275","time":"2024-12-06T14:54:55Z"}
{"level":"debug","logger":"deckhouse-controller.module-loader","msg":"the 'test-alpha' policy has selector: \u0026LabelSelector{MatchLabels:map[string]string{module: echo,source: losev-test,},MatchExpressions:[]LabelSelectorRequirement{},}","source":"deckhouse/deckhouse-controller/pkg/controller/moduleloader/sync.go:268","time":"2024-12-06T14:54:55Z"}
{"level":"debug","logger":"deckhouse-controller.module-loader","msg":"migrate the 'test-alpha' policy for the 'echo' module","source":"deckhouse/deckhouse-controller/pkg/controller/moduleloader/sync.go:279","time":"2024-12-06T14:54:55Z"}
```

Module after restart:

```

```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Add update policy migration.
```

