### PR TITLE
[user-authn] add dexclient with the specific annotation to kubernetes client trustedPeers

### DIFF
--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -47,6 +47,8 @@ type DexClient struct {
 
 	Labels      map[string]string `json:"labels"`
 	Annotations map[string]string `json:"annotations"`
+
+	AllowAccessToKubernetes bool `json:"allowAccessToKubernetes"`
 }
 
 type DexClientSecret struct {
@@ -105,16 +107,19 @@ func applyDexClientFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 		}
 	}
 
+	_, allowAccessToKubernetes := annotations["dexclient.deckhouse.io/allow-access-to-kubernetes"]
+
 	return DexClient{
-		ID:              id,
-		LegacyID:        legacyID,
-		EncodedID:       encoding.ToFnvLikeDex(id),
-		LegacyEncodedID: encoding.ToFnvLikeDex(legacyID),
-		Name:            name,
-		Namespace:       namespace,
-		Spec:            spec,
-		Labels:          labels,
-		Annotations:     annotations,
+		ID:                      id,
+		LegacyID:                legacyID,
+		EncodedID:               encoding.ToFnvLikeDex(id),
+		LegacyEncodedID:         encoding.ToFnvLikeDex(legacyID),
+		Name:                    name,
+		Namespace:               namespace,
+		Spec:                    spec,
+		Labels:                  labels,
+		Annotations:             annotations,
+		AllowAccessToKubernetes: allowAccessToKubernetes,
 	}, nil
 }
 

--- a/modules/150-user-authn/templates/dex/oauth2client.yaml
+++ b/modules/150-user-authn/templates/dex/oauth2client.yaml
@@ -26,6 +26,13 @@ trustedPeers:
     {{- end }}
   {{- end }}
 {{- end }}
+{{- if $context.Values.userAuthn.internal.dexClientCRDs }}
+  {{- range $crd := $context.Values.userAuthn.internal.dexClientCRDs }}
+    {{- if $crd.allowAccessToKubernetes }}
+- {{ $crd.id }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- if $context.Values.userAuthn.publishAPI.enabled }}
 - kubeconfig-generator
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add `DexClient` that has `dexclient.deckhouse.io/allow-access-to-kubernetes` annotation to kubernetes `OAuth2Client` `trustedPeers`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We want to allow some dex clients to authorize in kubernetes api.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: feature
summary: add dexclient with the specific annotation to kubernetes client trustedPeers
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
