### PR TITLE
[multitenancy-manager] add upmeter to the list of excluded service accounts which can create namespaces

### DIFF
--- a/modules/160-multitenancy-manager/images/multitenancy-manager/cmd/main.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/cmd/main.go
@@ -56,8 +56,8 @@ var (
 	helmNamespace = "d8-multitenancy-manager"
 	// controller service account
 	serviceAccount = "system:serviceaccount:d8-multitenancy-manager:multitenancy-manager"
-	// deckhouse service account
-	deckhouseServiceAccount = "system:serviceaccount:d8-system:deckhouse"
+	// list of service accounts allowed to create namespaces when allowNamespacesWithoutProjects is set to false
+	nsCreateAllowedServiceAccounts = []string{serviceAccount, "system:serviceaccount:d8-system:deckhouse", "system:serviceaccount:d8-upmeter:upmeter"}
 )
 
 const (
@@ -106,7 +106,7 @@ func main() {
 
 	if !allowOrphanNamespaces {
 		// register namespace webhook
-		namespacewebhook.Register(runtimeManager, serviceAccount, deckhouseServiceAccount)
+		namespacewebhook.Register(runtimeManager, nsCreateAllowedServiceAccounts)
 	}
 
 	// start runtime manager

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/cmd/main.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/cmd/main.go
@@ -57,7 +57,7 @@ var (
 	// controller service account
 	serviceAccount = "system:serviceaccount:d8-multitenancy-manager:multitenancy-manager"
 	// list of service accounts allowed to create namespaces when allowNamespacesWithoutProjects is set to false
-	nsCreateAllowedServiceAccounts = []string{serviceAccount, "system:serviceaccount:d8-system:deckhouse", "system:serviceaccount:d8-upmeter:upmeter"}
+	nsCreateAllowedServiceAccounts = []string{serviceAccount, "system:serviceaccount:d8-system:deckhouse", "system:serviceaccount:d8-upmeter:upmeter-agent"}
 )
 
 const (

--- a/modules/160-multitenancy-manager/templates/validation.yaml
+++ b/modules/160-multitenancy-manager/templates/validation.yaml
@@ -18,11 +18,9 @@ spec:
   validations:
     - expression: 'request.userInfo.username == "system:serviceaccount:d8-multitenancy-manager:multitenancy-manager"'
       reason: Forbidden
-{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
       messageExpression: 'object.kind == ''Namespace'' ? ''This resource is managed
             by '' + object.metadata.name + '' Project. Manual modification is forbidden.''
             : ''This resource is managed by '' + object.metadata.namespace + '' Project. Manual modification is forbidden.'''
-{{- end }}
 ---
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
 kind: ValidatingAdmissionPolicyBinding
@@ -31,9 +29,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "multitenancy-manager") ) | nindent 2 }}
 spec:
   policyName: {{ $policyName }}
-{{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   validationActions: [Deny, Audit]
-{{- end }}
   matchResources:
     namespaceSelector:
       matchLabels:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Permits the upmeter-agent service account to create namespaces when `allowNamespacesWithoutProjects` is set to false.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Without it, upmeter-agent isn't able to perform `namespace creation` checks and reports fails.
Closes #10965

## What is the expected result?
Upmeter-agent is able to create a namespace even when `allowNamespacesWithoutProjects` is set to false.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: multitenancy-manager
type: chore
summary: Allow upmeter-agent to create namespaces regardless the multitenancy-manager module's settings.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
