### PR TITLE
[cloud-provider-dynamix] RBAC fixes

### DIFF
--- a/ee/modules/030-cloud-provider-dynamix/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -22,6 +22,14 @@ rules:
   - list
   - watch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/modules/040-node-manager/hooks/set_instance_class_ng_usage.go
+++ b/modules/040-node-manager/hooks/set_instance_class_ng_usage.go
@@ -32,7 +32,7 @@ import (
 var kindToVersion = map[string]string{
 	"vcdinstanceclass":         "deckhouse.io/v1",
 	"zvirtinstanceclass":       "deckhouse.io/v1",
-	"dynamixinstanceclass":     "deckhouse.io/v1alpha1",
+	"dynamixinstanceclass":     "deckhouse.io/v1",
 	"huaweicloudinstanceclass": "deckhouse.io/v1",
 }
 


### PR DESCRIPTION
## Description
This PR fixes several non-critical bugs in `cloud-provider-dynamix` provider. 

## Why do we need it, and what problem does it solve?
```
  ModuleHookRun:/modules/node-manager/update_instance_class_ng:kubernetes:040-node-manager/hooks/set_instance_class_ng_usage.go:ics:OperatorStartup:failures 1671:3 errors occurred:
    * Patch object deckhouse.io/v1alpha1/DynamixInstanceClass//worker using application/merge-patch+json patch: apiVersion 'deckhouse.io/v1alpha1', kind 'DynamixInstanceClass' is not supported by cluster: DynamixInstanceClass.deckhouse.io """" not found
    * Patch object deckhouse.io/v1alpha1/DynamixInstanceClass//frontend using application/merge-patch+json patch: apiVersion 'deckhouse.io/v1alpha1', kind 'DynamixInstanceClass' is not supported by cluster: DynamixInstanceClass.deckhouse.io """" not found
    * Patch object deckhouse.io/v1alpha1/DynamixInstanceClass//system using application/merge-patch+json patch: apiVersion 'deckhouse.io/v1alpha1', kind 'DynamixInstanceClass' is not supported by cluster: DynamixInstanceClass.deckhouse.io """" not found"
```

```
{""level"":""error"",""msg"":""Attempt 2 of 15. Failed to get PersistentVolumes from cluster: persistentvolumes is forbidden: User \""system:serviceaccount:d8-cloud-provider-dynamix:cloud-data-discoverer\"" cannot list resource \""persistentvolumes\"" in API group \""\"" at the cluster scope"",""time"":""2024-12-12T07:53:37Z""}"
```    

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
Error messages are not reproducible. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dynamix
type: fix
summary: provider RBAC-for-us fixes.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
