### PR TITLE
[chrony] Add chrony-exporter

### DIFF
--- a/modules/040-control-plane-manager/hooks/audit_policy_basic_targets_generated.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_basic_targets_generated.go
@@ -106,6 +106,7 @@ var auditPolicyBasicServiceAccounts = []string{
 	"system:serviceaccount:d8-monitoring:alertmanager-internal",
 	"system:serviceaccount:d8-monitoring:alerts-receiver",
 	"system:serviceaccount:d8-monitoring:cert-exporter",
+	"system:serviceaccount:d8-monitoring:chrony-exporter",
 	"system:serviceaccount:d8-monitoring:control-plane-proxy",
 	"system:serviceaccount:d8-monitoring:ebpf-exporter",
 	"system:serviceaccount:d8-monitoring:events-exporter",

--- a/modules/340-monitoring-kubernetes/images/chrony-exporter/werf.inc.yaml
+++ b/modules/340-monitoring-kubernetes/images/chrony-exporter/werf.inc.yaml
@@ -1,0 +1,43 @@
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-promu-artifact
+from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+shell:
+  install:
+  - export GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+  - git clone --depth 1 --branch v0.14.0 {{ $.SOURCE_REPO }}/prometheus/promu.git /promu
+  - cd /promu
+  - go build -ldflags="-s -w" -o promu ./main.go
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-builder
+from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+import:
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-promu-artifact
+  add: /promu/promu
+  to: /bin/promu
+  before: install
+shell:
+  install:
+  - apk update && apk add --no-cache gcc g++
+  - export GOPROXY={{ $.GOPROXY }} CGO_ENABLED=1 GOOS=linux GOARCH=amd64 EXPORTER_VERSION=v0.11.0
+  - git clone -b "${EXPORTER_VERSION}" --single-branch {{ $.SOURCE_REPO }}/chrony/chrony_exporter /src
+  - cd /src
+  - /bin/promu build
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}
+fromImage: common/distroless
+import:
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-builder
+  add: /src/chrony_exporter
+  to: /usr/bin/chrony_exporter
+  before: install
+docker:
+  EXPOSE:
+    - "9123"
+  ENTRYPOINT:
+    - "/usr/bin/chrony_exporter"

