### PR TITLE
Add bashible step to update node labels from local directory

### DIFF
--- a/candi/bashible/common-steps/all/098_update_node_labels.sh.tpl
+++ b/candi/bashible/common-steps/all/098_update_node_labels.sh.tpl
@@ -116,6 +116,10 @@ fi
 if [[ -z $LABELS ]]
   then
     # No labels to apply, exit 0
+    if [[ $LABELS_FROM_ANNOTATION ]]
+      then
+        kubectl --request-timeout 60s --kubeconfig=/etc/kubernetes/kubelet.conf annotate node "${D8_NODE_HOSTNAME}" node.deckhouse.io/last-applied-local-labels-
+    fi
     exit 0
   else
     # Apply labels to node

--- a/candi/bashible/common-steps/all/098_update_node_labels.sh.tpl
+++ b/candi/bashible/common-steps/all/098_update_node_labels.sh.tpl
@@ -25,10 +25,14 @@ import sys
 import os
 import json
 
+system_lables = {"beta.kubernetes.io/arch", "beta.kubernetes.io/os", "failure-domain.beta.kubernetes.io/region", "failure-domain.beta.kubernetes.io/zone", "kubernetes.io/arch", "kubernetes.io/hostname", "kubernetes.io/os", "node.deckhouse.io/group", "node.deckhouse.io/type", "topology.kubernetes.io/region", "topology.kubernetes.io/zone"}
+
 def validate(string, is_key = True):
     if len(string) > 63:
         return False
     if is_key:
+        if string in system_lables:
+            return False
         pattern = re.compile("^(?:(?:(?:[a-z0-9][a-z0-9-]+)\.)+[a-z0-9]+/)*[A-Za-z0-9][A-Za-z0-9-._]*$")
     else:
         pattern = re.compile("^[A-Za-z0-9][A-Za-z0-9-._]*$")
@@ -49,6 +53,8 @@ def fetch_labels(fileglob, valid = True):
                         if valid:
                             if validate(label[0]) and validate(label[1], False):
                                 labels[label[0]] = label[1]
+                            else:
+                                sys.stderr.write("Validation failed for label key " + label[0] + "\n")
                         else:
                             labels[label[0]] = label[1]
     return labels

--- a/candi/bashible/common-steps/all/099_update_node_labels.sh.tpl
+++ b/candi/bashible/common-steps/all/099_update_node_labels.sh.tpl
@@ -1,0 +1,106 @@
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bb-ext-python 'fetch-local-labels' <<EOF
+import re
+import glob
+import sys
+import os
+import json
+
+def validate(string, is_key = True):
+    if len(string) > 63:
+        return False
+    if is_key:
+        pattern = re.compile("^(?:(?:(?:[a-z0-9][a-z0-9-]+)\\.)+[a-z0-9]+/)*[A-Za-z0-9][A-Za-z0-9-._]*$")
+    else:
+        pattern = re.compile("^[A-Za-z0-9][A-Za-z0-9-._]*$")
+    if pattern.fullmatch(string):
+        return True
+    return False
+
+def fetch_labels(fileglob, valid = True):
+    files = glob.glob(fileglob, recursive=True)
+    labels = dict()
+    for f in files:
+        if os.path.isfile(f):
+            with open(f) as file:
+                flines = [line.rstrip() for line in file]
+                for l in flines:
+                    label = l.split('=')
+                    if len(label) == 2:
+                        if valid:
+                            if validate(label[0]) and validate(label[1], False):
+                                labels[label[0]] = label[1]
+                        else:
+                            labels[label[0]] = label[1]
+    return labels
+
+def print_labels(labels):
+    label_string = ""
+    for key in labels:
+        label_string = label_string + key + "=" + labels[key] + " "
+    return label_string.rstrip()
+
+def get_removed(d1, d2):
+    d1_keys = set(d1.keys())
+    d2_keys = set(d2.keys())
+    shared_keys = d1_keys.intersection(d2_keys)
+    removed = d1_keys - d2_keys
+    return removed
+
+if len(sys.argv) < 3:
+    print(f"Usage: {sys.argv[0]} directory add|delete [json]")
+    sys.exit(0)
+
+labels = fetch_labels(sys.argv[1] + "/**", True)
+
+if sys.argv[2] == "add":
+    if len(sys.argv) == 4 and sys.argv[3] == "json":
+       print(json.dumps(json.dumps(labels)))
+    else: 
+        print(print_labels(labels))
+if sys.argv[2] == "delete":
+    try:
+        node_labels = json.loads(sys.argv[3])
+        removed = get_removed(node_labels, labels)
+        for k in removed:
+            print("{}-".format(k))
+    except:
+        print("To use delete pass json as third argument")
+        sys.exit(1)
+EOF
+
+LABEL_DIRECTORY_PATH=/var/lib/node_labels
+mkdir -p $LABEL_DIRECTORY_PATH
+
+LABELS_FROM_ANNOTATION="$( kubectl_exec get no "$D8_NODE_HOSTNAME" -o json |jq '.metadata.annotations."node.deckhouse.io/last-applied-local-labels"' | sed -e 's/[\]//g')"
+
+LABELS="$( fetch-local-labels "$LABEL_DIRECTORY_PATH" add)"
+LABLES_TO_REMOVE="$( fetch-local-labels "$LABEL_DIRECTORY_PATH" delete "$LABELS_FROM_ANNOTATION")"
+LABELS_ANNOTATION="$( fetch-local-labels "$LABEL_DIRECTORY_PATH" add json )"
+
+for label in $LABLES_TO_REMOVE; do
+    kubectl_exec label node "${D8_NODE_HOSTNAME}" "$label"
+done
+
+if [ -z $LABELS ]
+  then
+    # No labels to apply, exit 0
+    exit 0
+  else
+    # Apply labels to node
+    kubectl_exec label node "${D8_NODE_HOSTNAME}" "${LABELS}" --overwrite
+    annotate_node node.deckhouse.io/last-applied-local-labels=${LABELS_ANNOTATION}
+fi

