### PR TITLE
[ci] Fix "Set waiting for e2e" job

### DIFF
--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -225,15 +225,16 @@ jobs:
       - tests
     runs-on: ubuntu-latest
     steps:
-    - name: Set commit status after e2e run
-      id: set_e2e_requirement_status
-      uses: {!{ index (ds "actions") "actions/github-script" }!}
-      env:
-        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        PR_LABELS: ${{ needs.pull_request_info.outputs.labels }}
-      with:
-        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-        script: |
-          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+{!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        uses: {!{ index (ds "actions") "actions/github-script" }!}
+        env:
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+          PR_LABELS: ${{ needs.pull_request_info.outputs.labels }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-          await e2eStatus.setInitialStatus({github, context, core});
+            await e2eStatus.setInitialStatus({github, context, core});

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -223,7 +223,7 @@ jobs:
       - golangci_lint
       - dhctl_tests
       - tests
-    runs-on: [ self-hosted, regular ]
+    runs-on: ubuntu-latest
     steps:
     - name: Set commit status after e2e run
       id: set_e2e_requirement_status

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1651,15 +1651,21 @@ jobs:
       - tests
     runs-on: ubuntu-latest
     steps:
-    - name: Set commit status after e2e run
-      id: set_e2e_requirement_status
-      uses: actions/github-script@v6.4.1
-      env:
-        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        PR_LABELS: ${{ needs.pull_request_info.outputs.labels }}
-      with:
-        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-        script: |
-          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-          await e2eStatus.setInitialStatus({github, context, core});
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+
+      # </template: checkout_step>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        uses: actions/github-script@v6.4.1
+        env:
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+          PR_LABELS: ${{ needs.pull_request_info.outputs.labels }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            await e2eStatus.setInitialStatus({github, context, core});

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1649,7 +1649,7 @@ jobs:
       - golangci_lint
       - dhctl_tests
       - tests
-    runs-on: [ self-hosted, regular ]
+    runs-on: ubuntu-latest
     steps:
     - name: Set commit status after e2e run
       id: set_e2e_requirement_status


### PR DESCRIPTION
## Description
Fix "Set waiting for e2e" CI job.

## Why do we need it, and what problem does it solve?
After introduction of runner autocleaning, jobs that do not pull code before starting will fail.  This job doesn't need to run on static runners anyway, so switching to ephemeral runners.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix "Set waiting for e2e" job.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
