### PR TITLE
[extended-monitoring] Fix extended-monitoring-exporter CVEs

### DIFF
--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -5,3 +5,4 @@ requests==2.32.0
 setuptools==75.6.0
 urllib3==2.3.0
 cryptography==42.0.5
+cffi==1.16.0

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -6,3 +6,4 @@ setuptools==75.6.0
 urllib3==2.3.0
 cryptography==44.0.0
 pip==23.3
+setuptools==75.6.0

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -1,1 +1,8 @@
 kubernetes==22.6.0
+certifi==2024.12.14
+cryptography>=42.0.4
+idna==3.7
+pip==23.3
+requests==2.32.0
+setuptools==75.6.0
+urllib3>=1.26.19

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -4,3 +4,5 @@ idna==3.7
 requests==2.32.0
 setuptools==75.6.0
 urllib3>=1.26.19
+py==1.11.0
+cryptography==42.0.4

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -4,5 +4,3 @@ idna==3.7
 requests==2.32.0
 setuptools==75.6.0
 urllib3==2.3.0
-cryptography==42.0.5
-cffi==1.16.0

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -4,5 +4,4 @@ idna==3.7
 requests==2.32.0
 setuptools==75.6.0
 urllib3>=1.26.19
-py==1.11.0
 cryptography==42.0.4

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -1,6 +1,5 @@
 kubernetes==22.6.0
 certifi==2024.12.14
-cryptography>=42.0.4
 idna==3.7
 requests==2.32.0
 setuptools==75.6.0

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -3,5 +3,5 @@ certifi==2024.12.14
 idna==3.7
 requests==2.32.0
 setuptools==75.6.0
-urllib3>=1.26.19
-cryptography==42.0.4
+urllib3==2.3.0
+cryptography==42.0.5

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -5,5 +5,3 @@ requests==2.32.0
 setuptools==75.6.0
 urllib3==2.3.0
 cryptography==44.0.0
-pip==23.3
-setuptools==75.6.0

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -5,3 +5,4 @@ requests==2.32.0
 setuptools==75.6.0
 urllib3==2.3.0
 cryptography==44.0.0
+pip==23.3

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -4,3 +4,4 @@ idna==3.7
 requests==2.32.0
 setuptools==75.6.0
 urllib3==2.3.0
+cryptography==44.0.0

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/requirements.txt
@@ -2,7 +2,6 @@ kubernetes==22.6.0
 certifi==2024.12.14
 cryptography>=42.0.4
 idna==3.7
-pip==23.3
 requests==2.32.0
 setuptools==75.6.0
 urllib3>=1.26.19

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -8,14 +8,19 @@ git:
     stageDependencies:
       install:
         - '**/*'
+import:
+- artifact: common/python-static
+  add: /opt/python-static
+  to: /opt/python-static
+  before: install
 shell:
   install:
     - export SOURCE_REPO={{ .SOURCE_REPO }}
     - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
     - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
     - rm -rf /wheels/.git
-    - apt-get -y remove python3-module-cryptography
-    - pip3 install -f file:///wheels --no-index -r /requirements.txt
+    - apt-get -y remove python3-module-cryptography python3-pip
+    - /opt/python-static/bin/pip3 install -f file:///wheels --no-index -r /requirements.txt
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -9,6 +9,8 @@ git:
       install:
         - '**/*'
 shell:
+  beforeInstall:
+    - apt-get install -y git
   install:
     - export SOURCE_REPO={{ .SOURCE_REPO }}
     - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -15,7 +15,7 @@ shell:
     - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
     - rm -rf /wheels/.git
     - apt-get -y remove python3-module-cryptography
-    - pip3 install --upgrade /wheels/pip-23.3-py3-none-any.whl
+    - python3 -m pip install --force-reinstall /wheels/pip-23.3-py3-none-any.whl
     - pip3 install -f file:///wheels --no-index -r /requirements.txt
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 ---

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -15,7 +15,6 @@ shell:
     - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
     - rm -rf /wheels/.git
     - apt-get -y remove python3-module-cryptography
-    - pip install --force-reinstall /wheels/pip-23.3-py3-none-any.whl
     - pip3 install -f file:///wheels --no-index -r /requirements.txt
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 ---

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -8,12 +8,18 @@ git:
     stageDependencies:
       install:
         - '**/*'
+import:
+- artifact: common/python-static
+  add: /opt/python-static
+  to: /opt/python-static
+  before: install
 shell:
   install:
     - export SOURCE_REPO={{ .SOURCE_REPO }}
     - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
     - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
-    - pip3 install -f file:///wheels --no-index -r /requirements.txt
+    - rm -rf /wheels/.git
+    - /opt/python-static/bin/pip3 install -f file:///wheels --no-index -r /requirements.txt
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -15,7 +15,7 @@ shell:
     - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
     - rm -rf /wheels/.git
     - apt-get -y remove python3-module-cryptography
-    - python3 -m pip install --force-reinstall /wheels/pip-23.3-py3-none-any.whl
+    - pip install --force-reinstall /wheels/pip-23.3-py3-none-any.whl
     - pip3 install -f file:///wheels --no-index -r /requirements.txt
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 ---

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -14,6 +14,7 @@ shell:
     - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
     - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
     - rm -rf /wheels/.git
