### PR TITLE
[ci] Fix link-checker script execution in CI pipeline

### DIFF
--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -142,7 +142,7 @@ steps:
       DECKHOUSE_REGISTRY_READ_HOST: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}"
       CHECKER_IMAGE: "${{vars.DOC_LINK_CHECKER_IMAGE}}"
     run: |
-      docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
+      test ./tools/docs/link-checker/entrypoint.sh && docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
                 -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} /entrypoint.sh
 
   - name: Clean TMPDIR

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1523,7 +1523,7 @@ jobs:
           DECKHOUSE_REGISTRY_READ_HOST: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}"
           CHECKER_IMAGE: "${{vars.DOC_LINK_CHECKER_IMAGE}}"
         run: |
-          docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
+          test ./tools/docs/link-checker/entrypoint.sh && docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
                     -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} /entrypoint.sh
 
       - name: Clean TMPDIR

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -1268,7 +1268,7 @@ jobs:
           DECKHOUSE_REGISTRY_READ_HOST: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}"
           CHECKER_IMAGE: "${{vars.DOC_LINK_CHECKER_IMAGE}}"
         run: |
-          docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
+          test ./tools/docs/link-checker/entrypoint.sh && docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
                     -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} /entrypoint.sh
 
       - name: Clean TMPDIR

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -3568,7 +3568,7 @@ jobs:
           DECKHOUSE_REGISTRY_READ_HOST: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}"
           CHECKER_IMAGE: "${{vars.DOC_LINK_CHECKER_IMAGE}}"
         run: |
-          docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
+          test ./tools/docs/link-checker/entrypoint.sh && docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
                     -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} /entrypoint.sh
 
       - name: Clean TMPDIR


### PR DESCRIPTION
## Description
Ensure ./tools/docs/link-checker/entrypoint.sh is executable before running the Docker container.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix link-checker script execution in CI pipeline
impact_level: low
```
