### PR TITLE
[ingress-nginx] Add requirements check for ModuleConfig defaultControllerVersion

### DIFF
--- a/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
+++ b/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
@@ -80,6 +80,8 @@ func discoverMinimalNginxVersion(input *go_hook.HookInput) error {
 	configuredDefaultVersion := input.Values.Get("ingressNginx.defaultControllerVersion").String()
 	if configuredDefaultVersion != "" {
 		requirements.SaveValue(configuredDefaultVersionKey, configuredDefaultVersion)
+	} else {
+		requirements.RemoveValue(configuredDefaultVersionKey)
 	}
 
 	for _, s := range snap {

--- a/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
+++ b/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
@@ -46,6 +46,7 @@ const (
 	minVersionValuesKey     = "ingressNginx:minimalControllerVersion"
 	incompatibleVersionsKey = "ingressNginx:hasIncompatibleIngressClass"
 	disruptionKey           = "ingressNginx:hasDisruption"
+	moduleConfigVersionKey  = "ingressNginx:moduleConfigVersion"
 )
 
 func applySpecControllerFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -76,6 +77,11 @@ func discoverMinimalNginxVersion(input *go_hook.HookInput) error {
 	classVersionMap := make(map[string]*semver.Version)
 	var isDisruptionUpdate bool
 
+	moduleConfigVersion := input.Values.Get("ingressNginx.defaultControllerVersion").String()
+	if moduleConfigVersion != "" {
+		requirements.SaveValue(moduleConfigVersionKey, moduleConfigVersion)
+	}
+
 	for _, s := range snap {
 		if s == nil {
 			continue
@@ -83,7 +89,7 @@ func discoverMinimalNginxVersion(input *go_hook.HookInput) error {
 
 		ctrl := s.(ingressNginxController)
 		if ctrl.Version == "" {
-			ctrl.Version = input.Values.Get("ingressNginx.defaultControllerVersion").String()
+			ctrl.Version = moduleConfigVersion
 			if ctrl.Version == "0.33" {
 				isDisruptionUpdate = true
 			}

--- a/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
+++ b/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
@@ -43,10 +43,10 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, discoverMinimalNginxVersion)
 
 const (
-	minVersionValuesKey     = "ingressNginx:minimalControllerVersion"
-	incompatibleVersionsKey = "ingressNginx:hasIncompatibleIngressClass"
-	disruptionKey           = "ingressNginx:hasDisruption"
-	moduleConfigVersionKey  = "ingressNginx:moduleConfigVersion"
+	minVersionValuesKey         = "ingressNginx:minimalControllerVersion"
+	incompatibleVersionsKey     = "ingressNginx:hasIncompatibleIngressClass"
+	disruptionKey               = "ingressNginx:hasDisruption"
+	configuredDefaultVersionKey = "ingressNginx:configuredDefaultVersion"
 )
 
 func applySpecControllerFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -77,9 +77,9 @@ func discoverMinimalNginxVersion(input *go_hook.HookInput) error {
 	classVersionMap := make(map[string]*semver.Version)
 	var isDisruptionUpdate bool
 
-	moduleConfigVersion := input.Values.Get("ingressNginx.defaultControllerVersion").String()
-	if moduleConfigVersion != "" {
-		requirements.SaveValue(moduleConfigVersionKey, moduleConfigVersion)
+	configuredDefaultVersion := input.Values.Get("ingressNginx.defaultControllerVersion").String()
+	if configuredDefaultVersion != "" {
+		requirements.SaveValue(configuredDefaultVersionKey, configuredDefaultVersion)
 	}
 
 	for _, s := range snap {
@@ -89,7 +89,7 @@ func discoverMinimalNginxVersion(input *go_hook.HookInput) error {
 
 		ctrl := s.(ingressNginxController)
 		if ctrl.Version == "" {
-			ctrl.Version = moduleConfigVersion
+			ctrl.Version = configuredDefaultVersion
 			if ctrl.Version == "0.33" {
 				isDisruptionUpdate = true
 			}

--- a/modules/402-ingress-nginx/requirements/check.go
+++ b/modules/402-ingress-nginx/requirements/check.go
@@ -18,6 +18,7 @@ package requirements
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -27,6 +28,7 @@ import (
 const (
 	minVersionValuesKey     = "ingressNginx:minimalControllerVersion"
 	incompatibleVersionsKey = "ingressNginx:hasIncompatibleIngressClass"
+	moduleConfigVersionKey  = "ingressNginx:moduleConfigVersion"
 )
 
 func init() {
@@ -43,6 +45,14 @@ func init() {
 		if err != nil {
 			return false, err
 		}
+
+		moduleConfigVersionStr, exists := getter.Get(moduleConfigVersionKey)
+		if exists {
+			if moduleConfigVersion, err := semver.NewVersion(moduleConfigVersionStr.(string)); err == nil && moduleConfigVersion.LessThan(desiredVersion) {
+				return false, fmt.Errorf("ModuleConfig defaultControllerVersion %s is lower then required %s", moduleConfigVersion.String(), desiredVersion.String())
+			}
+		}
+
 		currentVersionRaw, exists := getter.Get(minVersionValuesKey)
 		if !exists {
 			// no IngressNginxController CRs exist

--- a/modules/402-ingress-nginx/requirements/check.go
+++ b/modules/402-ingress-nginx/requirements/check.go
@@ -26,9 +26,9 @@ import (
 )
 
 const (
-	minVersionValuesKey     = "ingressNginx:minimalControllerVersion"
-	incompatibleVersionsKey = "ingressNginx:hasIncompatibleIngressClass"
-	moduleConfigVersionKey  = "ingressNginx:moduleConfigVersion"
+	minVersionValuesKey         = "ingressNginx:minimalControllerVersion"
+	incompatibleVersionsKey     = "ingressNginx:hasIncompatibleIngressClass"
+	configuredDefaultVersionKey = "ingressNginx:configuredDefaultVersion"
 )
 
 func init() {
@@ -46,10 +46,10 @@ func init() {
 			return false, err
 		}
 
-		moduleConfigVersionStr, exists := getter.Get(moduleConfigVersionKey)
+		configuredDefaultVersionStr, exists := getter.Get(configuredDefaultVersionKey)
 		if exists {
-			if moduleConfigVersion, err := semver.NewVersion(moduleConfigVersionStr.(string)); err == nil && moduleConfigVersion.LessThan(desiredVersion) {
-				return false, fmt.Errorf("ModuleConfig defaultControllerVersion %s is lower then required %s", moduleConfigVersion.String(), desiredVersion.String())
+			if configuredDefaultVersion, err := semver.NewVersion(configuredDefaultVersionStr.(string)); err == nil && configuredDefaultVersion.LessThan(desiredVersion) {
+				return false, fmt.Errorf("ModuleConfig defaultControllerVersion %s is lower then required %s", configuredDefaultVersion.String(), desiredVersion.String())
 			}
 		}
 

--- a/modules/402-ingress-nginx/requirements/check_test.go
+++ b/modules/402-ingress-nginx/requirements/check_test.go
@@ -57,7 +57,7 @@ func TestIngressNginxVersionRequirement(t *testing.T) {
 	})
 
 	t.Run("Outdated ModuleConfig version", func(t *testing.T) {
-		requirements.SaveValue(moduleConfigVersionKey, "0.26")
+		requirements.SaveValue(configuredDefaultVersionKey, "0.26")
 		ok, err := requirements.CheckRequirement("ingressNginx", "0.33")
 		assert.False(t, ok)
 		require.Error(t, err)

--- a/modules/402-ingress-nginx/requirements/check_test.go
+++ b/modules/402-ingress-nginx/requirements/check_test.go
@@ -55,4 +55,11 @@ func TestIngressNginxVersionRequirement(t *testing.T) {
 		assert.False(t, ok)
 		require.Error(t, err)
 	})
+
+	t.Run("Outdated ModuleConfig version", func(t *testing.T) {
+		requirements.SaveValue(moduleConfigVersionKey, "0.26")
+		ok, err := requirements.CheckRequirement("ingressNginx", "0.33")
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
## Description
Added a check for the pre-release of the defaultControllerVersion value in the `ModuleConfig`.

## Why do we need it, and what problem does it solve?
The defaultControllerVersion MC parameter specifies the default version for IngressNginxControllers created without explicitly specifying the controller version.

The supported versions scope can change from release to release, if the defaultControllerVersion configured in cluster won't be supported in next release, the module will crash after update.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: chore
summary: Added a release requirement check for defaultControllerVersion parameter.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
