### PR TITLE
[dhctl] fix cluster configuration secret name label

### DIFF
--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -584,7 +584,7 @@ func SecretWithClusterConfig(data []byte) *apiv1.Secret {
 		"d8-cluster-configuration",
 		"kube-system",
 		map[string][]byte{"cluster-configuration.yaml": data},
-		nil,
+		map[string]string{"name": "d8-cluster-configuration"},
 	)
 }
 

--- a/global-hooks/migrate/migrate_cluster_configuration_label.go
+++ b/global-hooks/migrate/migrate_cluster_configuration_label.go
@@ -22,12 +22,11 @@ TODO: remove after deckhouse 1.68
 package hooks
 
 import (
-	"k8s.io/utils/ptr"
-
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{

--- a/global-hooks/migrate/migrate_cluster_configuration_label.go
+++ b/global-hooks/migrate/migrate_cluster_configuration_label.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This migration adds label name: d8-cluster-configuration to the d8-cluster-configuration secret
+TODO: remove after deckhouse 1.68
+*/
+
+package hooks
+
+import (
+	"k8s.io/utils/ptr"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:              "clusterConfiguration",
+			ApiVersion:        "v1",
+			Kind:              "Secret",
+			NamespaceSelector: &types.NamespaceSelector{NameSelector: &types.NameSelector{MatchNames: []string{"kube-system"}}},
+			NameSelector:      &types.NameSelector{MatchNames: []string{"d8-cluster-configuration"}},
+			// it's enough to start it only on the first run
+			ExecuteHookOnEvents: ptr.To(false),
+			FilterFunc:          filterName,
+		},
+	},
+}, handleClusterConfigurationLabel)
+
+// Required to run the hook when the k8s version has been changed
+func filterName(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return obj.GetLabels(), nil
+}
+
+func handleClusterConfigurationLabel(input *go_hook.HookInput) error {
+	snap := input.Snapshots["clusterConfiguration"]
+	if len(snap) == 0 {
+		return nil
+	}
+	labels := snap[0].(map[string]string)
+
+	if len(labels) > 0 {
+		if _, ok := labels["name"]; ok {
+			return nil
+		}
+	}
+
+	m := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": map[string]string{
+				"name": "d8-cluster-configuration",
+			},
+		},
+	}
+
+	input.PatchCollector.MergePatch(m, "v1", "Secret", "kube-system", "d8-cluster-configuration")
+	return nil
+}

--- a/global-hooks/migrate/migrate_cluster_configuration_label_test.go
+++ b/global-hooks/migrate/migrate_cluster_configuration_label_test.go
@@ -33,7 +33,6 @@ kind: Secret
 metadata:
   labels:
     a: b
-    name: d8-cluster-configuration
   name: d8-cluster-configuration
   namespace: kube-system
 type: Opaque

--- a/global-hooks/migrate/migrate_cluster_configuration_label_test.go
+++ b/global-hooks/migrate/migrate_cluster_configuration_label_test.go
@@ -1,0 +1,75 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Global hooks :: migrate cluster_configuration labels", func() {
+	f := HookExecutionConfigInit(`{"global": {"internal": {"modules": {"resourcesRequests": {}}}}}`, `{}`)
+
+	Context("Secret without label", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    a: b
+    name: d8-cluster-configuration
+  name: d8-cluster-configuration
+  namespace: kube-system
+type: Opaque
+`))
+			f.RunHook()
+		})
+
+		It("Should have added label name", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			sec := f.KubernetesResource("Secret", "kube-system", "d8-cluster-configuration")
+			Expect(sec.Field("metadata.labels.name").String()).To(Equal("d8-cluster-configuration"))
+		})
+	})
+
+	Context("Secret with label", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    a: b
+    c: d
+    name: d8-cluster-configuration
+  name: d8-cluster-configuration
+  namespace: kube-system
+type: Opaque
+`))
+			f.RunHook()
+		})
+
+		It("Should be kept untouch", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			sec := f.KubernetesResource("Secret", "kube-system", "d8-cluster-configuration")
+			Expect(sec.Field("metadata.labels").Map()).To(HaveLen(3))
+		})
+	})
+})


### PR DESCRIPTION
## Description
It sets the 'name' label to the 'd8-cluster-configuration' secret.

## Why do we need it, and what problem does it solve?
Deckhouse controller caches the 'd8-cluster-configuration' secret by the 'name' label. This label was removed, and deckhouse cannot check k8s automatic version.

## What is the expected result?
Deckhouse can check k8s automatic version

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: Add the 'name' label to the 'd8-cluster-configuration' secret.
impact_level: low
```
