### PR TITLE
[docs] Fix broken links in documentation files

### DIFF
--- a/docs/documentation/pages/module-development/STRUCTURE.md
+++ b/docs/documentation/pages/module-development/STRUCTURE.md
@@ -290,7 +290,7 @@ You can use the `conversion.TestConvert` function to write conversion tests. It 
 - path to the source configuration file (i.e., the version before the conversion);
 - path to the resulting configuration file (i.e., the version after the conversion).
 
-An [example](https://github.com/deckhouse/deckhouse/blob/main/modules/prometheus/openapi/conversions/conversions_test.go) of a conversion test.
+An [example](https://github.com/deckhouse/deckhouse/blob/main/modules/300-prometheus/openapi/conversions/conversions_test.go) of a conversion test.
 
 ### config-values.yaml
 

--- a/docs/documentation/pages/module-development/STRUCTURE_RU.md
+++ b/docs/documentation/pages/module-development/STRUCTURE_RU.md
@@ -290,7 +290,7 @@ conversions:
 - путь до исходного файла конфигурации (версия до конвертации);
 - путь до ожидаемого файла конфигурации (версия после конвертации).
 
-[Пример](https://github.com/deckhouse/deckhouse/blob/main/modules/prometheus/openapi/conversions/conversions_test.go) теста конверсии.
+[Пример](https://github.com/deckhouse/deckhouse/blob/main/modules/300-prometheus/openapi/conversions/conversions_test.go) теста конверсии.
 
 ### config-values.yaml
 

--- a/modules/101-cert-manager/docs/FAQ.md
+++ b/modules/101-cert-manager/docs/FAQ.md
@@ -58,7 +58,7 @@ The module automatically creates `ClusterIssuer` of supported cloud providers wh
 If necessary, you can create such `ClusterIssuer` yourself.
 
 An example of using AWS Route53 is available in the section [How to protect `cert-manager` credentials](#how-to-secure-cert-manager-credentials).  
-The list of all possible `ClusterIssuer`s that can be created is available in the [module templates](https://github.com/deckhouse/deckhouse/tree/main/modules/cert-manager/templates/cert-manager).
+The list of all possible `ClusterIssuer`s that can be created is available in the [module templates](https://github.com/deckhouse/deckhouse/tree/main/modules/101-cert-manager/templates/cert-manager).
 
 Using third-party DNS providers is implemented via the `webhook` method.  
 

--- a/modules/101-cert-manager/docs/FAQ_RU.md
+++ b/modules/101-cert-manager/docs/FAQ_RU.md
@@ -55,7 +55,7 @@ title: "Модуль cert-manager: FAQ"
 При необходимости можно создать такие `ClusterIssuer` самостоятельно.  
 
 Пример использования AWS Route53 доступен в разделе [Как защитить учетные данные `cert-manager`](#как-защитить-учетные-данные-cert-manager).  
-Актуальный перечень всех возможных для создания `ClusterIssuer` доступен в [шаблонах модуля](https://github.com/deckhouse/deckhouse/tree/main/modules/cert-manager/templates/cert-manager).
+Актуальный перечень всех возможных для создания `ClusterIssuer` доступен в [шаблонах модуля](https://github.com/deckhouse/deckhouse/tree/main/modules/101-cert-manager/templates/cert-manager).
 
 Использование сторонних DNS-провайдеров реализуется через метод `webhook`.  
 Когда `cert-manager` выполняет вызов `ACME` `DNS01`, он отправляет запрос на вебхук-сервер, который затем выполняет нужные операции для обновления записи DNS.  

--- a/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
@@ -619,7 +619,7 @@ spec:
                         [Подробнее...](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data)
                 legacySSL:
                   description: |
-                    Включены ли старые версии TLS. Также опция разрешает legacy cipher suites для поддержки старых библиотек и программ: [OWASP Cipher String 'C' ](https://cheatsheetseries.owasp.org/cheatsheets/TLS_Cipher_String_Cheat_Sheet.html). Подробнее [здесь](https://github.com/deckhouse/deckhouse/blob/main/modules/ingress-nginx/templates/controller/configmap.yaml).
+                    Включены ли старые версии TLS. Также опция разрешает legacy cipher suites для поддержки старых библиотек и программ: [OWASP Cipher String 'C' ](https://cheatsheetseries.owasp.org/cheatsheets/TLS_Cipher_String_Cheat_Sheet.html). Подробнее [здесь](https://github.com/deckhouse/deckhouse/blob/main/modules/402-ingress-nginx/templates/controller/configmap.yaml).
 
                     **По умолчанию** включены только TLSv1.2 и самые новые cipher suites.
                 disableHTTP2:

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -1015,7 +1015,7 @@ spec:
                   description: |
                     Enable old TLS protocol versions and legacy cipher suites.
 
-                    Also, this options enables legacy cipher suites to support legacy libraries and software: [OWASP Cipher String 'C' ](https://cheatsheetseries.owasp.org/cheatsheets/TLS_Cipher_String_Cheat_Sheet.html). Learn more [here](https://github.com/deckhouse/deckhouse/blob/main/modules/ingress-nginx/templates/controller/configmap.yaml).
+                    Also, this options enables legacy cipher suites to support legacy libraries and software: [OWASP Cipher String 'C' ](https://cheatsheetseries.owasp.org/cheatsheets/TLS_Cipher_String_Cheat_Sheet.html). Learn more [here](https://github.com/deckhouse/deckhouse/blob/main/modules/402-ingress-nginx/templates/controller/configmap.yaml).
 
                     By default, only TLSv1.2 and the newest cipher suites are enabled.
                 disableHTTP2:


### PR DESCRIPTION
## Description
Correct links to module templates and config files in various docs.

## Changelog entries

```changes
section: docs
type: chore
summary: Correct links to module templates and config files in various docs.
impact_level: low
```
