### PR TITLE
[cloud-provider-zvirt] remove DisksMeta from cloud-data-discoverer

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/discoverer.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/discoverer.go
@@ -14,9 +14,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	cloudDataV1 "github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
 	"github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1alpha1"
-	"github.com/sirupsen/logrus"
 
 	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
@@ -152,30 +153,9 @@ func (d *Discoverer) getStorageDomains(
 	return sd, nil
 }
 
+// NotImplemented
 func (d *Discoverer) DisksMeta(ctx context.Context) ([]v1alpha1.DiskMeta, error) {
-	zvirtClient, err := d.config.client()
-	if err != nil {
-		return nil, err
-	}
-
-	disks, err := zvirtClient.WithContext(ctx).ListDisks()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(disks) == 0 {
-		return []v1alpha1.DiskMeta{}, nil
-	}
-
-	diskMeta := make([]v1alpha1.DiskMeta, 0, len(disks))
-	for _, disk := range disks {
-		diskMeta = append(diskMeta, v1alpha1.DiskMeta{
-			ID:   string(disk.ID()),
-			Name: disk.Alias(),
-		})
-	}
-
-	return diskMeta, nil
+	return []v1alpha1.DiskMeta{}, nil
 }
 
 // NotImplemented


### PR DESCRIPTION
## Description
This PR removes DisksMeta implementation from cloud-data-discoverer

## Why do we need it, and what problem does it solve?
Cluster orphaned disk discovery is broken in zvirt cloud-data-discoverer, we should remove it. 

## What is the expected result?
cloud-data-discoverer will not crash anymore. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-zvirt
type: fix
summary: remove DisksMeta from cloud-data-discoverer
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
