### PR TITLE
[ci] Temporary: save info about built image

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -116,6 +116,10 @@ steps:
       # CE/EE/FE -> ce/ee/fe
       REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
 
+      #temporary: move temp dir
+      TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
+      mkdir -p "$TEMP_WORKDIR"
+
       # Registry path to publish images for Git branches.
       BRANCH_REGISTRY_PATH=
       # Registry path to publish images for Git tags.
@@ -135,6 +139,7 @@ steps:
           ${SECONDARY_REPO} \
           --parallel=true --parallel-tasks-limit=5 \
           --save-build-report=true \
+          --tmp-dir="$TEMP_WORKDIR" \
           --build-report-path images_tags_werf.json
         BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
         SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -146,11 +151,14 @@ steps:
         werf build \
           --parallel=true --parallel-tasks-limit=5 \
           --save-build-report=true \
+          --tmp-dir="$TEMP_WORKDIR" \
           --build-report-path images_tags_werf.json
         BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
         SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
         echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
       fi
+
+      cp images_tags_werf.json "$TEMP_WORKDIR"
 
       # Publish images for Git branch.
       if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -201,7 +209,9 @@ steps:
             --secondary-repo $WERF_REPO \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
+          cp images_tags_werf.json "$TEMP_WORKDIR"
         fi
         # Note: do not run second werf build for test repo, as it has no secondary repo.
 

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -733,6 +733,10 @@ jobs:
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
 
+          #temporary: move temp dir
+          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
+          mkdir -p "$TEMP_WORKDIR"
+
           # Registry path to publish images for Git branches.
           BRANCH_REGISTRY_PATH=
           # Registry path to publish images for Git tags.
@@ -752,6 +756,7 @@ jobs:
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -763,11 +768,14 @@ jobs:
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -433,6 +433,10 @@ jobs:
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
 
+          #temporary: move temp dir
+          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
+          mkdir -p "$TEMP_WORKDIR"
+
           # Registry path to publish images for Git branches.
           BRANCH_REGISTRY_PATH=
           # Registry path to publish images for Git tags.
@@ -452,6 +456,7 @@ jobs:
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -463,11 +468,14 @@ jobs:
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -591,6 +591,10 @@ jobs:
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
 
+          #temporary: move temp dir
+          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
+          mkdir -p "$TEMP_WORKDIR"
+
           # Registry path to publish images for Git branches.
           BRANCH_REGISTRY_PATH=
           # Registry path to publish images for Git tags.
@@ -610,6 +614,7 @@ jobs:
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -621,11 +626,14 @@ jobs:
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -676,7 +684,9 @@ jobs:
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
+                --tmp-dir="$TEMP_WORKDIR" \
                 --build-report-path images_tags_werf.json
+              cp images_tags_werf.json "$TEMP_WORKDIR"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -942,6 +952,10 @@ jobs:
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
 
+          #temporary: move temp dir
+          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
+          mkdir -p "$TEMP_WORKDIR"
+
           # Registry path to publish images for Git branches.
           BRANCH_REGISTRY_PATH=
           # Registry path to publish images for Git tags.
@@ -961,6 +975,7 @@ jobs:
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -972,11 +987,14 @@ jobs:
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1027,7 +1045,9 @@ jobs:
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
+                --tmp-dir="$TEMP_WORKDIR" \
                 --build-report-path images_tags_werf.json
+              cp images_tags_werf.json "$TEMP_WORKDIR"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -1293,6 +1313,10 @@ jobs:
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
 
+          #temporary: move temp dir
+          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
+          mkdir -p "$TEMP_WORKDIR"
+
           # Registry path to publish images for Git branches.
           BRANCH_REGISTRY_PATH=
           # Registry path to publish images for Git tags.
@@ -1312,6 +1336,7 @@ jobs:
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -1323,11 +1348,14 @@ jobs:
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1378,7 +1406,9 @@ jobs:
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
+                --tmp-dir="$TEMP_WORKDIR" \
                 --build-report-path images_tags_werf.json
+              cp images_tags_werf.json "$TEMP_WORKDIR"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -1644,6 +1674,10 @@ jobs:
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
 
+          #temporary: move temp dir
+          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
+          mkdir -p "$TEMP_WORKDIR"
+
           # Registry path to publish images for Git branches.
           BRANCH_REGISTRY_PATH=
           # Registry path to publish images for Git tags.
@@ -1663,6 +1697,7 @@ jobs:
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -1674,11 +1709,14 @@ jobs:
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1729,7 +1767,9 @@ jobs:
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
+                --tmp-dir="$TEMP_WORKDIR" \
                 --build-report-path images_tags_werf.json
+              cp images_tags_werf.json "$TEMP_WORKDIR"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -1995,6 +2035,10 @@ jobs:
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
 
+          #temporary: move temp dir
+          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
+          mkdir -p "$TEMP_WORKDIR"
+
           # Registry path to publish images for Git branches.
           BRANCH_REGISTRY_PATH=
           # Registry path to publish images for Git tags.
@@ -2014,6 +2058,7 @@ jobs:
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -2025,11 +2070,14 @@ jobs:
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -2080,7 +2128,9 @@ jobs:
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
+                --tmp-dir="$TEMP_WORKDIR" \
                 --build-report-path images_tags_werf.json
+              cp images_tags_werf.json "$TEMP_WORKDIR"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 
@@ -2346,6 +2396,10 @@ jobs:
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
 
+          #temporary: move temp dir
+          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
+          mkdir -p "$TEMP_WORKDIR"
+
           # Registry path to publish images for Git branches.
           BRANCH_REGISTRY_PATH=
           # Registry path to publish images for Git tags.
@@ -2365,6 +2419,7 @@ jobs:
               ${SECONDARY_REPO} \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
@@ -2376,11 +2431,14 @@ jobs:
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
+              --tmp-dir="$TEMP_WORKDIR" \
               --build-report-path images_tags_werf.json
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
+
+          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -2431,7 +2489,9 @@ jobs:
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --save-build-report=true \
+                --tmp-dir="$TEMP_WORKDIR" \
                 --build-report-path images_tags_werf.json
+              cp images_tags_werf.json "$TEMP_WORKDIR"
             fi
             # Note: do not run second werf build for test repo, as it has no secondary repo.
 


### PR DESCRIPTION
## Description
Save information about built image (Werf render file and Werf buiild report file) locally.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Save information about built image.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
