### PR TITLE
[extended-monitoring] Update alert for CronJobs

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -225,7 +225,14 @@ alerts:
       moduleUrl: 340-extended-monitoring
       module: extended-monitoring
       edition: ce
-      description: ""
+      description: |
+        Check what's going on: `kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}`
+
+        You can check the status of the Job:
+        `kubectl -n {{$labels.namespace}} get job {{$labels.job_name}}`
+
+        You can check the status of pods created by Job:
+        `kubectl -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}`
       summary: |
         Job {{$labels.namespace}}/{{$labels.job_name}} failed in CronJob {{$labels.namespace}}/{{$labels.owner_name}}.
       severity: "5"
@@ -246,7 +253,14 @@ alerts:
       moduleUrl: 340-extended-monitoring
       module: extended-monitoring
       edition: ce
-      description: ""
+      description: |
+        Check what's going on: `kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}`
+
+        You can check the status of the Job:
+        `kubectl -n {{$labels.namespace}} get job {{$labels.job_name}}`
+
+        You can check the status of pods created by Job:
+        `kubectl -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}`
       summary: |
         CronJob {{$labels.namespace}}/{{$labels.job_name}} pods still not created.
       severity: "5"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -226,12 +226,12 @@ alerts:
       module: extended-monitoring
       edition: ce
       description: |
-        Check what's going on: `kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}`
+        Print Job details: `kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}`
 
-        You can check the status of the Job:
+        Check the Job status:
         `kubectl -n {{$labels.namespace}} get job {{$labels.job_name}}`
 
-        You can check the status of pods created by Job:
+        Check the status of pods created by the Job:
         `kubectl -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}`
       summary: |
         Job {{$labels.namespace}}/{{$labels.job_name}} failed in CronJob {{$labels.namespace}}/{{$labels.owner_name}}.
@@ -254,12 +254,12 @@ alerts:
       module: extended-monitoring
       edition: ce
       description: |
-        Check what's going on: `kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}`
+        Print Job details: `kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}`
 
-        You can check the status of the Job:
+        Check the Job status:
         `kubectl -n {{$labels.namespace}} get job {{$labels.job_name}}`
 
-        You can check the status of pods created by Job:
+        Check the status of pods created by the Job:
         `kubectl -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}`
       summary: |
         CronJob {{$labels.namespace}}/{{$labels.job_name}} pods still not created.

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
@@ -31,6 +31,14 @@
       plk_create_group_if_not_exists__cron_job_failed: "CronJobFailedGroup,kubernetes=~kubernetes,namespace=~namespace,owner_name=~owner_name"
       plk_grouped_by__cron_job_failed: "CronJobFailedGroup,kubernetes=~kubernetes,namespace=~namespace,owner_name=~owner_name"
       summary: Job {{$labels.namespace}}/{{$labels.job_name}} failed in CronJob {{$labels.namespace}}/{{$labels.owner_name}}.
+      description: |
+        Check what's going on: `kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}`
+
+        You can check the status of the Job:
+        `kubectl -n {{$labels.namespace}} get job {{$labels.job_name}}`
+
+        You can check the status of pods created by Job:
+        `kubectl -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}`
 
   - alert: CronJobPodsNotCreated
     expr: |
@@ -59,6 +67,14 @@
       plk_create_group_if_not_exists__cron_job_pods_not_created: "CronJobPodsNotCreatedGroup,kubernetes=~kubernetes,namespace=~namespace,owner_name=~owner_name"
       plk_grouped_by__cron_job_pods_not_created: "CronJobPodsNotCreatedGroup,kubernetes=~kubernetes,namespace=~namespace,owner_name=~owner_name"
       summary: CronJob {{$labels.namespace}}/{{$labels.job_name}} pods still not created.
+      description: |
+        Check what's going on: `kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}`
+
+        You can check the status of the Job:
+        `kubectl -n {{$labels.namespace}} get job {{$labels.job_name}}`
+
+        You can check the status of pods created by Job:
+        `kubectl -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}`
 
   - alert: CronJobSchedulingError
     expr: |

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
@@ -32,12 +32,12 @@
       plk_grouped_by__cron_job_failed: "CronJobFailedGroup,kubernetes=~kubernetes,namespace=~namespace,owner_name=~owner_name"
       summary: Job {{$labels.namespace}}/{{$labels.job_name}} failed in CronJob {{$labels.namespace}}/{{$labels.owner_name}}.
       description: |
-        Check what's going on: `kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}`
+        Print Job details: `kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}`
 
-        You can check the status of the Job:
+        Check the Job status:
         `kubectl -n {{$labels.namespace}} get job {{$labels.job_name}}`
 
-        You can check the status of pods created by Job:
+        Check the status of pods created by the Job:
         `kubectl -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}`
 
   - alert: CronJobPodsNotCreated

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
@@ -68,12 +68,12 @@
       plk_grouped_by__cron_job_pods_not_created: "CronJobPodsNotCreatedGroup,kubernetes=~kubernetes,namespace=~namespace,owner_name=~owner_name"
       summary: CronJob {{$labels.namespace}}/{{$labels.job_name}} pods still not created.
       description: |
-        Check what's going on: `kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}`
+        Print Job details: `kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}`
 
-        You can check the status of the Job:
+        Check the Job status:
         `kubectl -n {{$labels.namespace}} get job {{$labels.job_name}}`
 
-        You can check the status of pods created by Job:
+        Check the status of pods created by the Job:
         `kubectl -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}`
 
   - alert: CronJobSchedulingError


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added some commands for diagnostics when triggered alert for CronJobs


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
There was a request from a client who did not understand what Job was the problem with.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
```
Check what's going on: `kubectl -n <namespace> describe job <example_job>`

You can check the status of the Job:
`kubectl -n <namespace> get job <example_job>`

You can check the status of pods created by Job:
`kubectl -n <namespace> get pods -l job-name=<example_job>`
```
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: chore
summary: Update alert for CronJobs
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
