### PR TITLE
Cilium add label for pod ip priority management

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-managment.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-managment.patch
@@ -1,0 +1,1349 @@
+From 66712fdc2c9e84c437a14246e1c170794a3053d0 Mon Sep 17 00:00:00 2001
+From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
+Date: Thu, 16 Jan 2025 10:42:38 +0300
+Subject: [PATCH] add: pod prioroty managment what shared single ip4 address
+
+Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
+---
+ cilium/cmd/bpf_endpoint_delete.go             |   2 +-
+ cilium/cmd/bpf_endpoint_list.go               |   2 +-
+ daemon/cmd/daemon.go                          |   4 +
+ daemon/cmd/datapath.go                        |   2 +-
+ daemon/cmd/state.go                           |   2 +-
+ daemon/cmd/status.go                          |   2 +-
+ .../pkg/ciliumendpointslice/endpointslice.go  |   2 +
+ operator/pkg/ciliumendpointslice/manager.go   |  20 +-
+ .../pkg/ciliumendpointslice/manager_test.go   |  42 +--
+ operator/watchers/cilium_endpoint.go          | 193 +++++++++-
+ pkg/datapath/alignchecker/alignchecker.go     |   2 +-
+ pkg/datapath/linux/config/config.go           |   2 +-
+ pkg/endpoint/bpf.go                           |   2 +-
+ pkg/endpoint/endpoint.go                      |   2 +-
+ pkg/ipcache/ipcache.go                        | 337 ++++++++++++++++++
+ pkg/labels/labels.go                          |   4 +
+ pkg/maps/bwmap/bwmap.go                       |   2 +-
+ pkg/maps/lxcmap/doc.go                        |   9 -
+ pkg/maps/lxcmap/lxcmap.go                     | 239 -------------
+ 19 files changed, 579 insertions(+), 291 deletions(-)
+ delete mode 100644 pkg/maps/lxcmap/doc.go
+ delete mode 100644 pkg/maps/lxcmap/lxcmap.go
+
+diff --git a/cilium/cmd/bpf_endpoint_delete.go b/cilium/cmd/bpf_endpoint_delete.go
+index 9b35099eb9..e7a6d97d16 100644
+--- a/cilium/cmd/bpf_endpoint_delete.go
++++ b/cilium/cmd/bpf_endpoint_delete.go
+@@ -9,7 +9,7 @@ import (
+ 	"github.com/spf13/cobra"
+ 
+ 	"github.com/cilium/cilium/pkg/common"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ )
+ 
+ var bpfEndpointDeleteCmd = &cobra.Command{
+diff --git a/cilium/cmd/bpf_endpoint_list.go b/cilium/cmd/bpf_endpoint_list.go
+index f047affb3c..2f20ad4a04 100644
+--- a/cilium/cmd/bpf_endpoint_list.go
++++ b/cilium/cmd/bpf_endpoint_list.go
+@@ -10,7 +10,7 @@ import (
+ 
+ 	"github.com/cilium/cilium/pkg/command"
+ 	"github.com/cilium/cilium/pkg/common"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ )
+ 
+ const (
+diff --git a/daemon/cmd/daemon.go b/daemon/cmd/daemon.go
+index 16bb59e973..e8b3068d9d 100644
+--- a/daemon/cmd/daemon.go
++++ b/daemon/cmd/daemon.go
+@@ -72,6 +72,8 @@ import (
+ 	"github.com/cilium/cilium/pkg/maps/ctmap"
+ 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
+ 	"github.com/cilium/cilium/pkg/maps/lbmap"
++
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	"github.com/cilium/cilium/pkg/maps/policymap"
+ 	"github.com/cilium/cilium/pkg/metrics"
+ 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
+@@ -546,6 +548,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
+ 		authManager:          params.AuthManager,
+ 	}
+ 
++	lxcmap.SetGlobalIPCache(d.ipcache)
++
+ 	d.configModifyQueue = eventqueue.NewEventQueueBuffered("config-modify-queue", ConfigModifyQueueSize)
+ 	d.configModifyQueue.Run()
+ 
+diff --git a/daemon/cmd/datapath.go b/daemon/cmd/datapath.go
+index 073bc25d89..be12a8e06b 100644
+--- a/daemon/cmd/datapath.go
++++ b/daemon/cmd/datapath.go
+@@ -26,6 +26,7 @@ import (
+ 	"github.com/cilium/cilium/pkg/identity"
+ 	ippkg "github.com/cilium/cilium/pkg/ip"
+ 	"github.com/cilium/cilium/pkg/ipcache"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
+ 	"github.com/cilium/cilium/pkg/labels"
+ 	"github.com/cilium/cilium/pkg/logging/logfields"
+@@ -34,7 +35,6 @@ import (
+ 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
+ 	"github.com/cilium/cilium/pkg/maps/ipmasq"
+ 	"github.com/cilium/cilium/pkg/maps/lbmap"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
+ 	"github.com/cilium/cilium/pkg/maps/metricsmap"
+ 	"github.com/cilium/cilium/pkg/maps/nat"
+ 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
+diff --git a/daemon/cmd/state.go b/daemon/cmd/state.go
+index c3fa2d23c0..c623c48060 100644
+--- a/daemon/cmd/state.go
++++ b/daemon/cmd/state.go
+@@ -19,6 +19,7 @@ import (
+ 	"github.com/cilium/cilium/pkg/controller"
+ 	"github.com/cilium/cilium/pkg/endpoint"
+ 	"github.com/cilium/cilium/pkg/ipam"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	"github.com/cilium/cilium/pkg/k8s"
+ 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+ 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
+@@ -26,7 +27,6 @@ import (
+ 	"github.com/cilium/cilium/pkg/lock"
+ 	"github.com/cilium/cilium/pkg/logging/logfields"
+ 	"github.com/cilium/cilium/pkg/maps/ctmap"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
+ 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+ 	"github.com/cilium/cilium/pkg/option"
+ )
+diff --git a/daemon/cmd/status.go b/daemon/cmd/status.go
+index 77f4e60d15..c58ba01d72 100644
+--- a/daemon/cmd/status.go
++++ b/daemon/cmd/status.go
+@@ -21,6 +21,7 @@ import (
+ 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
+ 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+ 	"github.com/cilium/cilium/pkg/identity"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
+ 	"github.com/cilium/cilium/pkg/kvstore"
+ 	"github.com/cilium/cilium/pkg/lock"
+@@ -28,7 +29,6 @@ import (
+ 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
+ 	ipmasqmap "github.com/cilium/cilium/pkg/maps/ipmasq"
+ 	"github.com/cilium/cilium/pkg/maps/lbmap"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
+ 	"github.com/cilium/cilium/pkg/maps/metricsmap"
+ 	"github.com/cilium/cilium/pkg/maps/timestamp"
+ 	tunnelmap "github.com/cilium/cilium/pkg/maps/tunnel"
+diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
+index de0288ef1f..9acb023a61 100644
+--- a/operator/pkg/ciliumendpointslice/endpointslice.go
++++ b/operator/pkg/ciliumendpointslice/endpointslice.go
+@@ -55,6 +55,8 @@ const (
+ 	// Default CES Synctime, multiple consecutive syncs with k8s-apiserver are
+ 	// batched and synced together after a short delay.
+ 	DefaultCESSyncTime = 500 * time.Millisecond
++	// Force CES update
++	ForceCESSyncTime = 5 * time.Millisecond
+ )
+ 
+ var (
+diff --git a/operator/pkg/ciliumendpointslice/manager.go b/operator/pkg/ciliumendpointslice/manager.go
+index 6de6fb7166..3e618b2478 100644
+--- a/operator/pkg/ciliumendpointslice/manager.go
++++ b/operator/pkg/ciliumendpointslice/manager.go
+@@ -47,7 +47,7 @@ type cesTracker struct {
+ // operations is an interface to all operations that a CES manager can perform.
+ type operations interface {
+ 	// External APIs to Insert/Remove CEP in local dataStore
+-	InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string) string
++	InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string, baseDelay time.Duration) string
+ 	updateCEPToCESMapping(cepName string, cesName string)
+ 	RemoveCEPFromCache(cepName string, baseDelay time.Duration)
+ 	removeCEPFromCES(cepName string, cesName string, baseDelay time.Duration, identity int64, checkIdentity bool)
+@@ -60,7 +60,7 @@ type operations interface {
+ 	getRemovedCEPs(string) map[string]struct{}
+ 	clearRemovedCEPs(string, map[string]struct{})
+ 	createCES(cesName string) *cesTracker
+-	addCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ces *cesTracker)
++	addCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ces *cesTracker, baseDelay time.Duration)
+ 	insertCESInWorkQueue(ces *cesTracker, baseDelay time.Duration)
+ 	// APIs to collect metrics of CES and CEP
+ 	getTotalCEPCount() int
+@@ -149,7 +149,7 @@ func newCESManagerIdentity(workQueue workqueue.RateLimitingInterface, maxCEPsInC
+ 
+ // addCEPtoCES inserts the CEP in a CES, if the CEP already exists in a CES
+ // it replaces with new CEP.
+-func (c *cesMgr) addCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ces *cesTracker) {
++func (c *cesMgr) addCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ces *cesTracker, baseDelay time.Duration) {
+ 	ces.backendMutex.Lock()
+ 	defer ces.backendMutex.Unlock()
+ 	// If cep already exists in ces, compare new cep with cached cep.
+@@ -181,7 +181,7 @@ func (c *cesMgr) addCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ces *cesTracker)
+ 	}
+ 	// Increment the cepInsert counter
+ 	ces.cepInserted += 1
+-	c.insertCESInWorkQueue(ces, DefaultCESSyncTime)
++	c.insertCESInWorkQueue(ces, baseDelay)
+ 	return
+ }
+ 
+@@ -301,7 +301,7 @@ func (c *cesMgr) getCESCopyFromCache(cesName string) (*cilium_v2.CiliumEndpointS
+ 
+ // InsertCEPInCache is used to insert CEP in local cache, this may result in creating a new
+ // CES object or updating an existing CES object.
+-func (c *cesMgr) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string) string {
++func (c *cesMgr) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string, baseDelay time.Duration) string {
+ 	log.WithFields(logrus.Fields{
+ 		logfields.CEPName: GetCEPNameFromCCEP(cep, ns),
+ 	}).Debug("Insert CEP in local cache")
+@@ -312,7 +312,7 @@ func (c *cesMgr) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string)
+ 	if cesName, exists := c.desiredCESs.getCESName(cepName); exists {
+ 		if ces, ok := c.desiredCESs.getCESTracker(cesName); ok {
+ 			// add a cep into the ces
+-			c.addCEPtoCES(cep, ces)
++			c.addCEPtoCES(cep, ces, baseDelay)
+ 			return cesName
+ 		} else {
+ 			log.WithFields(logrus.Fields{
+@@ -345,7 +345,7 @@ func (c *cesMgr) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string)
+ 	c.updateCEPToCESMapping(GetCEPNameFromCCEP(cep, ns), cesName)
+ 
+ 	// Queue the CEP in CES
+-	c.addCEPtoCES(cep, cb)
++	c.addCEPtoCES(cep, cb, baseDelay)
+ 	return cesName
+ }
+ 
+@@ -603,7 +603,7 @@ func (c *cesManagerIdentity) deleteCESFromCache(cesName string) {
+ 
+ // InsertCEPInCache is used to insert CEP in local cache, this may result in creating a new
+ // CES object or updating an existing CES object. CEPs are grouped based on CEP identity.
+-func (c *cesManagerIdentity) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string) string {
++func (c *cesManagerIdentity) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string, baseDelay time.Duration) string {
+ 	// check the given cep is already exists in any of the CES.
+ 	// if yes, compare the given CEP Identity with the CEPs stored in CES.
+ 	// If they are same UPDATE the CEP in the CES. This will trigger CES UPDATE to k8s-apiserver.
+@@ -618,7 +618,7 @@ func (c *cesManagerIdentity) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint,
+ 		} else {
+ 			if ces, ok := c.desiredCESs.getCESTracker(cesName); ok {
+ 				// add a cep into the ces
+-				c.addCEPtoCES(cep, ces)
++				c.addCEPtoCES(cep, ces, baseDelay)
+ 				return cesName
+ 			} else {
+ 				log.WithFields(logrus.Fields{
+@@ -669,7 +669,7 @@ func (c *cesManagerIdentity) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint,
+ 	c.desiredCESs.insertCEP(GetCEPNameFromCCEP(cep, ns), cesName)
+ 
+ 	// Queue the CEP in CES
+-	c.addCEPtoCES(cep, cb)
++	c.addCEPtoCES(cep, cb, baseDelay)
+ 	return cesName
+ }
+ 
+diff --git a/operator/pkg/ciliumendpointslice/manager_test.go b/operator/pkg/ciliumendpointslice/manager_test.go
+index bf47c44de9..ece7d4a286 100644
+--- a/operator/pkg/ciliumendpointslice/manager_test.go
++++ b/operator/pkg/ciliumendpointslice/manager_test.go
+@@ -73,9 +73,9 @@ func TestInsertAndRemoveCEPsInCache(t *testing.T) {
+ 	// Insert CEPs in Cache and count total number of CES and CEP
+ 	t.Run("Test Inserting CEPs in cache and count number of CEPs and CESs", func(*testing.T) {
+ 		m := newCESManagerFcfs(newQueue(), 2)
+-		m.InsertCEPInCache(cep1, "kube-system")
+-		m.InsertCEPInCache(cep2, "kube-system")
+-		m.InsertCEPInCache(cep3, "kube-system")
++		m.InsertCEPInCache(cep1, "kube-system", DefaultCESSyncTime)
++		m.InsertCEPInCache(cep2, "kube-system", DefaultCESSyncTime)
++		m.InsertCEPInCache(cep3, "kube-system", DefaultCESSyncTime)
+ 		assert.Equal(t, m.getCESCount(), 2, "Total number of CESs allocated is 2")
+ 		assert.Equal(t, m.getTotalCEPCount(), 3, "Total number of CEPs inserted is 3")
+ 	})
+@@ -84,15 +84,15 @@ func TestInsertAndRemoveCEPsInCache(t *testing.T) {
+ 	t.Run("Test Removing CEPs from cache and check number of CEPs and CESs", func(*testing.T) {
+ 		m := newCESManagerFcfs(newQueue(), 2)
+ 		u := newDesiredCESMap()
+-		cn := m.InsertCEPInCache(cep1, "kube-system")
++		cn := m.InsertCEPInCache(cep1, "kube-system", DefaultCESSyncTime)
+ 		u.insertCEP(cep1.Name, cn)
+-		cn = m.InsertCEPInCache(cep2, "kube-system")
++		cn = m.InsertCEPInCache(cep2, "kube-system", DefaultCESSyncTime)
+ 		u.insertCEP(cep2.Name, cn)
+-		cn = m.InsertCEPInCache(cep3, "kube-system")
++		cn = m.InsertCEPInCache(cep3, "kube-system", DefaultCESSyncTime)
+ 		u.insertCEP(cep3.Name, cn)
+-		cn = m.InsertCEPInCache(cep4, "kube-system")
++		cn = m.InsertCEPInCache(cep4, "kube-system", DefaultCESSyncTime)
+ 		u.insertCEP(cep4.Name, cn)
+-		cn = m.InsertCEPInCache(cep5, "kube-system")
++		cn = m.InsertCEPInCache(cep5, "kube-system", DefaultCESSyncTime)
+ 		u.insertCEP(cep5.Name, cn)
+ 		// Check all 5 CEP are inserted
+ 		assert.Equal(t, m.getCESCount(), 3, "Total number of CESs allocated is 3")
+@@ -148,7 +148,7 @@ func TestInsertAndRemoveCEPsInCache(t *testing.T) {
+ 			newCES := m.createCES(cesName)
+ 			newCES.ces.Namespace = ns
+ 			for _, cep := range cepList {
+-				m.addCEPtoCES(&cep, newCES)
++				m.addCEPtoCES(&cep, newCES, DefaultCESSyncTime)
+ 			}
+ 
+ 			m.updateCESInCache(newCES.ces, true)
+@@ -162,15 +162,15 @@ func TestInsertAndRemoveCEPsInCache(t *testing.T) {
+ 		ces5 := createCES("ces5", "namespace-a", []capi_v2a1.CoreCiliumEndpoint{*cep3})
+ 
+ 		// All CEPs should be added to the same CES (ces2) in default namespace.
+-		m.InsertCEPInCache(cep4, "default")
++		m.InsertCEPInCache(cep4, "default", DefaultCESSyncTime)
+ 		assert.Equal(t, 3, len(ces2.ces.Endpoints), "The largest CES in default namespace has 3 CEPs")
+-		m.InsertCEPInCache(cep5, "default")
++		m.InsertCEPInCache(cep5, "default", DefaultCESSyncTime)
+ 		assert.Equal(t, 4, len(ces2.ces.Endpoints), "The largest CES in default namespace has 4 CEPs")
+-		m.InsertCEPInCache(cep1a, "default")
++		m.InsertCEPInCache(cep1a, "default", DefaultCESSyncTime)
+ 		assert.Equal(t, 5, len(ces2.ces.Endpoints), "The largest CES in default namespace has 5 CEPs")
+ 
+ 		// All CEPs should be added to the same CES (ces4) in namespace-a.
+-		m.InsertCEPInCache(cep4, "namespace-a")
++		m.InsertCEPInCache(cep4, "namespace-a", DefaultCESSyncTime)
+ 		assert.Equal(t, 3, len(ces4.ces.Endpoints), "The largest CES in namespace-a has 3 CEPs")
+ 		assert.Equal(t, 5, len(ces2.ces.Endpoints), "The largest CES in default namespace still has 5 CEPs")
+ 
+@@ -185,8 +185,8 @@ func TestDeepCopyCEPs(t *testing.T) {
+ 	// Insert CEPs in Cache, then do the deep copy and compare CESs.
+ 	t.Run("Test Inserting CEPs in cache and count number of CEPs and CESs", func(*testing.T) {
+ 		m := newCESManagerFcfs(newQueue(), 2)
+-		m.InsertCEPInCache(cep1, "kube-system")
+-		cn := m.InsertCEPInCache(cep2, "kube-system")
++		m.InsertCEPInCache(cep1, "kube-system", DefaultCESSyncTime)
++		cn := m.InsertCEPInCache(cep2, "kube-system", DefaultCESSyncTime)
+ 		ces, _ := m.getCESFromCache(cn)
+ 		assert.Equal(t, m.getCESCount(), 1, "Total number of CESs allocated is 1")
+ 		assert.Equal(t, m.getTotalCEPCount(), 2, "Total number of CEPs inserted is 2")
+@@ -206,10 +206,10 @@ func TestDeepCopyCEPs(t *testing.T) {
+ 		assert.Equal(t, ces.DeepEqual(CES), true, "Local CES should match with CES in datastore")
+ 
+ 		m1 := newCESManagerIdentity(newQueue(), 2)
+-		m1.InsertCEPInCache(cep1, "kube-system")
+-		m1.InsertCEPInCache(cep1a, "kube-system")
+-		m1.InsertCEPInCache(cep2b, "kube-system")
+-		cn = m1.InsertCEPInCache(cep2, "kube-system")
++		m1.InsertCEPInCache(cep1, "kube-system", DefaultCESSyncTime)
++		m1.InsertCEPInCache(cep1a, "kube-system", DefaultCESSyncTime)
++		m1.InsertCEPInCache(cep2b, "kube-system", DefaultCESSyncTime)
++		cn = m1.InsertCEPInCache(cep2, "kube-system", DefaultCESSyncTime)
+ 		ces, _ = m1.getCESFromCache(cn)
+ 		assert.Equal(t, m1.getCESCount(), 2, "Total number of CESs allocated is 2")
+ 		assert.Equal(t, m1.getTotalCEPCount(), 4, "Total number of CEPs inserted is 4")
+@@ -233,8 +233,8 @@ func TestDeepCopyCEPs(t *testing.T) {
+ func TestRemovedCEPs(t *testing.T) {
+ 	t.Run("Test Deleting CEPs and Insert", func(*testing.T) {
+ 		m := newCESManagerFcfs(newQueue(), 2)
+-		m.InsertCEPInCache(cep1, "kube-system")
+-		cesName := m.InsertCEPInCache(cep2, "kube-system")
++		m.InsertCEPInCache(cep1, "kube-system", DefaultCESSyncTime)
++		cesName := m.InsertCEPInCache(cep2, "kube-system", DefaultCESSyncTime)
+ 		m.RemoveCEPFromCache(GetCEPNameFromCCEP(cep1, "kube-system"), DefaultCESSyncTime)
+ 		m.RemoveCEPFromCache(GetCEPNameFromCCEP(cep2, "kube-system"), DefaultCESSyncTime)
+ 		remCEPs := m.getRemovedCEPs(cesName)
+diff --git a/operator/watchers/cilium_endpoint.go b/operator/watchers/cilium_endpoint.go
+index 7c1b240f77..43878ae90a 100644
+--- a/operator/watchers/cilium_endpoint.go
++++ b/operator/watchers/cilium_endpoint.go
+@@ -7,8 +7,11 @@ import (
+ 	"context"
+ 	"errors"
+ 	"fmt"
++	"math"
+ 	"strconv"
++	"strings"
+ 	"sync"
++	"time"
+ 
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/client-go/tools/cache"
+@@ -19,8 +22,10 @@ import (
+ 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+ 	"github.com/cilium/cilium/pkg/k8s/informer"
+ 	"github.com/cilium/cilium/pkg/k8s/utils"
++	"github.com/cilium/cilium/pkg/labels"
+ 	"github.com/cilium/cilium/pkg/logging/logfields"
+ 	"github.com/cilium/cilium/pkg/option"
++	"github.com/sirupsen/logrus"
+ )
+ 
+ const identityIndex = "identity"
+@@ -73,6 +78,10 @@ func identityIndexFunc(obj interface{}) ([]string, error) {
+ // CiliumEndpointsInit starts a CiliumEndpointWatcher
+ func CiliumEndpointsInit(ctx context.Context, wg *sync.WaitGroup, clientset k8sClient.Clientset) {
+ 	once.Do(func() {
++		filter = priorityFilter{
++			ipToCepList: make(map[string][]coreCiliumEndpointInfo),
++		}
++
+ 		CiliumEndpointStore = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, indexers)
+ 
+ 		var cacheResourceHandler cache.ResourceEventHandlerFuncs
+@@ -88,7 +97,7 @@ func CiliumEndpointsInit(ctx context.Context, wg *sync.WaitGroup, clientset k8sC
+ 				UpdateFunc: func(oldObj, newObj interface{}) {
+ 					if oldCEP := objToCiliumEndpoint(oldObj); oldCEP != nil {
+ 						if newCEP := objToCiliumEndpoint(newObj); newCEP != nil {
+-							if oldCEP.DeepEqual(newCEP) {
++							if oldCEP.DeepEqual(newCEP) && !isUpdateForced(oldCEP, newCEP) {
+ 								return
+ 							}
+ 							endpointUpdated(newCEP)
+@@ -139,6 +148,7 @@ func transformToCiliumEndpoint(obj interface{}) (interface{}, error) {
+ 				ResourceVersion: concreteObj.ResourceVersion,
+ 				OwnerReferences: concreteObj.OwnerReferences,
+ 				UID:             concreteObj.UID,
++				Labels:          concreteObj.Labels,
+ 			},
+ 			Status: cilium_api_v2.EndpointStatus{
+ 				Identity:   concreteObj.Status.Identity,
+@@ -210,14 +220,193 @@ func HasCE(ns, name string) (*cilium_api_v2.CiliumEndpoint, bool, error) {
+ 	return cep, exists, nil
+ }
+ 
++func isUpdateForced(oldCEP, newCEP *cilium_api_v2.CiliumEndpoint) bool {
++	if _, exist := oldCEP.Labels[labels.IDNamePriority]; exist {
++		return false
++	}
++
++	forced := false
++	if lbl, exist := newCEP.Labels[labels.IDNamePriority]; exist {
++		priority := getPriority(lbl)
++		forced = priority == High
++	}
++	return forced
++}
++
++type cepPriority uint32
++
++const (
++	High    cepPriority = 0
++	Default cepPriority = math.MaxUint32 / 2
++	Low     cepPriority = math.MaxUint32
++)
++
++func (c cepPriority) isLess(rv cepPriority) bool {
++	return c > rv
++}
++
++func getPriority(s string) cepPriority {
++	// Normalize input
++	s = strings.ToLower(strings.TrimSpace(s))
++	if num, err := strconv.ParseUint(s, 10, 32); err == nil {
++		return cepPriority(num)
++	}
++	switch s {
++	case "low":
++		return Low
++	case "high":
++		return High
++	default:
++		return Default
++	}
++}
++
++type coreCiliumEndpointInfo struct {
++	cep      *cilium_api_v2.CiliumEndpoint
++	priority cepPriority
++}
++
++type priorityFilter struct {
++	ipToCepList map[string][]coreCiliumEndpointInfo
++}
++
++var filter priorityFilter
++
++func (c *priorityFilter) filterAddressByPriority(cep *cilium_api_v2.CiliumEndpoint) time.Duration {
++	delay := ces.DefaultCESSyncTime
++	var priority cepPriority = Default
++	for _, lbl := range cep.Status.Identity.Labels {
++		if !strings.Contains(lbl, labels.IDNamePriority) {
++			continue
++		}
++
++		parts := strings.SplitN(lbl, "=", 2)
++		if len(parts) < 2 {
++			continue
++		}
++
++		priority = getPriority(parts[1])
++		break
++	}
++
++	if lbl, exist := cep.Labels[labels.IDNamePriority]; exist {
++		priority = getPriority(lbl)
++	}
++
++	filteredIps := cilium_api_v2.AddressPairList{}
++
++	for _, pair := range cep.Status.Networking.Addressing {
++		if pair.IPV4 == "" {
++			continue
++		}
++
++		hidingAddress := false
++
++		info := coreCiliumEndpointInfo{
++			cep:      cep,
++			priority: priority,
++		}
++
++		if cepList, exist := c.ipToCepList[pair.IPV4]; exist {
++			isInserted := false
++			for i := range cepList {
++				if equalCeps(cep, cepList[i].cep) {
++					// WARNING this update logic will work only if CEP(new and old) network addresses is not changed !!!
++					// If some address was removed in new CEP - it will never removed from map
++					isInserted = true
++					cepList[i].cep = cep
++					// forced update only on first appearance
++					if cepList[i].priority != priority && priority == High {
++						delay = ces.ForceCESSyncTime
++					}
++					cepList[i].priority = priority
++					continue
++				}
++				if priority.isLess(cepList[i].priority) {
++					hidingAddress = true
++					break
++				}
++			}
++			if !isInserted {
++				if priority == High {
++					delay = ces.ForceCESSyncTime
++				}
++				c.ipToCepList[pair.IPV4] = append(cepList, info)
++			}
++		} else {
++			c.ipToCepList[pair.IPV4] = []coreCiliumEndpointInfo{info}
++			if priority == High {
++				delay = ces.ForceCESSyncTime
++			}
++		}
++
++		if hidingAddress {
++			log.WithFields(logrus.Fields{
++				logfields.CEPName: cep.Name,
++				logfields.CESName: cep.Namespace,
++				"ip4":             pair.IPV4,
++			}).Debug("hiding cep address by priority reason")
++			continue
++		}
++
++		addr := &cilium_api_v2.AddressPair{
++			IPV4: pair.IPV4,
++			IPV6: pair.IPV6,
++		}
++
++		filteredIps = append(filteredIps, addr)
++	}
++	cep.Status.Networking.Addressing = filteredIps
++	return delay
++}
++
++func equalCeps(cep0, cep1 *cilium_api_v2.CiliumEndpoint) bool {
++	return cep0.Name == cep1.Name && cep0.Namespace == cep1.Namespace
++}
++
++func (c *priorityFilter) removeCEPFromFilter(cep *cilium_api_v2.CiliumEndpoint) {
++	if cep.Status.Networking == nil || cep.GetName() == "" || cep.Namespace == "" {
++		return
++	}
++
++	for _, pair := range cep.Status.Networking.Addressing {
++		if pair.IPV4 == "" {
++			continue
++		}
++
++		if cepList, exist := c.ipToCepList[pair.IPV4]; exist {
++			if len(cepList) == 1 {
++				prev := cepList[0]
++				if equalCeps(prev.cep, cep) {
++					delete(filter.ipToCepList, pair.IPV4)
++				}
++				continue
++			}
++			// remove CEP from slice with several elements
++			newList := []coreCiliumEndpointInfo{}
++			for _, prev := range cepList {
++				if !equalCeps(prev.cep, cep) {
++					newList = append(newList, prev)
++				}
++			}
++			c.ipToCepList[pair.IPV4] = newList
++		}
++	}
++}
++
+ func endpointUpdated(cep *cilium_api_v2.CiliumEndpoint) {
+ 	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
+ 		return
+ 	}
+-	cesController.Manager.InsertCEPInCache(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
++
++	delay := filter.filterAddressByPriority(cep)
++
++	cesController.Manager.InsertCEPInCache(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace, delay)
+ }
+ 
+ func endpointDeleted(cep *cilium_api_v2.CiliumEndpoint) {
++	filter.removeCEPFromFilter(cep)
++
+ 	cesController.Manager.RemoveCEPFromCache(ces.GetCEPNameFromCCEP(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace), ces.DefaultCESSyncTime)
+ }
+ 
+diff --git a/pkg/datapath/alignchecker/alignchecker.go b/pkg/datapath/alignchecker/alignchecker.go
+index ebf4d4a1bb..b3dd580977 100644
+--- a/pkg/datapath/alignchecker/alignchecker.go
++++ b/pkg/datapath/alignchecker/alignchecker.go
+@@ -6,6 +6,7 @@ package alignchecker
+ import (
+ 	check "github.com/cilium/cilium/pkg/alignchecker"
+ 	"github.com/cilium/cilium/pkg/bpf"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	"github.com/cilium/cilium/pkg/maps/authmap"
+ 	"github.com/cilium/cilium/pkg/maps/bwmap"
+ 	"github.com/cilium/cilium/pkg/maps/ctmap"
+@@ -14,7 +15,6 @@ import (
+ 	"github.com/cilium/cilium/pkg/maps/fragmap"
+ 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
+ 	"github.com/cilium/cilium/pkg/maps/lbmap"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
+ 	"github.com/cilium/cilium/pkg/maps/metricsmap"
+ 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
+ 	"github.com/cilium/cilium/pkg/maps/policymap"
+diff --git a/pkg/datapath/linux/config/config.go b/pkg/datapath/linux/config/config.go
+index 333076b2ff..3863ff4b2d 100644
+--- a/pkg/datapath/linux/config/config.go
++++ b/pkg/datapath/linux/config/config.go
+@@ -26,6 +26,7 @@ import (
+ 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+ 	"github.com/cilium/cilium/pkg/defaults"
+ 	"github.com/cilium/cilium/pkg/identity"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	"github.com/cilium/cilium/pkg/labels"
+ 	"github.com/cilium/cilium/pkg/logging"
+ 	"github.com/cilium/cilium/pkg/logging/logfields"
+@@ -44,7 +45,6 @@ import (
+ 	"github.com/cilium/cilium/pkg/maps/ipmasq"
+ 	"github.com/cilium/cilium/pkg/maps/l2respondermap"
+ 	"github.com/cilium/cilium/pkg/maps/lbmap"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
+ 	"github.com/cilium/cilium/pkg/maps/metricsmap"
+ 	"github.com/cilium/cilium/pkg/maps/nat"
+ 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
+diff --git a/pkg/endpoint/bpf.go b/pkg/endpoint/bpf.go
+index 7cf0dcf319..6aeb7ca63c 100644
+--- a/pkg/endpoint/bpf.go
++++ b/pkg/endpoint/bpf.go
+@@ -27,11 +27,11 @@ import (
+ 	"github.com/cilium/cilium/pkg/controller"
+ 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+ 	"github.com/cilium/cilium/pkg/fqdn/restore"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	"github.com/cilium/cilium/pkg/loadinfo"
+ 	"github.com/cilium/cilium/pkg/logging/logfields"
+ 	"github.com/cilium/cilium/pkg/maps/bwmap"
+ 	"github.com/cilium/cilium/pkg/maps/ctmap"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
+ 	"github.com/cilium/cilium/pkg/maps/policymap"
+ 	"github.com/cilium/cilium/pkg/metrics"
+ 	"github.com/cilium/cilium/pkg/option"
+diff --git a/pkg/endpoint/endpoint.go b/pkg/endpoint/endpoint.go
+index 4a2b401797..64b4012b74 100644
+--- a/pkg/endpoint/endpoint.go
++++ b/pkg/endpoint/endpoint.go
+@@ -38,6 +38,7 @@ import (
+ 	"github.com/cilium/cilium/pkg/identity/identitymanager"
+ 	ippkg "github.com/cilium/cilium/pkg/ip"
+ 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+ 	"github.com/cilium/cilium/pkg/labels"
+ 	"github.com/cilium/cilium/pkg/labelsfilter"
+@@ -46,7 +47,6 @@ import (
+ 	"github.com/cilium/cilium/pkg/logging/logfields"
+ 	"github.com/cilium/cilium/pkg/mac"
+ 	"github.com/cilium/cilium/pkg/maps/ctmap"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
+ 	"github.com/cilium/cilium/pkg/maps/policymap"
+ 	"github.com/cilium/cilium/pkg/metrics"
+ 	"github.com/cilium/cilium/pkg/monitor/notifications"
+diff --git a/pkg/ipcache/ipcache.go b/pkg/ipcache/ipcache.go
+index 59f89704c1..08bb066aac 100644
+--- a/pkg/ipcache/ipcache.go
++++ b/pkg/ipcache/ipcache.go
+@@ -12,6 +12,10 @@ import (
+ 
+ 	"github.com/sirupsen/logrus"
+ 
++	"fmt"
++	"sync"
++
++	"github.com/cilium/cilium/pkg/bpf"
+ 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+ 	"github.com/cilium/cilium/pkg/controller"
+ 	"github.com/cilium/cilium/pkg/identity"
+@@ -22,12 +26,341 @@ import (
+ 	"github.com/cilium/cilium/pkg/labels/cidr"
+ 	"github.com/cilium/cilium/pkg/lock"
+ 	"github.com/cilium/cilium/pkg/logging/logfields"
++	"github.com/cilium/cilium/pkg/mac"
+ 	"github.com/cilium/cilium/pkg/metrics"
++	"github.com/cilium/cilium/pkg/node"
+ 	"github.com/cilium/cilium/pkg/option"
+ 	"github.com/cilium/cilium/pkg/source"
+ 	"github.com/cilium/cilium/pkg/types"
++	"github.com/cilium/ebpf"
++)
++
++// lxcmap module code start
++
++const (
++	MapName = "cilium_lxc"
++
++	// MaxEntries represents the maximum number of endpoints in the map
++	MaxEntries = 65535
++
++	// PortMapMax represents the maximum number of Ports Mapping per container.
++	PortMapMax = 16
++)
++
++var (
++	// LXCMap represents the BPF map for endpoints
++	lxcMap     *bpf.Map
++	lxcMapOnce sync.Once
+ )
+ 
++type LxcEndpointInfo struct {
++	key    *EndpointKey
++	info   *EndpointInfo
++	active bool
++}
++
++var globalIPCache *IPCache
++
++func SetGlobalIPCache(ipcache *IPCache) {
++	globalIPCache = ipcache
++}
++
++func (ipc *IPCache) isIPCacheHostLocal(epAddr string, nodeIPv4 net.IP) bool {
++	ipKeyPair := ipc.ipToHostIPCache[epAddr]
++	host := ipKeyPair.IP
++	if host == nil {
++		// cilium_health ep always have nil host - force default behavior
++		return true
++	}
++	return host.Equal(nodeIPv4)
++}
++
++func (ipc *IPCache) checkLxcMapRelation(ip string, hostIP, oldHostIP net.IP) {
++	if hostIP.Equal(oldHostIP) {
++		return
++	}
++
++	hostIP4 := hostIP.To4()
++	oldHostIP4 := oldHostIP.To4()
++	if hostIP4 == nil || oldHostIP4 == nil {
++		return
++	}
++
++	lxc, exist := ipc.ipToEndpointInfo[ip]
++	if !exist {
++		return
++	}
++
++	nodeIPv4 := node.GetIPv4()
++	isLocal := nodeIPv4.Equal(hostIP4)
++	if isLocal && !lxc.active {
++		LXCMap().Update(lxc.key, lxc.info)
++		lxc.active = true
++		log.WithFields(logrus.Fields{
++			logfields.IPAddr: ip,
++		}).Debug("restore record in in cilium_lxc map")
++	} else if !isLocal && lxc.active {
++		LXCMap().Delete(lxc.key)
++		lxc.active = false
++		log.WithFields(logrus.Fields{
++			logfields.IPAddr: ip,
++		}).Debug("hiding record in in cilium_lxc map")
++	}
++}
++
++func getEndpointAddress(v *EndpointKey) string {
++	ip := v.ToIP()
++	if ip == nil {
++		return ""
++	}
++
++	ip4 := ip.To4()
++	if ip4 == nil {
++		return ""
++	}
++
++	return ip4.String()
++}
++
++func LXCMap() *bpf.Map {
++	lxcMapOnce.Do(func() {
++		lxcMap = bpf.NewMap(MapName,
++			ebpf.Hash,
++			&EndpointKey{},
++			&EndpointInfo{},
++			MaxEntries,
++			0,
++		).WithCache().WithPressureMetric().
++			WithEvents(option.Config.GetEventBufferConfig(MapName))
++	})
++	return lxcMap
++}
++
++const (
++	// EndpointFlagHost indicates that this endpoint represents the host
++	EndpointFlagHost = 1
++)
++
++// EndpointFrontend is the interface to implement for an object to synchronize
++// with the endpoint BPF map.
++type EndpointFrontend interface {
++	LXCMac() mac.MAC
++	GetNodeMAC() mac.MAC
++	GetIfIndex() int
++	GetID() uint64
++	IPv4Address() netip.Addr
++	IPv6Address() netip.Addr
++	GetIdentity() identity.NumericIdentity
++}
++
++// GetBPFKeys returns all keys which should represent this endpoint in the BPF
++// endpoints map
++func GetBPFKeys(e EndpointFrontend) []*EndpointKey {
++	keys := []*EndpointKey{}
++	if e.IPv6Address().IsValid() {
++		keys = append(keys, NewEndpointKey(e.IPv6Address().AsSlice()))
++	}
++
++	if e.IPv4Address().IsValid() {
++		keys = append(keys, NewEndpointKey(e.IPv4Address().AsSlice()))
++	}
++
++	return keys
++}
++
++// GetBPFValue returns the value which should represent this endpoint in the
++// BPF endpoints map
++// Must only be called if init() succeeded.
++func GetBPFValue(e EndpointFrontend) (*EndpointInfo, error) {
++	mac, err := e.LXCMac().Uint64()
++	if err != nil {
++		return nil, fmt.Errorf("invalid LXC MAC: %w", err)
++	}
++
++	nodeMAC, err := e.GetNodeMAC().Uint64()
++	if err != nil {
++		return nil, fmt.Errorf("invalid node MAC: %w", err)
++	}
++
++	info := &EndpointInfo{
++		IfIndex: uint32(e.GetIfIndex()),
++		// Store security identity in network byte order so it can be
++		// written into the packet without an additional byte order
++		// conversion.
++		LxcID:   uint16(e.GetID()),
++		MAC:     mac,
++		NodeMAC: nodeMAC,
++		SecID:   e.GetIdentity().Uint32(),
++	}
++
++	return info, nil
++
++}
++
++type pad3uint32 [3]uint32
++
++// EndpointInfo represents the value of the endpoints BPF map.
++//
++// Must be in sync with struct endpoint_info in <bpf/lib/common.h>
++type EndpointInfo struct {
++	IfIndex uint32 `align:"ifindex"`
++	Unused  uint16 `align:"unused"`
++	LxcID   uint16 `align:"lxc_id"`
++	Flags   uint32 `align:"flags"`
++	// go alignment
++	_       uint32
++	MAC     mac.Uint64MAC `align:"mac"`
++	NodeMAC mac.Uint64MAC `align:"node_mac"`
++	SecID   uint32        `align:"sec_id"`
++	Pad     pad3uint32    `align:"pad"`
++}
++
++type EndpointKey struct {
++	bpf.EndpointKey
++}
++
++// NewEndpointKey returns an EndpointKey based on the provided IP address. The
++// address family is automatically detected
++func NewEndpointKey(ip net.IP) *EndpointKey {
++	return &EndpointKey{
++		EndpointKey: bpf.NewEndpointKey(ip, 0),
++	}
++}
++
++func (k *EndpointKey) New() bpf.MapKey { return &EndpointKey{} }
++
++// IsHost returns true if the EndpointInfo represents a host IP
++func (v *EndpointInfo) IsHost() bool {
++	return v.Flags&EndpointFlagHost != 0
++}
++
++// String returns the human readable representation of an EndpointInfo
++func (v *EndpointInfo) String() string {
++	if v.Flags&EndpointFlagHost != 0 {
++		return "(localhost)"
++	}
++
++	return fmt.Sprintf("id=%-5d sec_id=%-5d flags=0x%04X ifindex=%-3d mac=%s nodemac=%s",
++		v.LxcID,
++		v.SecID,
++		v.Flags,
++		v.IfIndex,
++		v.MAC,
++		v.NodeMAC,
++	)
++}
++
++func (v *EndpointInfo) New() bpf.MapValue { return &EndpointInfo{} }
++
++// WriteEndpoint updates the BPF map with the endpoint information and links
++// the endpoint information to all keys provided.
++func WriteEndpoint(f EndpointFrontend) error {
++	info, err := GetBPFValue(f)
++	if err != nil {
++		return err
++	}
++
++	// FIXME: Revert on failure
++	nodeIPv4 := node.GetIPv4()
++	// for prevent race conditions between ipcache upsert method used common mutex
++	globalIPCache.Lock()
++	defer globalIPCache.Unlock()
++	for _, v := range GetBPFKeys(f) {
++
++		epAddr := getEndpointAddress(v)
++		if epAddr == "" {
++			continue
++		}
++
++		if globalIPCache.isIPCacheHostLocal(epAddr, nodeIPv4) {
++			if err := LXCMap().Update(v, info); err != nil {
++				return err
++			}
++			globalIPCache.ipToEndpointInfo[epAddr] = &LxcEndpointInfo{
++				key:    v,
++				info:   info,
++				active: true,
++			}
++		} else {
++			LXCMap().Delete(v)
++			globalIPCache.ipToEndpointInfo[epAddr] = &LxcEndpointInfo{
++				key:    v,
++				info:   info,
++				active: false,
++			}
++			log.WithFields(logrus.Fields{
++				logfields.IPAddr: epAddr,
++			}).Debug("hiding pod address in cilium_lxc map")
++		}
++	}
++
++	return nil
++}
++
++// AddHostEntry adds a special endpoint which represents the local host
++func AddHostEntry(ip net.IP) error {
++	key := NewEndpointKey(ip)
++	ep := &EndpointInfo{Flags: EndpointFlagHost}
++	return LXCMap().Update(key, ep)
++}
++
++// SyncHostEntry checks if a host entry exists in the lxcmap and adds one if needed.
++// Returns boolean indicating if a new entry was added and an error.
++func SyncHostEntry(ip net.IP) (bool, error) {
++	key := NewEndpointKey(ip)
++	value, err := LXCMap().Lookup(key)
++	if err != nil || value.(*EndpointInfo).Flags&EndpointFlagHost == 0 {
++		err = AddHostEntry(ip)
++		if err == nil {
++			return true, nil
++		}
++	}
++	return false, err
++}
++
++// DELETE elements from new map
++
++// DeleteEntry deletes a single map entry
++func DeleteEntry(ip net.IP) error {
++	delete(globalIPCache.ipToEndpointInfo, ip.To4().String())
++	return LXCMap().Delete(NewEndpointKey(ip))
++}
++
++// DeleteElement deletes the endpoint using all keys which represent the
++// endpoint. It returns the number of errors encountered during deletion.
++func DeleteElement(f EndpointFrontend) []error {
++	var errors []error
++	for _, k := range GetBPFKeys(f) {
++		ip := getEndpointAddress(k)
++		delete(globalIPCache.ipToEndpointInfo, ip)
++		if err := LXCMap().Delete(k); err != nil {
++			errors = append(errors, fmt.Errorf("Unable to delete key %v from %s: %w", k, bpf.MapPath(MapName), err))
++		}
++	}
++
++	return errors
++}
++
++// DumpToMap dumps the contents of the lxcmap into a map and returns it
++func DumpToMap() (map[string]EndpointInfo, error) {
++	m := map[string]EndpointInfo{}
++	callback := func(key bpf.MapKey, value bpf.MapValue) {
++		if info, ok := value.(*EndpointInfo); ok {
++			if endpointKey, ok := key.(*EndpointKey); ok {
++				m[endpointKey.ToIP().String()] = *info
++			}
++		}
++	}
++
++	if err := LXCMap().DumpWithCallback(callback); err != nil {
++		return nil, fmt.Errorf("unable to read BPF endpoint list: %w", err)
++	}
++
++	return m, nil
++}
++
++// lxcmap end
++
+ // Identity is the identity representation of an IP<->Identity cache.
+ type Identity struct {
+ 	// ID is the numeric identity
+@@ -99,6 +432,7 @@ type IPCache struct {
+ 	identityToIPCache map[identity.NumericIdentity]map[string]struct{}
+ 	ipToHostIPCache   map[string]IPKeyPair
+ 	ipToK8sMetadata   map[string]K8sMetadata
++	ipToEndpointInfo  map[string]*LxcEndpointInfo
+ 
+ 	listeners []IPIdentityMappingListener
+ 
+@@ -140,6 +474,7 @@ func NewIPCache(c *Configuration) *IPCache {
+ 		identityToIPCache: map[identity.NumericIdentity]map[string]struct{}{},
+ 		ipToHostIPCache:   map[string]IPKeyPair{},
+ 		ipToK8sMetadata:   map[string]K8sMetadata{},
++		ipToEndpointInfo:  map[string]*LxcEndpointInfo{},
+ 		controllers:       controller.NewManager(),
+ 		namedPorts:        types.NewNamedPortMultiMap(),
+ 		metadata:          newMetadata(),
+@@ -389,6 +724,8 @@ func (ipc *IPCache) upsertLocked(
+ 
+ 	scopedLog.Debug("Upserting IP into ipcache layer")
+ 
++	ipc.checkLxcMapRelation(ip, hostIP, oldHostIP)
++
+ 	// Update both maps.
+ 	ipc.ipToIdentityCache[ip] = newIdentity
+ 	// Delete the old identity, if any.
+diff --git a/pkg/labels/labels.go b/pkg/labels/labels.go
+index 1c026356fa..ad0af6e774 100644
+--- a/pkg/labels/labels.go
++++ b/pkg/labels/labels.go
+@@ -59,6 +59,10 @@ const (
+ 	// IDNameUnknown is the label used to to identify an endpoint with an
+ 	// unknown identity.
+ 	IDNameUnknown = "unknown"
++
++	// IDNamePriority is the label used to set pod priority on shared ip4-address
++	// network access
++	IDNamePriority = "network.deckhouse.io/pod-common-ip-priority"
+ )
+ 
+ var (
+diff --git a/pkg/maps/bwmap/bwmap.go b/pkg/maps/bwmap/bwmap.go
+index 3a392e852c..7217fcd447 100644
+--- a/pkg/maps/bwmap/bwmap.go
++++ b/pkg/maps/bwmap/bwmap.go
+@@ -10,7 +10,7 @@ import (
+ 
+ 	"github.com/cilium/cilium/pkg/bpf"
+ 	"github.com/cilium/cilium/pkg/ebpf"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	"github.com/cilium/cilium/pkg/option"
+ )
+ 
+diff --git a/pkg/maps/lxcmap/doc.go b/pkg/maps/lxcmap/doc.go
+deleted file mode 100644
+index 01af96c4ad..0000000000
+--- a/pkg/maps/lxcmap/doc.go
++++ /dev/null
+@@ -1,9 +0,0 @@
+-// SPDX-License-Identifier: Apache-2.0
+-// Copyright Authors of Cilium
+-
+-// Package lxcmap represents the endpoints BPF map in the BPF programs. It is
+-// implemented as a hash table containing an entry for all local endpoints.
+-// The hashtable can be accessed through the key EndpointKey and points which
+-// points to the value EndpointInfo.
+-// +groupName=maps
+-package lxcmap
+diff --git a/pkg/maps/lxcmap/lxcmap.go b/pkg/maps/lxcmap/lxcmap.go
+deleted file mode 100644
+index 51261df078..0000000000
+--- a/pkg/maps/lxcmap/lxcmap.go
++++ /dev/null
+@@ -1,239 +0,0 @@
+-// SPDX-License-Identifier: Apache-2.0
+-// Copyright Authors of Cilium
+-
+-package lxcmap
+-
+-import (
+-	"fmt"
+-	"net"
+-	"net/netip"
+-	"sync"
+-
+-	"github.com/cilium/ebpf"
+-
+-	"github.com/cilium/cilium/pkg/bpf"
+-	"github.com/cilium/cilium/pkg/identity"
+-	"github.com/cilium/cilium/pkg/mac"
+-	"github.com/cilium/cilium/pkg/option"
+-)
+-
+-const (
+-	MapName = "cilium_lxc"
+-
+-	// MaxEntries represents the maximum number of endpoints in the map
+-	MaxEntries = 65535
+-
+-	// PortMapMax represents the maximum number of Ports Mapping per container.
+-	PortMapMax = 16
+-)
+-
+-var (
+-	// LXCMap represents the BPF map for endpoints
+-	lxcMap     *bpf.Map
+-	lxcMapOnce sync.Once
+-)
+-
+-func LXCMap() *bpf.Map {
+-	lxcMapOnce.Do(func() {
+-		lxcMap = bpf.NewMap(MapName,
+-			ebpf.Hash,
+-			&EndpointKey{},
+-			&EndpointInfo{},
+-			MaxEntries,
+-			0,
+-		).WithCache().WithPressureMetric().
+-			WithEvents(option.Config.GetEventBufferConfig(MapName))
+-	})
+-	return lxcMap
+-}
+-
+-const (
+-	// EndpointFlagHost indicates that this endpoint represents the host
+-	EndpointFlagHost = 1
+-)
+-
+-// EndpointFrontend is the interface to implement for an object to synchronize
+-// with the endpoint BPF map.
+-type EndpointFrontend interface {
+-	LXCMac() mac.MAC
+-	GetNodeMAC() mac.MAC
+-	GetIfIndex() int
+-	GetID() uint64
+-	IPv4Address() netip.Addr
+-	IPv6Address() netip.Addr
+-	GetIdentity() identity.NumericIdentity
+-}
+-
+-// GetBPFKeys returns all keys which should represent this endpoint in the BPF
+-// endpoints map
+-func GetBPFKeys(e EndpointFrontend) []*EndpointKey {
+-	keys := []*EndpointKey{}
+-	if e.IPv6Address().IsValid() {
+-		keys = append(keys, NewEndpointKey(e.IPv6Address().AsSlice()))
+-	}
+-
+-	if e.IPv4Address().IsValid() {
+-		keys = append(keys, NewEndpointKey(e.IPv4Address().AsSlice()))
+-	}
+-
+-	return keys
+-}
+-
+-// GetBPFValue returns the value which should represent this endpoint in the
+-// BPF endpoints map
+-// Must only be called if init() succeeded.
+-func GetBPFValue(e EndpointFrontend) (*EndpointInfo, error) {
+-	mac, err := e.LXCMac().Uint64()
+-	if err != nil {
+-		return nil, fmt.Errorf("invalid LXC MAC: %w", err)
+-	}
+-
+-	nodeMAC, err := e.GetNodeMAC().Uint64()
+-	if err != nil {
+-		return nil, fmt.Errorf("invalid node MAC: %w", err)
+-	}
+-
+-	info := &EndpointInfo{
+-		IfIndex: uint32(e.GetIfIndex()),
+-		// Store security identity in network byte order so it can be
+-		// written into the packet without an additional byte order
+-		// conversion.
+-		LxcID:   uint16(e.GetID()),
+-		MAC:     mac,
+-		NodeMAC: nodeMAC,
+-		SecID:   e.GetIdentity().Uint32(),
+-	}
+-
+-	return info, nil
+-
+-}
+-
+-type pad3uint32 [3]uint32
+-
+-// EndpointInfo represents the value of the endpoints BPF map.
+-//
+-// Must be in sync with struct endpoint_info in <bpf/lib/common.h>
+-type EndpointInfo struct {
+-	IfIndex uint32 `align:"ifindex"`
+-	Unused  uint16 `align:"unused"`
+-	LxcID   uint16 `align:"lxc_id"`
+-	Flags   uint32 `align:"flags"`
+-	// go alignment
+-	_       uint32
+-	MAC     mac.Uint64MAC `align:"mac"`
+-	NodeMAC mac.Uint64MAC `align:"node_mac"`
+-	SecID   uint32        `align:"sec_id"`
+-	Pad     pad3uint32    `align:"pad"`
+-}
+-
+-type EndpointKey struct {
+-	bpf.EndpointKey
+-}
+-
+-// NewEndpointKey returns an EndpointKey based on the provided IP address. The
+-// address family is automatically detected
+-func NewEndpointKey(ip net.IP) *EndpointKey {
+-	return &EndpointKey{
+-		EndpointKey: bpf.NewEndpointKey(ip, 0),
+-	}
+-}
+-
+-func (k *EndpointKey) New() bpf.MapKey { return &EndpointKey{} }
+-
+-// IsHost returns true if the EndpointInfo represents a host IP
+-func (v *EndpointInfo) IsHost() bool {
+-	return v.Flags&EndpointFlagHost != 0
+-}
+-
+-// String returns the human readable representation of an EndpointInfo
+-func (v *EndpointInfo) String() string {
+-	if v.Flags&EndpointFlagHost != 0 {
+-		return "(localhost)"
+-	}
+-
+-	return fmt.Sprintf("id=%-5d sec_id=%-5d flags=0x%04X ifindex=%-3d mac=%s nodemac=%s",
+-		v.LxcID,
+-		v.SecID,
+-		v.Flags,
+-		v.IfIndex,
+-		v.MAC,
+-		v.NodeMAC,
+-	)
+-}
+-
+-func (v *EndpointInfo) New() bpf.MapValue { return &EndpointInfo{} }
+-
+-// WriteEndpoint updates the BPF map with the endpoint information and links
+-// the endpoint information to all keys provided.
+-func WriteEndpoint(f EndpointFrontend) error {
+-	info, err := GetBPFValue(f)
+-	if err != nil {
+-		return err
+-	}
+-
+-	// FIXME: Revert on failure
+-	for _, v := range GetBPFKeys(f) {
+-		if err := LXCMap().Update(v, info); err != nil {
+-			return err
+-		}
+-	}
+-
+-	return nil
+-}
+-
+-// AddHostEntry adds a special endpoint which represents the local host
+-func AddHostEntry(ip net.IP) error {
+-	key := NewEndpointKey(ip)
+-	ep := &EndpointInfo{Flags: EndpointFlagHost}
+-	return LXCMap().Update(key, ep)
+-}
+-
+-// SyncHostEntry checks if a host entry exists in the lxcmap and adds one if needed.
+-// Returns boolean indicating if a new entry was added and an error.
+-func SyncHostEntry(ip net.IP) (bool, error) {
+-	key := NewEndpointKey(ip)
+-	value, err := LXCMap().Lookup(key)
+-	if err != nil || value.(*EndpointInfo).Flags&EndpointFlagHost == 0 {
+-		err = AddHostEntry(ip)
+-		if err == nil {
+-			return true, nil
+-		}
+-	}
+-	return false, err
+-}
+-
+-// DeleteEntry deletes a single map entry
+-func DeleteEntry(ip net.IP) error {
+-	return LXCMap().Delete(NewEndpointKey(ip))
+-}
+-
+-// DeleteElement deletes the endpoint using all keys which represent the
+-// endpoint. It returns the number of errors encountered during deletion.
+-func DeleteElement(f EndpointFrontend) []error {
+-	var errors []error
+-	for _, k := range GetBPFKeys(f) {
+-		if err := LXCMap().Delete(k); err != nil {
+-			errors = append(errors, fmt.Errorf("Unable to delete key %v from %s: %w", k, bpf.MapPath(MapName), err))
+-		}
+-	}
+-
+-	return errors
+-}
+-
+-// DumpToMap dumps the contents of the lxcmap into a map and returns it
+-func DumpToMap() (map[string]EndpointInfo, error) {
+-	m := map[string]EndpointInfo{}
+-	callback := func(key bpf.MapKey, value bpf.MapValue) {
+-		if info, ok := value.(*EndpointInfo); ok {
+-			if endpointKey, ok := key.(*EndpointKey); ok {
+-				m[endpointKey.ToIP().String()] = *info
+-			}
+-		}
+-	}
+-
+-	if err := LXCMap().DumpWithCallback(callback); err != nil {
+-		return nil, fmt.Errorf("unable to read BPF endpoint list: %w", err)
+-	}
+-
+-	return m, nil
+-}
+-- 
+2.34.1
+

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-managment.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-managment.patch
@@ -1,33 +1,3 @@
-From 66712fdc2c9e84c437a14246e1c170794a3053d0 Mon Sep 17 00:00:00 2001
-From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
-Date: Thu, 16 Jan 2025 10:42:38 +0300
-Subject: [PATCH] add: pod prioroty managment what shared single ip4 address
-
-Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
----
- cilium/cmd/bpf_endpoint_delete.go             |   2 +-
- cilium/cmd/bpf_endpoint_list.go               |   2 +-
- daemon/cmd/daemon.go                          |   4 +
- daemon/cmd/datapath.go                        |   2 +-
- daemon/cmd/state.go                           |   2 +-
- daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  |   2 +
- operator/pkg/ciliumendpointslice/manager.go   |  20 +-
- .../pkg/ciliumendpointslice/manager_test.go   |  42 +--
- operator/watchers/cilium_endpoint.go          | 193 +++++++++-
- pkg/datapath/alignchecker/alignchecker.go     |   2 +-
- pkg/datapath/linux/config/config.go           |   2 +-
- pkg/endpoint/bpf.go                           |   2 +-
- pkg/endpoint/endpoint.go                      |   2 +-
- pkg/ipcache/ipcache.go                        | 337 ++++++++++++++++++
- pkg/labels/labels.go                          |   4 +
- pkg/maps/bwmap/bwmap.go                       |   2 +-
- pkg/maps/lxcmap/doc.go                        |   9 -
- pkg/maps/lxcmap/lxcmap.go                     | 239 -------------
- 19 files changed, 579 insertions(+), 291 deletions(-)
- delete mode 100644 pkg/maps/lxcmap/doc.go
- delete mode 100644 pkg/maps/lxcmap/lxcmap.go
-
 diff --git a/cilium/cmd/bpf_endpoint_delete.go b/cilium/cmd/bpf_endpoint_delete.go
 index 9b35099eb9..e7a6d97d16 100644
 --- a/cilium/cmd/bpf_endpoint_delete.go
@@ -348,7 +318,7 @@ index bf47c44de9..ece7d4a286 100644
  		m.RemoveCEPFromCache(GetCEPNameFromCCEP(cep2, "kube-system"), DefaultCESSyncTime)
  		remCEPs := m.getRemovedCEPs(cesName)
 diff --git a/operator/watchers/cilium_endpoint.go b/operator/watchers/cilium_endpoint.go
-index 7c1b240f77..43878ae90a 100644
+index 7c1b240f77..cbba866ac2 100644
 --- a/operator/watchers/cilium_endpoint.go
 +++ b/operator/watchers/cilium_endpoint.go
 @@ -7,8 +7,11 @@ import (
@@ -402,7 +372,7 @@ index 7c1b240f77..43878ae90a 100644
  			},
  			Status: cilium_api_v2.EndpointStatus{
  				Identity:   concreteObj.Status.Identity,
-@@ -210,14 +220,193 @@ func HasCE(ns, name string) (*cilium_api_v2.CiliumEndpoint, bool, error) {
+@@ -210,14 +220,183 @@ func HasCE(ns, name string) (*cilium_api_v2.CiliumEndpoint, bool, error) {
  	return cep, exists, nil
  }
  
@@ -423,8 +393,7 @@ index 7c1b240f77..43878ae90a 100644
 +
 +const (
 +	High    cepPriority = 0
-+	Default cepPriority = math.MaxUint32 / 2
-+	Low     cepPriority = math.MaxUint32
++	Default cepPriority = math.MaxUint32
 +)
 +
 +func (c cepPriority) isLess(rv cepPriority) bool {
@@ -432,19 +401,10 @@ index 7c1b240f77..43878ae90a 100644
 +}
 +
 +func getPriority(s string) cepPriority {
-+	// Normalize input
-+	s = strings.ToLower(strings.TrimSpace(s))
 +	if num, err := strconv.ParseUint(s, 10, 32); err == nil {
 +		return cepPriority(num)
 +	}
-+	switch s {
-+	case "low":
-+		return Low
-+	case "high":
-+		return High
-+	default:
-+		return Default
-+	}
++	return Default
 +}
 +
 +type coreCiliumEndpointInfo struct {

--- a/modules/021-cni-cilium/images/bin-cilium/patches/007-fix-restoring-cep-for-dead-local-endpoint.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/007-fix-restoring-cep-for-dead-local-endpoint.patch
@@ -1,0 +1,66 @@
+diff --git a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+index 418b23cbc2..60693c117a 100644
+--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
++++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+@@ -4,11 +4,13 @@
+ package watchers
+ 
+ import (
++	"net"
+ 	"time"
+ 
+ 	"github.com/sirupsen/logrus"
+ 
+ 	"github.com/cilium/cilium/pkg/endpoint"
++	"github.com/cilium/cilium/pkg/node"
+ 
+ 	"github.com/cilium/cilium/pkg/k8s"
+ 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+@@ -148,6 +150,17 @@ func (cs *cesSubscriber) OnDelete(ces *cilium_v2a1.CiliumEndpointSlice) {
+ 	}
+ }
+ 
++func (cs *cesSubscriber) isDeadLocalEndpoint(c *types.CiliumEndpoint) bool {
++	nodeIPv4 := node.GetIPv4()
++	cepNodeIPv4 := net.ParseIP(c.Networking.NodeIP)
++	if !nodeIPv4.Equal(cepNodeIPv4) {
++		return false
++	}
++
++	p := cs.epCache.LookupPodName(k8sUtils.GetObjNamespaceName(c))
++	return p == nil
++}
++
+ // deleteCEP deletes the CEP and CES from the map.
+ // If this was last CES for the CEP it triggers endpointDeleted.
+ // If this was used CES for the CEP it picks other CES and triggers endpointUpdated.
+@@ -159,7 +172,25 @@ func (cs *cesSubscriber) deleteCEPfromCES(CEPName, CESName string, c *types.Cili
+ 	if !needUpdate {
+ 		return
+ 	}
+-	cep, exists := cs.cepMap.getCEPLocked(CEPName)
++
++	var cep *types.CiliumEndpoint
++	exists := false
++	for {
++		cep, exists = cs.cepMap.getCEPLocked(CEPName)
++		if !exists || !cs.isDeadLocalEndpoint(cep) {
++			break
++		}
++
++		currentCES := cs.cepMap.currentCES[CEPName]
++		log.WithFields(logrus.Fields{
++			"CESName": currentCES,
++			"CEPName": CEPName,
++		}).Debug("found dead local CEP, calling endpointDeleted")
++
++		cs.cepMap.deleteCEPLocked(CEPName, currentCES)
++		cs.epWatcher.endpointDeleted(cep)
++	}
++
+ 	if !exists {
+ 		log.WithFields(logrus.Fields{
+ 			"CESName": CESName,
+-- 
+2.34.1
+

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -27,12 +27,12 @@ Update go.mod and tidy.
 
 ## 005-ebpf-dhcp-server.patch
 
-Added DHCP server(ebpf-implementation) for pods
+Added DHCP server for pods (ebpf implementation).
 
 ## 006-add-pod-prioroty-managment.patch
 
-Added label allows you to control priority of pods sharing single IP4 address in cluster
+Added a `network.deckhouse.io/pod-common-ip-priority` label allows you to share a single IP between  several Pods and to switch the actual owner.
 
 ## 007-fix-restoring-cep-for-dead-local-endpoint.patch
 
-Fixed bug when agent restoring cep for dead local endpoint
+Fixed bug when agent uses CiliumEndpoint cache for dead local endpoints.

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -24,3 +24,15 @@ Upstream issue <https://github.com/cilium/cilium/issues/23711>
 ## 004-go-mod.patch
 
 Update go.mod and tidy.
+
+## 005-ebpf-dhcp-server.patch
+
+Added DHCP server(ebpf-implementation) for pods
+
+## 006-add-pod-prioroty-managment.patch
+
+Added label allows you to control priority of pods sharing single IP4 address in cluster
+
+## 007-fix-restoring-cep-for-dead-local-endpoint.patch
+
+Fixed bug when agent restoring cep for dead local endpoint


### PR DESCRIPTION
## Description

A `network.deckhouse.io/pod-common-ip-priority` label allows you to share a single IP between  several Pods and to switch the actual owner.
Label may have numeric values in range 0-4294967295. A lower value means a higher pod priority for the same address. By default, pod without a label have the lowest priority (4294967295).

## Why do we need it, and what problem does it solve?

During the VM migration process (in DVP), two pods with the same address are created and packets are randomly delivered to them. This label is used to force delivery of packets to the selected virtual machine pod during the migration process.

## What is the expected result?

In cluster two pods share single ip4 address. By default cilium will randomly use a pod for this ip4 address.
To force network packet delivery to a specific pod it must have higher priority then another pod.

Two pods in cluster have single ip4 address and default priority.

Set pod-1 priority to high:
`kubectl label pod pod-1 network.deckhouse.io/pod-common-ip-priority=0`

Now pod-1 will be used for packet delivery in all cluster nodes until pod-2 will have more or equal priority.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: feature
summary: DVP-specific feature that allows having two pods in the same cluster with equal IP addresses.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
