### PR TITLE
[docs] update API endpoints for document handling in docs-builder

### DIFF
--- a/docs/site/backends/docs-builder/internal/http/v1/handler.go
+++ b/docs/site/backends/docs-builder/internal/http/v1/handler.go
@@ -40,9 +40,6 @@ func NewHandler(docsService *docs.Service) *DocsBuilderHandler {
 	r.HandleFunc("/readyz", h.handleReadyZ)
 	r.HandleFunc("/healthz", h.handleHealthZ)
 
-	r.HandleFunc("POST /loadDocArchive/{moduleName}/{version}", h.handleUpload)
-	r.HandleFunc("POST /build", h.handleBuild)
-
 	r.HandleFunc("POST /api/v1/doc/{moduleName}/{version}", h.handleUpload)
 	r.HandleFunc("DELETE /api/v1/doc/{moduleName}", h.handleDelete)
 	r.HandleFunc("POST /api/v1/build", h.handleBuild)

--- a/docs/site/backends/registry-modules-watcher/internal/backends/pkg/sender/sender.go
+++ b/docs/site/backends/registry-modules-watcher/internal/backends/pkg/sender/sender.go
@@ -64,14 +64,14 @@ func (s *sender) Send(ctx context.Context, listBackends map[string]struct{}, ver
 
 					continue
 				}
-				url := "http://" + backend + "/loadDocArchive/" + version.Module + "/" + version.Version + "?channels=" + strings.Join(version.ReleaseChannels, ",")
+				url := "http://" + backend + "/api/v1/doc/" + version.Module + "/" + version.Version + "?channels=" + strings.Join(version.ReleaseChannels, ",")
 				err := s.loadDocArchive(ctx, url, version.TarFile)
 				if err != nil {
 					klog.Errorf("send docs error: %v", err)
 				}
 			}
 
-			url := "http://" + backend + "/build"
+			url := "http://" + backend + "/api/v1/build"
 			err := s.build(ctx, url)
 			if err != nil {
 				klog.Errorf("build docs error: %v", err)


### PR DESCRIPTION
## Description

Fixed: #10521

## Why do we need it, and what problem does it solve?

We are updating the endpoints used for docs-builder.

## What is the expected result?

docs-builder only uses new endpoints. The old ones have been deleted.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: update API endpoints for document handling in docs-builder
impact_level: low
```
