### PR TITLE
[snapshot-controller] Fix user and group

### DIFF
--- a/modules/045-snapshot-controller/images/snapshot-controller/werf.inc.yaml
+++ b/modules/045-snapshot-controller/images/snapshot-controller/werf.inc.yaml
@@ -44,7 +44,7 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd /src
-    - go mod vendor
+    - go mod vendor -x
     - cd /src/cmd/snapshot-controller
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /snapshot-controller
     - chown 65534:65534 /snapshot-controller

--- a/modules/045-snapshot-controller/images/snapshot-controller/werf.inc.yaml
+++ b/modules/045-snapshot-controller/images/snapshot-controller/werf.inc.yaml
@@ -1,6 +1,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
+fromCacheVersion: 2025011301
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /snapshot-controller

--- a/modules/045-snapshot-controller/images/snapshot-controller/werf.inc.yaml
+++ b/modules/045-snapshot-controller/images/snapshot-controller/werf.inc.yaml
@@ -47,5 +47,5 @@ shell:
     - go mod vendor
     - cd /src/cmd/snapshot-controller
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /snapshot-controller
-    - chown 64535:64535 /snapshot-controller
+    - chown 65534:65534 /snapshot-controller
     - chmod 700 /snapshot-controller

--- a/modules/045-snapshot-controller/images/snapshot-controller/werf.inc.yaml
+++ b/modules/045-snapshot-controller/images/snapshot-controller/werf.inc.yaml
@@ -44,7 +44,8 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd /src
-    - go mod vendor -x
+    - go mod download -x
+    - go mod vendor
     - cd /src/cmd/snapshot-controller
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /snapshot-controller
     - chown 65534:65534 /snapshot-controller

--- a/modules/045-snapshot-controller/images/snapshot-validation-webhook/werf.inc.yaml
+++ b/modules/045-snapshot-controller/images/snapshot-validation-webhook/werf.inc.yaml
@@ -1,6 +1,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
+fromCacheVersion: 2025011301
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /snapshot-validation-webhook

--- a/modules/045-snapshot-controller/images/snapshot-validation-webhook/werf.inc.yaml
+++ b/modules/045-snapshot-controller/images/snapshot-validation-webhook/werf.inc.yaml
@@ -47,5 +47,5 @@ shell:
     - go mod vendor
     - cd /src/cmd/snapshot-validation-webhook
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /snapshot-validation-webhook
-    - chown 64535:64535 /snapshot-validation-webhook
+    - chown 65534:65534 /snapshot-validation-webhook
     - chmod 700 /snapshot-validation-webhook

--- a/modules/045-snapshot-controller/images/snapshot-validation-webhook/werf.inc.yaml
+++ b/modules/045-snapshot-controller/images/snapshot-validation-webhook/werf.inc.yaml
@@ -44,7 +44,7 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd /src
-    - go mod vendor
+    - go mod vendor -x
     - cd /src/cmd/snapshot-validation-webhook
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /snapshot-validation-webhook
     - chown 65534:65534 /snapshot-validation-webhook

--- a/modules/045-snapshot-controller/images/snapshot-validation-webhook/werf.inc.yaml
+++ b/modules/045-snapshot-controller/images/snapshot-validation-webhook/werf.inc.yaml
@@ -44,7 +44,8 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
     - cd /src
-    - go mod vendor -x
+    - go mod download -x
+    - go mod vendor
     - cd /src/cmd/snapshot-validation-webhook
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /snapshot-validation-webhook
     - chown 65534:65534 /snapshot-validation-webhook


### PR DESCRIPTION
## Description
Fix snapshot-controller user and group for https://github.com/deckhouse/deckhouse/pull/11279

## Why do we need it, and what problem does it solve?

Application run by user with UID/GID 65534, but binary is owned by UID/GID 65535

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?

Module binary can be executed inside container

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: snapshot-controller
type: fix
summary: Fix snapshot-controller user and group.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
