### PR TITLE
Implement non-root etcd

### DIFF
--- a/candi/bashible/common-steps/all/003_create_deckhouse_user.sh.tpl
+++ b/candi/bashible/common-steps/all/003_create_deckhouse_user.sh.tpl
@@ -39,3 +39,4 @@ create_user_and_group() {
 }
 
 create_user_and_group deckhouse 64535 deckhouse 64535 /sbin/nologin
+create_user_and_group etcd 64530 etcd 64530 /sbin/nologin

--- a/candi/bashible/common-steps/all/004_integrate_kubernetes_data_device.sh.tpl
+++ b/candi/bashible/common-steps/all/004_integrate_kubernetes_data_device.sh.tpl
@@ -113,6 +113,7 @@ fi
 
 mkdir -p /mnt/kubernetes-data/var-lib-etcd
 chmod 700 /mnt/kubernetes-data/var-lib-etcd
+chown -R etcd:etcd /mnt/kubernetes-data/var-lib-etcd
 mkdir -p /mnt/kubernetes-data/etc-kubernetes
 
 # if there is kubernetes dir with regular files then we can't delete it

--- a/candi/bashible/common-steps/all/004_integrate_kubernetes_data_device.sh.tpl
+++ b/candi/bashible/common-steps/all/004_integrate_kubernetes_data_device.sh.tpl
@@ -126,6 +126,7 @@ fi
 if [[ "$(find /var/lib/etcd/ -type f 2>/dev/null | wc -l)" == "0" ]]; then
   rm -rf /var/lib/etcd
   ln -s /mnt/kubernetes-data/var-lib-etcd /var/lib/etcd
+  chown -R etcd:etcd /var/lib/etcd
 fi
 
 touch /var/lib/bashible/kubernetes-data-device-installed

--- a/candi/bashible/common-steps/cluster-bootstrap/070_install_control_plane.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/070_install_control_plane.sh.tpl
@@ -22,6 +22,7 @@ kubeadm init phase mark-control-plane --config /var/lib/bashible/kubeadm/config.
 
 # CIS becnhmark purposes
 chmod 600 /etc/kubernetes/pki/*.{crt,key} /etc/kubernetes/pki/etcd/*.{crt,key}
+chown -R etcd:etcd /etc/kubernetes/pki/etcd/
 
 # This phase add 'node.kubernetes.io/exclude-from-external-load-balancers' label to node
 # with this label we cannot use target load balancers to control-plane nodes, so we manually remove them

--- a/candi/bashible/common-steps/cluster-bootstrap/070_install_control_plane.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/070_install_control_plane.sh.tpl
@@ -17,12 +17,12 @@ cp /var/lib/bashible/kubeadm/patches/* /etc/kubernetes/deckhouse/kubeadm/patches
 kubeadm init phase certs all --config /var/lib/bashible/kubeadm/config.yaml
 kubeadm init phase kubeconfig all --config /var/lib/bashible/kubeadm/config.yaml
 kubeadm init phase etcd local --config /var/lib/bashible/kubeadm/config.yaml
+chown -R etcd:etcd /etc/kubernetes/pki/etcd/
 kubeadm init phase control-plane all --config /var/lib/bashible/kubeadm/config.yaml
 kubeadm init phase mark-control-plane --config /var/lib/bashible/kubeadm/config.yaml
 
 # CIS becnhmark purposes
 chmod 600 /etc/kubernetes/pki/*.{crt,key} /etc/kubernetes/pki/etcd/*.{crt,key}
-chown -R etcd:etcd /etc/kubernetes/pki/etcd/
 
 # This phase add 'node.kubernetes.io/exclude-from-external-load-balancers' label to node
 # with this label we cannot use target load balancers to control-plane nodes, so we manually remove them

--- a/candi/control-plane-kubeadm/patches/etcd.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/etcd.yaml.tpl
@@ -65,19 +65,6 @@ metadata:
   name: etcd
   namespace: kube-system
 spec:
-  initContainers:
-    - name: init-chown
-      image: {{ include "helm_lib_module_common_image" (list . "init") }}
-      imagePullPolicy: Always
-      command: ['sh', '-c', 'chown -R 64530:64530 /var/lib/etcd; chown -R 64530:64530 /etc/kubernetes/pki/etcd/']
-      securityContext:
-        runAsUser: 0
-        runAsNonRoot: false
-      volumeMounts:
-      - mountPath: /var/lib/etcd
-        name: etcd-data
-      - mountPath: /etc/kubernetes/pki/etcd
-        name: etcd-certs
   containers:
     - name: etcd
       securityContext:

--- a/candi/control-plane-kubeadm/patches/etcd.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/etcd.yaml.tpl
@@ -58,3 +58,28 @@ metadata:
   namespace: kube-system
 spec:
   dnsPolicy: ClusterFirstWithHostNet
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd
+  namespace: kube-system
+spec:
+  initContainers:
+    - name: init-chown
+      image: {{ include "helm_lib_module_common_image" (list . "init") }}
+      imagePullPolicy: Always
+      command: ['sh', '-c', 'chown -R 64530:64530 /var/lib/etcd; chown -R 64530:64530 /etc/kubernetes/pki/etcd/']
+      securityContext:
+        runAsUser: 0
+        runAsNonRoot: false
+      volumeMounts:
+      - mountPath: /var/lib/etcd
+        name: etcd-data
+      - mountPath: /etc/kubernetes/pki/etcd
+        name: etcd-certs
+  containers:
+    - name: etcd
+      securityContext:
+        runAsUser: 64530
+        runAsGroup: 64530


### PR DESCRIPTION
## Description

Run etcd as non root

## Why do we need it, and what problem does it solve?

Fixes #7356 

## What is the expected result?

etcd is run as etcd:etcd, it's data directory ownership is set to etcd:etcd as well

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: feature
summary: Run etcd as non root.
impact_level: default
```
