### PR TITLE
[CVE] Transition to using our trivy

### DIFF
--- a/.github/workflow_templates/cve-weekly.yml
+++ b/.github/workflow_templates/cve-weekly.yml
@@ -20,10 +20,24 @@
 {!{ define "cve_tests" }!}
 # <template: cve_tests>
 - name: Run base images CVE tests on ${{env.TAG}}
+  env:
+    TRIVY_TOKEN: ${{secrets.FOX_ACCESS_TOKEN}}
+    DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
+    TRIVY_PROJECT_ID: "2181"
+    TRIVY_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2 
+    TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-java-db:1
+    TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-bdu:1
   run: |
     echo "⚓️ 🏎 Running CVE tests on ${TAG}..."
     make cve-base-images
 - name: Run Deckhouse images CVE tests on ${{env.TAG}}
+  env:
+    TRIVY_TOKEN: ${{secrets.FOX_ACCESS_TOKEN}}
+    DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
+    TRIVY_PROJECT_ID: "2181"
+    TRIVY_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2 
+    TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-java-db:1
+    TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-bdu:1
   run: |
     echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
     make cve-report

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -119,7 +119,7 @@ jobs:
       # <template: cve_tests>
       - name: Run base images CVE tests on ${{env.TAG}}
         env:
-          TRIVY_TOKEN: ${{secrets.TRIVY_TOKEN}}
+          TRIVY_TOKEN: ${{secrets.FOX_ACCESS_TOKEN}}
           DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
           TRIVY_PROJECT_ID: "2181"
         run: |

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -122,10 +122,20 @@ jobs:
           TRIVY_TOKEN: ${{secrets.FOX_ACCESS_TOKEN}}
           DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
           TRIVY_PROJECT_ID: "2181"
+          TRIVY_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2 
+          TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-java-db:1
+          TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-bdu:1
         run: |
           echo "⚓️ 🏎 Running CVE tests on ${TAG}..."
           make cve-base-images
       - name: Run Deckhouse images CVE tests on ${{env.TAG}}
+        env:
+          TRIVY_TOKEN: ${{secrets.FOX_ACCESS_TOKEN}}
+          DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
+          TRIVY_PROJECT_ID: "2181"
+          TRIVY_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2 
+          TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-java-db:1
+          TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-bdu:1
         run: |
           echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
           make cve-report

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -118,6 +118,10 @@ jobs:
 
       # <template: cve_tests>
       - name: Run base images CVE tests on ${{env.TAG}}
+        env:
+          TRIVY_TOKEN: ${{secrets.TRIVY_TOKEN}}
+          DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
+          TRIVY_PROJECT_ID: "2181"
         run: |
           echo "⚓️ 🏎 Running CVE tests on ${TAG}..."
           make cve-base-images

--- a/Makefile
+++ b/Makefile
@@ -213,13 +213,13 @@ bin/regcopy: bin ## App to copy docker images to the Deckhouse registry
 	cd tools/regcopy; go build -o bin/regcopy
 
 bin/trivy-${TRIVY_VERSION}/trivy:
-	mkdir -p bin/trivy-${TRIVY_VERSION}
+	mkdir -p trivy-${TRIVY_VERSION}
 	# curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ./bin/trivy-${TRIVY_VERSION} v${TRIVY_VERSION}
 	curl --header "PRIVATE-TOKEN: ${TRIVY_TOKEN}" https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_PROJECT_ID}/packages/generic/deckhouse-trivy/v${TRIVY_VERSION}/trivy -o ./bin/trivy-${TRIVY_VERSION}/trivy
 
 .PHONY: trivy
 bin/trivy: bin bin/trivy-${TRIVY_VERSION}/trivy
-	rm -f bin/trivy
+	rm -f trivy
 	ln -s trivy-${TRIVY_VERSION}/trivy bin/trivy
 
 .PHONY: cve-report cve-base-images

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ bin/trivy-${TRIVY_VERSION}/trivy:
 .PHONY: trivy
 bin/trivy: bin bin/trivy-${TRIVY_VERSION}/trivy
 	rm -f trivy
