### PR TITLE
[prometheus] Rename targets for alerts and docs fixes

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -895,9 +895,9 @@ alerts:
 
         The Deployment is in the MinimumReplicasUnavailable state.
 
-        Run the following command to check the status of the Deployment: `kubectl -n d8-monitoring get deployment grafana-v10 -o json | jq .status`.
+        Run the following command to check the status of the Deployment: `kubectl -n d8-monitoring get deployment grafana -o json | jq .status`.
 
-        Run the following command to check the status of the Pods: `kubectl -n d8-monitoring get pods -l app=grafana-v10 -o json | jq '.items[] | {(.metadata.name):.status}'`.
+        Run the following command to check the status of the Pods: `kubectl -n d8-monitoring get pods -l app=grafana -o json | jq '.items[] | {(.metadata.name):.status}'`.
       summary: |
         One or more Grafana Pods are NOT Running.
       severity: "6"
@@ -936,7 +936,7 @@ alerts:
 
         Excessive Grafana restarts indicate that something is wrong. Normally, Grafana should be up and running all the time.
 
-        Please, refer to the corresponding logs: `kubectl -n d8-monitoring logs -f -l app=grafana-v10 -c grafana`.
+        Please, refer to the corresponding logs: `kubectl -n d8-monitoring logs -f -l app=grafana -c grafana`.
       summary: |
         Excessive Grafana restarts are detected.
       severity: "9"
@@ -952,9 +952,9 @@ alerts:
         Grafana unavailability can negatively impact users who actively use it in their work.
 
         The recommended course of action:
-        1. Check the availability and status of Grafana Pods: `kubectl -n d8-monitoring get pods -l app=grafana-v10`;
-        2. Check the availability of the Grafana Deployment: `kubectl -n d8-monitoring get deployment grafana-v10`;
-        3. Examine the status of the Grafana Deployment: `kubectl -n d8-monitoring describe deployment grafana-v10`.
+        1. Check the availability and status of Grafana Pods: `kubectl -n d8-monitoring get pods -l app=grafana`;
+        2. Check the availability of the Grafana Deployment: `kubectl -n d8-monitoring get deployment grafana`;
+        3. Examine the status of the Grafana Deployment: `kubectl -n d8-monitoring describe deployment grafana`.
       summary: |
         There is no Grafana target in Prometheus.
       severity: "6"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -895,9 +895,9 @@ alerts:
 
         The Deployment is in the MinimumReplicasUnavailable state.
 
-        Run the following command to check the status of the Deployment: `kubectl -n d8-monitoring get deployment grafana -o json | jq .status`.
+        Run the following command to check the status of the Deployment: `kubectl -n d8-monitoring get deployment grafana-v10 -o json | jq .status`.
 
-        Run the following command to check the status of the Pods: `kubectl -n d8-monitoring get pods -l app=grafana -o json | jq '.items[] | {(.metadata.name):.status}'`.
+        Run the following command to check the status of the Pods: `kubectl -n d8-monitoring get pods -l app=grafana-v10 -o json | jq '.items[] | {(.metadata.name):.status}'`.
       summary: |
         One or more Grafana Pods are NOT Running.
       severity: "6"
@@ -936,7 +936,7 @@ alerts:
 
         Excessive Grafana restarts indicate that something is wrong. Normally, Grafana should be up and running all the time.
 
-        Please, refer to the corresponding logs: `kubectl -n d8-monitoring logs -f -l app=grafana -c grafana`.
+        Please, refer to the corresponding logs: `kubectl -n d8-monitoring logs -f -l app=grafana-v10 -c grafana`.
       summary: |
         Excessive Grafana restarts are detected.
       severity: "9"
@@ -952,9 +952,9 @@ alerts:
         Grafana unavailability can negatively impact users who actively use it in their work.
 
         The recommended course of action:
-        1. Check the availability and status of Grafana Pods: `kubectl -n d8-monitoring get pods -l app=grafana`;
-        2. Check the availability of the Grafana Deployment: `kubectl -n d8-monitoring get deployment grafana`;
-        3. Examine the status of the Grafana Deployment: `kubectl -n d8-monitoring describe deployment grafana`.
+        1. Check the availability and status of Grafana Pods: `kubectl -n d8-monitoring get pods -l app=grafana-v10`;
+        2. Check the availability of the Grafana Deployment: `kubectl -n d8-monitoring get deployment grafana-v10`;
+        3. Examine the status of the Grafana Deployment: `kubectl -n d8-monitoring describe deployment grafana-v10`.
       summary: |
         There is no Grafana target in Prometheus.
       severity: "6"

--- a/modules/300-prometheus/monitoring/prometheus-rules/grafana.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/grafana.yaml
@@ -50,9 +50,9 @@
 
         The Deployment is in the MinimumReplicasUnavailable state.
 
-        Run the following command to check the status of the Deployment: `kubectl -n d8-monitoring get deployment grafana -o json | jq .status`.
+        Run the following command to check the status of the Deployment: `kubectl -n d8-monitoring get deployment grafana-v10 -o json | jq .status`.
 
