### PR TITLE
[deckhouse] fix deleting embedded module configs

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -182,7 +182,7 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 
 	if !moduleConfig.IsEnabled() {
 		if err := r.disableModule(ctx, module); err != nil {
-			r.log.Errorf("failed to disable the '%s' module: %v", module.Name, err)
+			r.log.Error("failed to disable the module", slog.String("module", module.Name), log.Err(err))
 			return ctrl.Result{Requeue: true}, nil
 		}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -376,7 +376,7 @@ func (r *reconciler) removeFinalizer(ctx context.Context, config *v1alpha1.Modul
 }
 
 func (r *reconciler) disableModule(ctx context.Context, module *v1alpha1.Module) error {
-	r.log.Debugf("disable the '%s' module", module.Name)
+	r.log.Debug("disable the module", slog.String("module", module.Name))
 	return utils.UpdateStatus[*v1alpha1.Module](ctx, r.client, module, func(module *v1alpha1.Module) bool {
 		if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
 			return false

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -394,7 +394,7 @@ func (r *reconciler) disableModule(ctx context.Context, module *v1alpha1.Module)
 }
 
 func (r *reconciler) enableModule(ctx context.Context, module *v1alpha1.Module) error {
-	r.log.Debugf("enable the '%s' module", module.Name)
+	r.log.Debug("enable the module", slog.String("module", module.Name))
 	return utils.UpdateStatus[*v1alpha1.Module](ctx, r.client, module, func(module *v1alpha1.Module) bool {
 		if module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
 			return false

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -211,7 +211,7 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 	}
 
 	if err := r.addFinalizer(ctx, moduleConfig); err != nil {
-		r.log.Errorf("failed to add finalizer to the '%s' module: %v", module.Name, err)
+		r.log.Error("failed to add finalizer", slog.String("module", module.Name), log.Err(err))
 		return ctrl.Result{Requeue: true}, nil
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -311,7 +311,7 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 
 	// disable module
 	if err := r.disableModule(ctx, module); err != nil {
-		r.log.Errorf("failed to disable the '%s' module: %v", module.Name, err)
+		r.log.Error("failed to disable the module", slog.String("module", module.Name), log.Err(err))
 		return ctrl.Result{Requeue: true}, nil
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -294,7 +294,7 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 		if apierrors.IsNotFound(err) {
 			r.log.Warnf("the module '%s' not found", moduleConfig.Name)
 			if err = r.removeFinalizer(ctx, moduleConfig); err != nil {
-				r.log.Errorf("failed to remove finalizer for the '%s' module config: %v", moduleConfig.Name, err)
+				r.log.Error("failed to remove finalizer", slog.String("module", moduleConfig.Name), log.Err(err))
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, nil

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -313,10 +313,6 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 	if err := r.client.Get(ctx, client.ObjectKey{Name: moduleConfig.Name}, module); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.log.Warnf("the module '%s' not found", moduleConfig.Name)
-			if err = r.removeFinalizer(ctx, moduleConfig); err != nil {
-				r.log.Errorf("failed to remove finalizer for the '%s' module config: %v", moduleConfig.Name, err)
-				return ctrl.Result{Requeue: true}, nil
-			}
 			return ctrl.Result{}, nil
 		}
 		r.log.Errorf("failed to get the '%s' module: %v", moduleConfig.Name, err)

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -329,7 +329,7 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 	}
 
 	if err := r.removeFinalizer(ctx, moduleConfig); err != nil {
-		r.log.Errorf("failed to remove finalizer for the '%s' module config: %v", moduleConfig.Name, err)
+		r.log.Error("failed to remove finalizer from ModuleConfig", slog.String("module", moduleConfig.Name), log.Err(err))
 		return ctrl.Result{Requeue: true}, nil
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -17,6 +17,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -323,7 +324,7 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 			return true
 		})
 		if err != nil {
-			r.log.Errorf("failed to update the '%s' module: %v", module.Name, err)
+			r.log.Error("failed to update the module", slog.String("module", module.Name), log.Err(err))
 			return ctrl.Result{Requeue: true}, nil
 		}
 	}

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -313,6 +313,10 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 	if err := r.client.Get(ctx, client.ObjectKey{Name: moduleConfig.Name}, module); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.log.Warnf("the module '%s' not found", moduleConfig.Name)
+			if err = r.removeFinalizer(ctx, moduleConfig); err != nil {
+				r.log.Errorf("failed to remove finalizer for the '%s' module config: %v", moduleConfig.Name, err)
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, nil
 		}
 		r.log.Errorf("failed to get the '%s' module: %v", moduleConfig.Name, err)

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -205,7 +205,7 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 
 	if moduleConfig.IsEnabled() {
 		if err := r.enableModule(ctx, module); err != nil {
-			r.log.Errorf("failed to enable the '%s' module: %v", module.Name, err)
+			r.log.Error("failed to enable the module", slog.String("module", module.Name), log.Err(err))
 			return ctrl.Result{Requeue: true}, nil
 		}
 	}

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -338,7 +338,7 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 }
 
 func (r *reconciler) changeModuleSource(ctx context.Context, module *v1alpha1.Module, source, updatePolicy string) error {
-	r.log.Debugf("set new '%s' source to the '%s' module", source, module.Name)
+	r.log.Debug("set new source to the module", slog.String("moduleSource", source), slog.String("module", module.Name))
 	err := utils.Update[*v1alpha1.Module](ctx, r.client, module, func(module *v1alpha1.Module) bool {
 		module.Properties.Source = source
 		module.Properties.UpdatePolicy = updatePolicy


### PR DESCRIPTION
## Description
It provides fix for deleting embedded modules configs.

## Why do we need it, and what problem does it solve?
The module-config-controller skips embedded modules, so the finalizer is not deleted, and the module config cannot be deleted. 

## Why do we need it in the patch release (if we do)?
The module-config-controller skips embedded modules, so the finalizer is not deleted, and the module config cannot be deleted. 

## What is the expected result?

Deleting embedded module config:

```
root@dev-master-0:~# kubectl get module upmeter 
NAME      WEIGHT   SOURCE     PHASE   ENABLED   READY
upmeter   500      Embedded   Ready   True      True
```

```
root@dev-master-0:~# kubectl get mc upmeter -oyaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  creationTimestamp: "2024-12-26T14:45:33Z"
  finalizers:
  - modules.deckhouse.io/module-config
  generation: 1
  name: upmeter
  resourceVersion: "250059259"
  uid: dcf0245f-c747-4165-afe8-191f793c4f9a
spec:
  enabled: true
status:
  message: ""
  version: "3"
```

```
root@dev-master-0:~# kubectl delete mc upmeter 
moduleconfig.deckhouse.io "upmeter" deleted
```

```
root@dev-master-0:~# kubectl get mc upmeter 
Error from server (NotFound): moduleconfigs.deckhouse.io "upmeter" not found
```

```
root@dev-master-0:~# kubectl get module upmeter -oyaml
apiVersion: deckhouse.io/v1alpha1
kind: Module
metadata:
  creationTimestamp: "2024-11-18T15:34:05Z"
  generation: 97
  labels:
    deckhouse.io/epoch: "429750889"
  name: upmeter
  resourceVersion: "250087474"
  uid: 2c9e5d43-4758-4fa9-af52-293ad87ae128
properties:
  releaseChannel: Stable
  requirements:
    bootstrapped: "true"
  source: Embedded
  version: v1.68.0-pr11347+756e64c
  weight: 500
status:
  conditions:
  - lastProbeTime: "2024-12-26T15:18:00Z"
    lastTransitionTime: "2024-12-26T15:16:29Z"
    status: "True"
    type: EnabledByModuleManager
  - lastProbeTime: "2024-12-26T15:18:00Z"
    lastTransitionTime: "2024-12-26T15:17:16Z"
    status: "True"
    type: IsReady
  - lastProbeTime: "2024-12-26T15:16:41Z"
    lastTransitionTime: "2024-12-26T15:16:41Z"
    message: disabled
    reason: Disabled
    status: "False"
    type: EnabledByModuleConfig
  hooksState: |-
    500-upmeter/hooks/disabled_probes.go: ok
    500-upmeter/hooks/dynamic_probe/hook.go: ok
    500-upmeter/hooks/https/copy_custom_certificate.go: ok
    500-upmeter/hooks/probe_deckhouse_configuration.go: ok
    500-upmeter/hooks/smokemini/reschedule.go: ok
    500-upmeter/hooks/upmeter_storage_class_change.go: ok
  phase: Ready
```

Deleting downloaded module config:
```
root@dev-master-0:~# kubectl get mc test
NAME   ENABLED   VERSION   AGE   MESSAGE
test   true      1         37d   
```

```
root@dev-master-0:~# kubectl get module test
NAME   WEIGHT   SOURCE   PHASE   ENABLED   READY
test   901      test     Ready   True      True
```

```
root@dev-master-0:~# kubectl delete mc test
moduleconfig.deckhouse.io "test" deleted
```

```
root@dev-master-0:~# kubectl get module test
NAME   WEIGHT   SOURCE   PHASE        ENABLED   READY
test   901               Downloaded   False     False
```

```
root@dev-master-0:~# kubectl get mc test
Error from server (NotFound): moduleconfigs.deckhouse.io "test" not found
```

```
apiVersion: deckhouse.io/v1alpha1
kind: Module
metadata:
  creationTimestamp: "2024-11-25T21:34:21Z"
  generation: 19
  labels:
    deckhouse.io/epoch: "429750889"
  name: test
  resourceVersion: "250088554"
  uid: 4a0fd3fd-9919-42f3-af45-d56590fb1123
properties:
  availableSources:
  - test
  releaseChannel: Alpha
  requirements:
    kubernetes: '>= 1.27'
  version: v0.9.0
  weight: 901
status:
  conditions:
  - lastProbeTime: "2024-12-26T15:19:21Z"
    lastTransitionTime: "2024-12-26T15:19:21Z"
    message: disabled
    reason: Disabled
    status: "False"
    type: EnabledByModuleConfig
  - lastProbeTime: "2024-12-26T15:19:25Z"
    lastTransitionTime: "2024-12-26T15:19:23Z"
    message: disabled
    reason: Disabled
    status: "False"
    type: EnabledByModuleManager
  - lastProbeTime: "2024-12-26T15:19:25Z"
    lastTransitionTime: "2024-12-26T15:19:21Z"
    message: disabled
    reason: Disabled
    status: "False"
    type: IsReady
  phase: Downloaded
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix deleting module config for embedded modules.
```

