### PR TITLE
Apply custom logo after the cluster bootstrap

### DIFF
--- a/ee/modules/150-user-authn/hooks/custom_logo.go
+++ b/ee/modules/150-user-authn/hooks/custom_logo.go
@@ -45,6 +45,11 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, customLogoHandler)
 
 func customLogoHandler(input *go_hook.HookInput) error {
+	if !input.Values.Get("global.clusterIsBootstrapped").Bool() {
+		input.Logger.Info("Cluster is not yet bootstrapped, skipping custom logo")
+		return nil
+	}
+
 	snap := input.Snapshots["logo-cm"]
 	if len(snap) == 0 || snap[0] == nil {
 		input.Values.Set("userAuthn.internal.customLogo.enabled", false)

--- a/ee/modules/150-user-authn/hooks/custom_logo_test.go
+++ b/ee/modules/150-user-authn/hooks/custom_logo_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var _ = Describe("Global hooks :: set custom logo for dex", func() {
-	f := HookExecutionConfigInit(`{"global": {}, "userAuthn": {"internal": {"customLogo": {}}}}`, `{}`)
+	f := HookExecutionConfigInit(`{"global": {"clusterIsBootstrapped": true}, "userAuthn": {"internal": {"customLogo": {}}}}`, `{}`)
 	Context("ConfigMap with logo in d8-system does not exist", func() {
 		BeforeEach(func() {
 			f.KubeStateSet(``)

--- a/ee/modules/300-prometheus/hooks/custom_logo.go
+++ b/ee/modules/300-prometheus/hooks/custom_logo.go
@@ -45,6 +45,11 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, customLogoHandler)
 
 func customLogoHandler(input *go_hook.HookInput) error {
+	if !input.Values.Get("global.clusterIsBootstrapped").Bool() {
+		input.Logger.Info("Cluster is not yet bootstrapped, skipping custom logo")
+		return nil
+	}
+
 	snap := input.Snapshots["logo-cm"]
 	if len(snap) == 0 || snap[0] == nil {
 		input.Values.Set("prometheus.internal.grafana.customLogo.enabled", false)

--- a/ee/modules/300-prometheus/hooks/custom_logo_test.go
+++ b/ee/modules/300-prometheus/hooks/custom_logo_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var _ = Describe("Global hooks :: set custom logo for grafana", func() {
-	f := HookExecutionConfigInit(`{"global": {}, "prometheus": {"internal": {"grafana": {"customLogo": {}}}}}`, `{}`)
+	f := HookExecutionConfigInit(`{"global": {"clusterIsBootstrapped": true}, "prometheus": {"internal": {"grafana": {"customLogo": {}}}}}`, `{}`)
 	Context("ConfigMap with logo in d8-system does not exist", func() {
 		BeforeEach(func() {
 			f.KubeStateSet(``)


### PR DESCRIPTION
## Description
Apply custom logo only after the bootstrap

## Why do we need it, and what problem does it solve?
Namespace `user-authn` does not exists on the bootstrap, generating the cm will lead to the error `Create object: v1/ConfigMap/d8-user-authn/whitelabel-custom-logo: namespaces "d8-user-authn" not found` 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Apply custom logo after the bootstrap.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
