### PR TITLE
[descheduler] fix conversion (#11223)

### DIFF
--- a/modules/400-descheduler/webhooks/conversion/deschedulers
+++ b/modules/400-descheduler/webhooks/conversion/deschedulers
@@ -43,7 +43,7 @@ function __on_conversion::alpha1_to_alpha2() {
        del(.spec.deschedulerPolicy.strategies.removePodsViolatingNodeTaints) |
        del(.spec.deschedulerPolicy.strategies.removePodsViolatingTopologySpreadConstraint) |
        if .spec.deschedulerPolicy.strategies.removeDuplicates.enabled then .spec.strategies.removeDuplicates.enabled = .spec.deschedulerPolicy.strategies.removeDuplicates.enabled end |
-       if .spec.deschedulerPolicy.strategies.removePodsViolatingNodeAffinity.enabled then .spec.strategies.removePodsViolatingNodeAffinity.enabled = .spec.deschedulerPolicy.strategies.removePodsViolatingNodeAffinity.enabled end |
+       if .spec.deschedulerPolicy.strategies.removePodsViolatingNodeAffinity.enabled then .spec.strategies.removePodsViolatingNodeAffinity.enabled = .spec.deschedulerPolicy.strategies.removePodsViolatingNodeAffinity.enabled | .spec.strategies.removePodsViolatingNodeAffinity.nodeAffinityType = ["requiredDuringSchedulingIgnoredDuringExecution"] end |
        if .spec.deschedulerPolicy.strategies.removePodsViolatingInterPodAntiAffinity.enabled then .spec.strategies.removePodsViolatingInterPodAntiAffinity.enabled = .spec.deschedulerPolicy.strategies.removePodsViolatingInterPodAntiAffinity.enabled end |
        if .spec.deschedulerPolicy.strategies.highNodeUtilization.enabled then .spec.strategies.highNodeUtilization.enabled = .spec.deschedulerPolicy.strategies.highNodeUtilization.enabled end |
        if .spec.deschedulerPolicy.strategies.lowNodeUtilization.enabled then .spec.strategies.lowNodeUtilization.enabled = .spec.deschedulerPolicy.strategies.lowNodeUtilization.enabled end |
@@ -52,17 +52,16 @@ function __on_conversion::alpha1_to_alpha2() {
      else . end
   )')
   then
-    data=""
-    for obj in $(jq -c './/[] | .[]' <<< ${converted}); do
-      node_selector="$(jq -cr '.spec.nodeLabelSelector//""' <<< ${obj})"
-      if [ -n "${node_selector}" ]; then
-        new_node_selector="$(echo "${node_selector}" | label-converter --to-set | sed 's|"|\"|g')"
-        obj="$(sed "s|\"${node_selector}\"|${new_node_selector}|g" <<< ${obj})"
-      fi
-      data="${data}${obj},"
+    items_count="$(jq -c 'length' <<< ${converted})"
+    for ((i=0; i<${items_count}; i++)); do
+     node_selector="$(jq -rc --argjson item_number "$i" '.[$item_number].spec.nodeLabelSelector//""' <<< ${converted})"
+     if [ -n "${node_selector}" ]; then
+       new_node_selector="$(label-converter --to-equality <<< "${node_selector}"| sed 's|"|\"|g')"
+       converted="$(jq -c --argjson new_node_selector "${new_node_selector}" --argjson item_number "${i}" '.[$item_number].spec.nodeLabelSelector = $new_node_selector' <<< ${converted})"
+     fi
     done
     cat <<EOF >"$CONVERSION_RESPONSE_PATH"
-{"convertedObjects": [${data%?}]}
+{"convertedObjects": $converted}
 EOF
   else
     cat <<EOF >"$CONVERSION_RESPONSE_PATH"
@@ -76,6 +75,7 @@ function __on_conversion::alpha2_to_alpha1() {
      if .apiVersion ==  "deckhouse.io/v1alpha2" then
        .apiVersion = "deckhouse.io/v1alpha1" |
        if .spec.nodeLabelSelector then .spec.deschedulerPolicy.globalParameters.nodeSelector = .spec.nodeLabelSelector end |
+       del(.spec.nodeLabelSelector) |
        del(.spec.strategies.removePodsViolatingNodeAffinity.nodeAffinityType) |
        del(.spec.strategies.lowNodeUtilization.thresholds) |
        del(.spec.strategies.lowNodeUtilization.targetThresholds) |
@@ -88,21 +88,20 @@ function __on_conversion::alpha2_to_alpha1() {
      else . end
   )')
   then
-    data=""
-    for obj in $(jq -c './/[] | .[]' <<< ${converted}); do
-      node_selector="$(jq -cr '.spec.deschedulerPolicy.globalParameters.nodeSelector//""' <<< ${obj})"
-      if [ -n "${node_selector}" ]; then
-        new_node_selector="$(echo "${node_selector}" | label-converter --to-equality | sed 's|"|\"|g')"
-        obj="$(sed "s|${node_selector}|\"${new_node_selector}\"|g" <<< ${obj})"
-      fi
-      data="${data}${obj},"
+    items_count="$(jq -c 'length' <<< ${converted})"
+    for ((i=0; i<${items_count}; i++)); do
+     node_selector="$(jq -rc --argjson item_number "$i" '.[$item_number].spec.deschedulerPolicy.globalParameters.nodeSelector//""' <<< ${converted})"
+     if [ -n "${node_selector}" ]; then
+       new_node_selector="$(label-converter --to-set <<< "${node_selector}"| sed 's|"|\"|g')"
+       converted="$(jq -c --argjson new_node_selector "${new_node_selector}" --argjson item_number "${i}" '.[$item_number].spec.deschedulerPolicy.globalParameters.nodeSelector = $new_node_selector' <<< ${converted})"
+     fi
     done
     cat <<EOF >"$CONVERSION_RESPONSE_PATH"
-{"convertedObjects": [${data%?}]}
+{"convertedObjects": $converted }
 EOF
   else
     cat <<EOF >"$CONVERSION_RESPONSE_PATH"
-{"failedMessage":"Conversion of nodegroups.deckhouse.io failed"}
+{"failedMessage":"Conversion of deschedulers.deckhouse.io failed"}
 EOF
   fi
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix descheduler webhook. https://github.com/deckhouse/deckhouse/pull/11223
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: descheduler
type: fix
summary: Fix descheduler webhook
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
