### PR TITLE
[multitenancy-manager] fix normalize function

### DIFF
--- a/modules/160-multitenancy-manager/images/multitenancy-manager/templates/_helpers.tpl
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/templates/_helpers.tpl
@@ -35,7 +35,8 @@
 
 {{- define "normalize" }}
   {{- $newName := lower . }}
-  {{- $newName = regexReplaceAll "\\W+" $newName "-" }}
+  {{- $newName = regexReplaceAll "[^a-z0-9.-]+" $newName "-" }}
   {{- $newName = regexReplaceAll "(^-+|-+$)" $newName "" }}
+  {{- $newName = regexReplaceAll "(^\\.|\\.$)" $newName "" }}
   {{- print $newName }}
 {{- end }}


### PR DESCRIPTION
## Description
It provides fix for the normalize function to support RFC 1123

## Why do we need it, and what problem does it solve?
Fixes #10657

## Why do we need it in the patch release (if we do)?
Groups with slash could be passed from keycloak, so projects cannot be created. 

## What is the expected result?
```
apiVersion: deckhouse.io/v1alpha2
kind: Project
metadata:
  creationTimestamp: "2024-12-23T18:17:42Z"
  finalizers:
  - projects.deckhouse.io/project-exists
  generation: 1
  labels:
    projects.deckhouse.io/project-template: default
  name: test-validation
  resourceVersion: "247586735"
  uid: 344acc65-b26d-4975-b694-4751f6b6a393
spec:
  description: test-validation for group with /
  parameters:
    administrators:
    - name: /Group_KVS
      subject: Group
    extendedMonitoringEnabled: true
    podSecurityProfile: Baseline
    resourceQuota:
      limits:
        cpu: 5
        memory: 5Gi
      requests:
        cpu: 5
        memory: 5Gi
        storage: 1Gi
  projectTemplateName: default
status:
  conditions:
  - lastTransitionTime: "2024-12-23T18:17:43Z"
    status: "True"
    type: ProjectTemplateFound
  - lastTransitionTime: "2024-12-23T18:17:43Z"
    status: "True"
    type: Validated
  - lastTransitionTime: "2024-12-23T18:17:45Z"
    status: "True"
    type: ResourcesUpgraded
  namespaces:
  - test-validation
  observedGeneration: 1
  state: Deployed
  templateGeneration: 23
```

```
root@dev-master-0:~# kubectl get authorizationrules.deckhouse.io -n test-validation 
NAME        AGE
group-kvs   77s
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: mulitenancy-manager
type: fix
summary: Fix normalize function.
impact_level: low
```
