### PR TITLE
[metallb] Fix the requirements test for the module

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/deckhouse/deckhouse/ee/se-plus/modules/030-cloud-provider-vsphere/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/se-plus/modules/030-cloud-provider-zvirt/hooks"
 	_ "github.com/deckhouse/deckhouse/ee/se/modules/380-metallb/hooks"
+	_ "github.com/deckhouse/deckhouse/ee/se/modules/380-metallb/requirements"
 	_ "github.com/deckhouse/deckhouse/global-hooks"
 	_ "github.com/deckhouse/deckhouse/global-hooks/deckhouse-config"
 	_ "github.com/deckhouse/deckhouse/global-hooks/discovery"

--- a/ee/se/modules/380-metallb/requirements/check.go
+++ b/ee/se/modules/380-metallb/requirements/check.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license.
+See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+// TODO: Delete this file and the corresponding requirements in 'release.yaml' after version 1.67.
+package requirements
+
+import (
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+const (
+	metallbConfigurationStatusRequirementsKey = "metallbHasStandardConfiguration"
+)
+
+func init() {
+	checkRequirementConfigurationStatus := func(_ string, _ requirements.ValueGetter) (bool, error) {
+		return true, nil
+	}
+	requirements.RegisterCheck(metallbConfigurationStatusRequirementsKey, checkRequirementConfigurationStatus)
+}


### PR DESCRIPTION
## Description
PR #9658 caused errors in requirements tests due to deletion of `check.go` file:
```shell
ERRORS:
  * release.yaml ... ERROR: found requirements for non-existent module checks, please review release requirements in release.yaml
exit status 1
      metallbHasStandardConfiguration
Validation failed.
```

## Why do we need it, and what problem does it solve?
Fixing an error.

## What is the expected result?
CI does not generate errors in requirements tests.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: fix
summary: Fixed the requirements test for the module.
impact_level:  low
```
