### PR TITLE
[candi][azure] Azure vNet DNS config fix

### DIFF
--- a/candi/cloud-providers/azure/terraform-modules/base-infrastructure/variables.tf
+++ b/candi/cloud-providers/azure/terraform-modules/base-infrastructure/variables.tf
@@ -50,5 +50,5 @@ locals {
   nat_gateway_public_ip_count = contains(keys(var.providerClusterConfiguration), "standard") ? lookup(var.providerClusterConfiguration.standard, "natGatewayPublicIpCount", 0) : 0
   ssh_allow_list              = lookup(var.providerClusterConfiguration, "sshAllowList", null)
   service_endpoints           = lookup(var.providerClusterConfiguration, "serviceEndpoints", [])
-  nameservers                 = lookup(var.providerClusterConfiguration.nameservers, "addresses", null)
+  nameservers                 = try(var.providerClusterConfiguration.nameservers, "addresses", null)
 }

--- a/candi/cloud-providers/azure/terraform-modules/base-infrastructure/variables.tf
+++ b/candi/cloud-providers/azure/terraform-modules/base-infrastructure/variables.tf
@@ -50,5 +50,5 @@ locals {
   nat_gateway_public_ip_count = contains(keys(var.providerClusterConfiguration), "standard") ? lookup(var.providerClusterConfiguration.standard, "natGatewayPublicIpCount", 0) : 0
   ssh_allow_list              = lookup(var.providerClusterConfiguration, "sshAllowList", null)
   service_endpoints           = lookup(var.providerClusterConfiguration, "serviceEndpoints", [])
-  nameservers                 = try(var.providerClusterConfiguration.nameservers, "addresses", null)
+  nameservers                 = try(var.providerClusterConfiguration.nameservers, "addresses", [])
 }

--- a/candi/cloud-providers/azure/terraform-modules/base-infrastructure/variables.tf
+++ b/candi/cloud-providers/azure/terraform-modules/base-infrastructure/variables.tf
@@ -50,5 +50,5 @@ locals {
   nat_gateway_public_ip_count = contains(keys(var.providerClusterConfiguration), "standard") ? lookup(var.providerClusterConfiguration.standard, "natGatewayPublicIpCount", 0) : 0
   ssh_allow_list              = lookup(var.providerClusterConfiguration, "sshAllowList", null)
   service_endpoints           = lookup(var.providerClusterConfiguration, "serviceEndpoints", [])
-  nameservers                 = try(var.providerClusterConfiguration.nameservers, "addresses", [])
+  nameservers                 = try(var.providerClusterConfiguration.nameservers.addresses, [])
 }

--- a/testing/cloud_layouts/Azure/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Azure/Standard/configuration.tpl.yaml
@@ -23,9 +23,6 @@ kind: AzureClusterConfiguration
 layout: Standard
 sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSNdUmV2ekit0rFrQE9IoRsVqKTJfR8h+skMYjXHBv/nJN6J2eBvQlebnhfZngxTvHYYxl0XeRu3KEz5v23gIidT21o9x0+tD4b2PcyZ24o64GwnF/oFnQ9mYBJDRisZNdXYPadTp/RafQ0qNUX/6h8vZYlSPM77dhW7Oyf6hcbaniAmOD30bO89UM//VHbllGgfhlIbU382/EnPOfGvAHReATADBBHmxxtTCLbu48rN35DlOtMgPob3ZwOsJI3keRrIZOf5qxeF3VB0Ox4inoR6PUzWMFLCJyIMp7hzY+JLakO4dqfvRJZjgTZHQUvjDs+aeUcH8tD4Wd5NDzmxnHLtJup0lkHkqgjo6vqWIcQeDXuXsk3+YGw0PwMpwO2HMVPs2SnfT6cZ+Mo6Dmq0t1EjtSBXLMe5C5aac5w6NrXuypRQDoce7p3uZP2TVsxmpyvkd6RyiWr+wuOOB3h/k8q+kRh4LKzivJMEkZoZeCxkJiIWDknxEAU1sl25W4hEU="
 vNetCIDR: 10.50.0.0/16
-nameservers:
-  addresses:
-    - 1.1.1.1
 standard:
   natGatewayPublicIpCount: 1
 subnetCIDR: 10.50.0.0/24


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix for this pr: https://github.com/deckhouse/deckhouse/pull/9554
This PR fixes error:

```
Error: Unsupported attribute

  on deckhouse/candi/cloud-providers/azure/layouts/standard/base-infrastructure/variables.tf line 53, in locals:
  53:   nameservers                 = lookup(var.providerClusterConfiguration.nameservers, "addresses", null)
    | var.providerClusterConfiguration is object with 9 attributes

This object does not have an attribute named "nameservers".
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Converge may crash if nameservers are not specified

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?

When creating `azurerm_virtual_network`, default nameserver will be used if no other nameserver is specified (as expected earlier).

It was tested as follows:

- Cluster was first deployed without nameservers 
- then the provider-cluster-configuration was changed (`kubectl -n d8-system exec -ti svc/deckhouse-leader -- deckhouse-controller edit provider-cluster-configuration`) 
- and then converged via `dhctl converge --ssh-host 1.1.1.1.1 --ssh-user azureuser --ssh-agent-private-keys /tmp/.ssh/id-rsa`

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix 
summary: Fix converge of Azure cluster without nameservers in config
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
