### PR TITLE
[containerd] fix runc tun device permission error

### DIFF
--- a/modules/007-registrypackages/images/containerd/patches/runc/001-readd-tuntap-to-default-device-rules.patch
+++ b/modules/007-registrypackages/images/containerd/patches/runc/001-readd-tuntap-to-default-device-rules.patch
@@ -1,0 +1,60 @@
+diff --git a/libcontainer/cgroups/devices/devicefilter_test.go b/libcontainer/cgroups/devices/devicefilter_test.go
+index 3a415a71..23ad92ea 100644
+--- a/libcontainer/cgroups/devices/devicefilter_test.go
++++ b/libcontainer/cgroups/devices/devicefilter_test.go
+@@ -120,14 +120,21 @@ block-8:
+         51: MovImm32 dst: r0 imm: 1
+         52: Exit
+ block-9:
+-// /dev/pts (c, 136, wildcard, rwm, true)
++// tuntap (c, 10, 200, rwm, true)
+         53: JNEImm dst: r2 off: -1 imm: 2 <block-10>
+-        54: JNEImm dst: r4 off: -1 imm: 136 <block-10>
+-        55: MovImm32 dst: r0 imm: 1
+-        56: Exit
++        54: JNEImm dst: r4 off: -1 imm: 10 <block-10>
++        55: JNEImm dst: r5 off: -1 imm: 200 <block-10>
++        56: MovImm32 dst: r0 imm: 1
++        57: Exit
+ block-10:
+-        57: MovImm32 dst: r0 imm: 0
+-        58: Exit
++// /dev/pts (c, 136, wildcard, rwm, true)
++	58: JNEImm dst: r2 off: -1 imm: 2 <block-11>
++        59: JNEImm dst: r4 off: -1 imm: 136 <block-11>
++        60: MovImm32 dst: r0 imm: 1
++        61: Exit
++block-11:
++        62: MovImm32 dst: r0 imm: 0
++        63: Exit
+ `
+ 	var devices []*devices.Rule
+ 	for _, device := range specconv.AllowedDevices {
+diff --git a/libcontainer/specconv/spec_linux.go b/libcontainer/specconv/spec_linux.go
+index e7c6faae..95ada499 100644
+--- a/libcontainer/specconv/spec_linux.go
++++ b/libcontainer/specconv/spec_linux.go
+@@ -315,6 +315,23 @@ var AllowedDevices = []*devices.Device{
+ 			Allow:       true,
+ 		},
+ 	},
++	// The following entry for /dev/net/tun device was there from the
++	// very early days of Docker, but got removed in runc 1.2.0-rc1,
++	// causing a number of regressions for users (see
++	// https://github.com/opencontainers/runc/pull/3468).
++	//
++	// Some upper-level orcherstration tools makes it either impossible
++	// or cumbersome to supply additional device rules, so we have to
++	// keep this for the sake of backward compatibility.
++	{
++		Rule: devices.Rule{
++			Type:        devices.CharDevice,
++			Major:       10,
++			Minor:       200,
++			Permissions: "rwm",
++			Allow:       true,
++		},
++	},
+ }
+ 
+ type CreateOpts struct {

--- a/modules/007-registrypackages/images/containerd/patches/runc/README.md
+++ b/modules/007-registrypackages/images/containerd/patches/runc/README.md
@@ -1,0 +1,16 @@
+# Patches
+
+## 1-readd-tuntap-to-default-device-rules.patch
+
+Re-add tun/tap to default device rules.
+
+Since runc v1.2.0 was released, a number of users complained that the removal
+of tun/tap device access from the default device ruleset is causing a
+regression in their workloads. In our case, we received an error when starting openvpn:
+```
+2024/12/23 12:28:27 open /dev/net/tun: operation not permitted 
+```
+Needs to be removed after upgrading to runc 1.2.4:
+https://github.com/opencontainers/runc/pull/4556
+
+

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -1,11 +1,11 @@
 {{- $containerd_version := "1.7.24" }}
 {{- $image_version := $containerd_version | replace "." "-" }}
-{{- $runc_version := "1.2.2" }}
+{{- $runc_version := "1.2.3" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -26,31 +26,56 @@ docker:
     containerd: {{ $containerd_version }}
     runc: {{ $runc_version }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
-from: {{ $.Images.BASE_GOLANG_22_BULLSEYE_DEV }}
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+final: false
+fromImage: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
-  to: /
+  to: /src/scripts
   stageDependencies:
     install:
       - '**/*'
+- add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+      - '**/*'
+shell:
+  install:
+  - git clone --depth=1 --branch v{{ $containerd_version }} {{ $.SOURCE_REPO }}/containerd/containerd.git /src/containerd
+  - git clone --depth=1 --branch v{{ $runc_version }} {{ $.SOURCE_REPO }}/opencontainers/runc /src/runc
+  - cd /src/containerd
+  - git describe --match 'v[0-9]*' --dirty='.m' --always > VERSION
+  - git rev-parse HEAD > REVISION
+  - cd /src/runc
+  - git apply /patches/runc/*.patch --verbose 
+  - git describe --dirty --long --always > COMMIT
+  - rm -rf /src/containerd/.git
+  - rm -rf /src/runc/.git
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+from: {{ $.Images.BASE_GOLANG_23_BULLSEYE }}
+final: false
+import:
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+  add: /src
+  to: /src
+  before: install
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
 shell:
+  beforeInstall:
+  {{- include "debian packages proxy" . | nindent 2 }}
+  - apt-get update && apt-get install libseccomp-dev -y
   install:
   - export GOPROXY={{ $.GOPROXY }}
-  - mkdir -p /src
-  - cd /src
-  - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
-  - git clone --depth=1 --branch v{{ $containerd_version }} {{ $.SOURCE_REPO }}/containerd/containerd.git
-  - cd containerd
+  - cd /src/containerd
   - git config --global user.email "builder@deckhouse.io"
-  - make STATIC=1 all
+  - make STATIC=1 VERSION="$(cat VERSION)" REVISION="$(cat REVISION)" all
   - mv bin/* /
-  - cd /src
-  - git clone --depth=1 --branch v{{ $runc_version }} {{ $.SOURCE_REPO }}/opencontainers/runc
-  - cd runc
+  - cd /src/runc
   - git config --global user.email "builder@deckhouse.io"
-  - make static
+  - make COMMIT="$(cat COMMIT)" static
   - mv runc /runc
+  - mv /src/scripts/* /


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Bump runc version to 1.2.3 and add patch to revert tun/tap to default device rules.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Since the release of runc v1.2.0, tuntap device access has been removed from the default device ruleset, causing problems when starting openvpn module:
```
[root@dev-master-0 ~]# kubectl -n d8-openvpn logs openvpn-0
Defaulted container "openvpn-tcp" out of: openvpn-tcp, ovpn-admin, kube-rbac-proxy, render-etc-hosts-with-cluster-domain-aliases (init), check-linux-kernel (init)
2024/12/25 06:24:47 open /dev/net/tun: operation not permitted
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Restoring openvpn functionality.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

<img width="1543" alt="image" src="https://github.com/user-attachments/assets/cbee8043-7818-46d5-a609-ea2d1e7b029e" />

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: containerd
type: fix
summary: Bump runc version to 1.2.3 and add patch to revert tun/tap to default device rules.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
