### PR TITLE
[deckhouse] fix deckhouse version parsing

### DIFF
--- a/go_lib/dependency/extenders/deckhouseversion/extender.go
+++ b/go_lib/dependency/extenders/deckhouseversion/extender.go
@@ -70,7 +70,7 @@ func Instance() *Extender {
 				instance.logger.Warn("this is dev cluster, v2.0.0 will be used")
 				return
 			}
-			if parsed, err := semver.NewVersion(string(raw)); err == nil {
+			if parsed, err := semver.NewVersion(strings.TrimSpace(string(raw))); err == nil {
 				instance.logger.Debugf("setting deckhouse version to %s from file", parsed.String())
 				instance.versionMatcher.ChangeBaseVersion(parsed)
 			} else {


### PR DESCRIPTION
## Description
It provides fix for deckhouse version parsing.

## Why do we need it, and what problem does it solve?
Deckhouse version parsing does not work for extender.

## What is the expected result?
It works

<img width="594" alt="Screenshot 2024-12-19 at 1 10 58 PM" src="https://github.com/user-attachments/assets/5cf5f106-eb2e-4686-a7fe-c4901c107297" />

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix deckhouse version parsing.
impact_level: low
```