-        Run the following command to check the status of the Pods: `kubectl -n d8-monitoring get pods -l app=grafana -o json | jq '.items[] | {(.metadata.name):.status}'`.
+        Run the following command to check the status of the Pods: `kubectl -n d8-monitoring get pods -l app=grafana-v10 -o json | jq '.items[] | {(.metadata.name):.status}'`.
 
   - alert: D8GrafanaTargetDown
     expr: max by (job) (up{job="grafana-v10", namespace="d8-monitoring"} == 0)
@@ -91,9 +91,9 @@
         Grafana unavailability can negatively impact users who actively use it in their work.
 
         The recommended course of action:
-        1. Check the availability and status of Grafana Pods: `kubectl -n d8-monitoring get pods -l app=grafana`;
-        2. Check the availability of the Grafana Deployment: `kubectl -n d8-monitoring get deployment grafana`;
-        3. Examine the status of the Grafana Deployment: `kubectl -n d8-monitoring describe deployment grafana`.
+        1. Check the availability and status of Grafana Pods: `kubectl -n d8-monitoring get pods -l app=grafana-v10`;
+        2. Check the availability of the Grafana Deployment: `kubectl -n d8-monitoring get deployment grafana-v10`;
+        3. Examine the status of the Grafana Deployment: `kubectl -n d8-monitoring describe deployment grafana-v10`.
 
 - name: d8.grafana.malfunctioning
   rules:
@@ -123,7 +123,7 @@
 
         Excessive Grafana restarts indicate that something is wrong. Normally, Grafana should be up and running all the time.
 
-        Please, refer to the corresponding logs: `kubectl -n d8-monitoring logs -f -l app=grafana -c grafana`.
+        Please, refer to the corresponding logs: `kubectl -n d8-monitoring logs -f -l app=grafana-v10 -c grafana`.
 
   - alert: D8GrafanaDeprecatedCustomDashboardDefinition
     expr: |

--- a/modules/300-prometheus/monitoring/prometheus-rules/grafana.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/grafana.yaml
@@ -3,7 +3,7 @@
   - alert: D8GrafanaPodIsNotReady
     expr: |
       min by (pod) (
-        kube_controller_pod{namespace="d8-monitoring", controller_type="Deployment", controller_name="grafana"}
+        kube_controller_pod{namespace="d8-monitoring", controller_type="Deployment", controller_name="grafana-v10"}
         * on (pod) group_right() kube_pod_status_ready{condition="true", namespace="d8-monitoring"}
       ) != 1
     for: 5m
@@ -24,11 +24,11 @@
     expr: |
       absent(
         max by (namespace) (
-          kube_controller_replicas{controller_name="grafana",controller_type="Deployment"}
+          kube_controller_replicas{controller_name="grafana-v10",controller_type="Deployment"}
         )
         <=
         count by (namespace) (
-          kube_controller_pod{controller_name="grafana",controller_type="Deployment"}
+          kube_controller_pod{controller_name="grafana-v10",controller_type="Deployment"}
           * on(pod) group_right() kube_pod_status_phase{namespace="d8-monitoring", phase="Running"} == 1
         )
       ) == 1
@@ -55,7 +55,7 @@
         Run the following command to check the status of the Pods: `kubectl -n d8-monitoring get pods -l app=grafana -o json | jq '.items[] | {(.metadata.name):.status}'`.
 
   - alert: D8GrafanaTargetDown
-    expr: max by (job) (up{job="grafana", namespace="d8-monitoring"} == 0)
+    expr: max by (job) (up{job="grafana-v10", namespace="d8-monitoring"} == 0)
     for: 5m
     labels:
       severity_level: "6"
@@ -72,7 +72,7 @@
       summary: Prometheus is unable to scrape Grafana metrics.
 
   - alert: D8GrafanaTargetAbsent
-    expr: absent(up{job="grafana", namespace="d8-monitoring"} == 1)
+    expr: absent(up{job="grafana-v10", namespace="d8-monitoring"} == 1)
     for: 5m
     labels:
       severity_level: "6"
@@ -100,10 +100,10 @@
   - alert: D8GrafanaPodIsRestartingTooOften
     expr: |
       max by (pod) (
-        kube_controller_pod{namespace="d8-monitoring", controller_type="Deployment", controller_name="grafana"}
+        kube_controller_pod{namespace="d8-monitoring", controller_type="Deployment", controller_name="grafana-v10"}
         * on (pod) group_right() increase(kube_pod_container_status_restarts_total{namespace="d8-monitoring"}[1h])
         and
-        kube_controller_pod{namespace="d8-monitoring", controller_type="Deployment", controller_name="grafana"}
+        kube_controller_pod{namespace="d8-monitoring", controller_type="Deployment", controller_name="grafana-v10"}
         * on (pod) group_right() kube_pod_container_status_restarts_total{namespace="d8-monitoring"}
       ) > 5
     labels:


### PR DESCRIPTION
## Description
After migrating to grafana v10  we need to change alert targets and some documentation refs.

## Why do we need it, and what problem does it solve?
To avoid fake alerts and misunderstanding in documents.

## Why do we need it in the patch release (if we do)?
Some alerts are firing right now.

## What is the expected result?
No fake alerts and correct docs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix 
summary: Rename targets for alerts and docs fixes
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
