### PR TITLE
Disallow ng labelselector changes

### DIFF
--- a/modules/040-node-manager/crds/node_group.yaml
+++ b/modules/040-node-manager/crds/node_group.yaml
@@ -72,6 +72,9 @@ spec:
             Defines the runtime parameters of a node group.
           required:
             - spec
+          x-kubernetes-validations:
+            - message: spec.staticInstances.labelSelector is immutable and cannot be changed
+              rule: "!has(oldSelf.spec.staticInstances.labelSelector) || self.spec.staticInstances.labelSelector == oldSelf.spec.staticInstances.labelSelector"
           properties:
             metadata:
               type: object

--- a/modules/040-node-manager/docs/EXAMPLES.md
+++ b/modules/040-node-manager/docs/EXAMPLES.md
@@ -181,7 +181,9 @@ A brief example of adding a static node to a cluster using [Cluster API Provider
    apiVersion: deckhouse.io/v1alpha1
    kind: StaticInstance
    metadata:
-     name: static-0
+     name: static-worker-1
+     labels:
+       role: worker
    spec:
      # Specify the IP address of the static node server.
      address: "<SERVER-IP>"
@@ -190,6 +192,10 @@ A brief example of adding a static node to a cluster using [Cluster API Provider
        name: credentials
    EOF
    ```
+
+{% alert level="warning" %}
+The `labelSelector` field in the `NodeGroup` resource is immutable. To update the `labelSelector`, you need to create a new `NodeGroup` and move the static nodes into it by changing their labels.
+{% endalert %}
 
 1. Create a [NodeGroup](cr.html#nodegroup) resource in the cluster:
 
@@ -203,16 +209,24 @@ A brief example of adding a static node to a cluster using [Cluster API Provider
      nodeType: Static
      staticInstances:
        count: 1
+       labelSelector:
+         matchLabels:
+           role: worker
    EOF
    ```
 
-### Using the Cluster API Provider Static and label selector filters
+### Using Cluster API Provider Static for multiple node groups
 
 This example shows how you can use filters in the StaticInstance [label selector](cr.html#nodegroup-v1-spec-staticinstances-labelselector) to group static nodes and use them in different NodeGroups. Here, two node groups (`front` and `worker`) are used for different tasks. Each group includes nodes with different characteristics — the `front` group has two servers and the `worker` group has one.
 
 1. Prepare the required resources (3 servers or virtual machines) and create the `SSHCredentials` resource in the same way as step 1 and step 2 [of the example](#using-the-cluster-api-provider-static).
 
 1. Create two [NodeGroup](cr.html#nodegroup) in the cluster (from this point on, use `kubectl` configured to manage the cluster):
+
+{% alert level="warning" %}
+The `labelSelector` field in the `NodeGroup` resource is immutable. To update the `labelSelector`, you need to create a new `NodeGroup` and move the static nodes into it by changing their labels.
+{% endalert %}
+
 
    ```shell
    kubectl create -f - <<EOF

--- a/modules/040-node-manager/docs/EXAMPLES_RU.md
+++ b/modules/040-node-manager/docs/EXAMPLES_RU.md
@@ -187,7 +187,9 @@ spec:
    apiVersion: deckhouse.io/v1alpha1
    kind: StaticInstance
    metadata:
-     name: static-0
+     name: static-worker-1
+     labels:
+       role: worker
    spec:
      # Укажите IP-адрес сервера статического узла.
      address: "<SERVER-IP>"
@@ -196,6 +198,10 @@ spec:
        name: credentials
    EOF
    ```
+
+{% alert level="warning" %}
+Поле `labelSelector` в ресурсе `NodeGroup` является неизменным. Чтобы обновить labelSelector, нужно создать новую NodeGroup и перенести в неё статические узлы, изменив их метки (labels).
+{% endalert %}
 
 1. Создайте в кластере ресурс [NodeGroup](cr.html#nodegroup):
 
@@ -209,16 +215,23 @@ spec:
      nodeType: Static
      staticInstances:
        count: 1
+       labelSelector:
+         matchLabels:
+           role: worker
    EOF
    ```
 
-### С помощью Cluster API Provider Static и фильтрами в label selector
+### С помощью Cluster API Provider Static для нескольких групп узлов
 
 Пример использования фильтров в [label selector](cr.html#nodegroup-v1-spec-staticinstances-labelselector) StaticInstance, для группировки статических узлов и использования их в разных NodeGroup. В примере используются две группы узлов (`front` и `worker`), предназначенные для разных задач, которые должны содержать разные по характеристикам узлы — два сервера для группы `front` и один для группы `worker`.
 
 1. Подготовьте необходимые ресурсы (3 сервера или виртуальные машины) и создайте ресурс `SSHCredentials`, аналогично п.1 и п.2 [примера](#с-помощью-cluster-api-provider-static).
 
 1. Создайте в кластере два ресурса [NodeGroup](cr.html#nodegroup) (здесь и далее используйте `kubectl`, настроенный на управление кластером):
+
+{% alert level="warning" %}
+Поле `labelSelector` в ресурсе `NodeGroup` является неизменным. Чтобы обновить labelSelector, нужно создать новую NodeGroup и перенести в неё статические узлы, изменив их метки (labels).
+{% endalert %}
 
    ```shell
    kubectl create -f - <<EOF

--- a/modules/040-node-manager/templates/caps-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/caps-controller-manager/deployment.yaml
@@ -87,6 +87,7 @@ spec:
             readOnly: true
         args:
           - "--leader-elect"
+          - "--sync-period=1m"
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
