### PR TITLE
[deckhouse] fix several deployed module releases

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +32,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/downloader"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
+	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 // restoreAbsentModulesFromOverrides checks ModulePullOverrides and restore modules on the FS
@@ -162,17 +165,40 @@ func (l *Loader) restoreAbsentModulesFromOverrides(ctx context.Context) error {
 
 // restoreAbsentModulesFromReleases checks ModuleReleases with Deployed status and restore them on the FS
 func (l *Loader) restoreAbsentModulesFromReleases(ctx context.Context) error {
-	releases := new(v1alpha1.ModuleReleaseList)
-	if err := l.client.List(ctx, releases); err != nil {
+	releaseList := new(v1alpha1.ModuleReleaseList)
+	if err := l.client.List(ctx, releaseList); err != nil {
 		return fmt.Errorf("list releases: %w", err)
 	}
 
+	releases := releaseList.Items
+
+	slices.SortFunc(releases, func(a, b v1alpha1.ModuleRelease) int {
+		return a.GetVersion().Compare(b.GetVersion())
+	})
+
+	deployedReleases := make(map[string]v1alpha1.ModuleRelease)
+
 	// TODO: add labels to list only Deployed releases
-	for _, release := range releases.Items {
+	for _, release := range releases {
 		// ignore deleted release and not deployed
 		if release.Status.Phase != v1alpha1.ModuleReleasePhaseDeployed || !release.ObjectMeta.DeletionTimestamp.IsZero() {
 			continue
 		}
+
+		dRelease, ok := deployedReleases[release.GetName()]
+		if ok {
+			newRelease := dRelease.DeepCopy()
+			newRelease.Status.Phase = v1alpha1.ModuleReleasePhaseSuperseded
+			newRelease.Status.Message = ""
+			newRelease.Status.TransitionTime = metav1.NewTime(l.dependencyContainer.GetClock().Now().UTC())
+
+			err := l.client.Status().Patch(ctx, newRelease, client.MergeFrom(&dRelease))
+			if err != nil {
+				l.log.Error("patch previous deployed release", slog.String("module_name", release.GetName()), log.Err(err))
+			}
+		}
+
+		deployedReleases[release.GetName()] = release
 
 		moduleVersion := "v" + release.Spec.Version.String()
 

--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -186,14 +186,14 @@ func (l *Loader) restoreAbsentModulesFromReleases(ctx context.Context) error {
 		}
 
 		// if we already have deployed release - make it superseded
-		dRelease, ok := deployedReleases[release.Spec.ModuleName]
+		deployedRelease, ok := deployedReleases[release.Spec.ModuleName]
 		if ok {
-			newRelease := dRelease.DeepCopy()
-			newRelease.Status.Phase = v1alpha1.ModuleReleasePhaseSuperseded
-			newRelease.Status.Message = ""
-			newRelease.Status.TransitionTime = metav1.NewTime(l.dependencyContainer.GetClock().Now().UTC())
+			updatedDeployedRelease := deployedRelease.DeepCopy()
+			updatedDeployedRelease.Status.Phase = v1alpha1.ModuleReleasePhaseSuperseded
+			updatedDeployedRelease.Status.Message = ""
+			updatedDeployedRelease.Status.TransitionTime = metav1.NewTime(l.dependencyContainer.GetClock().Now().UTC())
 
-			err := l.client.Status().Patch(ctx, newRelease, client.MergeFrom(&dRelease))
+			err := l.client.Status().Patch(ctx, updatedDeployedRelease, client.MergeFrom(&deployedRelease))
 			if err != nil {
 				l.log.Error("patch previous deployed module release", slog.String("name", release.GetName()), log.Err(err))
 			}

--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -185,6 +185,7 @@ func (l *Loader) restoreAbsentModulesFromReleases(ctx context.Context) error {
 			continue
 		}
 
+		// if we already have deployed release - make it superseded
 		dRelease, ok := deployedReleases[release.Spec.ModuleName]
 		if ok {
 			newRelease := dRelease.DeepCopy()


### PR DESCRIPTION
## Description
It makes outdated deployed module releases superseded at start

## Why do we need it, and what problem does it solve?
In some cases, deployed releases may remain in the deployed status, we need to ensure only one deployed module release, so at restart we make all outdated deployed module releases superseded.

## Why do we need it in the patch release (if we do)?
The module-release-controller runs in the concurrent mode, so several deployed module releases can start race.

## What is the expected result?
Only one module release is deployed.

Several deployed modules releases:

```bash
kubectl get mr -l module=deckhouse-commander
NAME                          PHASE      UPDATE POLICY   TRANSITIONTIME   MESSAGE
deckhouse-commander-v1.3.19   Deployed   deckhouse       47d
deckhouse-commander-v1.3.20   Deployed   deckhouse       47d
deckhouse-commander-v1.4.18   Skipped    deckhouse       47d
deckhouse-commander-v1.4.19   Skipped    deckhouse       47d
deckhouse-commander-v1.4.20   Skipped    deckhouse       47d
deckhouse-commander-v1.4.21   Deployed   deckhouse       47d
```

After restart, only one is deployed:

```bash
kubectl get mr -l module=deckhouse-commander
NAME                          PHASE      UPDATE POLICY   TRANSITIONTIME   MESSAGE
deckhouse-commander-v1.3.19   Superseded   deckhouse       1m
deckhouse-commander-v1.3.20   Superseded   deckhouse       1m
deckhouse-commander-v1.4.18   Skipped    deckhouse       47d
deckhouse-commander-v1.4.19   Skipped    deckhouse       47d
deckhouse-commander-v1.4.20   Skipped    deckhouse       47d
deckhouse-commander-v1.4.21   Deployed   deckhouse       47d
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix several deployed module releases.
```