-	ln -s trivy-${TRIVY_VERSION}/trivy bin/trivy
+	ln -s trivy-${TRIVY_VERSION}/trivy trivy
 
 .PHONY: cve-report cve-base-images
 cve-report: bin/trivy bin/jq ## Generate CVE report for a Deckhouse release.

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,6 @@ deps: bin/golangci-lint bin/trivy bin/regcopy bin/jq bin/yq bin/crane bin/promto
 ##@ Security
 bin:
 	mkdir -p bin
-	ls -ld bin
 
 ##@ Tests
 
@@ -213,16 +212,17 @@ render-workflow: ## Generate CI workflow instructions.
 bin/regcopy: bin ## App to copy docker images to the Deckhouse registry
 	cd tools/regcopy; go build -o bin/regcopy
 
-bin/trivy-${TRIVY_VERSION}/trivy:
-    ls -ld bin
-	mkdir -p trivy-${TRIVY_VERSION}
+bin/trivy-test/trivy:
+	mkdir -p bin/trivy-${TRIVY_VERSION}
 	# curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ./bin/trivy-${TRIVY_VERSION} v${TRIVY_VERSION}
-	curl --header "PRIVATE-TOKEN: ${TRIVY_TOKEN}" https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_PROJECT_ID}/packages/generic/deckhouse-trivy/v${TRIVY_VERSION}/trivy -o trivy-${TRIVY_VERSION}/trivy
+	curl --header "PRIVATE-TOKEN: ${TRIVY_TOKEN}" https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_PROJECT_ID}/packages/generic/deckhouse-trivy/v${TRIVY_VERSION}/trivy -o bin/trivy-${TRIVY_VERSION}/trivy
 
 .PHONY: trivy
-bin/trivy: bin bin/trivy-${TRIVY_VERSION}/trivy
-	rm -f trivy
-	ln -s trivy-${TRIVY_VERSION}/trivy trivy
+bin/trivy: bin bin/trivy-test/trivy
+	rm -rf bin/trivy
+	ln -s bin/trivy-${TRIVY_VERSION}/trivy bin/trivy
+	ls  -l bin/trivy-${TRIVY_VERSION}/trivy
+	cat bin/trivy-${TRIVY_VERSION}/trivy
 
 .PHONY: cve-report cve-base-images
 cve-report: bin/trivy bin/jq ## Generate CVE report for a Deckhouse release.

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ bin/regcopy: bin ## App to copy docker images to the Deckhouse registry
 bin/trivy-${TRIVY_VERSION}/trivy:
 	mkdir -p trivy-${TRIVY_VERSION}
 	# curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ./bin/trivy-${TRIVY_VERSION} v${TRIVY_VERSION}
-	curl --header "PRIVATE-TOKEN: ${TRIVY_TOKEN}" https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_PROJECT_ID}/packages/generic/deckhouse-trivy/v${TRIVY_VERSION}/trivy -o ./bin/trivy-${TRIVY_VERSION}/trivy
+	curl --header "PRIVATE-TOKEN: ${TRIVY_TOKEN}" https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_PROJECT_ID}/packages/generic/deckhouse-trivy/v${TRIVY_VERSION}/trivy -o trivy-${TRIVY_VERSION}/trivy
 
 .PHONY: trivy
 bin/trivy: bin bin/trivy-${TRIVY_VERSION}/trivy

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ deps: bin/golangci-lint bin/trivy bin/regcopy bin/jq bin/yq bin/crane bin/promto
 ##@ Security
 bin:
 	mkdir -p bin
+	ls -ld bin
 
 ##@ Tests
 
@@ -213,6 +214,7 @@ bin/regcopy: bin ## App to copy docker images to the Deckhouse registry
 	cd tools/regcopy; go build -o bin/regcopy
 
 bin/trivy-${TRIVY_VERSION}/trivy:
