### PR TITLE
[prometheus] Patch out grafana CVEs for CSE

### DIFF
--- a/modules/300-prometheus/images/grafana-v10/entrypoint/go.mod
+++ b/modules/300-prometheus/images/grafana-v10/entrypoint/go.mod
@@ -3,6 +3,6 @@ module entrypoint
 go 1.20
 
 require (
-	github.com/otiai10/copy v1.12.0 // indirect
-	golang.org/x/sys v0.11.0 // indirect
+	github.com/otiai10/copy v1.12.0
+	golang.org/x/sys v0.11.0
 )

--- a/modules/300-prometheus/images/grafana-v10/entrypoint/go.sum
+++ b/modules/300-prometheus/images/grafana-v10/entrypoint/go.sum
@@ -1,4 +1,5 @@
 github.com/otiai10/copy v1.12.0 h1:cLMgSQnXBs1eehF0Wy/FAGsgDTDmAqFR7rQylBb1nDY=
 github.com/otiai10/copy v1.12.0/go.mod h1:rSaLseMUsZFFbsFGc7wCJnnkTAvdc5L6VWxPE4308Ww=
+github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/modules/300-prometheus/images/grafana-v10/patches/security.patch
+++ b/modules/300-prometheus/images/grafana-v10/patches/security.patch
@@ -1,0 +1,128 @@
+diff --git a/go.mod b/go.mod
+index 7a97708abdf..8547133d3c9 100644
+--- a/go.mod
++++ b/go.mod
+@@ -98,11 +98,11 @@ require (
+ 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0 // @grafana/backend-platform
+ 	go.opentelemetry.io/otel/sdk v1.28.0 // @grafana/backend-platform
+ 	go.opentelemetry.io/otel/trace v1.28.0 // @grafana/backend-platform
+-	golang.org/x/crypto v0.26.0 // @grafana/backend-platform
++	golang.org/x/crypto v0.31.0 // @grafana/backend-platform
+ 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // @grafana/alerting-squad-backend
+-	golang.org/x/net v0.28.0 // @grafana/oss-big-tent @grafana/partner-datasources
++	golang.org/x/net v0.33.0 // @grafana/oss-big-tent @grafana/partner-datasources
+ 	golang.org/x/oauth2 v0.22.0 // @grafana/grafana-authnz-team
+-	golang.org/x/sync v0.8.0 // @grafana/alerting-squad-backend
++	golang.org/x/sync v0.10.0 // @grafana/alerting-squad-backend
+ 	golang.org/x/time v0.5.0 // @grafana/backend-platform
+ 	golang.org/x/tools v0.24.0 // @grafana/grafana-as-code
+ 	gonum.org/v1/gonum v0.12.0 // @grafana/observability-metrics
+@@ -153,7 +153,7 @@ require (
+ 	github.com/go-openapi/spec v0.20.14 // indirect
+ 	github.com/go-openapi/swag v0.22.9 // indirect
+ 	github.com/go-openapi/validate v0.23.0 // indirect
+-	github.com/golang-jwt/jwt/v4 v4.5.0 // @grafana/backend-platform
++	github.com/golang-jwt/jwt/v4 v4.5.1 // @grafana/backend-platform
+ 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
+ 	github.com/golang/glog v1.2.2 // indirect
+ 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+@@ -207,8 +207,8 @@ require (
+ 	go.opencensus.io v0.24.0 // indirect
+ 	go.uber.org/atomic v1.11.0 // @grafana/alerting-squad-backend
+ 	go.uber.org/goleak v1.3.0 // indirect
+-	golang.org/x/sys v0.24.0 // indirect
+-	golang.org/x/text v0.17.0 // @grafana/backend-platform
++	golang.org/x/sys v0.28.0 // indirect
++	golang.org/x/text v0.21.0 // @grafana/backend-platform
+ 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
+ 	google.golang.org/appengine v1.6.8 // indirect
+ 	google.golang.org/genproto v0.0.0-20240814211410-ddb44dafa142 // indirect; @grafana/backend-platform
+@@ -380,7 +380,7 @@ require (
+ 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.26.0 // indirect
+-	golang.org/x/term v0.23.0 // indirect
++	golang.org/x/term v0.27.0 // indirect
+ 	google.golang.org/genproto/googleapis/api v0.0.0-20240814211410-ddb44dafa142 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142 // indirect
+ 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect
+@@ -406,7 +406,7 @@ require (
+ require (
+ 	cloud.google.com/go/compute v1.27.4 // indirect
+ 	cloud.google.com/go/iam v1.1.12 // indirect
+-	filippo.io/age v1.1.1 // @grafana/grafana-authnz-team
++	filippo.io/age v1.2.1 // @grafana/grafana-authnz-team
+ 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 // indirect
+ 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.0 // indirect
+ 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
+diff --git a/go.sum b/go.sum
+index da1909d0601..c4ae7c4951e 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1189,6 +1189,8 @@ contrib.go.opencensus.io/integrations/ocsql v0.1.7/go.mod h1:8DsSdjz3F+APR+0z0Wk
+ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+ filippo.io/age v1.1.1 h1:pIpO7l151hCnQ4BdyBujnGP2YlUo0uj6sAVNHGBvXHg=
+ filippo.io/age v1.1.1/go.mod h1:l03SrzDUrBkdBx8+IILdnn2KZysqQdbEBUQ4p3sqEQE=
++filippo.io/age v1.2.1 h1:X0TZjehAZylOIj4DubWYU1vWQxv9bJpo+Uu2/LGhi1o=
++filippo.io/age v1.2.1/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
+ gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
+ git.sr.ht/~sbinet/gg v0.3.1/go.mod h1:KGYtlADtqsqANL9ueOFkWymvzUvLMQllU5Ixo+8v3pc=
+ github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
+@@ -2329,6 +2331,8 @@ github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w
+ github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+ github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+ github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
++github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
++github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+ github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+ github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
+ github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+@@ -4032,6 +4036,7 @@ golang.org/x/crypto v0.23.0 h1:dIJU/v2J8Mdglj/8rJ6UUOM3Zc9zLZxVZwwxMooUSAI=
+ golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
+ golang.org/x/crypto v0.26.0 h1:RrRspgV4mU+YwB4FYnuBoKsUapNIL5cohGAmSH3azsw=
+ golang.org/x/crypto v0.26.0/go.mod h1:GY7jblb9wI+FOo5y8/S2oY4zWP07AkOJ4+jxCqdqn54=
++golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+ golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+@@ -4227,6 +4232,8 @@ golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
+ golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
+ golang.org/x/net v0.28.0 h1:a9JDOJc5GMUJ0+UDqmLT86WiEy7iWyIhz8gz8E4e5hE=
+ golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=
++golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
++golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+@@ -4298,6 +4305,7 @@ golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+ golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+ golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+ golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
++golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+ golang.org/x/sys v0.0.0-20180816055513-1c9583448a9c/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+@@ -4473,6 +4481,7 @@ golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+ golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
+ golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+@@ -4497,6 +4506,7 @@ golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
+ golang.org/x/term v0.20.0 h1:VnkxpohqXaOBYJtBmEppKUG6mXpi+4O6purfc2+sMhw=
+ golang.org/x/term v0.20.0/go.mod h1:8UkIAJTvZgivsXaD6/pH6U9ecQzZ45awqEOzuCvwpFY=
+ golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=
++golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
+ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+@@ -4522,6 +4532,7 @@ golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
+ golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+ golang.org/x/text v0.17.0 h1:XtiM5bkSOt+ewxlOE/aE/AKEHibwj/6gvWMl9Rsh0Qc=
+ golang.org/x/text v0.17.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
++golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
+++ b/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
@@ -2,7 +2,8 @@
 {{ $grafanaVersion := "10.4.14" }}
 {{ $bundledPlugins := "petrslavotinek-carpetplot-panel,vonage-status-panel,btplc-status-dot-panel,natel-plotly-panel,savantly-heatmap-panel,grafana-piechart-panel,grafana-worldmap-panel" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
+image: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
+final: false
 from: {{ $.Images.BASE_ALPINE_DEV }}
 git:
 - add: /{{ $.ModulePath }}modules/300-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -23,13 +24,14 @@ shell:
   - git clone --depth 1 --branch v{{ $grafanaVersion }} {{ $.SOURCE_REPO }}/grafana/grafana-deps.git /grafana-public
   - find /patches -name '*.patch' -exec git apply {} \;
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-go-builder
+image: {{ $.ModuleName }}/{{ $.ImageName }}-go-builder
+final: false
 from: {{ $.Images.BASE_GOLANG_23_BULLSEYE }}
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
   add: /usr/src/app
   to: /usr/src/app
   before: install
@@ -44,7 +46,8 @@ shell:
   - /go/bin/wire gen -tags oss ./pkg/server
   - go build -ldflags -w -ldflags "-X main.version={{ $grafanaVersion }} -linkmode external -extldflags -static" -tags netgo -o ./bin/linux-amd64/grafana ./pkg/cmd/grafana
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-entrypoint
+image: {{ $.ModuleName }}/{{ $.ImageName }}-entrypoint
+final: false
 from: {{ $.Images.BASE_GOLANG_23_ALPINE }}
 mount:
 - fromPath: ~/go-pkg-cache
@@ -63,18 +66,19 @@ shell:
   - chown -R 64535:64535 /app/
   - chmod 0700 /app/entrypoint
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-grafana-distr
+image: {{ $.ModuleName }}/{{ $.ImageName }}-grafana-distr
+final: false
 from: {{ $.Images.BASE_UBUNTU_DEV }}
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-go-builder
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-go-builder
   add: /usr/src/app/bin/linux-amd64/grafana
   to: /usr/share/grafana/bin/grafana
   before: install
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
   add: /grafana-public/public
   to: /usr/share/grafana/public
   before: install
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
   add: /usr/src/app/conf
   to: /usr/share/grafana/conf
   before: install
@@ -134,36 +138,26 @@ shell:
   - chown -R 64535:64535 /var/log/grafana
   - chmod 0700 ./bin/grafana
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-from: {{ $.Images.BASE_ALT }}
----
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-  add: /
-  to: /
-  includePaths:
-  - usr/lib
-  - usr/lib64
-  before: install
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-entrypoint
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-entrypoint
   add: /app/entrypoint
   to: /usr/local/bin/entrypoint
   before: install
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-grafana-distr
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-grafana-distr
   add: /usr/share/grafana/
   to: /usr/share/grafana
   before: install
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-grafana-distr
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-grafana-distr
   add: /etc/grafana/
   to: /etc/grafana
   before: install
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-grafana-distr
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-grafana-distr
   add: /var/lib/grafana/
   to: /var/lib/grafana
   before: install
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-grafana-distr
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-grafana-distr
   add: /var/log/grafana/
   to: /var/log/grafana
   before: install

--- a/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
+++ b/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
@@ -1,9 +1,17 @@
 ---
-{{ $grafanaVersion := "10.4.5" }}
+{{ $grafanaVersion := "10.4.14" }}
 {{ $bundledPlugins := "petrslavotinek-carpetplot-panel,vonage-status-panel,btplc-status-dot-panel,natel-plotly-panel,savantly-heatmap-panel,grafana-piechart-panel,grafana-worldmap-panel" }}
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
 from: {{ $.Images.BASE_ALPINE_DEV }}
+git:
+- add: /{{ $.ModulePath }}modules/300-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  includePaths:
+  - '**/*.patch'
+  stageDependencies:
+    install:
+    - '**/*.patch'
 shell:
   beforeInstall:
   - apk add --no-cache openssh-client
@@ -12,28 +20,11 @@ shell:
   - cd /usr/src/app
   - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
   - git clone --depth 1 --branch v{{ $grafanaVersion }} {{ $.SOURCE_REPO }}/grafana/grafana.git .
-  - git clone --depth 1 --branch v{{ $grafanaVersion }} {{ $.SOURCE_REPO }}/grafana/grafana-deps.git /grafana-deps
-  - rm -rf .yarn
-  - mv /grafana-deps/.yarn .
-  - mv /grafana-deps/package.json .
-  - mv /grafana-deps/yarn.lock .
----
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-js-builder
-from: {{ $.Images.BASE_NODE_18_ALPINE }}
-import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
-  add: /usr/src/app
-  to: /usr/src/app
-  before: install
-shell:
-  install:
-  - cd /usr/src/app
-  - yarn install
-  - export NODE_ENV=production NODE_OPTIONS="--max_old_space_size=8000"
-  - yarn build
+  - git clone --depth 1 --branch v{{ $grafanaVersion }} {{ $.SOURCE_REPO }}/grafana/grafana-deps.git /grafana-public
+  - find /patches -name '*.patch' -exec git apply {} \;
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-go-builder
-from: {{ $.Images.BASE_GOLANG_22_BULLSEYE }}
+from: {{ $.Images.BASE_GOLANG_23_BULLSEYE }}
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
@@ -54,7 +45,7 @@ shell:
   - go build -ldflags -w -ldflags "-X main.version={{ $grafanaVersion }} -linkmode external -extldflags -static" -tags netgo -o ./bin/linux-amd64/grafana ./pkg/cmd/grafana
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-entrypoint
-from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
+from: {{ $.Images.BASE_GOLANG_23_ALPINE }}
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
@@ -79,13 +70,9 @@ import:
   add: /usr/src/app/bin/linux-amd64/grafana
   to: /usr/share/grafana/bin/grafana
   before: install
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-js-builder
-  add: /usr/src/app/public
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
+  add: /grafana-public/public
   to: /usr/share/grafana/public
-  before: install
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-js-builder
-  add: /usr/src/app/tools
-  to: /usr/share/grafana/tools
   before: install
 - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
   add: /usr/src/app/conf

--- a/modules/300-prometheus/templates/grafana/deployment-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment-v10.yaml
@@ -136,6 +136,14 @@ spec:
           value: "false"
         - name: GF_UNIFIED_ALERTING_DISABLED_ORGS
           value: "1"
+        - name: GF_ANALYTICS_REPORTING_ENABLED
+          value: "false"
+        - name: GF_ANALYTICS_CHECK_FOR_UPDATES
+          value: "false"
+        - name: GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES
+          value: "false"
+        - name: GF_ANALYTICS_FEEDBACK_LINKS_ENABLED
+          value: "false"
         {{- if hasKey .Values.prometheus "grafana" }}
           {{- if hasKey .Values.prometheus.grafana "customPlugins" }}
         - name: GF_INSTALL_PLUGINS

--- a/modules/300-prometheus/templates/grafana/deployment-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment-v10.yaml
@@ -151,6 +151,8 @@ spec:
         volumeMounts:
         - name: grafana-data
           mountPath: /var/lib/grafana/data
+        - name: grafana-alerting
+          mountPath: /var/lib/grafana/data/alerting
         - name: grafana-datasources
           mountPath: /etc/grafana/provisioning/datasources
         - name: grafana-alerts-channels
@@ -197,6 +199,8 @@ spec:
         volumeMounts:
         - name: grafana-data
           mountPath: /var/lib/grafana/data
+        - name: grafana-alerting
+          mountPath: /var/lib/grafana/data/alerting
         - name: shared-dashboards-folder
           mountPath: /etc/grafana/dashboards
         - name: tmp
@@ -282,6 +286,8 @@ spec:
           defaultMode: 420
           name: kube-rbac-proxy-ca.crt
       - name: grafana-data
+        emptyDir: {}
+      - name: grafana-alerting
         emptyDir: {}
       - name: tmp
         emptyDir: {}


### PR DESCRIPTION
## Description
Patch out grafana vulnerabilities to pass certification.

## Why do we need it, and what problem does it solve?
This PR fixes all possible vulnerabilities in grafana image found by trivy scanner. The only vulnerability that is not fixed is [CVE-2024-8986](https://avd.aquasec.com/nvd/cve-2024-8986). This issue however has no impact on a Deckhouse because the build process does not imply passing any credentials via the git URL.

## Why do we need it in the patch release (if we do)?
We don't

## What is the expected result?
The number of vulnerabilities is reduced to a minimum

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fix grafana CVEs
impact: grafana in cluster will be restarted as the image has changed
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
