### PR TITLE
[containerd] Escape character '%' in systemd for work proxy in containerd configuration

### DIFF
--- a/candi/bashible/common-steps/all/002_add_system_proxy.sh.tpl
+++ b/candi/bashible/common-steps/all/002_add_system_proxy.sh.tpl
@@ -30,6 +30,8 @@ bb-sync-file /etc/systemd/system.conf.d/proxy-default-environment.conf - << EOF
 [Manager]
 DefaultEnvironment="HTTP_PROXY=${HTTP_PROXY}" "http_proxy=${HTTP_PROXY}" "HTTPS_PROXY=${HTTPS_PROXY}" "https_proxy=${HTTPS_PROXY}" "NO_PROXY=${NO_PROXY}" "no_proxy=${NO_PROXY}"
 EOF
+#escape '%' character for systemd
+sed -i 's/%/%%/g' /etc/systemd/system.conf.d/proxy-default-environment.conf
 
   {{- if eq .cri "Containerd" }}
 mkdir -p /etc/systemd/system/containerd-deckhouse.service.d/
@@ -37,6 +39,8 @@ bb-sync-file /etc/systemd/system/containerd-deckhouse.service.d/proxy-environmen
 [Service]
 Environment="HTTP_PROXY=${HTTP_PROXY}" "http_proxy=${HTTP_PROXY}" "HTTPS_PROXY=${HTTPS_PROXY}" "https_proxy=${HTTPS_PROXY}" "NO_PROXY=${NO_PROXY}" "no_proxy=${NO_PROXY}"
 EOF
+#escape '%' character for systemd
+sed -i 's/%/%%/g' /etc/systemd/system/containerd-deckhouse.service.d/proxy-environment.conf
   {{- end }}
 
 bb-unset-proxy


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
this pr allow to avoid special character '%' in systemd when use http,https proxy for containerd systemd unit.
original https://github.com/systemd/systemd/blob/8da70b9d3036591a02986ddaf3574dea4001d493/NEWS#L6488

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this pr solve problem when containerd cannot use proxy because special character '%' in systemd.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
command 
```
systemctl show --property Environment containerd-deckhouse
Environment=PATH=/opt/deckhouse/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin HTTP_PROXY=http://test123:examplepass%@localhost:3128 http_proxy=http://test123:examplepass%@localhost:3128 HTTPS_PROXY=http://test123:examplepass%@localhost:3128 https_proxy=http://test123:examplepass%@localhost:3128 NO_PROXY=127.0.0.1,169.254.169.254,127.0.0.1,169.254.169.254,cluster.local,10.111.0.0/16,10.222.0.0/16 no_proxy=127.0.0.1,169.254.169.254,127.0.0.1,169.254.169.254,cluster.local,10.111.0.0/16,10.222.0.0/16
```
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: containerd
type: fix
summary: escape character '%' in systemd for work proxy in containerd configuration
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
