### PR TITLE
[candi] reword disable floppy step message

### DIFF
--- a/candi/bashible/common-steps/all/011_disable_floppy_drive.sh.tpl
+++ b/candi/bashible/common-steps/all/011_disable_floppy_drive.sh.tpl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # There is issue that blkid hangs on nodes with kernel 5.x.x version because of floppy drive presence.
+# https://bugs.launchpad.net/ubuntu/+source/util-linux/+bug/1044111
 # We don't need floppy drive on kubernetes nodes so we disable it for good.
 if [[ -f /etc/modprobe.d/blacklist-floppy.conf ]]; then
   return 0
@@ -26,8 +27,8 @@ if lsmod | grep floppy -q ; then
   elif command -v make-initrd >/dev/null 2>&1; then
     make-initrd
   else
-    bb-log-error "update-initramfs or make-initrd not found!"
-    exit 1
+    bb-log-warning "update-initramfs or make-initrd not found. If you observe the ‘blkid’ hang problem, try to update initramfs without the floppy module."
+    exit 0
   fi
 
   bb-flag-set reboot


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Reword message in floppy step message.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Different distributions use different ways to disable kernel modules in initramfs, so we can't and don't want to do it ourselves. Since in most cases this problem will not occur, but in rare cases (e.g. https://bugs.launchpad.net/ubuntu/+source/util-linux/+bug/1044111 ) it is useful to show the way to solve the problem.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: reword disable floppy step message
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
