### PR TITLE
Add command restriction to dhctl; restrict commands in terraform-manager

### DIFF
--- a/deckhouse-controller/pkg/helpers/register.go
+++ b/deckhouse-controller/pkg/helpers/register.go
@@ -53,8 +53,9 @@ func DefineHelperCommands(kpApp *kingpin.Application, logger *log.Logger) {
 			return changeregistry.ChangeRegistry(*newRegistry, *user, *password, *caFile, *newImageTag, *scheme, *dryRun, logger)
 		})
 	}
-
+	const parseClusterConfigurationSubcommand = "cluster-configuration"
+	const parseCloudDiscoveryDataSubcommand = "cloud-discovery-data"
 	// dhctl parser for ClusterConfiguration and <Provider-name>ClusterConfiguration secrets
-	dhctlapp.DefineCommandParseClusterConfiguration(kpApp, helpersCommand)
-	dhctlapp.DefineCommandParseCloudDiscoveryData(kpApp, helpersCommand)
+	dhctlapp.DefineCommandParseClusterConfiguration(kpApp, helpersCommand, parseClusterConfigurationSubcommand)
+	dhctlapp.DefineCommandParseCloudDiscoveryData(kpApp, helpersCommand, parseCloudDiscoveryDataSubcommand)
 }

--- a/deckhouse-controller/pkg/helpers/register.go
+++ b/deckhouse-controller/pkg/helpers/register.go
@@ -53,9 +53,8 @@ func DefineHelperCommands(kpApp *kingpin.Application, logger *log.Logger) {
 			return changeregistry.ChangeRegistry(*newRegistry, *user, *password, *caFile, *newImageTag, *scheme, *dryRun, logger)
 		})
 	}
-	const parseClusterConfigurationSubcommand = "cluster-configuration"
-	const parseCloudDiscoveryDataSubcommand = "cloud-discovery-data"
+
 	// dhctl parser for ClusterConfiguration and <Provider-name>ClusterConfiguration secrets
-	dhctlapp.DefineCommandParseClusterConfiguration(kpApp, helpersCommand, parseClusterConfigurationSubcommand)
-	dhctlapp.DefineCommandParseCloudDiscoveryData(kpApp, helpersCommand, parseCloudDiscoveryDataSubcommand)
+	dhctlapp.DefineCommandParseClusterConfiguration(kpApp, helpersCommand, kingpin.Command("cluster-configuration", "Parse configuration and print it."))
+	dhctlapp.DefineCommandParseCloudDiscoveryData(kpApp, helpersCommand, kingpin.Command("cloud-discovery-data", "Parse cloud discovery data and print it."))
 }

--- a/deckhouse-controller/pkg/helpers/register.go
+++ b/deckhouse-controller/pkg/helpers/register.go
@@ -55,6 +55,8 @@ func DefineHelperCommands(kpApp *kingpin.Application, logger *log.Logger) {
 	}
 
 	// dhctl parser for ClusterConfiguration and <Provider-name>ClusterConfiguration secrets
-	dhctlapp.DefineCommandParseClusterConfiguration(kpApp, helpersCommand, kingpin.Command("cluster-configuration", "Parse configuration and print it."))
-	dhctlapp.DefineCommandParseCloudDiscoveryData(kpApp, helpersCommand, kingpin.Command("cloud-discovery-data", "Parse cloud discovery data and print it."))
+	cmd := kpApp.Command("cluster-configuration", "Parse configuration and print it.")
+	dhctlapp.DefineCommandParseClusterConfiguration(cmd)
+	cmd = kpApp.Command("cloud-discovery-data", "Parse cloud discovery data and print it.")
+	dhctlapp.DefineCommandParseCloudDiscoveryData(cmd)
 }

--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -23,8 +23,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
 
-func DefineBootstrapCommand(kpApp *kingpin.Application, cmd *kingpin.CmdClause) *kingpin.CmdClause {
-	// cmd := kpApp.Command(command, "Bootstrap cluster.")
+func DefineBootstrapCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -23,8 +23,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
 
-func DefineBootstrapCommand(kpApp *kingpin.Application, command string) *kingpin.CmdClause {
-	cmd := kpApp.Command(command, "Bootstrap cluster.")
+func DefineBootstrapCommand(kpApp *kingpin.Application, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+	// cmd := kpApp.Command(command, "Bootstrap cluster.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -23,8 +23,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
 
-func DefineBootstrapCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
-	cmd := kpApp.Command("bootstrap", "Bootstrap cluster.")
+func DefineBootstrapCommand(kpApp *kingpin.Application, command string) *kingpin.CmdClause {
+	cmd := kpApp.Command(command, "Bootstrap cluster.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -26,8 +26,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
 
-func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Install deckhouse and wait for its readiness.")
+func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)
@@ -52,8 +51,7 @@ func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause, command s
 	return cmd
 }
 
-func DefineBootstrapExecuteBashibleCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Prepare Master node and install Kubernetes.")
+func DefineBootstrapExecuteBashibleCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)
@@ -75,8 +73,7 @@ func DefineBootstrapExecuteBashibleCommand(parent *kingpin.CmdClause, command st
 	return cmd
 }
 
-func DefineCreateResourcesCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Create resources in Kubernetes cluster.")
+func DefineCreateResourcesCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineConfigsForResourcesPhaseFlags(cmd)
@@ -99,8 +96,7 @@ func DefineCreateResourcesCommand(parent *kingpin.CmdClause, command string) *ki
 	return cmd
 }
 
-func DefineBootstrapAbortCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Delete every node, which was created during bootstrap process.")
+func DefineBootstrapAbortCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineConfigFlags(cmd)
@@ -120,8 +116,7 @@ func DefineBootstrapAbortCommand(parent *kingpin.CmdClause, command string) *kin
 	return cmd
 }
 
-func DefineBaseInfrastructureCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Create base infrastructure for Cloud Kubernetes cluster.")
+func DefineBaseInfrastructureCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineConfigFlags(cmd)
 	app.DefineCacheFlags(cmd)
 	app.DefineDropCacheFlags(cmd)
@@ -136,8 +131,7 @@ func DefineBaseInfrastructureCommand(parent *kingpin.CmdClause, command string) 
 	return cmd
 }
 
-func DefineExecPostBootstrapScript(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Test scp upload and ssh run uploaded script.")
+func DefineExecPostBootstrapScript(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefinePostBootstrapScriptFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -26,7 +26,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
 
-func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineBootstrapInstallDeckhouseCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)
@@ -51,7 +51,7 @@ func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause, cmd *king
 	return cmd
 }
 
-func DefineBootstrapExecuteBashibleCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineBootstrapExecuteBashibleCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)
@@ -73,7 +73,7 @@ func DefineBootstrapExecuteBashibleCommand(parent *kingpin.CmdClause, cmd *kingp
 	return cmd
 }
 
-func DefineCreateResourcesCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineCreateResourcesCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineConfigsForResourcesPhaseFlags(cmd)
@@ -96,7 +96,7 @@ func DefineCreateResourcesCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdCla
 	return cmd
 }
 
-func DefineBootstrapAbortCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineBootstrapAbortCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineConfigFlags(cmd)
@@ -116,7 +116,7 @@ func DefineBootstrapAbortCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClau
 	return cmd
 }
 
-func DefineBaseInfrastructureCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineBaseInfrastructureCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineConfigFlags(cmd)
 	app.DefineCacheFlags(cmd)
 	app.DefineDropCacheFlags(cmd)
@@ -131,7 +131,7 @@ func DefineBaseInfrastructureCommand(parent *kingpin.CmdClause, cmd *kingpin.Cmd
 	return cmd
 }
 
-func DefineExecPostBootstrapScript(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineExecPostBootstrapScript(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefinePostBootstrapScriptFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -26,8 +26,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
 
-func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("install-deckhouse", "Install deckhouse and wait for its readiness.")
+func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Install deckhouse and wait for its readiness.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)
@@ -52,8 +52,8 @@ func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause) *kingpin.
 	return cmd
 }
 
-func DefineBootstrapExecuteBashibleCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("execute-bashible-bundle", "Prepare Master node and install Kubernetes.")
+func DefineBootstrapExecuteBashibleCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Prepare Master node and install Kubernetes.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineConfigFlags(cmd)
 	app.DefineBecomeFlags(cmd)
@@ -75,8 +75,8 @@ func DefineBootstrapExecuteBashibleCommand(parent *kingpin.CmdClause) *kingpin.C
 	return cmd
 }
 
-func DefineCreateResourcesCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("create-resources", "Create resources in Kubernetes cluster.")
+func DefineCreateResourcesCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Create resources in Kubernetes cluster.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineConfigsForResourcesPhaseFlags(cmd)
@@ -99,8 +99,8 @@ func DefineCreateResourcesCommand(parent *kingpin.CmdClause) *kingpin.CmdClause 
 	return cmd
 }
 
-func DefineBootstrapAbortCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("abort", "Delete every node, which was created during bootstrap process.")
+func DefineBootstrapAbortCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Delete every node, which was created during bootstrap process.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineConfigFlags(cmd)
@@ -120,8 +120,8 @@ func DefineBootstrapAbortCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	return cmd
 }
 
-func DefineBaseInfrastructureCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("base-infra", "Create base infrastructure for Cloud Kubernetes cluster.")
+func DefineBaseInfrastructureCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Create base infrastructure for Cloud Kubernetes cluster.")
 	app.DefineConfigFlags(cmd)
 	app.DefineCacheFlags(cmd)
 	app.DefineDropCacheFlags(cmd)
@@ -136,8 +136,8 @@ func DefineBaseInfrastructureCommand(parent *kingpin.CmdClause) *kingpin.CmdClau
 	return cmd
 }
 