--- a/modules/340-monitoring-kubernetes/templates/chrony-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/chrony-exporter/daemonset.yaml
@@ -1,0 +1,122 @@
+{{- define "chrony_exporter_resources" }}
+cpu: 10m
+memory: 25Mi
+{{- end }}
+{{- define "kubelet_eviction_thresholds_exporter_resources" }}
+cpu: 10m
+memory: 25Mi
+{{- end }}
+
+{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: chrony-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-exporter" "workload-resource-policy.deckhouse.io" "every-node")) | nindent 2 }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: DaemonSet
+    name: chrony-exporter
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: chrony-exporter
+      minAllowed:
+        {{- include "chrony_exporter_resources" . | nindent 8 }}
+      maxAllowed:
+        cpu: 20m
+        memory: 50Mi
+    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: chrony-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-exporter")) | nindent 2 }}
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: chrony-exporter
+  template:
+    metadata:
+      labels:
+        app: chrony-exporter
+      name: chrony-exporter
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      hostPID: true
+      serviceAccountName: chrony-exporter
+      {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      containers:
+      - image: {{ include "helm_lib_module_image" (list . "chronyExporter") }}
+        name: chrony-exporter
+        {{- include "helm_lib_module_container_security_context_privileged" . | nindent 8 }}
+        args:
+        - '--web.listen-address=127.0.0.1:4228'
+        - '--chrony.address=$(HOST_IP):4234'
+        - '--collector.tracking'
+        - '--collector.sources'
+        - '--collector.serverstats'
+        - '--web.telemetry-path="/metrics"'
+        - '--log.level=info'
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
+{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+            {{- include "chrony_exporter_resources" . | nindent 12 }}
+{{- end }}
+      - name: kube-rbac-proxy
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
+        args:
+        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4228"
+        - "--v=2"
+        - "--logtostderr=true"
+        - "--stale-cache-interval=1h30m"
+        env:
+        - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: KUBE_RBAC_PROXY_CONFIG
+          value: |
+            upstreams:
+            - upstream: http://127.0.0.1:4228/metrics
+              path: /metrics
+              authorization:
+                resourceAttributes:
+                  namespace: d8-monitoring
+                  apiGroup: apps
+                  apiVersion: v1
+                  resource: daemonsets
+                  subresource: prometheus-metrics
+                  name: chrony-exporter
+        ports:
+        - containerPort: 4228
+          name: https-metrics
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+{{- end }}
+      imagePullSecrets:
+      - name: deckhouse-registry

--- a/modules/340-monitoring-kubernetes/templates/chrony-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/chrony-exporter/daemonset.yaml
@@ -70,7 +70,6 @@ spec:
         - '--collector.tracking'
         - '--collector.sources'
         - '--collector.serverstats'
-        - '--web.telemetry-path="/metrics"'
         - '--log.level=info'
         env:
         - name: HOST_IP

--- a/modules/340-monitoring-kubernetes/templates/chrony-exporter/podmonitor.yaml
+++ b/modules/340-monitoring-kubernetes/templates/chrony-exporter/podmonitor.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: chrony-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-exporter" "prometheus" "main")) | nindent 2 }}
+spec:
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: chrony-exporter
+  namespaceSelector:
+    matchNames:
+    - d8-monitoring
+  podMetricsEndpoints:
+  - port: https-metrics
+    scheme: https
+    scrapeTimeout: {{ include "helm_lib_prometheus_target_scrape_timeout_seconds" (list . 20) }}
+    bearerTokenSecret:
+      name: "prometheus-token"
+      key: "token"
+    tlsConfig:
+      insecureSkipVerify: true
+    relabelings:
+    - regex: endpoint|namespace|pod|service
+      action: labeldrop
+    - sourceLabels: [__meta_kubernetes_pod_node_name]
+      targetLabel: node
+    - targetLabel: tier
+      replacement: cluster

--- a/modules/340-monitoring-kubernetes/templates/chrony-exporter/rbac-for-us.yaml
+++ b/modules/340-monitoring-kubernetes/templates/chrony-exporter/rbac-for-us.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:monitoring-kubernetes:chrony-exporter
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-exporter")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:monitoring-kubernetes:chrony-exporter
+subjects:
+- kind: ServiceAccount
+  name: chrony-exporter
+  namespace: d8-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: d8:monitoring-kubernetes:chrony-exporter
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-exporter")) | nindent 2 }}
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:monitoring-kubernetes:chrony-exporter:rbac-proxy
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-exporter")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: chrony-exporter
+  namespace: d8-monitoring
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chrony-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-exporter")) | nindent 2 }}

--- a/modules/340-monitoring-kubernetes/templates/chrony-exporter/rbac-to-us.yaml
+++ b/modules/340-monitoring-kubernetes/templates/chrony-exporter/rbac-to-us.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: access-to-chrony-exporter-chrony-exporter-prometheus-metrics
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-exporter")) | nindent 2 }}
+rules:
+- apiGroups: ["apps"]
+  resources: ["daemonsets/prometheus-metrics"]
+  resourceNames: ["chrony-exporter"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: access-to-chrony-exporter-prometheus-metrics
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-exporter")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: access-to-chrony-exporter-chrony-exporter-prometheus-metrics
+subjects:
+- kind: User
+  name: d8-monitoring:scraper
+- kind: ServiceAccount
+  name: prometheus
+  namespace: d8-monitoring

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -323,6 +323,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"speaker":    "imageHash-metallb-speaker",
 	},
 	"monitoringKubernetes": map[string]interface{}{
+		"chronyExporter":                    "imageHash-monitoringKubernetes-chronyExporter",
 		"ebpfExporter":                      "imageHash-monitoringKubernetes-ebpfExporter",
 		"kubeStateMetrics":                  "imageHash-monitoringKubernetes-kubeStateMetrics",
 		"kubeletEvictionThresholdsExporter": "imageHash-monitoringKubernetes-kubeletEvictionThresholdsExporter",


### PR DESCRIPTION
## Description
Add chrony-exporter templates

## Why do we need it, and what problem does it solve?
Due to the fact that node-exporter [stopped](https://github.com/prometheus/node_exporter/blob/master/docs/TIME.md) supporting NTP metrics, we will have broken dashboards and alerts if we bump the version.

## Why do we need it in the patch release (if we do)?
Not necessarily

## What is the expected result?
New independent chrony metrics collector which will replace the old metrics in case of their deprecation. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: chrony
type: chore
summary: add chrony-exporter
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
