### PR TITLE
[prometheus] Upgrade Prometheus to v2.55.1

### DIFF
--- a/modules/300-prometheus/images/prometheus/README.md
+++ b/modules/300-prometheus/images/prometheus/README.md
@@ -1,28 +1,12 @@
-## Patches
-
-### Sample limit annotation
-
-Limit the number of metrics which Prometheus scrapes from a target.  
-
-```yaml
-metadata:
-  annotations:
-    prometheus.deckhouse.io/sample-limit: "5000"
-```
-
-### Successfully sent metric
-
-Exports gauge metric with the count of successfully sent alerts. 
-
 ### How-to build prometheus
 
-Current falco version is `PROMETHEUS_VERSION=v2.45.2`.
+Current prometheus version is `PROMETHEUS_VERSION=v2.55.1`.
 
 To build prometheus we need to repush used third-party libs to own registry. To do this we need to run specific Dockerfile:
 
 ```dockerfile
-ARG BASE_GOLANG_21_BULLSEYE_DEV
-FROM $BASE_GOLANG_21_BULLSEYE_DEV
+ARG BASE_GOLANG_22_BULLSEYE_DEV
+FROM $BASE_GOLANG_22_BULLSEYE_DEV
 ARG PROMETHEUS_VERSION
 ARG SOURCE_REPO
 
@@ -38,16 +22,26 @@ RUN mkdir /prometheus && cd /prometheus &&\
 To run Dockerfile exec the command:
 
 ```shell
-docker build --build-arg SOURCE_REPO=https://github.com --build-arg BASE_GOLANG_21_BULLSEYE_DEV=registry.deckhouse.io/base_images/dev-golang:1.21.6-bullseye --build-arg PROMETHEUS_VERSION=${PROMETHEUS_VERSION} -t prometheus-deps .
+export PROMETHEUS_VERSION=v2.55.1
+# Check the image:tag used in the runner that will execute `npm run build`,
+# and for consistency, ensure they are the same.”
+export BASE_GOLANG_22_BULLSEYE_DEV=registry.deckhouse.io/base_images/dev-golang:1.22.8-bullseye@sha256:b79c06949dd2a4e19b900b1c29372219cfb0418109439c8b38fc485d26bbccdb
+docker build --build-arg SOURCE_REPO=https://github.com --build-arg BASE_GOLANG_22_BULLSEYE_DEV=${BASE_GOLANG_22_BULLSEYE_DEV} --build-arg PROMETHEUS_VERSION=${PROMETHEUS_VERSION} -t prometheus-deps . --progress=plain --no-cache
 ```
 
 Than copy folders from container:
 
 ```shell
-docker run --name prometheus-deps -d prometheus-deps bash
-docker cp prometheus-deps:/prometheus/prometheus/web/ui/node_modules node_modules
-docker cp prometheus-deps:/prometheus/prometheus/web/ui/package-lock.json package-lock.json
+docker run --name prometheus-deps -d prometheus-deps 
+docker cp prometheus-deps:/prometheus/prometheus/web/ . 
 docker rm -f prometheus-deps
