### PR TITLE
[deckhouse] fire alert at deprecated mup

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3673,6 +3673,16 @@ alerts:
         ModuleConfig {{ $labels.name }} is outdated.
       severity: "4"
       markupFormat: markdown
+    - name: ModuleHasDeprecatedUpdatePolicy
+      sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+      moduleUrl: 340-monitoring-deckhouse
+      module: monitoring-deckhouse
+      edition: ce
+      description: "The  {{ $labels.moduleName }} module has a deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy. \n\nPlease specify the proper update policy in the module configuration to continue get updates.\n"
+      summary: |
+        The {{ $labels.moduleName }} module has a deprecated module update policy.
+      severity: "4"
+      markupFormat: markdown
     - name: ModuleReleaseIsBlockedByRequirements
       sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
       moduleUrl: 340-monitoring-deckhouse

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3678,9 +3678,9 @@ alerts:
       moduleUrl: 340-monitoring-deckhouse
       module: monitoring-deckhouse
       edition: ce
-      description: "The  {{ $labels.moduleName }} module has a deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy. \n\nPlease specify the proper update policy in the module configuration to continue get updates.\n"
+      description: "The '{{ $labels.moduleName }}' module has a deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy. \n\nPlease specify the proper update policy in the module configuration to continue get updates.\n"
       summary: |
-        The {{ $labels.moduleName }} module has a deprecated module update policy.
+        The '{{ $labels.moduleName }}' module has a deprecated module update policy.
       severity: "4"
       markupFormat: markdown
     - name: ModuleReleaseIsBlockedByRequirements

--- a/global-hooks/migrate/migrate_update_policy.go
+++ b/global-hooks/migrate/migrate_update_policy.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"k8s.io/utils/ptr"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+)
+
+// TODO(ipaqsa): remove it after 1.68
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "moduleUpdatePolicies",
+			ApiVersion: "deckhouse.io/v1alpha1",
+			Kind:       "ModuleUpdatePolicy",
+			FilterFunc: mupFilter,
+		},
+		{
+			Name:                         "modules",
+			ApiVersion:                   "deckhouse.io/v1alpha1",
+			Kind:                         "Module",
+			ExecuteHookOnEvents:          ptr.To(false),
+			ExecuteHookOnSynchronization: ptr.To(false),
+			FilterFunc:                   moduleFilter,
+		},
+	},
+}, fireMupAlerts)
+
+func mupFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	mup := new(v1alpha1.ModuleUpdatePolicy)
+	if err := sdk.FromUnstructured(obj, mup); err != nil {
+		return nil, err
+	}
+	if mup.Spec.ModuleReleaseSelector.LabelSelector == nil {
+		return nil, nil
+	}
+	return &filteredMup{LabelSelector: mup.Spec.ModuleReleaseSelector.LabelSelector}, nil
+}
+
+type filteredMup struct {
+	LabelSelector *metav1.LabelSelector
+}
+
+func moduleFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	module := new(v1alpha1.Module)
+	if err := sdk.FromUnstructured(obj, module); err != nil {
+		return nil, err
+	}
+	if module.Properties.Source != "" {
+		return nil, nil
+	}
+	return &filteredModule{Name: module.Name, Source: module.Properties.Source}, nil
+}
+
+type filteredModule struct {
+	Name   string
+	Source string
+}
+
+func fireMupAlerts(input *go_hook.HookInput) error {
+	input.MetricsCollector.Expire("d8_update_policy")
+
+	for _, moduleSnapshot := range input.Snapshots["modules"] {
+		module := moduleSnapshot.(*filteredModule)
+
+		var labelsSet labels.Set = map[string]string{"module": module.Name}
+
+		for _, policySnapshot := range input.Snapshots["moduleUpdatePolicies"] {
+			if policySnapshot == nil {
+				continue
+			}
+
+			policy := policySnapshot.(*filteredMup)
+
+			selector, err := metav1.LabelSelectorAsSelector(policy.LabelSelector)
+			if err != nil {
+				continue
+			}
+
+			if selectorSourceName, exists := selector.RequiresExactMatch("source"); exists && selectorSourceName != module.Source {
+				continue
+			}
+
+			if selector.Matches(labelsSet) {
+				input.MetricsCollector.Set("d8_deprecated_update_policy", 1.0, map[string]string{
+					"moduleName": module.Name,
+				}, metrics.WithGroup("d8_update_policy"))
+				continue
+			}
+		}
+	}
+
+	return nil
+}

--- a/global-hooks/migrate/migrate_update_policy.go
+++ b/global-hooks/migrate/migrate_update_policy.go
@@ -69,7 +69,7 @@ func moduleFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) 
 	if err := sdk.FromUnstructured(obj, module); err != nil {
 		return nil, err
 	}
