### PR TITLE
[dhctl] Add quotes to highlight the error in the component when loading

### DIFF
--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -567,7 +567,7 @@ func CheckDHCTLDependencies(nodeInteface node.Interface) error {
 				if errors.As(err, &ee) {
 					log.DebugF("exit code: %v", ee)
 				}
-				e := fmt.Errorf("bashible dependency %s error: %v - %s",
+				e := fmt.Errorf("bashible dependency '%s' error: %v - %s",
 					dep,
 					err,
 					string(output),


### PR DESCRIPTION

## Description
With bootstrap an error may occur:

 `❗ ~ bashible dependency tar error: execute command 'command': exit status 1 - Warning: Permanently`

This can lead to diagnostic confusion due to a misunderstanding of the "tar" component.

## Why do we need it, and what problem does it solve?
To avoid confusion during diagnostics, it is suggested to highlight the problematic component with quotation marks:

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?

` ❗ ~ bashible dependency 'tar' error: execute command 'command': exit status 1 - Warning: Permanently`

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: add quotes to highlight the error in the component when loading
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
