### PR TITLE
[monitoring] D8CNIMisconfigured alert fix — excluding unwanted labels

### DIFF
--- a/modules/021-cni-cilium/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/cni-checks.yaml
@@ -1,7 +1,7 @@
 - name: d8.cni-check
   rules:
     - alert: D8CNIMisconfigured
-      expr: cniMisconfigured == 1
+      expr: max(cniMisconfigured{}) by(cni, module) == 1
       for: 5m
       labels:
         severity_level: "3"

--- a/modules/035-cni-flannel/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/035-cni-flannel/monitoring/prometheus-rules/cni-checks.yaml
@@ -1,7 +1,7 @@
 - name: d8.cni-check
   rules:
     - alert: D8CNIMisconfigured
-      expr: cniMisconfigured == 1
+      expr: max(cniMisconfigured{}) by(cni, module) == 1
       for: 5m
       labels:
         severity_level: "3"

--- a/modules/035-cni-simple-bridge/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/035-cni-simple-bridge/monitoring/prometheus-rules/cni-checks.yaml
@@ -1,7 +1,7 @@
 - name: d8.cni-check
   rules:
     - alert: D8CNIMisconfigured
-      expr: cniMisconfigured == 1
+      expr: max(cniMisconfigured{}) by(cni, module) == 1
       for: 5m
       labels:
         severity_level: "3"


### PR DESCRIPTION
## Description
Excluding unwanted labels from D8CNIMisconfigured alert.

## Why do we need it, and what problem does it solve?
The alert aggregation systems (i.e. polk) can't merge alerts after restarting deckhouse pod (the `pod` label is being changed) and creates the new one.

## Why do we need it in the patch release (if we do)?
The D8CNIMisconfigured alert is designed to prepare setups for upgrading to 1.68.

## What is the expected result?
Restarting deckhouse pod don't change the alert label set.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitorint
type: fix
summary: Excluded unwanted labels from D8CNIMisconfigured alert.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
