### PR TITLE
[monitoring] Service Account permission for observability label-proxy to prometheus.

### DIFF
--- a/modules/300-prometheus/templates/prometheus/rbac-to-us.yaml
+++ b/modules/300-prometheus/templates/prometheus/rbac-to-us.yaml
@@ -49,3 +49,8 @@ subjects:
   name: pricing
   namespace: d8-flant-integration
 {{- end }}
+{{- if (.Values.global.enabledModules | has "observability") }}
+- kind: ServiceAccount
+  name: label-proxy
+  namespace: d8-observability
+{{- end }}


### PR DESCRIPTION
### Description  

Preparation for the new Observability module.  

### Why do we need it, and what problem does it solve?  

This change grants the `label-proxy` in the Observability module access to Prometheus via a service account token.  

### What is the expected result?  

The `label-proxy` from the Observability module will successfully access Prometheus.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Allow observability label-proxy to access prometheus.

```changes
section: prometheus
type: chore
summary: Service Account permission for observability label-proxy to prometheus.
impact: low
```