-func DefineExecPostBootstrapScript(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("exec-post-bootstrap", "Test scp upload and ssh run uploaded script.")
+func DefineExecPostBootstrapScript(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Test scp upload and ssh run uploaded script.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefinePostBootstrapScriptFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/config.go
+++ b/dhctl/cmd/dhctl/commands/config.go
@@ -33,7 +33,7 @@ var (
 	kubeadmTemplateOpenAPI = deckhouseDir + "/candi/control-plane-kubeadm/openapi.yaml"
 )
 
-func DefineRenderBashibleBundle(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineRenderBashibleBundle(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineConfigFlags(cmd)
 	app.DefineRenderConfigFlags(cmd)
 	app.DefineRenderBundleFlags(cmd)
@@ -68,7 +68,7 @@ func DefineRenderBashibleBundle(parent *kingpin.CmdClause, cmd *kingpin.CmdClaus
 	return cmd
 }
 
-func DefineRenderMasterBootstrap(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineRenderMasterBootstrap(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineConfigFlags(cmd)
 	app.DefineRenderConfigFlags(cmd)
 	app.DefineRenderBundleFlags(cmd)
@@ -92,7 +92,7 @@ func DefineRenderMasterBootstrap(parent *kingpin.CmdClause, cmd *kingpin.CmdClau
 	return cmd
 }
 
-func DefineRenderKubeadmConfig(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineRenderKubeadmConfig(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineConfigFlags(cmd)
 	app.DefineRenderConfigFlags(cmd)
 
@@ -115,7 +115,7 @@ func DefineRenderKubeadmConfig(parent *kingpin.CmdClause, cmd *kingpin.CmdClause
 	return cmd
 }
 
-func DefineCommandParseClusterConfiguration(kpApp *kingpin.Application, parentCmd *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineCommandParseClusterConfiguration(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineInputOutputRenderFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
@@ -157,7 +157,7 @@ func DefineCommandParseClusterConfiguration(kpApp *kingpin.Application, parentCm
 	return cmd
 }
 
-func DefineCommandParseCloudDiscoveryData(kpApp *kingpin.Application, parentCmd *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineCommandParseCloudDiscoveryData(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineInputOutputRenderFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {

--- a/dhctl/cmd/dhctl/commands/config.go
+++ b/dhctl/cmd/dhctl/commands/config.go
@@ -33,8 +33,8 @@ var (
 	kubeadmTemplateOpenAPI = deckhouseDir + "/candi/control-plane-kubeadm/openapi.yaml"
 )
 
-func DefineRenderBashibleBundle(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("bashible-bundle", "Render bashible bundle.")
+func DefineRenderBashibleBundle(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Render bashible bundle.")
 	app.DefineConfigFlags(cmd)
 	app.DefineRenderConfigFlags(cmd)
 	app.DefineRenderBundleFlags(cmd)
@@ -69,8 +69,8 @@ func DefineRenderBashibleBundle(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	return cmd
 }
 
-func DefineRenderMasterBootstrap(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("master-bootstrap-scripts", "Render master bootstrap scripts.")
+func DefineRenderMasterBootstrap(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Render master bootstrap scripts.")
 	app.DefineConfigFlags(cmd)
 	app.DefineRenderConfigFlags(cmd)
 	app.DefineRenderBundleFlags(cmd)
@@ -94,8 +94,8 @@ func DefineRenderMasterBootstrap(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	return cmd
 }
 
-func DefineRenderKubeadmConfig(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("kubeadm-config", "Render kubeadm config.")
+func DefineRenderKubeadmConfig(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Render kubeadm config.")
 	app.DefineConfigFlags(cmd)
 	app.DefineRenderConfigFlags(cmd)
 
@@ -118,12 +118,12 @@ func DefineRenderKubeadmConfig(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	return cmd
 }
 
-func DefineCommandParseClusterConfiguration(kpApp *kingpin.Application, parentCmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineCommandParseClusterConfiguration(kpApp *kingpin.Application, parentCmd *kingpin.CmdClause, command string) *kingpin.CmdClause {
 	var parseCmd *kingpin.CmdClause
 	if parentCmd == nil {
-		parseCmd = kpApp.Command("parse-cluster-configuration", "Parse configuration and print it.")
+		parseCmd = kpApp.Command("parse-"+command, "Parse configuration and print it.")
 	} else {
-		parseCmd = parentCmd.Command("cluster-configuration", "Parse configuration and print it.")
+		parseCmd = parentCmd.Command(command, "Parse configuration and print it.")
 	}
 	app.DefineInputOutputRenderFlags(parseCmd)
 
@@ -166,12 +166,12 @@ func DefineCommandParseClusterConfiguration(kpApp *kingpin.Application, parentCm
 	return parseCmd
 }
 
-func DefineCommandParseCloudDiscoveryData(kpApp *kingpin.Application, parentCmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineCommandParseCloudDiscoveryData(kpApp *kingpin.Application, parentCmd *kingpin.CmdClause, command string) *kingpin.CmdClause {
 	var parseCmd *kingpin.CmdClause
 	if parentCmd == nil {
-		parseCmd = kpApp.Command("parse-cloud-discovery-data", "Parse cloud discovery data and print it.")
+		parseCmd = kpApp.Command("parse-"+command, "Parse cloud discovery data and print it.")
 	} else {
-		parseCmd = parentCmd.Command("cloud-discovery-data", "Parse cloud discovery data and print it.")
+		parseCmd = parentCmd.Command(command, "Parse cloud discovery data and print it.")
 	}
 	app.DefineInputOutputRenderFlags(parseCmd)
 

--- a/dhctl/cmd/dhctl/commands/config.go
+++ b/dhctl/cmd/dhctl/commands/config.go
@@ -33,8 +33,7 @@ var (
 	kubeadmTemplateOpenAPI = deckhouseDir + "/candi/control-plane-kubeadm/openapi.yaml"
 )
 
-func DefineRenderBashibleBundle(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Render bashible bundle.")
+func DefineRenderBashibleBundle(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineConfigFlags(cmd)
 	app.DefineRenderConfigFlags(cmd)
 	app.DefineRenderBundleFlags(cmd)
@@ -69,8 +68,7 @@ func DefineRenderBashibleBundle(parent *kingpin.CmdClause, command string) *king
 	return cmd
 }
 
-func DefineRenderMasterBootstrap(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Render master bootstrap scripts.")
+func DefineRenderMasterBootstrap(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineConfigFlags(cmd)
 	app.DefineRenderConfigFlags(cmd)
 	app.DefineRenderBundleFlags(cmd)
@@ -94,8 +92,7 @@ func DefineRenderMasterBootstrap(parent *kingpin.CmdClause, command string) *kin
 	return cmd
 }
 
-func DefineRenderKubeadmConfig(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Render kubeadm config.")
+func DefineRenderKubeadmConfig(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineConfigFlags(cmd)
 	app.DefineRenderConfigFlags(cmd)
 
@@ -118,16 +115,10 @@ func DefineRenderKubeadmConfig(parent *kingpin.CmdClause, command string) *kingp
 	return cmd
 }
 
-func DefineCommandParseClusterConfiguration(kpApp *kingpin.Application, parentCmd *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	var parseCmd *kingpin.CmdClause
-	if parentCmd == nil {
-		parseCmd = kpApp.Command("parse-"+command, "Parse configuration and print it.")
-	} else {
-		parseCmd = parentCmd.Command(command, "Parse configuration and print it.")
-	}
-	app.DefineInputOutputRenderFlags(parseCmd)
+func DefineCommandParseClusterConfiguration(kpApp *kingpin.Application, parentCmd *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+	app.DefineInputOutputRenderFlags(cmd)
 
-	parseCmd.Action(func(c *kingpin.ParseContext) error {
+	cmd.Action(func(c *kingpin.ParseContext) error {
 		var err error
 		var metaConfig *config.MetaConfig
 
@@ -163,19 +154,13 @@ func DefineCommandParseClusterConfiguration(kpApp *kingpin.Application, parentCm
 		return nil
 	})
 
-	return parseCmd
+	return cmd
 }
 
-func DefineCommandParseCloudDiscoveryData(kpApp *kingpin.Application, parentCmd *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	var parseCmd *kingpin.CmdClause
-	if parentCmd == nil {
-		parseCmd = kpApp.Command("parse-"+command, "Parse cloud discovery data and print it.")
-	} else {
-		parseCmd = parentCmd.Command(command, "Parse cloud discovery data and print it.")
-	}
-	app.DefineInputOutputRenderFlags(parseCmd)
+func DefineCommandParseCloudDiscoveryData(kpApp *kingpin.Application, parentCmd *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+	app.DefineInputOutputRenderFlags(cmd)
 
-	parseCmd.Action(func(c *kingpin.ParseContext) error {
+	cmd.Action(func(c *kingpin.ParseContext) error {
 		var err error
 		var data []byte
 
@@ -211,7 +196,7 @@ func DefineCommandParseCloudDiscoveryData(kpApp *kingpin.Application, parentCmd 
 		return nil
 	})
 
-	return parseCmd
+	return cmd
 }
 
 func InitGlobalVars(pwd string) {

--- a/dhctl/cmd/dhctl/commands/control-plane.go
+++ b/dhctl/cmd/dhctl/commands/control-plane.go
@@ -28,8 +28,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 )
 
-func DefineTestControlPlaneManagerReadyCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("manager", "Test control plane manager is ready.")
+func DefineTestControlPlaneManagerReadyCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Test control plane manager is ready.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -68,8 +68,8 @@ func DefineTestControlPlaneManagerReadyCommand(parent *kingpin.CmdClause) *kingp
 	return cmd
 }
 
-func DefineTestControlPlaneNodeReadyCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("node", "Test control plane node is ready.")
+func DefineTestControlPlaneNodeReadyCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Test control plane node is ready.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/control-plane.go
+++ b/dhctl/cmd/dhctl/commands/control-plane.go
@@ -28,8 +28,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 )
 
-func DefineTestControlPlaneManagerReadyCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Test control plane manager is ready.")
+func DefineTestControlPlaneManagerReadyCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -68,8 +67,7 @@ func DefineTestControlPlaneManagerReadyCommand(parent *kingpin.CmdClause, comman
 	return cmd
 }
 
-func DefineTestControlPlaneNodeReadyCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Test control plane node is ready.")
+func DefineTestControlPlaneNodeReadyCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/control-plane.go
+++ b/dhctl/cmd/dhctl/commands/control-plane.go
@@ -28,7 +28,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 )
 
-func DefineTestControlPlaneManagerReadyCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineTestControlPlaneManagerReadyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -67,7 +67,7 @@ func DefineTestControlPlaneManagerReadyCommand(parent *kingpin.CmdClause, cmd *k
 	return cmd
 }
 
-func DefineTestControlPlaneNodeReadyCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineTestControlPlaneNodeReadyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/converge.go
+++ b/dhctl/cmd/dhctl/commands/converge.go
@@ -26,8 +26,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
 
-func DefineConvergeCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
-	cmd := kpApp.Command("converge", "Converge kubernetes cluster.")
+func DefineConvergeCommand(kpApp *kingpin.Application, command string) *kingpin.CmdClause {
+	cmd := kpApp.Command(command, "Converge kubernetes cluster.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -49,8 +49,8 @@ func DefineConvergeCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 	return cmd
 }
 
-func DefineAutoConvergeCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
-	cmd := kpApp.Command("converge-periodical", "Start service for periodical run converge.")
+func DefineAutoConvergeCommand(kpApp *kingpin.Application, command string) *kingpin.CmdClause {
+	cmd := kpApp.Command(command, "Start service for periodical run converge.")
 	app.DefineAutoConvergeFlags(cmd)
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/converge.go
+++ b/dhctl/cmd/dhctl/commands/converge.go
@@ -26,8 +26,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
 
-func DefineConvergeCommand(kpApp *kingpin.Application, command string) *kingpin.CmdClause {
-	cmd := kpApp.Command(command, "Converge kubernetes cluster.")
+func DefineConvergeCommand(kpApp *kingpin.Application, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -49,8 +48,7 @@ func DefineConvergeCommand(kpApp *kingpin.Application, command string) *kingpin.
 	return cmd
 }
 
-func DefineAutoConvergeCommand(kpApp *kingpin.Application, command string) *kingpin.CmdClause {
-	cmd := kpApp.Command(command, "Start service for periodical run converge.")
+func DefineAutoConvergeCommand(kpApp *kingpin.Application, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineAutoConvergeFlags(cmd)
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/converge.go
+++ b/dhctl/cmd/dhctl/commands/converge.go
@@ -26,7 +26,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
 
-func DefineConvergeCommand(kpApp *kingpin.Application, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineConvergeCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -48,7 +48,7 @@ func DefineConvergeCommand(kpApp *kingpin.Application, cmd *kingpin.CmdClause) *
 	return cmd
 }
 
-func DefineAutoConvergeCommand(kpApp *kingpin.Application, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineAutoConvergeCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineAutoConvergeFlags(cmd)
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/deckhouse.go
+++ b/dhctl/cmd/dhctl/commands/deckhouse.go
@@ -28,8 +28,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 )
 
-func DefineDeckhouseRemoveDeployment(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("remove-deployment", "Delete deckhouse deployment.")
+func DefineDeckhouseRemoveDeployment(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Delete deckhouse deployment.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -64,8 +64,8 @@ func DefineDeckhouseRemoveDeployment(parent *kingpin.CmdClause) *kingpin.CmdClau
 	return cmd
 }
 
-func DefineDeckhouseCreateDeployment(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("create-deployment", "Install deckhouse after terraform is applied successful.")
+func DefineDeckhouseCreateDeployment(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Install deckhouse after terraform is applied successful.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineConfigFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/deckhouse.go
+++ b/dhctl/cmd/dhctl/commands/deckhouse.go
@@ -28,7 +28,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 )
 
-func DefineDeckhouseRemoveDeployment(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineDeckhouseRemoveDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -63,7 +63,7 @@ func DefineDeckhouseRemoveDeployment(parent *kingpin.CmdClause, cmd *kingpin.Cmd
 	return cmd
 }
 
-func DefineDeckhouseCreateDeployment(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineDeckhouseCreateDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineConfigFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/deckhouse.go
+++ b/dhctl/cmd/dhctl/commands/deckhouse.go
@@ -28,8 +28,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 )
 
-func DefineDeckhouseRemoveDeployment(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Delete deckhouse deployment.")
+func DefineDeckhouseRemoveDeployment(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -64,8 +63,7 @@ func DefineDeckhouseRemoveDeployment(parent *kingpin.CmdClause, command string) 
 	return cmd
 }
 
-func DefineDeckhouseCreateDeployment(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Install deckhouse after terraform is applied successful.")
+func DefineDeckhouseCreateDeployment(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineConfigFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -42,7 +42,7 @@ If you understand what you are doing, you can use flag "--yes-i-am-sane-and-i-un
 `
 )
 
-func DefineDestroyCommand(parent *kingpin.Application, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineDestroyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineCacheFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -42,8 +42,7 @@ If you understand what you are doing, you can use flag "--yes-i-am-sane-and-i-un
 `
 )
 
-func DefineDestroyCommand(parent *kingpin.Application, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Destroy Kubernetes cluster.")
+func DefineDestroyCommand(parent *kingpin.Application, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineCacheFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -42,8 +42,8 @@ If you understand what you are doing, you can use flag "--yes-i-am-sane-and-i-un
 `
 )
 
-func DefineDestroyCommand(parent *kingpin.Application) *kingpin.CmdClause {
-	cmd := parent.Command("destroy", "Destroy Kubernetes cluster.")
+func DefineDestroyCommand(parent *kingpin.Application, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Destroy Kubernetes cluster.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineCacheFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/kube.go
+++ b/dhctl/cmd/dhctl/commands/kube.go
@@ -31,8 +31,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
 
-func DefineTestKubernetesAPIConnectionCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("kubernetes-api-connection", "Test connection to kubernetes api via ssh or directly.")
+func DefineTestKubernetesAPIConnectionCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Test connection to kubernetes api via ssh or directly.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -74,8 +74,8 @@ func DefineTestKubernetesAPIConnectionCommand(parent *kingpin.CmdClause) *kingpi
 	return cmd
 }
 
-func DefineWaitDeploymentReadyCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("deployment-ready", "Wait while deployment is ready.")
+func DefineWaitDeploymentReadyCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Wait while deployment is ready.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/kube.go
+++ b/dhctl/cmd/dhctl/commands/kube.go
@@ -31,7 +31,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
 
-func DefineTestKubernetesAPIConnectionCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineTestKubernetesAPIConnectionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -73,7 +73,7 @@ func DefineTestKubernetesAPIConnectionCommand(parent *kingpin.CmdClause, cmd *ki
 	return cmd
 }
 
-func DefineWaitDeploymentReadyCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineWaitDeploymentReadyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/kube.go
+++ b/dhctl/cmd/dhctl/commands/kube.go
@@ -31,8 +31,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
 
-func DefineTestKubernetesAPIConnectionCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Test connection to kubernetes api via ssh or directly.")
+func DefineTestKubernetesAPIConnectionCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
@@ -74,8 +73,7 @@ func DefineTestKubernetesAPIConnectionCommand(parent *kingpin.CmdClause, command
 	return cmd
 }
 
-func DefineWaitDeploymentReadyCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Wait while deployment is ready.")
+func DefineWaitDeploymentReadyCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/lock.go
+++ b/dhctl/cmd/dhctl/commands/lock.go
@@ -36,7 +36,7 @@ Lock info:
 %s
 `
 
-func DefineReleaseConvergeLockCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineReleaseConvergeLockCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSanityFlags(cmd)
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/lock.go
+++ b/dhctl/cmd/dhctl/commands/lock.go
@@ -36,8 +36,8 @@ Lock info:
 %s
 `
 
-func DefineReleaseConvergeLockCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("release", "Release converge lock fully. It's remove converge lease lock from cluster regardless of owner. Be careful")
+func DefineReleaseConvergeLockCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Release converge lock fully. It's remove converge lease lock from cluster regardless of owner. Be careful")
 	app.DefineSanityFlags(cmd)
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/lock.go
+++ b/dhctl/cmd/dhctl/commands/lock.go
@@ -36,8 +36,7 @@ Lock info:
 %s
 `
 
-func DefineReleaseConvergeLockCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Release converge lock fully. It's remove converge lease lock from cluster regardless of owner. Be careful")
+func DefineReleaseConvergeLockCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSanityFlags(cmd)
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)

--- a/dhctl/cmd/dhctl/commands/server.go
+++ b/dhctl/cmd/dhctl/commands/server.go
@@ -22,7 +22,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/server/singlethreaded"
 )
 
-func DefineServerCommand(parent *kingpin.Application, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineServerCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
+	// cmd = parent.Command(cmd.Model().Name, cmd.Model().Help)
 	app.DefineServerFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
@@ -31,7 +32,8 @@ func DefineServerCommand(parent *kingpin.Application, cmd *kingpin.CmdClause) *k
 	return cmd
 }
 
-func DefineSingleThreadedServerCommand(parent *kingpin.Application, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineSingleThreadedServerCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
+	// cmd = parent.Command(cmd.Model().Name, cmd.Model().Help)
 	app.DefineServerFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {

--- a/dhctl/cmd/dhctl/commands/server.go
+++ b/dhctl/cmd/dhctl/commands/server.go
@@ -22,8 +22,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/server/singlethreaded"
 )
 
-func DefineServerCommand(parent *kingpin.Application, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Start dhctl as GRPC server.")
+func DefineServerCommand(parent *kingpin.Application, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineServerFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
@@ -32,8 +31,7 @@ func DefineServerCommand(parent *kingpin.Application, command string) *kingpin.C
 	return cmd
 }
 
-func DefineSingleThreadedServerCommand(parent *kingpin.Application, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Start dhctl as GRPC server. Single threaded version.")
+func DefineSingleThreadedServerCommand(parent *kingpin.Application, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineServerFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {

--- a/dhctl/cmd/dhctl/commands/server.go
+++ b/dhctl/cmd/dhctl/commands/server.go
@@ -22,8 +22,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/server/singlethreaded"
 )
 
-func DefineServerCommand(parent *kingpin.Application) *kingpin.CmdClause {
-	cmd := parent.Command("server", "Start dhctl as GRPC server.")
+func DefineServerCommand(parent *kingpin.Application, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Start dhctl as GRPC server.")
 	app.DefineServerFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
@@ -32,8 +32,8 @@ func DefineServerCommand(parent *kingpin.Application) *kingpin.CmdClause {
 	return cmd
 }
 
-func DefineSingleThreadedServerCommand(parent *kingpin.Application) *kingpin.CmdClause {
-	cmd := parent.Command("_server", "Start dhctl as GRPC server. Single threaded version.")
+func DefineSingleThreadedServerCommand(parent *kingpin.Application, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Start dhctl as GRPC server. Single threaded version.")
 	app.DefineServerFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {

--- a/dhctl/cmd/dhctl/commands/ssh.go
+++ b/dhctl/cmd/dhctl/commands/ssh.go
@@ -29,8 +29,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 )
 
-func DefineTestSSHConnectionCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("ssh-connection", "Test connection via ssh.")
+func DefineTestSSHConnectionCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Test connection via ssh.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 
@@ -57,13 +57,13 @@ func DefineTestSSHConnectionCommand(parent *kingpin.CmdClause) *kingpin.CmdClaus
 	return cmd
 }
 
-func DefineTestSCPCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineTestSCPCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
 	var SrcPath string
 	var DstPath string
 	var Data string
 	var Direction string
 
-	cmd := parent.Command("scp", "Test scp file operations.")
+	cmd := parent.Command(command, "Test scp file operations.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 
@@ -126,10 +126,10 @@ func DefineTestSCPCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	return cmd
 }
 
-func DefineTestUploadExecCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineTestUploadExecCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
 	var ScriptPath string
 	var Sudo bool
-	cmd := parent.Command("upload-exec", "Test scp upload and ssh run uploaded script.")
+	cmd := parent.Command(command, "Test scp upload and ssh run uploaded script.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	cmd.Flag("script", "source path").
@@ -164,11 +164,11 @@ func DefineTestUploadExecCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 	return cmd
 }
 
-func DefineTestBundle(parent *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineTestBundle(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
 	var ScriptName string
 	var BundleDir string
 
-	cmd := parent.Command("bashible-bundle", "Test upload and execute a bundle.")
+	cmd := parent.Command(command, "Test upload and execute a bundle.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	cmd.Flag("bundle-dir", "path of a bundle root directory").

--- a/dhctl/cmd/dhctl/commands/ssh.go
+++ b/dhctl/cmd/dhctl/commands/ssh.go
@@ -29,7 +29,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 )
 
-func DefineTestSSHConnectionCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineTestSSHConnectionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 
@@ -56,7 +56,7 @@ func DefineTestSSHConnectionCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdC
 	return cmd
 }
 
-func DefineTestSCPCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineTestSCPCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	var SrcPath string
 	var DstPath string
 	var Data string
@@ -124,9 +124,10 @@ func DefineTestSCPCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *ki
 	return cmd
 }
 
-func DefineTestUploadExecCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineTestUploadExecCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	var ScriptPath string
 	var Sudo bool
+
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	cmd.Flag("script", "source path").
@@ -161,7 +162,7 @@ func DefineTestUploadExecCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClau
 	return cmd
 }
 
-func DefineTestBundle(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineTestBundle(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	var ScriptName string
 	var BundleDir string
 

--- a/dhctl/cmd/dhctl/commands/ssh.go
+++ b/dhctl/cmd/dhctl/commands/ssh.go
@@ -29,8 +29,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 )
 
-func DefineTestSSHConnectionCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Test connection via ssh.")
+func DefineTestSSHConnectionCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 
@@ -57,13 +56,12 @@ func DefineTestSSHConnectionCommand(parent *kingpin.CmdClause, command string) *
 	return cmd
 }
 
-func DefineTestSCPCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+func DefineTestSCPCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	var SrcPath string
 	var DstPath string
 	var Data string
 	var Direction string
 
-	cmd := parent.Command(command, "Test scp file operations.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 
@@ -126,10 +124,9 @@ func DefineTestSCPCommand(parent *kingpin.CmdClause, command string) *kingpin.Cm
 	return cmd
 }
 
-func DefineTestUploadExecCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+func DefineTestUploadExecCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	var ScriptPath string
 	var Sudo bool
-	cmd := parent.Command(command, "Test scp upload and ssh run uploaded script.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	cmd.Flag("script", "source path").
@@ -164,11 +161,10 @@ func DefineTestUploadExecCommand(parent *kingpin.CmdClause, command string) *kin
 	return cmd
 }
 
-func DefineTestBundle(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+func DefineTestBundle(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	var ScriptName string
 	var BundleDir string
 
-	cmd := parent.Command(command, "Test upload and execute a bundle.")
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
 	app.DefineBecomeFlags(cmd)
 	cmd.Flag("bundle-dir", "path of a bundle root directory").

--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"fmt"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -30,8 +31,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
 
-func DefineTerraformConvergeExporterCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("converge-exporter", "Run terraform converge exporter.")
+func DefineTerraformConvergeExporterCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Run terraform converge exporter.")
 	app.DefineKubeFlags(cmd)
 	app.DefineConvergeExporterFlags(cmd)
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
@@ -45,8 +46,8 @@ func DefineTerraformConvergeExporterCommand(parent *kingpin.CmdClause) *kingpin.
 	return cmd
 }
 
-func DefineTerraformCheckCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
-	cmd := parent.Command("check", "Check differences between state of Kubernetes cluster and Terraform state.")
+func DefineTerraformCheckCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
+	cmd := parent.Command(command, "Check differences between state of Kubernetes cluster and Terraform state.")
 	app.DefineKubeFlags(cmd)
 	app.DefineOutputFlag(cmd)
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})

--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -31,8 +31,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
 
-func DefineTerraformConvergeExporterCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Run terraform converge exporter.")
+func DefineTerraformConvergeExporterCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineKubeFlags(cmd)
 	app.DefineConvergeExporterFlags(cmd)
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
@@ -46,8 +45,7 @@ func DefineTerraformConvergeExporterCommand(parent *kingpin.CmdClause, command s
 	return cmd
 }
 
-func DefineTerraformCheckCommand(parent *kingpin.CmdClause, command string) *kingpin.CmdClause {
-	cmd := parent.Command(command, "Check differences between state of Kubernetes cluster and Terraform state.")
+func DefineTerraformCheckCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineKubeFlags(cmd)
 	app.DefineOutputFlag(cmd)
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})

--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -31,7 +31,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 )
 
-func DefineTerraformConvergeExporterCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineTerraformConvergeExporterCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineKubeFlags(cmd)
 	app.DefineConvergeExporterFlags(cmd)
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
@@ -45,7 +45,7 @@ func DefineTerraformConvergeExporterCommand(parent *kingpin.CmdClause, cmd *king
 	return cmd
 }
 
-func DefineTerraformCheckCommand(parent *kingpin.CmdClause, cmd *kingpin.CmdClause) *kingpin.CmdClause {
+func DefineTerraformCheckCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineKubeFlags(cmd)
 	app.DefineOutputFlag(cmd)
 	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -42,52 +42,296 @@ import (
 )
 
 var (
-	allowedCommands                         []string
-	bootstrapCommand                        = Command{Name: "bootstrap", Help: "Bootstrap cluster."}
-	bootstrapPhaseCommand                   = Command{Name: "bootstrap-phase", Help: "Commands to run a single phase of the bootstrap process."}
-	executeBashibleSubcommand               = Command{Name: "execute-bashible-bundle", Help: "Prepare Master node and install Kubernetes."}
-	createResourcesSubcommand               = Command{Name: "create-resources", Help: "Create resources in Kubernetes cluster."}
-	installDeckhouseSubcommand              = Command{Name: "install-deckhouse", Help: "Install deckhouse and wait for its readiness."}
-	abortSubcommand                         = Command{Name: "abort", Help: "Delete every node, which was created during bootstrap process."}
-	baseInfrastructureSubcommand            = Command{Name: "base-infra", Help: "Create base infrastructure for Cloud Kubernetes cluster."}
-	execPostBootstarpSubcommand             = Command{Name: "exec-post-bootstrap", Help: "Test scp upload and ssh run uploaded script."}
-	serverCommand                           = Command{Name: "server", Help: "Start dhctl as GRPC server."}
-	singleThreadedServerCommand             = Command{Name: "_server", Help: "Start dhctl as GRPC server. Single threaded version."}
-	convergeCommand                         = Command{Name: "converge", Help: "Converge kubernetes cluster."}
-	autoConvergeCommand                     = Command{Name: "converge-periodical", Help: "Start service for periodical run converge."}
-	lockCommand                             = Command{Name: "lock", Help: "Converge cluster lock"}
-	lockReleaseSubcommand                   = Command{Name: "release", Help: "Release converge lock fully. It's remove converge lease lock from cluster regardless of owner. Be careful"}
-	destroyCommand                          = Command{Name: "destroy", Help: "Destroy Kubernetes cluster."}
-	terraformCommand                        = Command{Name: "terraform", Help: "Terraform commands."}
-	convergeExporterSubcommand              = Command{Name: "converge-exporter", Help: "Run terraform converge exporter."}
-	terraformCheckSubcommand                = Command{Name: "check", Help: "Check differences between state of Kubernetes cluster and Terraform state."}
-	configCommand                           = Command{Name: "comfig", Help: "Load, edit and save various dhctl configurations."}
-	parseSubcommand                         = Command{Name: "parse", Help: "Parse, validate and output configurations."}
-	renderSubcommand                        = Command{Name: "render", Help: "Render transitional configurations."}
-	editSubcommand                          = Command{Name: "edit", Help: "Change configuration files in Kubernetes cluster conveniently and safely."}
-	parseClusterConfigurationSubcommand     = Command{Name: "cluster-configuration", Help: "Parse configuration and print it."}
-	parseCloudDiscoveryDataSubcommand       = Command{Name: "cloud-discovery-data", Help: "Parse cloud discovery data and print it."}
-	renderBashibleBundleSubcommand          = Command{Name: "bashible-bundle", Help: "Render bashible bundle."}
-	renderKubeadmConfigSubcommand           = Command{Name: "kubeadm-config", Help: "Render kubeadm config."}
-	renderMasterBootstrapSubcommand         = Command{Name: "master-bootstrap-scripts", Help: "Render master bootstrap scripts."}
-	testCommand                             = Command{Name: "test", Help: "Commands to test the parts of bootstrap and converge process."}
-	testSSHConnectionSubcommand             = Command{Name: "ssh-connection", Help: "Test connection via ssh."}
-	testKubernetesAPIConnectionSubcommand   = Command{Name: "kubernetes-api-connection", Help: "Test connection to kubernetes api via ssh or directly."}
-	testSCPSubcommand                       = Command{Name: "scp", Help: "Test scp file operations."}
-	testUploadExecSubcommand                = Command{Name: "upload-exec", Help: "Test scp upload and ssh run uploaded script."}
-	testBundleSubcommand                    = Command{Name: "bashible-bundle", Help: "Test upload and execute a bundle."}
-	testControlPlaneSubcommand              = Command{Name: "control-plane", Help: "Commands to test control plane nodes."}
-	testControlPlaneManagerSubcommand       = Command{Name: "manager", Help: "Test control plane manager is ready."}
-	testControlPlaneNodeSubcommand          = Command{Name: "node", Help: "Test control plane node is ready."}
-	testDeckhouseSubcommand                 = Command{Name: "deckhouse", Help: "Install and uninstall deckhouse."}
-	testDeckhouseCreateDeploymentSubcommand = Command{Name: "create-deployment", Help: "Install deckhouse after terraform is applied successful."}
-	testDeckhouseRemoveDeploymentSubcommand = Command{Name: "remove-deployment", Help: "Delete deckhouse deployment."}
-	testWaitDeploymentReadySubcommand       = Command{Name: "deployment-ready", Help: "Wait while deployment is ready."}
+	allowedCommands []string
+	commandList     = []Command{
+		{
+			Name: "server",
+			Help: "Start dhctl as GRPC server.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineServerCommand(cmd)
+			},
+		},
+		{
+			Name: "_server",
+			Help: "Start dhctl as GRPC server. Single threaded version.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineSingleThreadedServerCommand(cmd)
+			},
+		},
+		{
+			Name: "bootstrap",
+			Help: "Bootstrap cluster.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				bootstrap.DefineBootstrapCommand(cmd)
+			},
+		},
+		{
+			Name: "bootstrap-phase",
+			Help: "Commands to run a single phase of the bootstrap process.",
+		},
+		{
+			Name: "execute-bashible-bundle",
+			Help: "Prepare Master node and install Kubernetes.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				bootstrap.DefineBootstrapExecuteBashibleCommand(cmd)
+			},
+			Parrent: "bootstrap-phase",
+		},
+		{
+			Name: "create-resources",
+			Help: "Create resources in Kubernetes cluster.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				bootstrap.DefineCreateResourcesCommand(cmd)
+			},
+			Parrent: "bootstrap-phase",
+		},
+		{
+			Name: "install-deckhouse",
+			Help: "Install deckhouse and wait for its readiness.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				bootstrap.DefineBootstrapInstallDeckhouseCommand(cmd)
+			},
+			Parrent: "bootstrap-phase",
+		},
+		{
+			Name: "abort",
+			Help: "Delete every node, which was created during bootstrap process.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				bootstrap.DefineBootstrapAbortCommand(cmd)
+			},
+			Parrent: "bootstrap-phase",
+		},
+		{
+			Name: "base-infra",
+			Help: "Create base infrastructure for Cloud Kubernetes cluster.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				bootstrap.DefineBaseInfrastructureCommand(cmd)
+			},
+			Parrent: "bootstrap-phase",
+		},
+		{
+			Name: "exec-post-bootstrap",
+			Help: "Test scp upload and ssh run uploaded script.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				bootstrap.DefineExecPostBootstrapScript(cmd)
+			},
+			Parrent: "bootstrap-phase",
+		},
+		{
+			Name: "converge",
+			Help: "Converge kubernetes cluster.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineConvergeCommand(cmd)
+			},
+		},
+		{
+			Name: "converge-periodical",
+			Help: "Start service for periodical run converge.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineConvergeCommand(cmd)
+			},
+		},
+		{
+			Name: "lock",
+			Help: "Converge cluster lock",
+		},
+		{
+			Name: "release",
+			Help: "Release converge lock fully. It's remove converge lease lock from cluster regardless of owner. Be careful",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineReleaseConvergeLockCommand(cmd)
+			},
+			Parrent: "lock",
+		},
+		{
+			Name: "destroy",
+			Help: "Destroy Kubernetes cluster.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineDestroyCommand(cmd)
+			},
+		},
+		{
+			Name: "terraform",
+			Help: "Terraform commands.",
+		},
+		{
+			Name: "converge-exporter",
+			Help: "Run terraform converge exporter.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineTerraformConvergeExporterCommand(cmd)
+			},
+			Parrent: "terraform",
+		},
+		{
+			Name: "check",
+			Help: "Check differences between state of Kubernetes cluster and Terraform state.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineTerraformCheckCommand(cmd)
+			},
+			Parrent: "terraform",
+		},
+		{
+			Name: "config",
+			Help: "Load, edit and save various dhctl configurations.",
+		},
+		{
+			Name:    "parse",
+			Help:    "Parse, validate and output configurations.",
+			Parrent: "config",
+		},
+		{
+			Name: "cluster-configuration",
+			Help: "Parse configuration and print it.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineCommandParseClusterConfiguration(cmd)
+			},
+			Parrent: "parse",
+		},
+		{
+			Name: "cloud-discovery-data",
+			Help: "Parse cloud discovery data and print it.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineCommandParseCloudDiscoveryData(cmd)
+			},
+			Parrent: "parse",
+		},
+		{
+			Name:    "render",
+			Help:    "Render transitional configurations.",
+			Parrent: "config",
+		},
+		{
+			Name: "bashible-bundle",
+			Help: "Render bashible bundle.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineRenderBashibleBundle(cmd)
+			},
+			Parrent: "render",
+		},
+		{
+			Name: "kubeadm-config",
+			Help: "Render kubeadm config.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineRenderKubeadmConfig(cmd)
+			},
+			Parrent: "render",
+		},
+		{
+			Name: "master-bootstrap-scripts",
+			Help: "Render master bootstrap scripts.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineRenderMasterBootstrap(cmd)
+			},
+			Parrent: "render",
+		},
+		{
+			Name:    "edit",
+			Help:    "Change configuration files in Kubernetes cluster conveniently and safely.",
+			Parrent: "config",
+		},
+		{
+			Name: "test",
+			Help: "Commands to test the parts of bootstrap and converge process.",
+		},
+		{
+			Name: "ssh-connection",
+			Help: "Test connection via ssh.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineTestSSHConnectionCommand(cmd)
+			},
+			Parrent: "test",
+		},
+		{
+			Name: "kubernetes-api-connection",
+			Help: "Test connection to kubernetes api via ssh or directly.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineTestKubernetesAPIConnectionCommand(cmd)
+			},
+			Parrent: "test",
+		},
+		{
+			Name: "scp",
+			Help: "Test scp file operations.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineTestSCPCommand(cmd)
+			},
+			Parrent: "test",
+		},
+		{
+			Name: "upload-exec",
+			Help: "Test scp upload and ssh run uploaded script.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineTestUploadExecCommand(cmd)
+			},
+			Parrent: "test",
+		},
+		{
+			Name: "bashible-bundle",
+			Help: "Test upload and execute a bundle.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineTestBundle(cmd)
+			},
+			Parrent: "test",
+		},
+		{
+			Name:    "control-plane",
+			Help:    "Commands to test control plane nodes.",
+			Parrent: "test",
+		},
+		{
+			Name: "manager",
+			Help: "Test control plane manager is ready.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineTestControlPlaneManagerReadyCommand(cmd)
+			},
+			Parrent: "control-plane",
+		},
+		{
+			Name: "node",
+			Help: "Test control plane node is ready.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineTestControlPlaneNodeReadyCommand(cmd)
+			},
+			Parrent: "control-plane",
+		},
+		{
+			Name:    "deckhouse",
+			Help:    "Install and uninstall deckhouse.",
+			Parrent: "test",
+		},
+		{
+			Name: "create-deployment",
+			Help: "Install deckhouse after terraform is applied successful.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineDeckhouseCreateDeployment(cmd)
+			},
+			Parrent: "deckhouse",
+		},
+		{
+			Name: "remove-deployment",
+			Help: "Delete deckhouse deployment.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineDeckhouseRemoveDeployment(cmd)
+			},
+			Parrent: "deckhouse",
+		},
+		{
+			Name: "deployment-ready",
+			Help: "Wait while deployment is ready.",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineWaitDeploymentReadyCommand(cmd)
+			},
+			Parrent: "deckhouse",
+		},
+	}
 )
 
 type Command struct {
-	Name string
-	Help string
+	Name       string
+	Help       string
+	DefineFunc func(cmd *kingpin.CmdClause)
+	Parrent    string
+	cmd        *kingpin.CmdClause
 }
 
 func main() {
@@ -112,159 +356,9 @@ func main() {
 		return nil
 	})
 
-	allowed, _ := checkCommand(serverCommand.Name, allowedCommands)
-	if allowed {
-		commands.DefineServerCommand(kpApp, kingpin.Command(serverCommand.Name, serverCommand.Help))
-	}
-
-	allowed, _ = checkCommand(singleThreadedServerCommand.Name, allowedCommands)
-	if allowed {
-		commands.DefineSingleThreadedServerCommand(kpApp, kingpin.Command(singleThreadedServerCommand.Name, singleThreadedServerCommand.Help))
-	}
-
-	allowed, _ = checkCommand(bootstrapCommand.Name, allowedCommands)
-	if allowed {
-		bootstrap.DefineBootstrapCommand(kpApp, kingpin.Command(bootstrapCommand.Name, bootstrapCommand.Help))
-	}
-
-	allowed, subcommands := checkCommand(bootstrapPhaseCommand.Name, allowedCommands)
-	if allowed {
-		bootstrapPhaseCmd := kpApp.Command(bootstrapPhaseCommand.Name, bootstrapPhaseCommand.Help)
-		{
-			if checkSubcommand(executeBashibleSubcommand.Name, subcommands) {
-				bootstrap.DefineBootstrapExecuteBashibleCommand(bootstrapPhaseCmd, kingpin.Command(executeBashibleSubcommand.Name, executeBashibleSubcommand.Help))
-			}
-
-			if checkSubcommand(installDeckhouseSubcommand.Name, subcommands) {
-				bootstrap.DefineBootstrapInstallDeckhouseCommand(bootstrapPhaseCmd, kingpin.Command(installDeckhouseSubcommand.Name, installDeckhouseSubcommand.Help))
-			}
-
-			if checkSubcommand(createResourcesSubcommand.Name, subcommands) {
-				bootstrap.DefineCreateResourcesCommand(bootstrapPhaseCmd, kingpin.Command(createResourcesSubcommand.Name, createResourcesSubcommand.Help))
-			}
-
-			if checkSubcommand(abortSubcommand.Name, subcommands) {
-				bootstrap.DefineBootstrapAbortCommand(bootstrapPhaseCmd, kingpin.Command(abortSubcommand.Name, abortSubcommand.Help))
-			}
-
-			if checkSubcommand(baseInfrastructureSubcommand.Name, subcommands) {
-				bootstrap.DefineBaseInfrastructureCommand(bootstrapPhaseCmd, kingpin.Command(baseInfrastructureSubcommand.Name, baseInfrastructureSubcommand.Help))
-			}
-
-			if checkSubcommand(execPostBootstarpSubcommand.Name, subcommands) {
-				bootstrap.DefineExecPostBootstrapScript(bootstrapPhaseCmd, kingpin.Command(execPostBootstarpSubcommand.Name, execPostBootstarpSubcommand.Help))
-			}
-		}
-	}
-
-	allowed, _ = checkCommand(convergeCommand.Name, allowedCommands)
-	if allowed {
-		commands.DefineConvergeCommand(kpApp, kingpin.Command(convergeCommand.Name, convergeCommand.Help))
-	}
-
-	allowed, _ = checkCommand(autoConvergeCommand.Name, allowedCommands)
-	if allowed {
-		commands.DefineAutoConvergeCommand(kpApp, kingpin.Command(autoConvergeCommand.Name, autoConvergeCommand.Help))
-	}
-
-	allowed, _ = checkCommand(lockCommand.Name, allowedCommands)
-	if allowed {
-		lockCmd := kpApp.Command(lockCommand.Name, lockCommand.Help)
-		{
-			commands.DefineReleaseConvergeLockCommand(lockCmd, kingpin.Command(lockReleaseSubcommand.Name, lockReleaseSubcommand.Help))
-		}
-	}
-
-	allowed, _ = checkCommand(destroyCommand.Name, allowedCommands)
-	if allowed {
-		commands.DefineDestroyCommand(kpApp, kingpin.Command(destroyCommand.Name, destroyCommand.Help))
-	}
-
-	allowed, subcommands = checkCommand(terraformCommand.Name, allowedCommands)
-	if allowed {
-		terraformCmd := kpApp.Command(terraformCommand.Name, terraformCommand.Help)
-		{
-			if checkSubcommand(convergeExporterSubcommand.Name, subcommands) {
-				commands.DefineTerraformConvergeExporterCommand(terraformCmd, kingpin.Command(convergeExporterSubcommand.Name, convergeExporterSubcommand.Help))
-			}
-
-			if checkSubcommand(terraformCheckSubcommand.Name, subcommands) {
-				commands.DefineTerraformCheckCommand(terraformCmd, kingpin.Command(terraformCheckSubcommand.Name, terraformCheckSubcommand.Help))
-			}
-		}
-	}
-
-	allowed, subcommands = checkCommand(configCommand.Name, allowedCommands)
-	if allowed {
-		configCmd := kpApp.Command(configCommand.Name, configCommand.Help)
-		{
-			if checkSubcommand(parseSubcommand.Name, subcommands) {
-				parseCmd := configCmd.Command(parseSubcommand.Name, parseSubcommand.Help)
-				{
-					commands.DefineCommandParseClusterConfiguration(kpApp, parseCmd, kingpin.Command(parseClusterConfigurationSubcommand.Name, parseClusterConfigurationSubcommand.Help))
-					commands.DefineCommandParseCloudDiscoveryData(kpApp, parseCmd, kingpin.Command(parseCloudDiscoveryDataSubcommand.Name, parseCloudDiscoveryDataSubcommand.Help))
-				}
-			}
-
-			if checkSubcommand(renderSubcommand.Name, subcommands) {
-				renderCmd := configCmd.Command(renderSubcommand.Name, renderSubcommand.Help)
-				{
-					commands.DefineRenderBashibleBundle(renderCmd, kingpin.Command(renderBashibleBundleSubcommand.Name, renderBashibleBundleSubcommand.Help))
-					commands.DefineRenderKubeadmConfig(renderCmd, kingpin.Command(renderKubeadmConfigSubcommand.Name, renderKubeadmConfigSubcommand.Help))
-					commands.DefineRenderMasterBootstrap(renderCmd, kingpin.Command(renderMasterBootstrapSubcommand.Name, renderMasterBootstrapSubcommand.Help))
-				}
-			}
-
-			if checkSubcommand(editSubcommand.Name, subcommands) {
-				editCmd := configCmd.Command(editSubcommand.Name, editSubcommand.Help)
-				{
-					commands.DefineEditCommands(editCmd /* wConnFlags */, true)
-				}
-			}
-		}
-	}
-
-	allowed, subcommands = checkCommand(testCommand.Name, allowedCommands)
-	if allowed {
-		testCmd := kpApp.Command(testCommand.Help, testCommand.Help)
-		{
-			if checkSubcommand(testSSHConnectionSubcommand.Name, subcommands) {
-				commands.DefineTestSSHConnectionCommand(testCmd, kingpin.Command(testSSHConnectionSubcommand.Name, testSSHConnectionSubcommand.Help))
-			}
-
-			if checkSubcommand(testKubernetesAPIConnectionSubcommand.Name, subcommands) {
-				commands.DefineTestKubernetesAPIConnectionCommand(testCmd, kingpin.Command(testKubernetesAPIConnectionSubcommand.Name, testKubernetesAPIConnectionSubcommand.Help))
-			}
-
-			if checkSubcommand(testSCPSubcommand.Name, subcommands) {
-				commands.DefineTestSCPCommand(testCmd, kingpin.Command(testSCPSubcommand.Name, testSCPSubcommand.Help))
-			}
-
-			if checkSubcommand(testUploadExecSubcommand.Name, subcommands) {
-				commands.DefineTestUploadExecCommand(testCmd, kingpin.Command(testUploadExecSubcommand.Name, testUploadExecSubcommand.Help))
-			}
-
-			if checkSubcommand(testBundleSubcommand.Name, subcommands) {
-				commands.DefineTestBundle(testCmd, kingpin.Command(testBundleSubcommand.Name, testBundleSubcommand.Help))
-			}
-
-			if checkSubcommand(testControlPlaneSubcommand.Name, subcommands) {
-				controlPlaneCmd := testCmd.Command(testControlPlaneSubcommand.Name, testControlPlaneSubcommand.Help)
-				{
-					commands.DefineTestControlPlaneManagerReadyCommand(controlPlaneCmd, kingpin.Command(testControlPlaneManagerSubcommand.Name, testControlPlaneManagerSubcommand.Help))
-					commands.DefineTestControlPlaneNodeReadyCommand(controlPlaneCmd, kingpin.Command(testControlPlaneNodeSubcommand.Name, testControlPlaneNodeSubcommand.Help))
-				}
-			}
-		}
-
-		if checkSubcommand(testDeckhouseSubcommand.Name, subcommands) {
-			deckhouseCmd := testCmd.Command(testDeckhouseSubcommand.Name, testDeckhouseSubcommand.Help)
-			{
-				commands.DefineDeckhouseCreateDeployment(deckhouseCmd, kingpin.Command(testDeckhouseCreateDeploymentSubcommand.Name, testDeckhouseCreateDeploymentSubcommand.Help))
-				commands.DefineDeckhouseRemoveDeployment(deckhouseCmd, kingpin.Command(testDeckhouseRemoveDeploymentSubcommand.Name, testDeckhouseRemoveDeploymentSubcommand.Help))
-				commands.DefineWaitDeploymentReadyCommand(deckhouseCmd, kingpin.Command(testWaitDeploymentReadySubcommand.Name, testWaitDeploymentReadySubcommand.Help))
-			}
-		}
+	err := registerCommands(kpApp)
+	if err != nil {
+		panic(err)
 	}
 
 	runApplication(kpApp)
@@ -464,4 +558,93 @@ func checkSubcommand(name string, subcommands []string) bool {
 	}
 
 	return false
+}
+
+func getParrentIndex(commandList []Command, name string) (int, error) {
+	for i, cmd := range commandList {
+		if name == cmd.Name {
+			return i, nil
+		}
+	}
+
+	return -1, fmt.Errorf("parrent command %s not found in command list", name)
+}
+
+func getNestingDepth(cmd Command, commands []Command) (Command, int) {
+	depth := 0
+	visited := make(map[string]bool)
+	topLevel := cmd
+
+	for {
+		found := false
+		for _, c := range commands {
+			if c.Name == cmd.Parrent && !visited[c.Name] {
+				visited[c.Name] = true
+				cmd = c
+				depth++
+				topLevel = cmd
+				found = true
+				break
+			}
+		}
+
+		if !found || cmd.Parrent == "" {
+			break
+		}
+	}
+
+	return topLevel, depth
+}
+
+func initParrent(parrentCmdIndex int, kpApp *kingpin.Application) *kingpin.CmdClause {
+	var pcmd *kingpin.CmdClause
+
+	if commandList[parrentCmdIndex].cmd == nil {
+		pcmd = kpApp.Command(commandList[parrentCmdIndex].Name, commandList[parrentCmdIndex].Help)
+		commandList[parrentCmdIndex].cmd = pcmd
+	} else {
+		pcmd = commandList[parrentCmdIndex].cmd
+	}
+	return pcmd
+}
+
+func registerCommands(kpApp *kingpin.Application) error {
+	for i, command := range commandList {
+		firstNode, depth := getNestingDepth(command, commandList)
+		if depth == 0 {
+			allowed, _ := checkCommand(command.Name, allowedCommands)
+			if allowed {
+				cmd := kpApp.Command(command.Name, command.Help)
+				commandList[i].cmd = cmd
+
+				if command.DefineFunc != nil {
+					command.DefineFunc(cmd)
+				}
+			}
+		} else {
+			parrentCmdIndex, err := getParrentIndex(commandList, command.Parrent)
+			if err != nil {
+				return err
+			}
+
+			allowed, subcommands := checkCommand(firstNode.Name, allowedCommands)
+
+			if allowed && checkSubcommand(command.Name, subcommands) {
+				pcmd := initParrent(parrentCmdIndex, kpApp)
+
+				cmd := pcmd.Command(command.Name, command.Help)
+				commandList[i].cmd = cmd
+
+				if command.DefineFunc != nil {
+					if command.Name != "edit" {
+						command.DefineFunc(cmd)
+					} else {
+						commands.DefineEditCommands(cmd /* wConnFlags */, true)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -107,7 +107,7 @@ var (
 		{
 			Name:       "converge-periodical",
 			Help:       "Start service for periodical run converge.",
-			DefineFunc: commands.DefineConvergeCommand,
+			DefineFunc: commands.DefineAutoConvergeCommand,
 		},
 		{
 			Name: "lock",

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -45,130 +45,100 @@ var (
 	allowedCommands []string
 	commandList     = []Command{
 		{
-			Name: "server",
-			Help: "Start dhctl as GRPC server.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineServerCommand(cmd)
-			},
+			Name:       "server",
+			Help:       "Start dhctl as GRPC server.",
+			DefineFunc: commands.DefineServerCommand,
 		},
 		{
-			Name: "_server",
-			Help: "Start dhctl as GRPC server. Single threaded version.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineSingleThreadedServerCommand(cmd)
-			},
+			Name:       "_server",
+			Help:       "Start dhctl as GRPC server. Single threaded version.",
+			DefineFunc: commands.DefineSingleThreadedServerCommand,
 		},
 		{
-			Name: "bootstrap",
-			Help: "Bootstrap cluster.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				bootstrap.DefineBootstrapCommand(cmd)
-			},
+			Name:       "bootstrap",
+			Help:       "Bootstrap cluster.",
+			DefineFunc: bootstrap.DefineBootstrapCommand,
 		},
 		{
 			Name: "bootstrap-phase",
 			Help: "Commands to run a single phase of the bootstrap process.",
 		},
 		{
-			Name: "execute-bashible-bundle",
-			Help: "Prepare Master node and install Kubernetes.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				bootstrap.DefineBootstrapExecuteBashibleCommand(cmd)
-			},
-			Parrent: "bootstrap-phase",
+			Name:       "execute-bashible-bundle",
+			Help:       "Prepare Master node and install Kubernetes.",
+			DefineFunc: bootstrap.DefineBootstrapExecuteBashibleCommand,
+			Parrent:    "bootstrap-phase",
 		},
 		{
-			Name: "create-resources",
-			Help: "Create resources in Kubernetes cluster.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				bootstrap.DefineCreateResourcesCommand(cmd)
-			},
-			Parrent: "bootstrap-phase",
+			Name:       "create-resources",
+			Help:       "Create resources in Kubernetes cluster.",
+			DefineFunc: bootstrap.DefineCreateResourcesCommand,
+			Parrent:    "bootstrap-phase",
 		},
 		{
-			Name: "install-deckhouse",
-			Help: "Install deckhouse and wait for its readiness.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				bootstrap.DefineBootstrapInstallDeckhouseCommand(cmd)
-			},
-			Parrent: "bootstrap-phase",
+			Name:       "install-deckhouse",
+			Help:       "Install deckhouse and wait for its readiness.",
+			DefineFunc: bootstrap.DefineBootstrapInstallDeckhouseCommand,
+			Parrent:    "bootstrap-phase",
 		},
 		{
-			Name: "abort",
-			Help: "Delete every node, which was created during bootstrap process.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				bootstrap.DefineBootstrapAbortCommand(cmd)
-			},
-			Parrent: "bootstrap-phase",
+			Name:       "abort",
+			Help:       "Delete every node, which was created during bootstrap process.",
+			DefineFunc: bootstrap.DefineBootstrapAbortCommand,
+			Parrent:    "bootstrap-phase",
 		},
 		{
-			Name: "base-infra",
-			Help: "Create base infrastructure for Cloud Kubernetes cluster.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				bootstrap.DefineBaseInfrastructureCommand(cmd)
-			},
-			Parrent: "bootstrap-phase",
+			Name:       "base-infra",
+			Help:       "Create base infrastructure for Cloud Kubernetes cluster.",
+			DefineFunc: bootstrap.DefineBaseInfrastructureCommand,
+			Parrent:    "bootstrap-phase",
 		},
 		{
-			Name: "exec-post-bootstrap",
-			Help: "Test scp upload and ssh run uploaded script.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				bootstrap.DefineExecPostBootstrapScript(cmd)
-			},
-			Parrent: "bootstrap-phase",
+			Name:       "exec-post-bootstrap",
+			Help:       "Test scp upload and ssh run uploaded script.",
+			DefineFunc: bootstrap.DefineExecPostBootstrapScript,
+			Parrent:    "bootstrap-phase",
 		},
 		{
-			Name: "converge",
-			Help: "Converge kubernetes cluster.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineConvergeCommand(cmd)
-			},
+			Name:       "converge",
+			Help:       "Converge kubernetes cluster.",
+			DefineFunc: commands.DefineConvergeCommand,
 		},
 		{
-			Name: "converge-periodical",
-			Help: "Start service for periodical run converge.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineConvergeCommand(cmd)
-			},
+			Name:       "converge-periodical",
+			Help:       "Start service for periodical run converge.",
+			DefineFunc: commands.DefineConvergeCommand,
 		},
 		{
 			Name: "lock",
 			Help: "Converge cluster lock",
 		},
 		{
-			Name: "release",
-			Help: "Release converge lock fully. It's remove converge lease lock from cluster regardless of owner. Be careful",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineReleaseConvergeLockCommand(cmd)
-			},
-			Parrent: "lock",
+			Name:       "release",
+			Help:       "Release converge lock fully. It's remove converge lease lock from cluster regardless of owner. Be careful",
+			DefineFunc: commands.DefineReleaseConvergeLockCommand,
+			Parrent:    "lock",
 		},
 		{
-			Name: "destroy",
-			Help: "Destroy Kubernetes cluster.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineDestroyCommand(cmd)
-			},
+			Name:       "destroy",
+			Help:       "Destroy Kubernetes cluster.",
+			DefineFunc: commands.DefineDestroyCommand,
 		},
 		{
 			Name: "terraform",
 			Help: "Terraform commands.",
 		},
 		{
-			Name: "converge-exporter",
-			Help: "Run terraform converge exporter.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineTerraformConvergeExporterCommand(cmd)
-			},
-			Parrent: "terraform",
+			Name:       "converge-exporter",
+			Help:       "Run terraform converge exporter.",
+			DefineFunc: commands.DefineTerraformConvergeExporterCommand,
+			Parrent:    "terraform",
 		},
 		{
-			Name: "check",
-			Help: "Check differences between state of Kubernetes cluster and Terraform state.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineTerraformCheckCommand(cmd)
-			},
-			Parrent: "terraform",
+			Name:       "check",
+			Help:       "Check differences between state of Kubernetes cluster and Terraform state.",
+			DefineFunc: commands.DefineTerraformCheckCommand,
+			Parrent:    "terraform",
 		},
 		{
 			Name: "config",
@@ -180,20 +150,16 @@ var (
 			Parrent: "config",
 		},
 		{
-			Name: "cluster-configuration",
-			Help: "Parse configuration and print it.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineCommandParseClusterConfiguration(cmd)
-			},
-			Parrent: "parse",
+			Name:       "cluster-configuration",
+			Help:       "Parse configuration and print it.",
+			DefineFunc: commands.DefineCommandParseClusterConfiguration,
+			Parrent:    "parse",
 		},
 		{
-			Name: "cloud-discovery-data",
-			Help: "Parse cloud discovery data and print it.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineCommandParseCloudDiscoveryData(cmd)
-			},
-			Parrent: "parse",
+			Name:       "cloud-discovery-data",
+			Help:       "Parse cloud discovery data and print it.",
+			DefineFunc: commands.DefineCommandParseCloudDiscoveryData,
+			Parrent:    "parse",
 		},
 		{
 			Name:    "render",
@@ -201,35 +167,30 @@ var (
 			Parrent: "config",
 		},
 		{
-			Name: "bashible-bundle",
-			Help: "Render bashible bundle.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineRenderBashibleBundle(cmd)
-			},
-			Parrent: "render",
+			Name:       "bashible-bundle",
+			Help:       "Render bashible bundle.",
+			DefineFunc: commands.DefineRenderBashibleBundle,
+			Parrent:    "render",
 		},
 		{
-			Name: "kubeadm-config",
-			Help: "Render kubeadm config.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineRenderKubeadmConfig(cmd)
-			},
-			Parrent: "render",
+			Name:       "kubeadm-config",
+			Help:       "Render kubeadm config.",
+			DefineFunc: commands.DefineRenderKubeadmConfig,
+			Parrent:    "render",
 		},
 		{
-			Name: "master-bootstrap-scripts",
-			Help: "Render master bootstrap scripts.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineRenderMasterBootstrap(cmd)
-			},
-			Parrent: "render",
+			Name:       "master-bootstrap-scripts",
+			Help:       "Render master bootstrap scripts.",
+			DefineFunc: commands.DefineRenderMasterBootstrap,
+			Parrent:    "render",
 		},
 		{
 			Name:    "edit",
 			Help:    "Change configuration files in Kubernetes cluster conveniently and safely.",
 			Parrent: "config",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
+			DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 				commands.DefineEditCommands(cmd /* wConnFlags */, true)
+				return nil
 			},
 		},
 		{
@@ -237,44 +198,34 @@ var (
 			Help: "Commands to test the parts of bootstrap and converge process.",
 		},
 		{
-			Name: "ssh-connection",
-			Help: "Test connection via ssh.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineTestSSHConnectionCommand(cmd)
-			},
-			Parrent: "test",
+			Name:       "ssh-connection",
+			Help:       "Test connection via ssh.",
+			DefineFunc: commands.DefineTestSSHConnectionCommand,
+			Parrent:    "test",
 		},
 		{
-			Name: "kubernetes-api-connection",
-			Help: "Test connection to kubernetes api via ssh or directly.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineTestKubernetesAPIConnectionCommand(cmd)
-			},
-			Parrent: "test",
+			Name:       "kubernetes-api-connection",
+			Help:       "Test connection to kubernetes api via ssh or directly.",
+			DefineFunc: commands.DefineTestKubernetesAPIConnectionCommand,
+			Parrent:    "test",
 		},
 		{
-			Name: "scp",
-			Help: "Test scp file operations.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineTestSCPCommand(cmd)
-			},
-			Parrent: "test",
+			Name:       "scp",
+			Help:       "Test scp file operations.",
+			DefineFunc: commands.DefineTestSCPCommand,
+			Parrent:    "test",
 		},
 		{
-			Name: "upload-exec",
-			Help: "Test scp upload and ssh run uploaded script.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineTestUploadExecCommand(cmd)
-			},
-			Parrent: "test",
+			Name:       "upload-exec",
+			Help:       "Test scp upload and ssh run uploaded script.",
+			DefineFunc: commands.DefineTestUploadExecCommand,
+			Parrent:    "test",
 		},
 		{
-			Name: "bashible-bundle",
-			Help: "Test upload and execute a bundle.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineTestBundle(cmd)
-			},
-			Parrent: "test",
+			Name:       "bashible-bundle",
+			Help:       "Test upload and execute a bundle.",
+			DefineFunc: commands.DefineTestBundle,
+			Parrent:    "test",
 		},
 		{
 			Name:    "control-plane",
@@ -282,20 +233,16 @@ var (
 			Parrent: "test",
 		},
 		{
-			Name: "manager",
-			Help: "Test control plane manager is ready.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineTestControlPlaneManagerReadyCommand(cmd)
-			},
-			Parrent: "control-plane",
+			Name:       "manager",
+			Help:       "Test control plane manager is ready.",
+			DefineFunc: commands.DefineTestControlPlaneManagerReadyCommand,
+			Parrent:    "control-plane",
 		},
 		{
-			Name: "node",
-			Help: "Test control plane node is ready.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineTestControlPlaneNodeReadyCommand(cmd)
-			},
-			Parrent: "control-plane",
+			Name:       "node",
+			Help:       "Test control plane node is ready.",
+			DefineFunc: commands.DefineTestControlPlaneNodeReadyCommand,
+			Parrent:    "control-plane",
 		},
 		{
 			Name:    "deckhouse",
@@ -303,28 +250,22 @@ var (
 			Parrent: "test",
 		},
 		{
-			Name: "create-deployment",
-			Help: "Install deckhouse after terraform is applied successful.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineDeckhouseCreateDeployment(cmd)
-			},
-			Parrent: "deckhouse",
+			Name:       "create-deployment",
+			Help:       "Install deckhouse after terraform is applied successful.",
+			DefineFunc: commands.DefineDeckhouseCreateDeployment,
+			Parrent:    "deckhouse",
 		},
 		{
-			Name: "remove-deployment",
-			Help: "Delete deckhouse deployment.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineDeckhouseRemoveDeployment(cmd)
-			},
-			Parrent: "deckhouse",
+			Name:       "remove-deployment",
+			Help:       "Delete deckhouse deployment.",
+			DefineFunc: commands.DefineDeckhouseRemoveDeployment,
+			Parrent:    "deckhouse",
 		},
 		{
-			Name: "deployment-ready",
-			Help: "Wait while deployment is ready.",
-			DefineFunc: func(cmd *kingpin.CmdClause) {
-				commands.DefineWaitDeploymentReadyCommand(cmd)
-			},
-			Parrent: "deckhouse",
+			Name:       "deployment-ready",
+			Help:       "Wait while deployment is ready.",
+			DefineFunc: commands.DefineWaitDeploymentReadyCommand,
+			Parrent:    "deckhouse",
 		},
 	}
 )
