### PR TITLE
[deckhouse] fix global validation

### DIFF
--- a/go_lib/configtools/validator.go
+++ b/go_lib/configtools/validator.go
@@ -131,10 +131,6 @@ func (v *Validator) Validate(config *v1alpha1.ModuleConfig) ValidationResult {
 		return result
 	}
 
-	if module := v.valuesValidator.GetModule(config.Name); module == nil {
-		return result
-	}
-
 	if err := v.validateSettings(config.GetName(), result.Settings); err != nil {
 		convMsg := ""
 		if config.Spec.Version != result.Version {
@@ -167,6 +163,9 @@ func (v *Validator) validateSettings(configName string, configSettings map[strin
 		schemaStorage = v.valuesValidator.GetGlobal().GetSchemaStorage()
 	} else {
 		module := v.valuesValidator.GetModule(configName)
+		if module == nil {
+			return nil
+		}
 		schemaStorage = module.GetSchemaStorage()
 	}
 


### PR DESCRIPTION
## Description
It provides fix for validating the 'global' module config.

## Why do we need it, and what problem does it solve?
Validating the 'global' module config does not work.

## What is the expected result?
Validating works.

```
root@dev-master-0:~# k edit mc global
error: moduleconfigs.deckhouse.io "global" could not be patched: admission webhook "module-configs.deckhouse-webhook.deckhouse.io" denied the request: spec.settings are not valid (version 2):  1 error occurred: * global.test is a forbidden property  
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix validating the 'global' module config.
impact_level: low
```