+    - apt-get -y remove python3-module-cryptography
     - pip3 install -f file:///wheels --no-index -r /requirements.txt
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 ---

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -8,6 +8,11 @@ git:
     stageDependencies:
       install:
         - '**/*'
+import:
+- artifact: common/python-static
+  add: /opt/python-static
+  to: /opt/python-static
+  before: install
 shell:
   beforeInstall:
   - apt-get install -y git

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -8,11 +8,6 @@ git:
     stageDependencies:
       install:
         - '**/*'
-import:
-- artifact: common/python-static
-  add: /opt/python-static
-  to: /opt/python-static
-  before: install
 shell:
   install:
     - export SOURCE_REPO={{ .SOURCE_REPO }}
@@ -20,7 +15,7 @@ shell:
     - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
     - rm -rf /wheels/.git
     - apt-get -y remove python3-module-cryptography
-    - /opt/python-static/bin/pip3 install -f file:///wheels --no-index -r /requirements.txt
+    - pip3 install -f file:///wheels --no-index -r /requirements.txt
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so*" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-from: {{ .Images.BASE_ALT_DEV }}
+from: {{ .Images.BASE_ALT_P11 }}
 git:
   - add: /{{ $.ModulePath }}modules/340-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/requirements.txt
     to: /requirements.txt
@@ -16,6 +16,7 @@ shell:
     - rm -rf /wheels/.git
     - apt-get -y remove python3-module-cryptography
     - pip3 install -f file:///wheels --no-index -r /requirements.txt
+    - apt-get remove python3-module-pip
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -15,6 +15,7 @@ shell:
     - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
     - rm -rf /wheels/.git
     - apt-get -y remove python3-module-cryptography
+    - pip3 install --upgrade /wheels/pip-23.3-py3-none-any.whl
     - pip3 install -f file:///wheels --no-index -r /requirements.txt
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 ---

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -8,18 +8,13 @@ git:
     stageDependencies:
       install:
         - '**/*'
-import:
-- artifact: common/python-static
-  add: /opt/python-static
-  to: /opt/python-static
-  before: install
 shell:
   install:
     - export SOURCE_REPO={{ .SOURCE_REPO }}
     - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
     - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
     - rm -rf /wheels/.git
-    - /opt/python-static/bin/pip3 install -f file:///wheels --no-index -r /requirements.txt
+    - pip3 install -f file:///wheels --no-index -r /requirements.txt
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -1,6 +1,6 @@
 {{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binary-artifact
 fromImage: common/alt-p11-artifact
 git:
   - add: /{{ $.ModulePath }}modules/340-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/requirements.txt

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -10,7 +10,8 @@ git:
         - '**/*'
 shell:
   beforeInstall:
-    - apt-get install -y git
+  {{- include "alt packages proxy" . | nindent 2 }}
+  - apt-get install -y git
   install:
     - export SOURCE_REPO={{ .SOURCE_REPO }}
     - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so*" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-from: {{ .Images.BASE_ALT_P11 }}
+fromImage: common/alt-p11-artifact
 git:
   - add: /{{ $.ModulePath }}modules/340-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/requirements.txt
     to: /requirements.txt
@@ -10,17 +10,13 @@ git:
         - '**/*'
 shell:
   beforeInstall:
-  {{- include "alt packages proxy" . | nindent 2 }}
   - apt-get install -y git
   install:
     - export SOURCE_REPO={{ .SOURCE_REPO }}
     - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
     - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
     - rm -rf /wheels/.git
-    - apt-get -y remove python3-module-cryptography
-    - pip3 install -f file:///wheels --no-index -r /requirements.txt
-    - apt-get remove python3-module-pip
-    - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+    - /opt/python-static/bin/pip3 install -f file:///wheels --no-index -r /requirements.txt
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
@@ -28,25 +24,18 @@ git:
   - add: /{{ $.ModulePath }}modules/340-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/extended-monitoring.py
     to: /app/extended-monitoring.py
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-    add: /relocate
-    to: /
-    before: install
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-    add: /usr/lib64/python3
-    to: /usr/lib64/python3
-    before: install
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-    add: /usr/lib/python3
-    to: /usr/lib/python3
-    before: install
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-    add: /usr/lib64/python3.9
-    to: /usr/lib64/python3.9
-    before: install
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-    add: /usr/local/lib/python3
-    to: /usr/local/lib/python3
-    before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binary-artifact
+  add: /opt/python-static/bin
+  to: /usr/bin
+  before: install
+  includePaths:
+  - python3*
+  - python3
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binary-artifact
+  add: /opt/python-static/lib
+  to: /usr/lib
+  before: install
+  includePaths:
+  - python3*
 docker:
   ENTRYPOINT: ["python3"]

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -19,7 +19,7 @@ shell:
     - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
     - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
     - rm -rf /wheels/.git
-    - apt-get -y remove python3-module-cryptography python3-pip
+    - apt-get -y remove python3-module-cryptography
     - /opt/python-static/bin/pip3 install -f file:///wheels --no-index -r /requirements.txt
     - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 ---


### PR DESCRIPTION
## Description
Fix of image vulnerabilities

## Why do we need it, and what problem does it solve?
To improve security of deckhouse

## What is the expected result?
Fixed CVEs

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: fix
summary: Fix extended-monitoring-exporter CVE 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
