### PR TITLE
[deckhouse-controller] feat: update golang.org/x/net to 0.33.0

### DIFF
--- a/modules/002-deckhouse/images/webhook-handler/label-converter/go.mod
+++ b/modules/002-deckhouse/images/webhook-handler/label-converter/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/net v0.26.0 // indirect
-	golang.org/x/text v0.16.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/modules/002-deckhouse/images/webhook-handler/label-converter/go.sum
+++ b/modules/002-deckhouse/images/webhook-handler/label-converter/go.sum
@@ -45,8 +45,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
-golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -55,8 +55,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
-golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -14,26 +14,26 @@ import:
     add: /bin/promtool
     to: /usr/local/bin/promtool
     before: setup
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /usr/bin
     to: /usr/bin
     before: setup
     includePaths:
     - python3
     - python3.12
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /usr/lib/python3
     to: /usr/lib/python3
     before: setup
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /usr/lib64/python3
     to: /usr/lib64/python3
     before: setup
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /usr/lib64/python3.12
     to: /usr/lib64/python3.12
     before: setup
-  - artifact: {{ $.ModuleName }}/{{ .ImageName }}-label-converter-artifact
+  - image: {{ $.ModuleName }}/{{ .ImageName }}-label-converter-artifact
     add: /label-converter
     to: /usr/local/bin/label-converter
     before: setup
@@ -70,8 +70,9 @@ docker:
     PYTHONPATH: /frameworks/python
   ENTRYPOINT: ["/entrypoint.sh"]
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-label-converter-src-artifact
-fromArtifact: common/src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-label-converter-src-artifact
+final: false
+fromImage: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/label-converter
   to: /src
@@ -85,10 +86,11 @@ git:
     - '**/go.mod'
     - '**/go.sum'
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-label-converter-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-label-converter-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_23_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-label-converter-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-label-converter-src-artifact
   add: /src
   to: /src
   before: install
@@ -100,7 +102,8 @@ shell:
     - chown 64535:64535 /label-converter
     - chmod 755 /label-converter
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_P11 }}
 git:
 - add: /{{ .ModulePath }}modules/002-deckhouse/images/webhook-handler/requirements.txt


### PR DESCRIPTION
## Description

As part of the security closure, it is necessary to update the golang.org/x/net dependency to version 0.33.0 to resolve the issue CVE-2024-45338

## Why do we need it, and what problem does it solve?

Solving security problems

## What is the expected result?

The working image does not contain any security issues

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: update golang.org/x/net to 0.33.0
impact_level: default
```