+    ls -ld bin
 	mkdir -p trivy-${TRIVY_VERSION}
 	# curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ./bin/trivy-${TRIVY_VERSION} v${TRIVY_VERSION}
 	curl --header "PRIVATE-TOKEN: ${TRIVY_TOKEN}" https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_PROJECT_ID}/packages/generic/deckhouse-trivy/v${TRIVY_VERSION}/trivy -o trivy-${TRIVY_VERSION}/trivy

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ help:
 
 
 GOLANGCI_VERSION = 1.54.2
-TRIVY_VERSION= 0.38.3
+TRIVY_VERSION= 0.55.0
 PROMTOOL_VERSION = 2.37.0
 GATOR_VERSION = 3.9.0
 GH_VERSION = 2.52.0
@@ -214,7 +214,8 @@ bin/regcopy: bin ## App to copy docker images to the Deckhouse registry
 
 bin/trivy-${TRIVY_VERSION}/trivy:
 	mkdir -p bin/trivy-${TRIVY_VERSION}
-	curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ./bin/trivy-${TRIVY_VERSION} v${TRIVY_VERSION}
+	# curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ./bin/trivy-${TRIVY_VERSION} v${TRIVY_VERSION}
+	curl --header "PRIVATE-TOKEN: ${TRIVY_TOKEN}" https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_PROJECT_ID}/packages/generic/deckhouse-trivy/v${TRIVY_VERSION}/trivy -o ./bin/trivy-${TRIVY_VERSION}/trivy
 
 .PHONY: trivy
 bin/trivy: bin bin/trivy-${TRIVY_VERSION}/trivy

--- a/Makefile
+++ b/Makefile
@@ -212,17 +212,16 @@ render-workflow: ## Generate CI workflow instructions.
 bin/regcopy: bin ## App to copy docker images to the Deckhouse registry
 	cd tools/regcopy; go build -o bin/regcopy
 
-bin/trivy-test/trivy:
+bin/trivy-${TRIVY_VERSION}/trivy:
 	mkdir -p bin/trivy-${TRIVY_VERSION}
 	# curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ./bin/trivy-${TRIVY_VERSION} v${TRIVY_VERSION}
 	curl --header "PRIVATE-TOKEN: ${TRIVY_TOKEN}" https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_PROJECT_ID}/packages/generic/deckhouse-trivy/v${TRIVY_VERSION}/trivy -o bin/trivy-${TRIVY_VERSION}/trivy
 
 .PHONY: trivy
-bin/trivy: bin bin/trivy-test/trivy
+bin/trivy: bin bin/trivy-${TRIVY_VERSION}/trivy
 	rm -rf bin/trivy
-	ln -s bin/trivy-${TRIVY_VERSION}/trivy bin/trivy
-	ls  -l bin/trivy-${TRIVY_VERSION}/trivy
-	cat bin/trivy-${TRIVY_VERSION}/trivy
+	chmod u+x bin/trivy-${TRIVY_VERSION}/trivy
+	ln -s ${PWD}/bin/trivy-${TRIVY_VERSION}/trivy bin/trivy
 
 .PHONY: cve-report cve-base-images
 cve-report: bin/trivy bin/jq ## Generate CVE report for a Deckhouse release.

