### PR TITLE
[control-plane-manager] change free space detection for etcd-backup

### DIFF
--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -25,11 +25,11 @@ etcdctl \
     --key=/etc/kubernetes/pki/etcd/healthcheck-client.key \
     snapshot save "${etcd}"
 tar -czvf "${archive}" "${etcd}"
-# Check that there will be 25% free space left after adding the file
-if [ $(df /var/lib/etcd/ | tail -1 | awk '{printf "%.0f\n", $4 - ($2 * 0.25)}') -ge $(du -k "${archive}" | awk '{print $1}') ]; then
+# Check that there is enough free space
+if [ $(df -B1 /var/lib/etcd/ | tail -1 | awk -v ETCDQUOTA="${ETCDQUOTA}" '{printf "%.0f\n", $4 - (ETCDQUOTA * 2)}') -ge 0 ]; then
     chmod 0600 "${archive}"
     mv "${archive}" "/var/lib/etcd/${archive}"
 else
-    echo "Free space in /var/lib/etcd/ is too small for backup should be more than 25%"
+    echo "Free space in /var/lib/etcd/ is too small for backup should be more than double size ETCDQUOTA (${ETCDQUOTA} bytes)"
     exit 1
 fi

--- a/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
+++ b/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
@@ -2,6 +2,12 @@
 cpu: 25m
 memory: 40Mi
 {{- end }}
+
+{{- $etcdQuotaBackendBytes := "" -}}
+{{- if hasKey .Values.controlPlaneManager.internal "etcdQuotaBackendBytes" -}}
+  {{- $etcdQuotaBackendBytes = .Values.controlPlaneManager.internal.etcdQuotaBackendBytes -}}
+{{- end -}}
+
 {{- if .Values.global.clusterIsBootstrapped }}
   {{- if hasKey .Values.controlPlaneManager.internal "mastersNode" }}
     {{- range $node := .Values.controlPlaneManager.internal.mastersNode }}
@@ -37,6 +43,9 @@ spec:
             {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" $ | nindent 12 }}
             image: {{ include "helm_lib_module_image" (list $ "etcdBackup") }}
             imagePullPolicy: IfNotPresent
+            env:
+            - name: ETCDQUOTA
+              value: {{ $etcdQuotaBackendBytes | default "2147483648" | quote }}
             resources:
               requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 50 | nindent 16 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Change free space detection for etcd-backup job.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The current logic for determining free space is not effective in cases where large disks are used (when calculating free space we assume that there should be more than 25% free space). To solve this problem, we consider that the backup cannot be larger than the etcd database itself, so we just need to make sure that there is enough space on the drives for twice the size of `etcdQuotaBackendBytes` to create backup correctly.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

An example of the result of executing jobs with different `etcdQuotaBackendBytes` values:

<details>
  <summary>etcdQuotaBackendBytes ~ 4GB </summary>
  
  <img width="1419" alt="image" src="https://github.com/user-attachments/assets/84b539cd-b55b-4537-b7d2-571da0ec45ae" />
  </details>

<details>
  <summary>etcdQuotaBackendBytes ~ 8GB </summary>
  
  <img width="1419" alt="image" src="https://github.com/user-attachments/assets/a85b5b44-c3b3-4c38-b788-2ac930f5b016" />
  </details>




## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: feature
summary: Change of logic detection enough free space for etcd-backup.
impact_level: default 
```


<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
