### PR TITLE
[node-manager] bootstrap Fedora support

### DIFF
--- a/candi/bashible/bashbooster/56_detect_bundle.sh
+++ b/candi/bashible/bashbooster/56_detect_bundle.sh
@@ -23,7 +23,7 @@ bb-is-bundle(){
 
   . /etc/os-release
   case "$ID" in
-    centos|rocky|almalinux|rhel)
+    centos|fedora|rocky|almalinux|rhel)
       case "$VERSION_ID" in 7*|8*|9*)
         os="centos" ;;
       esac

--- a/candi/bashible/bootstrap/03-prepare-bashible.sh.tpl
+++ b/candi/bashible/bootstrap/03-prepare-bashible.sh.tpl
@@ -38,6 +38,10 @@ function get_bundle() {
   done
 }
 
+# avoid 'unbound variable' error
+ID=
+ID_LIKE=
+
 set -Eeuo pipefail
 shopt -s failglob
 

--- a/candi/bashible/detect_bundle.sh
+++ b/candi/bashible/detect_bundle.sh
@@ -32,7 +32,7 @@ fi
 
 . /etc/os-release
 case "$ID" in
-  centos|rocky|almalinux|rhel)
+  centos|fedora|rocky|almalinux|rhel)
     case "$VERSION_ID" in 7|7.*|8|8.*|9|9.*)
       echo "centos" && exit 0 ;;
     esac
@@ -65,7 +65,7 @@ esac
 # try to determine os by ID_LIKE
 for ID in $ID_LIKE; do
   case "$ID" in
-    centos|rhel)
+    centos|fedora|rhel)
       try_bundle "centos"
     ;;
     debian)

--- a/candi/bashible/openapi.yaml
+++ b/candi/bashible/openapi.yaml
@@ -75,7 +75,7 @@ apiVersions:
       bashible: &bashible
         type: object
         patternProperties:
-          "ubuntu-lts|centos|debian":
+          "ubuntu-lts|centos|fedora|debian":
             type: object
             patternProperties:
               '^[0-9.]+$':

--- a/ee/be/candi/bashible/detect_bundle.sh
+++ b/ee/be/candi/bashible/detect_bundle.sh
@@ -21,7 +21,7 @@ fi
 
 . /etc/os-release
 case "$ID" in
-  centos|rocky|almalinux|rhel)
+  centos|fedora|rocky|almalinux|rhel)
     case "$VERSION_ID" in 7|7.*|8|8.*|9|9.*)
       echo "centos" && exit 0 ;;
     esac
@@ -84,7 +84,7 @@ esac
 # try to determine os by ID_LIKE
 for ID in $ID_LIKE; do
   case "$ID" in
-    centos|rhel)
+    centos|fedora|rhel)
       try_bundle "centos"
     ;;
     debian)

--- a/ee/fe/modules/040-node-manager/templates/ngc-ca-certificate.yaml
+++ b/ee/fe/modules/040-node-manager/templates/ngc-ca-certificate.yaml
@@ -25,6 +25,6 @@ spec:
     case $(bb-is-bundle) in
       debian|ubuntu-lts|astra)  bb-apt-install ca-certificates ;;
       altlinux)                 bb-apt-rpm-install ca-certificates ;;
-      centos|redos|rosa)        bb-yum-install ca-certificates ;;
+      centos|fedora|redos|rosa) bb-yum-install ca-certificates ;;
       opensuse)                 bb-zypper-install ca-certificates ;;
     esac

--- a/modules/040-node-manager/templates/ngc-nfs-common.yaml
+++ b/modules/040-node-manager/templates/ngc-nfs-common.yaml
@@ -26,6 +26,6 @@ spec:
     case $(bb-is-bundle) in
       debian|ubuntu-lts|astra)  bb-apt-install nfs-common ;;
       altlinux)                 bb-apt-rpm-install nfs-utils ;;
-      centos|redos|rosa)        bb-yum-install nfs-utils ;;
+      centos|fedora|redos|rosa) bb-yum-install nfs-utils ;;
     esac
 


### PR DESCRIPTION
## Checklist
- [x] Changes were tested in the Kubernetes cluster manually.

## Description

added the ability to configure working nodes based on Fedora Core

![image](https://github.com/user-attachments/assets/6dd8be83-29f8-4a01-98d6-eb0fa6fb38df)
