### PR TITLE
[candi] Fix bashible step that makes the profiled script executable.

### DIFF
--- a/candi/bashible/common-steps/all/004_make_profiled_scripts_executable.sh.tpl
+++ b/candi/bashible/common-steps/all/004_make_profiled_scripts_executable.sh.tpl
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 # On AltLinux, scripts under /etc/profile.d should be executable.
-if $(bb-is-bundle) == 'altlinux'; then
+if [[ $(bb-is-bundle) == "altlinux" ]]; then
   chmod +x /etc/profile.d/*.sh
 fi


### PR DESCRIPTION
## Description

Fixes for #9761
Fix "command not found" error in `004_make_profiled_scripts_executable.sh.tpl` bashible step.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

```
дек 06 13:20:54 dev-master-0 bashible.sh[1024861]: === Step: /var/lib/bashible/bundle_steps/004_make_profiled_scripts_executable.sh
дек 06 13:20:54 dev-master-0 bashible.sh[1024861]: ===
дек 06 13:20:54 dev-master-0 bashible.sh[1026437]: /var/lib/bashible/bundle_steps/004_make_profiled_scripts_executable.sh: line 16: redos: command not found
```

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Correct step execution.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix bashible step that makes the profiled script executable.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
