### PR TITLE
[dhctl] Fix panic during commander masters converge

### DIFF
--- a/dhctl/pkg/kubernetes/actions/converge/master_node_group_controller.go
+++ b/dhctl/pkg/kubernetes/actions/converge/master_node_group_controller.go
@@ -426,7 +426,7 @@ func (c *MasterNodeGroupController) deleteNodes(nodesToDeleteInfo []nodeToDelete
 	title := fmt.Sprintf("Delete Nodes from NodeGroup %s (replicas: %v)", MasterNodeGroupName, c.desiredReplicas)
 	return log.Process("converge", title, func() error {
 		return c.deleteRedundantNodes(c.state.Settings, nodesToDeleteInfo, func(nodeName string) terraform.InfraActionHook {
-			return controlplane.NewHookForDestroyPipeline(c.client, nodeName)
+			return controlplane.NewHookForDestroyPipeline(c.client, nodeName, c.commanderMode)
 		})
 	})
 }

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
@@ -65,7 +65,7 @@ func (h *HookForDestroyPipeline) BeforeAction(runner terraform.RunnerInterface) 
 }
 
 func (h *HookForDestroyPipeline) AfterAction(runner terraform.RunnerInterface) error {
-	if !h.commanderMode {
+	if h.commanderMode {
 		return nil
 	}
 

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
@@ -37,12 +37,14 @@ type HookForDestroyPipeline struct {
 	kubeCl            *client.KubernetesClient
 	nodeToDestroy     string
 	oldMasterIPForSSH string
+	commanderMode     bool
 }
 
-func NewHookForDestroyPipeline(kubeCl *client.KubernetesClient, nodeToDestroy string) *HookForDestroyPipeline {
+func NewHookForDestroyPipeline(kubeCl *client.KubernetesClient, nodeToDestroy string, commanderMode bool) *HookForDestroyPipeline {
 	return &HookForDestroyPipeline{
 		kubeCl:        kubeCl,
 		nodeToDestroy: nodeToDestroy,
+		commanderMode: commanderMode,
 	}
 }
 
@@ -63,6 +65,10 @@ func (h *HookForDestroyPipeline) BeforeAction(runner terraform.RunnerInterface) 
 }
 
 func (h *HookForDestroyPipeline) AfterAction(runner terraform.RunnerInterface) error {
+	if !h.commanderMode {
+		return nil
+	}
+
 	cl := h.kubeCl.NodeInterfaceAsSSHClient()
 	if cl == nil {
 		log.DebugLn("Node interface is not ssh")

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_update_pipeline.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_update_pipeline.go
@@ -79,8 +79,9 @@ func NewHookForUpdatePipeline(
 	checker := NewChecker(nodeToHostForChecks, checkers, "", DefaultConfirm)
 
 	return &HookForUpdatePipeline{
-		Checker: checker,
-		kubeCl:  kubeCl,
+		Checker:       checker,
+		kubeCl:        kubeCl,
+		commanderMode: commanderMode,
 	}
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix panic during commander masters converge.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Converge in commander mode causes panic when switching from multi-master to single-master:

<details>
  <summary>converge log with error</summary>

   ```
  2024-12-18T14:15:53Z - [INFO] - │ │ │ │ ┌ Drain node 'ngorobatov-dev3-master-0'
  2024-12-18T14:16:16Z - [INFO] - │ │ │ │ │ 🎉 Succeeded!
  2024-12-18T14:16:16Z - [INFO] - │ │ │ │ └ Drain node 'ngorobatov-dev3-master-0' (23.21 seconds)
  2024-12-18T14:16:17Z - [INFO] - │ │ │ │ 
  2024-12-18T14:16:17Z - [INFO] - │ │ │ │ Start watcher for file /tmp/dhctl/cache_aa583e01-bd48-11ef-abe9-5eb2409e8d30/88b68e1c0cc11a32620fa04dbc16daacf ↵
  2024-12-18T14:16:17Z - [INFO] - │ │ │ │ c187b2d79ff27ebc642f5baed174887/ngorobatov-dev3-master-0.tfstate
  2024-12-18T14:16:18Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Destroying... [id=fhm5mso1p9dcf6a7c3n5]
  2024-12-18T14:16:28Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm5mso1p9dcf6a7c3n5, 10s elapsed]
  2024-12-18T14:16:38Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm5mso1p9dcf6a7c3n5, 20s elapsed]
  2024-12-18T14:16:48Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm5mso1p9dcf6a7c3n5, 30s elapsed]
  2024-12-18T14:16:58Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm5mso1p9dcf6a7c3n5, 40s elapsed]
  2024-12-18T14:17:08Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm5mso1p9dcf6a7c3n5, 50s elapsed]
  2024-12-18T14:17:18Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm5mso1p9dcf6a7c3n5, 1m0s elapsed]
  2024-12-18T14:17:28Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm5mso1p9dcf6a7c3n5, 1m10s elapsed]
  2024-12-18T14:17:38Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm5mso1p9dcf6a7c3n5, 1m20s elapsed]
  2024-12-18T14:17:48Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm5mso1p9dcf6a7c3n5, 1m30s elapsed]
  2024-12-18T14:17:48Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Destruction complete after 1m30s
  2024-12-18T14:17:48Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Creating...
  2024-12-18T14:17:58Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still creating... [10s elapsed]
  2024-12-18T14:18:08Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still creating... [20s elapsed]
  2024-12-18T14:18:18Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still creating... [30s elapsed]
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Creation complete after 39s [id=fhm5a489s45ept6p695c]
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ 
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ 
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ The state of your infrastructure has been saved to the path
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ below. This state is required to modify and destroy your
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ infrastructure, so keep it safe. To inspect the complete state
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ use the `terraform show` command.
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ 
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ State path: terraform.tfstate
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ 
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ Outputs:
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ 
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ kubernetes_data_device_path = "/dev/disk/by-id/virtio-kubernetes-data"
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ master_ip_address_for_ssh = "89.169.130.178"
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ node_internal_ip_address = "10.241.32.3"
  2024-12-18T14:18:27Z - [INFO] - │ │ │ │ Terraform runner "master-node" process exited.
  2024-12-18T14:18:29Z - [INFO] - │ │ │ │ Task done by DHCTL Server pod/commander-dhctl-fd5d12d9-pr11053-b65b6fc55-4h677
  2024-12-18T14:18:29Z - [DEBUG] - Job execution failed: panic: Node interface is not ssh, goroutine 29 [running]:
  runtime/debug.Stack()
	  /usr/local/go/src/runtime/debug/stack.go:26 +0x5e
  github.com/deckhouse/deckhouse/dhctl/pkg/server/rpc/dhctl.panicMessage({0x249d7e8, 0xc000e57740}, {0x1d13ce0, 0x2479cb0})
	  /dhctl/pkg/server/rpc/dhctl/service.go:202 +0x3f
  github.com/deckhouse/deckhouse/dhctl/pkg/server/rpc/dhctl.(*Service).convergeSafe.func1()
	  /dhctl/pkg/server/rpc/dhctl/converge.go:134 +0x51
  panic({0x1d13ce0?, 0x2479cb0?})
   ```
</details>

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Fix panic error.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

<details>
  <summary> converge log </summary>

  ```
  2024-12-19T07:37:53Z - [INFO] - │ │ │ │ │ ️⛱️️ Attempt #11 of 45 |
  2024-12-19T07:37:53Z - [INFO] - │ │ │ │ │ 	Drain node 'ngorbatov-dev2-master-0' failed, next attempt will be in 10s"
  2024-12-19T07:37:53Z - [INFO] - │ │ │ │ │ 	Error: failed to drain node 'ngorbatov-dev2-master-0': error when evicting pods/"smoke-mini-b-0" -n         ↵
  2024-12-19T07:37:53Z - [INFO] - │ │ │ │ │ "d8-upmeter": global timeout reached: 30s
  2024-12-19T07:37:53Z - [INFO] - │ │ │ │ │ 
  2024-12-19T07:38:05Z - [INFO] - │ │ │ │ │ 🎉 Succeeded!
  2024-12-19T07:38:05Z - [INFO] - │ │ │ │ └ Drain node 'ngorbatov-dev2-master-0' (436.98 seconds)
  2024-12-19T07:38:05Z - [INFO] - │ │ │ │ 
  2024-12-19T07:38:05Z - [INFO] - │ │ │ │ Start watcher for file /tmp/dhctl/cache_8a0fd254-bdd9-11ef-b2be-aed879cef8dd/0c2f9ae785bebd0dcc53218782bffcd8a ↵
  2024-12-19T07:38:05Z - [INFO] - │ │ │ │ e9b37530078b0fa209ef834689ebb74/ngorbatov-dev2-master-0.tfstate
  2024-12-19T07:38:06Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Destroying... [id=fhm7ineqoriei2mgu72b]
  2024-12-19T07:38:16Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm7ineqoriei2mgu72b, 10s elapsed]
  2024-12-19T07:38:26Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm7ineqoriei2mgu72b, 20s elapsed]
  2024-12-19T07:38:36Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm7ineqoriei2mgu72b, 30s elapsed]
  2024-12-19T07:38:46Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm7ineqoriei2mgu72b, 40s elapsed]
  2024-12-19T07:38:56Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm7ineqoriei2mgu72b, 50s elapsed]
  2024-12-19T07:39:06Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm7ineqoriei2mgu72b, 1m0s elapsed]
  2024-12-19T07:39:16Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm7ineqoriei2mgu72b, 1m10s elapsed]
  2024-12-19T07:39:26Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still destroying... [id=fhm7ineqoriei2mgu72b, 1m20s elapsed]
  2024-12-19T07:39:28Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Destruction complete after 1m21s
  2024-12-19T07:39:28Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Creating...
  2024-12-19T07:39:38Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still creating... [10s elapsed]
  2024-12-19T07:39:48Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still creating... [20s elapsed]
  2024-12-19T07:39:58Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still creating... [30s elapsed]
  2024-12-19T07:40:08Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still creating... [40s elapsed]
  2024-12-19T07:40:18Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still creating... [50s elapsed]
  2024-12-19T07:40:28Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Still creating... [1m0s elapsed]
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ yandex_compute_instance.master: Creation complete after 1m8s [id=fhms4aqeoqnulmjg716b]
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ 
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ 
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ The state of your infrastructure has been saved to the path
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ below. This state is required to modify and destroy your
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ infrastructure, so keep it safe. To inspect the complete state
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ use the `terraform show` command.
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ 
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ State path: terraform.tfstate
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ 
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ Outputs:
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ 
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ kubernetes_data_device_path = "/dev/disk/by-id/virtio-kubernetes-data"
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ master_ip_address_for_ssh = "62.84.124.152"
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ node_internal_ip_address = "10.241.32.17"
  2024-12-19T07:40:36Z - [INFO] - │ │ │ │ Terraform runner "master-node" process exited.
  2024-12-19T07:40:37Z - [INFO] - │ │ │ │ ┌ Save Kubernetes data device path for node 'ngorbatov-dev2-master-0'
  2024-12-19T07:40:37Z - [INFO] - │ │ │ │ │ Manifest for Secret "d8-masters-kubernetes-data-device-path"
  2024-12-19T07:40:37Z - [INFO] - │ │ │ │ │ Secret "d8-masters-kubernetes-data-device-path" already exists. Trying to update ... OK!
  2024-12-19T07:40:37Z - [INFO] - │ │ │ │ │ 🎉 Succeeded!
  2024-12-19T07:40:37Z - [INFO] - │ │ │ │ └ Save Kubernetes data device path for node 'ngorbatov-dev2-master-0' (0.20 seconds)
  2024-12-19T07:40:37Z - [INFO] - │ │ │ │ 
  2024-12-19T07:40:37Z - [INFO] - │ │ │ │ ┌ Check the master node 'ngorbatov-dev2-master-0' is listed as etcd cluster member
  2024-12-19T07:40:38Z - [INFO] - │ │ │ │ │ ️⛱️️ Attempt #1 of 100 |
  2024-12-19T07:40:38Z - [INFO] - │ │ │ │ │ 	Check the master node 'ngorbatov-dev2-master-0' is listed as etcd cluster member failed, next attempt will  ↵
  2024-12-19T07:40:38Z - [INFO] - │ │ │ │ │ be in 20s"
  2024-12-19T07:40:38Z - [INFO] - │ │ │ │ │ 	Error: node 'ngorbatov-dev2-master-0' is not listed as etcd cluster member
  2024-12-19T07:40:38Z - [INFO] - │ │ │ │ │ 
  ...
  2024-12-19T07:52:40Z - [INFO] - │ │ │ │ │ ️⛱️️ Attempt #36 of 100 |
  2024-12-19T07:52:40Z - [INFO] - │ │ │ │ │ 	Check the master node 'ngorbatov-dev2-master-0' is listed as etcd cluster member failed, next attempt will  ↵
  2024-12-19T07:52:40Z - [INFO] - │ │ │ │ │ be in 20s"
  2024-12-19T07:52:40Z - [INFO] - │ │ │ │ │ 	Error: node 'ngorbatov-dev2-master-0' is not listed as etcd cluster member
  2024-12-19T07:52:40Z - [INFO] - │ │ │ │ │ 
  2024-12-19T07:53:01Z - [INFO] - │ │ │ │ │ 🎉 Succeeded!
  2024-12-19T07:53:01Z - [INFO] - │ │ │ │ └ Check the master node 'ngorbatov-dev2-master-0' is listed as etcd cluster member (743.79 seconds)
  2024-12-19T07:53:01Z - [INFO] - │ │ │ │ 
  2024-12-19T07:53:01Z - [INFO] - │ │ │ │ ┌ Check the master node 'ngorbatov-dev2-master-0' is ready
  2024-12-19T07:53:01Z - [INFO] - │ │ │ │ │ ️⛱️️ Attempt #1 of 45 |
  2024-12-19T07:53:01Z - [INFO] - │ │ │ │ │ 	Check the master node 'ngorbatov-dev2-master-0' is ready failed, next attempt will be in 10s"
  2024-12-19T07:53:01Z - [INFO] - │ │ │ │ │ 	Error: Not ready.
  2024-12-19T07:53:01Z - [INFO] - │ │ │ │ │ 
  2024-12-19T07:53:11Z - [INFO] - │ │ │ │ │ 🎉 Succeeded!
  2024-12-19T07:53:11Z - [INFO] - │ │ │ │ └ Check the master node 'ngorbatov-dev2-master-0' is ready (10.29 seconds)
  2024-12-19T07:53:11Z - [INFO] - │ │ │ └ terraform apply ... (1395.47 seconds)
  2024-12-19T07:53:13Z - [INFO] - │ │ └ 🌱 ~ Terraform: Pipeline master-node for ngorbatov-dev2-master-0 (1400.71 seconds)
...
2024-12-19T07:53:13Z - [INFO] - │ │ ┌ Waiting for  Node ngorbatov-dev2-master-0 to become Ready
2024-12-19T07:53:13Z - [INFO] - │ │ │ 🎉 Succeeded!
2024-12-19T07:53:13Z - [INFO] - │ │ └ Waiting for  Node ngorbatov-dev2-master-0 to become Ready (0.07 seconds)
2024-12-19T07:53:13Z - [INFO] - │ │ 
2024-12-19T07:53:13Z - [INFO] - │ │ ┌ Waiting for master cloud config️
2024-12-19T07:53:13Z - [INFO] - │ │ │ Cloud configuration found!
2024-12-19T07:53:13Z - [INFO] - │ │ └ Waiting for master cloud config️ (0.06 seconds)
2024-12-19T07:53:13Z - [INFO] - │ └ 🛸 ~ Converge: Update Node ngorbatov-dev2-master-0 in NodeGroup master (replicas: 3) (1401.26 seconds)
...
2024-12-19T08:08:03Z - [INFO] - Got deckhouse UUID from dhctl state: 3868184c-4795-4733-85bb-252b03487714
2024-12-19T08:08:03Z - [INFO] - ┌ Converge deckhouse configuration
2024-12-19T08:08:03Z - [INFO] - │ Manifest for Secret "d8-cluster-configuration"
2024-12-19T08:08:03Z - [INFO] - │ Secret "d8-cluster-configuration" already exists. Trying to update ... OK!
2024-12-19T08:08:03Z - [INFO] - │ Manifest for Secret "d8-provider-cluster-configuration"
2024-12-19T08:08:04Z - [INFO] - │ Secret "d8-provider-cluster-configuration" already exists. Trying to update ... OK!
2024-12-19T08:08:04Z - [INFO] - │ Manifest for ConfigMap "d8-cluster-uuid"
2024-12-19T08:08:04Z - [INFO] - │ ConfigMap "d8-cluster-uuid" already exists. Trying to update ... OK!
2024-12-19T08:08:04Z - [INFO] - │ Manifest for ConfigMap "d8-commander-uuid"
2024-12-19T08:08:04Z - [INFO] - │ ConfigMap "d8-commander-uuid" already exists. Trying to update ... OK!
2024-12-19T08:08:04Z - [INFO] - └ Converge deckhouse configuration (0.92 seconds)
2024-12-19T08:08:04Z - [INFO] - Got deckhouse UUID from dhctl state: 3868184c-4795-4733-85bb-252b03487714
2024-12-19T08:08:04Z - [INFO] - Task done by DHCTL Server pod/commander-dhctl-fd5d12d9-pr11134-5765f6986c-299ls
  ```
</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix panic during commander masters converge.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
