### PR TITLE
 [prometheus] Fix trickster binary path

### DIFF
--- a/modules/300-prometheus/images/trickster/entrypoint/main.go
+++ b/modules/300-prometheus/images/trickster/entrypoint/main.go
@@ -43,7 +43,7 @@ func main() {
 	builder.WriteString("--config=")
 	builder.WriteString(tmpfile.Name())
 
-	err = syscall.Exec("/trickster", []string{"trickster", builder.String()}, os.Environ())
+	err = syscall.Exec("/usr/local/bin/trickster", []string{"trickster", builder.String()}, os.Environ())
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description
Fix path to trickster binary.

## Why do we need it, and what problem does it solve?
Trickster can't exec binary because of wrong path to binary.

## Why do we need it in the patch release (if we do)?
To fix trickster builds.

## What is the expected result?
Success builds.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fix trickster binary path
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
