### PR TITLE
[prometheus] Make metrics-web-interfaces hook consider  https.mode: OnlyInURI

### DIFF
--- a/modules/300-prometheus/hooks/metrics_web_interfaces.go
+++ b/modules/300-prometheus/hooks/metrics_web_interfaces.go
@@ -150,7 +150,7 @@ func filterIngress(obj *unstructured.Unstructured) (go_hook.FilterResult, error)
 func domainMetricHandler(input *go_hook.HookInput) error {
 	snap := input.Snapshots["ingresses"]
 	input.MetricsCollector.Expire("deckhouse_exported_domains")
-	globalHTTPSMode := input.ConfigValues.Get("global.https.mode").String()
+	globalHTTPSMode := input.ConfigValues.Get("global.modules.https.mode").String()
 
 	for _, sn := range snap {
 		if sn == nil {

--- a/modules/300-prometheus/hooks/metrics_web_interfaces.go
+++ b/modules/300-prometheus/hooks/metrics_web_interfaces.go
@@ -18,7 +18,6 @@ package hooks
 
 import (
 	"net/url"
-	"regexp"
 	"strings"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -44,30 +43,28 @@ import (
 //     2. Relative path to grafana container (/public/img/mylogo.png)
 //     3. Data URI base64 string
 
-var (
-	_ = sdk.RegisterFunc(&go_hook.HookConfig{
-		Queue: "/modules/prometheus/web_interfaces",
-		Kubernetes: []go_hook.KubernetesConfig{
-			{
-				Name:       "ingresses",
-				ApiVersion: "networking.k8s.io/v1",
-				Kind:       "Ingress",
-				LabelSelector: &v1.LabelSelector{
-					MatchLabels: map[string]string{
-						"heritage": "deckhouse",
-					},
-					MatchExpressions: []v1.LabelSelectorRequirement{
-						{
-							Key:      "module",
-							Operator: v1.LabelSelectorOpExists,
-						},
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/prometheus/web_interfaces",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "ingresses",
+			ApiVersion: "networking.k8s.io/v1",
+			Kind:       "Ingress",
+			LabelSelector: &v1.LabelSelector{
+				MatchLabels: map[string]string{
+					"heritage": "deckhouse",
+				},
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "module",
+						Operator: v1.LabelSelectorOpExists,
 					},
 				},
-				FilterFunc: filterIngress,
 			},
+			FilterFunc: filterIngress,
 		},
-	}, domainMetricHandler)
-)
+	},
+}, domainMetricHandler)
 
 type exportedWebInterface struct {
 	Icon string
@@ -160,8 +157,7 @@ func domainMetricHandler(input *go_hook.HookInput) error {
 		domain := sn.(exportedWebInterface)
 
 		if globalHTTPSMode == "OnlyInURI" {
-			re := regexp.MustCompile(`^http://`)
-			domain.URL = re.ReplaceAllString(domain.URL, "https://")
+			domain.URL = strings.ReplaceAll(domain.URL, "http://", "https://")
 		}
 
 		input.MetricsCollector.Set(

--- a/modules/300-prometheus/hooks/metrics_web_interfaces_test.go
+++ b/modules/300-prometheus/hooks/metrics_web_interfaces_test.go
@@ -92,24 +92,11 @@ spec:
     - test4-example.com
     secretName: test
 `
-		globalConfig = `
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: global
-spec:
-  version: 2
-  settings:
-    https:
-       mode: OnlyInURI
-`
 	)
 	f := HookExecutionConfigInit(
 		`{"prometheus":{"internal":{}},"global":{"enabledModules":[]}}`,
 		`{}`,
 	)
-	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
 	Context("Empty cluster", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(``))
@@ -183,8 +170,10 @@ spec:
 
 	Context("Cluster containing some services and global module https.mode:OnlyInURI", func() {
 		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(ingressMetrics + globalConfig))
+			f.BindingContexts.Set(f.KubeStateSet(ingressMetrics))
+			f.ConfigValuesSet("global.https.mode", "OnlyInURI")
 			f.RunHook()
+
 		})
 
 		It("Hook must not fail, should get metric", func() {

--- a/modules/300-prometheus/hooks/metrics_web_interfaces_test.go
+++ b/modules/300-prometheus/hooks/metrics_web_interfaces_test.go
@@ -171,7 +171,7 @@ spec:
 	Context("Cluster containing some services and global module https.mode:OnlyInURI", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(ingressMetrics))
-			f.ConfigValuesSet("global.https.mode", "OnlyInURI")
+			f.ConfigValuesSet("global.modules.https.mode", "OnlyInURI")
 			f.RunHook()
 
 		})

--- a/modules/300-prometheus/hooks/metrics_web_interfaces_test.go
+++ b/modules/300-prometheus/hooks/metrics_web_interfaces_test.go
@@ -92,12 +92,24 @@ spec:
     - test4-example.com
     secretName: test
 `
+		globalConfig = `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: global
+spec:
+  version: 2
+  settings:
+    https:
+       mode: OnlyInURI
+`
 	)
 	f := HookExecutionConfigInit(
 		`{"prometheus":{"internal":{}},"global":{"enabledModules":[]}}`,
 		`{}`,
 	)
-
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
 	Context("Empty cluster", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(``))
@@ -151,6 +163,64 @@ spec:
 					"icon": "/public/img/unknown.png",
 					"name": "test 3",
 					"url":  "http://test3-example.com/abc/def",
+				},
+				Value: ptr.To(1.0),
+				Group: "deckhouse_exported_domains",
+			}))
+			Expect(ops[4]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "deckhouse_web_interfaces",
+				Action: "set",
+				Labels: map[string]string{
+					"icon": "https://example.com/custom/icon",
+					"name": "test@4",
+					"url":  "https://test4-example.com",
+				},
+				Value: ptr.To(1.0),
+				Group: "deckhouse_exported_domains",
+			}))
+		})
+	})
+
+	Context("Cluster containing some services and global module https.mode:OnlyInURI", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(ingressMetrics + globalConfig))
+			f.RunHook()
+		})
+
+		It("Hook must not fail, should get metric", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ops := f.MetricsCollector.CollectedMetrics()
+			Expect(len(ops)).To(BeEquivalentTo(5))
+
+			Expect(ops[1]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "deckhouse_web_interfaces",
+				Action: "set",
+				Labels: map[string]string{
+					"icon": "/public/img/unknown.png",
+					"name": "test-1",
+					"url":  "https://test1-example.com/abc",
+				},
+				Value: ptr.To(1.0),
+				Group: "deckhouse_exported_domains",
+			}))
+			Expect(ops[2]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "deckhouse_web_interfaces",
+				Action: "set",
+				Labels: map[string]string{
+					"icon": "/custom/icon",
+					"name": "test-2",
+					"url":  "https://test1-example.com%2Fabc/abc",
+				},
+				Value: ptr.To(1.0),
+				Group: "deckhouse_exported_domains",
+			}))
+			Expect(ops[3]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "deckhouse_web_interfaces",
+				Action: "set",
+				Labels: map[string]string{
+					"icon": "/public/img/unknown.png",
+					"name": "test 3",
+					"url":  "https://test3-example.com/abc/def",
 				},
 				Value: ptr.To(1.0),
 				Group: "deckhouse_exported_domains",


### PR DESCRIPTION
## Description

The hook that generates metrics for service links 'Web Interfaces' Grafana panel now considers the https.mode: OnlyInURI parameter from the global configuration. If this parameter is set, the scheme for links is forced to https, even when TLS is not enabled in the ingress spec.

## Why do we need it, and what problem does it solve?

- This change ensures accurate generation of https links in metrics when https.mode: OnlyInURI is used
- Fixes https://github.com/deckhouse/deckhouse/issues/7306

## Why do we need it in the patch release (if we do)?

Not necessarily.

## What is the expected result?
- Metrics will correctly generate https links when https.mode: OnlyInURI is set, regardless of the ingress TLS spec.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: fix 
summary: Ensure grafana `Web Interfaces` panel use 'https' in links when 'https.mode: OnlyInURI' is enabled
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
