### PR TITLE
[docs] Changed info about editions in Getting Started  private environment

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
+++ b/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
@@ -16,7 +16,7 @@
 {%- endif %}
 {%- if page.platform_code == 'bm-private' %}
 {% alert level="warning" %}
-Доступно в SE, SE+, EE, CSE Lite, CSE Pro редакциях.
+Доступно в редакциях SE, SE+, EE, CSE Lite, CSE Pro.
 {% endalert %}
 {%- endif %}
 {%- else %}
@@ -27,7 +27,7 @@ Only [regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-regi
 {%- endif %}
 {%- if page.platform_code == 'bm-private' %}
 {% alert level="warning" %}
-This feature is available in SE, SE+, EE, CSE Lite, CSE Pro editions.
+This feature is available in Standard and Enterprise Edition only.
 {% endalert %}
 {%- endif %}
 {%- endif %}

--- a/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
+++ b/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
@@ -16,7 +16,7 @@
 {%- endif %}
 {%- if page.platform_code == 'bm-private' %}
 {% alert level="warning" %}
-Доступно только в Standard и Enterprise Edition.
+Доступно в SE, SE+, EE, CSE Lite, CSE Pro редакциях.
 {% endalert %}
 {%- endif %}
 {%- else %}
@@ -27,7 +27,7 @@ Only [regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-regi
 {%- endif %}
 {%- if page.platform_code == 'bm-private' %}
 {% alert level="warning" %}
-This feature is available in Standard and Enterprise Edition only.
+This feature is available in SE, SE+, EE, CSE Lite, CSE Pro editions.
 {% endalert %}
 {%- endif %}
 {%- endif %}


### PR DESCRIPTION
## Description
Changed info about editions in Getting Started  private environment.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?


## What is the expected result?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type:  chore
summary: Changed info about editions in Getting Started  private environment.
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
