### PR TITLE
[node-local-dns] fix stuck in iptables-loop

### DIFF
--- a/ee/be/modules/350-node-local-dns/images/iptables-loop/iptables-loop.sh
+++ b/ee/be/modules/350-node-local-dns/images/iptables-loop/iptables-loop.sh
@@ -53,7 +53,7 @@ until [[ $(< "$readiness_file_path") == "$ready_state" ]]; do
   sleep 1
 done
 
-echo "first run" >&3
+echo "First run."
 
 while true; do
 	inotifywait -q -e modify "$readiness_file_path" &> /dev/null

--- a/ee/be/modules/350-node-local-dns/images/iptables-loop/iptables-loop.sh
+++ b/ee/be/modules/350-node-local-dns/images/iptables-loop/iptables-loop.sh
@@ -13,14 +13,14 @@ latest_state=""
 function add_rule() {
   if ! iptables -w 60 -W 100000 -t raw -C PREROUTING -d "${KUBE_DNS_SVC_IP}/32" -m socket --nowildcard -j NOTRACK >/dev/null 2>&1 ; then
     iptables -w 60 -W 100000 -t raw -A PREROUTING -d "${KUBE_DNS_SVC_IP}/32" -m socket --nowildcard -j NOTRACK
-    echo "The state of the rule in iptables has changed to \"$latest_state\""
+    echo "Added rule to iptables."
   fi
 }
 
 function delete_rule() {
   if iptables -w 60 -W 100000 -t raw -C PREROUTING -d "${KUBE_DNS_SVC_IP}/32" -m socket --nowildcard -j NOTRACK >/dev/null 2>&1 ; then
     iptables -w 60 -W 100000 -t raw -D PREROUTING -d "${KUBE_DNS_SVC_IP}/32" -m socket --nowildcard -j NOTRACK
-    echo "The state of the rule in iptables has changed to \"$latest_state\""
+    echo "Deleted rule from iptables."
   fi
 }
 
@@ -53,14 +53,9 @@ until [[ $(< "$readiness_file_path") == "$ready_state" ]]; do
   sleep 1
 done
 
-pipe=$(mktemp -u)
-mkfifo "$pipe"
-exec 3<>"$pipe"
-rm "$pipe"
-
 echo "first run" >&3
 
-inotifywait -q -m -e modify "$readiness_file_path" >&3 |
-while read -r <&3; do
-  check_readiness
+while true; do
+	inotifywait -q -e modify "$readiness_file_path" &> /dev/null
+	check_readiness
 done


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix stuck in iptables-loop script.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Sometimes the iptables loop script can get stuck after throwing exit code 1 (inotifywatch continues to watch file, but second part of pipe doesn't apply). As a result, no iptables rule is created and node-local-dns becomes unusable. 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Container iptables-loop will exit if entrypoint throws exit code. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-local-dns
type: fix
summary: Fix stuck in iptables-loop script.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
