### PR TITLE
[dashboard] fix: remove duplicated roleRef in dashboard templates

### DIFF
--- a/modules/500-dashboard/templates/metrics-scraper/rbac-for-us.yaml
+++ b/modules/500-dashboard/templates/metrics-scraper/rbac-for-us.yaml
@@ -24,7 +24,6 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "metrics-scraper")) | nindent 2 }}
 roleRef:
-roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: d8:{{ .Chart.Name }}:metrics-scraper


### PR DESCRIPTION
## Description

[dmt](https://github.com/deckhouse/dmt) found a bug in the openAPI spec file for the dashboard. The field was duplicated, resulting in a compilation error.

## Why do we need it, and what problem does it solve?

The error leads to a problem with the metrics-scapper deployment, and a problem with its operation. The fix will allow the specified service to work fully.

## What is the expected result?

There are no errors in the openapi specs, the compilation of the helm chart passes without errors.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dashboard
type: fix
summary: remove duplicated roleRef in dashboard templates
impact_level: low
```
