### PR TITLE
[containerd] fix runc tun device permission error

### DIFF
--- a/modules/007-registrypackages/images/containerd/patches/runc/001-readd-tuntap-to-default-device-rules.patch
+++ b/modules/007-registrypackages/images/containerd/patches/runc/001-readd-tuntap-to-default-device-rules.patch
@@ -1,0 +1,60 @@
+diff --git a/libcontainer/cgroups/devices/devicefilter_test.go b/libcontainer/cgroups/devices/devicefilter_test.go
+index 3a415a71..23ad92ea 100644
+--- a/libcontainer/cgroups/devices/devicefilter_test.go
++++ b/libcontainer/cgroups/devices/devicefilter_test.go
+@@ -120,14 +120,21 @@ block-8:
+         51: MovImm32 dst: r0 imm: 1
+         52: Exit
+ block-9:
+-// /dev/pts (c, 136, wildcard, rwm, true)
++// tuntap (c, 10, 200, rwm, true)
+         53: JNEImm dst: r2 off: -1 imm: 2 <block-10>
+-        54: JNEImm dst: r4 off: -1 imm: 136 <block-10>
+-        55: MovImm32 dst: r0 imm: 1
+-        56: Exit
++        54: JNEImm dst: r4 off: -1 imm: 10 <block-10>
++        55: JNEImm dst: r5 off: -1 imm: 200 <block-10>
++        56: MovImm32 dst: r0 imm: 1
++        57: Exit
+ block-10:
+-        57: MovImm32 dst: r0 imm: 0
+-        58: Exit
++// /dev/pts (c, 136, wildcard, rwm, true)
++	58: JNEImm dst: r2 off: -1 imm: 2 <block-11>
++        59: JNEImm dst: r4 off: -1 imm: 136 <block-11>
++        60: MovImm32 dst: r0 imm: 1
++        61: Exit
++block-11:
++        62: MovImm32 dst: r0 imm: 0
++        63: Exit
+ `
+ 	var devices []*devices.Rule
+ 	for _, device := range specconv.AllowedDevices {
+diff --git a/libcontainer/specconv/spec_linux.go b/libcontainer/specconv/spec_linux.go
+index e7c6faae..95ada499 100644
+--- a/libcontainer/specconv/spec_linux.go
++++ b/libcontainer/specconv/spec_linux.go
+@@ -315,6 +315,23 @@ var AllowedDevices = []*devices.Device{
+ 			Allow:       true,
+ 		},
+ 	},
++	// The following entry for /dev/net/tun device was there from the
++	// very early days of Docker, but got removed in runc 1.2.0-rc1,
++	// causing a number of regressions for users (see
++	// https://github.com/opencontainers/runc/pull/3468).
++	//
++	// Some upper-level orcherstration tools makes it either impossible
++	// or cumbersome to supply additional device rules, so we have to
++	// keep this for the sake of backward compatibility.
++	{
++		Rule: devices.Rule{
++			Type:        devices.CharDevice,
++			Major:       10,
++			Minor:       200,
++			Permissions: "rwm",
++			Allow:       true,
++		},
++	},
+ }
+ 
+ type CreateOpts struct {

--- a/modules/007-registrypackages/images/containerd/patches/runc/README.md
+++ b/modules/007-registrypackages/images/containerd/patches/runc/README.md
@@ -1,0 +1,16 @@
+# Patches
+
+## 1-readd-tuntap-to-default-device-rules.patch
+
+Re-add tun/tap to default device rules.
+
+Since runc v1.2.0 was released, a number of users complained that the removal
+of tun/tap device access from the default device ruleset is causing a
+regression in their workloads. In our case, we received an error when starting openvpn:
+```
+2024/12/23 12:28:27 open /dev/net/tun: operation not permitted 
+```
+Needs to be removed after upgrading to runc 1.2.4:
+https://github.com/opencontainers/runc/pull/4556
+
+

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -1,6 +1,6 @@
 {{- $containerd_version := "1.7.24" }}
 {{- $image_version := $containerd_version | replace "." "-" }}
-{{- $runc_version := "1.2.2" }}
+{{- $runc_version := "1.2.3" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
@@ -35,6 +35,11 @@ git:
   stageDependencies:
     install:
       - '**/*'
+- add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+      - '**/*'
 shell:
   install:
   - git clone --depth=1 --branch v{{ $containerd_version }} {{ $.SOURCE_REPO }}/containerd/containerd.git /src/containerd
@@ -43,6 +48,7 @@ shell:
   - git describe --match 'v[0-9]*' --dirty='.m' --always > VERSION
   - git rev-parse HEAD > REVISION
   - cd /src/runc
+  - git apply /patches/runc/*.patch --verbose 
   - git describe --dirty --long --always > COMMIT
   - rm -rf /src/containerd/.git
   - rm -rf /src/runc/.git


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
