### PR TITLE
[testing] Fix spellcheck linter command to use local cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,10 +261,10 @@ docs-linkscheck: ## Build documentation and run checker of html links.
 .PHONY: docs-spellcheck
 docs-spellcheck: ## Check the spelling in the documentation.
   ##~ Options: file="path/to/file" (Specify a path to a specific file)
-	cd tools/spelling && werf run docs-spell-checker --dev --docker-options="--entrypoint=sh" -- /app/spell_check.sh -f $(file)
+	cd tools/spelling && werf run docs-spell-checker --dev --docker-options="--entrypoint=sh" --repo ":local" -- /app/spell_check.sh -f $(file)
 
 lint-doc-spellcheck-pr:
-	@cd tools/spelling && werf run docs-spell-checker --dev --docker-options="--entrypoint=bash" -- /app/check_diff.sh
+	@cd tools/spelling && werf run docs-spell-checker --dev --docker-options="--entrypoint=bash" --repo ":local" -- /app/check_diff.sh
 
 .PHONY: docs-spellcheck-generate-dictionary
 docs-spellcheck-generate-dictionary: ## Generate a dictionary (run it after adding new words to the tools/spelling/wordlist file).

--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ docs-spellcheck: ## Check the spelling in the documentation.
 	cd tools/spelling && werf run docs-spell-checker --dev --docker-options="--entrypoint=sh" --repo ":local" -- /app/spell_check.sh -f $(file)
 
 lint-doc-spellcheck-pr:
-	@cd tools/spelling && werf run docs-spell-checker --dev --docker-options="--entrypoint=bash" --repo ":local" -- /app/check_diff.sh
+	@cd tools/spelling && werf run docs-spell-checker --dev --docker-options="--entrypoint=bash" -- /app/check_diff.sh
 
 .PHONY: docs-spellcheck-generate-dictionary
 docs-spellcheck-generate-dictionary: ## Generate a dictionary (run it after adding new words to the tools/spelling/wordlist file).

--- a/tools/spelling/dictionaries/dev_OPS.dic
+++ b/tools/spelling/dictionaries/dev_OPS.dic
@@ -345,6 +345,7 @@ Dryrun
 DSL
 DSR
 dst
+DVP
 eBPF
 EBS
 ECMP

--- a/tools/spelling/wordlist
+++ b/tools/spelling/wordlist
@@ -344,6 +344,7 @@ Dryrun
 DSL
 DSR
 dst
+DVP
 eBPF
 EBS
 ECMP


### PR DESCRIPTION
## Description
Make spellcheck linter target the local repo and add `DVP` to the word list.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: testing
type: chore
summary: Fix spellcheck linter command to use local cache.
impact_level: low
```