--- a/candi/bashible/common-steps/all/099_update_node_labels.sh.tpl
+++ b/candi/bashible/common-steps/all/099_update_node_labels.sh.tpl
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bb-ext-python 'fetch-local-labels' <<EOF
+function kubectl_exec() {
+  kubectl --request-timeout 60s --kubeconfig=/etc/kubernetes/kubelet.conf ${@}
+}
+
+check_python
+function fetch-local-labels() {
+  cat - <<EOF | $python_binary
 import re
 import glob
 import sys
@@ -23,7 +29,7 @@ def validate(string, is_key = True):
     if len(string) > 63:
         return False
     if is_key:
-        pattern = re.compile("^(?:(?:(?:[a-z0-9][a-z0-9-]+)\\.)+[a-z0-9]+/)*[A-Za-z0-9][A-Za-z0-9-._]*$")
+        pattern = re.compile("^(?:(?:(?:[a-z0-9][a-z0-9-]+)\.)+[a-z0-9]+/)*[A-Za-z0-9][A-Za-z0-9-._]*$")
     else:
         pattern = re.compile("^[A-Za-z0-9][A-Za-z0-9-._]*$")
     if pattern.fullmatch(string):
@@ -60,20 +66,17 @@ def get_removed(d1, d2):
     removed = d1_keys - d2_keys
     return removed
 
-if len(sys.argv) < 3:
-    print(f"Usage: {sys.argv[0]} directory add|delete [json]")
-    sys.exit(0)
+labels = fetch_labels("$1" + "/**", True)
 
-labels = fetch_labels(sys.argv[1] + "/**", True)
-
-if sys.argv[2] == "add":
-    if len(sys.argv) == 4 and sys.argv[3] == "json":
-       print(json.dumps(json.dumps(labels)))
+if "$2" == "add":
+    format = "$4"
+    if format == "json":
+       print(json.dumps(labels))
     else: 
         print(print_labels(labels))
-if sys.argv[2] == "delete":
+if "$2" == "delete":
     try:
-        node_labels = json.loads(sys.argv[3])
+        node_labels = json.loads('$3')
         removed = get_removed(node_labels, labels)
         for k in removed:
             print("{}-".format(k))
@@ -81,26 +84,35 @@ if sys.argv[2] == "delete":
         print("To use delete pass json as third argument")
         sys.exit(1)
 EOF
+}
 
 LABEL_DIRECTORY_PATH=/var/lib/node_labels
 mkdir -p $LABEL_DIRECTORY_PATH
 
-LABELS_FROM_ANNOTATION="$( kubectl_exec get no "$D8_NODE_HOSTNAME" -o json |jq '.metadata.annotations."node.deckhouse.io/last-applied-local-labels"' | sed -e 's/[\]//g')"
+LABELS_FROM_ANNOTATION="$( kubectl_exec get no "$D8_NODE_HOSTNAME" -o json |jq -r '.metadata.annotations."node.deckhouse.io/last-applied-local-labels"' )"
+
+if [[ $LABELS_FROM_ANNOTATION == "null" ]]
+  then
+    LABELS_FROM_ANNOTATION='{}'
+fi
 
 LABELS="$( fetch-local-labels "$LABEL_DIRECTORY_PATH" add)"
 LABLES_TO_REMOVE="$( fetch-local-labels "$LABEL_DIRECTORY_PATH" delete "$LABELS_FROM_ANNOTATION")"
-LABELS_ANNOTATION="$( fetch-local-labels "$LABEL_DIRECTORY_PATH" add json )"
+LABELS_ANNOTATION="$( fetch-local-labels "$LABEL_DIRECTORY_PATH" add "$LABELS_FROM_ANNOTATION" json )"
 
-for label in $LABLES_TO_REMOVE; do
-    kubectl_exec label node "${D8_NODE_HOSTNAME}" "$label"
-done
+if [[ $LABLES_TO_REMOVE ]]
+  then
+    for label in $LABLES_TO_REMOVE; do
+        kubectl_exec label node "${D8_NODE_HOSTNAME}" "$label"
+    done
+fi
 
-if [ -z $LABELS ]
+if [[ -z $LABELS ]]
   then
     # No labels to apply, exit 0
     exit 0
   else
     # Apply labels to node
     kubectl_exec label node "${D8_NODE_HOSTNAME}" "${LABELS}" --overwrite
-    annotate_node node.deckhouse.io/last-applied-local-labels=${LABELS_ANNOTATION}
+    kubectl --request-timeout 60s --kubeconfig=/etc/kubernetes/kubelet.conf annotate node "${D8_NODE_HOSTNAME}" --overwrite node.deckhouse.io/last-applied-local-labels="${LABELS_ANNOTATION}"
 fi


### PR DESCRIPTION
## Description

This bashible step allows to add, remove and edit node labels from local directory and it subdirectories. A full set of labels also stored in node annotation `node.deckhouse.io/last-applied-local-labels`, what allows to control only local set labels.
Path to local directory: `/var/lib/node_labels`
Labels format: `foo=bar`

## Why do we need it, and what problem does it solve?

Fixes #9767

## What is the expected result?

Any labels, stored in any file in `/var/lib/node_labels` or it subdirectories must be applied to node. By changing and/or deleting, they must be changed/deleted from node as well.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: feature
summary: Added a way to control node labels from files, stored in local directory and it subdirectories.
impact_level: default
```

