### PR TITLE
[testing] Disable outdated block of matrix tests

### DIFF
--- a/testing/matrix/linter/rules/modules/images.go
+++ b/testing/matrix/linter/rules/modules/images.go
@@ -226,16 +226,16 @@ func lintOneDockerfileOrWerfYAML(name, filePath, imagesPath string) errors.LintR
 						continue
 					}
 
-					result, message := isWerfInstructionUnacceptable(fromTrimmed)
-					if result {
-						return errors.NewLintRuleError(
-							"MODULE001",
-							fmt.Sprintf("module = %s, image = %s", name, relativeFilePath),
-							fromTrimmed,
-							"%s",
-							message,
-						)
-					}
+					// result, message := isWerfInstructionUnacceptable(fromTrimmed)
+					// if result {
+					// 	return errors.NewLintRuleError(
+					// 		"MODULE001",
+					// 		fmt.Sprintf("module = %s, image = %s", name, relativeFilePath),
+					// 		fromTrimmed,
+					// 		"%s",
+					// 		message,
+					// 	)
+					// }
 				}
 			}
 			continue


### PR DESCRIPTION
## Description
Disable outdated block of matrix tests.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: chore
summary: Disable outdated block of matrix tests.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
