### PR TITLE
[core] fix security context for static pods and iptables containers

### DIFF
--- a/candi/bashible/common-steps/all/051_pull_and_configure_kubernetes_api_proxy.sh.tpl
+++ b/candi/bashible/common-steps/all/051_pull_and_configure_kubernetes_api_proxy.sh.tpl
@@ -32,6 +32,10 @@ metadata:
 spec:
   dnsPolicy: ClusterFirstWithHostNet
   hostNetwork: true
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
   shareProcessNamespace: true
   containers:
   - name: kubernetes-api-proxy

--- a/candi/control-plane-kubeadm/patches/etcd.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/etcd.yaml.tpl
@@ -58,3 +58,14 @@ metadata:
   namespace: kube-system
 spec:
   dnsPolicy: ClusterFirstWithHostNet
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd
+  namespace: kube-system
+spec:
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0

--- a/candi/control-plane-kubeadm/patches/kube-apiserver.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/kube-apiserver.yaml.tpl
@@ -177,3 +177,14 @@ spec:
   {{- end }}
 {{- end }}
 {{- end }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0

--- a/candi/control-plane-kubeadm/patches/kube-controller-manager.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/kube-controller-manager.yaml.tpl
@@ -75,3 +75,14 @@ metadata:
   namespace: kube-system
 spec:
   dnsPolicy: ClusterFirstWithHostNet
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+spec:
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0

--- a/candi/control-plane-kubeadm/patches/kube-scheduler.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/kube-scheduler.yaml.tpl
@@ -75,3 +75,14 @@ metadata:
   namespace: kube-system
 spec:
   dnsPolicy: ClusterFirstWithHostNet
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+spec:
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0

--- a/ee/be/modules/350-node-local-dns/templates/daemonset.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/daemonset.yaml
@@ -143,22 +143,12 @@ spec:
 {{- end }}
 {{- if not (.Values.global.enabledModules | has "cni-cilium" )}}
       - name: iptables-loop
-        {{- /*
-          UID: 0 GID:0 using for privilege access for iptables because using hostNetwork
-        */}}
-        securityContext:
-          allowPrivilegeEscalation: true
+        # containers messing with iptables and iptables-wrapper have to be run as root because iptables-legacy binary requires to be run as root (setsuid isn't an option).
+        {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 8 }}
           capabilities:
             add:
-            - DAC_OVERRIDE
             - NET_RAW
             - NET_ADMIN
-            - NET_BIND_SERVICE
-            drop:
-            - ALL
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
         image: {{ include "helm_lib_module_image" (list . "iptablesLoop") }}
         env:
         - name: KUBE_DNS_SVC_IP

--- a/ee/modules/450-network-gateway/templates/snat-daemonset.yaml
+++ b/ee/modules/450-network-gateway/templates/snat-daemonset.yaml
@@ -59,7 +59,12 @@ spec:
       - name: deckhouse-registry
       containers:
       - name: snat
-        {{- include "helm_lib_module_container_security_context_privileged" . | nindent 8 }}
+         # containers messing with iptables and iptables-wrapper have to be run as root because iptables-legacy binary requires to be run as root (setsuid isn't an option).
+        {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 8 }}
+          capabilities:
+            add:
+            - NET_RAW
+            - NET_ADMIN
         image: {{ include "helm_lib_module_image" (list . "snat") }}
         command: ["/usr/bin/python3", "/iptables-loop.py"]
         env:

--- a/modules/402-ingress-nginx/templates/failover/daemonset.yaml
+++ b/modules/402-ingress-nginx/templates/failover/daemonset.yaml
@@ -123,9 +123,8 @@ spec:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
             memory: 20Mi
             cpu: 10m
-        securityContext:
-          # containers messing with iptables and iptables-wrapper have to be run as root because iptables-legacy binary requires to be run as root (setsuid isn't an option).
-          runAsNonRoot: false
+        # containers messing with iptables and iptables-wrapper have to be run as root because iptables-legacy binary requires to be run as root (setsuid isn't an option).
+        {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 8 }}
           capabilities:
             add:
             - NET_RAW


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix security context for static pods and iptables containers.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When we set default user (deckhouse) for all docker images, pods with manifests without proper security context fail to start due to wrong user.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: core
type: fix
summary: fix security context for static pods and iptables containers
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
