### PR TITLE
[metallb] Fix RBAC rules

### DIFF
--- a/ee/se/modules/380-metallb/templates/l2lb/rbac-for-us.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/rbac-for-us.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: d8:metallb:rbac-proxy
+  name: d8:metallb:l2lb:rbac-proxy
   {{- include "helm_lib_module_labels" (list . (dict "app" "metallb")) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/ee/se/modules/380-metallb/templates/rbac-to-us.yaml
+++ b/ee/se/modules/380-metallb/templates/rbac-to-us.yaml
@@ -8,7 +8,7 @@ metadata:
 rules:
 - apiGroups: ["apps"]
   resources: ["daemonsets/prometheus-metrics", "deployments/prometheus-metrics"]
-  resourceNames: ["l2lb-controller", "metallb", "speaker"]
+  resourceNames: ["l2lb-controller", "l2lb-speaker", "metallb", "controller", "speaker"]
   verbs: ["get"]
 
 {{- if (.Values.global.enabledModules | has "prometheus") }}


### PR DESCRIPTION
## Description

Fix metallb RBAC rules.

## Why do we need it, and what problem does it solve?

1. There are `d8:metallb:rbac-proxy` ClusterRoleBinding in both EE and SE redactions. It can break RBAC in cluster.
2. There is a new linter which found it.


## Why do we need it in the patch release (if we do)?
1. A risk of ClusterRoleBinding collision.


## What is the expected result?
All linters are quiet.
There are two ClusterRoleBindings in cluster:
* `d8:metallb:rbac-proxy`
* `d8:metallb:l2lb:rbac-proxy`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: fix
summary: Fix metallb RBAC rules.
```
