### PR TITLE
[ci] Temporary: save info about built image

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -131,10 +131,12 @@ steps:
           SECONDARY_REPO=
         fi
 
+        mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
         werf build \
           ${SECONDARY_REPO} \
           --parallel=true --parallel-tasks-limit=5 \
           --save-build-report=true \
+          --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
           --build-report-path images_tags_werf.json
         BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
         SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -143,14 +145,18 @@ steps:
         # Build using dev-registry as a single primary repo and push:
         # - branches to Dev registry to run e2e tests.
         # - semver tags to Github Container Registry for testing release process.
+        mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
         werf build \
           --parallel=true --parallel-tasks-limit=5 \
           --save-build-report=true \
+          --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
           --build-report-path images_tags_werf.json
         BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
         SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
         echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
       fi
+
+      cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
       # Publish images for Git branch.
       if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -196,12 +202,15 @@ steps:
         if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
           # Copy stages to prod registry from dev registry.
           export WERF_DISABLE_META_TAGS=true
+          mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
           werf build \
             --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
             --secondary-repo $WERF_REPO \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
             --build-report-path images_tags_werf.json
+          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
         fi
         # Note: do not run second werf build for test repo, as it has no secondary repo.
 

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -748,10 +748,12 @@ jobs:
               SECONDARY_REPO=
             fi
 
+            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -760,14 +762,18 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
+            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -448,10 +448,12 @@ jobs:
               SECONDARY_REPO=
             fi
 
+            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -460,14 +462,18 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
+            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -575,10 +575,12 @@ jobs:
               SECONDARY_REPO=
             fi
 
+            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -587,14 +589,18 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
+            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -640,12 +646,15 @@ jobs:
             if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
+              mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
+                --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
                 --build-report-path images_tags_werf.json
+              cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -925,10 +934,12 @@ jobs:
               SECONDARY_REPO=
             fi
 
+            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -937,14 +948,18 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
+            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -990,12 +1005,15 @@ jobs:
             if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
+              mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
+                --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
                 --build-report-path images_tags_werf.json
+              cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -1275,10 +1293,12 @@ jobs:
               SECONDARY_REPO=
             fi
 
+            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -1287,14 +1307,18 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
+            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1340,12 +1364,15 @@ jobs:
             if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
+              mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
+                --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
                 --build-report-path images_tags_werf.json
+              cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -1625,10 +1652,12 @@ jobs:
               SECONDARY_REPO=
             fi
 
+            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -1637,14 +1666,18 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
+            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1690,12 +1723,15 @@ jobs:
             if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
+              mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
+                --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
                 --build-report-path images_tags_werf.json
+              cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -1975,10 +2011,12 @@ jobs:
               SECONDARY_REPO=
             fi
 
+            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -1987,14 +2025,18 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
+            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -2040,12 +2082,15 @@ jobs:
             if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
+              mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
+                --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
                 --build-report-path images_tags_werf.json
+              cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -2325,10 +2370,12 @@ jobs:
               SECONDARY_REPO=
             fi
 
+            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -2337,14 +2384,18 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
+            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -2390,12 +2441,15 @@ jobs:
             if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
+              mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
+                --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
                 --build-report-path images_tags_werf.json
+              cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 


### PR DESCRIPTION
## Description
Save information about built image (Werf render file and Werf buiild report file) locally.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Save information about built image.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
