### PR TITLE
[testing] Change zone for Azure e2e tests

### DIFF
--- a/testing/cloud_layouts/Azure/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Azure/Standard/configuration.tpl.yaml
@@ -4,19 +4,19 @@ kind: ClusterConfiguration
 clusterType: Cloud
 cloud:
   provider: Azure
-  prefix: 'candi-${PREFIX}'
+  prefix: "candi-${PREFIX}"
 podSubnetCIDR: 10.111.0.0/16
 serviceSubnetCIDR: 10.222.0.0/16
-kubernetesVersion: '${KUBERNETES_VERSION}'
-defaultCRI: '${CRI}'
+kubernetesVersion: "${KUBERNETES_VERSION}"
+defaultCRI: "${CRI}"
 clusterDomain: "cluster.local"
 ---
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration
 deckhouse:
-  devBranch: '${DEV_BRANCH}'
+  devBranch: "${DEV_BRANCH}"
   imagesRepo: dev-registry.deckhouse.io/sys/deckhouse-oss
-  registryDockerCfg: '${DECKHOUSE_DOCKERCFG}'
+  registryDockerCfg: "${DECKHOUSE_DOCKERCFG}"
 ---
 apiVersion: deckhouse.io/v1
 kind: AzureClusterConfiguration
@@ -28,16 +28,18 @@ standard:
 subnetCIDR: 10.50.0.0/24
 masterNodeGroup:
   replicas: ${MASTERS_COUNT}
-  zones: [3]
+  zones:
+    - "1"
+    - "3"
   instanceClass:
     machineSize: Standard_F4
     urn: OpenLogic:CentOS:8_3:8.3.2021020400
     enableExternalIP: true
 provider:
-  subscriptionId: '${SUBSCRIPTION_ID}'
-  clientId: '${CLIENT_ID}'
-  clientSecret: '${CLIENT_SECRET}'
-  tenantId: '${TENANT_ID}'
+  subscriptionId: "${SUBSCRIPTION_ID}"
+  clientId: "${CLIENT_ID}"
+  clientSecret: "${CLIENT_SECRET}"
+  tenantId: "${TENANT_ID}"
   location: "westeurope"
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/testing/cloud_layouts/Azure/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Azure/Standard/configuration.tpl.yaml
@@ -28,6 +28,7 @@ standard:
 subnetCIDR: 10.50.0.0/24
 masterNodeGroup:
   replicas: ${MASTERS_COUNT}
+  zones: [3]
   instanceClass:
     machineSize: Standard_F4
     urn: OpenLogic:CentOS:8_3:8.3.2021020400

--- a/testing/cloud_layouts/Azure/Standard/resources.yaml
+++ b/testing/cloud_layouts/Azure/Standard/resources.yaml
@@ -17,7 +17,7 @@ spec:
       name: worker
     maxPerZone: 1
     minPerZone: 1
-    zones: ["1"]
+    zones: 3
   disruptions:
     approvalMode: Manual
   nodeTemplate:
@@ -35,7 +35,7 @@ spec:
   inlet: LoadBalancer
   enableIstioSidecar: true
   nodeSelector:
-    node-role.kubernetes.io/master: ''
+    node-role.kubernetes.io/master: ""
   tolerations:
     - effect: NoSchedule
       operator: Exists
@@ -47,7 +47,7 @@ metadata:
 spec:
   uid: 10056
   sshPublicKeys:
-  - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSNdUmV2ekit0rFrQE9IoRsVqKTJfR8h+skMYjXHBv/nJN6J2eBvQlebnhfZngxTvHYYxl0XeRu3KEz5v23gIidT21o9x0+tD4b2PcyZ24o64GwnF/oFnQ9mYBJDRisZNdXYPadTp/RafQ0qNUX/6h8vZYlSPM77dhW7Oyf6hcbaniAmOD30bO89UM//VHbllGgfhlIbU382/EnPOfGvAHReATADBBHmxxtTCLbu48rN35DlOtMgPob3ZwOsJI3keRrIZOf5qxeF3VB0Ox4inoR6PUzWMFLCJyIMp7hzY+JLakO4dqfvRJZjgTZHQUvjDs+aeUcH8tD4Wd5NDzmxnHLtJup0lkHkqgjo6vqWIcQeDXuXsk3+YGw0PwMpwO2HMVPs2SnfT6cZ+Mo6Dmq0t1EjtSBXLMe5C5aac5w6NrXuypRQDoce7p3uZP2TVsxmpyvkd6RyiWr+wuOOB3h/k8q+kRh4LKzivJMEkZoZeCxkJiIWDknxEAU1sl25W4hEU= e2e@nodeuser"
+    - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSNdUmV2ekit0rFrQE9IoRsVqKTJfR8h+skMYjXHBv/nJN6J2eBvQlebnhfZngxTvHYYxl0XeRu3KEz5v23gIidT21o9x0+tD4b2PcyZ24o64GwnF/oFnQ9mYBJDRisZNdXYPadTp/RafQ0qNUX/6h8vZYlSPM77dhW7Oyf6hcbaniAmOD30bO89UM//VHbllGgfhlIbU382/EnPOfGvAHReATADBBHmxxtTCLbu48rN35DlOtMgPob3ZwOsJI3keRrIZOf5qxeF3VB0Ox4inoR6PUzWMFLCJyIMp7hzY+JLakO4dqfvRJZjgTZHQUvjDs+aeUcH8tD4Wd5NDzmxnHLtJup0lkHkqgjo6vqWIcQeDXuXsk3+YGw0PwMpwO2HMVPs2SnfT6cZ+Mo6Dmq0t1EjtSBXLMe5C5aac5w6NrXuypRQDoce7p3uZP2TVsxmpyvkd6RyiWr+wuOOB3h/k8q+kRh4LKzivJMEkZoZeCxkJiIWDknxEAU1sl25W4hEU= e2e@nodeuser"
   passwordHash: "$6$vUn3pWjfLzk8iARF$JTR4j5IV0u5aD7O/xK8ZBN4ie/1TE1YwLzfPutpJ4BCJozy1Rgw.Pl4x6gDiUwsPyQcylCuf/oxbL0iMqFdPL/"
   isSudoer: true
 ---

--- a/testing/cloud_layouts/Azure/Standard/resources.yaml
+++ b/testing/cloud_layouts/Azure/Standard/resources.yaml
@@ -17,7 +17,9 @@ spec:
       name: worker
     maxPerZone: 1
     minPerZone: 1
-    zones: 3
+    zones:
+      - "1"
+      - "3"
   disruptions:
     approvalMode: Manual
   nodeTemplate:


### PR DESCRIPTION
## Description
Change zones for Azure e2e tests.

## Why do we need it, and what problem does it solve?
Currently zone 2 in our region is unavailable.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: Change zones for Azure e2e tests.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
