### PR TITLE
[deckhouse-controller] check spec object in validations

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -52,16 +52,18 @@ spec:
     - name: 'exclude-kinds'
       expression: '!(has(request.kind) && ["StorageClass"].exists(e, (e == request.kind.kind)))'
     - name: 'exclude-restartedAt'
-      expression: '!((!has(oldObject.spec.template.metadata.annotations) && has(object.spec.template.metadata.annotations)
-                    && "kubectl.kubernetes.io/restartedAt" in object.spec.template.metadata.annotations)
-                    || (has(oldObject.spec.template.metadata.annotations) && has(object.spec.template.metadata.annotations)
-                    && !("kubectl.kubernetes.io/restartedAt" in oldObject.spec.template.metadata.annotations)
-                    && "kubectl.kubernetes.io/restartedAt" in object.spec.template.metadata.annotations)
-                    || (has(oldObject.spec.template.metadata.annotations) && has(object.spec.template.metadata.annotations)
-                    && "kubectl.kubernetes.io/restartedAt" in oldObject.spec.template.metadata.annotations
-                    && "kubectl.kubernetes.io/restartedAt" in object.spec.template.metadata.annotations
-                    && oldObject.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"]
-                    != object.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"]))'
+      expression: '!((has(object.spec) && has(object.spec.template) && has(object.spec.template.metadata)
+          && has(oldObject.spec) && has(oldObject.spec.template) && has(oldObject.spec.template.metadata))
+          && ((!has(oldObject.spec.template.metadata.annotations) && has(object.spec.template.metadata.annotations)
+          && "kubectl.kubernetes.io/restartedAt" in object.spec.template.metadata.annotations)
+          || (has(oldObject.spec.template.metadata.annotations) && has(object.spec.template.metadata.annotations)
+          && !("kubectl.kubernetes.io/restartedAt" in oldObject.spec.template.metadata.annotations)
+          && "kubectl.kubernetes.io/restartedAt" in object.spec.template.metadata.annotations)
+          || (has(oldObject.spec.template.metadata.annotations) && has(object.spec.template.metadata.annotations)
+          && "kubectl.kubernetes.io/restartedAt" in oldObject.spec.template.metadata.annotations
+          && "kubectl.kubernetes.io/restartedAt" in object.spec.template.metadata.annotations
+          && oldObject.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"]
+          != object.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"])))'
   validations:
     - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-")'
       reason: Forbidden


### PR DESCRIPTION
## Description

In the current release, a problem arose when checking the possibility of a restart. If an object does not have the spec field that we are targeting, the check fails and, as a result, operations that should have been allowed are blocked.

## Why do we need it, and what problem does it solve?

Access check fix.

## Why do we need it in the patch release (if we do)?

Lack of verification blocks the release of modules.

## What is the expected result?

The absence of a spec section in a module does not block operations.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: check spec object in validations
impact_level: default
```
