### PR TITLE
[ingress-nginx] Disable VPA for Istio sidecar

### DIFF
--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -52,6 +52,10 @@ spec:
       maxAllowed:
         cpu: {{ $resourcesRequestsVPA_CPU.max | default "50m" | quote }}
         memory: {{ $resourcesRequestsVPA_Memory.max | default "200Mi" | quote }}
+      {{- if $crd.spec.enableIstioSidecar }}
+    - containerName: istio-proxy
+      mode: "Off"
+      {{- end }}
     {{- else }}
   updatePolicy:
     updateMode: "Off"


### PR DESCRIPTION
## Description
Disabling `vertical-pod-autoscaler` for `istio-proxy` sidecar in `ingress-nginx`.

## Why do we need it, and what problem does it solve?
When `sidecar.resourcesManagement.static` is configured in `istio` module, the VPA in `ingress-nginx` module overrides the settings.

## What is the expected result?
VPA ignores `istio-proxy` sidecar in `ingress-nginx`.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ingress-nginx
type: chore
summary: Disable VPA for Istio sidecar
```