### PR TITLE
[monitoring] Fix wrong rbac for new observability module

### DIFF
--- a/modules/300-prometheus/templates/aggregating-proxy/rbac-to-us.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/rbac-to-us.yaml
@@ -39,6 +39,11 @@ subjects:
     name: prometheus-metrics-adapter
     namespace: d8-monitoring
 {{- end }}
+{{- if (.Values.global.enabledModules | has "observability") }}
+  - kind: ServiceAccount
+    name: label-proxy
+    namespace: d8-observability
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/modules/300-prometheus/templates/prometheus/rbac-to-us.yaml
+++ b/modules/300-prometheus/templates/prometheus/rbac-to-us.yaml
@@ -49,8 +49,3 @@ subjects:
   name: pricing
   namespace: d8-flant-integration
 {{- end }}
-{{- if (.Values.global.enabledModules | has "observability") }}
-- kind: ServiceAccount
-  name: label-proxy
-  namespace: d8-observability
-{{- end }}


### PR DESCRIPTION
## Description
1. Removed ServiceAccount access from observability label-proxy to prometheus
2. Added ServiceAccount access from observability label-proxy to aggregating-proxy

## Why do we need it, and what problem does it solve?
We need this change, because without it, label-proxy gets gaps between metrics. Access to aggregating proxy must help to eliminate this gaps.

## Why do we need it in the patch release (if we do)?
-

## What is the expected result?
Gaps between metrics must be gone.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Allow access from observability label-proxy to prometheus aggregating proxy.

```changes
section: prometheus
type: fix
summary: Observability must walk to aggregating proxy instead of directly to prometheus
impact_level: low
```
