### PR TITLE
[admission-policy-engine] Fix rendering constraints

### DIFF
--- a/modules/015-admission-policy-engine/templates/_helpers.tpl
+++ b/modules/015-admission-policy-engine/templates/_helpers.tpl
@@ -90,7 +90,7 @@ spec:
       {{- end }}
       # matches default enforcement action
       {{- if eq $policyAction ($context.Values.admissionPolicyEngine.podSecurityStandards.enforcementAction | default "deny" | lower) }}
-        # if there are other policy actions apart from the default one, we add all of them to NotIn list, so that namespaces with such labels aren't subject default policy
+        # if there are other policy actions apart from the default one, we add all of them to NotIn list, so that the namespaces with such labels aren't subject to the default policy
         {{- if gt (len $context.Values.admissionPolicyEngine.internal.podSecurityStandards.enforcementActions) 1 }}
         - { key: security.deckhouse.io/pod-policy-action, operator: NotIn, values: [{{ (without $context.Values.admissionPolicyEngine.internal.podSecurityStandards.enforcementActions $policyAction | join ",") }}] }
         {{- end }}

--- a/modules/015-admission-policy-engine/templates/policies/security-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/security-policy/constraint.yaml
@@ -36,7 +36,7 @@
   {{- if or (hasKey $cr.spec.policies "allowedCapabilities") (hasKey $cr.spec.policies "requiredDropCapabilities") }}
     {{- include "allowed_capabilities" (list $context $cr) }}
   {{- end }}
-  {{- if or (hasKey $cr.spec.policies "allowedAppArmor") }}
+  {{- if hasKey $cr.spec.policies "allowedAppArmor" }}
     {{- include "allowed_apparmor" (list $context $cr) }}
   {{- end }}
   {{- if hasKey $cr.spec.policies "allowedProcMount" }}
@@ -117,14 +117,8 @@ spec:
     scope: Namespaced
     {{- include "constraint_selector" (list $cr) }}
   parameters:
-    {{- if not $cr.spec.policies.allowHostPID }}
-    allowHostPID:
-      {{- $cr.spec.policies.allowHostPID | toYaml | nindent 6 }}
-    {{- end }}
-    {{- if not $cr.spec.policies.allowHostIPC }}
-    allowHostIPC:
-      {{- $cr.spec.policies.allowHostIPC | toYaml | nindent 6 }}
-    {{- end }}
+    allowHostPID: {{ $cr.spec.policies.allowHostPID | default false }}
+    allowHostIPC: {{ $cr.spec.policies.allowHostIPC | default false }}
 {{- end }}
 
 {{- define "allow_host_network" }}
@@ -145,10 +139,7 @@ spec:
     scope: Namespaced
     {{- include "constraint_selector" (list $cr) }}
   parameters:
-    {{- if not $cr.spec.policies.allowHostNetwork }}
-    allowHostNetwork:
-      {{- $cr.spec.policies.allowHostNetwork | toYaml | nindent 6 }}
-    {{- end }}
+    allowHostNetwork: {{ $cr.spec.policies.allowHostNetwork | default false }}
     {{- if hasKey $cr.spec.policies "allowedHostPorts" }}
     ranges:
       {{- $cr.spec.policies.allowedHostPorts | toYaml | nindent 6 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
There is a minor issue rendering D8HostNetwork constraints (if allowHostNetwork value of a security policy isn't set, the constraint is created with null value). Also, D8HostProcesses constraints were processed incorrectly (allowHostPID and allowHostIPC parameters set to true in a security policy might end up being ignored, unreasonably prohibiting corresponding settings).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Closes #10622 and fixes a couple of constraint rendering issues.

## What is the expected result?
D8HostNetwork and D8HostProcesses constraints are rendered correctly.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: chore
summary: Fix rendering constraints.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
