### PR TITLE
[ingress-nginx] fix problem in controller with default backend for services with externalName type

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -70,3 +70,10 @@ Add HTTP/3 support.
 ### new metrics
 
 This patch adds worker max connections, worker processes and worker max open files metrics.
+
+### default backend fix
+
+Fixes the problem with the controller when Ingress specifies `Service` with the `ExternalName` type as the main backend, and the default backend (using an annotation `nginx.ingress.kubernetes.io/default-backend `) - with the ClusterIP type. You can see the detailed cases here:
+https://github.com/kubernetes/ingress-nginx/issues/12158
+https://github.com/kubernetes/ingress-nginx/issues/12173
+https://github.com/deckhouse/deckhouse/issues/9933

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/default-backend-fix.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/default-backend-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
+index c1d4e4f..f105b9c 100644
+--- a/internal/ingress/controller/controller.go
++++ b/internal/ingress/controller/controller.go
+@@ -937,6 +937,7 @@ func (n *NGINXController) getBackendServers(ingresses []*ingress.Ingress) ([]*in
+ 					nb := upstream.DeepCopy()
+ 					nb.Name = name
+ 					nb.Endpoints = endps
++					nb.Service = location.DefaultBackend
+ 					aUpstreams = append(aUpstreams, nb)
+ 					location.DefaultBackendUpstreamName = name
+ 

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -47,6 +47,7 @@ shell:
   - patch -p1 < /patches/add-http3.patch
   - patch -p1 < /patches/nginx-build.patch
   - patch -p1 < /patches/new-metrics.patch
+  - patch -p1 < /patches/default-backend-fix.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/balancer-lua.patch
   - patch -p1 < /patches/nginx-tmpl.patch

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -65,6 +65,7 @@ COPY patches/util.patch /
 COPY patches/fix-cleanup.patch /
 COPY patches/geoip.patch /
 COPY patches/new-metrics.patch /
+COPY patches/default-backend-fix.patch /
 ENV GOARCH=amd64
 RUN mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
 RUN --mount=type=ssh git clone --branch $CONTROLLER_BRANCH --depth 1 ${SOURCE_REPO}/kubernetes/ingress-nginx.git /src && \
@@ -77,7 +78,8 @@ RUN patch -p1 < /lua-info.patch && \
     patch -p1 < /util.patch && \
     patch -p1 < /fix-cleanup.patch && \
     patch -p1 < /geoip.patch && \
-    patch -p1 < /new-metrics.patch
+    patch -p1 < /new-metrics.patch && \
+    patch -p1 < /default-backend-fix.patch
 RUN make GO111MODULE=on USE_DOCKER=false build
 
 # Build nginx for ingress controller

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/README.md
@@ -65,3 +65,10 @@ https://github.com/kubernetes/ingress-nginx/pull/10495
 ### new metrics
 
 This patch adds worker max connections, worker processes and worker max open files metrics.
+
+### default backend fix
+
+Fixes the problem with the controller when Ingress specifies `Service` with the `ExternalName` type as the main backend, and the default backend (using an annotation `nginx.ingress.kubernetes.io/default-backend `) - with the ClusterIP type. You can see the detailed cases here:
+https://github.com/kubernetes/ingress-nginx/issues/12158
+https://github.com/kubernetes/ingress-nginx/issues/12173
+https://github.com/deckhouse/deckhouse/issues/9933

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/default-backend-fix.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/default-backend-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
+index c1d4e4f..f105b9c 100644
+--- a/internal/ingress/controller/controller.go
++++ b/internal/ingress/controller/controller.go
+@@ -937,6 +937,7 @@ func (n *NGINXController) getBackendServers(ingresses []*ingress.Ingress) ([]*in
+ 					nb := upstream.DeepCopy()
+ 					nb.Name = name
+ 					nb.Endpoints = endps
++					nb.Service = location.DefaultBackend
+ 					aUpstreams = append(aUpstreams, nb)
+ 					location.DefaultBackendUpstreamName = name
+ 


### PR DESCRIPTION
## Description
We are fixing a problem in the controller with incorrect attempts to resolve the endpoints addresses of the `Service` specified as the default backend.

## Why do we need it, and what problem does it solve?
We are fixing a problem with the controller when Ingress specifies `Service` with the `ExternalName` type as the main backend, and the default backend (using an annotation `nginx.ingress.kubernetes.io/default-backend `) - with the ClusterIP type. You can see the detailed cases here:
https://github.com/kubernetes/ingress-nginx/issues/12158
https://github.com/kubernetes/ingress-nginx/issues/12173

## What is the expected result?
Successful operation of ingress, where service of external Name type is specified as the main backend, and service of ClusterIP type is specified as the default backend. It is often used to handle errors (404, 502) on a service with the ExternalName type.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Fixed controller behavior for Ingress with default backend
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
