### PR TITLE
[deckhouse] set module version

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -154,11 +154,15 @@ func (l *Loader) restoreAbsentModulesFromReleases(ctx context.Context) error {
 			if !apierrors.IsNotFound(err) {
 				return fmt.Errorf("get '%s' module: %w", release.Spec.ModuleName, err)
 			}
+			l.log.Warnf("the '%s' module is missing, skip setting version", release.Spec.ModuleName)
 		} else {
-			l.log.Infof("set the '%s' version for the '%s' module is restored", release.Spec.Version.String(), release.Spec.ModuleName)
+			l.log.Debugf("set the '%s' version for the '%s' module", release.Spec.Version.String(), release.Spec.ModuleName)
 			err = utils.Update[*v1alpha1.Module](ctx, l.client, module, func(module *v1alpha1.Module) bool {
-				module.Properties.Version = release.Spec.Version.String()
-				return true
+				if module.Properties.Version != "v"+release.Spec.Version.String() {
+					module.Properties.Version = "v" + release.Spec.Version.String()
+					return true
+				}
+				return false
 			})
 			if err != nil {
 				return fmt.Errorf("update the '%s' module: %w", release.Spec.ModuleName, err)

--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -154,6 +154,8 @@ func (l *Loader) restoreAbsentModulesFromReleases(ctx context.Context) error {
 			if !apierrors.IsNotFound(err) {
 				return fmt.Errorf("get '%s' module: %w", release.Spec.ModuleName, err)
 			}
+		} else {
+			l.log.Infof("set the '%s' version for the '%s' module is restored", release.Spec.Version.String(), release.Spec.ModuleName)
 			err = utils.Update[*v1alpha1.Module](ctx, l.client, module, func(module *v1alpha1.Module) bool {
 				module.Properties.Version = release.Spec.Version.String()
 				return true


### PR DESCRIPTION
## Description
It sets module versions by deployed release at start.

## Why do we need it, and what problem does it solve?
See version in module CR.

## What is the expected result?
<img width="763" alt="Screenshot 2024-12-06 at 10 24 02 PM" src="https://github.com/user-attachments/assets/fba82b7b-73f8-43fc-91b5-d0dea7ddc278">


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Set modules versions by releases.
```
