### PR TITLE
[dhctl] Add imagesRegistry variable during the bootstrap

### DIFF
--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -527,11 +527,13 @@ func DeckhouseRegistrySecret(registry config.RegistryData) *apiv1.Secret {
 			apiv1.DockerConfigJsonKey: data,
 			"address":                 []byte(registry.Address),
 			"scheme":                  []byte(registry.Scheme),
+			"imagesRegistry":          []byte(registry.Address),
 		},
 	}
 
 	if registry.Path != "" {
 		ret.Data["path"] = []byte(registry.Path)
+		ret.Data["imagesRegistry"] = []byte(registry.Address + registry.Path)
 	}
 
 	if registry.CA != "" {


### PR DESCRIPTION
## Description
Add `imagesRegistry` to the `deckhouse-registry` secret

## Why do we need it, and what problem does it solve?
During the bootstrap we don't have this field. It's set in the [deckhouse](https://github.com/deckhouse/deckhouse/blob/main/modules/002-deckhouse/templates/registry-secret.yaml#L25) module.
So, we have a small period of time. If deckhouse will reboot in this interval, it can lead that we will have no value here and it will be passed to the [release controller ](https://github.com/deckhouse/deckhouse/blob/44b9f34c9acf4de67c9775fcf20a3a50edc04614/deckhouse-controller/pkg/controller/deckhouse-release/controller.go#L274). This case will change the deckhouse image to the `:v1.XX.Y` without any registry.

It would be better to set it on boostrap, because we can :)

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix the deckhouse-registry secret on bootstrap.
impact_level: low 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
