### PR TITLE
[cni-cilium] Fixing tunnelMode setting for Static clusters

### DIFF
--- a/modules/021-cni-cilium/hooks/set_cilium_mode.go
+++ b/modules/021-cni-cilium/hooks/set_cilium_mode.go
@@ -94,11 +94,17 @@ func setCiliumMode(input *go_hook.HookInput) error {
 		}
 	}
 
+	value, ok = input.ConfigValues.GetOk("cniCilium.masqueradeMode")
+	if ok {
+		input.Values.Set("cniCilium.internal.masqueradeMode", value.String())
+	}
+
 	value, ok := input.ConfigValues.GetOk("cniCilium.tunnelMode")
 	if ok {
 		switch value.String() {
 		case "VXLAN":
 			input.Values.Set("cniCilium.internal.mode", "VXLAN")
+			return nil
 		case "Disabled":
 			// to recover default value if it was discovered before
 			input.Values.Set("cniCilium.internal.mode", "Direct")
@@ -108,11 +114,6 @@ func setCiliumMode(input *go_hook.HookInput) error {
 	value, ok = input.ConfigValues.GetOk("cniCilium.createNodeRoutes")
 	if ok && value.Bool() {
 		input.Values.Set("cniCilium.internal.mode", "DirectWithNodeRoutes")
-	}
-
-	value, ok = input.ConfigValues.GetOk("cniCilium.masqueradeMode")
-	if ok {
-		input.Values.Set("cniCilium.internal.masqueradeMode", value.String())
 	}
 
 	// for static clusters we should use DirectWithNodeRoutes mode

--- a/modules/021-cni-cilium/hooks/set_cilium_mode.go
+++ b/modules/021-cni-cilium/hooks/set_cilium_mode.go
@@ -94,12 +94,12 @@ func setCiliumMode(input *go_hook.HookInput) error {
 		}
 	}
 
-	value, ok = input.ConfigValues.GetOk("cniCilium.masqueradeMode")
+	value, ok := input.ConfigValues.GetOk("cniCilium.masqueradeMode")
 	if ok {
 		input.Values.Set("cniCilium.internal.masqueradeMode", value.String())
 	}
 
-	value, ok := input.ConfigValues.GetOk("cniCilium.tunnelMode")
+	value, ok = input.ConfigValues.GetOk("cniCilium.tunnelMode")
 	if ok {
 		switch value.String() {
 		case "VXLAN":


### PR DESCRIPTION
## Description
Fixed set_silium_mode.go for Static clusters with configured VXLAN.

## Why do we need it, and what problem does it solve?
After preraring for getting rid of d8-cni-configuration secret in https://github.com/deckhouse/deckhouse/pull/10640 we broke the set_silium_mode.go hook — in Static clusters tunnelMode setting doesn't work anymore.

## Why do we need it in the patch release (if we do)?
The Static clusters forced to use DirectWithNodeRoutes mode without any options.

## What is the expected result?
It is possible to configure tunnelMode: VXLAN in Static clusters.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: Fixed tunnelMode setting for Static clusters
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
