### PR TITLE
[ci] fix linter issues

### DIFF
--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -145,9 +145,9 @@ steps:
       test -e ./tools/docs/link-checker/entrypoint.sh && \
       docker run \
         --rm \
-        -v "${_TMPDIR}/site_en:/src/en:ro" \
-        -v "${_TMPDIR}/site_ru:/src/ru:ro" \
-        -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" \
+        --mount type=bind,src="${_TMPDIR}/site_en",dst="/src/en",ro \
+        --mount type=bind,src="${_TMPDIR}/site_ru",dst="/src/ru",ro \
+        --mount type=bind,src="./tools/docs/link-checker/entrypoint.sh",dst="/entrypoint.sh",r \
         -u $(id -u) \
         ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} \
         /entrypoint.sh

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1526,9 +1526,9 @@ jobs:
           test -e ./tools/docs/link-checker/entrypoint.sh && \
           docker run \
             --rm \
-            -v "${_TMPDIR}/site_en:/src/en:ro" \
-            -v "${_TMPDIR}/site_ru:/src/ru:ro" \
-            -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" \
+            --mount type=bind,src="${_TMPDIR}/site_en",dst="/src/en",ro \
+            --mount type=bind,src="${_TMPDIR}/site_ru",dst="/src/ru",ro \
+            --mount type=bind,src="./tools/docs/link-checker/entrypoint.sh",dst="/entrypoint.sh",r \
             -u $(id -u) \
             ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} \
             /entrypoint.sh

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -1271,9 +1271,9 @@ jobs:
           test -e ./tools/docs/link-checker/entrypoint.sh && \
           docker run \
             --rm \
-            -v "${_TMPDIR}/site_en:/src/en:ro" \
-            -v "${_TMPDIR}/site_ru:/src/ru:ro" \
-            -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" \
+            --mount type=bind,src="${_TMPDIR}/site_en",dst="/src/en",ro \
+            --mount type=bind,src="${_TMPDIR}/site_ru",dst="/src/ru",ro \
+            --mount type=bind,src="./tools/docs/link-checker/entrypoint.sh",dst="/entrypoint.sh",r \
             -u $(id -u) \
             ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} \
             /entrypoint.sh

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -3571,9 +3571,9 @@ jobs:
           test -e ./tools/docs/link-checker/entrypoint.sh && \
           docker run \
             --rm \
-            -v "${_TMPDIR}/site_en:/src/en:ro" \
-            -v "${_TMPDIR}/site_ru:/src/ru:ro" \
-            -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" \
+            --mount type=bind,src="${_TMPDIR}/site_en",dst="/src/en",ro \
+            --mount type=bind,src="${_TMPDIR}/site_ru",dst="/src/ru",ro \
+            --mount type=bind,src="./tools/docs/link-checker/entrypoint.sh",dst="/entrypoint.sh",r \
             -u $(id -u) \
             ${DECKHOUSE_REGISTRY_READ_HOST}/base_images/${CHECKER_IMAGE} \
             /entrypoint.sh

--- a/tools/docs/link-checker/run.sh
+++ b/tools/docs/link-checker/run.sh
@@ -89,8 +89,8 @@ echo "Moving DVP files..."
 mv  ${_TMPDIR}/site_ru/virtualization-platform ${_TMPDIR}/site_ru/products/virtualization-platform
 mv  ${_TMPDIR}/site_en/virtualization-platform ${_TMPDIR}/site_en/products/virtualization-platform
 
-docker run --rm -v "${_TMPDIR}/site_en:/src/en:ro" -v "${_TMPDIR}/site_ru:/src/ru:ro" \
-                -v "./tools/docs/link-checker/entrypoint.sh:/entrypoint.sh:ro" ${REGISTRY_PATH}${BASE_IMAGE} /entrypoint.sh
+docker run --rm --mount type=bind,src="${_TMPDIR}/site_en",dst="/src/en",ro --mount type=bind,src="${_TMPDIR}/site_ru",dst="/src/ru",ro \
+                --mount type=bind,src="./tools/docs/link-checker/entrypoint.sh",dst="/entrypoint.sh",ro ${REGISTRY_PATH}${BASE_IMAGE} /entrypoint.sh
 
 echo "Cleaning..."
 rm -rf $_TMPDIR


### PR DESCRIPTION
## Description
Fix linter issues.

Refactor Docker run commands to use --mount instead of -v options for binding directories. This change aligns with best practices and resolves current linter warnings.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix linter issues.
impact_level: low
```