@@ -332,7 +273,7 @@ var (
 type Command struct {
 	Name       string
 	Help       string
-	DefineFunc func(cmd *kingpin.CmdClause)
+	DefineFunc func(cmd *kingpin.CmdClause) *kingpin.CmdClause
 	Parrent    string
 	cmd        *kingpin.CmdClause
 }

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -45,6 +45,49 @@ var (
 	allowedCommands []string
 )
 
+const (
+	serverCommand                           = "server"
+	singleThreadedServerCommand             = "_server"
+	bootstrapCommand                        = "bootstrap"
+	bootstrapPhaseCommand                   = "bootstrap-phase"
+	executeBashibleSubcommand               = "execute-bashible-bundle"
+	installDeckhouseSubcommand              = "install-deckhouse"
+	createResourcesSubcommand               = "create-resources"
+	abortSubcommand                         = "abort"
+	baseInfrastructureSubcommand            = "base-infra"
+	execPostBootstarpSubcommand             = "exec-post-bootstrap"
+	convergeCommand                         = "converge"
+	autoConvergeCommand                     = "converge-periodical"
+	lockCommand                             = "lock"
+	lockReleaseSubcommand                   = "release"
+	destroyCommand                          = "destroy"
+	terraformCommand                        = "terraform"
+	convergeExporterSubcommand              = "converge-exporter"
+	terraformCheckSubcommand                = "check"
+	configCommand                           = "comfig"
+	parseSubcommand                         = "parse"
+	renderSubcommand                        = "render"
+	editSubcommand                          = "edit"
+	parseClusterConfigurationSubcommand     = "cluster-configuration"
+	parseCloudDiscoveryDataSubcommand       = "cloud-discovery-data"
+	renderBashibleBundleSubcommand          = "bashible-bundle"
+	renderKubeadmConfigSubcommand           = "kubeadm-config"
+	renderMasterBootstrapSubcommand         = "master-bootstrap-scripts"
+	testCommand                             = "test"
+	testSSHConnectionSubcommand             = "ssh-connection"
+	testKubernetesAPIConnectionSubcommand   = "kubernetes-api-connection"
+	testSCPSubcommand                       = "scp"
+	testUploadExecSubcommand                = "upload-exec"
+	testBundleSubcommand                    = "bashible-bundle"
+	testControlPlaneSubcommand              = "control-plane"
+	testControlPlaneManagerSubcommand       = "manager"
+	testControlPlaneNodeSubcommand          = "node"
+	testDeckhouseSubcommand                 = "deckhouse"
+	testDeckhouseCreateDeploymentSubcommand = "create-deployment"
+	testDeckhouseRemoveDeploymentSubcommand = "remove-deployment"
+	testWaitDeploymentReadySubcommand       = "deployment-ready"
+)
+
 func main() {
 	_ = os.Mkdir(app.TmpDirName, 0o755)
 
@@ -67,111 +110,111 @@ func main() {
 		return nil
 	})
 
-	allowed, _ := checkCommand("server", allowedCommands)
+	allowed, _ := checkCommand(serverCommand, allowedCommands)
 	if allowed {
-		commands.DefineServerCommand(kpApp)
+		commands.DefineServerCommand(kpApp, serverCommand)
 	}
 
-	allowed, _ = checkCommand("_server", allowedCommands)
+	allowed, _ = checkCommand(singleThreadedServerCommand, allowedCommands)
 	if allowed {
-		commands.DefineSingleThreadedServerCommand(kpApp)
+		commands.DefineSingleThreadedServerCommand(kpApp, singleThreadedServerCommand)
 	}
 
-	allowed, _ = checkCommand("bootstrap", allowedCommands)
+	allowed, _ = checkCommand(bootstrapCommand, allowedCommands)
 	if allowed {
-		bootstrap.DefineBootstrapCommand(kpApp)
+		bootstrap.DefineBootstrapCommand(kpApp, bootstrapCommand)
 	}
 
-	allowed, subcommands := checkCommand("bootstrap-phase", allowedCommands)
+	allowed, subcommands := checkCommand(bootstrapPhaseCommand, allowedCommands)
 	if allowed {
-		bootstrapPhaseCmd := kpApp.Command("bootstrap-phase", "Commands to run a single phase of the bootstrap process.")
+		bootstrapPhaseCmd := kpApp.Command(bootstrapPhaseCommand, "Commands to run a single phase of the bootstrap process.")
 		{
-			if checkSubcommand("execute-bashible-bundle", subcommands) {
-				bootstrap.DefineBootstrapExecuteBashibleCommand(bootstrapPhaseCmd)
+			if checkSubcommand(executeBashibleSubcommand, subcommands) {
+				bootstrap.DefineBootstrapExecuteBashibleCommand(bootstrapPhaseCmd, executeBashibleSubcommand)
 			}
 
-			if checkSubcommand("install-deckhouse", subcommands) {
-				bootstrap.DefineBootstrapInstallDeckhouseCommand(bootstrapPhaseCmd)
+			if checkSubcommand(installDeckhouseSubcommand, subcommands) {
+				bootstrap.DefineBootstrapInstallDeckhouseCommand(bootstrapPhaseCmd, installDeckhouseSubcommand)
 			}
 
-			if checkSubcommand("create-resources", subcommands) {
-				bootstrap.DefineCreateResourcesCommand(bootstrapPhaseCmd)
+			if checkSubcommand(createResourcesSubcommand, subcommands) {
+				bootstrap.DefineCreateResourcesCommand(bootstrapPhaseCmd, createResourcesSubcommand)
 			}
 
-			if checkSubcommand("abort", subcommands) {
-				bootstrap.DefineBootstrapAbortCommand(bootstrapPhaseCmd)
+			if checkSubcommand(abortSubcommand, subcommands) {
+				bootstrap.DefineBootstrapAbortCommand(bootstrapPhaseCmd, abortSubcommand)
 			}
 
-			if checkSubcommand("base-infra", subcommands) {
-				bootstrap.DefineBaseInfrastructureCommand(bootstrapPhaseCmd)
+			if checkSubcommand(baseInfrastructureSubcommand, subcommands) {
+				bootstrap.DefineBaseInfrastructureCommand(bootstrapPhaseCmd, baseInfrastructureSubcommand)
 			}
 
-			if checkSubcommand("exec-post-bootstrap", subcommands) {
-				bootstrap.DefineExecPostBootstrapScript(bootstrapPhaseCmd)
+			if checkSubcommand(execPostBootstarpSubcommand, subcommands) {
+				bootstrap.DefineExecPostBootstrapScript(bootstrapPhaseCmd, execPostBootstarpSubcommand)
 			}
 		}
 	}
 
-	allowed, _ = checkCommand("converge", allowedCommands)
+	allowed, _ = checkCommand(convergeCommand, allowedCommands)
 	if allowed {
-		commands.DefineConvergeCommand(kpApp)
+		commands.DefineConvergeCommand(kpApp, convergeCommand)
 	}
 
-	allowed, _ = checkCommand("converge-periodical", allowedCommands)
+	allowed, _ = checkCommand(autoConvergeCommand, allowedCommands)
 	if allowed {
-		commands.DefineAutoConvergeCommand(kpApp)
+		commands.DefineAutoConvergeCommand(kpApp, autoConvergeCommand)
 	}
 
-	allowed, _ = checkCommand("lock", allowedCommands)
+	allowed, _ = checkCommand(lockCommand, allowedCommands)
 	if allowed {
-		lockCmd := kpApp.Command("lock", "Converge cluster lock")
+		lockCmd := kpApp.Command(lockCommand, "Converge cluster lock")
 		{
-			commands.DefineReleaseConvergeLockCommand(lockCmd)
+			commands.DefineReleaseConvergeLockCommand(lockCmd, lockReleaseSubcommand)
 		}
 	}
 
-	allowed, _ = checkCommand("destroy", allowedCommands)
+	allowed, _ = checkCommand(destroyCommand, allowedCommands)
 	if allowed {
-		commands.DefineDestroyCommand(kpApp)
+		commands.DefineDestroyCommand(kpApp, destroyCommand)
 	}
 
-	allowed, subcommands = checkCommand("terraform", allowedCommands)
+	allowed, subcommands = checkCommand(terraformCommand, allowedCommands)
 	if allowed {
-		terraformCmd := kpApp.Command("terraform", "Terraform commands.")
+		terraformCmd := kpApp.Command(terraformCommand, "Terraform commands.")
 		{
-			if checkSubcommand("converge-exporter", subcommands) {
-				commands.DefineTerraformConvergeExporterCommand(terraformCmd)
+			if checkSubcommand(convergeExporterSubcommand, subcommands) {
+				commands.DefineTerraformConvergeExporterCommand(terraformCmd, convergeExporterSubcommand)
 			}
 
-			if checkSubcommand("check", subcommands) {
-				commands.DefineTerraformCheckCommand(terraformCmd)
+			if checkSubcommand(terraformCheckSubcommand, subcommands) {
+				commands.DefineTerraformCheckCommand(terraformCmd, terraformCheckSubcommand)
 			}
 		}
 	}
 
-	allowed, subcommands = checkCommand("config", allowedCommands)
+	allowed, subcommands = checkCommand(configCommand, allowedCommands)
 	if allowed {
-		configCmd := kpApp.Command("config", "Load, edit and save various dhctl configurations.")
+		configCmd := kpApp.Command(configCommand, "Load, edit and save various dhctl configurations.")
 		{
-			if checkSubcommand("parse", subcommands) {
-				parseCmd := configCmd.Command("parse", "Parse, validate and output configurations.")
+			if checkSubcommand(parseSubcommand, subcommands) {
+				parseCmd := configCmd.Command(parseSubcommand, "Parse, validate and output configurations.")
 				{
-					commands.DefineCommandParseClusterConfiguration(kpApp, parseCmd)
-					commands.DefineCommandParseCloudDiscoveryData(kpApp, parseCmd)
+					commands.DefineCommandParseClusterConfiguration(kpApp, parseCmd, parseClusterConfigurationSubcommand)
+					commands.DefineCommandParseCloudDiscoveryData(kpApp, parseCmd, parseCloudDiscoveryDataSubcommand)
 				}
 			}
 
-			if checkSubcommand("render", subcommands) {
-				renderCmd := configCmd.Command("render", "Render transitional configurations.")
+			if checkSubcommand(renderSubcommand, subcommands) {
+				renderCmd := configCmd.Command(renderSubcommand, "Render transitional configurations.")
 				{
-					commands.DefineRenderBashibleBundle(renderCmd)
-					commands.DefineRenderKubeadmConfig(renderCmd)
-					commands.DefineRenderMasterBootstrap(renderCmd)
+					commands.DefineRenderBashibleBundle(renderCmd, renderBashibleBundleSubcommand)
+					commands.DefineRenderKubeadmConfig(renderCmd, renderKubeadmConfigSubcommand)
+					commands.DefineRenderMasterBootstrap(renderCmd, renderMasterBootstrapSubcommand)
 				}
 			}
 
-			if checkSubcommand("edit", subcommands) {
-				editCmd := configCmd.Command("edit", "Change configuration files in Kubernetes cluster conveniently and safely.")
+			if checkSubcommand(editSubcommand, subcommands) {
+				editCmd := configCmd.Command(editSubcommand, "Change configuration files in Kubernetes cluster conveniently and safely.")
 				{
 					commands.DefineEditCommands(editCmd /* wConnFlags */, true)
 				}
@@ -179,45 +222,45 @@ func main() {
 		}
 	}
 
-	allowed, subcommands = checkCommand("test", allowedCommands)
+	allowed, subcommands = checkCommand(testCommand, allowedCommands)
 	if allowed {
-		testCmd := kpApp.Command("test", "Commands to test the parts of bootstrap and converge process.")
+		testCmd := kpApp.Command(testCommand, "Commands to test the parts of bootstrap and converge process.")
 		{
-			if checkSubcommand("ssh-connection", subcommands) {
-				commands.DefineTestSSHConnectionCommand(testCmd)
+			if checkSubcommand(testSSHConnectionSubcommand, subcommands) {
+				commands.DefineTestSSHConnectionCommand(testCmd, testSSHConnectionSubcommand)
 			}
 
-			if checkSubcommand("kubernetes-api-connection", subcommands) {
-				commands.DefineTestKubernetesAPIConnectionCommand(testCmd)
+			if checkSubcommand(testKubernetesAPIConnectionSubcommand, subcommands) {
+				commands.DefineTestKubernetesAPIConnectionCommand(testCmd, testKubernetesAPIConnectionSubcommand)
 			}
 
-			if checkSubcommand("scp", subcommands) {
-				commands.DefineTestSCPCommand(testCmd)
+			if checkSubcommand(testSCPSubcommand, subcommands) {
+				commands.DefineTestSCPCommand(testCmd, testSCPSubcommand)
 			}
 
-			if checkSubcommand("upload-exec", subcommands) {
-				commands.DefineTestUploadExecCommand(testCmd)
+			if checkSubcommand(testUploadExecSubcommand, subcommands) {
+				commands.DefineTestUploadExecCommand(testCmd, testUploadExecSubcommand)
 			}
 
-			if checkSubcommand("bashible-bundle", subcommands) {
-				commands.DefineTestBundle(testCmd)
+			if checkSubcommand(testBundleSubcommand, subcommands) {
+				commands.DefineTestBundle(testCmd, testBundleSubcommand)
 			}
 
-			if checkSubcommand("control-plane", subcommands) {
-				controlPlaneCmd := testCmd.Command("control-plane", "Commands to test control plane nodes.")
+			if checkSubcommand(testControlPlaneSubcommand, subcommands) {
+				controlPlaneCmd := testCmd.Command(testControlPlaneSubcommand, "Commands to test control plane nodes.")
 				{
-					commands.DefineTestControlPlaneManagerReadyCommand(controlPlaneCmd)
-					commands.DefineTestControlPlaneNodeReadyCommand(controlPlaneCmd)
+					commands.DefineTestControlPlaneManagerReadyCommand(controlPlaneCmd, testControlPlaneManagerSubcommand)
+					commands.DefineTestControlPlaneNodeReadyCommand(controlPlaneCmd, testControlPlaneNodeSubcommand)
 				}
 			}
 		}
 
-		if checkSubcommand("deckhouse", subcommands) {
-			deckhouseCmd := testCmd.Command("deckhouse", "Install and uninstall deckhouse.")
+		if checkSubcommand(testDeckhouseSubcommand, subcommands) {
+			deckhouseCmd := testCmd.Command(testDeckhouseSubcommand, "Install and uninstall deckhouse.")
 			{
-				commands.DefineDeckhouseCreateDeployment(deckhouseCmd)
-				commands.DefineDeckhouseRemoveDeployment(deckhouseCmd)
-				commands.DefineWaitDeploymentReadyCommand(deckhouseCmd)
+				commands.DefineDeckhouseCreateDeployment(deckhouseCmd, testDeckhouseCreateDeploymentSubcommand)
+				commands.DefineDeckhouseRemoveDeployment(deckhouseCmd, testDeckhouseRemoveDeploymentSubcommand)
+				commands.DefineWaitDeploymentReadyCommand(deckhouseCmd, testWaitDeploymentReadySubcommand)
 			}
 		}
 	}

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	allowedСommands []string
+	allowedCommands []string
 )
 
 func main() {
@@ -67,22 +67,22 @@ func main() {
 		return nil
 	})
 
-	allowed, _ := checkCommand("server", allowedСommands)
+	allowed, _ := checkCommand("server", allowedCommands)
 	if allowed {
 		commands.DefineServerCommand(kpApp)
 	}
 
-	allowed, _ = checkCommand("_server", allowedСommands)
+	allowed, _ = checkCommand("_server", allowedCommands)
 	if allowed {
 		commands.DefineSingleThreadedServerCommand(kpApp)
 	}
 
-	allowed, _ = checkCommand("bootstrap", allowedСommands)
+	allowed, _ = checkCommand("bootstrap", allowedCommands)
 	if allowed {
 		bootstrap.DefineBootstrapCommand(kpApp)
 	}
 
-	allowed, subcommands := checkCommand("bootstrap-phase", allowedСommands)
+	allowed, subcommands := checkCommand("bootstrap-phase", allowedCommands)
 	if allowed {
 		bootstrapPhaseCmd := kpApp.Command("bootstrap-phase", "Commands to run a single phase of the bootstrap process.")
 		{
@@ -112,17 +112,17 @@ func main() {
 		}
 	}
 
-	allowed, _ = checkCommand("converge", allowedСommands)
+	allowed, _ = checkCommand("converge", allowedCommands)
 	if allowed {
 		commands.DefineConvergeCommand(kpApp)
 	}
 
-	allowed, _ = checkCommand("converge-periodical", allowedСommands)
+	allowed, _ = checkCommand("converge-periodical", allowedCommands)
 	if allowed {
 		commands.DefineAutoConvergeCommand(kpApp)
 	}
 
-	allowed, _ = checkCommand("lock", allowedСommands)
+	allowed, _ = checkCommand("lock", allowedCommands)
 	if allowed {
 		lockCmd := kpApp.Command("lock", "Converge cluster lock")
 		{
@@ -130,12 +130,12 @@ func main() {
 		}
 	}
 
-	allowed, _ = checkCommand("destroy", allowedСommands)
+	allowed, _ = checkCommand("destroy", allowedCommands)
 	if allowed {
 		commands.DefineDestroyCommand(kpApp)
 	}
 
-	allowed, subcommands = checkCommand("terraform", allowedСommands)
+	allowed, subcommands = checkCommand("terraform", allowedCommands)
 	if allowed {
 		terraformCmd := kpApp.Command("terraform", "Terraform commands.")
 		{
@@ -149,7 +149,7 @@ func main() {
 		}
 	}
 
-	allowed, subcommands = checkCommand("config", allowedСommands)
+	allowed, subcommands = checkCommand("config", allowedCommands)
 	if allowed {
 		configCmd := kpApp.Command("config", "Load, edit and save various dhctl configurations.")
 		{
@@ -179,7 +179,7 @@ func main() {
 		}
 	}
 
-	allowed, subcommands = checkCommand("test", allowedСommands)
+	allowed, subcommands = checkCommand("test", allowedCommands)
 	if allowed {
 		testCmd := kpApp.Command("test", "Commands to test the parts of bootstrap and converge process.")
 		{
@@ -385,7 +385,7 @@ func initGlobalVars() {
 	commandsEnv := os.Getenv("DHCTL_CLI_ALLOWED_COMMANDS")
 
 	if len(commandsEnv) > 0 {
-		allowedСommands = strings.Split(commandsEnv, ", ")
+		allowedCommands = strings.Split(commandsEnv, ", ")
 	}
 
 	// set relative path to config and template files
@@ -397,12 +397,12 @@ func initGlobalVars() {
 	template.InitGlobalVars(dhctlPath)
 }
 
-func checkCommand(name string, allowedСommands []string) (bool, []string) {
-	if len(allowedСommands) == 0 || slices.Index(allowedСommands, name) != -1 {
+func checkCommand(name string, allowedCommands []string) (bool, []string) {
+	if len(allowedCommands) == 0 || slices.Index(allowedCommands, name) != -1 {
 		return true, []string{}
 	}
 
-	for _, cm := range allowedСommands {
+	for _, cm := range allowedCommands {
 		c := strings.Split(cm, " ")
 		if c[0] == name {
 			return true, c

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -228,6 +228,9 @@ var (
 			Name:    "edit",
 			Help:    "Change configuration files in Kubernetes cluster conveniently and safely.",
 			Parrent: "config",
+			DefineFunc: func(cmd *kingpin.CmdClause) {
+				commands.DefineEditCommands(cmd /* wConnFlags */, true)
+			},
 		},
 		{
 			Name: "test",
@@ -636,11 +639,7 @@ func registerCommands(kpApp *kingpin.Application) error {
 				commandList[i].cmd = cmd
 
 				if command.DefineFunc != nil {
-					if command.Name != "edit" {
-						command.DefineFunc(cmd)
-					} else {
-						commands.DefineEditCommands(cmd /* wConnFlags */, true)
-					}
+					command.DefineFunc(cmd)
 				}
 			}
 		}

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -42,51 +42,53 @@ import (
 )
 
 var (
-	allowedCommands []string
+	allowedCommands                         []string
+	bootstrapCommand                        = Command{Name: "bootstrap", Help: "Bootstrap cluster."}
+	bootstrapPhaseCommand                   = Command{Name: "bootstrap-phase", Help: "Commands to run a single phase of the bootstrap process."}
+	executeBashibleSubcommand               = Command{Name: "execute-bashible-bundle", Help: "Prepare Master node and install Kubernetes."}
+	createResourcesSubcommand               = Command{Name: "create-resources", Help: "Create resources in Kubernetes cluster."}
+	installDeckhouseSubcommand              = Command{Name: "install-deckhouse", Help: "Install deckhouse and wait for its readiness."}
+	abortSubcommand                         = Command{Name: "abort", Help: "Delete every node, which was created during bootstrap process."}
+	baseInfrastructureSubcommand            = Command{Name: "base-infra", Help: "Create base infrastructure for Cloud Kubernetes cluster."}
+	execPostBootstarpSubcommand             = Command{Name: "exec-post-bootstrap", Help: "Test scp upload and ssh run uploaded script."}
+	serverCommand                           = Command{Name: "server", Help: "Start dhctl as GRPC server."}
+	singleThreadedServerCommand             = Command{Name: "_server", Help: "Start dhctl as GRPC server. Single threaded version."}
+	convergeCommand                         = Command{Name: "converge", Help: "Converge kubernetes cluster."}
+	autoConvergeCommand                     = Command{Name: "converge-periodical", Help: "Start service for periodical run converge."}
+	lockCommand                             = Command{Name: "lock", Help: "Converge cluster lock"}
+	lockReleaseSubcommand                   = Command{Name: "release", Help: "Release converge lock fully. It's remove converge lease lock from cluster regardless of owner. Be careful"}
+	destroyCommand                          = Command{Name: "destroy", Help: "Destroy Kubernetes cluster."}
+	terraformCommand                        = Command{Name: "terraform", Help: "Terraform commands."}
+	convergeExporterSubcommand              = Command{Name: "converge-exporter", Help: "Run terraform converge exporter."}
+	terraformCheckSubcommand                = Command{Name: "check", Help: "Check differences between state of Kubernetes cluster and Terraform state."}
+	configCommand                           = Command{Name: "comfig", Help: "Load, edit and save various dhctl configurations."}
+	parseSubcommand                         = Command{Name: "parse", Help: "Parse, validate and output configurations."}
+	renderSubcommand                        = Command{Name: "render", Help: "Render transitional configurations."}
+	editSubcommand                          = Command{Name: "edit", Help: "Change configuration files in Kubernetes cluster conveniently and safely."}
+	parseClusterConfigurationSubcommand     = Command{Name: "cluster-configuration", Help: "Parse configuration and print it."}
+	parseCloudDiscoveryDataSubcommand       = Command{Name: "cloud-discovery-data", Help: "Parse cloud discovery data and print it."}
+	renderBashibleBundleSubcommand          = Command{Name: "bashible-bundle", Help: "Render bashible bundle."}
+	renderKubeadmConfigSubcommand           = Command{Name: "kubeadm-config", Help: "Render kubeadm config."}
+	renderMasterBootstrapSubcommand         = Command{Name: "master-bootstrap-scripts", Help: "Render master bootstrap scripts."}
+	testCommand                             = Command{Name: "test", Help: "Commands to test the parts of bootstrap and converge process."}
+	testSSHConnectionSubcommand             = Command{Name: "ssh-connection", Help: "Test connection via ssh."}
+	testKubernetesAPIConnectionSubcommand   = Command{Name: "kubernetes-api-connection", Help: "Test connection to kubernetes api via ssh or directly."}
+	testSCPSubcommand                       = Command{Name: "scp", Help: "Test scp file operations."}
+	testUploadExecSubcommand                = Command{Name: "upload-exec", Help: "Test scp upload and ssh run uploaded script."}
+	testBundleSubcommand                    = Command{Name: "bashible-bundle", Help: "Test upload and execute a bundle."}
+	testControlPlaneSubcommand              = Command{Name: "control-plane", Help: "Commands to test control plane nodes."}
+	testControlPlaneManagerSubcommand       = Command{Name: "manager", Help: "Test control plane manager is ready."}
+	testControlPlaneNodeSubcommand          = Command{Name: "node", Help: "Test control plane node is ready."}
+	testDeckhouseSubcommand                 = Command{Name: "deckhouse", Help: "Install and uninstall deckhouse."}
+	testDeckhouseCreateDeploymentSubcommand = Command{Name: "create-deployment", Help: "Install deckhouse after terraform is applied successful."}
+	testDeckhouseRemoveDeploymentSubcommand = Command{Name: "remove-deployment", Help: "Delete deckhouse deployment."}
+	testWaitDeploymentReadySubcommand       = Command{Name: "deployment-ready", Help: "Wait while deployment is ready."}
 )
 
-const (
-	serverCommand                           = "server"
-	singleThreadedServerCommand             = "_server"
-	bootstrapCommand                        = "bootstrap"
-	bootstrapPhaseCommand                   = "bootstrap-phase"
-	executeBashibleSubcommand               = "execute-bashible-bundle"
-	installDeckhouseSubcommand              = "install-deckhouse"
-	createResourcesSubcommand               = "create-resources"
-	abortSubcommand                         = "abort"
-	baseInfrastructureSubcommand            = "base-infra"
-	execPostBootstarpSubcommand             = "exec-post-bootstrap"
-	convergeCommand                         = "converge"
-	autoConvergeCommand                     = "converge-periodical"
-	lockCommand                             = "lock"
-	lockReleaseSubcommand                   = "release"
-	destroyCommand                          = "destroy"
-	terraformCommand                        = "terraform"
-	convergeExporterSubcommand              = "converge-exporter"
-	terraformCheckSubcommand                = "check"
-	configCommand                           = "comfig"
-	parseSubcommand                         = "parse"
-	renderSubcommand                        = "render"
-	editSubcommand                          = "edit"
-	parseClusterConfigurationSubcommand     = "cluster-configuration"
-	parseCloudDiscoveryDataSubcommand       = "cloud-discovery-data"
-	renderBashibleBundleSubcommand          = "bashible-bundle"
-	renderKubeadmConfigSubcommand           = "kubeadm-config"
-	renderMasterBootstrapSubcommand         = "master-bootstrap-scripts"
-	testCommand                             = "test"
-	testSSHConnectionSubcommand             = "ssh-connection"
-	testKubernetesAPIConnectionSubcommand   = "kubernetes-api-connection"
-	testSCPSubcommand                       = "scp"
-	testUploadExecSubcommand                = "upload-exec"
-	testBundleSubcommand                    = "bashible-bundle"
-	testControlPlaneSubcommand              = "control-plane"
-	testControlPlaneManagerSubcommand       = "manager"
-	testControlPlaneNodeSubcommand          = "node"
-	testDeckhouseSubcommand                 = "deckhouse"
-	testDeckhouseCreateDeploymentSubcommand = "create-deployment"
-	testDeckhouseRemoveDeploymentSubcommand = "remove-deployment"
-	testWaitDeploymentReadySubcommand       = "deployment-ready"
-)
+type Command struct {
+	Name string
+	Help string
+}
 
 func main() {
 	_ = os.Mkdir(app.TmpDirName, 0o755)
@@ -110,111 +112,111 @@ func main() {
 		return nil
 	})
 
-	allowed, _ := checkCommand(serverCommand, allowedCommands)
+	allowed, _ := checkCommand(serverCommand.Name, allowedCommands)
 	if allowed {
-		commands.DefineServerCommand(kpApp, serverCommand)
+		commands.DefineServerCommand(kpApp, kingpin.Command(serverCommand.Name, serverCommand.Help))
 	}
 
-	allowed, _ = checkCommand(singleThreadedServerCommand, allowedCommands)
+	allowed, _ = checkCommand(singleThreadedServerCommand.Name, allowedCommands)
 	if allowed {
-		commands.DefineSingleThreadedServerCommand(kpApp, singleThreadedServerCommand)
+		commands.DefineSingleThreadedServerCommand(kpApp, kingpin.Command(singleThreadedServerCommand.Name, singleThreadedServerCommand.Help))
 	}
 
-	allowed, _ = checkCommand(bootstrapCommand, allowedCommands)
+	allowed, _ = checkCommand(bootstrapCommand.Name, allowedCommands)
 	if allowed {
-		bootstrap.DefineBootstrapCommand(kpApp, bootstrapCommand)
+		bootstrap.DefineBootstrapCommand(kpApp, kingpin.Command(bootstrapCommand.Name, bootstrapCommand.Help))
 	}
 
-	allowed, subcommands := checkCommand(bootstrapPhaseCommand, allowedCommands)
+	allowed, subcommands := checkCommand(bootstrapPhaseCommand.Name, allowedCommands)
 	if allowed {
-		bootstrapPhaseCmd := kpApp.Command(bootstrapPhaseCommand, "Commands to run a single phase of the bootstrap process.")
+		bootstrapPhaseCmd := kpApp.Command(bootstrapPhaseCommand.Name, bootstrapPhaseCommand.Help)
 		{
-			if checkSubcommand(executeBashibleSubcommand, subcommands) {
-				bootstrap.DefineBootstrapExecuteBashibleCommand(bootstrapPhaseCmd, executeBashibleSubcommand)
+			if checkSubcommand(executeBashibleSubcommand.Name, subcommands) {
+				bootstrap.DefineBootstrapExecuteBashibleCommand(bootstrapPhaseCmd, kingpin.Command(executeBashibleSubcommand.Name, executeBashibleSubcommand.Help))
 			}
 
-			if checkSubcommand(installDeckhouseSubcommand, subcommands) {
-				bootstrap.DefineBootstrapInstallDeckhouseCommand(bootstrapPhaseCmd, installDeckhouseSubcommand)
+			if checkSubcommand(installDeckhouseSubcommand.Name, subcommands) {
+				bootstrap.DefineBootstrapInstallDeckhouseCommand(bootstrapPhaseCmd, kingpin.Command(installDeckhouseSubcommand.Name, installDeckhouseSubcommand.Help))
 			}
 
-			if checkSubcommand(createResourcesSubcommand, subcommands) {
-				bootstrap.DefineCreateResourcesCommand(bootstrapPhaseCmd, createResourcesSubcommand)
+			if checkSubcommand(createResourcesSubcommand.Name, subcommands) {
+				bootstrap.DefineCreateResourcesCommand(bootstrapPhaseCmd, kingpin.Command(createResourcesSubcommand.Name, createResourcesSubcommand.Help))
 			}
 
-			if checkSubcommand(abortSubcommand, subcommands) {
-				bootstrap.DefineBootstrapAbortCommand(bootstrapPhaseCmd, abortSubcommand)
+			if checkSubcommand(abortSubcommand.Name, subcommands) {
+				bootstrap.DefineBootstrapAbortCommand(bootstrapPhaseCmd, kingpin.Command(abortSubcommand.Name, abortSubcommand.Help))
 			}
 
-			if checkSubcommand(baseInfrastructureSubcommand, subcommands) {
-				bootstrap.DefineBaseInfrastructureCommand(bootstrapPhaseCmd, baseInfrastructureSubcommand)
+			if checkSubcommand(baseInfrastructureSubcommand.Name, subcommands) {
+				bootstrap.DefineBaseInfrastructureCommand(bootstrapPhaseCmd, kingpin.Command(baseInfrastructureSubcommand.Name, baseInfrastructureSubcommand.Help))
 			}
 
-			if checkSubcommand(execPostBootstarpSubcommand, subcommands) {
-				bootstrap.DefineExecPostBootstrapScript(bootstrapPhaseCmd, execPostBootstarpSubcommand)
+			if checkSubcommand(execPostBootstarpSubcommand.Name, subcommands) {
+				bootstrap.DefineExecPostBootstrapScript(bootstrapPhaseCmd, kingpin.Command(execPostBootstarpSubcommand.Name, execPostBootstarpSubcommand.Help))
 			}
 		}
 	}
 
-	allowed, _ = checkCommand(convergeCommand, allowedCommands)
+	allowed, _ = checkCommand(convergeCommand.Name, allowedCommands)
 	if allowed {
-		commands.DefineConvergeCommand(kpApp, convergeCommand)
+		commands.DefineConvergeCommand(kpApp, kingpin.Command(convergeCommand.Name, convergeCommand.Help))
 	}
 
-	allowed, _ = checkCommand(autoConvergeCommand, allowedCommands)
+	allowed, _ = checkCommand(autoConvergeCommand.Name, allowedCommands)
 	if allowed {
-		commands.DefineAutoConvergeCommand(kpApp, autoConvergeCommand)
+		commands.DefineAutoConvergeCommand(kpApp, kingpin.Command(autoConvergeCommand.Name, autoConvergeCommand.Help))
 	}
 
-	allowed, _ = checkCommand(lockCommand, allowedCommands)
+	allowed, _ = checkCommand(lockCommand.Name, allowedCommands)
 	if allowed {
-		lockCmd := kpApp.Command(lockCommand, "Converge cluster lock")
+		lockCmd := kpApp.Command(lockCommand.Name, lockCommand.Help)
 		{
-			commands.DefineReleaseConvergeLockCommand(lockCmd, lockReleaseSubcommand)
+			commands.DefineReleaseConvergeLockCommand(lockCmd, kingpin.Command(lockReleaseSubcommand.Name, lockReleaseSubcommand.Help))
 		}
 	}
 
-	allowed, _ = checkCommand(destroyCommand, allowedCommands)
+	allowed, _ = checkCommand(destroyCommand.Name, allowedCommands)
 	if allowed {
-		commands.DefineDestroyCommand(kpApp, destroyCommand)
+		commands.DefineDestroyCommand(kpApp, kingpin.Command(destroyCommand.Name, destroyCommand.Help))
 	}
 
-	allowed, subcommands = checkCommand(terraformCommand, allowedCommands)
+	allowed, subcommands = checkCommand(terraformCommand.Name, allowedCommands)
 	if allowed {
-		terraformCmd := kpApp.Command(terraformCommand, "Terraform commands.")
+		terraformCmd := kpApp.Command(terraformCommand.Name, terraformCommand.Help)
 		{
-			if checkSubcommand(convergeExporterSubcommand, subcommands) {
-				commands.DefineTerraformConvergeExporterCommand(terraformCmd, convergeExporterSubcommand)
+			if checkSubcommand(convergeExporterSubcommand.Name, subcommands) {
+				commands.DefineTerraformConvergeExporterCommand(terraformCmd, kingpin.Command(convergeExporterSubcommand.Name, convergeExporterSubcommand.Help))
 			}
 
-			if checkSubcommand(terraformCheckSubcommand, subcommands) {
-				commands.DefineTerraformCheckCommand(terraformCmd, terraformCheckSubcommand)
+			if checkSubcommand(terraformCheckSubcommand.Name, subcommands) {
+				commands.DefineTerraformCheckCommand(terraformCmd, kingpin.Command(terraformCheckSubcommand.Name, terraformCheckSubcommand.Help))
 			}
 		}
 	}
 
-	allowed, subcommands = checkCommand(configCommand, allowedCommands)
+	allowed, subcommands = checkCommand(configCommand.Name, allowedCommands)
 	if allowed {
-		configCmd := kpApp.Command(configCommand, "Load, edit and save various dhctl configurations.")
+		configCmd := kpApp.Command(configCommand.Name, configCommand.Help)
 		{
-			if checkSubcommand(parseSubcommand, subcommands) {
-				parseCmd := configCmd.Command(parseSubcommand, "Parse, validate and output configurations.")
+			if checkSubcommand(parseSubcommand.Name, subcommands) {
+				parseCmd := configCmd.Command(parseSubcommand.Name, parseSubcommand.Help)
 				{
-					commands.DefineCommandParseClusterConfiguration(kpApp, parseCmd, parseClusterConfigurationSubcommand)
-					commands.DefineCommandParseCloudDiscoveryData(kpApp, parseCmd, parseCloudDiscoveryDataSubcommand)
+					commands.DefineCommandParseClusterConfiguration(kpApp, parseCmd, kingpin.Command(parseClusterConfigurationSubcommand.Name, parseClusterConfigurationSubcommand.Help))
+					commands.DefineCommandParseCloudDiscoveryData(kpApp, parseCmd, kingpin.Command(parseCloudDiscoveryDataSubcommand.Name, parseCloudDiscoveryDataSubcommand.Help))
 				}
 			}
 
-			if checkSubcommand(renderSubcommand, subcommands) {
-				renderCmd := configCmd.Command(renderSubcommand, "Render transitional configurations.")
+			if checkSubcommand(renderSubcommand.Name, subcommands) {
+				renderCmd := configCmd.Command(renderSubcommand.Name, renderSubcommand.Help)
 				{
-					commands.DefineRenderBashibleBundle(renderCmd, renderBashibleBundleSubcommand)
-					commands.DefineRenderKubeadmConfig(renderCmd, renderKubeadmConfigSubcommand)
-					commands.DefineRenderMasterBootstrap(renderCmd, renderMasterBootstrapSubcommand)
+					commands.DefineRenderBashibleBundle(renderCmd, kingpin.Command(renderBashibleBundleSubcommand.Name, renderBashibleBundleSubcommand.Help))
+					commands.DefineRenderKubeadmConfig(renderCmd, kingpin.Command(renderKubeadmConfigSubcommand.Name, renderKubeadmConfigSubcommand.Help))
+					commands.DefineRenderMasterBootstrap(renderCmd, kingpin.Command(renderMasterBootstrapSubcommand.Name, renderMasterBootstrapSubcommand.Help))
 				}
 			}
 
-			if checkSubcommand(editSubcommand, subcommands) {
-				editCmd := configCmd.Command(editSubcommand, "Change configuration files in Kubernetes cluster conveniently and safely.")
+			if checkSubcommand(editSubcommand.Name, subcommands) {
+				editCmd := configCmd.Command(editSubcommand.Name, editSubcommand.Help)
 				{
 					commands.DefineEditCommands(editCmd /* wConnFlags */, true)
 				}
@@ -222,45 +224,45 @@ func main() {
 		}
 	}
 
-	allowed, subcommands = checkCommand(testCommand, allowedCommands)
+	allowed, subcommands = checkCommand(testCommand.Name, allowedCommands)
 	if allowed {
-		testCmd := kpApp.Command(testCommand, "Commands to test the parts of bootstrap and converge process.")
+		testCmd := kpApp.Command(testCommand.Help, testCommand.Help)
 		{
-			if checkSubcommand(testSSHConnectionSubcommand, subcommands) {
-				commands.DefineTestSSHConnectionCommand(testCmd, testSSHConnectionSubcommand)
+			if checkSubcommand(testSSHConnectionSubcommand.Name, subcommands) {
+				commands.DefineTestSSHConnectionCommand(testCmd, kingpin.Command(testSSHConnectionSubcommand.Name, testSSHConnectionSubcommand.Help))
 			}
 
-			if checkSubcommand(testKubernetesAPIConnectionSubcommand, subcommands) {
-				commands.DefineTestKubernetesAPIConnectionCommand(testCmd, testKubernetesAPIConnectionSubcommand)
+			if checkSubcommand(testKubernetesAPIConnectionSubcommand.Name, subcommands) {
+				commands.DefineTestKubernetesAPIConnectionCommand(testCmd, kingpin.Command(testKubernetesAPIConnectionSubcommand.Name, testKubernetesAPIConnectionSubcommand.Help))
 			}
 
-			if checkSubcommand(testSCPSubcommand, subcommands) {
-				commands.DefineTestSCPCommand(testCmd, testSCPSubcommand)
+			if checkSubcommand(testSCPSubcommand.Name, subcommands) {
+				commands.DefineTestSCPCommand(testCmd, kingpin.Command(testSCPSubcommand.Name, testSCPSubcommand.Help))
 			}
 
-			if checkSubcommand(testUploadExecSubcommand, subcommands) {
-				commands.DefineTestUploadExecCommand(testCmd, testUploadExecSubcommand)
+			if checkSubcommand(testUploadExecSubcommand.Name, subcommands) {
+				commands.DefineTestUploadExecCommand(testCmd, kingpin.Command(testUploadExecSubcommand.Name, testUploadExecSubcommand.Help))
 			}
 
-			if checkSubcommand(testBundleSubcommand, subcommands) {
-				commands.DefineTestBundle(testCmd, testBundleSubcommand)
+			if checkSubcommand(testBundleSubcommand.Name, subcommands) {
+				commands.DefineTestBundle(testCmd, kingpin.Command(testBundleSubcommand.Name, testBundleSubcommand.Help))
 			}
 
-			if checkSubcommand(testControlPlaneSubcommand, subcommands) {
-				controlPlaneCmd := testCmd.Command(testControlPlaneSubcommand, "Commands to test control plane nodes.")
+			if checkSubcommand(testControlPlaneSubcommand.Name, subcommands) {
+				controlPlaneCmd := testCmd.Command(testControlPlaneSubcommand.Name, testControlPlaneSubcommand.Help)
 				{
-					commands.DefineTestControlPlaneManagerReadyCommand(controlPlaneCmd, testControlPlaneManagerSubcommand)
-					commands.DefineTestControlPlaneNodeReadyCommand(controlPlaneCmd, testControlPlaneNodeSubcommand)
+					commands.DefineTestControlPlaneManagerReadyCommand(controlPlaneCmd, kingpin.Command(testControlPlaneManagerSubcommand.Name, testControlPlaneManagerSubcommand.Help))
+					commands.DefineTestControlPlaneNodeReadyCommand(controlPlaneCmd, kingpin.Command(testControlPlaneNodeSubcommand.Name, testControlPlaneNodeSubcommand.Help))
 				}
 			}
 		}
 
-		if checkSubcommand(testDeckhouseSubcommand, subcommands) {
-			deckhouseCmd := testCmd.Command(testDeckhouseSubcommand, "Install and uninstall deckhouse.")
+		if checkSubcommand(testDeckhouseSubcommand.Name, subcommands) {
+			deckhouseCmd := testCmd.Command(testDeckhouseSubcommand.Name, testDeckhouseSubcommand.Help)
 			{
-				commands.DefineDeckhouseCreateDeployment(deckhouseCmd, testDeckhouseCreateDeploymentSubcommand)
-				commands.DefineDeckhouseRemoveDeployment(deckhouseCmd, testDeckhouseRemoveDeploymentSubcommand)
-				commands.DefineWaitDeploymentReadyCommand(deckhouseCmd, testWaitDeploymentReadySubcommand)
+				commands.DefineDeckhouseCreateDeployment(deckhouseCmd, kingpin.Command(testDeckhouseCreateDeploymentSubcommand.Name, testDeckhouseCreateDeploymentSubcommand.Help))
+				commands.DefineDeckhouseRemoveDeployment(deckhouseCmd, kingpin.Command(testDeckhouseRemoveDeploymentSubcommand.Name, testDeckhouseRemoveDeploymentSubcommand.Help))
+				commands.DefineWaitDeploymentReadyCommand(deckhouseCmd, kingpin.Command(testWaitDeploymentReadySubcommand.Name, testWaitDeploymentReadySubcommand.Help))
 			}
 		}
 	}

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
@@ -73,6 +73,8 @@ spec:
         env:
         - name: DHCTL_CLI_KUBE_CLIENT_FROM_CLUSTER
           value: "true"
+        - name: DHCTL_CLI_ALLOWED_COMMANDS
+          value: "converge-periodical, terraform check"
         - name: DHCTL_CLI_RUNNING_NODE_NAME
           valueFrom:
             fieldRef:

--- a/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
@@ -86,6 +86,8 @@ spec:
         env:
         - name: DHCTL_CLI_KUBE_CLIENT_FROM_CLUSTER
           value: "true"
+        - name: DHCTL_CLI_ALLOWED_COMMANDS
+          value: "terraform converge-exporter"
         {{- include "helm_lib_envs_for_proxy" . | nindent 8 }}
         resources:
           requests:


### PR DESCRIPTION
## Description

Restrict dhctl command according to environment variable `DHCTL_CLI_ALLOWED_COMMANDS`. Allow in `terraform-auto-converger` only `converge-periodical` and `terraform check`, in `terraform-state-exporter` only `terraform converge-exporter`

## Why do we need it, and what problem does it solve?
Fixes #5206 

## What is the expected result?

If environment variable `DHCTL_CLI_ALLOWED_COMMANDS` not set, all commands can be run with `dhctl`. If it set, only restricted list of commands can be executed. From `terraform-auto-converger` can be executed only `dhctl converge-periodical` and `dhctl terraform-state-exporter`, from `terraform-state-exporter`  only `dhctl terraform converge-exporter`.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: feature
summary: Added restriction to dhctl allowed command, according to environment variable DHCTL_CLI_ALLOWED_COMMANDS.
impact_level: default
```

```changes
section: terraform-manager
type: fix
summary: Allow only dhctl converge-periodical and dhctl terraform-state-exporter in terraform-auto-converger, dhctl terraform converge-exporter in terraform-state-exporter.
impact_level: low
```
