### PR TITLE
chore: deprecate werf artifact

### DIFF
--- a/.werf/werf-terraform.yaml
+++ b/.werf/werf-terraform.yaml
@@ -7,11 +7,11 @@ from: {{ .Images.BASE_UBUNTU }}
 import:
   {{- $k8sVersion := "1.27"}}
   {{- $image_version := printf "%s.%d" $k8sVersion (index $.CandiVersionMap "k8s" $k8sVersion "patch") | replace "." "-" }}
-  - artifact: common/kubernetes-artifact-{{ $image_version }}
+  - image: common/kubernetes-artifact-{{ $image_version }}
     add: /src/_output/bin/kubectl
     to: /usr/local/bin/kubectl
     before: setup
-  - artifact: terraform # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
+  - image: terraform # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
     add: /terraform/terraform
     to: /image/bin/terraform
     before: setup
@@ -19,7 +19,7 @@ import:
       {{- if $edition.terraformProviders }}
         {{- range $_, $tfProvider := $edition.terraformProviders }}
           {{- $tf := index $.TF $tfProvider }}
-  - artifact: {{ $tf.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
+  - image: {{ $tf.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
     add: /{{ $tf.artifactBinary }}
     to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ $tf.namespace }}/{{ $tf.type }}/{{ $tf.version }}//linux_amd64/{{ $tf.destinationBinary }}
     before: setup
@@ -29,19 +29,19 @@ import:
       {{- break -}}
     {{- end }}
   {{- end }}
-  - artifact: e2e-eks-terraform-plugins
+  - image: e2e-eks-terraform-plugins
     add: /terraform-provider-random
     to: /usr/local/share/terraform/plugins/registry.terraform.io/hashicorp/random/3.4.3/linux_amd64/terraform-provider-random_v3.4.3_x5
     before: setup
-  - artifact: e2e-eks-terraform-plugins
+  - image: e2e-eks-terraform-plugins
     add: /terraform-provider-tls
     to: /usr/local/share/terraform/plugins/registry.terraform.io/hashicorp/tls/4.0.5/linux_amd64/terraform-provider-tls_v4.0.5_x5
     before: setup
-  - artifact: e2e-eks-terraform-plugins
+  - image: e2e-eks-terraform-plugins
     add: /terraform-provider-cloudinit
     to: /usr/local/share/terraform/plugins/registry.terraform.io/hashicorp/cloudinit/2.2.0/linux_amd64/terraform-provider-cloudinit_v2.2.0_x5
     before: setup
-  - artifact: e2e-eks-terraform-plugins
+  - image: e2e-eks-terraform-plugins
     add: /terraform-provider-kubernetes
     to: /usr/local/share/terraform/plugins/registry.terraform.io/hashicorp/kubernetes/2.31.0/linux_amd64/terraform-provider-kubernetes_v2.31.0_x5
     before: setup

--- a/docs/site/werf-debug.yaml
+++ b/docs/site/werf-debug.yaml
@@ -79,7 +79,7 @@ git:
       install: 'go.mod'
       setup: '**/*'
 import:
-  - artifact: web-static
+  - image: web-static
     add: /app/_site
     to: /app/root
     before: setup
@@ -95,7 +95,7 @@ shell:
       {{- .Files.Get ".werf/nginx.conf" | nindent 6 }}
       EOD
 import:
-- artifact: web-static
+- image: web-static
   add: /app/_site
   to: /app
   before: setup

--- a/ee/modules/025-static-routing-manager/images/agent/werf.inc.yaml
+++ b/ee/modules/025-static-routing-manager/images/agent/werf.inc.yaml
@@ -1,5 +1,6 @@
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_22_ALPINE }}
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}
@@ -30,7 +31,7 @@ shell:
 image: {{ $.ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
   add: /src/cmd/agent
   to: /agent
   before: install

--- a/ee/modules/030-cloud-provider-dynamix/images/capd-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/capd-controller-manager/werf.inc.yaml
@@ -4,12 +4,13 @@ fromImage: common/distroless
 docker:
   ENTRYPOINT: ["/capd-controller-manager"]
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /capd-controller-manager
   to: /capd-controller-manager
   before: setup
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_22_ALPINE_DEV }}
 mount:
   - fromPath: ~/go-pkg-cache

--- a/ee/modules/030-cloud-provider-dynamix/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/cloud-controller-manager/werf.inc.yaml
@@ -2,14 +2,15 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /dynamix-cloud-controller-manager
     to: /dynamix-cloud-controller-manager
     before: setup
 docker:
   ENTRYPOINT: ["/dynamix-cloud-controller-manager"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_22_BULLSEYE_DEV }}
 mount:
   - fromPath: ~/go-pkg-cache

--- a/ee/modules/030-cloud-provider-dynamix/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/cloud-data-discoverer/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer
     to: /discoverer
     before: setup
@@ -10,7 +10,8 @@ docker:
   ENTRYPOINT: ["/discoverer"]
 ---
 {{ $discovererRelPath := printf "%s/modules/030-cloud-provider-dynamix/images/cloud-data-discoverer" .ModulePath }}
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_22_ALPINE_DEV }}
 shell:
   beforeInstall:

--- a/ee/modules/030-cloud-provider-dynamix/images/dynamix-csi-driver/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/dynamix-csi-driver/werf.inc.yaml
@@ -2,30 +2,31 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /dynamix-csi-driver
   to: /dynamix-csi-driver
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
   includePaths:
   - '**/*'
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib64
   to: /lib64
   before: install
   includePaths:
   - 'libresolv*'
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib/udev/scsi_id
   to: /lib/udev/scsi_id
   before: setup
 docker:
   ENTRYPOINT: ["/dynamix-csi-driver"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_22_ALPINE_DEV }}
 mount:
 - fromPath: ~/go-pkg-cache
@@ -49,7 +50,8 @@ shell:
 ---
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /sbin/xfs_repair /usr/sbin/nvme /usr/sbin/parted /usr/sbin/xfs*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   setup:

--- a/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
@@ -4,12 +4,13 @@ fromImage: common/distroless
 docker:
   ENTRYPOINT: ["/caphc-controller-manager"]
 import:
-  - artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  - image: {{ .ModuleName }}/{{ .ImageName }}-artifact
     add: /caphc-controller-manager
     to: /caphc-controller-manager
     before: setup
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_22_ALPINE_DEV }}
 mount:
   - fromPath: ~/go-pkg-cache

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/werf.inc.yaml
@@ -2,14 +2,15 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /huaweicloud-cloud-controller-manager
     to: /huaweicloud-cloud-controller-manager
     before: setup
 docker:
   ENTRYPOINT: ["/huaweicloud-cloud-controller-manager"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_21_BULLSEYE }}
 mount:
   - fromPath: ~/go-pkg-cache

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer
     to: /discoverer
     before: setup
@@ -10,7 +10,8 @@ docker:
   ENTRYPOINT: ["/discoverer"]
 ---
 {{ $discovererRelPath := printf "%s/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer" .ModulePath }}
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_22_ALPINE_DEV }}
 shell:
   beforeInstall:

--- a/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/werf.inc.yaml
@@ -2,34 +2,35 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /evs-csi-plugin
   to: /evs-csi-plugin
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /sfs-csi-plugin
   to: /sfs-csi-plugin
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
   includePaths:
   - '**/*'
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib64
   to: /lib64
   before: install
   includePaths:
   - 'libresolv*'
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib/udev/scsi_id
   to: /lib/udev/scsi_id
   before: setup
 docker:
   ENTRYPOINT: ["/evs-csi-plugin"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_19_BULLSEYE_DEV }}
 mount:
 - fromPath: ~/go-pkg-cache
@@ -50,7 +51,8 @@ shell:
 ---
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /sbin/xfs_repair /usr/sbin/nvme /usr/sbin/parted /usr/sbin/xfs*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   setup:

--- a/ee/modules/030-cloud-provider-openstack/images/cinder-csi-plugin/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cinder-csi-plugin/werf.inc.yaml
@@ -5,11 +5,11 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /src/cinder-csi-plugin
   to: /bin/cinder-csi-plugin
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -18,7 +18,8 @@ import:
 docker:
   ENTRYPOINT: ["/bin/cinder-csi-plugin"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
     {{- if semverCompare ">=1.30" $version }}
 from: {{ $.Images.BASE_GOLANG_22_BULLSEYE }}
     {{- else if semverCompare "=1.29" $version }}
@@ -50,7 +51,8 @@ shell:
 ---
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /usr/sbin/parted /usr/sbin/xfs*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   setup:

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/werf.inc.yaml
@@ -5,14 +5,15 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /src/openstack-cloud-controller-manager
   to: /bin/openstack-cloud-controller-manager
   before: setup
 docker:
   ENTRYPOINT: ["/bin/openstack-cloud-controller-manager"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
     {{- if semverCompare ">=1.30" $version }}
 from: {{ $.Images.BASE_GOLANG_22_BULLSEYE }}
     {{- else if semverCompare "=1.29" $version }}

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer
     to: /discoverer
     before: setup
@@ -11,8 +11,8 @@ docker:
 ---
 {{ $discovererAbsPath := "/deckhouse/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer" }}
 {{ $discovererRelPath := printf "%s/modules/030-cloud-provider-openstack/images/cloud-data-discoverer" .ModulePath }}
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromCacheVersion: "2023-03-24.2"
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_21_ALPINE }}
 shell:
   install:

