### PR TITLE
[node-local-dns] fix CAPs for stale-dns-connections-cleaner

### DIFF
--- a/ee/be/modules/350-node-local-dns/images/stale-dns-connections-cleaner/werf.inc.yaml
+++ b/ee/be/modules/350-node-local-dns/images/stale-dns-connections-cleaner/werf.inc.yaml
@@ -16,7 +16,7 @@ git:
     - "**/*.go"
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
-from: {{ $.Images.BASE_GOLANG_23_ALPINE }}
+fromImage: common/alt-p11-artifact
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -27,6 +27,8 @@ mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
 shell:
+  beforeInstall:
+    - apt-get install -y ca-certificates golang libcap-utils
   install:
   - cd /src
   - go mod download
@@ -36,6 +38,8 @@ shell:
   - cd /src
   - go build -ldflags="-s -w" -o stale-dns-connections-cleaner .
   - chmod +x /src/stale-dns-connections-cleaner
+  - setcap    cap_net_admin=+ep /src/stale-dns-connections-cleaner
+  - setcap -v cap_net_admin=+ep /src/stale-dns-connections-cleaner
   - chmod -R 0700 /src/stale-dns-connections-cleaner
   - chown -R 64535:64535 /src/stale-dns-connections-cleaner
 ---


### PR DESCRIPTION
## Description
Set capabilities NET_ADMIN (via setcap) on the executable file `stale-dns-connections-cleaner` so that there are no socket deletion errors.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-local-dns
type: fix
summary: Set capabilities (via setcap) on the executable file.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
