### PR TITLE
[dhct] parallel bootstrap cloudpermanent nodegroup

### DIFF
--- a/dhctl/pkg/kubernetes/actions/converge/check.go
+++ b/dhctl/pkg/kubernetes/actions/converge/check.go
@@ -441,7 +441,7 @@ func sortNodesByIndex(nodesState map[string][]byte) ([]string, error) {
 func getStatusForMissedNode(kubeCl *client.KubernetesClient, nodeName, nodeGroupName string, allErrs **multierror.Error) NodeCheckResult {
 	status := AbsentStatus
 
-	exists, err := IsNodeExistsInCluster(kubeCl, nodeName)
+	exists, err := IsNodeExistsInCluster(kubeCl, nodeName, log.GetDefaultLogger())
 	if err != nil {
 		*allErrs = multierror.Append(*allErrs, err)
 		status = ErrorStatus

--- a/dhctl/pkg/kubernetes/actions/converge/cloud_permanent_node_group_controller.go
+++ b/dhctl/pkg/kubernetes/actions/converge/cloud_permanent_node_group_controller.go
@@ -60,7 +60,7 @@ func (c *CloudPermanentNodeGroupController) addNodes() error {
 
 	err := log.Process("terraform", fmt.Sprintf("Pipelines %s for %s-%s-%v", c.layoutStep, c.config.ClusterPrefix, c.name, nodesIndexToCreate), func() error {
 		var err error
-		nodesToWait, err = ParallelBootstrapAdditionalNodes(c.client, c.config, nodesIndexToCreate, c.layoutStep, c.name, c.cloudConfig, true, c.terraformContext)
+		nodesToWait, err = ParallelBootstrapAdditionalNodes(c.client, c.config, nodesIndexToCreate, c.layoutStep, c.name, c.cloudConfig, true, c.terraformContext, log.GetDefaultLogger(), false)
 		return err
 	})
 	if err != nil {
@@ -115,7 +115,7 @@ func (c *CloudPermanentNodeGroupController) updateNode(nodeName string) error {
 		return ErrConvergeInterrupted
 	}
 
-	err = SaveNodeTerraformState(c.client, nodeName, c.name, outputs.TerraformState, nodeGroupSettingsFromConfig)
+	err = SaveNodeTerraformState(c.client, nodeName, c.name, outputs.TerraformState, nodeGroupSettingsFromConfig, log.GetDefaultLogger())
 	if err != nil {
 		return err
 	}

--- a/dhctl/pkg/kubernetes/actions/converge/converge.go
+++ b/dhctl/pkg/kubernetes/actions/converge/converge.go
@@ -15,6 +15,7 @@
 package converge
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -244,6 +245,13 @@ func (r *Runner) converge() error {
 		}
 
 		var nodeGroupsWithStateInCluster []string
+		var nodeGroupsWithoutStateInCluster []config.TerraNodeGroupSpec
+
+		type checkResult struct {
+			name    string
+			buffLog *bytes.Buffer
+			err     error
+		}
 
 		for _, group := range terraNodeGroups {
 			// Skip if node group terraform state exists, we will update node group state below
@@ -251,9 +259,11 @@ func (r *Runner) converge() error {
 				nodeGroupsWithStateInCluster = append(nodeGroupsWithStateInCluster, group.Name)
 				continue
 			}
-			if err := r.createPreviouslyNotExistedNodeGroup(group, metaConfig); err != nil {
-				return err
-			}
+
+			nodeGroupsWithoutStateInCluster = append(nodeGroupsWithoutStateInCluster, group)
+		}
+		if err := r.parallelCreatePreviouslyNotExistedNodeGroup(nodeGroupsWithoutStateInCluster, metaConfig); err != nil {
+			return err
 		}
 
 		for _, nodeGroupName := range sortNodeGroupsStateKeys(nodesState, nodeGroupsWithStateInCluster) {
@@ -362,31 +372,8 @@ func (r *Runner) updateClusterState(metaConfig *config.MetaConfig) error {
 	})
 }
 
-func (r *Runner) createPreviouslyNotExistedNodeGroup(group config.TerraNodeGroupSpec, metaConfig *config.MetaConfig) error {
-	return log.Process("converge", fmt.Sprintf("Add NodeGroup %s (replicas: %v)️", group.Name, group.Replicas), func() error {
-		err := CreateNodeGroup(r.kubeCl, group.Name, metaConfig.NodeGroupManifest(group))
-		if err != nil {
-			return err
-		}
-
-		nodeCloudConfig, err := GetCloudConfig(r.kubeCl, group.Name, ShowDeckhouseLogs)
-		if err != nil {
-			return err
-		}
-
-		var nodesIndexToCreate []int
-
-		for i := 0; i < group.Replicas; i++ {
-			nodesIndexToCreate = append(nodesIndexToCreate, i)
-		}
-
-		_, err = ParallelBootstrapAdditionalNodes(r.kubeCl, metaConfig, nodesIndexToCreate, "static-node", group.Name, nodeCloudConfig, true, r.terraformContext)
-		if err != nil {
-			return err
-		}
-
-		return WaitForNodesBecomeReady(r.kubeCl, group.Name, group.Replicas)
-	})
+func (r *Runner) parallelCreatePreviouslyNotExistedNodeGroup(groups []config.TerraNodeGroupSpec, metaConfig *config.MetaConfig) error {
+	return ParallelCreateNodeGroup(r.kubeCl, metaConfig, groups, r.terraformContext)
 }
 
 func GetMetaConfig(kubeCl *client.KubernetesClient) (*config.MetaConfig, error) {

--- a/dhctl/pkg/kubernetes/actions/converge/master_node_group_controller.go
+++ b/dhctl/pkg/kubernetes/actions/converge/master_node_group_controller.go
@@ -299,7 +299,7 @@ func (c *MasterNodeGroupController) addNodes() error {
 		}
 
 		// we hide deckhouse logs because we always have config
-		nodeCloudConfig, err := GetCloudConfig(c.client, c.name, HideDeckhouseLogs, nodeInternalIPList...)
+		nodeCloudConfig, err := GetCloudConfig(c.client, c.name, HideDeckhouseLogs, log.GetDefaultLogger(), nodeInternalIPList...)
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/kubernetes/actions/converge/node_group_controller.go
+++ b/dhctl/pkg/kubernetes/actions/converge/node_group_controller.go
@@ -86,7 +86,7 @@ func NewNodeGroupController(
 
 func (c *NodeGroupController) Run() error {
 	// we hide deckhouse logs because we always have config
-	nodeCloudConfig, err := GetCloudConfig(c.client, c.name, HideDeckhouseLogs)
+	nodeCloudConfig, err := GetCloudConfig(c.client, c.name, HideDeckhouseLogs, log.GetDefaultLogger())
 	if err != nil {
 		return err
 	}
@@ -324,7 +324,7 @@ func (c *NodeGroupController) updateNodes() error {
 			}
 
 			// we hide deckhouse logs because we always have config
-			nodeCloudConfig, err := GetCloudConfig(c.client, c.name, HideDeckhouseLogs)
+			nodeCloudConfig, err := GetCloudConfig(c.client, c.name, HideDeckhouseLogs, log.GetDefaultLogger())
 			if err != nil {
 				return err
 			}

--- a/dhctl/pkg/kubernetes/actions/converge/state.go
+++ b/dhctl/pkg/kubernetes/actions/converge/state.go
@@ -55,7 +55,7 @@ func CreateNodeTerraformState(kubeCl *client.KubernetesClient, nodeName, nodeGro
 	return retry.NewLoop(fmt.Sprintf("Create Terraform state for Node %q", nodeName), 45, 10*time.Second).Run(task.CreateOrUpdate)
 }
 
-func SaveNodeTerraformState(kubeCl *client.KubernetesClient, nodeName, nodeGroup string, tfState, settings []byte) error {
+func SaveNodeTerraformState(kubeCl *client.KubernetesClient, nodeName, nodeGroup string, tfState, settings []byte, logger log.Logger) error {
 	if len(tfState) == 0 {
 		return ErrNoTerraformState
 	}
@@ -74,7 +74,7 @@ func SaveNodeTerraformState(kubeCl *client.KubernetesClient, nodeName, nodeGroup
 			return err
 		},
 	}
-	return retry.NewLoop(fmt.Sprintf("Save Terraform state for Node %q", nodeName), 45, 10*time.Second).Run(task.CreateOrUpdate)
+	return retry.NewLoop(fmt.Sprintf("Save Terraform state for Node %q", nodeName), 45, 10*time.Second).WithLogger(logger).Run(task.CreateOrUpdate)
 }
 
 func SaveMasterNodeTerraformState(kubeCl *client.KubernetesClient, nodeName string, tfState, devicePath []byte) error {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -310,6 +310,7 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 				NodeGroupName:   "master",
 				NodeIndex:       0,
 				NodeCloudConfig: "",
+				RunnerLogger:    log.GetDefaultLogger(),
 			})
 
 			masterOutputs, err := terraform.ApplyPipeline(masterRunner, masterNodeName, terraform.GetMasterNodeResult)
@@ -576,13 +577,8 @@ func bootstrapAdditionalNodesForCloudCluster(kubeCl *client.KubernetesClient, me
 	}
 
 	return log.Process("bootstrap", "Waiting for Node Groups are ready", func() error {
-		if err := converge.WaitForNodesBecomeReady(kubeCl, "master", metaConfig.MasterNodeGroupSpec.Replicas); err != nil {
+		if err := converge.WaitForNodesBecomeReady(kubeCl, map[string]int{"master": metaConfig.MasterNodeGroupSpec.Replicas}); err != nil {
 			return err
-		}
-		for _, terraNodeGroup := range terraNodeGroups {
-			if err := converge.WaitForNodesBecomeReady(kubeCl, terraNodeGroup.Name, terraNodeGroup.Replicas); err != nil {
-				return err
-			}
 		}
 		return nil
 	})

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -721,31 +721,9 @@ func InstallDeckhouse(kubeCl *client.KubernetesClient, config *config.DeckhouseI
 }
 
 func BootstrapTerraNodes(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, terraNodeGroups []config.TerraNodeGroupSpec, terraformContext *terraform.TerraformContext) error {
-	for _, ng := range terraNodeGroups {
-		err := log.Process("bootstrap", fmt.Sprintf("Create %s NodeGroup", ng.Name), func() error {
-			err := converge.CreateNodeGroup(kubeCl, ng.Name, metaConfig.NodeGroupManifest(ng))
-			if err != nil {
-				return err
-			}
-
-			cloudConfig, err := converge.GetCloudConfig(kubeCl, ng.Name, converge.ShowDeckhouseLogs)
-			if err != nil {
-				return err
-			}
-
-			for i := 0; i < ng.Replicas; i++ {
-				err = converge.BootstrapAdditionalNode(kubeCl, metaConfig, i, "static-node", ng.Name, cloudConfig, false, terraformContext)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return log.Process("bootstrap", "Create CloudPermanent NG", func() error {
+		return converge.ParallelCreateNodeGroup(kubeCl, metaConfig, terraNodeGroups, terraformContext)
+	})
 }
 
 func SaveMasterHostsToCache(hosts map[string]string) {
@@ -801,7 +779,7 @@ func BootstrapAdditionalMasterNodes(kubeCl *client.KubernetesClient, metaConfig 
 	}
 
 	return log.Process("bootstrap", "Bootstrap additional master nodes", func() error {
-		masterCloudConfig, err := converge.GetCloudConfig(kubeCl, converge.MasterNodeGroupName, converge.ShowDeckhouseLogs)
+		masterCloudConfig, err := converge.GetCloudConfig(kubeCl, converge.MasterNodeGroupName, converge.ShowDeckhouseLogs, log.GetDefaultLogger())
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/terraform/pipeline.go
+++ b/dhctl/pkg/terraform/pipeline.go
@@ -73,11 +73,8 @@ func ApplyPipeline(r RunnerInterface, name string, extractFn func(r RunnerInterf
 		return err
 	}
 
-	if r.IsLogToBuffer() {
-		return extractedData, pipelineFunc()
-	}
-
-	err := log.Process("terraform", fmt.Sprintf("Pipeline %s for %s", r.GetStep(), name), pipelineFunc)
+	logger := r.GetLogger()
+	err := logger.LogProcess("terraform", fmt.Sprintf("Pipeline %s for %s", r.GetStep(), name), pipelineFunc)
 	return extractedData, err
 }
 

--- a/dhctl/pkg/terraform/runner_interface.go
+++ b/dhctl/pkg/terraform/runner_interface.go
@@ -14,6 +14,8 @@
 
 package terraform
 
+import "github.com/deckhouse/deckhouse/dhctl/pkg/log"
+
 type PlanOptions struct {
 	Destroy bool
 }
@@ -33,6 +35,5 @@ type RunnerInterface interface {
 	GetPlanDestructiveChanges() *PlanDestructiveChanges
 	GetPlanPath() string
 	GetTerraformExecutor() Executor
-	IsLogToBuffer() bool
-	GetLog() []string
+	GetLogger() log.Logger
 }

--- a/dhctl/pkg/terraform/runner_test.go
+++ b/dhctl/pkg/terraform/runner_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestRunner() *Runner {
@@ -173,17 +173,18 @@ func TestCheckRunnerHandleChanges(t *testing.T) {
 
 type sleepExecutor struct {
 	cancelCh chan struct{}
+	logger   log.Logger
 }
 
 func (s *sleepExecutor) Output(_ ...string) ([]byte, error) {
 	return nil, nil
 }
 
-func (s *sleepExecutor) GetStdout() []string {
-	return nil
+func (s *sleepExecutor) SetExecutorLogger(logger log.Logger) {
+	s.logger = logger
 }
 
-func (s *sleepExecutor) Exec(_ bool, _ ...string) (int, error) {
+func (s *sleepExecutor) Exec(_ ...string) (int, error) {
 	ticker := time.NewTicker(time.Second)
 loop:
 	for {

--- a/dhctl/pkg/terraform/single_shot_runner.go
+++ b/dhctl/pkg/terraform/single_shot_runner.go
@@ -14,7 +14,10 @@
 
 package terraform
 
-import "sync"
+import (
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"sync"
+)
 
 func NewSingleShotRunner(runner *Runner) *SingleShotRunner {
 	return &SingleShotRunner{
@@ -68,4 +71,8 @@ func (r *SingleShotRunner) Stop() {
 	r.stop.Do(func() {
 		r.Runner.Stop()
 	})
+}
+
+func (r *SingleShotRunner) GetLogger() log.Logger {
+	return r.Runner.logger
 }

--- a/dhctl/pkg/terraform/state_saver.go
+++ b/dhctl/pkg/terraform/state_saver.go
@@ -75,7 +75,7 @@ func (s *StateSaver) Start(runner *Runner) error {
 
 	var err error
 	s.doneCh = make(chan struct{})
-	s.watcher, err = fs.StartFileWatcher(s.runner.statePath, s.FsEventHandler, s.doneCh)
+	s.watcher, err = fs.StartFileWatcher(s.runner.statePath, s.FsEventHandler, s.doneCh, s.runner.logger)
 	if err != nil {
 		return fmt.Errorf("fs watcher for intermediate terraform state file: %s: %v", s.runner.statePath, err)
 	}

--- a/dhctl/pkg/terraform/terraform_context.go
+++ b/dhctl/pkg/terraform/terraform_context.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	dstate "github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
@@ -276,7 +277,7 @@ type BootstrapNodeRunnerOptions struct {
 	NodeIndex                        int
 	NodeCloudConfig                  string
 	AdditionalStateSaverDestinations []SaverDestination
-	LogToBuffer                      bool
+	RunnerLogger                     log.Logger
 }
 
 func (f *TerraformContext) GetBootstrapNodeRunner(metaConfig *config.MetaConfig, stateCache dstate.Cache, opts BootstrapNodeRunnerOptions) RunnerInterface {
@@ -292,7 +293,7 @@ func (f *TerraformContext) GetBootstrapNodeRunner(metaConfig *config.MetaConfig,
 				WithName(opts.NodeName).
 				WithAutoApprove(opts.AutoApprove).
 				WithAdditionalStateSaverDestination(opts.AdditionalStateSaverDestinations...).
-				WithCatchOutput(opts.LogToBuffer)
+				WithLogger(opts.RunnerLogger)
 
 			tomb.RegisterOnShutdown(opts.NodeName, r.Stop)
 

--- a/dhctl/pkg/util/fs/file_watcher.go
+++ b/dhctl/pkg/util/fs/file_watcher.go
@@ -20,7 +20,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
-func StartFileWatcher(path string, fsEventHanlder func(event fsnotify.Event), done chan struct{}) (watcher *fsnotify.Watcher, err error) {
+func StartFileWatcher(path string, fsEventHanlder func(event fsnotify.Event), done chan struct{}, logger log.Logger) (watcher *fsnotify.Watcher, err error) {
 	watcher, err = fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func StartFileWatcher(path string, fsEventHanlder func(event fsnotify.Event), do
 		return nil, err
 	}
 
-	log.InfoF("Start watcher for file %s\n", path)
+	logger.LogInfoF("Start watcher for file %s\n", path)
 
 	go func() {
 		defer close(done)
@@ -49,7 +49,7 @@ func StartFileWatcher(path string, fsEventHanlder func(event fsnotify.Event), do
 					// r.stateWatcher.Close() was called
 					return
 				}
-				log.WarnF("fs watcher: %v\n", err.Error())
+				logger.LogWarnF("fs watcher: %v\n", err.Error())
 			}
 		}
 	}()

--- a/dhctl/pkg/util/retry/retry.go
+++ b/dhctl/pkg/util/retry/retry.go
@@ -101,6 +101,11 @@ func (l *Loop) WithContext(ctx context.Context) *Loop {
 	return l
 }
 
+func (l *Loop) WithLogger(logger log.Logger) *Loop {
+	l.logger = logger
+	return l
+}
+
 func (l *Loop) WithShowError(flag bool) *Loop {
 	l.showError = flag
 	return l


### PR DESCRIPTION
## Description

Parallel bootstrap cloudpermanent nodegroups with nodes.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Reduces bootstrap time for cloud permanent nodes.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

summary time of bootstrap 3 ng with 2 nodes in each:
<details>
  <summary>Before (~ 693 seconds (203.30 + 242.30+ 247.99 )): </summary>
      
<img width="1183" alt="image" src="https://github.com/user-attachments/assets/941f2a8e-c6b8-4bf1-945d-ae263e9fcc24" />
...
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/9a01d43b-35ee-4a8b-a61e-43606a1a8d8c" />
...
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/aa17c52c-6ade-42ac-ade3-e5b10dccc886" />
...
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/e1451739-5fe4-4f01-b6b3-557abfc07c50" />


</details>

<details>
  <summary>After (~ 252 seconds ):</summary>
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/2fca30c3-d25e-4be4-91c3-3912433ae4c5" />
...
<img width="1327" alt="image" src="https://github.com/user-attachments/assets/162ba1e3-ce2f-4013-91c0-b70d8fd4dece" />


</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Parallel bootstrap cloud permanent node groups.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
