### PR TITLE
[monitoring] Turn on observability module with prometheus module.

### DIFF
--- a/modules/300-prometheus/hooks/create_observability_module_config.go
+++ b/modules/300-prometheus/hooks/create_observability_module_config.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const observabilityMCSnapshotName = "observability_moduleconfig"
+
+var observabilityMCManifest = map[string]interface{}{
+	"apiVersion": "deckhouse.io/v1alpha1",
+	"kind":       "ModuleConfig",
+	"metadata": map[string]interface{}{
+		"name": "observability",
+	},
+	"spec": map[string]interface{}{
+		"enabled": "true",
+	},
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnAfterHelm: &go_hook.OrderedConfig{Order: 10},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       observabilityMCSnapshotName,
+			ApiVersion: "deckhouse.io/v1alpha1",
+			Kind:       "ModuleConfig",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"observability"},
+			},
+			FilterFunc: applyObservabilityMCFilter,
+		},
+	},
+}, observabilityMCHookHandler)
+
+func applyObservabilityMCFilter(_ *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return true, nil
+}
+
+func observabilityMCHookHandler(input *go_hook.HookInput) error {
+	observabilityMCSnapshots := input.Snapshots[observabilityMCSnapshotName]
+
+	if len(observabilityMCSnapshots) == 0 {
+		input.PatchCollector.Create(&unstructured.Unstructured{
+			Object: observabilityMCManifest,
+		})
+	}
+
+	return nil
+}

--- a/modules/300-prometheus/hooks/create_observability_module_config.go
+++ b/modules/300-prometheus/hooks/create_observability_module_config.go
@@ -56,6 +56,10 @@ func applyObservabilityMCFilter(_ *unstructured.Unstructured) (go_hook.FilterRes
 }
 
 func observabilityMCHookHandler(input *go_hook.HookInput) error {
+	if input.Values.Get("global.modulesImages.digests.observability").Value() == nil {
+		return nil
+	}
+
 	observabilityMCSnapshots := input.Snapshots[observabilityMCSnapshotName]
 
 	if len(observabilityMCSnapshots) == 0 {

--- a/modules/300-prometheus/hooks/create_observability_module_config_test.go
+++ b/modules/300-prometheus/hooks/create_observability_module_config_test.go
@@ -33,8 +33,19 @@ spec:
   enabled: false
 `
 
+const hookExecutionConfig = `{
+  "global": {
+    "enabledModules": ["prometheus"],
+	"modulesImages": {
+	  "digests": {
+	    "observability": {"a": "b", "c": "d", "e": "f"}
+	  }
+	}
+  }
+}`
+
 var _ = Describe("Modules :: prometheus :: hooks :: create_observability_module_config ::", func() {
-	f := HookExecutionConfigInit(`{"global":{"enabledModules":["prometheus"]}}`, ``)
+	f := HookExecutionConfigInit(hookExecutionConfig, "")
 	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
 
 	Context("Without observability module config", func() {

--- a/modules/300-prometheus/hooks/create_observability_module_config_test.go
+++ b/modules/300-prometheus/hooks/create_observability_module_config_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const observabilityMCTestManifest = `---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  creationTimestamp: null
+  name: observability
+spec:
+  enabled: false
+`
+
+var _ = Describe("Modules :: prometheus :: hooks :: create_observability_module_config ::", func() {
+	f := HookExecutionConfigInit(`{"global":{"enabledModules":["prometheus"]}}`, ``)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
+
+	Context("Without observability module config", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.RunHook()
+		})
+
+		It("Must create observability module config", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			observabilityMC := f.KubernetesGlobalResource("ModuleConfig", "observability")
+			Expect(observabilityMC.Exists()).Should(BeTrue())
+			Expect(observabilityMC.Field("spec.enabled").Bool()).Should(BeTrue())
+		})
+	})
+
+	Context("Observability module is turned off", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(observabilityMCTestManifest))
+			f.RunHook()
+		})
+
+		It("Must do nothing", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			observabilityMC := f.KubernetesGlobalResource("ModuleConfig", "observability")
+			Expect(observabilityMC.Exists()).Should(BeTrue())
+			Expect(observabilityMC.Field("spec.enabled").Bool()).Should(BeFalse())
+		})
+	})
+})

--- a/modules/300-prometheus/templates/prometheus/rbac-to-us.yaml
+++ b/modules/300-prometheus/templates/prometheus/rbac-to-us.yaml
@@ -49,8 +49,3 @@ subjects:
   name: pricing
   namespace: d8-flant-integration
 {{- end }}
-{{- if (.Values.global.enabledModules | has "observability") }}
-- kind: ServiceAccount
-  name: label-proxy
-  namespace: d8-observability
-{{- end }}

--- a/modules/300-prometheus/templates/prometheus/rbac-to-us.yaml
+++ b/modules/300-prometheus/templates/prometheus/rbac-to-us.yaml
@@ -49,3 +49,8 @@ subjects:
   name: pricing
   namespace: d8-flant-integration
 {{- end }}
+{{- if (.Values.global.enabledModules | has "observability") }}
+- kind: ServiceAccount
+  name: label-proxy
+  namespace: d8-observability
+{{- end }}


### PR DESCRIPTION
## Description
This changes brings automatic switching on observability module, if 300-prometheus module is on.

## Why do we need it, and what problem does it solve?
Observability module is important part of DKP when Prometheus module is enabled. Create in this pull request hook performs observability module switch on, if there is no already existing ModuleConfig with "observability" name.

## Why do we need it in the patch release (if we do)?
-

## What is the expected result?
If prometheus module is turned on, and observability module turned off, and observability ModuleConfig CR is absent, then this hook must create observability ModuleConfig CR with `spec.enabled: true` field and value.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Observability module automatic switch on with prometheus module.

```changes
section: prometheus
type: feature
summary: Observability module automatic switch on
impact_level: low
```
