### PR TITLE
[cni] Add CNI cleaner

### DIFF
--- a/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
+++ b/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
@@ -35,6 +35,20 @@ shell:
     - cd /src
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /entrypoint main.go
 ---
+artifact: {{ .ModuleName }}/wrapper-artifact
+from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
+git:
+- add: /{{ .ModulePath }}modules/035-cni-flannel/images/flanneld/wrapper
+  to: /src
+  stageDependencies:
+    install:
+      - '**/*'
+shell:
+  install:
+    - export GOPROXY={{ $.GOPROXY }}
+    - cd /src
+    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /wrapper main.go
+---
 artifact: {{ .ModuleName }}/flanneld-artifact
 from: {{ .Images.BASE_GOLANG_20_ALPINE_DEV }}
 shell:
@@ -75,5 +89,9 @@ import:
   add: /entrypoint
   to: /entrypoint
   before: setup
+- artifact: {{ .ModuleName }}/wrapper-artifact
+  add: /wrapper
+  to: /wrapper
+  before: setup
 docker:
-  ENTRYPOINT: ["/entrypoint"]
+  ENTRYPOINT: ["/wrapper"]

--- a/modules/035-cni-flannel/images/flanneld/wrapper/go.mod
+++ b/modules/035-cni-flannel/images/flanneld/wrapper/go.mod
@@ -1,0 +1,9 @@
+module cni-cleaner
+
+go 1.23.3
+
+require (
+	github.com/vishvananda/netlink v1.3.0 // direct
+	github.com/vishvananda/netns v0.0.4 // indirect
+	golang.org/x/sys v0.10.0 // indirect
+)

--- a/modules/035-cni-flannel/images/flanneld/wrapper/go.sum
+++ b/modules/035-cni-flannel/images/flanneld/wrapper/go.sum
@@ -1,0 +1,7 @@
+github.com/vishvananda/netlink v1.3.0 h1:X7l42GfcV4S6E4vHTsw48qbrV+9PVojNfIhZcwQdrZk=
+github.com/vishvananda/netlink v1.3.0/go.mod h1:i6NetklAujEcC6fK0JPjT8qSwWyO0HLn4UKG+hGqeJs=
+github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
+github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/modules/035-cni-flannel/images/flanneld/wrapper/main.go
+++ b/modules/035-cni-flannel/images/flanneld/wrapper/main.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+func runWrapper(done chan<- error, pidChan chan<- int) {
+	cmd := exec.Command("/entrypoint", os.Args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+
+	err := cmd.Start()
+	if err != nil {
+		done <- err
+		return
+	}
+
+	pidChan <- cmd.Process.Pid
+	log.Printf("Wrapper started with PID: %d", cmd.Process.Pid)
+
+	done <- cmd.Wait()
+}
+
+func deleteInterface() {
+	interfaceName := "cni0"
+	link, err := netlink.LinkByName(interfaceName)
+	if err == nil {
+		if err := netlink.LinkDel(link); err != nil {
+			log.Printf("failed to delete interface %s: %v", link.Attrs().Name, err)
+		} else {
+			log.Printf("interface removed: %s", link.Attrs().Name)
+		}
+	}
+}
+
+func deleteConfigFiles() {
+	configsDir := "/etc/cni/net.d/"
+	files, _ := os.ReadDir(configsDir)
+	for _, file := range files {
+		if strings.Contains(file.Name(), "flannel") {
+			fullPath := filepath.Join(configsDir, file.Name())
+			if err := os.Remove(fullPath); err != nil {
+				log.Printf("failed to delete configuration file %s: %v", fullPath, err)
+			} else {
+				log.Printf("configuration file removed: %s", fullPath)
+			}
+		}
+	}
+}
+
+func main() {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	pidChan := make(chan int, 1)
+	wrapperDone := make(chan error, 1)
+	go runWrapper(wrapperDone, pidChan)
+
+	select {
+	case sig := <-sigCh:
+		log.Printf("Received signal: %v", sig)
+
+		p, err := os.FindProcess(<-pidChan)
+		if err == nil {
+			if err := p.Signal(syscall.SIGTERM); err != nil {
+				log.Printf("error sending SIGTERM to wrapper: %v", err)
+			}
+		}
+
+		select {
+		case err := <-wrapperDone:
+			if err != nil {
+				log.Printf("wrapper exited with error: %v", err)
+			} else {
+				log.Println("wrapper exited gracefully")
+			}
+		case <-time.After(15 * time.Second):
+			log.Println("timeout waiting for wrapper to exit, killing it")
+			if err := p.Kill(); err != nil {
+				log.Printf("error killing wrapper: %v", err)
+			}
+		}
+
+	case err := <-wrapperDone:
+		if err != nil {
+			log.Printf("wrapper exited with error: %v", err)
+		} else {
+			log.Println("wrapper exited")
+		}
+	}
+
+	log.Println("start system cleaning")
+	// deleteInterface()
+	// deleteConfigFiles()
+}


### PR DESCRIPTION
Signed-off-by: Denis Tarabrin <denis.tarabrin@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
