### PR TITLE
[docs] Fix missing "create" command in DVP and DKP Getting Started sections

### DIFF
--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -123,7 +123,7 @@ ssh-keygen -t rsa -f /dev/shm/caps-id -C "" -N ""
     <p>Create an <a href="/products/kubernetes-platform/documentation/v1/modules/node-manager/cr.html#sshcredentials">SSHCredentials</a> resource in the cluster. To do so, run the following command on the <strong>master node</strong>:</p>
 {% snippetcut %}
 ```bash
-sudo -i d8 k -f - <<EOF
+sudo -i d8 k create -f - <<EOF
 apiVersion: deckhouse.io/v1alpha1
 kind: SSHCredentials
 metadata:
@@ -166,7 +166,7 @@ chmod 600 /home/caps/.ssh/authorized_keys
 ```bash
 # Specify the IP address of the node you want to connect to the cluster.
 export NODE=<NODE-IP-ADDRESS>
-sudo -i d8 k -f - <<EOF
+sudo -i d8 k create -f - <<EOF
 apiVersion: deckhouse.io/v1alpha1
 kind: StaticInstance
 metadata:

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -123,7 +123,7 @@ ssh-keygen -t rsa -f /dev/shm/caps-id -C "" -N ""
     <p>Создайте в кластере ресурс <a href="/products/kubernetes-platform/documentation/v1/modules/node-manager/cr.html#sshcredentials">SSHCredentials</a>. Для этого выполните на <strong>master-узле</strong> следующую команду:</p>
 {% snippetcut %}
 ```bash
-sudo -i d8 k -f - <<EOF
+sudo -i d8 k create -f - <<EOF
 apiVersion: deckhouse.io/v1alpha1
 kind: SSHCredentials
 metadata:
@@ -174,7 +174,7 @@ pdpl-user -i 63 caps
 ```bash
 # Укажите IP-адрес узла, который необходимо подключить к кластеру.
 export NODE=<NODE-IP-ADDRESS>
-sudo -i d8 k -f - <<EOF
+sudo -i d8 k create -f - <<EOF
 apiVersion: deckhouse.io/v1alpha1
 kind: StaticInstance
 metadata:

--- a/docs/site/_includes/getting_started/dvp/global/STEP_NODES.md
+++ b/docs/site/_includes/getting_started/dvp/global/STEP_NODES.md
@@ -40,7 +40,7 @@ ssh-keygen -t rsa -f /dev/shm/caps-id -C "" -N ""
 
   {% snippetcut %}
   ```shell
-sudo -i d8 k -f - <<EOF
+sudo -i d8 k create -f - <<EOF
   apiVersion: deckhouse.io/v1alpha1
   kind: SSHCredentials
   metadata:
@@ -81,7 +81,7 @@ chmod 600 /home/caps/.ssh/authorized_keys
   {% snippetcut %}
   ```shell
 export NODE=<NODE-IP-ADDRESS> # Specify the IP address of the node you want to connect to the cluster.
-  sudo -i d8 k -f - <<EOF
+  sudo -i d8 k create -f - <<EOF
   apiVersion: deckhouse.io/v1alpha1
   kind: StaticInstance
   metadata:


### PR DESCRIPTION
## Description
Add missing "create" command in "sudo -i d8 k create -f - <<EOF" in DVP and DKP Getting Started sections.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## What is the expected result?

## Checklist

## Changelog entries

```changes
section: docs
type: fix
summary: Add missing "create" command in "sudo -i d8 k create -f - <<EOF" in DVP and DKP Getting Started sections.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
