### PR TITLE
[user-authz] fix can-i api request

### DIFF
--- a/ee/be/modules/140-user-authz/images/webhook/src/internal/cache/retry.go
+++ b/ee/be/modules/140-user-authz/images/webhook/src/internal/cache/retry.go
@@ -6,6 +6,7 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package cache
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -26,6 +27,10 @@ func Retry(fn retryable) error {
 		cont, err = fn()
 		if !cont || err == nil {
 			break
+		}
+
+		if errors.Is(err, ErrNotFound) {
+			return ErrNotFound
 		}
 
 		attempt++

--- a/ee/be/modules/140-user-authz/images/webhook/src/internal/web/hook/handler_test.go
+++ b/ee/be/modules/140-user-authz/images/webhook/src/internal/web/hook/handler_test.go
@@ -615,7 +615,8 @@ func TestAuthorizeRequest(t *testing.T) {
 						},
 					},
 					preferredVersions: map[string]string{
-						"test": "v1",
+						"object2.test": "v1",
+						"object1.test": "v1",
 					},
 				},
 				directory: map[string]map[string]DirectoryEntry{
@@ -688,8 +689,8 @@ func (d *dummyCache) Get(api, key string) (bool, error) {
 	return d.data[api][key], nil
 }
 
-func (d *dummyCache) GetPreferredVersion(group string) (string, error) {
-	if v, ok := d.preferredVersions[group]; ok {
+func (d *dummyCache) GetPreferredVersion(group, resource string) (string, error) {
+	if v, ok := d.preferredVersions[fmt.Sprintf("%s.%s", resource, group)]; ok {
 		return v, nil
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Updates the webhook cache's logic regarding fetching the preferred version of an apiGroup when processing a subjectaccessreview request without the "version" field or when the field equals to "*" (in case of an `auth can-i` requests).

Before the changes, the webhook would get the preferred version for the whole ApiGroup from the `/apis/<group_name>` path, yet the response would contain all possible apiVersions for the group (like v1, v1alpha1, v1alpha2, etc for `deckhouse.io` group), not the versions of the specific resource related to the group. 

For example, according to the current logic, checking `auth can-i securitypolicies` of `deckhouse.io` group would make the webhook check if `securitypolicies.v1.deckhouse.io` GVR is presented in the cluster and the request would fail with `not found` api error. `v1` version would be discovered as the preferred one for the `deckhouse.io` group, but not for securty policy objects - so far, only v1alpha1 is available.

After applying the changes, the webhook fetches all available versions for the group, sorts them in descending order in accordance with the kubernetes version logic, and gets the first version from the list which reports that the related resource is represented by this version. This logic should't put substantial strain on the kube api since requests without the "version" field a pretty rare and the webhook's cache has been adjusted to store preferred version for resources with groups, not for groups only.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fixes #9474 .

## What is the expected result?
`kubectl auth can-i --as=<some external user> list <some existing resource name>` reports no error with `enableMultiTenancy: true`.

<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authz
type: fix
summary: Fix can-i api requets processing.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
