### PR TITLE
[docs] Fixed broken links at Getting Started

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
@@ -83,7 +83,7 @@ Scheme of Deckhouse installation in a private environment:<br />
 <li>
 {% if page.platform_type == "existing" %}
   <p><strong>The existing Kubernetes cluster.</strong></p>
-  <p>The Kubernetes versions and OS of cluster nodes should be on <a href="../../products/kubernetes-platform/documentation/v1/supported_versions.html">the list of supported</a>.</p>
+  <p>The Kubernetes versions and OS of cluster nodes should be on <a href="https://deckhouse.io/products/kubernetes-platform/documentation/v1/supported_versions.html">the list of supported</a>.</p>
   <p>During the installation, the Deckhouse installer running on the <strong>personal computer</strong> (see step 1) will connect to the cluster and deploy Deckhouse.</p>
   <p><strong>Note</strong> that master node-based installation is not currently supported.</p>
 {%- elsif page.platform_type == 'cloud' and page.platform_code != 'zvirt' %}
@@ -112,7 +112,7 @@ Scheme of Deckhouse installation in a private environment:<br />
    - at least 4 CPU cores
    - at least 8 GB of RAM
    - at least 60 GB of disk space for the cluster and etcd data on a fast disk (400+ IOPS)
-   - [supported OS](/products/kubernetes-platform/documentation/v1/supported_versions.html)
+   - [supported OS](https://deckhouse.io/products/kubernetes-platform/documentation/v1/supported_versions.html)
    - Linux kernel version >= `5.7`
    - **Unique hostname** within servers (virtual machines) of the cluster
    {% if page.platform_code == "bm-private" %}

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
@@ -83,7 +83,7 @@ Scheme of Deckhouse installation in a private environment:<br />
 <li>
 {% if page.platform_type == "existing" %}
   <p><strong>The existing Kubernetes cluster.</strong></p>
-  <p>The Kubernetes versions and OS of cluster nodes should be on <a href="https://deckhouse.io/products/kubernetes-platform/documentation/v1/supported_versions.html">the list of supported</a>.</p>
+  <p>The Kubernetes versions and OS of cluster nodes should be on <a href="/kubernetes-platform/documentation/v1/supported_versions.html">the list of supported</a>.</p>
   <p>During the installation, the Deckhouse installer running on the <strong>personal computer</strong> (see step 1) will connect to the cluster and deploy Deckhouse.</p>
   <p><strong>Note</strong> that master node-based installation is not currently supported.</p>
 {%- elsif page.platform_type == 'cloud' and page.platform_code != 'zvirt' %}
@@ -112,7 +112,7 @@ Scheme of Deckhouse installation in a private environment:<br />
    - at least 4 CPU cores
    - at least 8 GB of RAM
    - at least 60 GB of disk space for the cluster and etcd data on a fast disk (400+ IOPS)
-   - [supported OS](https://deckhouse.io/products/kubernetes-platform/documentation/v1/supported_versions.html)
+   - [supported OS](/products/kubernetes-platform/documentation/v1/supported_versions.html)
    - Linux kernel version >= `5.7`
    - **Unique hostname** within servers (virtual machines) of the cluster
    {% if page.platform_code == "bm-private" %}

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
@@ -83,7 +83,7 @@ Scheme of Deckhouse installation in a private environment:<br />
 <li>
 {% if page.platform_type == "existing" %}
   <p><strong>The existing Kubernetes cluster.</strong></p>
-  <p>The Kubernetes versions and OS of cluster nodes should be on <a href="/kubernetes-platform/documentation/v1/supported_versions.html">the list of supported</a>.</p>
+  <p>The Kubernetes versions and OS of cluster nodes should be on <a href="/products/kubernetes-platform/documentation/v1/supported_versions.html">the list of supported</a>.</p>
   <p>During the installation, the Deckhouse installer running on the <strong>personal computer</strong> (see step 1) will connect to the cluster and deploy Deckhouse.</p>
   <p><strong>Note</strong> that master node-based installation is not currently supported.</p>
 {%- elsif page.platform_type == 'cloud' and page.platform_code != 'zvirt' %}

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
@@ -91,7 +91,7 @@
 <li>
 {% if page.platform_type == "existing" %}
   <p><strong>Существующий кластер Kubernetes.</strong></p>
-  <p>Версии Kubernetes и ОС узлов кластера должны быть <a href="../../products/kubernetes-platform/documentation/v1/supported_versions.html">в списке поддерживаемых</a>.</p>
+  <p>Версии Kubernetes и ОС узлов кластера должны быть <a href="https://deckhouse.ru/products/kubernetes-platform/documentation/v1/supported_versions.html">в списке поддерживаемых</a>.</p>
   <p>В процессе установки инсталлятор, запущенный на <strong>персональном компьютере</strong> (см. п.1), подключится к кластеру и развернет Deckhouse.</p>
   <p><strong>Обратите внимание</strong>, что установка непосредственно с master-узла не поддерживается.</p>
 {%- elsif page.platform_type == 'cloud' and page.platform_code != 'zvirt' %}
@@ -120,7 +120,7 @@
    - не менее 4 ядер CPU;
    - не менее 8 ГБ RAM;
    - не менее 60 ГБ дискового пространства на быстром диске (400+ IOPS);
-   - [поддерживаемая ОС](/products/kubernetes-platform/documentation/v1/supported_versions.html);
+   - [поддерживаемая ОС](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/supported_versions.html);
    - ядро Linux версии `5.7` или новее;
    - **Уникальный hostname** в пределах серверов (виртуальных машин) кластера;
    {% if page.platform_code == "bm-private" %}

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
@@ -91,7 +91,7 @@
 <li>
 {% if page.platform_type == "existing" %}
   <p><strong>Существующий кластер Kubernetes.</strong></p>
-  <p>Версии Kubernetes и ОС узлов кластера должны быть <a href="https://deckhouse.ru/products/kubernetes-platform/documentation/v1/supported_versions.html">в списке поддерживаемых</a>.</p>
+  <p>Версии Kubernetes и ОС узлов кластера должны быть <a href="/products/kubernetes-platform/documentation/v1/supported_versions.html">в списке поддерживаемых</a>.</p>
   <p>В процессе установки инсталлятор, запущенный на <strong>персональном компьютере</strong> (см. п.1), подключится к кластеру и развернет Deckhouse.</p>
   <p><strong>Обратите внимание</strong>, что установка непосредственно с master-узла не поддерживается.</p>
 {%- elsif page.platform_type == 'cloud' and page.platform_code != 'zvirt' %}
@@ -120,7 +120,7 @@
    - не менее 4 ядер CPU;
    - не менее 8 ГБ RAM;
    - не менее 60 ГБ дискового пространства на быстром диске (400+ IOPS);
-   - [поддерживаемая ОС](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/supported_versions.html);
+   - [поддерживаемая ОС](/products/kubernetes-platform/documentation/v1/supported_versions.html);
    - ядро Linux версии `5.7` или новее;
    - **Уникальный hostname** в пределах серверов (виртуальных машин) кластера;
    {% if page.platform_code == "bm-private" %}


### PR DESCRIPTION
## Description
Fixed broken links at Getting Started.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## What is the expected result?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix
summary: Fixed broken links at Getting Started.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
