### PR TITLE
Revert "[ci] Save build info (#10911)"

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -131,12 +131,10 @@ steps:
           SECONDARY_REPO=
         fi
 
-        mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
         werf build \
           ${SECONDARY_REPO} \
           --parallel=true --parallel-tasks-limit=5 \
           --save-build-report=true \
-          --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
           --build-report-path images_tags_werf.json
         BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
         SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -145,18 +143,14 @@ steps:
         # Build using dev-registry as a single primary repo and push:
         # - branches to Dev registry to run e2e tests.
         # - semver tags to Github Container Registry for testing release process.
-        mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
         werf build \
           --parallel=true --parallel-tasks-limit=5 \
           --save-build-report=true \
-          --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
           --build-report-path images_tags_werf.json
         BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
         SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
         echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
       fi
-
-      cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
       # Publish images for Git branch.
       if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -202,15 +196,12 @@ steps:
         if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
           # Copy stages to prod registry from dev registry.
           export WERF_DISABLE_META_TAGS=true
-          mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
           werf build \
             --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
             --secondary-repo $WERF_REPO \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
-            --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
             --build-report-path images_tags_werf.json
-          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
         fi
         # Note: do not run second werf build for test repo, as it has no secondary repo.
 

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -748,12 +748,10 @@ jobs:
               SECONDARY_REPO=
             fi
 
-            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -762,18 +760,14 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
-            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
-
-          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -448,12 +448,10 @@ jobs:
               SECONDARY_REPO=
             fi
 
-            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -462,18 +460,14 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
-            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
-
-          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -575,12 +575,10 @@ jobs:
               SECONDARY_REPO=
             fi
 
-            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -589,18 +587,14 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
-            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
-
-          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -646,15 +640,12 @@ jobs:
             if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
-              mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
-                --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
                 --build-report-path images_tags_werf.json
-              cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -934,12 +925,10 @@ jobs:
               SECONDARY_REPO=
             fi
 
-            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -948,18 +937,14 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
-            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
-
-          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1005,15 +990,12 @@ jobs:
             if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
-              mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
-                --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
                 --build-report-path images_tags_werf.json
-              cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -1293,12 +1275,10 @@ jobs:
               SECONDARY_REPO=
             fi
 
-            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -1307,18 +1287,14 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
-            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
-
-          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1364,15 +1340,12 @@ jobs:
             if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
-              mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
-                --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
                 --build-report-path images_tags_werf.json
-              cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -1652,12 +1625,10 @@ jobs:
               SECONDARY_REPO=
             fi
 
-            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -1666,18 +1637,14 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
-            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
-
-          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1723,15 +1690,12 @@ jobs:
             if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
-              mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
-                --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
                 --build-report-path images_tags_werf.json
-              cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -2011,12 +1975,10 @@ jobs:
               SECONDARY_REPO=
             fi
 
-            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -2025,18 +1987,14 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
-            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
-
-          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -2082,15 +2040,12 @@ jobs:
             if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
-              mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
-                --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
                 --build-report-path images_tags_werf.json
-              cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -2370,12 +2325,10 @@ jobs:
               SECONDARY_REPO=
             fi
 
-            mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
             werf build \
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -2384,18 +2337,14 @@ jobs:
             # Build using dev-registry as a single primary repo and push:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
-            mkdir ../${{github.run_id}}-${REGISTRY_SUFFIX}
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
-              --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
-
-          cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -2441,15 +2390,12 @@ jobs:
             if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
-              mkdir "../${{github.run_id}}-${REGISTRY_SUFFIX}"
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
-                --tmp-dir="../${{github.run_id}}-${REGISTRY_SUFFIX}" \
                 --build-report-path images_tags_werf.json
-              cp images_tags_werf.json "../${{github.run_id}}-${REGISTRY_SUFFIX}/"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 


### PR DESCRIPTION

## Description
This reverts commit fb566e8c593b9f9dc054ba555268f9976f3c0589 (https://github.com/deckhouse/deckhouse/pull/10911)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Revert:  Save build info (#10911)
impact_level: low
```
