### PR TITLE
[prometheus] Use statically linked python for grafana dashboard provisioner CSE

### DIFF
--- a/modules/300-prometheus/images/grafana-dashboard-provisioner/werf.inc.yaml
+++ b/modules/300-prometheus/images/grafana-dashboard-provisioner/werf.inc.yaml
@@ -2,46 +2,38 @@ image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/shell-operator
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-  add: /
-  to: /
-  before: setup
+  add: /opt/python-static/bin
+  to: /usr/bin
+  before: install
   includePaths:
-  - usr/bin/python3
-  - usr/bin/python3.*
-  - usr/lib/python3
-  - usr/lib64/python3
-  - usr/lib64/python3.*
+  - python3*
+  - python3
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  add: /opt/python-static/lib
+  to: /usr/lib
+  before: install
+  includePaths:
+  - python3*
 git:
 - add: /{{ $.ModulePath }}modules/300-{{ $.ModuleName }}/images/{{ $.ImageName }}/hooks
   to: /hooks
-  stageDependencies:
-    install:
-    - '**/*'
-
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 fromImage: common/alt-p11-artifact
 final: false
-import:
-- image: common/shell-operator-artifact
-  add: /
-  to: /
-  before: setup
-  includePaths:
-  - usr/bin/python3
-  - usr/bin/python3.*
-  - usr/lib/python3
-  - usr/lib64/python3
-  - usr/lib64/python3.*
 git:
 - add: /{{ $.ModulePath }}modules/300-{{ $.ModuleName }}/images/{{ $.ImageName }}/requirements.txt
   to: /requirements.txt
   stageDependencies:
     install:
     - '**/*'
+import:
+- artifact: common/python-static
+  add: /opt/python-static
+  to: /opt/python-static
+  before: install
 shell:
   beforeInstall:
-  - apt-get update
-  - apt-get install -y python3-module-pip-run
+  - apt-get install -y git
   install:
-  - pip3 install -r /requirements.txt
+  - /opt/python-static/bin/pip3 install -r requirements.txt


### PR DESCRIPTION
## Description
Use statically linked python binary to run grafana dashboard provisioner hooks.

## Why do we need it, and what problem does it solve?
This forces the component to use common python static binary which is well maintained.

## Why do we need it in the patch release (if we do)?
We don't

## What is the expected result?
No changes for an end user.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: chore
summary: use static python binary for the grafana dashboard provisioner
impact: grafana deployment will be rollout restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
 