### PR TITLE
Fix static cluster master nodes destroy logic

### DIFF
--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -141,7 +141,7 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) erro
 				if err := b.initSSHClient(); err != nil {
 					return err
 				}
-				destroyer = destroy.NewStaticMastersDestroyer(wrapper.Client())
+				destroyer = destroy.NewStaticMastersDestroyer(wrapper.Client(), []destroy.NodeIP{})
 			}
 
 			logMsg := "Deckhouse installation was not started before. Abort from cache"

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -38,6 +38,7 @@ import (
 	tf "github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -114,38 +115,7 @@ func NewClusterDestroyer(params *Params) (*ClusterDestroyer, error) {
 
 	clusterInfra := infra.NewClusterInfraWithOptions(terraStateLoader, state.cache, params.TerraformContext, infra.ClusterInfraOptions{PhasedExecutionContext: pec})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	kubeCl, err := d8Destroyer.GetKubeClient()
-	if err != nil {
-		log.DebugF("Cannot get kubernetes client. Got error: %v", err)
-		return nil, err
-	}
-
-	nodes, err := kubeCl.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/control-plane="})
-	if err != nil {
-		log.DebugF("Cannot get nodes. Got error: %v", err)
-		return nil, err
-	}
-
-	var nodeIPs []NodeIP
-	for _, node := range nodes.Items {
-		var ip NodeIP
-
-		for _, addr := range node.Status.Addresses {
-			if addr.Type == "InternalIP" {
-				ip.internalIP = addr.Address
-			}
-			if addr.Type == "ExternalIP" {
-				ip.externalIP = addr.Address
-			}
-		}
-
-		nodeIPs = append(nodeIPs, ip)
-	}
-
-	staticDestroyer := NewStaticMastersDestroyer(wrapper.Client(), nodeIPs)
+	staticDestroyer := NewStaticMastersDestroyer(wrapper.Client(), []NodeIP{})
 
 	return &ClusterDestroyer{
 		state:           state,
@@ -196,6 +166,47 @@ func (d *ClusterDestroyer) DestroyCluster(autoApprove bool) error {
 	case config.CloudClusterType:
 		infraDestroyer = d.cloudClusterInfra
 	case config.StaticClusterType:
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		kubeCl, err := d.d8Destroyer.GetKubeClient()
+		if err != nil {
+			log.DebugF("Cannot get kubernetes client. Got error: %v", err)
+			return err
+		}
+
+		var nodes *v1.NodeList
+		err = retry.NewLoop("Get control plane nodes from Kubernetes cluster", 5, 5*time.Second).Run(func() error {
+			nodes, err = kubeCl.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/control-plane="})
+			if err != nil {
+				log.DebugF("Cannot get nodes. Got error: %v", err)
+				return err
+			}
+			return nil
+		})
+
+		if err != nil {
+			log.DebugF("Cannot get nodes after 5 attemts")
+			return err
+		}
+
+		var nodeIPs []NodeIP
+		for _, node := range nodes.Items {
+			var ip NodeIP
+
+			for _, addr := range node.Status.Addresses {
+				if addr.Type == "InternalIP" {
+					ip.internalIP = addr.Address
+				}
+				if addr.Type == "ExternalIP" {
+					ip.externalIP = addr.Address
+				}
+			}
+
+			nodeIPs = append(nodeIPs, ip)
+		}
+
+		d.staticDestroyer.IPs = nodeIPs
 		infraDestroyer = d.staticDestroyer
 	default:
 		return fmt.Errorf("Unknown cluster type '%s'", clusterType)


### PR DESCRIPTION
## Description

Fix static cluster destroy behavior: discover additional master nodes and cleanup them through first master passed as --ssh-host flag

## Why do we need it, and what problem does it solve?

Fix the problem whole additional master nodes, didn't passed as --ssh-host, didn't cleanup

## What is the expected result?

`dhctl destroy` cleanup all nodes of static cluster

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: Fix destroy of static cluster: cleanup additional master nodes, didn't passed as --ssh-host.
impact_level: default
```