-	if module.Properties.Source != "" {
+	if module.Properties.UpdatePolicy != "" {
 		return nil, nil
 	}
 	return &filteredModule{Name: module.Name, Source: module.Properties.Source}, nil
@@ -84,9 +84,13 @@ func fireMupAlerts(input *go_hook.HookInput) error {
 	input.MetricsCollector.Expire("d8_update_policy")
 
 	for _, moduleSnapshot := range input.Snapshots["modules"] {
+		if moduleSnapshot == nil {
+			continue
+		}
+
 		module := moduleSnapshot.(*filteredModule)
 
-		var labelsSet labels.Set = map[string]string{"module": module.Name}
+		var labelsSet labels.Set = map[string]string{"module": module.Name, "source": module.Source}
 
 		for _, policySnapshot := range input.Snapshots["moduleUpdatePolicies"] {
 			if policySnapshot == nil {

--- a/global-hooks/migrate/migrate_update_policy.go
+++ b/global-hooks/migrate/migrate_update_policy.go
@@ -17,14 +17,13 @@ limitations under the License.
 package hooks
 
 import (
-	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
-	"k8s.io/utils/ptr"
-
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 )

--- a/modules/140-user-authz/hooks/handle_manage_bindings.go
+++ b/modules/140-user-authz/hooks/handle_manage_bindings.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/utils/ptr"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -60,9 +59,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 					"rbac.deckhouse.io/automated": "true",
 				},
 			},
-			ExecuteHookOnEvents:          ptr.To(false),
-			ExecuteHookOnSynchronization: ptr.To(false),
-			FilterFunc:                   filterUseBinding,
+			FilterFunc: filterUseBinding,
 		},
 	},
 }, syncBindings)

--- a/modules/140-user-authz/hooks/handle_manage_bindings.go
+++ b/modules/140-user-authz/hooks/handle_manage_bindings.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -59,7 +60,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 					"rbac.deckhouse.io/automated": "true",
 				},
 			},
-			FilterFunc: filterUseBinding,
+			ExecuteHookOnEvents:          ptr.To(false),
+			ExecuteHookOnSynchronization: ptr.To(false),
+			FilterFunc:                   filterUseBinding,
 		},
 	},
 }, syncBindings)

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -200,8 +200,8 @@
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       description: |
-        The  {{ $labels.moduleName }} module has an deprecated module update policy, the policy selector does not work, and the module does not has the active source. 
+        The  {{ $labels.moduleName }} module has a deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy. 
         
-        Please specify the proper source in the module configuration to continue get updates.
+        Please specify the proper update policy in the module configuration to continue get updates.
       summary: |
-        Conflict detected for module {{ $labels.moduleName }}.
+        The {{ $labels.moduleName }} module has a deprecated module update policy.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -193,7 +193,7 @@
       summary: |
         ModuleConfig {{ $labels.name }} is outdated.
   - alert: ModuleHasDeprecatedUpdatePolicy
-    expr: max by (moduleName) (d8_module_at_conflict) >= 1
+    expr: max by (moduleName) (d8_deprecated_update_policy) >= 1
     labels:
       severity_level: "4"
     annotations:

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -192,3 +192,16 @@
         ModuleConfig {{ $labels.name }} is outdated. Update ModuleConfig {{ $labels.name }} to the latest version.
       summary: |
         ModuleConfig {{ $labels.name }} is outdated.
+  - alert: ModuleHasDeprecatedUpdatePolicy
+    expr: max by (moduleName) (d8_module_at_conflict) >= 1
+    labels:
+      severity_level: "4"
+    annotations:
+      plk_markup_format: "markdown"
+      plk_protocol_version: "1"
+      description: |
+        The  {{ $labels.moduleName }} module has an deprecated module update policy, the policy selector does not work, and the module does not has the active source. 
+        
+        Please specify the proper source in the module configuration to continue get updates.
+      summary: |
+        Conflict detected for module {{ $labels.moduleName }}.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -200,8 +200,8 @@
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       description: |
-        The  {{ $labels.moduleName }} module has a deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy. 
+        The '{{ $labels.moduleName }}' module has a deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy. 
         
         Please specify the proper update policy in the module configuration to continue get updates.
       summary: |
-        The {{ $labels.moduleName }} module has a deprecated module update policy.
+        The '{{ $labels.moduleName }}' module has a deprecated module update policy.


### PR DESCRIPTION
## Description
It fires alert at deprecated mup.

## Why do we need it, and what problem does it solve?
The module update policy now is specified by the module config, labelSelectors do not work, so we need to fire an alert at deprecated mup.

## What is the expected result?
<img width="1511" alt="Screenshot 2024-12-12 at 2 37 08 PM" src="https://github.com/user-attachments/assets/7c6cf484-372b-495e-9bee-e598dbfc8fed" />

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fire alert at deprecated ModuleUpdatePolicy.
impact_level: low
```