--- a/tools/cve/base-images.sh
+++ b/tools/cve/base-images.sh
@@ -80,7 +80,6 @@ function __main__() {
     echo "----------------------------------------------"
     echo "👾 Image: $image"
     echo ""
-
     trivyGetCVEListForImage -r "$REGISTRY" -i "$image" > "$WORKDIR/$(echo "$image" | tr "/" "_").cve"
     trivyGetHTMLReportPartForImage -r "$REGISTRY" -i "$image" -l "$(echo "$image" | cut -d@ -f1)" >> out/base-images.html
   done

--- a/tools/cve/html/body-part.tpl
+++ b/tools/cve/html/body-part.tpl
@@ -1,7 +1,7 @@
 {{- if . }}
       <table>
       {{- range . }}
-        <tr class="group-header"><th colspan="6">Source type: {{ escapeXML .Type }}<br>Source: {{ escapeXML .Target }}</br></th></tr>
+        <tr class="group-header"><th colspan="6">Source type: {{ .Type | toString | escapeXML }}<br>Source: {{ escapeXML .Target }}</br></th></tr>
         {{- if (eq (len .Vulnerabilities) 0) }}
         <tr><th colspan="6">No Vulnerabilities found</th></tr>
         {{- else }}

--- a/tools/cve/trivy-wrapper.sh
+++ b/tools/cve/trivy-wrapper.sh
@@ -98,7 +98,7 @@ function prepareImageArgs() {
 
 function trivyGetCVEListForImage() (
   prepareImageArgs "$@"
-  trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format json --quiet "$IMAGE_ARGS" | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
+  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format json --quiet "$IMAGE_ARGS" | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
 )
 
 function htmlReportHeader() (
@@ -108,7 +108,7 @@ function htmlReportHeader() (
 function trivyGetHTMLReportPartForImage() (
   prepareImageArgs "$@"
   echo -n "    <h1>$LABEL</h1>"
-  trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format template --template "@tools/cve/html/body-part.tpl" --quiet "$IMAGE_ARGS"
+  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format template --template "@tools/cve/html/body-part.tpl" --quiet "$IMAGE_ARGS"
   echo -n "    <br/>"
 )
 

--- a/tools/cve/trivy-wrapper.sh
+++ b/tools/cve/trivy-wrapper.sh
@@ -98,7 +98,7 @@ function prepareImageArgs() {
 
 function trivyGetCVEListForImage() (
   prepareImageArgs "$@"
-  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format json --quiet "$IMAGE_ARGS" | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
+  trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format json --quiet "$IMAGE_ARGS" | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
 )
 
 function htmlReportHeader() (
@@ -108,7 +108,7 @@ function htmlReportHeader() (
 function trivyGetHTMLReportPartForImage() (
   prepareImageArgs "$@"
   echo -n "    <h1>$LABEL</h1>"
-  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format template --template "@tools/cve/html/body-part.tpl" --quiet "$IMAGE_ARGS"
+  trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format template --template "@tools/cve/html/body-part.tpl" --quiet "$IMAGE_ARGS"
   echo -n "    <br/>"
 )
 

--- a/tools/cve/trivy-wrapper.sh
+++ b/tools/cve/trivy-wrapper.sh
@@ -98,7 +98,8 @@ function prepareImageArgs() {
 
 function trivyGetCVEListForImage() (
   prepareImageArgs "$@"
-  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format json --quiet "$IMAGE_ARGS" | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
+  bin/trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "$IGNORE" --format json --quiet "$IMAGE_ARGS" | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
+  # bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format json --quiet "$IMAGE_ARGS" | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
 )
 
 function htmlReportHeader() (
@@ -108,7 +109,7 @@ function htmlReportHeader() (
 function trivyGetHTMLReportPartForImage() (
   prepareImageArgs "$@"
   echo -n "    <h1>$LABEL</h1>"
-  bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format template --template "@tools/cve/html/body-part.tpl" --quiet "$IMAGE_ARGS"
+  bin/trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "$IGNORE" --format template --template "@tools/cve/html/body-part.tpl" --quiet "$IMAGE_ARGS"
   echo -n "    <br/>"
 )
 


### PR DESCRIPTION
## Description
Updated the cve-weekly workflow to use our custom Trivy, which leverages internal vulnerability databases and security policies instead of the standard version.

## Why do we need it, and what problem does it solve?
This change ensures cve-weekly aligns with our security needs by using custom Trivy with internal databases and policies, providing more accurate and relevant vulnerability scanning.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
The expected result is a more accurate and reliable cve-weekly workflow, leveraging internal vulnerability databases and policies to identify and report security issues that are relevant to our infrastructure.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type:  chore
summary: Use our trivy to scan images
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
