### PR TITLE
[testing] Update module schema version for e2e tests

### DIFF
--- a/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
@@ -79,7 +79,7 @@ spec:
   enabled: true
   settings:
     earlyOomEnabled: false
-  version: 1
+  version: 2
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig

--- a/testing/cloud_layouts/Azure/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Azure/Standard/configuration.tpl.yaml
@@ -78,7 +78,7 @@ spec:
   enabled: true
   settings:
     earlyOomEnabled: false
-  version: 1
+  version: 2
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig

--- a/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
@@ -20,17 +20,6 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
-  name: deckhouse
-spec:
-  enabled: true
-  version: 1
-  settings:
-    bundle: Minimal
-    logLevel: Info
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
   name: cert-manager
 spec:
   enabled: true

--- a/testing/cloud_layouts/Static/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Static/configuration.tpl.yaml
@@ -59,7 +59,7 @@ spec:
   enabled: true
   settings:
     earlyOomEnabled: false
-  version: 1
+  version: 2
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig

--- a/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
@@ -89,7 +89,7 @@ kind: ModuleConfig
 metadata:
   name: node-manager
 spec:
-  version: 1
+  version: 2
   enabled: true
   settings:
     earlyOomEnabled: false # openSUSE

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_alerts.sh
@@ -25,7 +25,6 @@ allow_alerts=(
 "CertmanagerCertificateExpiredSoon" # Same as above
 "DeckhouseModuleUseEmptyDir" # TODO Need made split storage class
 "D8EtcdExcessiveDatabaseGrowth" # It may trigger during bootstrap due to a sudden increase in resource count
-"ModuleConfigObsoleteVersion" # Suppress false positive errors on old versions of modules
 )
 
 # In e2e tests with OS on older cores (AWS, Azure), ebpf_exporter does not initiliaze. Ignore this alerts


### PR DESCRIPTION
## Description
Update module schema version for e2e tests.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: Update module schema version for e2e tests.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
