### PR TITLE
[user-authz] move the 'related-with' label to annotations

### DIFF
--- a/modules/140-user-authz/hooks/handle_manage_bindings.go
+++ b/modules/140-user-authz/hooks/handle_manage_bindings.go
@@ -210,6 +210,9 @@ func createBinding(binding *filteredManageBinding, useRoleName string, namespace
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("d8:use:%s:binding:%s", useRoleName, binding.Name),
 			Namespace: namespace,
+			Annotations: map[string]string{
+				"rbac.deckhouse.io/related-with": binding.Name,
+			},
 			Labels: map[string]string{
 				"heritage":                    "deckhouse",
 				"rbac.deckhouse.io/automated": "true",

--- a/modules/140-user-authz/hooks/handle_manage_bindings.go
+++ b/modules/140-user-authz/hooks/handle_manage_bindings.go
@@ -68,11 +68,10 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, syncBindings)
 
 type filteredUseBinding struct {
-	Name        string           `json:"name"`
-	Namespace   string           `json:"namespace"`
-	RelatedWith string           `json:"related_with"`
-	RoleName    string           `json:"role_name"`
-	Subjects    []rbacv1.Subject `json:"subjects"`
+	Name      string           `json:"name"`
+	Namespace string           `json:"namespace"`
+	RoleName  string           `json:"role_name"`
+	Subjects  []rbacv1.Subject `json:"subjects"`
 }
 
 func filterUseBinding(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -81,11 +80,10 @@ func filterUseBinding(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 		return nil, err
 	}
 	return &filteredUseBinding{
-		Name:        binding.Name,
-		Namespace:   binding.Namespace,
-		RelatedWith: binding.Labels["rbac.deckhouse.io/related-with"],
-		RoleName:    binding.RoleRef.Name,
-		Subjects:    binding.Subjects,
+		Name:      binding.Name,
+		Namespace: binding.Namespace,
+		RoleName:  binding.RoleRef.Name,
+		Subjects:  binding.Subjects,
 	}, nil
 }
 
@@ -213,9 +211,8 @@ func createBinding(binding *filteredManageBinding, useRoleName string, namespace
 			Name:      fmt.Sprintf("d8:use:%s:binding:%s", useRoleName, binding.Name),
 			Namespace: namespace,
 			Labels: map[string]string{
-				"heritage":                       "deckhouse",
-				"rbac.deckhouse.io/automated":    "true",
-				"rbac.deckhouse.io/related-with": binding.Name,
+				"heritage":                    "deckhouse",
+				"rbac.deckhouse.io/automated": "true",
 			},
 		},
 		RoleRef: rbacv1.RoleRef{

--- a/modules/140-user-authz/hooks/handle_manage_bindings_test.go
+++ b/modules/140-user-authz/hooks/handle_manage_bindings_test.go
@@ -194,9 +194,8 @@ func useBinding(relatedWith, namespace string) string {
 			Name:      fmt.Sprintf("d8:binding:%s", relatedWith),
 			Namespace: namespace,
 			Labels: map[string]string{
-				"heritage":                       "deckhouse",
-				"rbac.deckhouse.io/automated":    "true",
-				"rbac.deckhouse.io/related-with": relatedWith,
+				"heritage":                    "deckhouse",
+				"rbac.deckhouse.io/automated": "true",
 			},
 		},
 		Subjects: []rbacv1.Subject{


### PR DESCRIPTION
## Description
It moves the 'related-with' label to annotations.

## Why do we need it, and what problem does it solve?
Labels cannot contain some characters, but name can, so the hook fails. We need to move this label to annotations.

## What is the expected result?
No the 'related with' label.

```
root@dev-master-0:~# kubectl get rolebindings -A -o json | jq '.items[] | select(.metadata.annotations["rbac.deckhouse.io/related-with"]) | {namespace: .metadata.namespace, name: .metadata.name, annotation: .metadata.annotations["rbac.deckhouse.io/related-with"]}'
{
  "namespace": "d8-chrony",
  "name": "d8:use:viewer:binding:mybinding",
  "annotation": "mybinding"
}
{
  "namespace": "d8-cloud-instance-manager",
  "name": "d8:use:viewer:binding:mybinding",
  "annotation": "mybinding"
}
{
  "namespace": "d8-cloud-provider-openstack",
  "name": "d8:use:viewer:binding:mybinding",
  "annotation": "mybinding"
}
{
  "namespace": "d8-local-path-provisioner",
  "name": "d8:use:viewer:binding:mybinding",
  "annotation": "mybinding"
}
{
  "namespace": "d8-pod-reloader",
  "name": "d8:use:viewer:binding:mybinding",
  "annotation": "mybinding"
}
{
  "namespace": "d8-snapshot-controller",
  "name": "d8:use:viewer:binding:mybinding",
  "annotation": "mybinding"
}
{
  "namespace": "d8-system",
  "name": "d8:use:viewer:binding:mybinding",
  "annotation": "mybinding"
}
{
  "namespace": "kube-system",
  "name": "d8:use:viewer:binding:mybinding",
  "annotation": "mybinding"
}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: Move the 'related-with' label to annotations.
impact_level: low
```