### PR TITLE
[docs] New network ports for VXLAN

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -97,7 +97,7 @@ groups:
     description:
       en: "*sds-replicated-volume* DRBD replication"
       ru: "Репликация DRBD для *sds-replicated-volume*"
-  - ports: "8469, 8472"
+  - ports: "8469, 8472, 4299, 4298"
     protocol: UDP
     description:
       en: VXLAN for pod-to-pod traffic encapsulation


### PR DESCRIPTION
## Description
New network ports for VXLAN.

## Why do we need it, and what problem does it solve?
The table doesn't cover the new VXLAN ports configured in https://github.com/deckhouse/deckhouse/pull/9089.

## What is the expected result?
The https://deckhouse.io/products/kubernetes-platform/documentation/v1/network_security_setup.html page has 4299 and 4298 VXLAN ports.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: New network ports for VXLAN described.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
