### PR TITLE
[admission-policy-engine] update x-doc-examples structure in SecurityPolicy CRD

### DIFF
--- a/modules/015-admission-policy-engine/crds/security-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/security-policy.yaml
@@ -97,7 +97,7 @@ spec:
                     allowedHostPaths:
                       type: array
                       description: The list of allowed hostpath prefixes. An empty list means any path can be used.
-                      x-doc-examples: [{"pathPrefix":"/dev", "readOnly": true}]
+                      x-doc-examples: [[{"pathPrefix":"/dev", "readOnly": true}]]
                       items:
                         type: object
                         required: ["pathPrefix"]
@@ -154,7 +154,7 @@ spec:
                         The list of capabilities that the containers are permitted to use.
 
                         To allow all capabilities, use `ALL`.
-                      x-doc-examples: ["SETGID", "SETUID", "NET_BIND_SERVICE"]
+                      x-doc-examples: [["SETGID", "SETUID", "NET_BIND_SERVICE"]]
                       items:
                         type: string
                         description: A linux capability.
@@ -203,7 +203,7 @@ spec:
                         The list of capabilities that have to be dropped from the containers.
 
                         To exclude all capabilities, use `ALL`'.
-                      x-doc-examples: ["SETGID", "SETUID", "NET_BIND_SERVICE"]
+                      x-doc-examples: [["SETGID", "SETUID", "NET_BIND_SERVICE"]]
                       items:
                         type: string
                         description: A linux capability to drop from the containers' specs.
@@ -212,7 +212,7 @@ spec:
                       type: array
                       description: |
                         The list of AppArmor profiles the containers are permitted to use.
-                      x-doc-examples: ["runtime/default", "unconfined"]
+                      x-doc-examples: [["runtime/default", "unconfined"]]
                       items:
                         type: string
                         description: An AppArmor profile.
@@ -231,7 +231,7 @@ spec:
                         The list of explicitly allowed unsafe sysctls.
 
                         To allow all unsafe sysctls, use `*`.
-                      x-doc-examples: ["kernel.msg*", "net.core.somaxconn"]
+                      x-doc-examples: [["kernel.msg*", "net.core.somaxconn"]]
                       items:
                         type: string
                     forbiddenSysctls:
@@ -240,7 +240,7 @@ spec:
                         The list of forbidden sysctls.
 
                         Takes precedence over allowed unsafe sysctls ([allowedUnsafeSysctls](#securitypolicy-v1alpha1-spec-policies-allowedunsafesysctls)).
-                      x-doc-examples: ["kernel.msg*", "net.core.somaxconn"]
+                      x-doc-examples: [["kernel.msg*", "net.core.somaxconn"]]
                       items:
                         type: string
                     fsGroup:
@@ -388,7 +388,7 @@ spec:
                     allowedVolumes:
                       type: array
                       description: The set of the permitted volume plugins.
-                      x-doc-examples: ["hostPath", "persistentVolumeClaim"]
+                      x-doc-examples: [["hostPath", "persistentVolumeClaim"]]
                       items:
                         type: string
                         enum:


### PR DESCRIPTION
## Description
Update x-doc-examples structure in SecurityPolicy CRD to show examples correctly in the documentation.

## Changelog entries
```changes
section: docs
type: chore
summary: Update x-doc-examples structure in SecurityPolicy CRD to show examples correctly in the documentation.
impact_level: low
```
