### PR TITLE
[chore] fix: sync dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/clarketm/json v1.15.7
 	github.com/cloudflare/cfssl v1.5.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
-	github.com/deckhouse/deckhouse/pkg/log v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
 	github.com/flant/kube-client v1.2.2
 	github.com/flant/shell-operator v1.5.3-0.20241209162655-7e40c61f7666
@@ -113,6 +112,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/deckhouse/deckhouse/go_lib/registry-packages-proxy v0.0.0-20240626081445-38c0dcfd3af7 // indirect
+	github.com/deckhouse/deckhouse/pkg/log v0.0.0-20241219045931-ca7514dfb873 // indirect
 	github.com/deckhouse/module-sdk v0.1.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v27.1.1+incompatible // indirect


### PR DESCRIPTION
## Description

In goland, dependencies are synchronized using the go list command.
If a dependency is specified with a version that does not exist, then we get an error. And because dependencies are updated regularly, we get a lot of warnings that distract us from our work.

The dependency itself is used directly through replace, that is, it does not affect the assembly of the project. And the changes are only needed to ensure that the go list commands run without errors.

## Why do we need it, and what problem does it solve?

Get rid of errors in Goland.

## What is the expected result?

Goland performs dependency updates without warnings or errors.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: chore
type: chore
summary: sync dependencies
impact_level: low
```
