### PR TITLE
[monitoring-kubernetes] Node label for EbpfExporterKernelNotSupported alert

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/ebpf-exporter.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/ebpf-exporter.yaml
@@ -26,7 +26,7 @@
         max by (uid) (label_replace(ebpf_exporter_oom_kills{cgroup_path=~".*burstable.*"}, "uid", "$1", "cgroup_path", ".+burstable/pod(.*)"))
       )
   - alert: EbpfExporterKernelNotSupported
-    expr: min by (job) (ebpf_exporter_btf_support_unavailable_in_kernel{job="ebpf-exporter"}) == 1
+    expr: min by (job, node) (ebpf_exporter_btf_support_unavailable_in_kernel{job="ebpf-exporter"}) == 1
     for: 3m
     labels:
       severity_level: "8"

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/ebpf-exporter.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/ebpf-exporter.yaml
@@ -36,8 +36,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_ebpf_exporter_malfunctioning: "EbpfExporterKernelNotSupportedGroup,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_grouped_by__d8_ebpf_exporter_malfunctioning: "EbpfExporterKernelNotSupportedGroup,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_create_group_if_not_exists__d8_ebpf_exporter_malfunctioning: "EbpfExporterKernelNotSupportedGroup,tier=cluster, node={{ $labels.node }},prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_ebpf_exporter_malfunctioning: "EbpfExporterKernelNotSupportedGroup,tier=cluster, node={{ $labels.node }},prometheus=deckhouse,kubernetes=~kubernetes"
       plk_labels_as_annotations: "job"
       summary: >
         The BTF module required for ebpf_exporter is missing in the kernel.


### PR DESCRIPTION
## Description
Add node label for EbpfExporterKernelNotSupported alert.

## Why do we need it, and what problem does it solve?
To make EbpfExporterKernelNotSupported more informative for better debugging.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## What is the expected result?
Node label in alerts description.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes]
type: chore
summary: Add node label for EbpfExporterKernelNotSupported alert
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
