### PR TITLE
[deckhouse] fix embedded source for downloaded modules

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -363,6 +363,7 @@ func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, 
 			// TODO(ipaqsa): it is needed for migration, can be removed after 1.68
 			if !embedded && module.IsEmbedded() {
 				module.Properties.Source = ""
+				needsUpdate = true
 			}
 
 			if needsUpdate {

--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -361,10 +361,8 @@ func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, 
 			}
 
 			// TODO(ipaqsa): it is needed for migration, can be removed after 1.68
-			if !embedded {
-				if module.IsEmbedded() {
-					module.Properties.Source = ""
-				}
+			if !embedded && module.IsEmbedded() {
+				module.Properties.Source = ""
 			}
 
 			if needsUpdate {

--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -50,6 +50,8 @@ import (
 const (
 	moduleOrderIdx = 2
 	moduleNameIdx  = 3
+
+	embeddedModulesDir = "/deckhouse/modules"
 )
 
 var (
@@ -257,7 +259,7 @@ func (l *Loader) LoadModulesFromFS(ctx context.Context) error {
 			}
 
 			l.log.Debugf("ensure the '%s' module", def.Name)
-			if err = l.ensureModule(ctx, def, !strings.HasPrefix(def.Path, d8env.GetDownloadedModulesDir())); err != nil {
+			if err = l.ensureModule(ctx, def, strings.HasPrefix(def.Path, embeddedModulesDir)); err != nil {
 				return fmt.Errorf("ensure the '%s' embedded module: %w", def.Name, err)
 			}
 
@@ -355,6 +357,13 @@ func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, 
 				if module.Properties.Source != v1alpha1.ModuleSourceEmbedded {
 					module.Properties.Source = v1alpha1.ModuleSourceEmbedded
 					needsUpdate = true
+				}
+			}
+
+			// TODO(ipaqsa): it is needed for migration, can be removed after 1.68
+			if !embedded {
+				if module.IsEmbedded() {
+					module.Properties.Source = ""
 				}
 			}
 


### PR DESCRIPTION
## Description
It unsets the source for downloaded modules if it has the 'Embedded' source.

## Why do we need it, and what problem does it solve?
Somehow, downloaded module can have the 'Embedded' source.

## What is the expected result?

Before restart: 
```
root@dev-master-0:~# kubectl get module echo -owide 
NAME   WEIGHT   RELEASE CHANNEL   SOURCE     VERSION   PHASE       ENABLED   DISABLED MESSAGE              READY
echo   910                        Embedded             Available   False     turned off by module config   False
```

After restart:
```
root@dev-master-0:~# kubectl get module echo -owide 
NAME   WEIGHT   RELEASE CHANNEL   SOURCE   VERSION   PHASE       ENABLED   DISABLED MESSAGE              READY
echo   910                                           Available   False     turned off by module config   False
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix embedded source for downloaded modules.
impact_level: low
```
