### PR TITLE
[monitoring] CNI misconfiguration alerts fix

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -523,7 +523,7 @@ alerts:
       module: cni-cilium
       edition: ce
       description: |
-        It is necessary to correct the settings in the CNI {{ $labels.cni }} moduleConfig.
+        It is necessary to correct the settings in the CNI {{ $labels.cni }} ModuleConfig.
         You can find the desired settings in the `d8-system/desired-cni-moduleconfig` configmap.
         To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
       summary: |
@@ -536,7 +536,7 @@ alerts:
       module: cni-flannel
       edition: ce
       description: |
-        It is necessary to correct the settings in the CNI {{ $labels.cni }} moduleConfig.
+        It is necessary to correct the settings in the CNI {{ $labels.cni }} ModuleConfig.
         You can find the desired settings in the `d8-system/desired-cni-moduleconfig` configmap.
         To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
       summary: |
@@ -549,7 +549,7 @@ alerts:
       module: cni-simple-bridge
       edition: ce
       description: |
-        It is necessary to correct the settings in the CNI {{ $labels.cni }} moduleConfig.
+        It is necessary to correct the settings in the CNI {{ $labels.cni }} ModuleConfig.
         You can find the desired settings in the `d8-system/desired-cni-moduleconfig` configmap.
         To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
       summary: |

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -527,7 +527,7 @@ alerts:
         You can find the desired settings in the `d8-system/desired-cni-moduleconfig` configmap.
         To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
       summary: |
-        The settings from the secret d8-cni-configuratuin and the moduleConfig contradict each other.
+        The settings from the secret d8-cni-configuration and the ModuleConfig contradict each other.
       severity: "3"
       markupFormat: markdown
     - name: D8CNIMisconfigured
@@ -540,7 +540,7 @@ alerts:
         You can find the desired settings in the `d8-system/desired-cni-moduleconfig` configmap.
         To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
       summary: |
-        The settings from the secret d8-cni-configuratuin and the moduleConfig contradict each other.
+        The settings from the secret d8-cni-configuration and the ModuleConfig contradict each other.
       severity: "3"
       markupFormat: markdown
     - name: D8CNIMisconfigured
@@ -553,7 +553,7 @@ alerts:
         You can find the desired settings in the `d8-system/desired-cni-moduleconfig` configmap.
         To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
       summary: |
-        The settings from the secret d8-cni-configuratuin and the moduleConfig contradict each other.
+        The settings from the secret d8-cni-configuration and the ModuleConfig contradict each other.
       severity: "3"
       markupFormat: markdown
     - name: D8ControlPlaneManagerPodNotRunning

--- a/modules/021-cni-cilium/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/cni-checks.yaml
@@ -12,7 +12,7 @@
         plk_create_group_if_not_exists__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         plk_grouped_by__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         description: |
-          It is necessary to correct the settings in the CNI {{ $labels.cni }} moduleConfig.
+          It is necessary to correct the settings in the CNI {{ $labels.cni }} ModuleConfig.
           You can find the desired settings in the `d8-system/desired-cni-moduleconfig` configmap.
           To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
         summary: The settings from the secret `d8-cni-configuration` and the ModuleConfig contradict each other.

--- a/modules/021-cni-cilium/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/cni-checks.yaml
@@ -9,10 +9,10 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_cni_check: D8CNIMisconfigured,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-        plk_grouped_by__d8_cni_check: D8CNIMisconfigured,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_create_group_if_not_exists__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         description: |
           It is necessary to correct the settings in the CNI {{ $labels.cni }} moduleConfig.
           You can find the desired settings in the `d8-system/desired-cni-moduleconfig` configmap.
           To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
-        summary: The settings from the secret `d8-cni-configuratuin` and the moduleConfig contradict each other.
+        summary: The settings from the secret `d8-cni-configuration` and the ModuleConfig contradict each other.

--- a/modules/035-cni-flannel/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/035-cni-flannel/monitoring/prometheus-rules/cni-checks.yaml
@@ -12,7 +12,7 @@
         plk_create_group_if_not_exists__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         plk_grouped_by__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         description: |
-          It is necessary to correct the settings in the CNI {{ $labels.cni }} moduleConfig.
+          It is necessary to correct the settings in the CNI {{ $labels.cni }} ModuleConfig.
           You can find the desired settings in the `d8-system/desired-cni-moduleconfig` configmap.
           To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
         summary: The settings from the secret `d8-cni-configuration` and the ModuleConfig contradict each other.

--- a/modules/035-cni-flannel/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/035-cni-flannel/monitoring/prometheus-rules/cni-checks.yaml
@@ -9,10 +9,10 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_cni_check: D8CNIMisconfigured,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-        plk_grouped_by__d8_cni_check: D8CNIMisconfigured,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_create_group_if_not_exists__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         description: |
           It is necessary to correct the settings in the CNI {{ $labels.cni }} moduleConfig.
           You can find the desired settings in the `d8-system/desired-cni-moduleconfig` configmap.
           To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
-        summary: The settings from the secret `d8-cni-configuratuin` and the moduleConfig contradict each other.
+        summary: The settings from the secret `d8-cni-configuration` and the ModuleConfig contradict each other.

--- a/modules/035-cni-simple-bridge/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/035-cni-simple-bridge/monitoring/prometheus-rules/cni-checks.yaml
@@ -12,7 +12,7 @@
         plk_create_group_if_not_exists__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         plk_grouped_by__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         description: |
-          It is necessary to correct the settings in the CNI {{ $labels.cni }} moduleConfig.
+          It is necessary to correct the settings in the CNI {{ $labels.cni }} ModuleConfig.
           You can find the desired settings in the `d8-system/desired-cni-moduleconfig` configmap.
           To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
         summary: The settings from the secret `d8-cni-configuration` and the ModuleConfig contradict each other.

--- a/modules/035-cni-simple-bridge/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/035-cni-simple-bridge/monitoring/prometheus-rules/cni-checks.yaml
@@ -9,10 +9,10 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_cni_check: D8CNIMisconfigured,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-        plk_grouped_by__d8_cni_check: D8CNIMisconfigured,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_create_group_if_not_exists__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         description: |
           It is necessary to correct the settings in the CNI {{ $labels.cni }} moduleConfig.
           You can find the desired settings in the `d8-system/desired-cni-moduleconfig` configmap.
           To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
-        summary: The settings from the secret `d8-cni-configuratuin` and the moduleConfig contradict each other.
+        summary: The settings from the secret `d8-cni-configuration` and the ModuleConfig contradict each other.


### PR DESCRIPTION
## Description
Fixes for D8CNIMisconfigured alerts — renamed group and typos fixed.

## Why do we need it, and what problem does it solve?
Polk can't handle the alerts:
```
Couldn't create event due to error: Usage of current alert's trigger (D8CNIMisconfigured) is forbidden in grouping to prevent circular dependencies!
```

## Why do we need it in the patch release (if we do)?
These alerts are important to handle before upgrading to 1.68.

## What is the expected result?
Alerts are visible in polk.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring
type: fix
summary: Fixes for D8CNIMisconfigured alerts — renamed group and typos fixed.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
