### PR TITLE
[chrony] Fix ports conflict

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -207,6 +207,11 @@ groups:
     description:
       en: "*cilium-hubble* API"
       ru: "API для модуля *cilium-hubble*"
+  - ports: "4245"
+    protocol: TCP
+    description:
+      en: chrony-exporter metrics port
+      ru: Метрики chrony-exporter
 
 - group: ExternalToMaster
   description:

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -189,7 +189,7 @@ spec:
         name: chrony-exporter
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         args:
-        - '--web.listen-address=127.0.0.1:4295'
+        - '--web.listen-address=127.0.0.1:4245'
         - '--chrony.address=unix:///var/run/chrony/chronyd.sock'
         - '--collector.tracking'
         - '--collector.serverstats'
@@ -198,12 +198,12 @@ spec:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 4295
+            port: 4245
         readinessProbe:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 4295
+            port: 4245
         volumeMounts:
         - name: var-run
           mountPath: /var/run
@@ -217,7 +217,7 @@ spec:
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         args:
-        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4295"
+        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4245"
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
@@ -232,7 +232,7 @@ spec:
             excludePaths:
             - /healthz
             upstreams:
-            - upstream: http://127.0.0.1:4295/
+            - upstream: http://127.0.0.1:4245/
               path: /
               authorization:
                 resourceAttributes:
@@ -243,17 +243,17 @@ spec:
                   subresource: prometheus-metrics
                   name: chrony
         ports:
-        - containerPort: 4295
+        - containerPort: 4245
           name: https-metrics
         livenessProbe:
           httpGet:
             path: /livez
-            port: 4295
+            port: 4245
             scheme: HTTPS
         readinessProbe:
           httpGet:
             path: /livez
-            port: 4295
+            port: 4245
             scheme: HTTPS
         resources:
           requests:
@@ -385,7 +385,7 @@ spec:
         name: chrony-exporter
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         args:
-        - '--web.listen-address=127.0.0.1:4295'
+        - '--web.listen-address=127.0.0.1:4245'
         - '--chrony.address=unix:///var/run/chrony/chronyd.sock'
         - '--collector.tracking'
         - '--collector.serverstats'
@@ -394,12 +394,12 @@ spec:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 4295
+            port: 4245
         readinessProbe:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 4295
+            port: 4245
         volumeMounts:
         - name: var-run
           mountPath: /var/run
@@ -413,7 +413,7 @@ spec:
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         args:
-        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4295"
+        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4245"
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
@@ -428,7 +428,7 @@ spec:
             excludePaths:
             - /healthz
             upstreams:
-            - upstream: http://127.0.0.1:4295/
+            - upstream: http://127.0.0.1:4245/
               path: /
               authorization:
                 resourceAttributes:
@@ -439,17 +439,17 @@ spec:
                   subresource: prometheus-metrics
                   name: chrony-master
         ports:
-        - containerPort: 4295
+        - containerPort: 4245
           name: https-metrics
         livenessProbe:
           httpGet:
             path: /livez
-            port: 4295
+            port: 4245
             scheme: HTTPS
         readinessProbe:
           httpGet:
             path: /livez
-            port: 4295
+            port: 4245
             scheme: HTTPS
         resources:
           requests:

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -189,7 +189,7 @@ spec:
         name: chrony-exporter
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         args:
-        - '--web.listen-address=127.0.0.1:4228'
+        - '--web.listen-address=127.0.0.1:4295'
         - '--chrony.address=unix:///var/run/chrony/chronyd.sock'
         - '--collector.tracking'
         - '--collector.serverstats'
@@ -198,12 +198,12 @@ spec:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 4228
+            port: 4295
         readinessProbe:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 4228
+            port: 4295
         volumeMounts:
         - name: var-run
           mountPath: /var/run
@@ -217,7 +217,7 @@ spec:
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         args:
-        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4228"
+        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4295"
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
@@ -232,7 +232,7 @@ spec:
             excludePaths:
             - /healthz
             upstreams:
-            - upstream: http://127.0.0.1:4228/
+            - upstream: http://127.0.0.1:4295/
               path: /
               authorization:
                 resourceAttributes:
@@ -243,17 +243,17 @@ spec:
                   subresource: prometheus-metrics
                   name: chrony
         ports:
-        - containerPort: 4228
+        - containerPort: 4295
           name: https-metrics
         livenessProbe:
           httpGet:
             path: /livez
-            port: 4228
+            port: 4295
             scheme: HTTPS
         readinessProbe:
           httpGet:
             path: /livez
-            port: 4228
+            port: 4295
             scheme: HTTPS
         resources:
           requests:
@@ -385,7 +385,7 @@ spec:
         name: chrony-exporter
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         args:
-        - '--web.listen-address=127.0.0.1:4228'
+        - '--web.listen-address=127.0.0.1:4295'
         - '--chrony.address=unix:///var/run/chrony/chronyd.sock'
         - '--collector.tracking'
         - '--collector.serverstats'
@@ -394,12 +394,12 @@ spec:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 4228
+            port: 4295
         readinessProbe:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 4228
+            port: 4295
         volumeMounts:
         - name: var-run
           mountPath: /var/run
@@ -413,7 +413,7 @@ spec:
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         args:
-        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4228"
+        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4295"
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
@@ -428,7 +428,7 @@ spec:
             excludePaths:
             - /healthz
             upstreams:
-            - upstream: http://127.0.0.1:4228/
+            - upstream: http://127.0.0.1:4295/
               path: /
               authorization:
                 resourceAttributes:
@@ -439,17 +439,17 @@ spec:
                   subresource: prometheus-metrics
                   name: chrony-master
         ports:
-        - containerPort: 4228
+        - containerPort: 4295
           name: https-metrics
         livenessProbe:
           httpGet:
             path: /livez
-            port: 4228
+            port: 4295
             scheme: HTTPS
         readinessProbe:
           httpGet:
             path: /livez
-            port: 4228
+            port: 4295
             scheme: HTTPS
         resources:
           requests:


### PR DESCRIPTION
## Description
FIx ports conflict.

## Why do we need it, and what problem does it solve?
We have ports conflict between chrony-exporter and sds-node-configurator. 

## Why do we need it in the patch release (if we do)?
Yes. 
To fix conflict. 

## What is the expected result?
No ports conflict

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: chrony
type: fix 
summary: Fix ports conflict
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