+```
+
+Before commiting your changes, remove the `.gitignore` files, so that all
+changes made by `npm install` are included into the repostiory.
+
+```shell
+find . -name ".gitignore" -type f -delete
 ```
 
 Then commit content to `fox.flant.com/deckhouse/3p/prometheus/prometheus-deps` to the branch `${PROMETHEUS_VERSION}`.

--- a/modules/300-prometheus/images/prometheus/patches/README.md
+++ b/modules/300-prometheus/images/prometheus/patches/README.md
@@ -1,0 +1,16 @@
+## Patches
+
+### Sample limit annotation
+
+Limit the number of metrics which Prometheus scrapes from a target.  
+
+```yaml
+metadata:
+  annotations:
+    prometheus.deckhouse.io/sample-limit: "5000"
+```
+
+### Successfully sent metric
+
+Exports gauge metric with the count of successfully sent alerts. 
+

--- a/modules/300-prometheus/images/prometheus/patches/fix-cve.patch
+++ b/modules/300-prometheus/images/prometheus/patches/fix-cve.patch
@@ -1,0 +1,113 @@
+From bf0a2e2dcd8da9b7c26c51f2db320d602c15cd18 Mon Sep 17 00:00:00 2001
+From: Yaroslav Kavokin <yaroslav.kavokin@flant.com>
+Date: Thu, 9 Jan 2025 20:21:08 +0300
+Subject: [PATCH] Update net/crypto packages
+
+---
+ go.mod | 12 ++++++------
+ go.sum | 24 ++++++++++++------------
+ 2 files changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 0631611..35e9b04 100644
+--- a/go.mod
++++ b/go.mod
+@@ -76,9 +76,9 @@ require (
+ 	go.uber.org/goleak v1.3.0
+ 	go.uber.org/multierr v1.11.0
+ 	golang.org/x/oauth2 v0.23.0
+-	golang.org/x/sync v0.8.0
+-	golang.org/x/sys v0.25.0
+-	golang.org/x/text v0.18.0
++	golang.org/x/sync v0.10.0
++	golang.org/x/sys v0.28.0
++	golang.org/x/text v0.21.0
+ 	golang.org/x/time v0.6.0
+ 	golang.org/x/tools v0.24.0
+ 	google.golang.org/api v0.195.0
+@@ -190,11 +190,11 @@ require (
+ 	go.opencensus.io v0.24.0 // indirect
+ 	go.opentelemetry.io/otel/metric v1.29.0 // indirect
+ 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
+-	golang.org/x/crypto v0.26.0 // indirect
++	golang.org/x/crypto v0.31.0 // indirect
+ 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect
+ 	golang.org/x/mod v0.20.0 // indirect
+-	golang.org/x/net v0.28.0 // indirect
+-	golang.org/x/term v0.23.0 // indirect
++	golang.org/x/net v0.33.0 // indirect
++	golang.org/x/term v0.27.0 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
+ 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+ 	gopkg.in/inf.v0 v0.9.1 // indirect
+diff --git a/go.sum b/go.sum
+index 0246a37..7b3b493 100644
+--- a/go.sum
++++ b/go.sum
+@@ -782,8 +782,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
+ golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+ golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
+ golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
+-golang.org/x/crypto v0.26.0 h1:RrRspgV4mU+YwB4FYnuBoKsUapNIL5cohGAmSH3azsw=
+-golang.org/x/crypto v0.26.0/go.mod h1:GY7jblb9wI+FOo5y8/S2oY4zWP07AkOJ4+jxCqdqn54=
++golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
++golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
+@@ -865,8 +865,8 @@ golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+ golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
+ golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+ golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
+-golang.org/x/net v0.28.0 h1:a9JDOJc5GMUJ0+UDqmLT86WiEy7iWyIhz8gz8E4e5hE=
+-golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=
++golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
++golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+@@ -888,8 +888,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
+ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+-golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
++golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
++golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+@@ -955,16 +955,16 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+-golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+-golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
++golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+ golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
+ golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
+ golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
+ golang.org/x/term v0.20.0/go.mod h1:8UkIAJTvZgivsXaD6/pH6U9ecQzZ45awqEOzuCvwpFY=
+-golang.org/x/term v0.23.0 h1:F6D4vR+EHoL9/sWAWgAR1H2DcHr4PareCbAaCo1RpuU=
+-golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=
++golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
++golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
+ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+@@ -976,8 +976,8 @@ golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+ golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+ golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+ golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+-golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
+-golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
++golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
++golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+-- 
+2.47.0

--- a/modules/300-prometheus/images/prometheus/patches/sample_limit_annotation.patch
+++ b/modules/300-prometheus/images/prometheus/patches/sample_limit_annotation.patch
@@ -1,8 +1,8 @@
 diff --git a/discovery/kubernetes/pod.go b/discovery/kubernetes/pod.go
-index 732cf52ad..3080f013b 100644
+index 02990e415..69aba7e25 100644
 --- a/discovery/kubernetes/pod.go
 +++ b/discovery/kubernetes/pod.go
-@@ -299,6 +299,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
+@@ -284,6 +284,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
  			// The user has to add a port manually.
  			tg.Targets = append(tg.Targets, model.LabelSet{
  				model.AddressLabel:     lv(pod.Status.PodIP),
@@ -10,8 +10,8 @@ index 732cf52ad..3080f013b 100644
  				podContainerNameLabel:  lv(c.Name),
  				podContainerIDLabel:    lv(cID),
  				podContainerImageLabel: lv(c.Image),
-@@ -313,6 +314,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
-
+@@ -298,6 +299,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
+ 
  			tg.Targets = append(tg.Targets, model.LabelSet{
  				model.AddressLabel:            lv(addr),
 +				"__sample_limit__":            lv(""),
@@ -19,11 +19,11 @@ index 732cf52ad..3080f013b 100644
  				podContainerIDLabel:           lv(cID),
  				podContainerImageLabel:        lv(c.Image),
 diff --git a/discovery/kubernetes/service.go b/discovery/kubernetes/service.go
-index 40e17679e..32e3ea46c 100644
+index 51204a5a1..31a8df2ce 100644
 --- a/discovery/kubernetes/service.go
 +++ b/discovery/kubernetes/service.go
-@@ -193,6 +193,7 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
-
+@@ -180,6 +180,7 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
+ 
  		labelSet := model.LabelSet{
  			model.AddressLabel:       lv(addr),
 +			"__sample_limit__":       lv(""),
@@ -31,13 +31,13 @@ index 40e17679e..32e3ea46c 100644
  			servicePortNumberLabel:   lv(strconv.FormatInt(int64(port.Port), 10)),
  			servicePortProtocolLabel: lv(string(port.Protocol)),
 diff --git a/scrape/scrape.go b/scrape/scrape.go
-index 8c4cc51e7..e7bff4dcb 100644
+index c285f05e3..97f57252d 100644
 --- a/scrape/scrape.go
 +++ b/scrape/scrape.go
-@@ -314,6 +314,11 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed
+@@ -155,6 +155,11 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed
  		}
  		opts.target.SetMetadataStore(cache)
-
+ 
 +		limit := opts.target.SampleLimit()
 +		if limit == 0 {
 +			limit = opts.sampleLimit
@@ -46,20 +46,20 @@ index 8c4cc51e7..e7bff4dcb 100644
  		return newScrapeLoop(
  			ctx,
  			opts.scraper,
-@@ -327,7 +332,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed
- 			cache,
- 			offsetSeed,
+@@ -171,7 +176,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed
  			opts.honorTimestamps,
+ 			opts.trackTimestampsStaleness,
+ 			opts.enableCompression,
 -			opts.sampleLimit,
 +			limit,
  			opts.bucketLimit,
+ 			opts.maxSchema,
  			opts.labelLimits,
- 			opts.interval,
 diff --git a/scrape/target.go b/scrape/target.go
-index a655e8541..fbd437e01 100644
+index ad4b4f685..c58bf6c2f 100644
 --- a/scrape/target.go
 +++ b/scrape/target.go
-@@ -18,6 +18,7 @@ import (
+@@ -19,6 +19,7 @@ import (
  	"hash/fnv"
  	"net"
  	"net/url"
@@ -67,7 +67,7 @@ index a655e8541..fbd437e01 100644
  	"strings"
  	"sync"
  	"time"
-@@ -546,3 +547,15 @@ func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig, noDefault
+@@ -578,3 +579,15 @@ func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig, noDefault
  	}
  	return targets, failures
  }

--- a/modules/300-prometheus/images/prometheus/patches/successfully_sent_metric.patch
+++ b/modules/300-prometheus/images/prometheus/patches/successfully_sent_metric.patch
@@ -1,8 +1,8 @@
 diff --git a/notifier/notifier.go b/notifier/notifier.go
-index 3d2ee5949..aa000dcf9 100644
+index 4cf376aa0..2725a4d72 100644
 --- a/notifier/notifier.go
 +++ b/notifier/notifier.go
-@@ -135,6 +135,7 @@ type alertMetrics struct {
+@@ -134,6 +134,7 @@ type alertMetrics struct {
  	latency                 *prometheus.SummaryVec
  	errors                  *prometheus.CounterVec
  	sent                    *prometheus.CounterVec
@@ -10,10 +10,11 @@ index 3d2ee5949..aa000dcf9 100644
  	dropped                 prometheus.Counter
  	queueLength             prometheus.GaugeFunc
  	queueCapacity           prometheus.Gauge
-@@ -168,6 +169,12 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
+@@ -167,6 +168,13 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
  		},
  			[]string{alertmanagerLabel},
  		),
++
 +		successfullySent: prometheus.NewCounterVec(prometheus.CounterOpts{
 +			Namespace: namespace,
 +			Subsystem: subsystem,
@@ -23,7 +24,7 @@ index 3d2ee5949..aa000dcf9 100644
  		dropped: prometheus.NewCounter(prometheus.CounterOpts{
  			Namespace: namespace,
  			Subsystem: subsystem,
-@@ -199,6 +206,7 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
+@@ -198,6 +206,7 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
  			m.latency,
  			m.errors,
  			m.sent,
@@ -31,19 +32,19 @@ index 3d2ee5949..aa000dcf9 100644
  			m.dropped,
  			m.queueLength,
  			m.queueCapacity,
-@@ -535,6 +543,7 @@ func (n *Manager) sendAll(alerts ...*Alert) bool {
+@@ -550,6 +559,7 @@ func (n *Manager) sendAll(alerts ...*Alert) bool {
  					n.metrics.errors.WithLabelValues(url).Inc()
  				} else {
  					numSuccess.Inc()
 +					n.metrics.successfullySent.WithLabelValues(url).Add(float64(len(alerts)))
  				}
  				n.metrics.latency.WithLabelValues(url).Observe(time.Since(begin).Seconds())
- 				n.metrics.sent.WithLabelValues(url).Add(float64(len(alerts)))
-@@ -687,6 +696,7 @@ func (s *alertmanagerSet) sync(tgs []*targetgroup.Group) {
+ 				n.metrics.sent.WithLabelValues(url).Add(float64(len(amAlerts)))
+@@ -713,6 +723,7 @@ func (s *alertmanagerSet) sync(tgs []*targetgroup.Group) {
  		// This will initialize the Counters for the AM to 0.
  		s.metrics.sent.WithLabelValues(us)
  		s.metrics.errors.WithLabelValues(us)
 +		s.metrics.successfullySent.WithLabelValues(us)
-
+ 
  		seen[us] = struct{}{}
  		s.ams = append(s.ams, am)

--- a/modules/300-prometheus/images/prometheus/werf.inc.yaml
+++ b/modules/300-prometheus/images/prometheus/werf.inc.yaml
@@ -57,8 +57,8 @@ git:
 shell:
   install:
   - git clone --depth 1 --branch v0.17.0 {{ .SOURCE_REPO }}/prometheus/promu.git /src/promu
-  - git clone --depth 1 --branch v2.55.1 {{ .SOURCE_REPO }}/prometheus/prometheus.git /src/prometheus
   - git clone --depth 1 --branch v2.55.1 {{ .SOURCE_REPO }}/prometheus/prometheus-deps.git /src/prometheus-deps
+  - git clone --depth 1 --branch v2.55.1 {{ .SOURCE_REPO }}/prometheus/prometheus.git /src/prometheus
   - cd /src/prometheus
   - git apply /patches/*.patch --verbose
   - rm -rf web/ui/*

--- a/modules/300-prometheus/images/prometheus/werf.inc.yaml
+++ b/modules/300-prometheus/images/prometheus/werf.inc.yaml
@@ -1,107 +1,31 @@
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-promu-artifact
-from: {{ $.Images.BASE_GOLANG_18_ALPINE_DEV }}
-mount:
-- fromPath: ~/go-pkg-cache
-  to: /go/pkg
-shell:
-  beforeInstall:
-  - apk add --no-cache openssh-client
-  install:
-  - export GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
-  - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
-  - git clone --depth 1 --branch v0.14.0 {{ $.SOURCE_REPO }}/prometheus/promu.git /promu
-  - cd /promu
-  - go build -ldflags="-s -w" -o promu ./main.go
----
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ $.Images.BASE_GOLANG_21_BULLSEYE_DEV }}
-fromCacheVersion: 2024022701
-mount:
-- fromPath: ~/go-pkg-cache
-  to: /go/pkg
-import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-promu-artifact
-  add: /promu/promu
-  to: /bin/promu
-  before: install
-git:
-- add: /{{ $.ModulePath }}modules/300-{{ $.ModuleName }}/images/{{ $.ImageName }}
-  to: /patches
-  includePaths:
-  - '**/*.patch'
-  stageDependencies:
-    install:
-    - '**/*'
-shell:
-  install:
-  - export NODE_MAJOR=20
-  - export GOPROXY={{ $.GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 PROMETHEUS_VERSION=v2.45.2
-  - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
-  - git clone -b "${PROMETHEUS_VERSION}" --single-branch {{ $.SOURCE_REPO }}/prometheus/prometheus-deps
-  - mkdir /prometheus && cd /prometheus
-  - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
-  - git clone -b "${PROMETHEUS_VERSION}" --single-branch {{ $.SOURCE_REPO }}/prometheus/prometheus
-  - cd /prometheus/prometheus/web/ui
-  - mv /prometheus-deps/* .
-  - npm run build
-  - cd /prometheus/prometheus
-  - scripts/compress_assets.sh
-  - go mod tidy
-  - git apply /patches/*.patch --verbose
-  - go generate -tags plugins ./plugins
-  - /bin/promu build --prefix /prometheus/prometheus
-  - mkdir -p /consoles
-  - cp /prometheus/prometheus/consoles/* /consoles
-  - cp /prometheus/prometheus/console_libraries/* /consoles
-  - mkdir -p /etc
-  - cp /prometheus/prometheus/documentation/examples/prometheus.yml /etc
-  - cp /prometheus/prometheus/console_libraries/* /etc
-  - mkdir /empty
-  - chown -R 64535:64535 /empty
-  - chown -R 64535:64535 /prometheus/
-  - chown -R 64535:64535 /etc/
-  - chown -R 64535:64535 /consoles/
-  - chmod 0700 /prometheus/prometheus/prometheus
-  - chmod 0700 /prometheus/prometheus/promtool
----
-{{ $binariesList := "/usr/bin/curl /bin/sh /bin/df" }}
----
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-from: {{ $.Images.BASE_ALT_DEV }}
-shell:
-  install:
-    - /binary_replace.sh -i "{{ $binariesList }}" -o /relocate
----
-image: {{ $.ModuleName }}/{{ $.ImageName }}
+image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
-fromCacheVersion: 2024022701
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-  add: /prometheus/prometheus/prometheus
-  to: /bin/prometheus
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  add: /src
+  to: /bin
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-  add: /prometheus/prometheus/promtool
-  to: /bin/promtool
-  before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-  add: /prometheus/prometheus/console_libraries/
-  to: /usr/share/prometheus/console_libraries
-  before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-  add: /consoles/
+  includePaths:
+  - 'promtool'
+  - 'prometheus'
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  add: /src/consoles
   to: /usr/share/prometheus/consoles
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-  add: /etc/
-  to: /etc/prometheus
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  add: /src/console_libraries
+  to: /usr/share/prometheus/console_libraries
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-  add: /empty/
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  add: /src/documentation/examples/prometheus.yml
+  to: /etc/prometheus/prometheus.yml
+  before: setup
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  add: /empty
   to: /prometheus
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -120,3 +44,81 @@ docker:
   - "--storage.tsdb.path=/prometheus"
   - "--web.console.libraries=/usr/share/prometheus/console_libraries"
   - "--web.console.templates=/usr/share/prometheus/consoles"
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+fromImage: common/src-artifact
+final: false
+git:
+- add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+    - '**/*'
+shell:
+  install:
+  - git clone --depth 1 --branch v0.17.0 {{ .SOURCE_REPO }}/prometheus/promu.git /src/promu
+  - git clone --depth 1 --branch v2.55.1 {{ .SOURCE_REPO }}/prometheus/prometheus.git /src/prometheus
+  - git clone --depth 1 --branch v2.55.1 {{ .SOURCE_REPO }}/prometheus/prometheus-deps.git /src/prometheus-deps
+  - cd /src/prometheus
+  - git apply /patches/*.patch --verbose
+  - rm -rf web/ui/*
+  - cp -r /src/prometheus-deps/web/ui/* web/ui/.
+  - scripts/compress_assets.sh
+  - rm -r documentation/examples/remote_storage
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-promu-artifact
+from: {{ .Images.BASE_GOLANG_23_ALPINE }}
+final: false
+import:
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+  add: /src/promu
+  to: /src
+  before: install
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+shell:
+  install:
+  - export GOPROXY={{ .GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+  - cd /src
+  - go build -ldflags="-s -w" -o promu ./main.go
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+from: {{ .Images.BASE_GOLANG_23_ALPINE }}
+final: false
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+import:
+- image: {{ .ModuleName }}/{{ .ImageName }}-promu-artifact
+  add: /src/promu
+  to: /bin/promu
+  before: install
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+  add: /src/prometheus
+  to: /src
+  before: install
+shell:
+  install:
+  - export GOPROXY={{ .GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+  - cd /src
+  - go generate -tags plugins ./plugins
+  - /bin/promu build --prefix /src
+  - mkdir -p /empty
+  - chown 64535:64535 /src/prometheus /src/promtool
+  - chmod 0700 /src/prometheus /src/promtool
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+fromImage: common/relocate-artifact
+final: false
+shell:
+  beforeInstall:
+  {{- include "alt packages proxy" . | nindent 2 }}
+  - apt-get install -y curl
+  install:
+  - |
+    /binary_replace.sh -i "\
+      /usr/bin/curl \
+      /bin/sh \
+      /bin/df \
+      " -o /relocate

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -52,7 +52,7 @@ spec:
   retention: {{ .Values.prometheus.longtermRetentionDays }}d
   retentionSize: {{ .Values.prometheus.internal.prometheusLongterm.retentionGigabytes }}GB
   image: {{ include "helm_lib_module_image" (list . "prometheus") }}
-  version: v2.45.2
+  version: v2.55.1
   imagePullSecrets:
   - name: deckhouse-registry
   listenLocal: true

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -51,7 +51,7 @@ spec:
   retention: {{ .Values.prometheus.retentionDays }}d
   retentionSize: {{ .Values.prometheus.internal.prometheusMain.retentionGigabytes }}GB
   image: {{ include "helm_lib_module_image" (list . "prometheus") }}
-  version: v2.45.2
+  version: v2.55.1
   enableRemoteWriteReceiver: true
   enableFeatures:
   - memory-snapshot-on-shutdown # https://ganeshvernekar.com/blog/prometheus-tsdb-snapshot-on-shutdown/

--- a/modules/303-prometheus-pushgateway/images/pushgateway/werf.inc.yaml
+++ b/modules/303-prometheus-pushgateway/images/pushgateway/werf.inc.yaml
@@ -6,7 +6,7 @@ mount:
   to: /go/pkg
 import:
 - artifact: prometheus/prometheus-promu-artifact
-  add: /promu/promu
+  add: /src/promu
   to: /bin/promu
   before: install
 shell:


### PR DESCRIPTION
## Description
- Update the Prometheus v2.45.2 -> v2.55.1
- New werf format (separate src-artifact/artifcat/final image)
- Repalce `npm build` step with pre-build static files for UI. 
- Add patch to fix CVE in net/crypto packages.

####
Manual regression tests:
- [x] Rules/Alerts
- [x] Remote write
- [x] Sample Limit


## Why do we need it, and what problem does it solve?
- To improve security.
- Keep up with latest version.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: prometheus
type: chore
summary: Prometheus version v2.45.2 -> v2.55.1
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
