### PR TITLE
[tests] Fix eks e2e

### DIFF
--- a/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
@@ -71,7 +71,7 @@ spec:
   settings:
     modules:
       publicDomainTemplate: "%s.k8s.smoke.flant.com"
-    storageClass: localpath-all
+      storageClass: localpath-all
   version: 1
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
@@ -72,7 +72,7 @@ spec:
     modules:
       publicDomainTemplate: "%s.k8s.smoke.flant.com"
       storageClass: localpath-all
-  version: 1
+  version: 2
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig

--- a/testing/cloud_layouts/EKS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/resources.yaml
@@ -20,6 +20,7 @@ metadata:
   namespace: d8-system
 data:
   .file: "content"
+  .file2: "content2"
 ---
 # testing creating multiple resources for one non exists resource
 apiVersion: v1

--- a/testing/cloud_layouts/EKS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/resources.yaml
@@ -20,7 +20,6 @@ metadata:
   namespace: d8-system
 data:
   .file: "content"
-  .file2: "content2"
 ---
 # testing creating multiple resources for one non exists resource
 apiVersion: v1


### PR DESCRIPTION
## Description
We have bug in the main branch with global.storageClass, but we should use global.modules.storageClass in the future anyway.

## Why do we need it, and what problem does it solve?
EKS e2e was failed

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tests
type: fix
summary: Fix eks e2e
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
