### PR TITLE
[ci] Fix 'trdl' startup in older versions of 'make'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ bin/trdl: bin
 	chmod +x bin/trdl
 
 bin/werf: bin bin/trdl ## Install werf for images-digests generator.
-	trdl --home-dir bin/.trdl add werf https://tuf.werf.io 1 b7ff6bcbe598e072a86d595a3621924c8612c7e6dc6a82e919abe89707d7e3f468e616b5635630680dd1e98fc362ae5051728406700e6274c5ed1ad92bea52a2
+	@bash -c 'trdl --home-dir bin/.trdl add werf https://tuf.werf.io 1 b7ff6bcbe598e072a86d595a3621924c8612c7e6dc6a82e919abe89707d7e3f468e616b5635630680dd1e98fc362ae5051728406700e6274c5ed1ad92bea52a2'
 	@if command -v bin/werf >/dev/null 2>&1; then \
 		trdl --home-dir bin/.trdl --no-self-update=true update --in-background werf 1.2 stable; \
 	else \


### PR DESCRIPTION
## Description
After that PR #10952, `trdl` stopped running on local macOS due to features of an older version of `make`.

## Why do we need it, and what problem does it solve?
Fix the `make generate`.

## What is the expected result?
In `make` version 3.81 `make generate` works. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: Fixed 'trdl' startup in older versions of 'make'.
impact_level: low
```
