### PR TITLE
[testing] add okmeter to exclude dmtlint

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -384,5 +384,6 @@ linters-settings:
     skip-vpa-checks:
       - "d8-system:deckhouse"
       - "d8-cloud-instance-manager:node-manager"
+      - "d8-okmeter:okmeter"
     skip-pdb-checks:
       - "d8-cloud-instance-manager:node-manager"


### PR DESCRIPTION
## Description

Adding to okmeter error exception

## Why do we need it, and what problem does it solve?

After adding dmtlint, errors appeared in the okmeter module, you need to add them to exceptions to unblock development.

## What is the expected result?

Linter works without errors

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tesing
type: fix
summary: add okmeter to exclude dmtlint
impact_level: low
```
