### PR TITLE
[ci] add nonamedreturns linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -81,3 +81,4 @@ linters:
   - unparam
   - whitespace
   - copyloopvar
+  - nonamedreturns

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -58,6 +58,10 @@ linters-settings:
         - time
       # Enforce putting arguments on separate lines.
       args-on-sep-lines: false
+  nonamedreturns:
+    # Report named error if it is assigned inside defer.
+    # Default: false
+    report-error-in-defer: false
 
 linters:
   disable-all: true

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
@@ -69,7 +69,8 @@ func (in *DeckhouseRelease) GetChangelogLink() string {
 	return in.Spec.ChangelogLink
 }
 
-func (in *DeckhouseRelease) GetCooldownUntil() (cooldown *time.Time) {
+func (in *DeckhouseRelease) GetCooldownUntil() *time.Time {
+	cooldown := new(time.Time)
 	if v, ok := in.Annotations["release.deckhouse.io/cooldown"]; ok {
 		cd, err := time.Parse(time.RFC3339, v)
 		if err == nil {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module.go
@@ -29,7 +29,7 @@ import (
 )
 
 func moduleValidationHandler() http.Handler {
-	vf := kwhvalidating.ValidatorFunc(func(_ context.Context, review *model.AdmissionReview, _ metav1.Object) (result *kwhvalidating.ValidatorResult, err error) {
+	vf := kwhvalidating.ValidatorFunc(func(_ context.Context, review *model.AdmissionReview, _ metav1.Object) (*kwhvalidating.ValidatorResult, error) {
 		// UserInfo groups: [system:serviceaccounts system:serviceaccounts:d8-system system:authenticated]
 		if review.UserInfo.Username != "system:serviceaccount:d8-system:deckhouse" {
 			return rejectResult("manual Module change is forbidden")

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -50,7 +50,7 @@ const disableReasonSuffix = "Please annotate ModuleConfig with `modules.deckhous
 
 // moduleConfigValidationHandler validations for ModuleConfig creation
 func moduleConfigValidationHandler(cli client.Client, moduleStorage moduleStorage, metricStorage *metricstorage.MetricStorage, configValidator *configtools.Validator) http.Handler {
-	vf := kwhvalidating.ValidatorFunc(func(ctx context.Context, review *kwhmodel.AdmissionReview, obj metav1.Object) (result *kwhvalidating.ValidatorResult, err error) {
+	vf := kwhvalidating.ValidatorFunc(func(ctx context.Context, review *kwhmodel.AdmissionReview, obj metav1.Object) (*kwhvalidating.ValidatorResult, error) {
 		var (
 			cfg = new(v1alpha1.ModuleConfig)
 			ok  bool
@@ -107,7 +107,7 @@ func moduleConfigValidationHandler(cli client.Client, moduleStorage moduleStorag
 			oldModuleMeta := new(AnnotationsOnly)
 
 			buf := bytes.NewBuffer(review.OldObjectRaw)
-			if err = json.NewDecoder(buf).Decode(oldModuleMeta); err != nil {
+			if err := json.NewDecoder(buf).Decode(oldModuleMeta); err != nil {
 				return nil, fmt.Errorf("can not parse old module config: %w", err)
 			}
 
@@ -148,7 +148,7 @@ func moduleConfigValidationHandler(cli client.Client, moduleStorage moduleStorag
 		// skip checking source for the global module
 		if cfg.Name != "global" {
 			module := new(v1alpha1.Module)
-			if err = cli.Get(ctx, client.ObjectKey{Name: cfg.Name}, module); err != nil {
+			if err := cli.Get(ctx, client.ObjectKey{Name: cfg.Name}, module); err != nil {
 				if apierrors.IsNotFound(err) {
 					return allowResult(fmt.Sprintf("the '%s' module not found", cfg.Name))
 				}
@@ -163,7 +163,7 @@ func moduleConfigValidationHandler(cli client.Client, moduleStorage moduleStorag
 		// empty policy means module uses deckhouse embedded policy
 		if cfg.Spec.UpdatePolicy != "" {
 			tmp := new(v1alpha1.ModuleUpdatePolicy)
-			if err = cli.Get(ctx, client.ObjectKey{Name: cfg.Spec.UpdatePolicy}, tmp); err != nil {
+			if err := cli.Get(ctx, client.ObjectKey{Name: cfg.Spec.UpdatePolicy}, tmp); err != nil {
 				if !apierrors.IsNotFound(err) {
 					return nil, fmt.Errorf("get the '%s' module policy: %w", cfg.Spec.UpdatePolicy, err)
 				}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -348,7 +348,7 @@ func (dcr *DeckhouseReleaseChecker) releaseCanarySettings() canarySettings {
 	return dcr.releaseMetadata.Canary[dcr.releaseChannel]
 }
 
-func (dcr *DeckhouseReleaseChecker) FetchReleaseMetadata(previousImageHash string) (digestHash string, err error) {
+func (dcr *DeckhouseReleaseChecker) FetchReleaseMetadata(previousImageHash string) (string, error) {
 	image, err := dcr.registryClient.Image(context.TODO(), dcr.releaseChannel)
 	if err != nil {
 		return "", err

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -122,7 +122,8 @@ func NewDeckhouseReleaseController(ctx context.Context, mgr manager.Manager, dc 
 		Complete(ctr)
 }
 
-func (r *deckhouseReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
+func (r *deckhouseReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var result ctrl.Result
 	r.logger.Debugf("%s release processing started", req.Name)
 	defer func() { r.logger.Debugf("%s release processing complete: %+v", req.Name, result) }()
 
@@ -134,7 +135,7 @@ func (r *deckhouseReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	r.metricStorage.Grouped().ExpireGroupMetrics(metricReleasesGroup)
 
 	release := new(v1alpha1.DeckhouseRelease)
-	err = r.client.Get(ctx, req.NamespacedName, release)
+	err := r.client.Get(ctx, req.NamespacedName, release)
 	if err != nil {
 		r.logger.Debugf("get release: %s", err.Error())
 		// The DeckhouseRelease resource may no longer exist, in which case we stop
@@ -154,14 +155,10 @@ func (r *deckhouseReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	return r.createOrUpdateReconcile(ctx, release)
 }
 
-func (r *deckhouseReleaseReconciler) PreflightCheck(ctx context.Context) (err error) {
-	defer func() {
-		if err == nil {
-			r.preflightCountDown.Done()
-		}
-	}()
-
+func (r *deckhouseReleaseReconciler) PreflightCheck(ctx context.Context) error {
 	r.clusterUUID = r.getClusterUUID(ctx)
+	r.preflightCountDown.Done()
+
 	return nil
 }
 

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
@@ -940,15 +940,17 @@ func (suite *ControllerTestSuite) fetchResults() []byte {
 	return result.Bytes()
 }
 
-func singleDocToManifests(doc []byte) (result []string) {
+func singleDocToManifests(doc []byte) []string {
 	split := mDelimiter.Split(string(doc), -1)
 
+	result := make([]string, 0, len(split))
 	for i := range split {
 		if split[i] != "" {
 			result = append(result, split[i])
 		}
 	}
-	return
+
+	return result
 }
 
 func (suite *ControllerTestSuite) getDeckhouseRelease(name string) *v1alpha1.DeckhouseRelease {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/update_by_image_hash_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/update_by_image_hash_test.go
@@ -29,7 +29,7 @@ func (suite *ControllerTestSuite) TestUpdateByImageHash() {
 	ctx := context.Background()
 
 	suite.Run("No new deckhouse image", func() {
-		dependency.TestDC.CRClient.DigestMock.Set(func(_ string) (s1 string, err error) {
+		dependency.TestDC.CRClient.DigestMock.Set(func(_ string) (string, error) {
 			return "sha256:d57f01a88e54f863ff5365c989cb4e2654398fa274d46389e0af749090b862d1", nil
 		})
 
@@ -42,7 +42,7 @@ func (suite *ControllerTestSuite) TestUpdateByImageHash() {
 	})
 
 	suite.Run("Have new deckhouse image", func() {
-		dependency.TestDC.CRClient.DigestMock.Set(func(_ string) (s1 string, err error) {
+		dependency.TestDC.CRClient.DigestMock.Set(func(_ string) (string, error) {
 			return "sha256:123456", nil
 		})
 

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/docs_controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/docs_controller.go
@@ -305,13 +305,13 @@ func (mdr *moduleDocumentationReconciler) createOrUpdateReconcile(ctx context.Co
 	return result, nil
 }
 
-func (mdr *moduleDocumentationReconciler) getDocsBuilderAddresses(ctx context.Context) (addresses []string, err error) {
+func (mdr *moduleDocumentationReconciler) getDocsBuilderAddresses(ctx context.Context) ([]string, error) {
 	var leasesList coordv1.LeaseList
-	err = mdr.client.List(ctx, &leasesList, client.InNamespace("d8-system"), client.HasLabels{"deckhouse.io/documentation-builder-sync"})
-	if err != nil {
+	if err := mdr.client.List(ctx, &leasesList, client.InNamespace("d8-system"), client.HasLabels{"deckhouse.io/documentation-builder-sync"}); err != nil {
 		return nil, fmt.Errorf("list leases: %w", err)
 	}
 
+	addresses := make([]string, 0, len(leasesList.Items))
 	for _, lease := range leasesList.Items {
 		if lease.Spec.HolderIdentity == nil {
 			continue
@@ -325,7 +325,7 @@ func (mdr *moduleDocumentationReconciler) getDocsBuilderAddresses(ctx context.Co
 		addresses = append(addresses, "http://"+*lease.Spec.HolderIdentity)
 	}
 
-	return
+	return addresses, nil
 }
 
 func (mdr *moduleDocumentationReconciler) getDocumentationFromModuleDir(modulePath string, buf *bytes.Buffer) error {

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/docs_controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/docs_controller_test.go
@@ -101,7 +101,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "v1.0.0", "openapi"), 0777)
 		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "v1.0.0", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 
-		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (rp1 *http.Response, err error) {
+		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
 			case "/api/v1/doc/testmodule/v1.0.0":
 				return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(""))}, nil
@@ -124,7 +124,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "v1.0.0", "openapi"), 0777)
 		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "v1.0.0", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 
-		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (rp1 *http.Response, err error) {
+		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
 			case "/api/v1/doc/testmodule/v1.0.0":
 				return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(""))}, nil
@@ -147,7 +147,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "v1.0.0", "openapi"), 0777)
 		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "v1.0.0", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 
-		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (rp1 *http.Response, err error) {
+		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (*http.Response, error) {
 			if strings.HasPrefix(req.Host, "10-111-111-11") {
 				return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader("I'm broken"))}, nil
 			}
@@ -174,7 +174,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "v1.1.1", "openapi"), 0777)
 		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "v1.1.1", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 
-		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (rp1 *http.Response, err error) {
+		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
 			case "/api/v1/doc/testmodule/v1.1.1":
 				return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(""))}, nil
@@ -197,7 +197,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "v1.1.1", "openapi"), 0777)
 		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "v1.1.1", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 
-		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (rp1 *http.Response, err error) {
+		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
 			case "/api/v1/doc/testmodule/v1.1.1":
 				return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(""))}, nil
@@ -220,7 +220,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "dev", "openapi"), 0777)
 		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "dev", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 
-		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (rp1 *http.Response, err error) {
+		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
 			case "/api/v1/doc/testmodule/mpo-tag":
 				return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(""))}, nil

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
@@ -588,15 +588,17 @@ func (s stubModulesManager) RunModuleWithNewOpenAPISchema(_, _, _ string) error 
 	return nil
 }
 
-func singleDocToManifests(doc []byte) (result []string) {
+func singleDocToManifests(doc []byte) []string {
 	split := mDelimiter.Split(string(doc), -1)
 
+	result := make([]string, 0, len(split))
 	for i := range split {
 		if split[i] != "" {
 			result = append(result, split[i])
 		}
 	}
-	return
+
+	return result
 }
 
 func TestValidateModule(t *testing.T) {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -259,7 +259,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 
 	suite.Run("source with module with pull error", func() {
 		dependency.TestDC.CRClient.ListTagsMock.Return([]string{"enabledmodule", "errormodule"}, nil)
-		dependency.TestDC.CRClient.ImageMock.Set(func(tag string) (i1 v1.Image, err error) {
+		dependency.TestDC.CRClient.ImageMock.Set(func(tag string) (v1.Image, error) {
 			if tag == "alpha" {
 				return nil, errors.New("GET https://registry.deckhouse.io/v2/deckhouse/ee/modules/errormodule/release/manifests/alpha:\n      MANIFEST_UNKNOWN: manifest unknown; map[Tag:alpha]")
 			}

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -219,15 +219,17 @@ func (suite *ControllerTestSuite) fetchResults() []byte {
 	return result.Bytes()
 }
 
-func splitManifests(doc []byte) (result []string) {
+func splitManifests(doc []byte) []string {
 	splits := manifestsDelimiter.Split(string(doc), -1)
 
+	result := make([]string, 0, len(splits))
 	for i := range splits {
 		if splits[i] != "" {
 			result = append(result, splits[i])
 		}
 	}
-	return
+
+	return result
 }
 
 func (suite *ControllerTestSuite) TestCreateReconcile() {

--- a/ee/modules/025-static-routing-manager/hooks/lib/common.go
+++ b/ee/modules/025-static-routing-manager/hooks/lib/common.go
@@ -48,7 +48,7 @@ func GenerateShortHash(input string) string {
 	return fullHash
 }
 
-func SetStatusCondition(conditions *[]v1alpha1.ExtendedCondition, newCondition v1alpha1.ExtendedCondition) (changed bool) {
+func SetStatusCondition(conditions *[]v1alpha1.ExtendedCondition, newCondition v1alpha1.ExtendedCondition) bool {
 	if conditions == nil {
 		return false
 	}
@@ -72,6 +72,8 @@ func SetStatusCondition(conditions *[]v1alpha1.ExtendedCondition, newCondition v
 	} else {
 		existingCondition.LastHeartbeatTime = timeNow
 	}
+
+	changed := false
 
 	if existingCondition.Status != newCondition.Status {
 		existingCondition.Status = newCondition.Status

--- a/ee/modules/110-istio/hooks/ee/federation_discovery_test.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery_test.go
@@ -198,7 +198,7 @@ status:
 				},
 			}
 			dependency.TestDC.HTTPClient.DoMock.
-				Set(func(req *http.Request) (rp1 *http.Response, err error) {
+				Set(func(req *http.Request) (*http.Response, error) {
 					host := strings.Split(req.Host, ":")[0]
 					uri := req.URL.Path
 					mockResponse := respMap[host][uri]
@@ -563,7 +563,7 @@ status: {}
 				},
 			}
 			dependency.TestDC.HTTPClient.DoMock.
-				Set(func(req *http.Request) (rp1 *http.Response, err error) {
+				Set(func(req *http.Request) (*http.Response, error) {
 					host := strings.Split(req.Host, ":")[0]
 					uri := req.URL.Path
 					mockResponse := respMap[host][uri]

--- a/ee/modules/110-istio/hooks/ee/multicluster_discovery_test.go
+++ b/ee/modules/110-istio/hooks/ee/multicluster_discovery_test.go
@@ -187,7 +187,7 @@ status:
 				},
 			}
 			dependency.TestDC.HTTPClient.DoMock.
-				Set(func(req *http.Request) (rp1 *http.Response, err error) {
+				Set(func(req *http.Request) (*http.Response, error) {
 					host := strings.Split(req.Host, ":")[0]
 					uri := req.URL.Path
 					mockResponse := respMap[host][uri]
@@ -532,7 +532,7 @@ status: {}
 				},
 			}
 			dependency.TestDC.HTTPClient.DoMock.
-				Set(func(req *http.Request) (rp1 *http.Response, err error) {
+				Set(func(req *http.Request) (*http.Response, error) {
 					host := strings.Split(req.Host, ":")[0]
 					uri := req.URL.Path
 					mockResponse := respMap[host][uri]

--- a/ee/modules/110-istio/hooks/ee/multicluster_monitoring_api_hosts_test.go
+++ b/ee/modules/110-istio/hooks/ee/multicluster_monitoring_api_hosts_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Istio hooks :: multicluster_monitoring_api_hosts ::", func() {
 				},
 			}
 			dependency.TestDC.HTTPClient.DoMock.
-				Set(func(req *http.Request) (rp1 *http.Response, err error) {
+				Set(func(req *http.Request) (*http.Response, error) {
 					host := strings.Split(req.Host, ":")[0]
 					uri := req.URL.Path
 					mockResponse := respMap[host][uri]

--- a/global-hooks/discovery/kubernetes_version_test.go
+++ b/global-hooks/discovery/kubernetes_version_test.go
@@ -204,7 +204,7 @@ subsets:
 			Context(fmt.Sprintf("%s created", s.title), func() {
 				BeforeEach(func() {
 					dependency.TestDC.HTTPClient.DoMock.
-						Set(func(_ *http.Request) (rp1 *http.Response, err error) {
+						Set(func(_ *http.Request) (*http.Response, error) {
 							return versionsResponse(initialVersion), nil
 						})
 					f.BindingContexts.Set(f.KubeStateSet(podState))
@@ -228,7 +228,7 @@ subsets:
 			const initialVersion = "1.19.2"
 			BeforeEach(func() {
 				dependency.TestDC.HTTPClient.DoMock.
-					Set(func(_ *http.Request) (rp1 *http.Response, err error) {
+					Set(func(_ *http.Request) (*http.Response, error) {
 						return versionsResponse(initialVersion), nil
 					})
 				f.BindingContexts.Set(f.KubeStateSet(stateEndpoints(endpointsOne)))
@@ -316,7 +316,7 @@ status:
 			const initialVersion = "1.19.2"
 			BeforeEach(func() {
 				dependency.TestDC.HTTPClient.DoMock.
-					Set(func(req *http.Request) (rp1 *http.Response, err error) {
+					Set(func(req *http.Request) (*http.Response, error) {
 						switch req.Host {
 						case "10.245.0.1":
 							return versionsResponse(initialVersion), nil
@@ -364,7 +364,7 @@ status:
 		endpointsState := stateEndpoints(endpointsOne)
 		BeforeEach(func() {
 			dependency.TestDC.HTTPClient.DoMock.
-				Set(func(_ *http.Request) (rp1 *http.Response, err error) {
+				Set(func(_ *http.Request) (*http.Response, error) {
 					return versionsResponse(initialVersion), nil
 				})
 			f.BindingContexts.Set(f.KubeStateSet(endpointsState))
@@ -401,7 +401,7 @@ status:
 			Context("Change version", func() {
 				BeforeEach(func() {
 					dependency.TestDC.HTTPClient.DoMock.
-						Set(func(_ *http.Request) (rp1 *http.Response, err error) {
+						Set(func(_ *http.Request) (*http.Response, error) {
 							return versionsResponse(verToChange), nil
 						})
 					f.RunHook()
@@ -441,7 +441,7 @@ status:
 				Context("Change version", func() {
 					BeforeEach(func() {
 						dependency.TestDC.HTTPClient.DoMock.
-							Set(func(_ *http.Request) (rp1 *http.Response, err error) {
+							Set(func(_ *http.Request) (*http.Response, error) {
 								return versionsResponse(verToChange), nil
 							})
 						f.RunHook()
@@ -467,7 +467,7 @@ status:
 
 			BeforeEach(func() {
 				dependency.TestDC.HTTPClient.DoMock.
-					Set(func(_ *http.Request) (rp1 *http.Response, err error) {
+					Set(func(_ *http.Request) (*http.Response, error) {
 						return versionsResponse(initialVersion), nil
 					})
 
@@ -493,7 +493,7 @@ status:
 		k8sVer := initVers[1]
 		BeforeEach(func() {
 			dependency.TestDC.HTTPClient.DoMock.
-				Set(func(req *http.Request) (rp1 *http.Response, err error) {
+				Set(func(req *http.Request) (*http.Response, error) {
 					host := strings.Split(req.Host, ":")[0]
 					ver := initVers[indexOf(host, endpointsMul)]
 					return versionsResponse(ver), nil
@@ -534,7 +534,7 @@ status:
 				k8sVer := changeVers[1]
 				BeforeEach(func() {
 					dependency.TestDC.HTTPClient.DoMock.
-						Set(func(req *http.Request) (rp1 *http.Response, err error) {
+						Set(func(req *http.Request) (*http.Response, error) {
 							host := strings.Split(req.Host, ":")[0]
 							ver := changeVers[indexOf(host, endpointsMul)]
 							return versionsResponse(ver), nil
@@ -578,7 +578,7 @@ status:
 					k8sVer := changeVers[1]
 					BeforeEach(func() {
 						dependency.TestDC.HTTPClient.DoMock.
-							Set(func(req *http.Request) (rp1 *http.Response, err error) {
+							Set(func(req *http.Request) (*http.Response, error) {
 								host := strings.Split(req.Host, ":")[0]
 								ver := changeVers[indexOf(host, endpointsMul)]
 								return versionsResponse(ver), nil
@@ -631,7 +631,7 @@ status:
 
 		BeforeEach(func() {
 			dependency.TestDC.HTTPClient.DoMock.
-				Set(func(req *http.Request) (rp1 *http.Response, err error) {
+				Set(func(req *http.Request) (*http.Response, error) {
 					host := strings.Split(req.Host, ":")[0]
 					ver := initVers[indexOf(host, endpointsMul)]
 					return versionsResponse(ver), nil

--- a/go_lib/certificate/csr.go
+++ b/go_lib/certificate/csr.go
@@ -24,7 +24,7 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 )
 
-func GenerateCSR(logger go_hook.Logger, cn string, options ...Option) (csrPEM, key []byte, err error) {
+func GenerateCSR(logger go_hook.Logger, cn string, options ...Option) ([]byte, []byte, error) {
 	request := &csr.CertificateRequest{
 		CN:         cn,
 		KeyRequest: csr.NewKeyRequest(),
@@ -43,12 +43,12 @@ func GenerateCSR(logger go_hook.Logger, cn string, options ...Option) (csrPEM, k
 	log.SetOutput(&buf)
 	defer log.SetOutput(logWriter)
 
-	csrPEM, key, err = g.ProcessRequest(request)
+	csrPEM, key, err := g.ProcessRequest(request)
 	if err != nil && logger != nil {
 		logger.Error(buf.String())
 	}
 
-	return
+	return csrPEM, key, err
 }
 
 // Validator does nothing and will never return an error. It exists because creating a

--- a/go_lib/configtools/conversion/store.go
+++ b/go_lib/configtools/conversion/store.go
@@ -37,14 +37,21 @@ func Store() *ConversionsStore {
 	return instance
 }
 
-func (s *ConversionsStore) Add(module, pathToConversions string) (err error) {
+func (s *ConversionsStore) Add(module, pathToConversions string) error {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	if s.converters == nil {
 		s.converters = make(map[string]*Converter)
 	}
-	s.converters[module], err = newConverter(pathToConversions)
-	return err
+
+	newConverter, err := newConverter(pathToConversions)
+	if err != nil {
+		return err
+	}
+
+	s.converters[module] = newConverter
+
+	return nil
 }
 
 func (s *ConversionsStore) Get(module string) *Converter {

--- a/go_lib/dependency/cr/cr.go
+++ b/go_lib/dependency/cr/cr.go
@@ -217,7 +217,7 @@ func readAuthConfig(repo, dockerCfgBase64 string) (authn.AuthConfig, error) {
 	return authn.AuthConfig{}, fmt.Errorf("%q credentials not found in the dockerCfg", repo)
 }
 
-func GetHTTPTransport(ca string) (transport http.RoundTripper) {
+func GetHTTPTransport(ca string) http.RoundTripper {
 	if ca == "" {
 		return http.DefaultTransport
 	}

--- a/go_lib/dependency/extenders/kubernetesversion/watcher.go
+++ b/go_lib/dependency/extenders/kubernetesversion/watcher.go
@@ -33,8 +33,10 @@ type versionWatcher struct {
 	logger      *log.Logger
 }
 
-func (w *versionWatcher) watch(path string) (err error) {
-	if w.watcher, err = fsnotify.NewWatcher(); err != nil {
+func (w *versionWatcher) watch(path string) error {
+	var err error
+	w.watcher, err = fsnotify.NewWatcher()
+	if err != nil {
 		return err
 	}
 	if err = w.watcher.Add(path); err != nil {
@@ -46,7 +48,7 @@ func (w *versionWatcher) watch(path string) (err error) {
 			if !ok {
 				return nil
 			}
-			if err = w.handler(path); err != nil {
+			if err := w.handler(path); err != nil {
 				return err
 			}
 		case err, ok := <-w.watcher.Errors:

--- a/go_lib/hooks/nodes/hook.go
+++ b/go_lib/hooks/nodes/hook.go
@@ -62,7 +62,7 @@ func isAllMasterNodesInitialized(input *go_hook.HookInput, dc dependency.Contain
 func waitForAllMasterNodesToBecomeInitialized(input *go_hook.HookInput, dc dependency.Container) error {
 	var lastErr error
 
-	err := wait.PollUntilContextTimeout(context.TODO(), time.Second, 120*time.Second, false, func(_ context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(context.TODO(), time.Second, 120*time.Second, false, func(_ context.Context) (bool, error) {
 		input.Logger.Infof("waiting for master nodes to become initialized by cloud provider")
 		ok, err := isAllMasterNodesInitialized(input, dc)
 

--- a/go_lib/module/module.go
+++ b/go_lib/module/module.go
@@ -42,11 +42,11 @@ func getFirstDefined(values go_hook.PatchableValuesCollector, keys ...string) (g
 	return v, ok
 }
 
-func GetValuesFirstDefined(input *go_hook.HookInput, keys ...string) (v gjson.Result, ok bool) {
+func GetValuesFirstDefined(input *go_hook.HookInput, keys ...string) (gjson.Result, bool) {
 	return getFirstDefined(input.Values, keys...)
 }
 
-func GetConfigValuesFirstDefined(input *go_hook.HookInput, keys ...string) (v gjson.Result, ok bool) {
+func GetConfigValuesFirstDefined(input *go_hook.HookInput, keys ...string) (gjson.Result, bool) {
 	return getFirstDefined(input.ConfigValues, keys...)
 }
 

--- a/go_lib/updater/deploy_delay_reason.go
+++ b/go_lib/updater/deploy_delay_reason.go
@@ -114,10 +114,12 @@ func (r deployDelayReason) GoString() string {
 	return fmt.Sprintf("deployDelayReason(0b%b)", byte(r))
 }
 
-func (r deployDelayReason) splitReasons() (reasons []string) {
+func (r deployDelayReason) splitReasons() []string {
 	if r == noDelay {
 		return []string{"noDelay"}
 	}
+
+	reasons := make([]string, 0)
 
 	if r.contains(cooldownDelayReason) {
 		reasons = append(reasons, "cooldownDelayReason")

--- a/go_lib/updater/updater.go
+++ b/go_lib/updater/updater.go
@@ -220,9 +220,12 @@ func (u *Updater[R]) checkMinorReleaseConditions(release R, metricLabels MetricL
 	return u.postponeDeploy(release, delayReason, resultDeployTime)
 }
 
-func (u *Updater[R]) calculateMinorResultDeployTime(release R, metricLabels MetricLabels) (releaseApplyTime time.Time, reason deployDelayReason, err error) {
-	var newApplyAfter time.Time
-	releaseApplyTime = u.now
+func (u *Updater[R]) calculateMinorResultDeployTime(release R, metricLabels MetricLabels) (time.Time, deployDelayReason, error) {
+	var (
+		newApplyAfter    time.Time
+		releaseApplyTime = u.now
+		reason           deployDelayReason
+	)
 
 	if release.GetApplyNow() {
 		return releaseApplyTime, reason, nil
@@ -279,9 +282,12 @@ func (u *Updater[R]) calculateMinorResultDeployTime(release R, metricLabels Metr
 	return releaseApplyTime, reason, nil
 }
 
-func (u *Updater[R]) calculatePatchResultDeployTime(release R, metricLabels MetricLabels) (releaseApplyTime time.Time, reason deployDelayReason, err error) {
-	var newApplyAfter time.Time
-	releaseApplyTime = u.now
+func (u *Updater[R]) calculatePatchResultDeployTime(release R, metricLabels MetricLabels) (time.Time, deployDelayReason, error) {
+	var (
+		newApplyAfter    time.Time
+		releaseApplyTime = u.now
+		reason           deployDelayReason
+	)
 
 	if release.GetApplyNow() {
 		return releaseApplyTime, reason, nil
@@ -349,7 +355,8 @@ func (u *Updater[R]) setReleaseQueueDepthLabel(metricLabels map[string]string) {
 //   - Release requirements
 //
 // In addition to the regular error, ErrDeployConditionsNotMet or NotReadyForDeployError is returned as appropriate.
-func (u *Updater[R]) ApplyPredictedRelease() (err error) {
+func (u *Updater[R]) ApplyPredictedRelease() error {
+	var err error
 	if u.predictedReleaseIndex == -1 {
 		return ErrDeployConditionsNotMet // has no predicted release
 	}

--- a/modules/002-deckhouse/hooks/set_deckhouse_ready_nodes.go
+++ b/modules/002-deckhouse/hooks/set_deckhouse_ready_nodes.go
@@ -120,7 +120,7 @@ func applyPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error
 	}, nil
 }
 
-func setDeckhouseReadyNodes(input *go_hook.HookInput) (err error) {
+func setDeckhouseReadyNodes(input *go_hook.HookInput) error {
 	pods := input.Snapshots["control-plane-pods"]
 	nodes := input.Snapshots["control-plane-nodes"]
 	if len(nodes) == 0 {

--- a/modules/030-cloud-provider-gcp/hooks/wait_for_all_master_nodes_to_become_initialized.go
+++ b/modules/030-cloud-provider-gcp/hooks/wait_for_all_master_nodes_to_become_initialized.go
@@ -58,7 +58,7 @@ func isAllMasterNodesInitialized(input *go_hook.HookInput, dc dependency.Contain
 }
 
 func waitForAllMasterNodesToBecomeInitialized(input *go_hook.HookInput, dc dependency.Container) error {
-	err := wait.PollUntilContextTimeout(context.TODO(), time.Second, 120*time.Second, false, func(_ context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(context.TODO(), time.Second, 120*time.Second, false, func(_ context.Context) (bool, error) {
 		input.Logger.Infof("waiting for master nodes to become initialized by cloud provider")
 		ok, err := isAllMasterNodesInitialized(input, dc)
 		if ok {

--- a/modules/040-control-plane-manager/hooks/common_test.go
+++ b/modules/040-control-plane-manager/hooks/common_test.go
@@ -43,7 +43,7 @@ func testHelperSetETCDMembers(members []*etcdserverpb.Member) {
 		a := *member
 		mems[i] = &a
 	}
-	dependency.TestDC.EtcdClient.MemberListMock.Set(func(_ context.Context) (mp1 *clientv3.MemberListResponse, err error) {
+	dependency.TestDC.EtcdClient.MemberListMock.Set(func(_ context.Context) (*clientv3.MemberListResponse, error) {
 		return &clientv3.MemberListResponse{
 			Members: mems,
 		}, nil
@@ -51,7 +51,7 @@ func testHelperSetETCDMembers(members []*etcdserverpb.Member) {
 }
 
 func testHelperRegisterEtcdMemberUpdate() {
-	dependency.TestDC.EtcdClient.MemberUpdateMock.Set(func(ctx context.Context, id uint64, peers []string) (mp1 *clientv3.MemberUpdateResponse, err error) {
+	dependency.TestDC.EtcdClient.MemberUpdateMock.Set(func(ctx context.Context, id uint64, peers []string) (*clientv3.MemberUpdateResponse, error) {
 		resp, _ := dependency.TestDC.EtcdClient.MemberList(ctx)
 		members := resp.Members
 		for i, member := range members {
@@ -67,7 +67,7 @@ func testHelperRegisterEtcdMemberUpdate() {
 		return nil, nil
 	})
 
-	dependency.TestDC.EtcdClient.MemberRemoveMock.Set(func(ctx context.Context, id uint64) (mp1 *clientv3.MemberRemoveResponse, err error) {
+	dependency.TestDC.EtcdClient.MemberRemoveMock.Set(func(ctx context.Context, id uint64) (*clientv3.MemberRemoveResponse, error) {
 		resp, _ := dependency.TestDC.EtcdClient.MemberList(ctx)
 		members := resp.Members
 		var index int

--- a/modules/040-control-plane-manager/hooks/effective_kubernetes_version.go
+++ b/modules/040-control-plane-manager/hooks/effective_kubernetes_version.go
@@ -303,7 +303,8 @@ func handleEffectiveK8sVersion(input *go_hook.HookInput, dc dependency.Container
 }
 
 // process control plane pods snapshot with annotation, gettings minimum and maximum from control-plane-pods
-func ekvProcessPodsSnapshot(input *go_hook.HookInput, dc dependency.Container) (minControlPlaneVersion, maxControlPlaneVersion *semver.Version, err error) {
+// returns minControlPlaneVersion, maxControlPlaneVersion and error
+func ekvProcessPodsSnapshot(input *go_hook.HookInput, dc dependency.Container) (*semver.Version, *semver.Version, error) {
 	snap := input.Snapshots["control_plane_versions"]
 
 	var controlPlaneVersions []controlPlanePod
@@ -346,14 +347,11 @@ func ekvProcessPodsSnapshot(input *go_hook.HookInput, dc dependency.Container) (
 	}
 	sort.Sort(semver.Collection(controlPlaneVs))
 
-	minControlPlaneVersion = controlPlaneVs[0]
-	maxControlPlaneVersion = controlPlaneVs[len(controlPlaneVs)-1]
-
-	return
+	return controlPlaneVs[0], controlPlaneVs[len(controlPlaneVs)-1], nil
 }
 
 // determine minimum and maximum node versions
-func ekvProcessNodeSnapshot(input *go_hook.HookInput) (minNodeVersion, maxNodeVersion *semver.Version, err error) {
+func ekvProcessNodeSnapshot(input *go_hook.HookInput) (*semver.Version /*minNodeVersion*/, *semver.Version /*maxNodeVersion*/, error) {
 	snap := input.Snapshots["node_versions"]
 
 	var nodeVersions []*semver.Version
@@ -366,14 +364,11 @@ func ekvProcessNodeSnapshot(input *go_hook.HookInput) (minNodeVersion, maxNodeVe
 	}
 	sort.Sort(semver.Collection(nodeVersions))
 
-	minNodeVersion = nodeVersions[0]
-	maxNodeVersion = nodeVersions[len(nodeVersions)-1]
-
-	return
+	return nodeVersions[0], nodeVersions[len(nodeVersions)-1], nil
 }
 
 // get semver from secret
-func ekvProcessSecretSnapshot(input *go_hook.HookInput) (maxUsedControlPlaneVersion kubernetesVersionsInSecret) {
+func ekvProcessSecretSnapshot(input *go_hook.HookInput) kubernetesVersionsInSecret {
 	snap := input.Snapshots["max_used_control_plane_version"]
 
 	if len(snap) > 0 && snap[0] != nil {

--- a/modules/040-node-manager/hooks/get_crds.go
+++ b/modules/040-node-manager/hooks/get_crds.go
@@ -543,7 +543,8 @@ var epochTimestampAccessor = func() int64 {
 	return time.Now().Unix()
 }
 
-var detectInstanceClassKind = func(input *go_hook.HookInput, config *go_hook.HookConfig) (inUse string, fromSecret string) {
+var detectInstanceClassKind = func(input *go_hook.HookInput, config *go_hook.HookConfig) (string, string) {
+	var fromSecret string
 	if len(input.Snapshots["cloud_provider_secret"]) > 0 {
 		if secretInfo, ok := input.Snapshots["cloud_provider_secret"][0].(map[string]interface{}); ok {
 			if kind, ok := secretInfo["instanceClassKind"].(string); ok {

--- a/modules/040-node-manager/hooks/get_crds_test.go
+++ b/modules/040-node-manager/hooks/get_crds_test.go
@@ -327,7 +327,7 @@ metadata:
 	// Set Kind for "ics" binding.
 	getCRDsHookConfig.Kubernetes[0].Kind = "D8TestInstanceClass"
 	getCRDsHookConfig.Kubernetes[0].ApiVersion = "deckhouse.io/v1alpha1"
-	detectInstanceClassKind = func(_ *go_hook.HookInput, _ *go_hook.HookConfig) (inUse string, fromSecret string) {
+	detectInstanceClassKind = func(_ *go_hook.HookInput, _ *go_hook.HookConfig) (string, string) {
 		return "D8TestInstanceClass", "D8TestInstanceClass"
 	}
 

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances.go
@@ -323,7 +323,7 @@ func deleteMachines(input *go_hook.HookInput) error {
 	return nil
 }
 
-func getMachinesToDelete(machines []*Machine) (machinesToDelete []string) {
+func getMachinesToDelete(machines []*Machine) []string {
 	sort.Slice(machines, func(i, j int) bool {
 		return machines[i].nodeCreationTimestamp.Before(&machines[j].nodeCreationTimestamp)
 	})
@@ -334,11 +334,14 @@ func getMachinesToDelete(machines []*Machine) (machinesToDelete []string) {
 		batch = 1
 	}
 
+	machinesToDelete := make([]string, 0, batch)
 	for _, currentMachine := range machines {
 		if len(machinesToDelete) < batch {
 			machinesToDelete = append(machinesToDelete, currentMachine.Name)
+		} else {
+			break
 		}
 	}
 
-	return
+	return machinesToDelete
 }

--- a/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy.go
+++ b/modules/150-user-authn/hooks/delete_crowd_basic_auth_proxy.go
@@ -57,12 +57,13 @@ func filterIngressName(obj *unstructured.Unstructured) (go_hook.FilterResult, er
 	return ingress.Name, nil
 }
 
-func deleteCrowdIngress(input *go_hook.HookInput) (err error) {
+func deleteCrowdIngress(input *go_hook.HookInput) error {
 	for _, snap := range input.Snapshots["crowd-proxy-ingress"] {
 		if snap == nil {
 			continue
 		}
 		input.PatchCollector.Delete("networking.k8s.io/v1", "Ingress", "d8-user-authn", snap.(string))
 	}
+
 	return nil
 }

--- a/modules/300-prometheus/hooks/disk_metrics.go
+++ b/modules/300-prometheus/hooks/disk_metrics.go
@@ -144,9 +144,13 @@ func prometheusDiskMetrics(input *go_hook.HookInput, dc dependency.Container) er
 	return nil
 }
 
-func getFsInfo(input *go_hook.HookInput, kubeClient k8s.Client, pod PodFilter) (fsSizeBytes, fsUsedBytes, fsUsedPercent float64) {
-	containerName := "prometheus"
-	command := "df -PB1 /prometheus/"
+func getFsInfo(input *go_hook.HookInput, kubeClient k8s.Client, pod PodFilter) (float64, float64, float64) {
+	var (
+		command                                 = "df -PB1 /prometheus/"
+		containerName                           = "prometheus"
+		fsSizeBytes, fsUsedBytes, fsUsedPercent float64
+	)
+
 	output, _, err := execToPodThroughAPI(kubeClient, command, containerName, pod.Name, pod.Namespace)
 	if err != nil {
 		input.Logger.Warnf("%s: %s", pod.Name, err.Error())
@@ -160,7 +164,8 @@ func getFsInfo(input *go_hook.HookInput, kubeClient k8s.Client, pod PodFilter) (
 			}
 		}
 	}
-	return
+
+	return fsSizeBytes, fsUsedBytes, fsUsedPercent
 }
 
 func execToPodThroughAPI(kubeClient k8s.Client, command, containerName, podName, namespace string) (string, string, error) {

--- a/modules/300-prometheus/hooks/grafana_alerts_channels.go
+++ b/modules/300-prometheus/hooks/grafana_alerts_channels.go
@@ -56,9 +56,9 @@ type GrafanaAlertsChannelsConfig struct {
 	Notifiers []*GrafanaAlertsChannel `json:"notifiers"`
 }
 
-func getChannelSettings(notifyChannel *v1alpha1.GrafanaAlertsChannel) (settings map[string]interface{}, secureSettings map[string]interface{}) {
-	settings = make(map[string]interface{})
-	secureSettings = make(map[string]interface{})
+func getChannelSettings(notifyChannel *v1alpha1.GrafanaAlertsChannel) (map[string]interface{}, map[string]interface{}) {
+	settings := make(map[string]interface{})
+	secureSettings := make(map[string]interface{})
 
 	if notifyChannel.Spec.Type == "PrometheusAlertManager" {
 		alertManager := notifyChannel.Spec.AlertManager

--- a/modules/402-ingress-nginx/hooks/alert_deprecated_geoip_version.go
+++ b/modules/402-ingress-nginx/hooks/alert_deprecated_geoip_version.go
@@ -88,7 +88,7 @@ func inletHostWithFailoverFilter(obj *unstructured.Unstructured) (go_hook.Filter
 	return controller, nil
 }
 
-func searchForDeprecatedGeoip(input *go_hook.HookInput, dc dependency.Container) (err error) {
+func searchForDeprecatedGeoip(input *go_hook.HookInput, dc dependency.Container) error {
 	kubeClient := dc.MustGetK8sClient()
 	input.MetricsCollector.Expire(metricsGroup)
 	defaultVersion, err := semver.NewVersion(input.Values.Get("ingressNginx.defaultControllerVersion").String())

--- a/modules/402-ingress-nginx/hooks/chaos_monkey.go
+++ b/modules/402-ingress-nginx/hooks/chaos_monkey.go
@@ -98,7 +98,7 @@ func applyIngressDaemonSetFilter(obj *unstructured.Unstructured) (go_hook.Filter
 
 	err := sdk.FromUnstructured(obj, d)
 	if err != nil {
-		return nil, fmt.Errorf("cannot convert kubernetes object: %v", err)
+		return nil, fmt.Errorf("cannot convert kubernetes object: %w", err)
 	}
 
 	return ingressDaemonSetFilterResult{
@@ -109,7 +109,7 @@ func applyIngressDaemonSetFilter(obj *unstructured.Unstructured) (go_hook.Filter
 	}, nil
 }
 
-func chaosMonkey(input *go_hook.HookInput, dc dependency.Container) (err error) {
+func chaosMonkey(input *go_hook.HookInput, dc dependency.Container) error {
 	controllers := input.Snapshots["controllers"]
 	daemonsets := input.Snapshots["daemonsets"]
 
@@ -136,9 +136,7 @@ func chaosMonkey(input *go_hook.HookInput, dc dependency.Container) (err error) 
 			continue
 		}
 
-		podList, err := kubeClient.CoreV1().
-			Pods(internal.Namespace).
-			List(context.TODO(), metav1.ListOptions{LabelSelector: labels.FormatLabels(res.LabelSelector)})
+		podList, err := kubeClient.CoreV1().Pods(internal.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.FormatLabels(res.LabelSelector)})
 		if err != nil {
 			return err
 		}
@@ -155,9 +153,7 @@ func chaosMonkey(input *go_hook.HookInput, dc dependency.Container) (err error) 
 			}
 		}
 
-		err = kubeClient.CoreV1().
-			Pods(internal.Namespace).
-			EvictV1(context.TODO(), &policyv1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: oldestPod.Name}})
+		err = kubeClient.CoreV1().Pods(internal.Namespace).EvictV1(context.TODO(), &policyv1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: oldestPod.Name}})
 		if err != nil {
 			input.Logger.Infof("can't evict ingress controller pod %q: %v", oldestPod.Name, err)
 		}

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
@@ -87,7 +87,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	},
 }, safeControllerUpdate)
 
-func safeControllerUpdate(input *go_hook.HookInput) (err error) {
+func safeControllerUpdate(input *go_hook.HookInput) error {
 	controllerPods := input.Snapshots["for_delete"]
 	if len(controllerPods) == 0 {
 		return nil

--- a/testing/hooks/matchers.go
+++ b/testing/hooks/matchers.go
@@ -32,7 +32,7 @@ type successfulExecutionMatcher struct {
 	path int
 }
 
-func (matcher *successfulExecutionMatcher) Match(actual interface{}) (success bool, err error) {
+func (matcher *successfulExecutionMatcher) Match(actual interface{}) (bool, error) {
 	hec, ok := actual.(*HookExecutionConfig)
 	if !ok {
 		return false, fmt.Errorf("matcher ExecuteSuccessfully expects a *HookExecutionConfig")
@@ -54,7 +54,7 @@ func (matcher *successfulExecutionMatcher) Match(actual interface{}) (success bo
 	return false, nil
 }
 
-func (matcher *successfulExecutionMatcher) FailureMessage(actual interface{}) (message string) {
+func (matcher *successfulExecutionMatcher) FailureMessage(actual interface{}) string {
 	hec := actual.(*HookExecutionConfig)
 	if hec.GoHook != nil && hec.GoHookError != nil {
 		return fmt.Sprintf("Expected\n\t%v\n to be nil", hec.GoHookError)
@@ -63,7 +63,7 @@ func (matcher *successfulExecutionMatcher) FailureMessage(actual interface{}) (m
 	return fmt.Sprintf("Expected\n\t%v\nto be zero", actual.(*HookExecutionConfig).Session.ExitCode())
 }
 
-func (matcher *successfulExecutionMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (matcher *successfulExecutionMatcher) NegatedFailureMessage(actual interface{}) string {
 	hec := actual.(*HookExecutionConfig)
 	if hec.GoHook != nil && hec.GoHookError == nil {
 		return fmt.Sprintf("Expected\n\t%v\nnot to be nil", hec.GoHookError)

--- a/testing/hooks/tmpdir.go
+++ b/testing/hooks/tmpdir.go
@@ -44,7 +44,7 @@ func nextRandom() string {
 	return strconv.Itoa(int(1e9 + r%1e9))[1:]
 }
 
-func TempFileWithPerms(dir, pattern string, perms int) (f *os.File, err error) {
+func TempFileWithPerms(dir, pattern string, perms int) (*os.File, error) {
 	if dir == "" {
 		dir = os.TempDir()
 	}
@@ -56,7 +56,12 @@ func TempFileWithPerms(dir, pattern string, perms int) (f *os.File, err error) {
 		prefix = pattern
 	}
 
-	nconflict := 0
+	var (
+		nconflict = 0
+		f         = new(os.File)
+		err       error
+	)
+
 	for i := 0; i < 10000; i++ {
 		name := filepath.Join(dir, prefix+nextRandom()+suffix)
 		f, err = os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, os.FileMode(perms))
@@ -70,15 +75,21 @@ func TempFileWithPerms(dir, pattern string, perms int) (f *os.File, err error) {
 		}
 		break
 	}
-	return
+
+	return f, err
 }
 
-func TempDirWithPerms(dir, prefix string, perms int) (name string, err error) {
+func TempDirWithPerms(dir, prefix string, perms int) (string, error) {
 	if dir == "" {
 		dir = os.TempDir()
 	}
 
-	nconflict := 0
+	var (
+		nconflict = 0
+		err       error
+		name      string
+	)
+
 	for i := 0; i < 10000; i++ {
 		try := filepath.Join(dir, prefix+nextRandom())
 		err = os.Mkdir(try, os.FileMode(perms))
@@ -100,5 +111,6 @@ func TempDirWithPerms(dir, prefix string, perms int) (name string, err error) {
 		}
 		break
 	}
-	return
+
+	return name, err
 }

--- a/testing/library/helm/log.go
+++ b/testing/library/helm/log.go
@@ -29,7 +29,7 @@ type FilteredHelmWriter struct {
 
 var _ io.Writer = (*FilteredHelmWriter)(nil)
 
-func (w *FilteredHelmWriter) Write(p []byte) (n int, err error) {
+func (w *FilteredHelmWriter) Write(p []byte) (int, error) {
 	builder := strings.Builder{}
 
 	scanner := bufio.NewScanner(bytes.NewReader(p))

--- a/testing/library/helm/render.go
+++ b/testing/library/helm/render.go
@@ -37,7 +37,7 @@ type Renderer struct {
 	LintMode  bool
 }
 
-func (r Renderer) RenderChartFromDir(dir string, values string) (files map[string]string, err error) {
+func (r Renderer) RenderChartFromDir(dir string, values string) (map[string]string, error) {
 	c, err := loader.Load(dir)
 	if err != nil {
 		panic(fmt.Errorf("chart load from '%s': %v", dir, err))
@@ -45,10 +45,10 @@ func (r Renderer) RenderChartFromDir(dir string, values string) (files map[strin
 	return r.RenderChart(c, values)
 }
 
-func (r Renderer) RenderChart(c *chart.Chart, values string) (files map[string]string, err error) {
+func (r Renderer) RenderChart(c *chart.Chart, values string) (map[string]string, error) {
 	vals, err := chartutil.ReadValues([]byte(values))
 	if err != nil {
-		return nil, fmt.Errorf("helm chart read raw values: %v", err)
+		return nil, fmt.Errorf("helm chart read raw values: %w", err)
 	}
 
 	releaseName := "release"
@@ -81,20 +81,20 @@ func (r Renderer) RenderChart(c *chart.Chart, values string) (files map[string]s
 
 	valuesToRender, err := chartutil.ToRenderValues(c, vals, releaseOptions, nil)
 	if err != nil {
-		return nil, fmt.Errorf("helm chart prepare render values: %v", err)
+		return nil, fmt.Errorf("helm chart prepare render values: %w", err)
 	}
 
 	return r.RenderChartFromRawValues(c, valuesToRender)
 }
 
-func (r Renderer) RenderChartFromRawValues(c *chart.Chart, values chartutil.Values) (files map[string]string, err error) {
+func (r Renderer) RenderChartFromRawValues(c *chart.Chart, values chartutil.Values) (map[string]string, error) {
 	// render chart with prepared values
 	var e engine.Engine
 	e.LintMode = r.LintMode
 
 	out, err := e.Render(c, values)
 	if err != nil {
-		return nil, fmt.Errorf("helm chart render: %v", err)
+		return nil, fmt.Errorf("helm chart render: %w", err)
 	}
 
 	return out, nil

--- a/testing/library/object_store/store.go
+++ b/testing/library/object_store/store.go
@@ -84,10 +84,10 @@ func (store ObjectStore) DeleteObject(index MetaIndex) {
 	delete(store, normalizeMetaIndex(index))
 }
 
-func (store ObjectStore) RetrieveObjectByMetaIndex(index MetaIndex) (object KubeObject, exists bool) {
-	object, exists = store[index]
+func (store ObjectStore) RetrieveObjectByMetaIndex(index MetaIndex) (KubeObject, bool) {
+	object, exists := store[index]
 
-	return
+	return object, exists
 }
 
 func (store ObjectStore) KubernetesGlobalResource(kind, name string) KubeObject {

--- a/testing/matrix/linter/rules/modules/prometheus_rules.go
+++ b/testing/matrix/linter/rules/modules/prometheus_rules.go
@@ -73,7 +73,7 @@ func marshalChartYaml(object storage.StoreObject) ([]byte, error) {
 	return marshal, nil
 }
 
-func writeTempRuleFileFromObject(m utils.Module, marshalledYaml []byte) (path string, err error) {
+func writeTempRuleFileFromObject(m utils.Module, marshalledYaml []byte) (string, error) {
 	renderedFile, err := os.CreateTemp("", m.Name+".*.yml")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Adds nonamedreturns linter to the deckhouse repository.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
For the sake of readability.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Ceased using of named returns (except for in defer calls) and naked rerturns.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Add nonamedreturns linter and corresponding fixes.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
