### PR TITLE
[deckhouse] support global conversions

### DIFF
--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -201,7 +201,7 @@ func NewDeckhouseController(ctx context.Context, version string, operator *addon
 
 	bundle := os.Getenv("DECKHOUSE_BUNDLE")
 
-	loader := moduleloader.New(runtimeManager.GetClient(), version, operator.ModuleManager.ModulesDir, dc, embeddedPolicy, logger.Named("module-loader"))
+	loader := moduleloader.New(runtimeManager.GetClient(), version, operator.ModuleManager.ModulesDir, operator.ModuleManager.GlobalHooksDir, dc, embeddedPolicy, logger.Named("module-loader"))
 	operator.ModuleManager.SetModuleLoader(loader)
 
 	err = deckhouserelease.NewDeckhouseReleaseController(ctx, runtimeManager, dc, operator.ModuleManager, settingsContainer, operator.MetricStorage, preflightCountDown, logger.Named("deckhouse-release-controller"))

--- a/deckhouse-controller/pkg/controller/module-controllers/config/status.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/status.go
@@ -89,14 +89,18 @@ func (r *reconciler) refreshModuleConfig(ctx context.Context, configName string)
 				return err
 			}
 
-			// update metrics
-			converter := conversion.Store().Get(moduleConfig.Name)
-			if moduleConfig.Spec.Version > 0 && moduleConfig.Spec.Version < converter.LatestVersion() {
-				r.metricStorage.Grouped().GaugeSet(metricGroup, "d8_module_config_obsolete_version", 1.0, map[string]string{
-					"name":    moduleConfig.Name,
-					"version": strconv.Itoa(moduleConfig.Spec.Version),
-					"latest":  strconv.Itoa(converter.LatestVersion()),
-				})
+			// skip firing alert for global module
+			if moduleConfig.Name != "global" {
+				// update metrics
+				converter := conversion.Store().Get(moduleConfig.Name)
+				// fire alert at obsolete version
+				if moduleConfig.Spec.Version > 0 && moduleConfig.Spec.Version < converter.LatestVersion() {
+					r.metricStorage.Grouped().GaugeSet(metricGroup, "d8_module_config_obsolete_version", 1.0, map[string]string{
+						"name":    moduleConfig.Name,
+						"version": strconv.Itoa(moduleConfig.Spec.Version),
+						"latest":  strconv.Itoa(converter.LatestVersion()),
+					})
+				}
 			}
 			return nil
 		})


### PR DESCRIPTION
## Description
It provides supporting the 'global' module conversions.

## Why do we need it, and what problem does it solve?
The 'global' module has conversions, but they are not loaded.

Fixes #11024

## What is the expected result?
The 'global' module has conversions.

```
root@dev-master-0:~# k get mc
NAME                         ENABLED   VERSION   AGE    MESSAGE
admission-policy-engine      false     1         208d   
cni-cilium                   true      1         99d    
deckhouse                    true      1         286d   
descheduler                  false     2         74d    
documentation                false     1         285d   
echo                         true      1         37d    
flant-integration            false     1         286d   
global                       true      1         286d   Update available, latest spec.settings schema version is 2
```

Logs:
```
{"level":"debug","logger":"deckhouse-controller.module-loader","msg":"conversions for the 'global' module found","source":"deckhouse/deckhouse-controller/pkg/controller/moduleloader/loader.go:232","time":"2024-12-10T10:37:27Z"}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Add support the 'global' module conversions.
impact_level: low
```