### PR TITLE
[deckhouse] fire alert only for enabled modules

### DIFF
--- a/global-hooks/migrate/migrate_update_policy.go
+++ b/global-hooks/migrate/migrate_update_policy.go
@@ -71,6 +71,9 @@ func moduleFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) 
 	if module.Properties.UpdatePolicy != "" {
 		return nil, nil
 	}
+	if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+		return nil, nil
+	}
 	return &filteredModule{Name: module.Name, Source: module.Properties.Source}, nil
 }
 


### PR DESCRIPTION
## Description
It fires an alert about deprecated module update policy only for enabled modules.

## Why do we need it, and what problem does it solve?
No sense to fire the alert for disabled modules.

## Why do we need it in the patch release (if we do)?
No sense to fire the alert for disabled modules.

## What is the expected result?
Fire the alert only for enabled modules. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fire the deprecated module update policy alert only for enabled modules.
impact_level: low
```