--- a/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager/werf.inc.yaml
@@ -5,14 +5,15 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /cluster-api-provider-cloud-director
     to: /cluster-api-provider-cloud-director
     before: setup
 docker:
   ENTRYPOINT: ["/cluster-api-provider-cloud-director"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
 from: {{ $.Images.BASE_GOLANG_20_BUSTER }}
 git:
   - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager/werf.inc.yaml
@@ -5,14 +5,15 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /src/bin/cloud-provider-for-cloud-director
   to: /cloud-provider-for-cloud-director
   before: setup
 docker:
   ENTRYPOINT: ["/cloud-provider-for-cloud-director"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
 from: {{ $.Images.BASE_GOLANG_20_BUSTER }}
 git:
   - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer
     to: /discoverer
     before: setup
@@ -11,7 +11,8 @@ docker:
 ---
 {{ $discovererAbsPath := "/deckhouse/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer" }}
 {{ $discovererRelPath := printf "%s/modules/030-cloud-provider-vcd/images/cloud-data-discoverer" .ModulePath }}
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_20_ALPINE }}
 shell:
   install:

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/werf.inc.yaml
@@ -4,30 +4,31 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /src/bin/cloud-director-named-disk-csi-driver
   to: /cloud-director-named-disk-csi-driver
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
   includePaths:
   - '**/*'
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib64
   to: /lib64
   before: install
   includePaths:
   - 'libresolv*'
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib/udev/scsi_id
   to: /lib/udev/scsi_id
   before: setup
 docker:
   ENTRYPOINT: ["/cloud-director-named-disk-csi-driver"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
 from: {{ $.Images.BASE_GOLANG_20_BUSTER }}
 git:
 - add: /{{ $.ModulePath }}/modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -59,7 +60,8 @@ shell:
 ---
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /sbin/xfs_repair /usr/sbin/nvme /usr/sbin/parted /usr/sbin/xfs*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   setup:

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin/werf.inc.yaml
@@ -5,30 +5,31 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /src/bin/cloud-director-named-disk-csi-driver
   to: /cloud-director-named-disk-csi-driver
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
   includePaths:
   - '**/*'
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib64
   to: /lib64
   before: install
   includePaths:
   - 'libresolv*'
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib/udev/scsi_id
   to: /lib/udev/scsi_id
   before: setup
 docker:
   ENTRYPOINT: ["/cloud-director-named-disk-csi-driver"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
 from: {{ $.Images.BASE_GOLANG_20_BUSTER }}
 git:
 - add: /{{ $.ModulePath }}/modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -56,11 +57,12 @@ shell:
   - go mod vendor
   - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/vmware/cloud-director-named-disk-csi-driver/version.Version={{ $value.csi.vcd }}" -o bin/cloud-director-named-disk-csi-driver cmd/csi/main.go
  {{- end }}
-{{- end }}  
+{{- end }}
 ---
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /sbin/xfs_repair /usr/sbin/nvme /usr/sbin/parted /usr/sbin/xfs*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   setup:

--- a/ee/modules/040-terraform-manager/images/terraform-manager-dynamix/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-dynamix/werf.inc.yaml
@@ -4,7 +4,7 @@ git:
   - add: /{{ .ModulePath }}candi/cloud-providers/dynamix
     to: /deckhouse/candi/cloud-providers/dynamix
 import:
-  - artifact: terraform-provider-decort
+  - image: terraform-provider-decort
     add: /terraform-provider-decort
     to: /plugins/registry.terraform.io/{{ .TF.decort.namespace }}/{{ .TF.decort.type }}/{{ .TF.decort.version }}/linux_amd64/terraform-provider-decort
     before: setup

--- a/ee/modules/040-terraform-manager/images/terraform-manager-huaweicloud/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-huaweicloud/werf.inc.yaml
@@ -4,7 +4,7 @@ git:
   - add: /{{ .ModulePath }}candi/cloud-providers/huaweicloud
     to: /deckhouse/candi/cloud-providers/huaweicloud
 import:
-  - artifact: terraform-provider-huaweicloud
+  - image: terraform-provider-huaweicloud
     add: /terraform-provider-huaweicloud
     to: /plugins/registry.terraform.io/{{ .TF.huaweicloud.namespace }}/{{ .TF.huaweicloud.type }}/{{ .TF.huaweicloud.version }}/linux_amd64/terraform-provider-huaweicloud
     before: setup

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
@@ -4,7 +4,7 @@ git:
 - add: /{{ .ModulePath }}candi/cloud-providers/openstack
   to: /deckhouse/candi/cloud-providers/openstack
 import:
-- artifact: terraform-provider-openstack
+- image: terraform-provider-openstack
   add: /terraform-provider-openstack
   to: /plugins/registry.terraform.io/{{ .TF.openstack.namespace }}/{{ .TF.openstack.type }}/{{ .TF.openstack.version }}/linux_amd64/terraform-provider-openstack
   before: setup

--- a/ee/modules/040-terraform-manager/images/terraform-manager-vcd/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-vcd/werf.inc.yaml
@@ -5,7 +5,7 @@ git:
 - add: /{{ .ModulePath }}candi/cloud-providers/vcd
   to: /deckhouse/candi/cloud-providers/vcd
 import:
-- artifact: terraform-provider-vcd-artifact
+- image: terraform-provider-vcd-artifact
   add: /terraform-provider-vcd
   to: /plugins/registry.terraform.io/{{ .TF.vcd.namespace }}/{{ .TF.vcd.type }}/{{ .TF.vcd.version }}/linux_amd64/terraform-provider-vcd
   before: setup

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -1,6 +1,7 @@
 {{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so* /usr/lib64/libsqlite3.so* /usr/bin/pip3" }}
 ---
-artifact: {{ .ModuleName }}/build-keepalived
+image: {{ .ModuleName }}/build-keepalived
+final: false
 from: {{ .Images.BASE_ALPINE_DEV }}
 shell:
   beforeInstall:
@@ -18,7 +19,8 @@ shell:
     - chmod 0700 /opt/keepalived-static/usr/sbin/keepalived
     - chmod 0700 /opt/keepalived-static/usr/bin/genhash
 ---
-artifact: {{ $.ModuleName }}/python
+image: {{ $.ModuleName }}/python
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   install:
@@ -32,31 +34,31 @@ git:
   - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/prepare-config.py
     to: /prepare-config.py
 import:
-  - artifact: {{ $.ModuleName }}/python
+  - image: {{ $.ModuleName }}/python
     add: /relocate
     to: /
     before: install
-  - artifact: {{ $.ModuleName }}/python
+  - image: {{ $.ModuleName }}/python
     add: /usr/lib64/python3
     to: /usr/lib64/python3
     before: install
-  - artifact: {{ $.ModuleName }}/python
+  - image: {{ $.ModuleName }}/python
     add: /usr/local/lib/python3/site-packages
     to: /usr/local/lib/python3/site-packages
     before: install
-  - artifact: {{ $.ModuleName }}/python
+  - image: {{ $.ModuleName }}/python
     add: /usr/lib64/python3.9
     to: /usr/lib64/python3.9
     before: install
-  - artifact: {{ $.ModuleName }}/build-keepalived
+  - image: {{ $.ModuleName }}/build-keepalived
     add: /opt/keepalived-static/usr/sbin/keepalived
     to: /usr/sbin/keepalived
     before: install
-  - artifact: {{ $.ModuleName }}/build-keepalived
+  - image: {{ $.ModuleName }}/build-keepalived
     add: /opt/keepalived-static/usr/bin/genhash
     to: /usr/bin/genhash
     before: install
-  - artifact: {{ $.ModuleName }}/python
+  - image: {{ $.ModuleName }}/python
     add: /empty
     to: /run
     before: setup

--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -1,6 +1,7 @@
 {{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so* /usr/lib64/libsqlite3.so* /usr/sbin/dnsmasq /lib64/libnss_*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ .Images.BASE_ALT_DEV }}
 shell:
   install:
@@ -15,25 +16,25 @@ git:
   - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/prepare-config.py
     to: /prepare-config.py
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /relocate
     to: /
     before: install
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /usr/lib64/python3
     before: install
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /usr/lib64/python3.9
     before: install
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /usr/lib/python3/site-packages
     before: install
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /usr/local/lib/python3/site-packages
     before: install
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /etc/dnsmasq.conf
     before: install
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /etc/dnsmasq.conf.d
     before: install

--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -2,7 +2,8 @@
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
 {{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so* /bin/grep /bin/sed /bin/sh" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   install:
@@ -29,19 +30,19 @@ git:
   - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/iptables-loop.py
     to: /iptables-loop.py
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /usr/lib64/python3
   to: /usr/lib64/python3
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /usr/lib64/python3.9
   to: /usr/lib64/python3.9
   before: setup
-- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin
   includePaths:

--- a/ee/modules/610-service-with-healthchecks/images/agent/werf.inc.yaml
+++ b/ee/modules/610-service-with-healthchecks/images/agent/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/service-with-healthchecks-build-artifact
+  - image: {{ $.ModuleName }}/service-with-healthchecks-build-artifact
     add: /agent
     to: /agent
     before: install

--- a/ee/modules/610-service-with-healthchecks/images/artifact/werf.inc.yaml
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/werf.inc.yaml
@@ -1,5 +1,6 @@
 ---
-artifact: {{ $.ModuleName }}/service-with-healthchecks-build-artifact
+image: {{ $.ModuleName }}/service-with-healthchecks-build-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_22_ALPINE }}
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}

--- a/ee/modules/610-service-with-healthchecks/images/controller/werf.inc.yaml
+++ b/ee/modules/610-service-with-healthchecks/images/controller/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/service-with-healthchecks-build-artifact
+  - image: {{ $.ModuleName }}/service-with-healthchecks-build-artifact
     add: /controller
     to: /controller
     before: install

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/werf.inc.yaml
@@ -46,7 +46,7 @@ git:
     install:
     - '**/*'
 import:
-- artifact: common/python-static
+- image: common/python-static
   add: /opt/python-static
   to: /opt/python-static
   before: install

--- a/ee/se-plus/modules/021-cni-cilium/images/egress-gateway-agent/werf.inc.yaml
+++ b/ee/se-plus/modules/021-cni-cilium/images/egress-gateway-agent/werf.inc.yaml
@@ -1,7 +1,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /egress-gateway-agent
     to: /egress-gateway-agent
     before: setup
@@ -10,8 +10,8 @@ docker:
 ---
 {{ $discovererAbsPath := "/deckhouse/ee/se-plus/modules/021-cni-cilium/images/egress-gateway-agent" }}
   {{ $discovererRelPath := printf "%s/modules/021-cni-cilium/images/egress-gateway-agent" .ModulePath }}
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromCacheVersion: 20241021-1
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 shell:
   install:

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-controller-manager/werf.inc.yaml
@@ -5,14 +5,15 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /src/.build/bin/vsphere-cloud-controller-manager.linux_amd64
   to: /bin/vsphere-cloud-controller-manager
   before: setup
 docker:
   ENTRYPOINT: ["/bin/vsphere-cloud-controller-manager"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
     {{- if semverCompare ">=1.30" $version }}
 from: {{ $.Images.BASE_GOLANG_22_ALPINE_DEV }}
     {{- else if semverCompare "=1.29" $version }}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer
     to: /discoverer
     before: setup
@@ -11,7 +11,8 @@ docker:
 ---
 {{ $discovererAbsPath := "/deckhouse/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer" }}
 {{ $discovererRelPath := printf "%s/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer" .ModulePath }}
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_21_ALPINE }}
 shell:
   install:

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin-legacy/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin-legacy/werf.inc.yaml
@@ -2,11 +2,11 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-csi-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-csi-artifact
   add: /src/vsphere-csi
   to: /bin/vsphere-csi
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -15,7 +15,8 @@ import:
 docker:
   ENTRYPOINT: ["/bin/vsphere-csi"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-cloud-provider-vsphere-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-cloud-provider-vsphere-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_20_ALPINE_DEV }}
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/cloud-provider-vsphere-patches
@@ -36,10 +37,11 @@ shell:
   - cd /src
   - git apply /patches/*.patch --verbose
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-csi-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-csi-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_20_ALPINE_DEV }}
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-cloud-provider-vsphere-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-cloud-provider-vsphere-artifact
   add: /src
   to: /cloud-provider-vsphere
   before: install
@@ -71,7 +73,8 @@ shell:
 ---
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /usr/sbin/parted /usr/sbin/xfs* /sbin/mount.nfs* /sbin/umount.nfs*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   setup:

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin/werf.inc.yaml
@@ -5,11 +5,11 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /src/vsphere-csi
   to: /bin/vsphere-csi
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -18,7 +18,8 @@ import:
 docker:
   ENTRYPOINT: ["/bin/vsphere-csi"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
 from: {{ $.Images.BASE_GOLANG_21_ALPINE_DEV }}
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -48,7 +49,8 @@ shell:
 ---
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /usr/sbin/parted /usr/sbin/xfs* /sbin/mount.nfs* /sbin/umount.nfs*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   setup:

--- a/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
+++ b/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
@@ -5,7 +5,7 @@ git:
 - add: /{{ .ModulePath }}candi/cloud-providers/vsphere
   to: /deckhouse/candi/cloud-providers/vsphere
 import:
-- artifact: terraform-provider-vsphere
+- image: terraform-provider-vsphere
   add: /terraform-provider-vsphere
   to: /plugins/registry.terraform.io/{{ .TF.vsphere.namespace }}/{{ .TF.vsphere.type }}/{{ .TF.vsphere.version }}/linux_amd64/terraform-provider-vsphere
   before: setup

--- a/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-zvirt/werf.inc.yaml
+++ b/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-zvirt/werf.inc.yaml
@@ -4,7 +4,7 @@ git:
   - add: /{{ .ModulePath }}candi/cloud-providers/zvirt
     to: /deckhouse/candi/cloud-providers/zvirt
 import:
-  - artifact: terraform-provider-ovirt
+  - image: terraform-provider-ovirt
     add: /terraform-provider-ovirt
     to: /plugins/registry.terraform.io/{{ .TF.ovirt.namespace }}/{{ .TF.ovirt.type }}/{{ .TF.ovirt.version }}/linux_amd64/terraform-provider-ovirt
     before: setup

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -46,7 +46,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "
 from: {{ $.Images.BASE_GOLANG_23_ALPINE }}
 final: false
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/iptables-wrapper/werf.inc.yaml
+++ b/modules/000-common/images/iptables-wrapper/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/iptables-wrapper
   to: /iptables-wrapper
   before: setup

--- a/modules/000-common/images/nginx-static/werf.inc.yaml
+++ b/modules/000-common/images/nginx-static/werf.inc.yaml
@@ -35,7 +35,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/build-nginx-static-artifact
+- image: {{ $.ModuleName }}/build-nginx-static-artifact
   add: /opt/nginx-static
   to: /opt/nginx-static
   before: setup

--- a/modules/007-registrypackages/images/amazon-ec2-utils/werf.inc.yaml
+++ b/modules/007-registrypackages/images/amazon-ec2-utils/werf.inc.yaml
@@ -4,7 +4,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -18,7 +18,8 @@ docker:
     version: all
     growpart: {{ $version }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+final: false
 from: {{ $.Images.BASE_ALPINE_DEV }}
 git:
   - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts

--- a/modules/007-registrypackages/images/d8-ca-updater/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8-ca-updater/werf.inc.yaml
@@ -4,7 +4,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -20,7 +20,8 @@ docker:
     version: all
     d8-ca-updater: {{ $version }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+final: false
 from: {{ $.Images.BASE_UBUNTU_DEV }}
 git:
   - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
@@ -38,7 +39,7 @@ shell:
     - mkdir /certs
     - mv /mk-ca-bundle.pl /ca-certificates/mozilla
     - cd ca-certificates/mozilla
-    - perl mk-ca-bundle.pl -n 
+    - perl mk-ca-bundle.pl -n
     - mv ca-bundle.crt /ca-bundle.crt
     - python3 certdata2pem.py
     - mv *.crt /certs/

--- a/modules/007-registrypackages/images/drbd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/drbd/werf.inc.yaml
@@ -4,7 +4,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $.Images.BASE_SCRATCH }}
 
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /
     to: /
     includePaths:
@@ -18,7 +18,8 @@ docker:
     version: all
     drbd: {{ $version }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+final: false
 from: {{ $.Images.BASE_ALPINE }}
 
 git:

--- a/modules/007-registrypackages/images/ecr-credential-provider/werf.inc.yaml
+++ b/modules/007-registrypackages/images/ecr-credential-provider/werf.inc.yaml
@@ -6,7 +6,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -20,7 +20,8 @@ docker:
     version: all
     ecr-credential-provider: {{ $version }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+final: false
 {{- if semverCompare ">=1.30" $version }}
 from: {{ $.Images.BASE_GOLANG_22_BULLSEYE_DEV }}
 {{- else }}

--- a/modules/007-registrypackages/images/jq/werf.inc.yaml
+++ b/modules/007-registrypackages/images/jq/werf.inc.yaml
@@ -4,7 +4,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -18,7 +18,8 @@ docker:
     version: all
     jq: {{ $version }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+final: false
 from: {{ $.Images.BASE_ALPINE }}
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts

--- a/modules/007-registrypackages/images/kubeadm/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubeadm/werf.inc.yaml
@@ -6,7 +6,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -20,7 +20,8 @@ docker:
     version: all
     kubectl: {{ printf "%s.%s" $version $patch }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+final: false
 from: {{ $.Images.BASE_SCRATCH }}
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
@@ -29,7 +30,7 @@ git:
     setup:
     - '**/*'
 import:
-- artifact: common/kubernetes-artifact-{{ $image_version }}
+- image: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kubeadm
   to: /kubeadm
   before: setup

--- a/modules/007-registrypackages/images/kubectl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubectl/werf.inc.yaml
@@ -6,7 +6,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -20,7 +20,8 @@ docker:
     version: all
     kubectl: {{ printf "%s.%s" $version $patch }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+final: false
 from: {{ $.Images.BASE_SCRATCH }}
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
@@ -29,7 +30,7 @@ git:
     setup:
     - '**/*'
 import:
-- artifact: common/kubernetes-artifact-{{ $image_version }}
+- image: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kubectl
   to: /kubectl
   before: setup

--- a/modules/007-registrypackages/images/kubelet/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubelet/werf.inc.yaml
@@ -6,7 +6,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -21,7 +21,8 @@ docker:
     version: all
     kubelet: {{ printf "%s.%s" $version $patch }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+final: false
 from: {{ $.Images.BASE_SCRATCH }}
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
@@ -30,7 +31,7 @@ git:
     setup:
     - '**/*'
 import:
-- artifact: common/kubernetes-artifact-{{ $image_version }}
+- image: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kubelet
   to: /kubelet
   before: setup

--- a/modules/007-registrypackages/images/lsblk/werf.inc.yaml
+++ b/modules/007-registrypackages/images/lsblk/werf.inc.yaml
@@ -4,7 +4,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -18,7 +18,8 @@ docker:
     version: all
     lsblk: {{ $version }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+final: false
 from: {{ $.Images.BASE_GOLANG_20_ALPINE_DEV }}
 git:
   - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
@@ -33,7 +34,7 @@ shell:
     - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
     - git clone -b v{{ $version }} --depth 1 {{ $.SOURCE_REPO }}/util-linux/util-linux.git  /src
     - cd /src
-    - export LDFLAGS="-Wl,-z,now -Wl,-z,relro -static -s" 
+    - export LDFLAGS="-Wl,-z,now -Wl,-z,relro -static -s"
     - export CFLAGS="-fPIC -pie -fstack-protector-all -O2 -D_FORTIFY_SOURCE=2 -static -s"
     - ./autogen.sh
     - ./configure --enable-static --enable-static-programs=lsblk --disable-pylibmount --without-python --disable-liblastlog2

--- a/modules/007-registrypackages/images/nvme-cli/werf.inc.yaml
+++ b/modules/007-registrypackages/images/nvme-cli/werf.inc.yaml
@@ -4,7 +4,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}-{{ $image_version }}
 from: {{ .Images.BASE_SCRATCH }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
   add: /relocate
   to: /
   includePaths:
@@ -18,7 +18,8 @@ docker:
     version: all
     growpart: {{ $version }}
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+final: false
 fromImage: common/src-artifact
 git:
 - add: /{{ .ModulePath }}/modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/scripts
@@ -33,10 +34,11 @@ shell:
   - git clone -b v1.11.1 --depth 1 {{ .SOURCE_REPO }}/linux-nvme/libnvme.git /src/nvme-cli/subprojects/libnvme
   - rm -rf /src/nvme-cli/.git /src/nvme-cli/subprojects/libnvme/.git
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
+final: false
 from: {{ .Images.BASE_ALT_P11 }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/021-cni-cilium/images/agent/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/agent/werf.inc.yaml
@@ -66,7 +66,8 @@
 # #####################################################################
 # Binaries artifact for distroless agent (based on Ubuntu)
 ---
-artifact: {{ $.ModuleName }}/agent-binaries-artifact
+image: {{ $.ModuleName }}/agent-binaries-artifact
+final: false
 fromImage: {{ $.ModuleName }}/base-cilium-dev
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}
@@ -78,26 +79,26 @@ git:
     install:
     - "**/*.sh"
 import:
-- artifact: {{ $.ModuleName }}/llvm-artifact
+- image: {{ $.ModuleName }}/llvm-artifact
   add: /usr/local/bin/
   to: /usr/local/bin
   before: install
   includePaths:
   - clang
   - llc
-- artifact: {{ $.ModuleName }}/bpftool-artifact
+- image: {{ $.ModuleName }}/bpftool-artifact
   add: /usr/local/bin/bpftool
   to: /usr/local/bin/bpftool
   before: install
-- artifact: {{ $.ModuleName }}/cni-plugins-artifact
+- image: {{ $.ModuleName }}/cni-plugins-artifact
   add: /out/linux/amd64/bin/loopback
   to: /cni/loopback
   before: install
-- artifact: {{ $.ModuleName }}/gops-artifact
+- image: {{ $.ModuleName }}/gops-artifact
   add: /out/linux/amd64/bin/gops
   to: /bin/gops
   before: install
-- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin
   includePaths:
@@ -108,7 +109,7 @@ import:
   add: /iptables-wrapper
   to: /usr/sbin/iptables-wrapper
   before: install
-- artifact: {{ $.ModuleName }}/cilium-artifact
+- image: {{ $.ModuleName }}/cilium-artifact
   add: /tmp/install
   to: /
   before: install
@@ -121,7 +122,7 @@ import:
   - opt/cni/bin/cilium-cni
   - usr/bin/cilium*
   - var/lib/cilium/bpf
-- artifact: {{ $.ModuleName }}/cilium-envoy-artifact
+- image: {{ $.ModuleName }}/cilium-envoy-artifact
   add: /tmp/install/usr
   to: /usr
   before: install
@@ -129,11 +130,11 @@ import:
   - bin/cilium-envoy
   - bin/cilium-envoy-starter
   - lib/libcilium.so
-- artifact: {{ $.ModuleName }}/hubble-artifact
+- image: {{ $.ModuleName }}/hubble-artifact
   add: /hubble
   to: /usr/bin/hubble
   before: install
-- artifact: {{ $.ModuleName }}/hubble-artifact
+- image: {{ $.ModuleName }}/hubble-artifact
   add: /bash_completion
   to: /etc/bash_completion.d/hubble
   before: install
@@ -226,7 +227,7 @@ shell:
 image: {{ $.ModuleName }}/agent-distroless
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/agent-binaries-artifact
+- image: {{ $.ModuleName }}/agent-binaries-artifact
   add: /relocate
   to: /
   before: install

--- a/modules/021-cni-cilium/images/bin-bpftool/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-bpftool/werf.inc.yaml
@@ -14,7 +14,8 @@
 # Corresponding commit is 063fa0d879d9560b85b6134c48ece08e672fa057 (https://github.com/cilium/image-tools/tree/063fa0d879d9560b85b6134c48ece08e672fa057)
 # #####################################################################
 ---
-artifact: {{ $.ModuleName }}/bpftool-artifact
+image: {{ $.ModuleName }}/bpftool-artifact
+final: false
 fromImage: {{ $.ModuleName }}/base-cilium-dev
 shell:
   beforeInstall:

--- a/modules/021-cni-cilium/images/bin-cilium-envoy/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cilium-envoy/werf.inc.yaml
@@ -12,7 +12,8 @@
 # and https://github.com/cilium/proxy/blob/39a2a56bbd5b3a591f69dbca51d3e30ef97e0e51/.github/workflows/build-envoy-images-release.yaml
 # #####################################################################
 ---
-artifact: {{ $.ModuleName }}/cilium-envoy-artifact
+image: {{ $.ModuleName }}/cilium-envoy-artifact
+final: false
 fromImage: {{ $.ModuleName }}/base-cilium-dev
 mount:
 - fromPath: ~/go-pkg-cache

--- a/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
@@ -4,8 +4,8 @@
 # Build cilium-agent binaries
 # Based on https://github.com/cilium/cilium/blob/v1.14.14/images/cilium/Dockerfile (builder stage)
 ---
-artifact: {{ $.ModuleName }}/cilium-artifact
-fromCacheVersion: "2024-11-21.0"
+image: {{ $.ModuleName }}/cilium-artifact
+final: false
 fromImage: {{ $.ModuleName }}/base-cilium-dev
 git:
 - add: /{{ $.ModulePath }}modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -14,7 +14,7 @@ git:
     install:
       - '**/*'
 import:
-- artifact: {{ $.ModuleName }}/llvm-artifact
+- image: {{ $.ModuleName }}/llvm-artifact
   add: /usr/local/bin/
   to: /usr/local/bin
   before: install
@@ -22,15 +22,15 @@ import:
   - clang
   - llc
   - llvm-objcopy
-- artifact: {{ $.ModuleName }}/bpftool-artifact
+- image: {{ $.ModuleName }}/bpftool-artifact
   add: /usr/local/bin/bpftool
   to: /usr/local/bin/bpftool
   before: install
-- artifact: {{ $.ModuleName }}/cni-plugins-artifact
+- image: {{ $.ModuleName }}/cni-plugins-artifact
   add: /out/linux/amd64/bin/loopback
   to: /cni/loopback
   before: install
-- artifact: {{ $.ModuleName }}/gops-artifact
+- image: {{ $.ModuleName }}/gops-artifact
   add: /out/linux/amd64/bin/gops
   to: /bin/gops
   before: install

--- a/modules/021-cni-cilium/images/bin-cni-plugins/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cni-plugins/werf.inc.yaml
@@ -6,7 +6,8 @@
 # and https://github.com/cilium/cilium/blob/v1.14.14/images/runtime/download-cni.sh
 # #####################################################################
 ---
-artifact: {{ $.ModuleName }}/cni-plugins-artifact
+image: {{ $.ModuleName }}/cni-plugins-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
 mount:
 - fromPath: ~/go-pkg-cache

--- a/modules/021-cni-cilium/images/bin-gops/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-gops/werf.inc.yaml
@@ -6,7 +6,8 @@
 # and https://github.com/cilium/cilium/blob/v1.14.14/images/runtime/build-gops.sh
 # #####################################################################
 ---
-artifact: {{ $.ModuleName }}/gops-artifact
+image: {{ $.ModuleName }}/gops-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
 mount:
 - fromPath: ~/go-pkg-cache

--- a/modules/021-cni-cilium/images/bin-hubble/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-hubble/werf.inc.yaml
@@ -7,7 +7,8 @@
 # and https://github.com/cilium/hubble/blob/v1.16.0/Dockerfile
 # #####################################################################
 ---
-artifact: {{ $.ModuleName }}/hubble-artifact
+image: {{ $.ModuleName }}/hubble-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
 git:
 - add: /{{ $.ModulePath }}modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches

--- a/modules/021-cni-cilium/images/bin-iptables/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-iptables/werf.inc.yaml
@@ -12,7 +12,8 @@
 # and https://packages.altlinux.org/ru/p10/srpms/iptables/specfiles/2623143627906179825
 # #####################################################################
 ---
-artifact: {{ $.ModuleName }}/iptables-artifact
+image: {{ $.ModuleName }}/iptables-artifact
+final: false
 fromImage: {{ $.ModuleName }}/base-cilium-dev
 shell:
   beforeInstall:

--- a/modules/021-cni-cilium/images/bin-llvm/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-llvm/werf.inc.yaml
@@ -12,7 +12,8 @@
 # and https://github.com/cilium/image-tools/blob/063fa0d879d9560b85b6134c48ece08e672fa057/images/compilers/install-deps.sh
 # #####################################################################
 ---
-artifact: {{ $.ModuleName }}/llvm-artifact
+image: {{ $.ModuleName }}/llvm-artifact
+final: false
 fromImage: {{ $.ModuleName }}/base-cilium-dev
 shell:
   beforeInstall:

--- a/modules/021-cni-cilium/images/check-kernel-version/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/check-kernel-version/werf.inc.yaml
@@ -6,7 +6,7 @@ import:
   add: /check-kernel-version
   to: /check-kernel-version
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate/bin/true
   to: /bin/true
   before: setup
@@ -19,7 +19,8 @@ docker:
 ---
 {{- $binaries := "/bin/true" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
  setup:

--- a/modules/021-cni-cilium/images/kube-rbac-proxy/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/kube-rbac-proxy/werf.inc.yaml
@@ -6,7 +6,7 @@ import:
   add: /kube-rbac-proxy
   to: /kube-rbac-proxy
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate/bin/true
   to: /bin/true
   before: setup
@@ -20,7 +20,8 @@ docker:
 ---
 {{- $binaries := "/bin/true" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
  setup:

--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -4,7 +4,8 @@
 ---
 {{- $ciliumVersion := "1.14.14" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
 git:
 - add: /{{ $.ModulePath }}modules/021-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -35,7 +36,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
   add: /out/linux/amd64/usr/bin/cilium-operator
   to: /usr/bin/cilium-operator
   before: install

--- a/modules/021-cni-cilium/images/safe-agent-updater/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/safe-agent-updater/werf.inc.yaml
@@ -1,5 +1,6 @@
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_23_ALPINE }}
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}
@@ -31,7 +32,7 @@ shell:
 image: {{ $.ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
   add: /src/safe-agent-updater
   to: /safe-agent-updater
   before: install

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
@@ -5,14 +5,15 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /src/aws-cloud-controller-manager
   to: /usr/local/bin/aws-cloud-controller-manager
   before: setup
 docker:
   ENTRYPOINT: ["/usr/local/bin/aws-cloud-controller-manager"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
     {{- if semverCompare ">=1.30" $version }}
 from: {{ $.Images.BASE_GOLANG_22_ALPINE }}
     {{- else if semverCompare "=1.29" $version }}

--- a/modules/030-cloud-provider-aws/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-data-discoverer/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer
     to: /discoverer
     before: setup
@@ -11,7 +11,8 @@ docker:
 ---
 {{ $discovererAbsPath := "/deckhouse/modules/030-cloud-provider-aws/images/cloud-data-discoverer" }}
 {{ $discovererRelPath := printf "%smodules/030-cloud-provider-aws/images/cloud-data-discoverer" .ModulePath }}
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 shell:
   install:

--- a/modules/030-cloud-provider-aws/images/ebs-csi-plugin/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/ebs-csi-plugin/werf.inc.yaml
@@ -5,11 +5,11 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver
   to: /bin/aws-ebs-csi-driver
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -18,7 +18,8 @@ import:
 docker:
   ENTRYPOINT: ["/bin/aws-ebs-csi-driver"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
     {{- if semverCompare ">=1.31" $version }}
 from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
     {{- else if semverCompare "=1.30" $version }}
@@ -43,11 +44,12 @@ mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
  {{- end }}
-{{- end }} 
+{{- end }}
 ---
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /usr/sbin/parted /usr/sbin/xfs*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   setup:

--- a/modules/030-cloud-provider-aws/images/node-termination-handler/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/node-termination-handler/werf.inc.yaml
@@ -2,21 +2,22 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/build/node-termination-handler
     to: /node-termination-handler
     before: setup
 docker:
   ENTRYPOINT: ["/node-termination-handler"]
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_20_ALPINE }}
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
 shell:
   beforeInstall:
-  - | 
+  - |
     apk upgrade --available --no-cache && \
     apk add --no-cache ca-certificates git make openssh-client
   install:

--- a/modules/030-cloud-provider-azure/images/azuredisk-csi/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/azuredisk-csi/werf.inc.yaml
@@ -5,11 +5,11 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /src/_output/amd64/azurediskplugin
   to: /azurediskplugin
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -18,7 +18,8 @@ import:
 docker:
   ENTRYPOINT: ["/azurediskplugin"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
     {{- if semverCompare ">=1.31" $version }}
 from: {{ $.Images.BASE_GOLANG_23_ALPINE_DEV }}
     {{- else if semverCompare "=1.30" $version }}
@@ -43,11 +44,12 @@ shell:
   - cd /src
   - make azuredisk
  {{- end }}
-{{- end }}    
+{{- end }}
 ---
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /usr/sbin/parted /usr/sbin/xfs*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   setup:

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/werf.inc.yaml
@@ -6,14 +6,15 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /src/bin/azure-cloud-controller-manager
     to: /usr/local/bin/azure-cloud-controller-manager
     before: setup
 docker:
   ENTRYPOINT: ["/usr/local/bin/azure-cloud-controller-manager"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
     {{- if semverCompare ">=1.31" $version }}
 from: {{ $.Images.BASE_GOLANG_23_ALPINE }}
     {{- else if semverCompare "=1.30" $version }}

--- a/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer
     to: /discoverer
     before: setup
@@ -11,7 +11,8 @@ docker:
 ---
 {{ $discovererAbsPath := "/deckhouse/modules/030-cloud-provider-azure/images/cloud-data-discoverer" }}
 {{ $discovererRelPath := printf "%smodules/030-cloud-provider-azure/images/cloud-data-discoverer" .ModulePath }}
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 shell:
   install:

--- a/modules/030-cloud-provider-gcp/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/cloud-controller-manager/werf.inc.yaml
@@ -5,14 +5,15 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     add: /src/gcp-cloud-controller-manager
     to: /usr/local/bin/cloud-controller-manager
     before: setup
 docker:
   ENTRYPOINT: ["/usr/local/bin/cloud-controller-manager"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
     {{- if semverCompare ">=1.30" $version }}
 from: {{ $.Images.BASE_GOLANG_22_ALPINE }}
     {{- else if semverCompare "=1.29" $version }}

--- a/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer
     to: /discoverer
     before: setup
@@ -11,7 +11,8 @@ docker:
 ---
 {{ $discovererAbsPath := "/deckhouse/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/" }}
 {{ $discovererRelPath := printf "%smodules/030-cloud-provider-gcp/images/cloud-data-discoverer/" .ModulePath }}
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 shell:
   install:

--- a/modules/030-cloud-provider-gcp/images/pd-csi-plugin/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/pd-csi-plugin/werf.inc.yaml
@@ -5,36 +5,37 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /src/bin/gce-pd-csi-driver
   to: /gce-pd-csi-driver
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
   includePaths:
   - '**/*'
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib64
   to: /lib64
   before: install
   includePaths:
   - 'libresolv*'
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib/udev/scsi_id
   to: /lib/udev_containerized/scsi_id
   before: setup
     {{- if semverCompare ">=1.31" $version }}
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-  add: /src/deploy/kubernetes/udev/google_nvme_id 
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+  add: /src/deploy/kubernetes/udev/google_nvme_id
   to: /lib/udev_containerized/google_nvme_id
-  before: setup 
-    {{- end }} 
+  before: setup
+    {{- end }}
 docker:
   ENTRYPOINT: ["/gce-pd-csi-driver"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
     {{- if semverCompare ">=1.31" $version }}
 from: {{ $.Images.BASE_GOLANG_22_BULLSEYE_DEV }}
     {{- else if semverCompare ">=1.27" $version }}
@@ -57,7 +58,8 @@ shell:
 ---
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /sbin/xfs_repair /usr/sbin/nvme /usr/sbin/parted /usr/sbin/xfs*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   setup:

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -5,14 +5,15 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /src/yandex-cloud-controller-manager
   to: /usr/local/bin/cloud-controller-manager
   before: setup
 docker:
   ENTRYPOINT: ["/usr/local/bin/cloud-controller-manager"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
     {{- if semverCompare ">=1.30" $version }}
 from: {{ $.Images.BASE_GOLANG_22_ALPINE_DEV }}
     {{- else if semverCompare "=1.29" $version }}

--- a/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /discoverer
     to: /discoverer
     before: setup
@@ -11,7 +11,8 @@ docker:
 ---
 {{ $discovererAbsPath := "/deckhouse/modules/030-cloud-provider-yandex/images/cloud-data-discoverer" }}
 {{ $discovererRelPath := printf "%smodules/030-cloud-provider-yandex/images/cloud-data-discoverer" .ModulePath }}
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_21_ALPINE }}
 shell:
   install:

--- a/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
@@ -2,14 +2,15 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/exporter
   to: /exporter
   after: setup
 docker:
   ENTRYPOINT: [ "/exporter"]
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 git:
 - add: /{{ .ModulePath }}modules/030-{{ .ModuleName }}/images/{{ .ImageName }}

--- a/modules/030-cloud-provider-yandex/images/cloud-migrator/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-migrator/werf.inc.yaml
@@ -10,6 +10,7 @@ docker:
   ENTRYPOINT: ["/migrator"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_21_ALPINE }}
 shell:
   setup:

--- a/modules/030-cloud-provider-yandex/images/cloud-migrator/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-migrator/werf.inc.yaml
@@ -2,14 +2,14 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /migrator
   to: /migrator
   before: setup
 docker:
   ENTRYPOINT: ["/migrator"]
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ .Images.BASE_GOLANG_21_ALPINE }}
 shell:
   setup:

--- a/modules/030-cloud-provider-yandex/images/yandex-csi-plugin/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/yandex-csi-plugin/werf.inc.yaml
@@ -5,11 +5,11 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /go/bin/yandex-csi-driver
   to: /bin/yandex-csi-driver
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -18,7 +18,8 @@ import:
 docker:
   ENTRYPOINT: ["/bin/yandex-csi-driver"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+final: false
     {{- if semverCompare ">=1.27" $version }}
 from: {{ $.Images.BASE_GOLANG_21_ALPINE_DEV }}
     {{- end }}
@@ -45,7 +46,8 @@ shell:
 ---
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /usr/sbin/parted /usr/sbin/xfs*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ $.Images.BASE_ALT_DEV }}
 shell:
   setup:

--- a/modules/031-ceph-csi/images/cephcsi/werf.inc.yaml
+++ b/modules/031-ceph-csi/images/cephcsi/werf.inc.yaml
@@ -1,6 +1,7 @@
 {{- $binaries := "/cephcsi /sbin/mount.ceph /usr/bin/ceph-fuse /bin/mount /bin/umount /sbin/fsck /sbin/modprobe /bin/kmod /usr/bin/rbd /usr/bin/rbd-nbd /sbin/blkid /sbin/mkfs /sbin/mkfs.ext4 /sbin/mkfs.xfs /sbin/blockdev /sbin/dumpe2fs /usr/sbin/xfs_io /usr/sbin/xfs_growfs /sbin/resize2fs" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ .Images.BASE_ALT_DEV }}
 shell:
   install:
@@ -17,7 +18,7 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /relocate
     to: /
     before: setup

--- a/modules/031-local-path-provisioner/images/helper/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/helper/werf.inc.yaml
@@ -1,5 +1,6 @@
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-dir-manager
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-dir-manager
+final: false
 from: {{ $.Images.BASE_GOLANG_20_ALPINE }}
 fromCacheVersion: "2023-10-16.1"
 git:
@@ -23,7 +24,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 fromCacheVersion: "2023-10-16.3"
 import:
- - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-dir-manager
+ - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-dir-manager
    add: /tmp/manager
    to: /manager
    after: install

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -4,14 +4,15 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /local-path-provisioner
     to: /usr/bin/local-path-provisioner
     after: install
 docker:
   ENTRYPOINT: ["/usr/bin/local-path-provisioner"]
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+final: false
 from: {{ $.Images.BASE_GOLANG_21_ALPINE_DEV }}
 git:
   - add: /{{ $.ModulePath }}modules/031-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches

--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -4,18 +4,18 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
-- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /usr/lib64
   to: /usr/lib64
   before: setup
@@ -30,7 +30,8 @@ docker:
 ---
 {{ $simpleBridgeBinaries := "/bin/awk /bin/cat /bin/rm /bin/echo /usr/bin/tee /bin/sleep /bin/hostname /usr/bin/python3 /usr/bin/curl /usr/bin/jq /bin/bash /bin/grep /sbin/ip /usr/sbin/bridge" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ .Images.BASE_ALT_DEV }}
 git:
 - add: /{{ $.ModulePath }}modules/035-{{ $.ModuleName }}/images/{{ $.ImageName }}/rootfs

--- a/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
@@ -6,11 +6,11 @@ docker:
   ENV:
     PATH: "/root:/"
 import:
-- artifact: dhctl # from main werf.yaml
+- image: dhctl # from main werf.yaml
   add: /dhctl/bin/dhctl
   to: /dhctl
   before: setup
-- artifact: terraform
+- image: terraform
   add: /terraform/terraform
   to: /root/terraform
   before: setup

--- a/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
@@ -4,7 +4,7 @@ git:
 - add: /{{ .ModulePath }}candi/cloud-providers/aws
   to: /deckhouse/candi/cloud-providers/aws
 import:
-- artifact: terraform-provider-aws
+- image: terraform-provider-aws
   add: /terraform-provider-aws
   to: /plugins/registry.terraform.io/{{ .TF.aws.namespace }}/{{ .TF.aws.type }}/{{ .TF.aws.version }}/linux_amd64/terraform-provider-aws
   before: setup

--- a/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
@@ -4,7 +4,7 @@ git:
 - add: /{{ .ModulePath }}candi/cloud-providers/azure
   to: /deckhouse/candi/cloud-providers/azure
 import:
-- artifact: terraform-provider-azure
+- image: terraform-provider-azure
   add: /terraform-provider-azurerm
   to: /plugins/registry.terraform.io/{{ .TF.azure.namespace }}/{{ .TF.azure.type }}/{{ .TF.azure.version }}/linux_amd64/terraform-provider-azurerm
   before: setup

--- a/modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
@@ -5,7 +5,7 @@ git:
 - add: /{{ .ModulePath }}candi/cloud-providers/gcp
   to: /deckhouse/candi/cloud-providers/gcp
 import:
-- artifact: terraform-provider-gcp
+- image: terraform-provider-gcp
   add: /terraform-provider-gcp
   to: /plugins/registry.terraform.io/{{ .TF.gcp.namespace }}/{{ .TF.gcp.type }}/{{ .TF.gcp.version }}/linux_amd64/terraform-provider-google
   before: setup

--- a/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
@@ -4,7 +4,7 @@ git:
 - add: /{{ .ModulePath }}candi/cloud-providers/yandex
   to: /deckhouse/candi/cloud-providers/yandex
 import:
-- artifact: terraform-provider-yandex
+- image: terraform-provider-yandex
   add: /terraform-provider-yandex
   to: /plugins/registry.terraform.io/{{ .TF.yandex.namespace }}/{{ .TF.yandex.type }}/{{ .TF.yandex.version }}/linux_amd64/terraform-provider-yandex
   before: setup

--- a/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
+++ b/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
@@ -2,7 +2,8 @@
 {{- $iptables_version := "1.8.9" }}
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+final: false
 from: {{ .Images.BASE_ALT_DEV }}
 shell:
   install:
@@ -14,7 +15,8 @@ shell:
       # broken symlinks are not imported from the artifact
       touch /iptables-wrapper
 ---
-artifact: {{ .ModuleName }}/kube-router-artifact
+image: {{ .ModuleName }}/kube-router-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_20_ALPINE_DEV }}
 shell:
   beforeInstall:
@@ -32,15 +34,15 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/kube-router-artifact
+- image: {{ .ModuleName }}/kube-router-artifact
   add: /src/kube-router
   to: /opt/bin/kube-router
   before: setup
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
-- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin
   includePaths:

--- a/modules/150-user-authn/images/basic-auth-proxy/werf.inc.yaml
+++ b/modules/150-user-authn/images/basic-auth-proxy/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-basic-auth-proxy-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-basic-auth-proxy-artifact
     add: /src/basic-auth-proxy
     to: /basic-auth-proxy
     before: setup

--- a/modules/200-operator-prometheus/images/prometheus-config-reloader/werf.inc.yaml
+++ b/modules/200-operator-prometheus/images/prometheus-config-reloader/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/prometheus-operator-artifact-{{ $version | replace "." "-" }}
+- image: {{ $.ModuleName }}/prometheus-operator-artifact-{{ $version | replace "." "-" }}
   add: /prometheus-config-reloader
   to: /bin/prometheus-config-reloader
   before: setup

--- a/modules/300-prometheus/images/grafana-dashboard-provisioner/werf.inc.yaml
+++ b/modules/300-prometheus/images/grafana-dashboard-provisioner/werf.inc.yaml
@@ -28,7 +28,7 @@ git:
     install:
     - '**/*'
 import:
-- artifact: common/python-static
+- image: common/python-static
   add: /opt/python-static
   to: /opt/python-static
   before: install

--- a/modules/300-prometheus/images/mimir/werf.inc.yaml
+++ b/modules/300-prometheus/images/mimir/werf.inc.yaml
@@ -40,7 +40,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/mimir
     to: /bin/mimir
     after: setup

--- a/modules/300-prometheus/images/promxy/werf.inc.yaml
+++ b/modules/300-prometheus/images/promxy/werf.inc.yaml
@@ -38,7 +38,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/promxy
     to: /app/promxy
     after: setup

--- a/modules/300-prometheus/images/trickster/werf.inc.yaml
+++ b/modules/300-prometheus/images/trickster/werf.inc.yaml
@@ -2,19 +2,20 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
   add: /src/entrypoint
   to: /usr/local/bin/entrypoint
   before: setup
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/OPATH/trickster
   to: /usr/local/bin/trickster
   before: setup
 docker:
   ENTRYPOINT: ["entrypoint"]
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromArtifact: common/src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+final: false
+fromImage: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/entrypoint
   to: /src/entrypoint
@@ -41,10 +42,11 @@ shell:
   - rm -rf .git
   - rm -rf .git
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/trickster
   to: /src
   before: install
@@ -62,10 +64,11 @@ shell:
   - chown -R 64535:64535 /src
   - chmod 0700 /src/OPATH/trickster
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/entrypoint
   to: /src
   before: install

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -1,6 +1,7 @@
 {{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so*" }}
 ---
-artifact: {{ $.ModuleName }}/{{ $.ImageName }}-binary-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-binary-artifact
+final: false
 fromImage: common/alt-p11-artifact
 git:
   - add: /{{ $.ModulePath }}modules/340-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/requirements.txt
@@ -9,7 +10,7 @@ git:
       install:
         - '**/*'
 import:
-- artifact: common/python-static
+- image: common/python-static
   add: /opt/python-static
   to: /opt/python-static
   before: install

--- a/modules/340-monitoring-kubernetes/images/ebpf-exporter/werf.inc.yaml
+++ b/modules/340-monitoring-kubernetes/images/ebpf-exporter/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromArtifact: common/src-artifact
+fromImage: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/entrypoint

--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/werf.inc.yaml
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/werf.inc.yaml
@@ -10,7 +10,7 @@ docker:
   ENTRYPOINT: ["/bin/kube-state-metrics"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromArtifact: common/src-artifact
+fromImage: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/werf.inc.yaml
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/werf.inc.yaml
@@ -10,7 +10,7 @@ docker:
   ENTRYPOINT: ["/bin/loop"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromArtifact: common/src-artifact
+fromImage: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src

--- a/modules/340-monitoring-kubernetes/images/node-exporter/werf.inc.yaml
+++ b/modules/340-monitoring-kubernetes/images/node-exporter/werf.inc.yaml
@@ -10,7 +10,7 @@ docker:
   ENTRYPOINT: ["/bin/node_exporter"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromArtifact: common/src-artifact
+fromImage: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches

--- a/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
+++ b/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromArtifact: common/src-artifact
+fromImage: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
@@ -43,7 +43,7 @@ import:
   add: /src/monitoring-ping/requirements.txt
   to: /requirements.txt
   before: install
-- artifact: common/python-static
+- image: common/python-static
   add: /opt/python-static
   before: install
 shell:

--- a/modules/400-descheduler/images/descheduler/werf.inc.yaml
+++ b/modules/400-descheduler/images/descheduler/werf.inc.yaml
@@ -21,7 +21,7 @@ image: {{ .ModuleName }}/build-artifact
 final: false
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -41,7 +41,7 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ .ModuleName }}/build-artifact
+  - image: {{ .ModuleName }}/build-artifact
     add: /descheduler
     to: /descheduler
     before: setup

--- a/modules/402-ingress-nginx/images/proxy-failover-iptables/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/proxy-failover-iptables/werf.inc.yaml
@@ -50,7 +50,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-- image: {{ $.ModuleName }}/distroless-proxy-failover-iptables-artifact
+- artifact: {{ $.ModuleName }}/distroless-proxy-failover-iptables-artifact
   add: /relocate
   to: /
   before: setup

--- a/modules/462-loki/images/loki/werf.inc.yaml
+++ b/modules/462-loki/images/loki/werf.inc.yaml
@@ -40,7 +40,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
-  - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/loki
     to: /usr/bin/loki
     after: setup

--- a/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
+++ b/modules/465-pod-reloader/images/pod-reloader/werf.inc.yaml
@@ -1,5 +1,6 @@
 ---
-artifact: {{ .ModuleName }}/reloader-artifact
+image: {{ .ModuleName }}/reloader-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_19_ALPINE }}
 shell:
   beforeInstall:
@@ -19,7 +20,7 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/reloader-artifact
+- image: {{ .ModuleName }}/reloader-artifact
   add: /reloader
   to: /reloader
   before: setup

--- a/modules/500-cilium-hubble/images/ui/werf.inc.yaml
+++ b/modules/500-cilium-hubble/images/ui/werf.inc.yaml
@@ -43,7 +43,7 @@ shell:
   - export GOPROXY={{ $.GOPROXY }}
   - export "GOARCH=amd64"
   - cd /src/backend
-  - go mod vendor && go mod download -x 
+  - go mod vendor && go mod download -x
   - CGO_ENABLED=0 go build -ldflags "-s -w" -o backend
   - chown 64535:64535 /src/backend/backend
   - chmod 0700 /src/backend/backend
@@ -51,7 +51,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-frontend
 fromImage: common/nginx-static
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src/server/public
   to: /app
   before: install
@@ -62,7 +62,7 @@ docker:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-backend
 fromImage: common/distroless
 import:
-- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-backend-build-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-backend-build-artifact
   add: /src/backend/backend
   to: /usr/local/bin/hubble-ui-backend
   before: install

--- a/modules/500-dashboard/images/api/werf.inc.yaml
+++ b/modules/500-dashboard/images/api/werf.inc.yaml
@@ -6,16 +6,17 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /dashboard-api
   before: setup
 docker:
   ENTRYPOINT: ["/dashboard-api"]
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   before: install
 mount:
@@ -30,7 +31,8 @@ shell:
   - chown 64535:64535 /dashboard-api
   - chmod 0755 /dashboard-api
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+final: false
 fromImage: common/src-artifact
 shell:
   install:

--- a/modules/500-dashboard/images/auth/werf.inc.yaml
+++ b/modules/500-dashboard/images/auth/werf.inc.yaml
@@ -6,16 +6,17 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /dashboard-auth
   before: setup
 docker:
   ENTRYPOINT: ["/dashboard-auth"]
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   before: install
 mount:
@@ -30,7 +31,8 @@ shell:
   - chown 64535:64535 /dashboard-auth
   - chmod 0755 /dashboard-auth
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+final: false
 fromImage: common/src-artifact
 shell:
   install:

--- a/modules/500-dashboard/images/metrics-scraper/werf.inc.yaml
+++ b/modules/500-dashboard/images/metrics-scraper/werf.inc.yaml
@@ -6,16 +6,17 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /dashboard-metrics-scraper
   before: setup
 docker:
   ENTRYPOINT: ["/dashboard-metrics-scraper"]
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   before: install
 mount:
@@ -30,7 +31,8 @@ shell:
   - chown 64535:64535 /dashboard-metrics-scraper
   - chmod 0755 /dashboard-metrics-scraper
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+final: false
 fromImage: common/src-artifact
 shell:
   install:

--- a/modules/500-dashboard/images/web/werf.inc.yaml
+++ b/modules/500-dashboard/images/web/werf.inc.yaml
@@ -6,24 +6,25 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /dashboard-web
   before: setup
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-node-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-node-artifact
   add: /src/modules/web/.dist/public
   to: /public
   before: setup
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-node-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-node-artifact
   add: /src/modules/web/.dist/public/locale_conf.json
   to: /locale_conf.json
   before: setup
 docker:
   ENTRYPOINT: ["/dashboard-web"]
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   before: install
 mount:
@@ -38,10 +39,11 @@ shell:
   - chown 64535:64535 /dashboard-web
   - chmod 0755 /dashboard-web
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-node-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-node-artifact
+final: false
 from: {{ .Images.BASE_NODE_20_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   before: install
 mount:
@@ -61,7 +63,8 @@ shell:
   - ./install_logout.sh
   - rm -r node_modules .angular .yarn /root/.cache /root/.yarn #1Gi
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+final: false
 fromImage: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches

--- a/modules/500-openvpn/images/easyrsa-migrator/werf.inc.yaml
+++ b/modules/500-openvpn/images/easyrsa-migrator/werf.inc.yaml
@@ -2,14 +2,15 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/easyrsa-migrator
   to: /bin/easyrsa-migrator
   before: setup
 docker:
   ENTRYPOINT: ["/bin/easyrsa-migrator"]
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+final: false
 fromImage: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
@@ -27,10 +28,11 @@ shell:
   install:
   - cd /src
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/500-openvpn/images/openvpn/werf.inc.yaml
+++ b/modules/500-openvpn/images/openvpn/werf.inc.yaml
@@ -12,27 +12,28 @@ import:
   add: /iptables-wrapper
   to: /sbin/iptables-wrapper
   before: setup
-- artifact: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/openvpn/src/openvpn/openvpn
   to: /usr/sbin/openvpn
   before: setup
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
   add: /src/entrypoint
   to: /entrypoint
   before: setup
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+final: false
 fromImage: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/entrypoint
@@ -52,10 +53,11 @@ shell:
   - git clone --depth 1 -b v{{ $libcapNgVersion }} {{ .SOURCE_REPO }}/stevegrubb/libcap-ng.git /src/libcap-ng && cd /src/libcap-ng && rm -rf .git
   - git clone --depth 1 -b v{{ $openvpnVersion }} {{ .SOURCE_REPO }}/OpenVPN/openvpn.git /src/openvpn && cd /src/openvpn && rm -rf .git
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/entrypoint
   to: /src
   before: install
@@ -71,10 +73,11 @@ shell:
   - chown -R 64535:64535 /src
   - chmod 0755 /src/entrypoint
 ---
-artifact: {{ .ModuleName }}/openssl-artifact
+image: {{ .ModuleName }}/openssl-artifact
+final: false
 from: {{ .Images.BASE_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/openssl
   to: /src
   before: install
@@ -88,14 +91,15 @@ shell:
   - make -j4
   - make install_sw DESTDIR=/openssl
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
 from: {{ .Images.BASE_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
-- artifact: {{ .ModuleName }}/openssl-artifact
+- image: {{ .ModuleName }}/openssl-artifact
   add: /openssl
   to: /
   before: install
@@ -114,8 +118,9 @@ shell:
   - ./configure --enable-static --disable-shared --disable-debug --disable-unit-tests --disable-lzo --disable-lz4 --disable-plugin-auth-pam --disable-plugin-down-root --disable-dco
   - make LIBS="-all-static -lcap-ng"
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
-fromArtifact: common/relocate-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+final: false
+fromImage: common/relocate-artifact
 shell:
   beforeInstall:
   {{- include "alt packages proxy" . | nindent 2 }}

--- a/modules/500-openvpn/images/ovpn-admin/werf.inc.yaml
+++ b/modules/500-openvpn/images/ovpn-admin/werf.inc.yaml
@@ -10,30 +10,31 @@ git:
     install:
       - '**/*'
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-backend-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-backend-artifact
   add: /src/ovpn-admin
   to: /app/ovpn-admin
   before: setup
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/version
   to: /app/version
   before: setup
-- artifact: {{ .ModuleName }}/openvpn-artifact
+- image: {{ .ModuleName }}/openvpn-artifact
   add: /src/openvpn/src/openvpn/openvpn
   to: /usr/sbin/openvpn
   before: setup
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-frontend-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-frontend-artifact
   add: /src/frontend/static
   to: /app/frontend/static
   before: setup
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
 docker:
   WORKDIR: /app
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+final: false
 fromImage: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -52,10 +53,11 @@ shell:
   - rm -rf .git
   - echo {{ $gitCommit }} > version
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-backend-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-backend-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -71,10 +73,11 @@ shell:
   - chown -R 64535:64535 /src
   - chmod 0755 /src/ovpn-admin
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-frontend-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-frontend-artifact
+final: false
 from: {{ .Images.BASE_NODE_16_ALPINE }}
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -85,10 +88,11 @@ shell:
   - npm install
   - npm run build
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
-fromArtifact: common/relocate-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+final: false
+fromImage: common/relocate-artifact
 import:
-- artifact: {{ .ModuleName }}/openssl-artifact
+- image: {{ .ModuleName }}/openssl-artifact
   add: /openssl
   to: /openssl
   before: install

--- a/modules/500-openvpn/images/pmacct/werf.inc.yaml
+++ b/modules/500-openvpn/images/pmacct/werf.inc.yaml
@@ -2,14 +2,15 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /relocate
   to: /
   before: setup
 docker:
   ENTRYPOINT: ["/usr/sbin/pmacctd"]
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+final: false
 fromImage: common/src-artifact
 shell:
   install:
@@ -24,10 +25,11 @@ shell:
   - git submodule update --init
   - rm -rf /src/.git
 ---
-artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromArtifact: common/relocate-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+final: false
+fromImage: common/relocate-artifact
 import:
-- artifact: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/500-upmeter/images/smoke-mini/werf.inc.yaml
+++ b/modules/500-upmeter/images/smoke-mini/werf.inc.yaml
@@ -1,5 +1,6 @@
 ---
-artifact: {{ .ModuleName }}/build-smoke-mini-artifact
+image: {{ .ModuleName }}/build-smoke-mini-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_20_ALPINE }}
 git:
 - add: /{{ $.ModulePath }}modules/500-{{ $.ModuleName }}/images/{{ $.ImageName }}/
@@ -26,7 +27,7 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/build-smoke-mini-artifact
+- image: {{ .ModuleName }}/build-smoke-mini-artifact
   add: /src/smoke-mini
   to: /smoke-mini
   before: setup

--- a/modules/500-upmeter/images/status/werf.inc.yaml
+++ b/modules/500-upmeter/images/status/werf.inc.yaml
@@ -1,5 +1,6 @@
 ---
-artifact: {{ .ModuleName }}/build-status-artifact
+image: {{ .ModuleName }}/build-status-artifact
+final: false
 from: node:14-alpine3.12@sha256:426384fb33a11d27dbbdc545f39bb8daacd3e7db7c60b52cd6bc0597e0045b8d
 git:
 - add: /{{ $.ModulePath }}modules/500-{{ $.ModuleName }}/images/{{ $.ImageName }}/
@@ -18,7 +19,7 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/nginx-static
 import:
-- artifact: {{ .ModuleName }}/build-status-artifact
+- image: {{ .ModuleName }}/build-status-artifact
   add: /src/dist
   to: /opt/nginx-static/html
   before: setup

--- a/modules/500-upmeter/images/upmeter/werf.inc.yaml
+++ b/modules/500-upmeter/images/upmeter/werf.inc.yaml
@@ -1,5 +1,6 @@
 ---
-artifact: {{ .ModuleName }}/build-upmeter-artifact
+image: {{ .ModuleName }}/build-upmeter-artifact
+final: false
 from: {{ .Images.BASE_GOLANG_20_ALPINE }}
 git:
 - add: /{{ $.ModulePath }}modules/500-{{ $.ModuleName }}/images/{{ $.ImageName }}/
@@ -33,19 +34,19 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- artifact: {{ .ModuleName }}/build-upmeter-artifact
+- image: {{ .ModuleName }}/build-upmeter-artifact
   add: /src/pkg/db/migrations/agent
   to: /data/migrations/agent
   before: setup
-- artifact: {{ .ModuleName }}/build-upmeter-artifact
+- image: {{ .ModuleName }}/build-upmeter-artifact
   add: /src/pkg/db/migrations/server
   to: /data/migrations/server
   before: setup
-- artifact: {{ .ModuleName }}/build-upmeter-artifact
+- image: {{ .ModuleName }}/build-upmeter-artifact
   add: /src/migrate
   to: /migrate
   before: setup
-- artifact: {{ .ModuleName }}/build-upmeter-artifact
+- image: {{ .ModuleName }}/build-upmeter-artifact
   add: /src/upmeter
   to: /upmeter
   before: setup

--- a/modules/500-upmeter/images/webui/werf.inc.yaml
+++ b/modules/500-upmeter/images/webui/werf.inc.yaml
@@ -1,5 +1,6 @@
 ---
-artifact: {{ .ModuleName }}/build-webui-artifact
+image: {{ .ModuleName }}/build-webui-artifact
+final: false
 from: node:14-alpine3.12@sha256:426384fb33a11d27dbbdc545f39bb8daacd3e7db7c60b52cd6bc0597e0045b8d
 git:
 - add: /{{ $.ModulePath }}modules/500-{{ $.ModuleName }}/images/{{ $.ImageName }}/
@@ -18,7 +19,7 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/nginx-static
 import:
-- artifact: {{ .ModuleName }}/build-webui-artifact
+- image: {{ .ModuleName }}/build-webui-artifact
   add: /src/dist
   to: /opt/nginx-static/html
   before: setup


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Werf is dropping support for artifacts
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Remove all artifacts from the build process
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not related to release
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Artifacts are no longer used during build
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Artifacts are no longer used during build
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
