### PR TITLE
[deckhouse] return unknown module message

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_config.go
@@ -29,6 +29,8 @@ const (
 	ModuleConfigAnnotationAllowDisable = "modules.deckhouse.io/allow-disable"
 
 	ModuleConfigFinalizer = "modules.deckhouse.io/module-config"
+
+	ModuleConfigMessageUnknownModule = "Ignored: unknown module name"
 )
 
 var (

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -155,7 +155,7 @@ func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alp
 	if err := r.client.Get(ctx, client.ObjectKey{Name: moduleConfig.Name}, module); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.log.Warnf("the module '%s' not found", moduleConfig.Name)
-			err = utils.Update[*v1alpha1.ModuleConfig](ctx, r.client, moduleConfig, func(moduleConfig *v1alpha1.ModuleConfig) bool {
+			err = utils.UpdateStatus[*v1alpha1.ModuleConfig](ctx, r.client, moduleConfig, func(moduleConfig *v1alpha1.ModuleConfig) bool {
 				moduleConfig.Status.Message = v1alpha1.ModuleConfigMessageUnknownModule
 				return true
 			})

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -155,6 +155,14 @@ func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alp
 	if err := r.client.Get(ctx, client.ObjectKey{Name: moduleConfig.Name}, module); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.log.Warnf("the module '%s' not found", moduleConfig.Name)
+			err = utils.Update[*v1alpha1.ModuleConfig](ctx, r.client, moduleConfig, func(moduleConfig *v1alpha1.ModuleConfig) bool {
+				moduleConfig.Status.Message = v1alpha1.ModuleConfigMessageUnknownModule
+				return true
+			})
+			if err != nil {
+				r.log.Errorf("failed to update the '%s' module config: %v", moduleConfig.Name, err)
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{Requeue: true}, nil

--- a/deckhouse-controller/pkg/controller/module-controllers/config/sync.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/sync.go
@@ -96,7 +96,7 @@ func (r *reconciler) runModuleEventLoop(ctx context.Context) error {
 			continue
 		}
 		if err := r.refreshModule(ctx, event.ModuleName); err != nil {
-			r.log.Errorf("failed to handle the event for the '%s' module: %v", event.ModuleName, err)
+			r.log.Warnf("failed to handle the event for the '%s' module: %v", event.ModuleName, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Description
It returns the message about unknown module.

## Why do we need it, and what problem does it solve?
To know that a module is unknown.

## What is the expected result?
<img width="502" alt="Screenshot 2024-12-12 at 12 18 10 PM" src="https://github.com/user-attachments/assets/2fa4be26-01d0-4e04-bfe0-ee6a78cfabf1" />

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Return unknown module message.
impact_level: low
```

