### PR TITLE
[ci] Switch user for web_links_test

### DIFF
--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -142,8 +142,15 @@ steps:
       DECKHOUSE_REGISTRY_READ_HOST: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}"
       CHECKER_IMAGE: "${{vars.DOC_LINK_CHECKER_IMAGE}}"
     run: |
-      test ./tools/docs/link-checker/entrypoint.sh && docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
-                -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} /entrypoint.sh
+      test ./tools/docs/link-checker/entrypoint.sh && \
+      docker run \
+        --rm \
+        -v "${_TMPDIR}/site_en:/src/en:ro" \
+        -v "${_TMPDIR}/site_ru:/src/ru:ro" \
+        -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" \
+        -u $(id -u) \
+        ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} \
+        /entrypoint.sh
 
   - name: Clean TMPDIR
     if: always()

--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -142,7 +142,7 @@ steps:
       DECKHOUSE_REGISTRY_READ_HOST: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}"
       CHECKER_IMAGE: "${{vars.DOC_LINK_CHECKER_IMAGE}}"
     run: |
-      test ./tools/docs/link-checker/entrypoint.sh && \
+      test -e ./tools/docs/link-checker/entrypoint.sh && \
       docker run \
         --rm \
         -v "${_TMPDIR}/site_en:/src/en:ro" \

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1523,7 +1523,7 @@ jobs:
           DECKHOUSE_REGISTRY_READ_HOST: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}"
           CHECKER_IMAGE: "${{vars.DOC_LINK_CHECKER_IMAGE}}"
         run: |
-          test ./tools/docs/link-checker/entrypoint.sh && \
+          test -e ./tools/docs/link-checker/entrypoint.sh && \
           docker run \
             --rm \
             -v "${_TMPDIR}/site_en:/src/en:ro" \

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1523,8 +1523,15 @@ jobs:
           DECKHOUSE_REGISTRY_READ_HOST: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}"
           CHECKER_IMAGE: "${{vars.DOC_LINK_CHECKER_IMAGE}}"
         run: |
-          test ./tools/docs/link-checker/entrypoint.sh && docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
-                    -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} /entrypoint.sh
+          test ./tools/docs/link-checker/entrypoint.sh && \
+          docker run \
+            --rm \
+            -v "${_TMPDIR}/site_en:/src/en:ro" \
+            -v "${_TMPDIR}/site_ru:/src/ru:ro" \
+            -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" \
+            -u $(id -u) \
+            ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} \
+            /entrypoint.sh
 
       - name: Clean TMPDIR
         if: always()

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -1268,8 +1268,15 @@ jobs:
           DECKHOUSE_REGISTRY_READ_HOST: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}"
           CHECKER_IMAGE: "${{vars.DOC_LINK_CHECKER_IMAGE}}"
         run: |
-          test ./tools/docs/link-checker/entrypoint.sh && docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
-                    -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} /entrypoint.sh
+          test ./tools/docs/link-checker/entrypoint.sh && \
+          docker run \
+            --rm \
+            -v "${_TMPDIR}/site_en:/src/en:ro" \
+            -v "${_TMPDIR}/site_ru:/src/ru:ro" \
+            -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" \
+            -u $(id -u) \
+            ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} \
+            /entrypoint.sh
 
       - name: Clean TMPDIR
         if: always()

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -1268,7 +1268,7 @@ jobs:
           DECKHOUSE_REGISTRY_READ_HOST: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}"
           CHECKER_IMAGE: "${{vars.DOC_LINK_CHECKER_IMAGE}}"
         run: |
-          test ./tools/docs/link-checker/entrypoint.sh && \
+          test -e ./tools/docs/link-checker/entrypoint.sh && \
           docker run \
             --rm \
             -v "${_TMPDIR}/site_en:/src/en:ro" \

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -3568,8 +3568,15 @@ jobs:
           DECKHOUSE_REGISTRY_READ_HOST: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}"
           CHECKER_IMAGE: "${{vars.DOC_LINK_CHECKER_IMAGE}}"
         run: |
-          test ./tools/docs/link-checker/entrypoint.sh && docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
-                    -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} /entrypoint.sh
+          test ./tools/docs/link-checker/entrypoint.sh && \
+          docker run \
+            --rm \
+            -v "${_TMPDIR}/site_en:/src/en:ro" \
+            -v "${_TMPDIR}/site_ru:/src/ru:ro" \
+            -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" \
+            -u $(id -u) \
+            ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} \
+            /entrypoint.sh
 
       - name: Clean TMPDIR
         if: always()

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -3568,7 +3568,7 @@ jobs:
           DECKHOUSE_REGISTRY_READ_HOST: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}"
           CHECKER_IMAGE: "${{vars.DOC_LINK_CHECKER_IMAGE}}"
         run: |
-          test ./tools/docs/link-checker/entrypoint.sh && \
+          test -e ./tools/docs/link-checker/entrypoint.sh && \
           docker run \
             --rm \
             -v "${_TMPDIR}/site_en:/src/en:ro" \


### PR DESCRIPTION
## Description
Change user for documentation links linter docker container.

## Why do we need it, and what problem does it solve?
This change helps to prevent littering runners with root-owned files.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Switch user for web_links_test.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
