### PR TITLE
[prometheus] Promxy CVE patch

### DIFF
--- a/modules/300-prometheus/images/promxy/patches/0001-update-crypto-net-cve.patch
+++ b/modules/300-prometheus/images/promxy/patches/0001-update-crypto-net-cve.patch
@@ -1,164 +1,24 @@
-From 8ccc963d458f709cc62a1cc2b5e91003b84e13f1 Mon Sep 17 00:00:00 2001
-From: Yaroslav Kavokin <yaroslav.kavokin@flant.com>
-Date: Fri, 27 Dec 2024 21:49:45 +0300
-Subject: [PATCH] Update crypto/net packages
-
----
- go.mod                                        |    12 +-
- go.sum                                        |    24 +-
- vendor/golang.org/x/crypto/LICENSE            |     4 +-
- .../x/crypto/chacha20/chacha_noasm.go         |     2 +-
- .../{chacha_ppc64le.go => chacha_ppc64x.go}   |     2 +-
- .../{chacha_ppc64le.s => chacha_ppc64x.s}     |   114 +-
- .../chacha20poly1305/chacha20poly1305_amd64.s | 11503 +++++++++++++---
- .../x/crypto/internal/poly1305/mac_noasm.go   |     2 +-
- .../x/crypto/internal/poly1305/sum_amd64.s    |   133 +-
- .../{sum_ppc64le.go => sum_ppc64x.go}         |     2 +-
- .../poly1305/{sum_ppc64le.s => sum_ppc64x.s}  |    30 +-
- vendor/golang.org/x/net/LICENSE               |     4 +-
- .../x/net/http2/client_conn_pool.go           |     8 +-
- vendor/golang.org/x/net/http2/config.go       |   122 +
- vendor/golang.org/x/net/http2/config_go124.go |    61 +
- .../x/net/http2/config_pre_go124.go           |    16 +
- vendor/golang.org/x/net/http2/frame.go        |     4 +-
- vendor/golang.org/x/net/http2/http2.go        |   114 +-
- vendor/golang.org/x/net/http2/server.go       |   312 +-
- vendor/golang.org/x/net/http2/testsync.go     |   331 -
- vendor/golang.org/x/net/http2/timer.go        |    20 +
- vendor/golang.org/x/net/http2/transport.go    |   818 +-
- vendor/golang.org/x/net/http2/unencrypted.go  |    32 +
- vendor/golang.org/x/net/http2/write.go        |    10 +
- .../x/net/http2/writesched_priority.go        |     4 +-
- .../net/internal/socket/zsys_openbsd_ppc64.go |    28 +-
- .../internal/socket/zsys_openbsd_riscv64.go   |    28 +-
- vendor/golang.org/x/net/proxy/per_host.go     |     8 +-
- vendor/golang.org/x/sync/LICENSE              |     4 +-
- vendor/golang.org/x/sys/LICENSE               |     4 +-
- .../golang.org/x/sys/cpu/asm_darwin_x86_gc.s  |    17 +
- vendor/golang.org/x/sys/cpu/cpu.go            |    21 +
- vendor/golang.org/x/sys/cpu/cpu_arm64.go      |    12 +
- vendor/golang.org/x/sys/cpu/cpu_darwin_x86.go |    61 +
- vendor/golang.org/x/sys/cpu/cpu_gc_x86.go     |     4 +-
- .../x/sys/cpu/{cpu_x86.s => cpu_gc_x86.s}     |     2 +-
- vendor/golang.org/x/sys/cpu/cpu_gccgo_x86.go  |     6 -
- .../golang.org/x/sys/cpu/cpu_linux_arm64.go   |     4 +
- .../golang.org/x/sys/cpu/cpu_linux_noinit.go  |     2 +-
- .../golang.org/x/sys/cpu/cpu_linux_riscv64.go |   137 +
- vendor/golang.org/x/sys/cpu/cpu_other_x86.go  |    11 +
- vendor/golang.org/x/sys/cpu/cpu_riscv64.go    |    11 +-
- vendor/golang.org/x/sys/cpu/cpu_x86.go        |     6 +-
- .../x/sys/cpu/syscall_darwin_x86_gc.go        |    98 +
- vendor/golang.org/x/sys/unix/README.md        |     2 +-
- vendor/golang.org/x/sys/unix/ioctl_linux.go   |    96 +
- vendor/golang.org/x/sys/unix/mkerrors.sh      |    18 +-
- vendor/golang.org/x/sys/unix/syscall_aix.go   |     2 +-
- .../golang.org/x/sys/unix/syscall_darwin.go   |    49 +
- vendor/golang.org/x/sys/unix/syscall_hurd.go  |     1 +
- vendor/golang.org/x/sys/unix/syscall_linux.go |    65 +-
- .../x/sys/unix/syscall_linux_arm64.go         |     2 +
- .../x/sys/unix/syscall_linux_loong64.go       |     2 +
- .../x/sys/unix/syscall_linux_riscv64.go       |     2 +
- .../golang.org/x/sys/unix/syscall_openbsd.go  |     1 +
- .../x/sys/unix/syscall_zos_s390x.go           |   104 +-
- .../golang.org/x/sys/unix/vgetrandom_linux.go |    13 +
- .../x/sys/unix/vgetrandom_unsupported.go      |    11 +
- .../x/sys/unix/zerrors_darwin_amd64.go        |    12 +
- .../x/sys/unix/zerrors_darwin_arm64.go        |    12 +
- vendor/golang.org/x/sys/unix/zerrors_linux.go |    82 +-
- .../x/sys/unix/zerrors_linux_386.go           |    27 +
- .../x/sys/unix/zerrors_linux_amd64.go         |    27 +
- .../x/sys/unix/zerrors_linux_arm.go           |    27 +
- .../x/sys/unix/zerrors_linux_arm64.go         |    28 +
- .../x/sys/unix/zerrors_linux_loong64.go       |    27 +
- .../x/sys/unix/zerrors_linux_mips.go          |    27 +
- .../x/sys/unix/zerrors_linux_mips64.go        |    27 +
- .../x/sys/unix/zerrors_linux_mips64le.go      |    27 +
- .../x/sys/unix/zerrors_linux_mipsle.go        |    27 +
- .../x/sys/unix/zerrors_linux_ppc.go           |    27 +
- .../x/sys/unix/zerrors_linux_ppc64.go         |    27 +
- .../x/sys/unix/zerrors_linux_ppc64le.go       |    27 +
- .../x/sys/unix/zerrors_linux_riscv64.go       |    27 +
- .../x/sys/unix/zerrors_linux_s390x.go         |    27 +
- .../x/sys/unix/zerrors_linux_sparc64.go       |    27 +
- .../x/sys/unix/zerrors_zos_s390x.go           |     2 +
- .../x/sys/unix/zsyscall_darwin_amd64.go       |    68 +
- .../x/sys/unix/zsyscall_darwin_amd64.s        |    15 +
- .../x/sys/unix/zsyscall_darwin_arm64.go       |    68 +
- .../x/sys/unix/zsyscall_darwin_arm64.s        |    15 +
- .../golang.org/x/sys/unix/zsyscall_linux.go   |    43 +-
- .../x/sys/unix/zsyscall_openbsd_386.go        |    24 +
- .../x/sys/unix/zsyscall_openbsd_386.s         |     5 +
- .../x/sys/unix/zsyscall_openbsd_amd64.go      |    24 +
- .../x/sys/unix/zsyscall_openbsd_amd64.s       |     5 +
- .../x/sys/unix/zsyscall_openbsd_arm.go        |    24 +
- .../x/sys/unix/zsyscall_openbsd_arm.s         |     5 +
- .../x/sys/unix/zsyscall_openbsd_arm64.go      |    24 +
- .../x/sys/unix/zsyscall_openbsd_arm64.s       |     5 +
- .../x/sys/unix/zsyscall_openbsd_mips64.go     |    24 +
- .../x/sys/unix/zsyscall_openbsd_mips64.s      |     5 +
- .../x/sys/unix/zsyscall_openbsd_ppc64.go      |    24 +
- .../x/sys/unix/zsyscall_openbsd_ppc64.s       |     6 +
- .../x/sys/unix/zsyscall_openbsd_riscv64.go    |    24 +
- .../x/sys/unix/zsyscall_openbsd_riscv64.s     |     5 +
- .../x/sys/unix/zsysnum_linux_386.go           |     1 +
- .../x/sys/unix/zsysnum_linux_amd64.go         |     2 +
- .../x/sys/unix/zsysnum_linux_arm.go           |     1 +
- .../x/sys/unix/zsysnum_linux_arm64.go         |     3 +-
- .../x/sys/unix/zsysnum_linux_loong64.go       |     3 +
- .../x/sys/unix/zsysnum_linux_mips.go          |     1 +
- .../x/sys/unix/zsysnum_linux_mips64.go        |     1 +
- .../x/sys/unix/zsysnum_linux_mips64le.go      |     1 +
- .../x/sys/unix/zsysnum_linux_mipsle.go        |     1 +
- .../x/sys/unix/zsysnum_linux_ppc.go           |     1 +
- .../x/sys/unix/zsysnum_linux_ppc64.go         |     1 +
- .../x/sys/unix/zsysnum_linux_ppc64le.go       |     1 +
- .../x/sys/unix/zsysnum_linux_riscv64.go       |     3 +-
- .../x/sys/unix/zsysnum_linux_s390x.go         |     1 +
- .../x/sys/unix/zsysnum_linux_sparc64.go       |     1 +
- .../x/sys/unix/ztypes_darwin_amd64.go         |    73 +
- .../x/sys/unix/ztypes_darwin_arm64.go         |    73 +
- .../x/sys/unix/ztypes_freebsd_386.go          |     1 +
- .../x/sys/unix/ztypes_freebsd_amd64.go        |     1 +
- .../x/sys/unix/ztypes_freebsd_arm.go          |     1 +
- .../x/sys/unix/ztypes_freebsd_arm64.go        |     1 +
- .../x/sys/unix/ztypes_freebsd_riscv64.go      |     1 +
- vendor/golang.org/x/sys/unix/ztypes_linux.go  |   230 +-
- .../x/sys/unix/ztypes_linux_riscv64.go        |    33 +
- .../golang.org/x/sys/unix/ztypes_zos_s390x.go |     6 +
- .../golang.org/x/sys/windows/dll_windows.go   |     2 +-
- .../x/sys/windows/security_windows.go         |     2 +-
- .../x/sys/windows/syscall_windows.go          |    52 +-
- .../golang.org/x/sys/windows/types_windows.go |   199 +-
- .../x/sys/windows/zsyscall_windows.go         |   158 +-
- vendor/golang.org/x/term/LICENSE              |     4 +-
- vendor/golang.org/x/term/README.md            |    11 +-
- vendor/golang.org/x/term/term_windows.go      |     1 +
- vendor/golang.org/x/text/LICENSE              |     4 +-
- vendor/modules.txt                            |    12 +-
- 131 files changed, 12962 insertions(+), 3368 deletions(-)
- rename vendor/golang.org/x/crypto/chacha20/{chacha_ppc64le.go => chacha_ppc64x.go} (89%)
- rename vendor/golang.org/x/crypto/chacha20/{chacha_ppc64le.s => chacha_ppc64x.s} (76%)
- rename vendor/golang.org/x/crypto/internal/poly1305/{sum_ppc64le.go => sum_ppc64x.go} (95%)
- rename vendor/golang.org/x/crypto/internal/poly1305/{sum_ppc64le.s => sum_ppc64x.s} (89%)
- create mode 100644 vendor/golang.org/x/net/http2/config.go
- create mode 100644 vendor/golang.org/x/net/http2/config_go124.go
- create mode 100644 vendor/golang.org/x/net/http2/config_pre_go124.go
- delete mode 100644 vendor/golang.org/x/net/http2/testsync.go
- create mode 100644 vendor/golang.org/x/net/http2/timer.go
- create mode 100644 vendor/golang.org/x/net/http2/unencrypted.go
- create mode 100644 vendor/golang.org/x/sys/cpu/asm_darwin_x86_gc.s
- create mode 100644 vendor/golang.org/x/sys/cpu/cpu_darwin_x86.go
- rename vendor/golang.org/x/sys/cpu/{cpu_x86.s => cpu_gc_x86.s} (94%)
- create mode 100644 vendor/golang.org/x/sys/cpu/cpu_linux_riscv64.go
- create mode 100644 vendor/golang.org/x/sys/cpu/cpu_other_x86.go
- create mode 100644 vendor/golang.org/x/sys/cpu/syscall_darwin_x86_gc.go
- create mode 100644 vendor/golang.org/x/sys/unix/vgetrandom_linux.go
- create mode 100644 vendor/golang.org/x/sys/unix/vgetrandom_unsupported.go
-
 diff --git a/go.mod b/go.mod
-index d3a81405..8bdeb2d6 100644
+index d3a81405..3b7de568 100644
 --- a/go.mod
 +++ b/go.mod
+@@ -1,6 +1,6 @@
+ module github.com/jacksontj/promxy
+ 
+-go 1.21
++go 1.23
+ 
+ require (
+ 	github.com/Azure/go-autorest/autorest v0.11.29
+@@ -79,7 +79,7 @@ require (
+ 	github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48 // indirect
+ 	github.com/go-stack/stack v1.8.1 // indirect
+ 	github.com/go-zookeeper/zk v1.0.3 // indirect
+-	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
++	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
+ 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+ 	github.com/golang/protobuf v1.5.3 // indirect
+ 	github.com/google/gnostic v0.5.7-v3refs // indirect
 @@ -143,15 +143,15 @@ require (
  	go.opentelemetry.io/otel/sdk v1.18.0 // indirect
  	go.opentelemetry.io/otel/trace v1.18.0 // indirect
@@ -182,10 +42,21 @@ index d3a81405..8bdeb2d6 100644
  	google.golang.org/api v0.128.0 // indirect
  	google.golang.org/appengine v1.6.7 // indirect
 diff --git a/go.sum b/go.sum
-index 28cca9e9..48f85d41 100644
+index 28cca9e9..40c9d80b 100644
 --- a/go.sum
 +++ b/go.sum
-@@ -759,8 +759,8 @@ golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b/go.mod h1:IxCIyHEi3zRg3s0
+@@ -281,8 +281,9 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
+ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
+ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+ github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+-github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+ github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
++github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
++github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+ github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+ github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+ github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+@@ -759,8 +760,8 @@ golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b/go.mod h1:IxCIyHEi3zRg3s0
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
  golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
@@ -196,7 +67,7 @@ index 28cca9e9..48f85d41 100644
  golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
-@@ -856,8 +856,8 @@ golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su
+@@ -856,8 +857,8 @@ golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su
  golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
  golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
  golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
@@ -207,7 +78,7 @@ index 28cca9e9..48f85d41 100644
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
  golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-@@ -887,8 +887,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
+@@ -887,8 +888,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
  golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -218,7 +89,7 @@ index 28cca9e9..48f85d41 100644
  golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-@@ -970,16 +970,16 @@ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+@@ -970,16 +971,16 @@ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
@@ -239,7 +110,7 @@ index 28cca9e9..48f85d41 100644
  golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-@@ -993,8 +993,8 @@ golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+@@ -993,8 +994,8 @@ golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
  golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
  golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
  golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
@@ -250,6 +121,622 @@ index 28cca9e9..48f85d41 100644
  golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
  golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
  golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+diff --git a/vendor/github.com/golang-jwt/jwt/v4/parser.go b/vendor/github.com/golang-jwt/jwt/v4/parser.go
+index c0a6f692..9dd36e5a 100644
+--- a/vendor/github.com/golang-jwt/jwt/v4/parser.go
++++ b/vendor/github.com/golang-jwt/jwt/v4/parser.go
+@@ -36,19 +36,21 @@ func NewParser(options ...ParserOption) *Parser {
+ 	return p
+ }
+ 
+-// Parse parses, validates, verifies the signature and returns the parsed token.
+-// keyFunc will receive the parsed token and should return the key for validating.
++// Parse parses, validates, verifies the signature and returns the parsed token. keyFunc will
++// receive the parsed token and should return the key for validating.
+ func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
+ 	return p.ParseWithClaims(tokenString, MapClaims{}, keyFunc)
+ }
+ 
+-// ParseWithClaims parses, validates, and verifies like Parse, but supplies a default object implementing the Claims
+-// interface. This provides default values which can be overridden and allows a caller to use their own type, rather
+-// than the default MapClaims implementation of Claims.
++// ParseWithClaims parses, validates, and verifies like Parse, but supplies a default object
++// implementing the Claims interface. This provides default values which can be overridden and
++// allows a caller to use their own type, rather than the default MapClaims implementation of
++// Claims.
+ //
+-// Note: If you provide a custom claim implementation that embeds one of the standard claims (such as RegisteredClaims),
+-// make sure that a) you either embed a non-pointer version of the claims or b) if you are using a pointer, allocate the
+-// proper memory for it before passing in the overall claims, otherwise you might run into a panic.
++// Note: If you provide a custom claim implementation that embeds one of the standard claims (such
++// as RegisteredClaims), make sure that a) you either embed a non-pointer version of the claims or
++// b) if you are using a pointer, allocate the proper memory for it before passing in the overall
++// claims, otherwise you might run into a panic.
+ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
+ 	token, parts, err := p.ParseUnverified(tokenString, claims)
+ 	if err != nil {
+@@ -85,12 +87,17 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
+ 		return token, &ValidationError{Inner: err, Errors: ValidationErrorUnverifiable}
+ 	}
+ 
++	// Perform validation
++	token.Signature = parts[2]
++	if err := token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
++		return token, &ValidationError{Inner: err, Errors: ValidationErrorSignatureInvalid}
++	}
++
+ 	vErr := &ValidationError{}
+ 
+ 	// Validate Claims
+ 	if !p.SkipClaimsValidation {
+ 		if err := token.Claims.Valid(); err != nil {
+-
+ 			// If the Claims Valid returned an error, check if it is a validation error,
+ 			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
+ 			if e, ok := err.(*ValidationError); !ok {
+@@ -98,22 +105,14 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
+ 			} else {
+ 				vErr = e
+ 			}
++			return token, vErr
+ 		}
+ 	}
+ 
+-	// Perform validation
+-	token.Signature = parts[2]
+-	if err = token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
+-		vErr.Inner = err
+-		vErr.Errors |= ValidationErrorSignatureInvalid
+-	}
+-
+-	if vErr.valid() {
+-		token.Valid = true
+-		return token, nil
+-	}
++	// No errors so far, token is valid.
++	token.Valid = true
+ 
+-	return token, vErr
++	return token, nil
+ }
+ 
+ // ParseUnverified parses the token but doesn't validate the signature.
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_intermediate_cert.der b/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_intermediate_cert.der
+deleted file mode 100644
+index 958f3cfa..00000000
+Binary files a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_intermediate_cert.der and /dev/null differ
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_leaf_cert.der b/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_leaf_cert.der
+deleted file mode 100644
+index d2817641..00000000
+Binary files a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_leaf_cert.der and /dev/null differ
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_root_cert.der b/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_root_cert.der
+deleted file mode 100644
+index d8c3710c..00000000
+Binary files a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_root_cert.der and /dev/null differ
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_intermediate_cert.der b/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_intermediate_cert.der
+deleted file mode 100644
+index dae619c0..00000000
+Binary files a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_intermediate_cert.der and /dev/null differ
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_leaf_cert.der b/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_leaf_cert.der
+deleted file mode 100644
+index ce7f8d31..00000000
+Binary files a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_leaf_cert.der and /dev/null differ
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_root_cert.der b/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_root_cert.der
+deleted file mode 100644
+index 04b0d736..00000000
+Binary files a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_root_cert.der and /dev/null differ
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_cert.der b/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_cert.der
+deleted file mode 100644
+index d8c3710c..00000000
+Binary files a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_cert.der and /dev/null differ
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_cert.pem b/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_cert.pem
+deleted file mode 100644
+index 493a5a26..00000000
+--- a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_cert.pem
++++ /dev/null
+@@ -1,24 +0,0 @@
+------BEGIN CERTIFICATE-----
+-MIID8TCCAtmgAwIBAgIUKXNlBRVe6UepjQUijIFPZBd/4qYwDQYJKoZIhvcNAQEL
+-BQAwgYcxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTESMBAGA1UEBwwJU3Vubnl2
+-YWxlMRAwDgYDVQQKDAdDb21wYW55MREwDwYDVQQLDAhEaXZpc2lvbjEWMBQGA1UE
+-AwwNczJhX3Rlc3RfY2VydDEaMBgGCSqGSIb3DQEJARYLeHl6QHh5ei5jb20wHhcN
+-MjIwNTMxMjAwMzE1WhcNNDIwNTI2MjAwMzE1WjCBhzELMAkGA1UEBhMCVVMxCzAJ
+-BgNVBAgMAkNBMRIwEAYDVQQHDAlTdW5ueXZhbGUxEDAOBgNVBAoMB0NvbXBhbnkx
+-ETAPBgNVBAsMCERpdmlzaW9uMRYwFAYDVQQDDA1zMmFfdGVzdF9jZXJ0MRowGAYJ
+-KoZIhvcNAQkBFgt4eXpAeHl6LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+-AQoCggEBAOOFuIucH7XXfohGxKd3uR/ihUA/LdduR9I8kfpUEbq5BOt8xZe5/Yn9
+-a1ozEHVW6cOAbHbnwAR8tkSgZ/t42QIA2k77HWU1Jh2xiEIsJivo3imm4/kZWuR0
+-OqPh7MhzxpR/hvNwpI5mJsAVBWFMa5KtecFZLnyZtwHylrRN1QXzuLrOxuKFufK3
+-RKbTABScn5RbZL976H/jgfSeXrbt242NrIoBnVe6fRbekbq2DQ6zFArbQMUgHjHK
+-P0UqBgdr1QmHfi9KytFyx9BTP3gXWnWIu+bY7/v7qKJMHFwGETo+dCLWYevJL316
+-HnLfhApDMfP8U+Yv/y1N/YvgaSOSlEcCAwEAAaNTMFEwHQYDVR0OBBYEFKhAU4nu
+-0h/lrnggbIGvx4ej0WklMB8GA1UdIwQYMBaAFKhAU4nu0h/lrnggbIGvx4ej0Wkl
+-MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAE/6NghzQ5fu6yR6
+-EHKbj/YMrFdT7aGn5n2sAf7wJ33LIhiFHkpWBsVlm7rDtZtwhe891ZK/P60anlg9
+-/P0Ua53tSRVRmCvTnEbXWOVMN4is6MsR7BlmzUxl4AtIn7jbeifEwRL7B4xDYmdA
+-QrQnsqoz45dLgS5xK4WDqXATP09Q91xQDuhud/b+A4jrvgwFASmL7rMIZbp4f1JQ
+-nlnl/9VoTBQBvJiWkDUtQDMpRLtauddEkv4AGz75p5IspXWD6cOemuh2iQec11xD
+-X20rs2WZbAcAiUa3nmy8OKYw435vmpj8gp39WYbX/Yx9TymrFFbVY92wYn+quTco
+-pKklVz0=
+------END CERTIFICATE-----
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_key.pem b/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_key.pem
+deleted file mode 100644
+index 55a7f10c..00000000
+--- a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_key.pem
++++ /dev/null
+@@ -1,27 +0,0 @@
+------BEGIN RSA PRIVATE KEY-----
+-MIIEogIBAAKCAQEA44W4i5wftdd+iEbEp3e5H+KFQD8t125H0jyR+lQRurkE63zF
+-l7n9if1rWjMQdVbpw4BsdufABHy2RKBn+3jZAgDaTvsdZTUmHbGIQiwmK+jeKabj
+-+Rla5HQ6o+HsyHPGlH+G83CkjmYmwBUFYUxrkq15wVkufJm3AfKWtE3VBfO4us7G
+-4oW58rdEptMAFJyflFtkv3vof+OB9J5etu3bjY2sigGdV7p9Ft6RurYNDrMUCttA
+-xSAeMco/RSoGB2vVCYd+L0rK0XLH0FM/eBdadYi75tjv+/uookwcXAYROj50ItZh
+-68kvfXoect+ECkMx8/xT5i//LU39i+BpI5KURwIDAQABAoIBABgyjo/6iLzUMFbZ
+-/+w3pW6orrdIgN2akvTfED9pVYFgUA+jc3hRhY95bkNnjuaL2cy7Cc4Tk65mfRQL
+-Y0OxdJLr+EvSFSxAXM9npDA1ddHRsF8JqtFBSxNk8R+g1Yf0GDiO35Fgd3/ViWWA
+-VtQkRoSRApP3oiQKTRZd8H04keFR+PvmDk/Lq11l3Kc24A1PevKIPX1oI990ggw9
+-9i4uSV+cnuMxmcI9xxJtgwdDFdjr39l2arLOHr4s6LGoV2IOdXHNlv5xRqWUZ0FH
+-MDHowkLgwDrdSTnNeaVNkce14Gqx+bd4hNaLCdKXMpedBTEmrut3f3hdV1kKjaKt
+-aqRYr8ECgYEA/YDGZY2jvFoHHBywlqmEMFrrCvQGH51m5R1Ntpkzr+Rh3YCmrpvq
+-xgwJXING0PUw3dz+xrH5lJICrfNE5Kt3fPu1rAEy+13mYsNowghtUq2Rtu0Hsjjx
+-2E3Bf8vEB6RNBMmGkUpTTIAroGF5tpJoRvfnWax+k4pFdrKYFtyZdNcCgYEA5cNv
+-EPltvOobjTXlUmtVP3n27KZN2aXexTcagLzRxE9CV4cYySENl3KuOMmccaZpIl6z
+-aHk6BT4X+M0LqElNUczrInfVqI+SGAFLGy7W6CJaqSr6cpyFUP/fosKpm6wKGgLq
+-udHfpvz5rckhKd8kJxFLvhGOK9yN5qpzih0gfhECgYAJfwRvk3G5wYmYpP58dlcs
+-VIuPenqsPoI3PPTHTU/hW+XKnWIhElgmGRdUrto9Q6IT/Y5RtSMLTLjq+Tzwb/fm
+-56rziYv2XJsfwgAvnI8z1Kqrto9ePsHYf3krJ1/thVsZPc9bq/QY3ohD1sLvcuaT
+-GgBBnLOVJU3a12/ZE2RwOwKBgF0csWMAoj8/5IB6if+3ral2xOGsl7oPZVMo/J2V
+-Z7EVqb4M6rd/pKFugTpUQgkwtkSOekhpcGD1hAN5HTNK2YG/+L5UMAsKe9sskwJm
+-HgOfAHy0BSDzW3ey6i9skg2bT9Cww+0gJ3Hl7U1HSCBO5LjMYpSZSrNtwzfqdb5Q
+-BX3xAoGARZdR28Ej3+/+0+fz47Yu2h4z0EI/EbrudLOWY936jIeAVwHckI3+BuqH
+-qR4poj1gfbnMxNuI9UzIXzjEmGewx9kDZ7IYnvloZKqoVQODO5GlKF2ja6IcMNlh
+-GCNdD6PSAS6HcmalmWo9sj+1YMkrl+GJikKZqVBHrHNwMGAG67w=
+------END RSA PRIVATE KEY-----
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_cert.der b/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_cert.der
+deleted file mode 100644
+index 04b0d736..00000000
+Binary files a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_cert.der and /dev/null differ
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_cert.pem b/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_cert.pem
+deleted file mode 100644
+index 0f98322c..00000000
+--- a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_cert.pem
++++ /dev/null
+@@ -1,24 +0,0 @@
+------BEGIN CERTIFICATE-----
+-MIID8TCCAtmgAwIBAgIUKCoDuLtiZXvhsBY2RoDm0ugizJ8wDQYJKoZIhvcNAQEL
+-BQAwgYcxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTESMBAGA1UEBwwJU3Vubnl2
+-YWxlMRAwDgYDVQQKDAdDb21wYW55MREwDwYDVQQLDAhEaXZpc2lvbjEWMBQGA1UE
+-AwwNczJhX3Rlc3RfY2VydDEaMBgGCSqGSIb3DQEJARYLeHl6QHh5ei5jb20wHhcN
+-MjIwNTMxMjAwODI1WhcNNDIwNTI2MjAwODI1WjCBhzELMAkGA1UEBhMCVVMxCzAJ
+-BgNVBAgMAkNBMRIwEAYDVQQHDAlTdW5ueXZhbGUxEDAOBgNVBAoMB0NvbXBhbnkx
+-ETAPBgNVBAsMCERpdmlzaW9uMRYwFAYDVQQDDA1zMmFfdGVzdF9jZXJ0MRowGAYJ
+-KoZIhvcNAQkBFgt4eXpAeHl6LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+-AQoCggEBAKK1++PXQ+M3hjYH/v0K4UEYl5ljzpNM1i52eQM+gFooojT87PDSaphT
+-fs0PXy/PTAjHBEvPhWpOpmQXfJNYzjwcCvg66hbqkv++/VTZiFLAsHagzkEz+FRJ
+-qT5Eq7G5FLyw1izX1uxyPN7tAEWEEg7eqsiaXD3Cq8+TYN9cjirPeF7RZF8yFCYE
+-xqvbo+Yc6RL6xw19iXVTfctRgQe581KQuIY5/LXo3dWDEilFdsADAe8XAEcO64es
+-Ow0g1UvXLnpXSE151kXBFb3sKH/ZjCecDYMCIMEb4sWLSblkSxJ5sNSmXIG4wtr2
+-Qnii7CXZgnVYraQE/Jyh+NMQANuoSdMCAwEAAaNTMFEwHQYDVR0OBBYEFAyQQQuM
+-ab+YUQqjK8dVVOoHVFmXMB8GA1UdIwQYMBaAFAyQQQuMab+YUQqjK8dVVOoHVFmX
+-MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBADj0vQ6ykWhicoqR
+-e6VZMwlEJV7/DSvWWKBd9MUjfKye0A4565ya5lmnzP3DiD3nqGe3miqmLsXKDs+X
+-POqlPXTWIamP7D4MJ32XtSLwZB4ru+I+Ao/P/VngPepoRPQoBnzHe7jww0rokqxl
+-AZERjlbTUwUAy/BPWPSzSJZ2j0tcs6ZLDNyYzpK4ao8R9/1VmQ92Tcp3feJs1QTg
+-odRQc3om/AkWOwsll+oyX0UbJeHkFHiLanUPXbdh+/BkSvZJ8ynL+feSDdaurPe+
+-PSfnqLtQft9/neecGRdEaQzzzSFVQUVQzTdK1Q7hA7b55b2HvIa3ktDiks+sJsYN
+-Dhm6uZM=
+------END CERTIFICATE-----
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_key.pem b/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_key.pem
+deleted file mode 100644
+index 81afea78..00000000
+--- a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_key.pem
++++ /dev/null
+@@ -1,27 +0,0 @@
+------BEGIN RSA PRIVATE KEY-----
+-MIIEpAIBAAKCAQEAorX749dD4zeGNgf+/QrhQRiXmWPOk0zWLnZ5Az6AWiiiNPzs
+-8NJqmFN+zQ9fL89MCMcES8+Fak6mZBd8k1jOPBwK+DrqFuqS/779VNmIUsCwdqDO
+-QTP4VEmpPkSrsbkUvLDWLNfW7HI83u0ARYQSDt6qyJpcPcKrz5Ng31yOKs94XtFk
+-XzIUJgTGq9uj5hzpEvrHDX2JdVN9y1GBB7nzUpC4hjn8tejd1YMSKUV2wAMB7xcA
+-Rw7rh6w7DSDVS9cueldITXnWRcEVvewof9mMJ5wNgwIgwRvixYtJuWRLEnmw1KZc
+-gbjC2vZCeKLsJdmCdVitpAT8nKH40xAA26hJ0wIDAQABAoIBACaNR+lsD8G+XiZf
+-LqN1+HkcAo9tfnyYMAdCOtnx7SdviT9Uzi8hK/B7mAeuJLeHPlS2EuaDfPD7QaFl
+-jza6S+MiIdc+3kgfvESsVAnOoOY6kZUJ9NSuI6CU82y1iJjLaYZrv9NQMLRFPPb0
+-4KOX709mosB1EnXvshW0rbc+jtDFhrm1SxMt+k9TuzmMxjbOeW4LOLXPgU8X1T3Q
+-Xy0hMZZtcgBs9wFIo8yCtmOixax9pnFE8rRltgDxTodn9LLdz1FieyntNgDksZ0P
+-nt4kV7Mqly7ELaea+Foaj244mKsesic2e3GhAlMRLun/VSunSf7mOCxfpITB8dp1
+-drDhOYECgYEA19151dVxRcviuovN6Dar+QszMTnU8pDJ8BjLFjXjP/hNBBwMTHDE
+-duMuWk2qnwZqMooI/shxrF/ufmTgS0CFrh2+ANBZu27vWConJNXcyNtdigI4wt50
+-L0Y2qcZn2mg67qFXHwoR3QNwrwnPwEjRXA09at9CSRZzcwDQ0ETXhYsCgYEAwPaG
+-06QdK8Zyly7TTzZJwxzv9uGiqzodmGtX6NEKjgij2JaCxHpukqZBJoqa0jKeK1cm
+-eNVkOvT5ff9TMzarSHQLr3pZen2/oVLb5gaFkbcJt/klv9Fd+ZRilHY3i6QwS6pD
+-uMiPOWS4DrLHDRVoVlAZTDjT1RVwwTs+P2NhJdkCgYEAsriXysbxBYyMp05gqEW7
+-lHIFbFgpSrs9th+Q5U6wW6JEgYaHWDJ1NslY80MiZI93FWjbkbZ7BvBWESeL3EIL
+-a+EMErht0pVCbIhZ6FF4foPAqia0wAJVx14mm+G80kNBp5jE/NnleEsE3KcO7nBb
+-hg8gLn+x7bk81JZ0TDrzBYkCgYEAuQKluv47SeF3tSScTfKLPpvcKCWmxe1uutkQ
+-7JShPhVioyOMNb39jnYBOWbjkm4d4QgqRuiytSR0oi3QI+Ziy5EYMyNn713qAk9j
+-r2TJZDDPDKnBW+zt4YI4EohWMXk3JRUW4XDKggjjwJQA7bZ812TtHHvP/xoThfG7
+-eSNb3eECgYBw6ssgCtMrdvQiEmjKVX/9yI38mvC2kSGyzbrQnGUfgqRGomRpeZuD
+-B5E3kysA4td5pT5lvcLgSW0TbOz+YbiriXjwOihPIelCvc9gE2eOUI71/byUWPFz
+-7u5F/xQ4NaGr5suLF+lBC6h7pSbM4El9lIHQAQadpuEdzHqrw+hs3g==
+------END RSA PRIVATE KEY-----
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/testdata/client_cert.pem b/vendor/github.com/google/s2a-go/internal/v2/testdata/client_cert.pem
+deleted file mode 100644
+index 493a5a26..00000000
+--- a/vendor/github.com/google/s2a-go/internal/v2/testdata/client_cert.pem
++++ /dev/null
+@@ -1,24 +0,0 @@
+------BEGIN CERTIFICATE-----
+-MIID8TCCAtmgAwIBAgIUKXNlBRVe6UepjQUijIFPZBd/4qYwDQYJKoZIhvcNAQEL
+-BQAwgYcxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTESMBAGA1UEBwwJU3Vubnl2
+-YWxlMRAwDgYDVQQKDAdDb21wYW55MREwDwYDVQQLDAhEaXZpc2lvbjEWMBQGA1UE
+-AwwNczJhX3Rlc3RfY2VydDEaMBgGCSqGSIb3DQEJARYLeHl6QHh5ei5jb20wHhcN
+-MjIwNTMxMjAwMzE1WhcNNDIwNTI2MjAwMzE1WjCBhzELMAkGA1UEBhMCVVMxCzAJ
+-BgNVBAgMAkNBMRIwEAYDVQQHDAlTdW5ueXZhbGUxEDAOBgNVBAoMB0NvbXBhbnkx
+-ETAPBgNVBAsMCERpdmlzaW9uMRYwFAYDVQQDDA1zMmFfdGVzdF9jZXJ0MRowGAYJ
+-KoZIhvcNAQkBFgt4eXpAeHl6LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+-AQoCggEBAOOFuIucH7XXfohGxKd3uR/ihUA/LdduR9I8kfpUEbq5BOt8xZe5/Yn9
+-a1ozEHVW6cOAbHbnwAR8tkSgZ/t42QIA2k77HWU1Jh2xiEIsJivo3imm4/kZWuR0
+-OqPh7MhzxpR/hvNwpI5mJsAVBWFMa5KtecFZLnyZtwHylrRN1QXzuLrOxuKFufK3
+-RKbTABScn5RbZL976H/jgfSeXrbt242NrIoBnVe6fRbekbq2DQ6zFArbQMUgHjHK
+-P0UqBgdr1QmHfi9KytFyx9BTP3gXWnWIu+bY7/v7qKJMHFwGETo+dCLWYevJL316
+-HnLfhApDMfP8U+Yv/y1N/YvgaSOSlEcCAwEAAaNTMFEwHQYDVR0OBBYEFKhAU4nu
+-0h/lrnggbIGvx4ej0WklMB8GA1UdIwQYMBaAFKhAU4nu0h/lrnggbIGvx4ej0Wkl
+-MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAE/6NghzQ5fu6yR6
+-EHKbj/YMrFdT7aGn5n2sAf7wJ33LIhiFHkpWBsVlm7rDtZtwhe891ZK/P60anlg9
+-/P0Ua53tSRVRmCvTnEbXWOVMN4is6MsR7BlmzUxl4AtIn7jbeifEwRL7B4xDYmdA
+-QrQnsqoz45dLgS5xK4WDqXATP09Q91xQDuhud/b+A4jrvgwFASmL7rMIZbp4f1JQ
+-nlnl/9VoTBQBvJiWkDUtQDMpRLtauddEkv4AGz75p5IspXWD6cOemuh2iQec11xD
+-X20rs2WZbAcAiUa3nmy8OKYw435vmpj8gp39WYbX/Yx9TymrFFbVY92wYn+quTco
+-pKklVz0=
+------END CERTIFICATE-----
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/testdata/client_key.pem b/vendor/github.com/google/s2a-go/internal/v2/testdata/client_key.pem
+deleted file mode 100644
+index 55a7f10c..00000000
+--- a/vendor/github.com/google/s2a-go/internal/v2/testdata/client_key.pem
++++ /dev/null
+@@ -1,27 +0,0 @@
+------BEGIN RSA PRIVATE KEY-----
+-MIIEogIBAAKCAQEA44W4i5wftdd+iEbEp3e5H+KFQD8t125H0jyR+lQRurkE63zF
+-l7n9if1rWjMQdVbpw4BsdufABHy2RKBn+3jZAgDaTvsdZTUmHbGIQiwmK+jeKabj
+-+Rla5HQ6o+HsyHPGlH+G83CkjmYmwBUFYUxrkq15wVkufJm3AfKWtE3VBfO4us7G
+-4oW58rdEptMAFJyflFtkv3vof+OB9J5etu3bjY2sigGdV7p9Ft6RurYNDrMUCttA
+-xSAeMco/RSoGB2vVCYd+L0rK0XLH0FM/eBdadYi75tjv+/uookwcXAYROj50ItZh
+-68kvfXoect+ECkMx8/xT5i//LU39i+BpI5KURwIDAQABAoIBABgyjo/6iLzUMFbZ
+-/+w3pW6orrdIgN2akvTfED9pVYFgUA+jc3hRhY95bkNnjuaL2cy7Cc4Tk65mfRQL
+-Y0OxdJLr+EvSFSxAXM9npDA1ddHRsF8JqtFBSxNk8R+g1Yf0GDiO35Fgd3/ViWWA
+-VtQkRoSRApP3oiQKTRZd8H04keFR+PvmDk/Lq11l3Kc24A1PevKIPX1oI990ggw9
+-9i4uSV+cnuMxmcI9xxJtgwdDFdjr39l2arLOHr4s6LGoV2IOdXHNlv5xRqWUZ0FH
+-MDHowkLgwDrdSTnNeaVNkce14Gqx+bd4hNaLCdKXMpedBTEmrut3f3hdV1kKjaKt
+-aqRYr8ECgYEA/YDGZY2jvFoHHBywlqmEMFrrCvQGH51m5R1Ntpkzr+Rh3YCmrpvq
+-xgwJXING0PUw3dz+xrH5lJICrfNE5Kt3fPu1rAEy+13mYsNowghtUq2Rtu0Hsjjx
+-2E3Bf8vEB6RNBMmGkUpTTIAroGF5tpJoRvfnWax+k4pFdrKYFtyZdNcCgYEA5cNv
+-EPltvOobjTXlUmtVP3n27KZN2aXexTcagLzRxE9CV4cYySENl3KuOMmccaZpIl6z
+-aHk6BT4X+M0LqElNUczrInfVqI+SGAFLGy7W6CJaqSr6cpyFUP/fosKpm6wKGgLq
+-udHfpvz5rckhKd8kJxFLvhGOK9yN5qpzih0gfhECgYAJfwRvk3G5wYmYpP58dlcs
+-VIuPenqsPoI3PPTHTU/hW+XKnWIhElgmGRdUrto9Q6IT/Y5RtSMLTLjq+Tzwb/fm
+-56rziYv2XJsfwgAvnI8z1Kqrto9ePsHYf3krJ1/thVsZPc9bq/QY3ohD1sLvcuaT
+-GgBBnLOVJU3a12/ZE2RwOwKBgF0csWMAoj8/5IB6if+3ral2xOGsl7oPZVMo/J2V
+-Z7EVqb4M6rd/pKFugTpUQgkwtkSOekhpcGD1hAN5HTNK2YG/+L5UMAsKe9sskwJm
+-HgOfAHy0BSDzW3ey6i9skg2bT9Cww+0gJ3Hl7U1HSCBO5LjMYpSZSrNtwzfqdb5Q
+-BX3xAoGARZdR28Ej3+/+0+fz47Yu2h4z0EI/EbrudLOWY936jIeAVwHckI3+BuqH
+-qR4poj1gfbnMxNuI9UzIXzjEmGewx9kDZ7IYnvloZKqoVQODO5GlKF2ja6IcMNlh
+-GCNdD6PSAS6HcmalmWo9sj+1YMkrl+GJikKZqVBHrHNwMGAG67w=
+------END RSA PRIVATE KEY-----
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/testdata/server_cert.pem b/vendor/github.com/google/s2a-go/internal/v2/testdata/server_cert.pem
+deleted file mode 100644
+index 0f98322c..00000000
+--- a/vendor/github.com/google/s2a-go/internal/v2/testdata/server_cert.pem
++++ /dev/null
+@@ -1,24 +0,0 @@
+------BEGIN CERTIFICATE-----
+-MIID8TCCAtmgAwIBAgIUKCoDuLtiZXvhsBY2RoDm0ugizJ8wDQYJKoZIhvcNAQEL
+-BQAwgYcxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTESMBAGA1UEBwwJU3Vubnl2
+-YWxlMRAwDgYDVQQKDAdDb21wYW55MREwDwYDVQQLDAhEaXZpc2lvbjEWMBQGA1UE
+-AwwNczJhX3Rlc3RfY2VydDEaMBgGCSqGSIb3DQEJARYLeHl6QHh5ei5jb20wHhcN
+-MjIwNTMxMjAwODI1WhcNNDIwNTI2MjAwODI1WjCBhzELMAkGA1UEBhMCVVMxCzAJ
+-BgNVBAgMAkNBMRIwEAYDVQQHDAlTdW5ueXZhbGUxEDAOBgNVBAoMB0NvbXBhbnkx
+-ETAPBgNVBAsMCERpdmlzaW9uMRYwFAYDVQQDDA1zMmFfdGVzdF9jZXJ0MRowGAYJ
+-KoZIhvcNAQkBFgt4eXpAeHl6LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+-AQoCggEBAKK1++PXQ+M3hjYH/v0K4UEYl5ljzpNM1i52eQM+gFooojT87PDSaphT
+-fs0PXy/PTAjHBEvPhWpOpmQXfJNYzjwcCvg66hbqkv++/VTZiFLAsHagzkEz+FRJ
+-qT5Eq7G5FLyw1izX1uxyPN7tAEWEEg7eqsiaXD3Cq8+TYN9cjirPeF7RZF8yFCYE
+-xqvbo+Yc6RL6xw19iXVTfctRgQe581KQuIY5/LXo3dWDEilFdsADAe8XAEcO64es
+-Ow0g1UvXLnpXSE151kXBFb3sKH/ZjCecDYMCIMEb4sWLSblkSxJ5sNSmXIG4wtr2
+-Qnii7CXZgnVYraQE/Jyh+NMQANuoSdMCAwEAAaNTMFEwHQYDVR0OBBYEFAyQQQuM
+-ab+YUQqjK8dVVOoHVFmXMB8GA1UdIwQYMBaAFAyQQQuMab+YUQqjK8dVVOoHVFmX
+-MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBADj0vQ6ykWhicoqR
+-e6VZMwlEJV7/DSvWWKBd9MUjfKye0A4565ya5lmnzP3DiD3nqGe3miqmLsXKDs+X
+-POqlPXTWIamP7D4MJ32XtSLwZB4ru+I+Ao/P/VngPepoRPQoBnzHe7jww0rokqxl
+-AZERjlbTUwUAy/BPWPSzSJZ2j0tcs6ZLDNyYzpK4ao8R9/1VmQ92Tcp3feJs1QTg
+-odRQc3om/AkWOwsll+oyX0UbJeHkFHiLanUPXbdh+/BkSvZJ8ynL+feSDdaurPe+
+-PSfnqLtQft9/neecGRdEaQzzzSFVQUVQzTdK1Q7hA7b55b2HvIa3ktDiks+sJsYN
+-Dhm6uZM=
+------END CERTIFICATE-----
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/testdata/server_key.pem b/vendor/github.com/google/s2a-go/internal/v2/testdata/server_key.pem
+deleted file mode 100644
+index 81afea78..00000000
+--- a/vendor/github.com/google/s2a-go/internal/v2/testdata/server_key.pem
++++ /dev/null
+@@ -1,27 +0,0 @@
+------BEGIN RSA PRIVATE KEY-----
+-MIIEpAIBAAKCAQEAorX749dD4zeGNgf+/QrhQRiXmWPOk0zWLnZ5Az6AWiiiNPzs
+-8NJqmFN+zQ9fL89MCMcES8+Fak6mZBd8k1jOPBwK+DrqFuqS/779VNmIUsCwdqDO
+-QTP4VEmpPkSrsbkUvLDWLNfW7HI83u0ARYQSDt6qyJpcPcKrz5Ng31yOKs94XtFk
+-XzIUJgTGq9uj5hzpEvrHDX2JdVN9y1GBB7nzUpC4hjn8tejd1YMSKUV2wAMB7xcA
+-Rw7rh6w7DSDVS9cueldITXnWRcEVvewof9mMJ5wNgwIgwRvixYtJuWRLEnmw1KZc
+-gbjC2vZCeKLsJdmCdVitpAT8nKH40xAA26hJ0wIDAQABAoIBACaNR+lsD8G+XiZf
+-LqN1+HkcAo9tfnyYMAdCOtnx7SdviT9Uzi8hK/B7mAeuJLeHPlS2EuaDfPD7QaFl
+-jza6S+MiIdc+3kgfvESsVAnOoOY6kZUJ9NSuI6CU82y1iJjLaYZrv9NQMLRFPPb0
+-4KOX709mosB1EnXvshW0rbc+jtDFhrm1SxMt+k9TuzmMxjbOeW4LOLXPgU8X1T3Q
+-Xy0hMZZtcgBs9wFIo8yCtmOixax9pnFE8rRltgDxTodn9LLdz1FieyntNgDksZ0P
+-nt4kV7Mqly7ELaea+Foaj244mKsesic2e3GhAlMRLun/VSunSf7mOCxfpITB8dp1
+-drDhOYECgYEA19151dVxRcviuovN6Dar+QszMTnU8pDJ8BjLFjXjP/hNBBwMTHDE
+-duMuWk2qnwZqMooI/shxrF/ufmTgS0CFrh2+ANBZu27vWConJNXcyNtdigI4wt50
+-L0Y2qcZn2mg67qFXHwoR3QNwrwnPwEjRXA09at9CSRZzcwDQ0ETXhYsCgYEAwPaG
+-06QdK8Zyly7TTzZJwxzv9uGiqzodmGtX6NEKjgij2JaCxHpukqZBJoqa0jKeK1cm
+-eNVkOvT5ff9TMzarSHQLr3pZen2/oVLb5gaFkbcJt/klv9Fd+ZRilHY3i6QwS6pD
+-uMiPOWS4DrLHDRVoVlAZTDjT1RVwwTs+P2NhJdkCgYEAsriXysbxBYyMp05gqEW7
+-lHIFbFgpSrs9th+Q5U6wW6JEgYaHWDJ1NslY80MiZI93FWjbkbZ7BvBWESeL3EIL
+-a+EMErht0pVCbIhZ6FF4foPAqia0wAJVx14mm+G80kNBp5jE/NnleEsE3KcO7nBb
+-hg8gLn+x7bk81JZ0TDrzBYkCgYEAuQKluv47SeF3tSScTfKLPpvcKCWmxe1uutkQ
+-7JShPhVioyOMNb39jnYBOWbjkm4d4QgqRuiytSR0oi3QI+Ziy5EYMyNn713qAk9j
+-r2TJZDDPDKnBW+zt4YI4EohWMXk3JRUW4XDKggjjwJQA7bZ812TtHHvP/xoThfG7
+-eSNb3eECgYBw6ssgCtMrdvQiEmjKVX/9yI38mvC2kSGyzbrQnGUfgqRGomRpeZuD
+-B5E3kysA4td5pT5lvcLgSW0TbOz+YbiriXjwOihPIelCvc9gE2eOUI71/byUWPFz
+-7u5F/xQ4NaGr5suLF+lBC6h7pSbM4El9lIHQAQadpuEdzHqrw+hs3g==
+------END RSA PRIVATE KEY-----
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/testdata/client_cert.pem b/vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/testdata/client_cert.pem
+deleted file mode 100644
+index 493a5a26..00000000
+--- a/vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/testdata/client_cert.pem
++++ /dev/null
+@@ -1,24 +0,0 @@
+------BEGIN CERTIFICATE-----
+-MIID8TCCAtmgAwIBAgIUKXNlBRVe6UepjQUijIFPZBd/4qYwDQYJKoZIhvcNAQEL
+-BQAwgYcxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTESMBAGA1UEBwwJU3Vubnl2
+-YWxlMRAwDgYDVQQKDAdDb21wYW55MREwDwYDVQQLDAhEaXZpc2lvbjEWMBQGA1UE
+-AwwNczJhX3Rlc3RfY2VydDEaMBgGCSqGSIb3DQEJARYLeHl6QHh5ei5jb20wHhcN
+-MjIwNTMxMjAwMzE1WhcNNDIwNTI2MjAwMzE1WjCBhzELMAkGA1UEBhMCVVMxCzAJ
+-BgNVBAgMAkNBMRIwEAYDVQQHDAlTdW5ueXZhbGUxEDAOBgNVBAoMB0NvbXBhbnkx
+-ETAPBgNVBAsMCERpdmlzaW9uMRYwFAYDVQQDDA1zMmFfdGVzdF9jZXJ0MRowGAYJ
+-KoZIhvcNAQkBFgt4eXpAeHl6LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+-AQoCggEBAOOFuIucH7XXfohGxKd3uR/ihUA/LdduR9I8kfpUEbq5BOt8xZe5/Yn9
+-a1ozEHVW6cOAbHbnwAR8tkSgZ/t42QIA2k77HWU1Jh2xiEIsJivo3imm4/kZWuR0
+-OqPh7MhzxpR/hvNwpI5mJsAVBWFMa5KtecFZLnyZtwHylrRN1QXzuLrOxuKFufK3
+-RKbTABScn5RbZL976H/jgfSeXrbt242NrIoBnVe6fRbekbq2DQ6zFArbQMUgHjHK
+-P0UqBgdr1QmHfi9KytFyx9BTP3gXWnWIu+bY7/v7qKJMHFwGETo+dCLWYevJL316
+-HnLfhApDMfP8U+Yv/y1N/YvgaSOSlEcCAwEAAaNTMFEwHQYDVR0OBBYEFKhAU4nu
+-0h/lrnggbIGvx4ej0WklMB8GA1UdIwQYMBaAFKhAU4nu0h/lrnggbIGvx4ej0Wkl
+-MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAE/6NghzQ5fu6yR6
+-EHKbj/YMrFdT7aGn5n2sAf7wJ33LIhiFHkpWBsVlm7rDtZtwhe891ZK/P60anlg9
+-/P0Ua53tSRVRmCvTnEbXWOVMN4is6MsR7BlmzUxl4AtIn7jbeifEwRL7B4xDYmdA
+-QrQnsqoz45dLgS5xK4WDqXATP09Q91xQDuhud/b+A4jrvgwFASmL7rMIZbp4f1JQ
+-nlnl/9VoTBQBvJiWkDUtQDMpRLtauddEkv4AGz75p5IspXWD6cOemuh2iQec11xD
+-X20rs2WZbAcAiUa3nmy8OKYw435vmpj8gp39WYbX/Yx9TymrFFbVY92wYn+quTco
+-pKklVz0=
+------END CERTIFICATE-----
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/testdata/client_key.pem b/vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/testdata/client_key.pem
+deleted file mode 100644
+index 55a7f10c..00000000
+--- a/vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/testdata/client_key.pem
++++ /dev/null
+@@ -1,27 +0,0 @@
+------BEGIN RSA PRIVATE KEY-----
+-MIIEogIBAAKCAQEA44W4i5wftdd+iEbEp3e5H+KFQD8t125H0jyR+lQRurkE63zF
+-l7n9if1rWjMQdVbpw4BsdufABHy2RKBn+3jZAgDaTvsdZTUmHbGIQiwmK+jeKabj
+-+Rla5HQ6o+HsyHPGlH+G83CkjmYmwBUFYUxrkq15wVkufJm3AfKWtE3VBfO4us7G
+-4oW58rdEptMAFJyflFtkv3vof+OB9J5etu3bjY2sigGdV7p9Ft6RurYNDrMUCttA
+-xSAeMco/RSoGB2vVCYd+L0rK0XLH0FM/eBdadYi75tjv+/uookwcXAYROj50ItZh
+-68kvfXoect+ECkMx8/xT5i//LU39i+BpI5KURwIDAQABAoIBABgyjo/6iLzUMFbZ
+-/+w3pW6orrdIgN2akvTfED9pVYFgUA+jc3hRhY95bkNnjuaL2cy7Cc4Tk65mfRQL
+-Y0OxdJLr+EvSFSxAXM9npDA1ddHRsF8JqtFBSxNk8R+g1Yf0GDiO35Fgd3/ViWWA
+-VtQkRoSRApP3oiQKTRZd8H04keFR+PvmDk/Lq11l3Kc24A1PevKIPX1oI990ggw9
+-9i4uSV+cnuMxmcI9xxJtgwdDFdjr39l2arLOHr4s6LGoV2IOdXHNlv5xRqWUZ0FH
+-MDHowkLgwDrdSTnNeaVNkce14Gqx+bd4hNaLCdKXMpedBTEmrut3f3hdV1kKjaKt
+-aqRYr8ECgYEA/YDGZY2jvFoHHBywlqmEMFrrCvQGH51m5R1Ntpkzr+Rh3YCmrpvq
+-xgwJXING0PUw3dz+xrH5lJICrfNE5Kt3fPu1rAEy+13mYsNowghtUq2Rtu0Hsjjx
+-2E3Bf8vEB6RNBMmGkUpTTIAroGF5tpJoRvfnWax+k4pFdrKYFtyZdNcCgYEA5cNv
+-EPltvOobjTXlUmtVP3n27KZN2aXexTcagLzRxE9CV4cYySENl3KuOMmccaZpIl6z
+-aHk6BT4X+M0LqElNUczrInfVqI+SGAFLGy7W6CJaqSr6cpyFUP/fosKpm6wKGgLq
+-udHfpvz5rckhKd8kJxFLvhGOK9yN5qpzih0gfhECgYAJfwRvk3G5wYmYpP58dlcs
+-VIuPenqsPoI3PPTHTU/hW+XKnWIhElgmGRdUrto9Q6IT/Y5RtSMLTLjq+Tzwb/fm
+-56rziYv2XJsfwgAvnI8z1Kqrto9ePsHYf3krJ1/thVsZPc9bq/QY3ohD1sLvcuaT
+-GgBBnLOVJU3a12/ZE2RwOwKBgF0csWMAoj8/5IB6if+3ral2xOGsl7oPZVMo/J2V
+-Z7EVqb4M6rd/pKFugTpUQgkwtkSOekhpcGD1hAN5HTNK2YG/+L5UMAsKe9sskwJm
+-HgOfAHy0BSDzW3ey6i9skg2bT9Cww+0gJ3Hl7U1HSCBO5LjMYpSZSrNtwzfqdb5Q
+-BX3xAoGARZdR28Ej3+/+0+fz47Yu2h4z0EI/EbrudLOWY936jIeAVwHckI3+BuqH
+-qR4poj1gfbnMxNuI9UzIXzjEmGewx9kDZ7IYnvloZKqoVQODO5GlKF2ja6IcMNlh
+-GCNdD6PSAS6HcmalmWo9sj+1YMkrl+GJikKZqVBHrHNwMGAG67w=
+------END RSA PRIVATE KEY-----
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/testdata/server_cert.pem b/vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/testdata/server_cert.pem
+deleted file mode 100644
+index 0f98322c..00000000
+--- a/vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/testdata/server_cert.pem
++++ /dev/null
+@@ -1,24 +0,0 @@
+------BEGIN CERTIFICATE-----
+-MIID8TCCAtmgAwIBAgIUKCoDuLtiZXvhsBY2RoDm0ugizJ8wDQYJKoZIhvcNAQEL
+-BQAwgYcxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTESMBAGA1UEBwwJU3Vubnl2
+-YWxlMRAwDgYDVQQKDAdDb21wYW55MREwDwYDVQQLDAhEaXZpc2lvbjEWMBQGA1UE
+-AwwNczJhX3Rlc3RfY2VydDEaMBgGCSqGSIb3DQEJARYLeHl6QHh5ei5jb20wHhcN
+-MjIwNTMxMjAwODI1WhcNNDIwNTI2MjAwODI1WjCBhzELMAkGA1UEBhMCVVMxCzAJ
+-BgNVBAgMAkNBMRIwEAYDVQQHDAlTdW5ueXZhbGUxEDAOBgNVBAoMB0NvbXBhbnkx
+-ETAPBgNVBAsMCERpdmlzaW9uMRYwFAYDVQQDDA1zMmFfdGVzdF9jZXJ0MRowGAYJ
+-KoZIhvcNAQkBFgt4eXpAeHl6LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+-AQoCggEBAKK1++PXQ+M3hjYH/v0K4UEYl5ljzpNM1i52eQM+gFooojT87PDSaphT
+-fs0PXy/PTAjHBEvPhWpOpmQXfJNYzjwcCvg66hbqkv++/VTZiFLAsHagzkEz+FRJ
+-qT5Eq7G5FLyw1izX1uxyPN7tAEWEEg7eqsiaXD3Cq8+TYN9cjirPeF7RZF8yFCYE
+-xqvbo+Yc6RL6xw19iXVTfctRgQe581KQuIY5/LXo3dWDEilFdsADAe8XAEcO64es
+-Ow0g1UvXLnpXSE151kXBFb3sKH/ZjCecDYMCIMEb4sWLSblkSxJ5sNSmXIG4wtr2
+-Qnii7CXZgnVYraQE/Jyh+NMQANuoSdMCAwEAAaNTMFEwHQYDVR0OBBYEFAyQQQuM
+-ab+YUQqjK8dVVOoHVFmXMB8GA1UdIwQYMBaAFAyQQQuMab+YUQqjK8dVVOoHVFmX
+-MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBADj0vQ6ykWhicoqR
+-e6VZMwlEJV7/DSvWWKBd9MUjfKye0A4565ya5lmnzP3DiD3nqGe3miqmLsXKDs+X
+-POqlPXTWIamP7D4MJ32XtSLwZB4ru+I+Ao/P/VngPepoRPQoBnzHe7jww0rokqxl
+-AZERjlbTUwUAy/BPWPSzSJZ2j0tcs6ZLDNyYzpK4ao8R9/1VmQ92Tcp3feJs1QTg
+-odRQc3om/AkWOwsll+oyX0UbJeHkFHiLanUPXbdh+/BkSvZJ8ynL+feSDdaurPe+
+-PSfnqLtQft9/neecGRdEaQzzzSFVQUVQzTdK1Q7hA7b55b2HvIa3ktDiks+sJsYN
+-Dhm6uZM=
+------END CERTIFICATE-----
+diff --git a/vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/testdata/server_key.pem b/vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/testdata/server_key.pem
+deleted file mode 100644
+index 81afea78..00000000
+--- a/vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/testdata/server_key.pem
++++ /dev/null
+@@ -1,27 +0,0 @@
+------BEGIN RSA PRIVATE KEY-----
+-MIIEpAIBAAKCAQEAorX749dD4zeGNgf+/QrhQRiXmWPOk0zWLnZ5Az6AWiiiNPzs
+-8NJqmFN+zQ9fL89MCMcES8+Fak6mZBd8k1jOPBwK+DrqFuqS/779VNmIUsCwdqDO
+-QTP4VEmpPkSrsbkUvLDWLNfW7HI83u0ARYQSDt6qyJpcPcKrz5Ng31yOKs94XtFk
+-XzIUJgTGq9uj5hzpEvrHDX2JdVN9y1GBB7nzUpC4hjn8tejd1YMSKUV2wAMB7xcA
+-Rw7rh6w7DSDVS9cueldITXnWRcEVvewof9mMJ5wNgwIgwRvixYtJuWRLEnmw1KZc
+-gbjC2vZCeKLsJdmCdVitpAT8nKH40xAA26hJ0wIDAQABAoIBACaNR+lsD8G+XiZf
+-LqN1+HkcAo9tfnyYMAdCOtnx7SdviT9Uzi8hK/B7mAeuJLeHPlS2EuaDfPD7QaFl
+-jza6S+MiIdc+3kgfvESsVAnOoOY6kZUJ9NSuI6CU82y1iJjLaYZrv9NQMLRFPPb0
+-4KOX709mosB1EnXvshW0rbc+jtDFhrm1SxMt+k9TuzmMxjbOeW4LOLXPgU8X1T3Q
+-Xy0hMZZtcgBs9wFIo8yCtmOixax9pnFE8rRltgDxTodn9LLdz1FieyntNgDksZ0P
+-nt4kV7Mqly7ELaea+Foaj244mKsesic2e3GhAlMRLun/VSunSf7mOCxfpITB8dp1
+-drDhOYECgYEA19151dVxRcviuovN6Dar+QszMTnU8pDJ8BjLFjXjP/hNBBwMTHDE
+-duMuWk2qnwZqMooI/shxrF/ufmTgS0CFrh2+ANBZu27vWConJNXcyNtdigI4wt50
+-L0Y2qcZn2mg67qFXHwoR3QNwrwnPwEjRXA09at9CSRZzcwDQ0ETXhYsCgYEAwPaG
+-06QdK8Zyly7TTzZJwxzv9uGiqzodmGtX6NEKjgij2JaCxHpukqZBJoqa0jKeK1cm
+-eNVkOvT5ff9TMzarSHQLr3pZen2/oVLb5gaFkbcJt/klv9Fd+ZRilHY3i6QwS6pD
+-uMiPOWS4DrLHDRVoVlAZTDjT1RVwwTs+P2NhJdkCgYEAsriXysbxBYyMp05gqEW7
+-lHIFbFgpSrs9th+Q5U6wW6JEgYaHWDJ1NslY80MiZI93FWjbkbZ7BvBWESeL3EIL
+-a+EMErht0pVCbIhZ6FF4foPAqia0wAJVx14mm+G80kNBp5jE/NnleEsE3KcO7nBb
+-hg8gLn+x7bk81JZ0TDrzBYkCgYEAuQKluv47SeF3tSScTfKLPpvcKCWmxe1uutkQ
+-7JShPhVioyOMNb39jnYBOWbjkm4d4QgqRuiytSR0oi3QI+Ziy5EYMyNn713qAk9j
+-r2TJZDDPDKnBW+zt4YI4EohWMXk3JRUW4XDKggjjwJQA7bZ812TtHHvP/xoThfG7
+-eSNb3eECgYBw6ssgCtMrdvQiEmjKVX/9yI38mvC2kSGyzbrQnGUfgqRGomRpeZuD
+-B5E3kysA4td5pT5lvcLgSW0TbOz+YbiriXjwOihPIelCvc9gE2eOUI71/byUWPFz
+-7u5F/xQ4NaGr5suLF+lBC6h7pSbM4El9lIHQAQadpuEdzHqrw+hs3g==
+------END RSA PRIVATE KEY-----
+diff --git a/vendor/github.com/google/s2a-go/testdata/client_cert.pem b/vendor/github.com/google/s2a-go/testdata/client_cert.pem
+deleted file mode 100644
+index 493a5a26..00000000
+--- a/vendor/github.com/google/s2a-go/testdata/client_cert.pem
++++ /dev/null
+@@ -1,24 +0,0 @@
+------BEGIN CERTIFICATE-----
+-MIID8TCCAtmgAwIBAgIUKXNlBRVe6UepjQUijIFPZBd/4qYwDQYJKoZIhvcNAQEL
+-BQAwgYcxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTESMBAGA1UEBwwJU3Vubnl2
+-YWxlMRAwDgYDVQQKDAdDb21wYW55MREwDwYDVQQLDAhEaXZpc2lvbjEWMBQGA1UE
+-AwwNczJhX3Rlc3RfY2VydDEaMBgGCSqGSIb3DQEJARYLeHl6QHh5ei5jb20wHhcN
+-MjIwNTMxMjAwMzE1WhcNNDIwNTI2MjAwMzE1WjCBhzELMAkGA1UEBhMCVVMxCzAJ
+-BgNVBAgMAkNBMRIwEAYDVQQHDAlTdW5ueXZhbGUxEDAOBgNVBAoMB0NvbXBhbnkx
+-ETAPBgNVBAsMCERpdmlzaW9uMRYwFAYDVQQDDA1zMmFfdGVzdF9jZXJ0MRowGAYJ
+-KoZIhvcNAQkBFgt4eXpAeHl6LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+-AQoCggEBAOOFuIucH7XXfohGxKd3uR/ihUA/LdduR9I8kfpUEbq5BOt8xZe5/Yn9
+-a1ozEHVW6cOAbHbnwAR8tkSgZ/t42QIA2k77HWU1Jh2xiEIsJivo3imm4/kZWuR0
+-OqPh7MhzxpR/hvNwpI5mJsAVBWFMa5KtecFZLnyZtwHylrRN1QXzuLrOxuKFufK3
+-RKbTABScn5RbZL976H/jgfSeXrbt242NrIoBnVe6fRbekbq2DQ6zFArbQMUgHjHK
+-P0UqBgdr1QmHfi9KytFyx9BTP3gXWnWIu+bY7/v7qKJMHFwGETo+dCLWYevJL316
+-HnLfhApDMfP8U+Yv/y1N/YvgaSOSlEcCAwEAAaNTMFEwHQYDVR0OBBYEFKhAU4nu
+-0h/lrnggbIGvx4ej0WklMB8GA1UdIwQYMBaAFKhAU4nu0h/lrnggbIGvx4ej0Wkl
+-MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAE/6NghzQ5fu6yR6
+-EHKbj/YMrFdT7aGn5n2sAf7wJ33LIhiFHkpWBsVlm7rDtZtwhe891ZK/P60anlg9
+-/P0Ua53tSRVRmCvTnEbXWOVMN4is6MsR7BlmzUxl4AtIn7jbeifEwRL7B4xDYmdA
+-QrQnsqoz45dLgS5xK4WDqXATP09Q91xQDuhud/b+A4jrvgwFASmL7rMIZbp4f1JQ
+-nlnl/9VoTBQBvJiWkDUtQDMpRLtauddEkv4AGz75p5IspXWD6cOemuh2iQec11xD
+-X20rs2WZbAcAiUa3nmy8OKYw435vmpj8gp39WYbX/Yx9TymrFFbVY92wYn+quTco
+-pKklVz0=
+------END CERTIFICATE-----
+diff --git a/vendor/github.com/google/s2a-go/testdata/client_key.pem b/vendor/github.com/google/s2a-go/testdata/client_key.pem
+deleted file mode 100644
+index 55a7f10c..00000000
+--- a/vendor/github.com/google/s2a-go/testdata/client_key.pem
++++ /dev/null
+@@ -1,27 +0,0 @@
+------BEGIN RSA PRIVATE KEY-----
+-MIIEogIBAAKCAQEA44W4i5wftdd+iEbEp3e5H+KFQD8t125H0jyR+lQRurkE63zF
+-l7n9if1rWjMQdVbpw4BsdufABHy2RKBn+3jZAgDaTvsdZTUmHbGIQiwmK+jeKabj
+-+Rla5HQ6o+HsyHPGlH+G83CkjmYmwBUFYUxrkq15wVkufJm3AfKWtE3VBfO4us7G
+-4oW58rdEptMAFJyflFtkv3vof+OB9J5etu3bjY2sigGdV7p9Ft6RurYNDrMUCttA
+-xSAeMco/RSoGB2vVCYd+L0rK0XLH0FM/eBdadYi75tjv+/uookwcXAYROj50ItZh
+-68kvfXoect+ECkMx8/xT5i//LU39i+BpI5KURwIDAQABAoIBABgyjo/6iLzUMFbZ
+-/+w3pW6orrdIgN2akvTfED9pVYFgUA+jc3hRhY95bkNnjuaL2cy7Cc4Tk65mfRQL
+-Y0OxdJLr+EvSFSxAXM9npDA1ddHRsF8JqtFBSxNk8R+g1Yf0GDiO35Fgd3/ViWWA
+-VtQkRoSRApP3oiQKTRZd8H04keFR+PvmDk/Lq11l3Kc24A1PevKIPX1oI990ggw9
+-9i4uSV+cnuMxmcI9xxJtgwdDFdjr39l2arLOHr4s6LGoV2IOdXHNlv5xRqWUZ0FH
+-MDHowkLgwDrdSTnNeaVNkce14Gqx+bd4hNaLCdKXMpedBTEmrut3f3hdV1kKjaKt
+-aqRYr8ECgYEA/YDGZY2jvFoHHBywlqmEMFrrCvQGH51m5R1Ntpkzr+Rh3YCmrpvq
+-xgwJXING0PUw3dz+xrH5lJICrfNE5Kt3fPu1rAEy+13mYsNowghtUq2Rtu0Hsjjx
+-2E3Bf8vEB6RNBMmGkUpTTIAroGF5tpJoRvfnWax+k4pFdrKYFtyZdNcCgYEA5cNv
+-EPltvOobjTXlUmtVP3n27KZN2aXexTcagLzRxE9CV4cYySENl3KuOMmccaZpIl6z
+-aHk6BT4X+M0LqElNUczrInfVqI+SGAFLGy7W6CJaqSr6cpyFUP/fosKpm6wKGgLq
+-udHfpvz5rckhKd8kJxFLvhGOK9yN5qpzih0gfhECgYAJfwRvk3G5wYmYpP58dlcs
+-VIuPenqsPoI3PPTHTU/hW+XKnWIhElgmGRdUrto9Q6IT/Y5RtSMLTLjq+Tzwb/fm
+-56rziYv2XJsfwgAvnI8z1Kqrto9ePsHYf3krJ1/thVsZPc9bq/QY3ohD1sLvcuaT
+-GgBBnLOVJU3a12/ZE2RwOwKBgF0csWMAoj8/5IB6if+3ral2xOGsl7oPZVMo/J2V
+-Z7EVqb4M6rd/pKFugTpUQgkwtkSOekhpcGD1hAN5HTNK2YG/+L5UMAsKe9sskwJm
+-HgOfAHy0BSDzW3ey6i9skg2bT9Cww+0gJ3Hl7U1HSCBO5LjMYpSZSrNtwzfqdb5Q
+-BX3xAoGARZdR28Ej3+/+0+fz47Yu2h4z0EI/EbrudLOWY936jIeAVwHckI3+BuqH
+-qR4poj1gfbnMxNuI9UzIXzjEmGewx9kDZ7IYnvloZKqoVQODO5GlKF2ja6IcMNlh
+-GCNdD6PSAS6HcmalmWo9sj+1YMkrl+GJikKZqVBHrHNwMGAG67w=
+------END RSA PRIVATE KEY-----
+diff --git a/vendor/github.com/google/s2a-go/testdata/server_cert.pem b/vendor/github.com/google/s2a-go/testdata/server_cert.pem
+deleted file mode 100644
+index 0f98322c..00000000
+--- a/vendor/github.com/google/s2a-go/testdata/server_cert.pem
++++ /dev/null
+@@ -1,24 +0,0 @@
+------BEGIN CERTIFICATE-----
+-MIID8TCCAtmgAwIBAgIUKCoDuLtiZXvhsBY2RoDm0ugizJ8wDQYJKoZIhvcNAQEL
+-BQAwgYcxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTESMBAGA1UEBwwJU3Vubnl2
+-YWxlMRAwDgYDVQQKDAdDb21wYW55MREwDwYDVQQLDAhEaXZpc2lvbjEWMBQGA1UE
+-AwwNczJhX3Rlc3RfY2VydDEaMBgGCSqGSIb3DQEJARYLeHl6QHh5ei5jb20wHhcN
+-MjIwNTMxMjAwODI1WhcNNDIwNTI2MjAwODI1WjCBhzELMAkGA1UEBhMCVVMxCzAJ
+-BgNVBAgMAkNBMRIwEAYDVQQHDAlTdW5ueXZhbGUxEDAOBgNVBAoMB0NvbXBhbnkx
+-ETAPBgNVBAsMCERpdmlzaW9uMRYwFAYDVQQDDA1zMmFfdGVzdF9jZXJ0MRowGAYJ
+-KoZIhvcNAQkBFgt4eXpAeHl6LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+-AQoCggEBAKK1++PXQ+M3hjYH/v0K4UEYl5ljzpNM1i52eQM+gFooojT87PDSaphT
+-fs0PXy/PTAjHBEvPhWpOpmQXfJNYzjwcCvg66hbqkv++/VTZiFLAsHagzkEz+FRJ
+-qT5Eq7G5FLyw1izX1uxyPN7tAEWEEg7eqsiaXD3Cq8+TYN9cjirPeF7RZF8yFCYE
+-xqvbo+Yc6RL6xw19iXVTfctRgQe581KQuIY5/LXo3dWDEilFdsADAe8XAEcO64es
+-Ow0g1UvXLnpXSE151kXBFb3sKH/ZjCecDYMCIMEb4sWLSblkSxJ5sNSmXIG4wtr2
+-Qnii7CXZgnVYraQE/Jyh+NMQANuoSdMCAwEAAaNTMFEwHQYDVR0OBBYEFAyQQQuM
+-ab+YUQqjK8dVVOoHVFmXMB8GA1UdIwQYMBaAFAyQQQuMab+YUQqjK8dVVOoHVFmX
+-MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBADj0vQ6ykWhicoqR
+-e6VZMwlEJV7/DSvWWKBd9MUjfKye0A4565ya5lmnzP3DiD3nqGe3miqmLsXKDs+X
+-POqlPXTWIamP7D4MJ32XtSLwZB4ru+I+Ao/P/VngPepoRPQoBnzHe7jww0rokqxl
+-AZERjlbTUwUAy/BPWPSzSJZ2j0tcs6ZLDNyYzpK4ao8R9/1VmQ92Tcp3feJs1QTg
+-odRQc3om/AkWOwsll+oyX0UbJeHkFHiLanUPXbdh+/BkSvZJ8ynL+feSDdaurPe+
+-PSfnqLtQft9/neecGRdEaQzzzSFVQUVQzTdK1Q7hA7b55b2HvIa3ktDiks+sJsYN
+-Dhm6uZM=
+------END CERTIFICATE-----
+diff --git a/vendor/github.com/google/s2a-go/testdata/server_key.pem b/vendor/github.com/google/s2a-go/testdata/server_key.pem
+deleted file mode 100644
+index 81afea78..00000000
+--- a/vendor/github.com/google/s2a-go/testdata/server_key.pem
++++ /dev/null
+@@ -1,27 +0,0 @@
+------BEGIN RSA PRIVATE KEY-----
+-MIIEpAIBAAKCAQEAorX749dD4zeGNgf+/QrhQRiXmWPOk0zWLnZ5Az6AWiiiNPzs
+-8NJqmFN+zQ9fL89MCMcES8+Fak6mZBd8k1jOPBwK+DrqFuqS/779VNmIUsCwdqDO
+-QTP4VEmpPkSrsbkUvLDWLNfW7HI83u0ARYQSDt6qyJpcPcKrz5Ng31yOKs94XtFk
+-XzIUJgTGq9uj5hzpEvrHDX2JdVN9y1GBB7nzUpC4hjn8tejd1YMSKUV2wAMB7xcA
+-Rw7rh6w7DSDVS9cueldITXnWRcEVvewof9mMJ5wNgwIgwRvixYtJuWRLEnmw1KZc
+-gbjC2vZCeKLsJdmCdVitpAT8nKH40xAA26hJ0wIDAQABAoIBACaNR+lsD8G+XiZf
+-LqN1+HkcAo9tfnyYMAdCOtnx7SdviT9Uzi8hK/B7mAeuJLeHPlS2EuaDfPD7QaFl
+-jza6S+MiIdc+3kgfvESsVAnOoOY6kZUJ9NSuI6CU82y1iJjLaYZrv9NQMLRFPPb0
+-4KOX709mosB1EnXvshW0rbc+jtDFhrm1SxMt+k9TuzmMxjbOeW4LOLXPgU8X1T3Q
+-Xy0hMZZtcgBs9wFIo8yCtmOixax9pnFE8rRltgDxTodn9LLdz1FieyntNgDksZ0P
+-nt4kV7Mqly7ELaea+Foaj244mKsesic2e3GhAlMRLun/VSunSf7mOCxfpITB8dp1
+-drDhOYECgYEA19151dVxRcviuovN6Dar+QszMTnU8pDJ8BjLFjXjP/hNBBwMTHDE
+-duMuWk2qnwZqMooI/shxrF/ufmTgS0CFrh2+ANBZu27vWConJNXcyNtdigI4wt50
+-L0Y2qcZn2mg67qFXHwoR3QNwrwnPwEjRXA09at9CSRZzcwDQ0ETXhYsCgYEAwPaG
+-06QdK8Zyly7TTzZJwxzv9uGiqzodmGtX6NEKjgij2JaCxHpukqZBJoqa0jKeK1cm
+-eNVkOvT5ff9TMzarSHQLr3pZen2/oVLb5gaFkbcJt/klv9Fd+ZRilHY3i6QwS6pD
+-uMiPOWS4DrLHDRVoVlAZTDjT1RVwwTs+P2NhJdkCgYEAsriXysbxBYyMp05gqEW7
+-lHIFbFgpSrs9th+Q5U6wW6JEgYaHWDJ1NslY80MiZI93FWjbkbZ7BvBWESeL3EIL
+-a+EMErht0pVCbIhZ6FF4foPAqia0wAJVx14mm+G80kNBp5jE/NnleEsE3KcO7nBb
+-hg8gLn+x7bk81JZ0TDrzBYkCgYEAuQKluv47SeF3tSScTfKLPpvcKCWmxe1uutkQ
+-7JShPhVioyOMNb39jnYBOWbjkm4d4QgqRuiytSR0oi3QI+Ziy5EYMyNn713qAk9j
+-r2TJZDDPDKnBW+zt4YI4EohWMXk3JRUW4XDKggjjwJQA7bZ812TtHHvP/xoThfG7
+-eSNb3eECgYBw6ssgCtMrdvQiEmjKVX/9yI38mvC2kSGyzbrQnGUfgqRGomRpeZuD
+-B5E3kysA4td5pT5lvcLgSW0TbOz+YbiriXjwOihPIelCvc9gE2eOUI71/byUWPFz
+-7u5F/xQ4NaGr5suLF+lBC6h7pSbM4El9lIHQAQadpuEdzHqrw+hs3g==
+------END RSA PRIVATE KEY-----
 diff --git a/vendor/golang.org/x/crypto/LICENSE b/vendor/golang.org/x/crypto/LICENSE
 index 6a66aea5..2a7cf70d 100644
 --- a/vendor/golang.org/x/crypto/LICENSE
@@ -257,7 +744,7 @@ index 6a66aea5..2a7cf70d 100644
 @@ -1,4 +1,4 @@
 -Copyright (c) 2009 The Go Authors. All rights reserved.
 +Copyright 2009 The Go Authors.
-
+ 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are
 @@ -10,7 +10,7 @@ notice, this list of conditions and the following disclaimer.
@@ -268,7 +755,7 @@ index 6a66aea5..2a7cf70d 100644
 +   * Neither the name of Google LLC nor the names of its
  contributors may be used to endorse or promote products derived from
  this software without specific prior written permission.
-
+ 
 diff --git a/vendor/golang.org/x/crypto/chacha20/chacha_noasm.go b/vendor/golang.org/x/crypto/chacha20/chacha_noasm.go
 index db42e667..c709b728 100644
 --- a/vendor/golang.org/x/crypto/chacha20/chacha_noasm.go
@@ -276,48 +763,78 @@ index db42e667..c709b728 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build (!arm64 && !s390x && !ppc64le) || !gc || purego
 +//go:build (!arm64 && !s390x && !ppc64 && !ppc64le) || !gc || purego
-
+ 
  package chacha20
-
-diff --git a/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.go b/vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.go
-similarity index 89%
-rename from vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.go
-rename to vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.go
-index 3a4287f9..bd183d9b 100644
+ 
+diff --git a/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.go b/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.go
+deleted file mode 100644
+index 3a4287f9..00000000
 --- a/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.go
-+++ b/vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
-
++++ /dev/null
+@@ -1,16 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
 -//go:build gc && !purego
-+//go:build gc && !purego && (ppc64 || ppc64le)
-
- package chacha20
-
-diff --git a/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.s b/vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.s
-similarity index 76%
-rename from vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.s
-rename to vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.s
-index c672ccf6..a660b411 100644
+-
+-package chacha20
+-
+-const bufSize = 256
+-
+-//go:noescape
+-func chaCha20_ctr32_vsx(out, inp *byte, len int, key *[8]uint32, counter *uint32)
+-
+-func (c *Cipher) xorKeyStreamBlocks(dst, src []byte) {
+-	chaCha20_ctr32_vsx(&dst[0], &src[0], len(src), &c.key, &c.counter)
+-}
+diff --git a/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.s b/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.s
+deleted file mode 100644
+index c672ccf6..00000000
 --- a/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.s
-+++ b/vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.s
-@@ -19,7 +19,7 @@
- // The differences in this and the original implementation are
- // due to the calling conventions and initialization of constants.
-
++++ /dev/null
+@@ -1,443 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-// Based on CRYPTOGAMS code with the following comment:
+-// # ====================================================================
+-// # Written by Andy Polyakov <appro@openssl.org> for the OpenSSL
+-// # project. The module is, however, dual licensed under OpenSSL and
+-// # CRYPTOGAMS licenses depending on where you obtain it. For further
+-// # details see http://www.openssl.org/~appro/cryptogams/.
+-// # ====================================================================
+-
+-// Code for the perl script that generates the ppc64 assembler
+-// can be found in the cryptogams repository at the link below. It is based on
+-// the original from openssl.
+-
+-// https://github.com/dot-asm/cryptogams/commit/a60f5b50ed908e91
+-
+-// The differences in this and the original implementation are
+-// due to the calling conventions and initialization of constants.
+-
 -//go:build gc && !purego
-+//go:build gc && !purego && (ppc64 || ppc64le)
-
- #include "textflag.h"
-
-@@ -36,32 +36,68 @@
- // for VPERMXOR
- #define MASK  R18
-
+-
+-#include "textflag.h"
+-
+-#define OUT  R3
+-#define INP  R4
+-#define LEN  R5
+-#define KEY  R6
+-#define CNT  R7
+-#define TMP  R15
+-
+-#define CONSTBASE  R16
+-#define BLOCKS R17
+-
+-// for VPERMXOR
+-#define MASK  R18
+-
 -DATA consts<>+0x00(SB)/8, $0x3320646e61707865
 -DATA consts<>+0x08(SB)/8, $0x6b20657479622d32
 -DATA consts<>+0x10(SB)/8, $0x0000000000000001
@@ -342,150 +859,387 @@ index c672ccf6..a660b411 100644
 -DATA consts<>+0xa8(SB)/8, $0xddeeffcc99aabb88
 -DATA consts<>+0xb0(SB)/8, $0x6677445522330011
 -DATA consts<>+0xb8(SB)/8, $0xeeffccddaabb8899
-+DATA consts<>+0x00(SB)/4, $0x61707865
-+DATA consts<>+0x04(SB)/4, $0x3320646e
-+DATA consts<>+0x08(SB)/4, $0x79622d32
-+DATA consts<>+0x0c(SB)/4, $0x6b206574
-+DATA consts<>+0x10(SB)/4, $0x00000001
-+DATA consts<>+0x14(SB)/4, $0x00000000
-+DATA consts<>+0x18(SB)/4, $0x00000000
-+DATA consts<>+0x1c(SB)/4, $0x00000000
-+DATA consts<>+0x20(SB)/4, $0x00000004
-+DATA consts<>+0x24(SB)/4, $0x00000000
-+DATA consts<>+0x28(SB)/4, $0x00000000
-+DATA consts<>+0x2c(SB)/4, $0x00000000
-+DATA consts<>+0x30(SB)/4, $0x0e0f0c0d
-+DATA consts<>+0x34(SB)/4, $0x0a0b0809
-+DATA consts<>+0x38(SB)/4, $0x06070405
-+DATA consts<>+0x3c(SB)/4, $0x02030001
-+DATA consts<>+0x40(SB)/4, $0x0d0e0f0c
-+DATA consts<>+0x44(SB)/4, $0x090a0b08
-+DATA consts<>+0x48(SB)/4, $0x05060704
-+DATA consts<>+0x4c(SB)/4, $0x01020300
-+DATA consts<>+0x50(SB)/4, $0x61707865
-+DATA consts<>+0x54(SB)/4, $0x61707865
-+DATA consts<>+0x58(SB)/4, $0x61707865
-+DATA consts<>+0x5c(SB)/4, $0x61707865
-+DATA consts<>+0x60(SB)/4, $0x3320646e
-+DATA consts<>+0x64(SB)/4, $0x3320646e
-+DATA consts<>+0x68(SB)/4, $0x3320646e
-+DATA consts<>+0x6c(SB)/4, $0x3320646e
-+DATA consts<>+0x70(SB)/4, $0x79622d32
-+DATA consts<>+0x74(SB)/4, $0x79622d32
-+DATA consts<>+0x78(SB)/4, $0x79622d32
-+DATA consts<>+0x7c(SB)/4, $0x79622d32
-+DATA consts<>+0x80(SB)/4, $0x6b206574
-+DATA consts<>+0x84(SB)/4, $0x6b206574
-+DATA consts<>+0x88(SB)/4, $0x6b206574
-+DATA consts<>+0x8c(SB)/4, $0x6b206574
-+DATA consts<>+0x90(SB)/4, $0x00000000
-+DATA consts<>+0x94(SB)/4, $0x00000001
-+DATA consts<>+0x98(SB)/4, $0x00000002
-+DATA consts<>+0x9c(SB)/4, $0x00000003
-+DATA consts<>+0xa0(SB)/4, $0x11223300
-+DATA consts<>+0xa4(SB)/4, $0x55667744
-+DATA consts<>+0xa8(SB)/4, $0x99aabb88
-+DATA consts<>+0xac(SB)/4, $0xddeeffcc
-+DATA consts<>+0xb0(SB)/4, $0x22330011
-+DATA consts<>+0xb4(SB)/4, $0x66774455
-+DATA consts<>+0xb8(SB)/4, $0xaabb8899
-+DATA consts<>+0xbc(SB)/4, $0xeeffccdd
- GLOBL consts<>(SB), RODATA, $0xc0
-
-+#ifdef GOARCH_ppc64
-+#define BE_XXBRW_INIT() \
-+		LVSL (R0)(R0), V24 \
-+		VSPLTISB $3, V25   \
-+		VXOR V24, V25, V24 \
-+
-+#define BE_XXBRW(vr) VPERM vr, vr, V24, vr
-+#else
-+#define BE_XXBRW_INIT()
-+#define BE_XXBRW(vr)
-+#endif
-+
- //func chaCha20_ctr32_vsx(out, inp *byte, len int, key *[8]uint32, counter *uint32)
- TEXT ·chaCha20_ctr32_vsx(SB),NOSPLIT,$64-40
- 	MOVD out+0(FP), OUT
-@@ -94,6 +130,8 @@ TEXT ·chaCha20_ctr32_vsx(SB),NOSPLIT,$64-40
- 	// Clear V27
- 	VXOR V27, V27, V27
-
-+	BE_XXBRW_INIT()
-+
- 	// V28
- 	LXVW4X (CONSTBASE)(R11), VS60
-
-@@ -299,6 +337,11 @@ loop_vsx:
- 	VADDUWM V8, V18, V8
- 	VADDUWM V12, V19, V12
-
-+	BE_XXBRW(V0)
-+	BE_XXBRW(V4)
-+	BE_XXBRW(V8)
-+	BE_XXBRW(V12)
-+
- 	CMPU LEN, $64
- 	BLT tail_vsx
-
-@@ -327,6 +370,11 @@ loop_vsx:
- 	VADDUWM V9, V18, V8
- 	VADDUWM V13, V19, V12
-
-+	BE_XXBRW(V0)
-+	BE_XXBRW(V4)
-+	BE_XXBRW(V8)
-+	BE_XXBRW(V12)
-+
- 	CMPU  LEN, $64
- 	BLT   tail_vsx
-
-@@ -334,8 +382,8 @@ loop_vsx:
- 	LXVW4X (INP)(R8), VS60
- 	LXVW4X (INP)(R9), VS61
- 	LXVW4X (INP)(R10), VS62
+-GLOBL consts<>(SB), RODATA, $0xc0
+-
+-//func chaCha20_ctr32_vsx(out, inp *byte, len int, key *[8]uint32, counter *uint32)
+-TEXT ·chaCha20_ctr32_vsx(SB),NOSPLIT,$64-40
+-	MOVD out+0(FP), OUT
+-	MOVD inp+8(FP), INP
+-	MOVD len+16(FP), LEN
+-	MOVD key+24(FP), KEY
+-	MOVD counter+32(FP), CNT
+-
+-	// Addressing for constants
+-	MOVD $consts<>+0x00(SB), CONSTBASE
+-	MOVD $16, R8
+-	MOVD $32, R9
+-	MOVD $48, R10
+-	MOVD $64, R11
+-	SRD $6, LEN, BLOCKS
+-	// for VPERMXOR
+-	MOVD $consts<>+0xa0(SB), MASK
+-	MOVD $16, R20
+-	// V16
+-	LXVW4X (CONSTBASE)(R0), VS48
+-	ADD $80,CONSTBASE
+-
+-	// Load key into V17,V18
+-	LXVW4X (KEY)(R0), VS49
+-	LXVW4X (KEY)(R8), VS50
+-
+-	// Load CNT, NONCE into V19
+-	LXVW4X (CNT)(R0), VS51
+-
+-	// Clear V27
+-	VXOR V27, V27, V27
+-
+-	// V28
+-	LXVW4X (CONSTBASE)(R11), VS60
+-
+-	// Load mask constants for VPERMXOR
+-	LXVW4X (MASK)(R0), V20
+-	LXVW4X (MASK)(R20), V21
+-
+-	// splat slot from V19 -> V26
+-	VSPLTW $0, V19, V26
+-
+-	VSLDOI $4, V19, V27, V19
+-	VSLDOI $12, V27, V19, V19
+-
+-	VADDUWM V26, V28, V26
+-
+-	MOVD $10, R14
+-	MOVD R14, CTR
+-	PCALIGN $16
+-loop_outer_vsx:
+-	// V0, V1, V2, V3
+-	LXVW4X (R0)(CONSTBASE), VS32
+-	LXVW4X (R8)(CONSTBASE), VS33
+-	LXVW4X (R9)(CONSTBASE), VS34
+-	LXVW4X (R10)(CONSTBASE), VS35
+-
+-	// splat values from V17, V18 into V4-V11
+-	VSPLTW $0, V17, V4
+-	VSPLTW $1, V17, V5
+-	VSPLTW $2, V17, V6
+-	VSPLTW $3, V17, V7
+-	VSPLTW $0, V18, V8
+-	VSPLTW $1, V18, V9
+-	VSPLTW $2, V18, V10
+-	VSPLTW $3, V18, V11
+-
+-	// VOR
+-	VOR V26, V26, V12
+-
+-	// splat values from V19 -> V13, V14, V15
+-	VSPLTW $1, V19, V13
+-	VSPLTW $2, V19, V14
+-	VSPLTW $3, V19, V15
+-
+-	// splat   const values
+-	VSPLTISW $-16, V27
+-	VSPLTISW $12, V28
+-	VSPLTISW $8, V29
+-	VSPLTISW $7, V30
+-	PCALIGN $16
+-loop_vsx:
+-	VADDUWM V0, V4, V0
+-	VADDUWM V1, V5, V1
+-	VADDUWM V2, V6, V2
+-	VADDUWM V3, V7, V3
+-
+-	VPERMXOR V12, V0, V21, V12
+-	VPERMXOR V13, V1, V21, V13
+-	VPERMXOR V14, V2, V21, V14
+-	VPERMXOR V15, V3, V21, V15
+-
+-	VADDUWM V8, V12, V8
+-	VADDUWM V9, V13, V9
+-	VADDUWM V10, V14, V10
+-	VADDUWM V11, V15, V11
+-
+-	VXOR V4, V8, V4
+-	VXOR V5, V9, V5
+-	VXOR V6, V10, V6
+-	VXOR V7, V11, V7
+-
+-	VRLW V4, V28, V4
+-	VRLW V5, V28, V5
+-	VRLW V6, V28, V6
+-	VRLW V7, V28, V7
+-
+-	VADDUWM V0, V4, V0
+-	VADDUWM V1, V5, V1
+-	VADDUWM V2, V6, V2
+-	VADDUWM V3, V7, V3
+-
+-	VPERMXOR V12, V0, V20, V12
+-	VPERMXOR V13, V1, V20, V13
+-	VPERMXOR V14, V2, V20, V14
+-	VPERMXOR V15, V3, V20, V15
+-
+-	VADDUWM V8, V12, V8
+-	VADDUWM V9, V13, V9
+-	VADDUWM V10, V14, V10
+-	VADDUWM V11, V15, V11
+-
+-	VXOR V4, V8, V4
+-	VXOR V5, V9, V5
+-	VXOR V6, V10, V6
+-	VXOR V7, V11, V7
+-
+-	VRLW V4, V30, V4
+-	VRLW V5, V30, V5
+-	VRLW V6, V30, V6
+-	VRLW V7, V30, V7
+-
+-	VADDUWM V0, V5, V0
+-	VADDUWM V1, V6, V1
+-	VADDUWM V2, V7, V2
+-	VADDUWM V3, V4, V3
+-
+-	VPERMXOR V15, V0, V21, V15
+-	VPERMXOR V12, V1, V21, V12
+-	VPERMXOR V13, V2, V21, V13
+-	VPERMXOR V14, V3, V21, V14
+-
+-	VADDUWM V10, V15, V10
+-	VADDUWM V11, V12, V11
+-	VADDUWM V8, V13, V8
+-	VADDUWM V9, V14, V9
+-
+-	VXOR V5, V10, V5
+-	VXOR V6, V11, V6
+-	VXOR V7, V8, V7
+-	VXOR V4, V9, V4
+-
+-	VRLW V5, V28, V5
+-	VRLW V6, V28, V6
+-	VRLW V7, V28, V7
+-	VRLW V4, V28, V4
+-
+-	VADDUWM V0, V5, V0
+-	VADDUWM V1, V6, V1
+-	VADDUWM V2, V7, V2
+-	VADDUWM V3, V4, V3
+-
+-	VPERMXOR V15, V0, V20, V15
+-	VPERMXOR V12, V1, V20, V12
+-	VPERMXOR V13, V2, V20, V13
+-	VPERMXOR V14, V3, V20, V14
+-
+-	VADDUWM V10, V15, V10
+-	VADDUWM V11, V12, V11
+-	VADDUWM V8, V13, V8
+-	VADDUWM V9, V14, V9
+-
+-	VXOR V5, V10, V5
+-	VXOR V6, V11, V6
+-	VXOR V7, V8, V7
+-	VXOR V4, V9, V4
+-
+-	VRLW V5, V30, V5
+-	VRLW V6, V30, V6
+-	VRLW V7, V30, V7
+-	VRLW V4, V30, V4
+-	BDNZ   loop_vsx
+-
+-	VADDUWM V12, V26, V12
+-
+-	VMRGEW V0, V1, V27
+-	VMRGEW V2, V3, V28
+-
+-	VMRGOW V0, V1, V0
+-	VMRGOW V2, V3, V2
+-
+-	VMRGEW V4, V5, V29
+-	VMRGEW V6, V7, V30
+-
+-	XXPERMDI VS32, VS34, $0, VS33
+-	XXPERMDI VS32, VS34, $3, VS35
+-	XXPERMDI VS59, VS60, $0, VS32
+-	XXPERMDI VS59, VS60, $3, VS34
+-
+-	VMRGOW V4, V5, V4
+-	VMRGOW V6, V7, V6
+-
+-	VMRGEW V8, V9, V27
+-	VMRGEW V10, V11, V28
+-
+-	XXPERMDI VS36, VS38, $0, VS37
+-	XXPERMDI VS36, VS38, $3, VS39
+-	XXPERMDI VS61, VS62, $0, VS36
+-	XXPERMDI VS61, VS62, $3, VS38
+-
+-	VMRGOW V8, V9, V8
+-	VMRGOW V10, V11, V10
+-
+-	VMRGEW V12, V13, V29
+-	VMRGEW V14, V15, V30
+-
+-	XXPERMDI VS40, VS42, $0, VS41
+-	XXPERMDI VS40, VS42, $3, VS43
+-	XXPERMDI VS59, VS60, $0, VS40
+-	XXPERMDI VS59, VS60, $3, VS42
+-
+-	VMRGOW V12, V13, V12
+-	VMRGOW V14, V15, V14
+-
+-	VSPLTISW $4, V27
+-	VADDUWM V26, V27, V26
+-
+-	XXPERMDI VS44, VS46, $0, VS45
+-	XXPERMDI VS44, VS46, $3, VS47
+-	XXPERMDI VS61, VS62, $0, VS44
+-	XXPERMDI VS61, VS62, $3, VS46
+-
+-	VADDUWM V0, V16, V0
+-	VADDUWM V4, V17, V4
+-	VADDUWM V8, V18, V8
+-	VADDUWM V12, V19, V12
+-
+-	CMPU LEN, $64
+-	BLT tail_vsx
+-
+-	// Bottom of loop
+-	LXVW4X (INP)(R0), VS59
+-	LXVW4X (INP)(R8), VS60
+-	LXVW4X (INP)(R9), VS61
+-	LXVW4X (INP)(R10), VS62
+-
+-	VXOR V27, V0, V27
+-	VXOR V28, V4, V28
+-	VXOR V29, V8, V29
+-	VXOR V30, V12, V30
+-
+-	STXVW4X VS59, (OUT)(R0)
+-	STXVW4X VS60, (OUT)(R8)
+-	ADD     $64, INP
+-	STXVW4X VS61, (OUT)(R9)
+-	ADD     $-64, LEN
+-	STXVW4X VS62, (OUT)(R10)
+-	ADD     $64, OUT
+-	BEQ     done_vsx
+-
+-	VADDUWM V1, V16, V0
+-	VADDUWM V5, V17, V4
+-	VADDUWM V9, V18, V8
+-	VADDUWM V13, V19, V12
+-
+-	CMPU  LEN, $64
+-	BLT   tail_vsx
+-
+-	LXVW4X (INP)(R0), VS59
+-	LXVW4X (INP)(R8), VS60
+-	LXVW4X (INP)(R9), VS61
+-	LXVW4X (INP)(R10), VS62
 -	VXOR   V27, V0, V27
-
-+	VXOR V27, V0, V27
- 	VXOR V28, V4, V28
- 	VXOR V29, V8, V29
- 	VXOR V30, V12, V30
-@@ -354,6 +402,11 @@ loop_vsx:
- 	VADDUWM V10, V18, V8
- 	VADDUWM V14, V19, V12
-
-+	BE_XXBRW(V0)
-+	BE_XXBRW(V4)
-+	BE_XXBRW(V8)
-+	BE_XXBRW(V12)
-+
- 	CMPU LEN, $64
- 	BLT  tail_vsx
-
-@@ -381,6 +434,11 @@ loop_vsx:
- 	VADDUWM V11, V18, V8
- 	VADDUWM V15, V19, V12
-
-+	BE_XXBRW(V0)
-+	BE_XXBRW(V4)
-+	BE_XXBRW(V8)
-+	BE_XXBRW(V12)
-+
- 	CMPU  LEN, $64
- 	BLT   tail_vsx
-
-@@ -408,9 +466,9 @@ loop_vsx:
-
- done_vsx:
- 	// Increment counter by number of 64 byte blocks
+-
+-	VXOR V28, V4, V28
+-	VXOR V29, V8, V29
+-	VXOR V30, V12, V30
+-
+-	STXVW4X VS59, (OUT)(R0)
+-	STXVW4X VS60, (OUT)(R8)
+-	ADD     $64, INP
+-	STXVW4X VS61, (OUT)(R9)
+-	ADD     $-64, LEN
+-	STXVW4X VS62, (OUT)(V10)
+-	ADD     $64, OUT
+-	BEQ     done_vsx
+-
+-	VADDUWM V2, V16, V0
+-	VADDUWM V6, V17, V4
+-	VADDUWM V10, V18, V8
+-	VADDUWM V14, V19, V12
+-
+-	CMPU LEN, $64
+-	BLT  tail_vsx
+-
+-	LXVW4X (INP)(R0), VS59
+-	LXVW4X (INP)(R8), VS60
+-	LXVW4X (INP)(R9), VS61
+-	LXVW4X (INP)(R10), VS62
+-
+-	VXOR V27, V0, V27
+-	VXOR V28, V4, V28
+-	VXOR V29, V8, V29
+-	VXOR V30, V12, V30
+-
+-	STXVW4X VS59, (OUT)(R0)
+-	STXVW4X VS60, (OUT)(R8)
+-	ADD     $64, INP
+-	STXVW4X VS61, (OUT)(R9)
+-	ADD     $-64, LEN
+-	STXVW4X VS62, (OUT)(R10)
+-	ADD     $64, OUT
+-	BEQ     done_vsx
+-
+-	VADDUWM V3, V16, V0
+-	VADDUWM V7, V17, V4
+-	VADDUWM V11, V18, V8
+-	VADDUWM V15, V19, V12
+-
+-	CMPU  LEN, $64
+-	BLT   tail_vsx
+-
+-	LXVW4X (INP)(R0), VS59
+-	LXVW4X (INP)(R8), VS60
+-	LXVW4X (INP)(R9), VS61
+-	LXVW4X (INP)(R10), VS62
+-
+-	VXOR V27, V0, V27
+-	VXOR V28, V4, V28
+-	VXOR V29, V8, V29
+-	VXOR V30, V12, V30
+-
+-	STXVW4X VS59, (OUT)(R0)
+-	STXVW4X VS60, (OUT)(R8)
+-	ADD     $64, INP
+-	STXVW4X VS61, (OUT)(R9)
+-	ADD     $-64, LEN
+-	STXVW4X VS62, (OUT)(R10)
+-	ADD     $64, OUT
+-
+-	MOVD $10, R14
+-	MOVD R14, CTR
+-	BNE  loop_outer_vsx
+-
+-done_vsx:
+-	// Increment counter by number of 64 byte blocks
 -	MOVD (CNT), R14
-+	MOVWZ (CNT), R14
- 	ADD  BLOCKS, R14
+-	ADD  BLOCKS, R14
 -	MOVD R14, (CNT)
-+	MOVWZ R14, (CNT)
- 	RET
-
- tail_vsx:
+-	RET
+-
+-tail_vsx:
+-	ADD  $32, R1, R11
+-	MOVD LEN, CTR
+-
+-	// Save values on stack to copy from
+-	STXVW4X VS32, (R11)(R0)
+-	STXVW4X VS36, (R11)(R8)
+-	STXVW4X VS40, (R11)(R9)
+-	STXVW4X VS44, (R11)(R10)
+-	ADD $-1, R11, R12
+-	ADD $-1, INP
+-	ADD $-1, OUT
+-	PCALIGN $16
+-looptail_vsx:
+-	// Copying the result to OUT
+-	// in bytes.
+-	MOVBZU 1(R12), KEY
+-	MOVBZU 1(INP), TMP
+-	XOR    KEY, TMP, KEY
+-	MOVBU  KEY, 1(OUT)
+-	BDNZ   looptail_vsx
+-
+-	// Clear the stack values
+-	STXVW4X VS48, (R11)(R0)
+-	STXVW4X VS48, (R11)(R8)
+-	STXVW4X VS48, (R11)(R9)
+-	STXVW4X VS48, (R11)(R10)
+-	BR      done_vsx
 diff --git a/vendor/golang.org/x/crypto/chacha20poly1305/chacha20poly1305_amd64.s b/vendor/golang.org/x/crypto/chacha20poly1305/chacha20poly1305_amd64.s
 index 731d2ac6..fd5ee845 100644
 --- a/vendor/golang.org/x/crypto/chacha20poly1305/chacha20poly1305_amd64.s
@@ -497,9 +1251,9 @@ index 731d2ac6..fd5ee845 100644
 -
 -// This file was originally from https://golang.org/cl/24717 by Vlad Krasnov of CloudFlare.
 +// Code generated by command: go run chacha20poly1305_amd64_asm.go -out ../chacha20poly1305_amd64.s -pkg chacha20poly1305. DO NOT EDIT.
-
+ 
  //go:build gc && !purego
-
+ 
  #include "textflag.h"
 -// General register allocation
 -#define oup DI
@@ -810,7 +1564,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
  	RET
-
+ 
  hashADLoop:
  	// Hash in 16 byte chunks
 -	CMPQ itr2, $16
@@ -866,12 +1620,12 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	JMP   hashADLoop
-
+ 
  hashADTail:
 -	CMPQ itr2, $0
 +	CMPQ R9, $0x00
  	JE   hashADDone
-
+ 
  	// Hash last < 16 byte tail
 -	XORQ t0, t0
 -	XORQ t1, t1
@@ -881,7 +1635,7 @@ index 731d2ac6..fd5ee845 100644
 +	XORQ R14, R14
 +	XORQ R15, R15
 +	ADDQ R9, CX
-
+ 
  hashADTailLoop:
 -	SHLQ $8, t0, t1
 -	SHLQ $8, t0
@@ -947,7 +1701,7 @@ index 731d2ac6..fd5ee845 100644
 +
  hashADDone:
  	RET
-
+ 
 -// ----------------------------------------------------------------------------
 -// func chacha20Poly1305Open(dst, key, src, ad []byte) bool
 -TEXT ·chacha20Poly1305Open(SB), 0, $288-97
@@ -969,18 +1723,18 @@ index 731d2ac6..fd5ee845 100644
 +	MOVQ src_base+48(FP), SI
 +	MOVQ src_len+56(FP), BX
 +	MOVQ ad_base+72(FP), CX
-
+ 
  	// Check for AVX2 support
 -	CMPB ·useAVX2(SB), $1
 +	CMPB ·useAVX2+0(SB), $0x01
  	JE   chacha20Poly1305Open_AVX2
-
+ 
  	// Special optimization, for very short buffers
 -	CMPQ inl, $128
 -	JBE  openSSE128 // About 16% faster
 +	CMPQ BX, $0x80
 +	JBE  openSSE128
-
+ 
  	// For long buffers, prepare the poly key first
 -	MOVOU ·chacha20Constants<>(SB), A0
 -	MOVOU (1*16)(keyp), B0
@@ -992,7 +1746,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVOU 32(R8), X6
 +	MOVOU 48(R8), X9
 +	MOVO  X9, X13
-
+ 
  	// Store state on stack for future use
 -	MOVO B0, state1Store
 -	MOVO C0, state2Store
@@ -1002,7 +1756,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO X6, 48(BP)
 +	MOVO X9, 128(BP)
 +	MOVQ $0x0000000a, R9
-
+ 
  openSSEPreparePolyKey:
 -	chachaQR(A0, B0, C0, D0, T0)
 -	shiftB0Left;  shiftC0Left; shiftD0Left
@@ -1086,29 +1840,29 @@ index 731d2ac6..fd5ee845 100644
 +	BYTE  $0x04
 +	DECQ  R9
 +	JNE   openSSEPreparePolyKey
-
+ 
  	// A0|B0 hold the Poly1305 32-byte key, C0,D0 can be discarded
 -	PADDL ·chacha20Constants<>(SB), A0; PADDL state1Store, B0
 +	PADDL ·chacha20Constants<>+0(SB), X0
 +	PADDL 32(BP), X3
-
+ 
  	// Clamp and store the key
 -	PAND ·polyClampMask<>(SB), A0
 -	MOVO A0, rStore; MOVO B0, sStore
 +	PAND ·polyClampMask<>+0(SB), X0
 +	MOVO X0, (BP)
 +	MOVO X3, 16(BP)
-
+ 
  	// Hash AAD
 -	MOVQ ad_len+80(FP), itr2
 +	MOVQ ad_len+80(FP), R9
  	CALL polyHashADInternal<>(SB)
-
+ 
  openSSEMainLoop:
 -	CMPQ inl, $256
 +	CMPQ BX, $0x00000100
  	JB   openSSEMainLoopDone
-
+ 
  	// Load state, increment counter blocks
 -	MOVO ·chacha20Constants<>(SB), A0; MOVO state1Store, B0; MOVO state2Store, C0; MOVO ctr3Store, D0; PADDL ·sseIncMask<>(SB), D0
 -	MOVO A0, A1; MOVO B0, B1; MOVO C0, C1; MOVO D0, D1; PADDL ·sseIncMask<>(SB), D1
@@ -1134,14 +1888,14 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO  X8, X14
 +	MOVO  X11, X15
 +	PADDL ·sseIncMask<>+0(SB), X15
-
+ 
  	// Store counters
 -	MOVO D0, ctr0Store; MOVO D1, ctr1Store; MOVO D2, ctr2Store; MOVO D3, ctr3Store
 +	MOVO X9, 80(BP)
 +	MOVO X10, 96(BP)
 +	MOVO X11, 112(BP)
 +	MOVO X15, 128(BP)
-
+ 
 -	// There are 10 ChaCha20 iterations of 2QR each, so for 6 iterations we hash 2 blocks, and for the remaining 4 only 1 block - for a total of 16
 -	MOVQ $4, itr1
 -	MOVQ inp, itr2
@@ -1149,7 +1903,7 @@ index 731d2ac6..fd5ee845 100644
 +	// 2 blocks, and for the remaining 4 only 1 block - for a total of 16
 +	MOVQ $0x00000004, CX
 +	MOVQ SI, R9
-
+ 
  openSSEInternalLoop:
 -	MOVO          C3, tmpStore
 -	chachaQR(A0, B0, C0, D0, C3); chachaQR(A1, B1, C1, D1, C3); chachaQR(A2, B2, C2, D2, C3)
@@ -1582,7 +2336,7 @@ index 731d2ac6..fd5ee845 100644
 +	LEAQ  16(R9), R9
 +	CMPQ  CX, $-6
 +	JG    openSSEInternalLoop
-
+ 
  	// Add in the state
 -	PADDD ·chacha20Constants<>(SB), A0; PADDD ·chacha20Constants<>(SB), A1; PADDD ·chacha20Constants<>(SB), A2; PADDD ·chacha20Constants<>(SB), A3
 -	PADDD state1Store, B0; PADDD state1Store, B1; PADDD state1Store, B2; PADDD state1Store, B3
@@ -1604,7 +2358,7 @@ index 731d2ac6..fd5ee845 100644
 +	PADDD 96(BP), X10
 +	PADDD 112(BP), X11
 +	PADDD 128(BP), X15
-
+ 
  	// Load - xor - store
 -	MOVO  D3, tmpStore
 -	MOVOU (0*16)(inp), D3; PXOR D3, A0; MOVOU A0, (0*16)(oup)
@@ -1679,7 +2433,7 @@ index 731d2ac6..fd5ee845 100644
 +	LEAQ  256(DI), DI
 +	SUBQ  $0x00000100, BX
  	JMP   openSSEMainLoop
-
+ 
  openSSEMainLoopDone:
  	// Handle the various tail sizes efficiently
 -	TESTQ inl, inl
@@ -1695,7 +2449,7 @@ index 731d2ac6..fd5ee845 100644
 +	CMPQ  BX, $0xc0
  	JBE   openSSETail192
  	JMP   openSSETail256
-
+ 
  openSSEFinalize:
  	// Hash in the PT, AAD lengths
 -	ADDQ ad_len+80(FP), acc0; ADCQ src_len+56(FP), acc1; ADCQ $1, acc2
@@ -1741,7 +2495,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ  R15, R10
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
-
+ 
  	// Final reduce
 -	MOVQ    acc0, t0
 -	MOVQ    acc1, t1
@@ -1761,13 +2515,13 @@ index 731d2ac6..fd5ee845 100644
 +	CMOVQCS R13, R10
 +	CMOVQCS R14, R11
 +	CMOVQCS R15, R12
-
+ 
  	// Add in the "s" part of the key
 -	ADDQ 0+sStore, acc0
 -	ADCQ 8+sStore, acc1
 +	ADDQ 16(BP), R10
 +	ADCQ 24(BP), R11
-
+ 
  	// Finally, constant time compare to the tag at the end of the message
  	XORQ    AX, AX
 -	MOVQ    $1, DX
@@ -1779,11 +2533,11 @@ index 731d2ac6..fd5ee845 100644
 +	XORQ    8(SI), R11
 +	ORQ     R11, R10
  	CMOVQEQ DX, AX
-
+ 
  	// Return true iff tags are equal
  	MOVB AX, ret+96(FP)
  	RET
-
+ 
 -// ----------------------------------------------------------------------------
 -// Special optimization for buffers smaller than 129 bytes
  openSSE128:
@@ -1811,7 +2565,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO  X6, X14
 +	MOVO  X10, X15
 +	MOVQ  $0x0000000a, R9
-
+ 
  openSSE128InnerCipherLoop:
 -	chachaQR(A0, B0, C0, D0, T0); chachaQR(A1, B1, C1, D1, T0); chachaQR(A2, B2, C2, D2, T0)
 -	shiftB0Left;  shiftB1Left; shiftB2Left
@@ -2049,7 +2803,7 @@ index 731d2ac6..fd5ee845 100644
 +	BYTE  $0x04
 +	DECQ  R9
 +	JNE   openSSE128InnerCipherLoop
-
+ 
  	// A0|B0 hold the Poly1305 32-byte key, C0,D0 can be discarded
 -	PADDL ·chacha20Constants<>(SB), A0; PADDL ·chacha20Constants<>(SB), A1; PADDL ·chacha20Constants<>(SB), A2
 -	PADDL T1, B0; PADDL T1, B1; PADDL T1, B2
@@ -2066,32 +2820,32 @@ index 731d2ac6..fd5ee845 100644
 +	PADDL X15, X10
 +	PADDL ·sseIncMask<>+0(SB), X15
 +	PADDL X15, X11
-
+ 
  	// Clamp and store the key
 -	PAND  ·polyClampMask<>(SB), A0
 -	MOVOU A0, rStore; MOVOU B0, sStore
 +	PAND  ·polyClampMask<>+0(SB), X0
 +	MOVOU X0, (BP)
 +	MOVOU X3, 16(BP)
-
+ 
  	// Hash
 -	MOVQ ad_len+80(FP), itr2
 +	MOVQ ad_len+80(FP), R9
  	CALL polyHashADInternal<>(SB)
-
+ 
  openSSE128Open:
 -	CMPQ inl, $16
 +	CMPQ BX, $0x10
  	JB   openSSETail16
 -	SUBQ $16, inl
 +	SUBQ $0x10, BX
-
+ 
  	// Load for hashing
 -	polyAdd(0(inp))
 +	ADDQ (SI), R10
 +	ADCQ 8(SI), R11
 +	ADCQ $0x01, R12
-
+ 
  	// Load for decryption
 -	MOVOU (inp), T0; PXOR T0, A1; MOVOU A1, (oup)
 -	LEAQ  (1*16)(inp), inp
@@ -2140,7 +2894,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ  R15, R10
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
-
+ 
  	// Shift the stream "left"
 -	MOVO B1, A1
 -	MOVO C1, B1
@@ -2157,12 +2911,12 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO X8, X5
 +	MOVO X11, X8
  	JMP  openSSE128Open
-
+ 
  openSSETail16:
 -	TESTQ inl, inl
 +	TESTQ BX, BX
  	JE    openSSEFinalize
-
+ 
  	// We can safely load the CT from the end, because it is padded with the MAC
 -	MOVQ   inl, itr2
 -	SHLQ   $4, itr2
@@ -2184,7 +2938,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVQ  X12, R13
 +	MOVQ  72(BP), R14
 +	PXOR  X1, X12
-
+ 
  	// We can only store one byte at a time, since plaintext can be shorter than 16 bytes
  openSSETail16Store:
 -	MOVQ T0, t3
@@ -2242,7 +2996,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ   R8, R11
 +	ADCQ   $0x00, R12
  	JMP    openSSEFinalize
-
+ 
 -// ----------------------------------------------------------------------------
 -// Special optimization for the last 64 bytes of ciphertext
  openSSETail64:
@@ -2262,7 +3016,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVQ  BX, CX
 +	CMPQ  CX, $0x10
 +	JB    openSSETail64LoopB
-
+ 
  openSSETail64LoopA:
 -	// Perform ChaCha rounds, while hashing the remaining input
 -	polyAdd(0(inp)(itr2*1))
@@ -2310,7 +3064,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	SUBQ  $0x10, CX
-
+ 
  openSSETail64LoopB:
 -	ADDQ          $16, itr2
 -	chachaQR(A0, B0, C0, D0, T0)
@@ -2408,7 +3162,7 @@ index 731d2ac6..fd5ee845 100644
 +	PADDL 32(BP), X3
 +	PADDL 48(BP), X6
 +	PADDL 80(BP), X9
-
+ 
  openSSETail64DecLoop:
 -	CMPQ  inl, $16
 +	CMPQ  BX, $0x10
@@ -2432,12 +3186,12 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO  X6, X3
 +	MOVO  X9, X6
  	JMP   openSSETail64DecLoop
-
+ 
  openSSETail64DecLoopDone:
 -	MOVO A0, A1
 +	MOVO X0, X1
  	JMP  openSSETail16
-
+ 
 -// ----------------------------------------------------------------------------
 -// Special optimization for the last 128 bytes of ciphertext
  openSSETail128:
@@ -2462,7 +3216,7 @@ index 731d2ac6..fd5ee845 100644
 +	XORQ  R9, R9
 +	MOVQ  BX, CX
 +	ANDQ  $-16, CX
-
+ 
  openSSETail128LoopA:
 -	// Perform ChaCha rounds, while hashing the remaining input
 -	polyAdd(0(inp)(itr2*1))
@@ -2508,7 +3262,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ  R15, R10
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
-
+ 
  openSSETail128LoopB:
 -	ADDQ          $16, itr2
 -	chachaQR(A0, B0, C0, D0, T0); chachaQR(A1, B1, C1, D1, T0)
@@ -2754,7 +3508,7 @@ index 731d2ac6..fd5ee845 100644
 +	CMOVQGT R9, CX
 +	ANDQ    $-16, CX
 +	XORQ    R9, R9
-
+ 
  openSSLTail192LoopA:
 -	// Perform ChaCha rounds, while hashing the remaining input
 -	polyAdd(0(inp)(itr2*1))
@@ -2800,7 +3554,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ  R15, R10
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
-
+ 
  openSSLTail192LoopB:
 -	ADDQ         $16, itr2
 -	chachaQR(A0, B0, C0, D0, T0); chachaQR(A1, B1, C1, D1, T0); chachaQR(A2, B2, C2, D2, T0)
@@ -3145,7 +3899,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ  R15, R10
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
-
+ 
  openSSLTail192Store:
 -	PADDL ·chacha20Constants<>(SB), A0; PADDL ·chacha20Constants<>(SB), A1; PADDL ·chacha20Constants<>(SB), A2
 -	PADDL state1Store, B0; PADDL state1Store, B1; PADDL state1Store, B2
@@ -3234,7 +3988,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO  X8, X14
 +	MOVO  X11, X15
 +	PADDL ·sseIncMask<>+0(SB), X15
-
+ 
  	// Store counters
 -	MOVO D0, ctr0Store; MOVO D1, ctr1Store; MOVO D2, ctr2Store; MOVO D3, ctr3Store
 -	XORQ itr2, itr2
@@ -3243,7 +3997,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO X11, 112(BP)
 +	MOVO X15, 128(BP)
 +	XORQ R9, R9
-
+ 
  openSSETail256Loop:
 -	// This loop inteleaves 8 ChaCha quarter rounds with 1 poly multiplication
 -	polyAdd(0(inp)(itr2*1))
@@ -3630,7 +4384,7 @@ index 731d2ac6..fd5ee845 100644
 +	JB    openSSETail256Loop
 +	MOVQ  BX, CX
 +	ANDQ  $-16, CX
-
+ 
  openSSETail256HashLoop:
 -	polyAdd(0(inp)(itr2*1))
 -	polyMul
@@ -3681,7 +4435,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ  $0x10, R9
 +	CMPQ  R9, CX
 +	JB    openSSETail256HashLoop
-
+ 
  	// Add in the state
 -	PADDD ·chacha20Constants<>(SB), A0; PADDD ·chacha20Constants<>(SB), A1; PADDD ·chacha20Constants<>(SB), A2; PADDD ·chacha20Constants<>(SB), A3
 -	PADDD state1Store, B0; PADDD state1Store, B1; PADDD state1Store, B2; PADDD state1Store, B3
@@ -3705,7 +4459,7 @@ index 731d2ac6..fd5ee845 100644
 +	PADDD 112(BP), X11
 +	PADDD 128(BP), X15
 +	MOVO  X15, 64(BP)
-
+ 
  	// Load - xor - store
 -	MOVOU (0*16)(inp), D3; PXOR D3, A0
 -	MOVOU (1*16)(inp), D3; PXOR D3, B0
@@ -3805,7 +4559,7 @@ index 731d2ac6..fd5ee845 100644
 +	BYTE    $0x60
 +	BYTE    $0x30
 +	VPADDD  ·avx2InitMask<>+0(SB), Y4, Y4
-
+ 
  	// Special optimization, for very short buffers
 -	CMPQ inl, $192
 +	CMPQ BX, $0xc0
@@ -3813,7 +4567,7 @@ index 731d2ac6..fd5ee845 100644
 -	CMPQ inl, $320
 +	CMPQ BX, $0x00000140
  	JBE  openAVX2320
-
+ 
  	// For the general key prepare the key first - as a byproduct we have 64 bytes of cipher stream
 -	VMOVDQA BB0, state1StoreAVX2
 -	VMOVDQA CC0, state2StoreAVX2
@@ -3823,7 +4577,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y12, 64(BP)
 +	VMOVDQA Y4, 192(BP)
 +	MOVQ    $0x0000000a, R9
-
+ 
  openAVX2PreparePolyKey:
 -	chachaQR_AVX2(AA0, BB0, CC0, DD0, TT0)
 -	VPALIGNR $4, BB0, BB0, BB0; VPALIGNR $8, CC0, CC0, CC0; VPALIGNR $12, DD0, DD0, DD0
@@ -3883,26 +4637,26 @@ index 731d2ac6..fd5ee845 100644
 +	VPADDD     64(BP), Y12, Y12
 +	VPADDD     192(BP), Y4, Y4
 +	VPERM2I128 $0x02, Y0, Y14, Y3
-
+ 
  	// Clamp and store poly key
 -	VPAND   ·polyClampMask<>(SB), TT0, TT0
 -	VMOVDQA TT0, rsStoreAVX2
 +	VPAND   ·polyClampMask<>+0(SB), Y3, Y3
 +	VMOVDQA Y3, (BP)
-
+ 
  	// Stream for the first 64 bytes
 -	VPERM2I128 $0x13, AA0, BB0, AA0
 -	VPERM2I128 $0x13, CC0, DD0, BB0
 +	VPERM2I128 $0x13, Y0, Y14, Y0
 +	VPERM2I128 $0x13, Y12, Y4, Y14
-
+ 
  	// Hash AD + first 64 bytes
 -	MOVQ ad_len+80(FP), itr2
 +	MOVQ ad_len+80(FP), R9
  	CALL polyHashADInternal<>(SB)
 -	XORQ itr1, itr1
 +	XORQ CX, CX
-
+ 
  openAVX2InitialHash64:
 -	polyAdd(0(inp)(itr1*1))
 -	polyMulAVX2
@@ -3946,7 +4700,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ  $0x10, CX
 +	CMPQ  CX, $0x40
 +	JNE   openAVX2InitialHash64
-
+ 
  	// Decrypt the first 64 bytes
 -	VPXOR   (0*32)(inp), AA0, AA0
 -	VPXOR   (1*32)(inp), BB0, BB0
@@ -3962,12 +4716,12 @@ index 731d2ac6..fd5ee845 100644
 +	LEAQ    64(SI), SI
 +	LEAQ    64(DI), DI
 +	SUBQ    $0x40, BX
-
+ 
  openAVX2MainLoop:
 -	CMPQ inl, $512
 +	CMPQ BX, $0x00000200
  	JB   openAVX2MainLoopDone
-
+ 
  	// Load state, increment counter blocks, store the incremented counters
 -	VMOVDQU ·chacha20Constants<>(SB), AA0; VMOVDQA AA0, AA1; VMOVDQA AA0, AA2; VMOVDQA AA0, AA3
 -	VMOVDQA state1StoreAVX2, BB0; VMOVDQA BB0, BB1; VMOVDQA BB0, BB2; VMOVDQA BB0, BB3
@@ -3997,7 +4751,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y2, 160(BP)
 +	VMOVDQA Y3, 192(BP)
 +	XORQ    CX, CX
-
+ 
  openAVX2InternalLoop:
 -	// Lets just say this spaghetti loop interleaves 2 quarter rounds with 3 poly multiplications
 -	// Effectively per 512 bytes of stream we hash 480 bytes of ciphertext
@@ -4356,7 +5110,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPADDD   160(BP), Y2, Y2
 +	VPADDD   192(BP), Y3, Y3
 +	VMOVDQA  Y15, 224(BP)
-
+ 
  	// We only hashed 480 of the 512 bytes available - hash the remaining 32 here
 -	polyAdd(480(inp))
 -	polyMulAVX2
@@ -4424,7 +5178,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQU    Y14, 160(DI)
 +	VMOVDQU    Y12, 192(DI)
 +	VMOVDQU    Y4, 224(DI)
-
+ 
  	// and here
 -	polyAdd(496(inp))
 -	polyMulAVX2
@@ -4499,7 +5253,7 @@ index 731d2ac6..fd5ee845 100644
 +	LEAQ       512(DI), DI
 +	SUBQ       $0x00000200, BX
  	JMP        openAVX2MainLoop
-
+ 
  openAVX2MainLoopDone:
  	// Handle the various tail sizes efficiently
 -	TESTQ inl, inl
@@ -4515,7 +5269,7 @@ index 731d2ac6..fd5ee845 100644
 +	CMPQ  BX, $0x00000180
  	JBE   openAVX2Tail384
  	JMP   openAVX2Tail512
-
+ 
 -// ----------------------------------------------------------------------------
 -// Special optimization for buffers smaller than 193 bytes
  openAVX2192:
@@ -4540,7 +5294,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y4, Y2
 +	VMOVDQA Y1, Y15
 +	MOVQ    $0x0000000a, R9
-
+ 
  openAVX2192InnerCipherLoop:
 -	chachaQR_AVX2(AA0, BB0, CC0, DD0, TT0); chachaQR_AVX2(AA1, BB1, CC1, DD1, TT0)
 -	VPALIGNR   $4, BB0, BB0, BB0; VPALIGNR $4, BB1, BB1, BB1
@@ -4643,13 +5397,13 @@ index 731d2ac6..fd5ee845 100644
 +	VPADDD     Y2, Y4, Y4
 +	VPADDD     Y15, Y1, Y1
 +	VPERM2I128 $0x02, Y0, Y14, Y3
-
+ 
  	// Clamp and store poly key
 -	VPAND   ·polyClampMask<>(SB), TT0, TT0
 -	VMOVDQA TT0, rsStoreAVX2
 +	VPAND   ·polyClampMask<>+0(SB), Y3, Y3
 +	VMOVDQA Y3, (BP)
-
+ 
  	// Stream for up to 192 bytes
 -	VPERM2I128 $0x13, AA0, BB0, AA0
 -	VPERM2I128 $0x13, CC0, DD0, BB0
@@ -4663,20 +5417,20 @@ index 731d2ac6..fd5ee845 100644
 +	VPERM2I128 $0x02, Y13, Y1, Y4
 +	VPERM2I128 $0x13, Y5, Y9, Y5
 +	VPERM2I128 $0x13, Y13, Y1, Y9
-
+ 
  openAVX2ShortOpen:
  	// Hash
 -	MOVQ ad_len+80(FP), itr2
 +	MOVQ ad_len+80(FP), R9
  	CALL polyHashADInternal<>(SB)
-
+ 
  openAVX2ShortOpenLoop:
 -	CMPQ inl, $32
 +	CMPQ BX, $0x20
  	JB   openAVX2ShortTail32
 -	SUBQ $32, inl
 +	SUBQ $0x20, BX
-
+ 
  	// Load for hashing
 -	polyAdd(0*8(inp))
 -	polyMulAVX2
@@ -4750,7 +5504,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ  R15, R10
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
-
+ 
  	// Load for decryption
 -	VPXOR   (inp), AA0, AA0
 -	VMOVDQU AA0, (oup)
@@ -4760,7 +5514,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQU Y0, (DI)
 +	LEAQ    32(SI), SI
 +	LEAQ    32(DI), DI
-
+ 
  	// Shift stream left
 -	VMOVDQA BB0, AA0
 -	VMOVDQA CC0, BB0
@@ -4781,7 +5535,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y6, Y1
 +	VMOVDQA Y10, Y6
  	JMP     openAVX2ShortOpenLoop
-
+ 
  openAVX2ShortTail32:
 -	CMPQ    inl, $16
 -	VMOVDQA A0, A1
@@ -4791,7 +5545,7 @@ index 731d2ac6..fd5ee845 100644
 -
 -	SUBQ $16, inl
 +	SUBQ    $0x10, BX
-
+ 
  	// Load for hashing
 -	polyAdd(0*8(inp))
 -	polyMulAVX2
@@ -4829,7 +5583,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ  R15, R10
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
-
+ 
  	// Load for decryption
 -	VPXOR      (inp), A0, T0
 -	VMOVDQU    T0, (oup)
@@ -4843,11 +5597,11 @@ index 731d2ac6..fd5ee845 100644
 +	LEAQ       16(DI), DI
 +	VPERM2I128 $0x11, Y0, Y0, Y0
 +	VMOVDQA    X0, X1
-
+ 
  openAVX2ShortDone:
  	VZEROUPPER
  	JMP openSSETail16
-
+ 
 -// ----------------------------------------------------------------------------
 -// Special optimization for buffers smaller than 321 bytes
  openAVX2320:
@@ -4868,7 +5622,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y12, Y11
 +	VMOVDQA Y4, Y15
 +	MOVQ    $0x0000000a, R9
-
+ 
  openAVX2320InnerCipherLoop:
 -	chachaQR_AVX2(AA0, BB0, CC0, DD0, TT0); chachaQR_AVX2(AA1, BB1, CC1, DD1, TT0); chachaQR_AVX2(AA2, BB2, CC2, DD2, TT0)
 -	VPALIGNR $4, BB0, BB0, BB0; VPALIGNR $4, BB1, BB1, BB1; VPALIGNR $4, BB2, BB2, BB2
@@ -5020,7 +5774,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPADDD   Y15, Y1, Y1
 +	VPADDD   Y3, Y15, Y15
 +	VPADDD   Y15, Y2, Y2
-
+ 
  	// Clamp and store poly key
 -	VPERM2I128 $0x02, AA0, BB0, TT0
 -	VPAND      ·polyClampMask<>(SB), TT0, TT0
@@ -5028,7 +5782,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPERM2I128 $0x02, Y0, Y14, Y3
 +	VPAND      ·polyClampMask<>+0(SB), Y3, Y3
 +	VMOVDQA    Y3, (BP)
-
+ 
  	// Stream for up to 320 bytes
 -	VPERM2I128 $0x13, AA0, BB0, AA0
 -	VPERM2I128 $0x13, CC0, DD0, BB0
@@ -5051,7 +5805,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPERM2I128 $0x13, Y6, Y10, Y6
 +	VPERM2I128 $0x13, Y8, Y2, Y10
  	JMP        openAVX2ShortOpen
-
+ 
 -// ----------------------------------------------------------------------------
 -// Special optimization for the last 128 bytes of ciphertext
  openAVX2Tail128:
@@ -5079,7 +5833,7 @@ index 731d2ac6..fd5ee845 100644
 +	ANDQ    $-16, CX
 +	TESTQ   CX, CX
 +	JE      openAVX2Tail128LoopB
-
+ 
  openAVX2Tail128LoopA:
 -	// Perform ChaCha rounds, while hashing the remaining input
 -	polyAdd(0(inp)(itr2*1))
@@ -5118,7 +5872,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ  R15, R10
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
-
+ 
  openAVX2Tail128LoopB:
 -	ADDQ     $16, itr2
 -	chachaQR_AVX2(AA1, BB1, CC1, DD1, TT0)
@@ -5190,14 +5944,14 @@ index 731d2ac6..fd5ee845 100644
 +	VPERM2I128 $0x02, Y13, Y1, Y14
 +	VPERM2I128 $0x13, Y5, Y9, Y12
 +	VPERM2I128 $0x13, Y13, Y1, Y4
-
+ 
  openAVX2TailLoop:
 -	CMPQ inl, $32
 +	CMPQ BX, $0x20
  	JB   openAVX2Tail
 -	SUBQ $32, inl
 +	SUBQ $0x20, BX
-
+ 
  	// Load for decryption
 -	VPXOR   (inp), AA0, AA0
 -	VMOVDQU AA0, (oup)
@@ -5214,7 +5968,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y12, Y14
 +	VMOVDQA Y4, Y12
  	JMP     openAVX2TailLoop
-
+ 
  openAVX2Tail:
 -	CMPQ    inl, $16
 -	VMOVDQA A0, A1
@@ -5223,7 +5977,7 @@ index 731d2ac6..fd5ee845 100644
  	JB      openAVX2TailDone
 -	SUBQ    $16, inl
 +	SUBQ    $0x10, BX
-
+ 
  	// Load for decryption
 -	VPXOR      (inp), A0, T0
 -	VMOVDQU    T0, (oup)
@@ -5237,11 +5991,11 @@ index 731d2ac6..fd5ee845 100644
 +	LEAQ       16(DI), DI
 +	VPERM2I128 $0x11, Y0, Y0, Y0
 +	VMOVDQA    X0, X1
-
+ 
  openAVX2TailDone:
  	VZEROUPPER
  	JMP openSSETail16
-
+ 
 -// ----------------------------------------------------------------------------
 -// Special optimization for the last 256 bytes of ciphertext
  openAVX2Tail256:
@@ -5265,7 +6019,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPADDD  ·avx2IncMask<>+0(SB), Y4, Y1
 +	VMOVDQA Y4, Y7
 +	VMOVDQA Y1, Y11
-
+ 
  	// Compute the number of iterations that will hash data
 -	MOVQ    inl, tmpStoreAVX2
 -	MOVQ    inl, itr1
@@ -5285,7 +6039,7 @@ index 731d2ac6..fd5ee845 100644
 +	CMOVQGT R9, CX
 +	MOVQ    SI, BX
 +	XORQ    R9, R9
-
+ 
  openAVX2Tail256LoopA:
 -	polyAdd(0(inl))
 -	polyMulAVX2
@@ -5325,7 +6079,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	LEAQ  16(BX), BX
-
+ 
 -	// Perform ChaCha rounds, while hashing the remaining input
  openAVX2Tail256LoopB:
 -	chachaQR_AVX2(AA0, BB0, CC0, DD0, TT0); chachaQR_AVX2(AA1, BB1, CC1, DD1, TT0)
@@ -5423,7 +6177,7 @@ index 731d2ac6..fd5ee845 100644
 +	SUBQ     SI, BX
 +	MOVQ     BX, CX
 +	MOVQ     224(BP), BX
-
+ 
 -	CMPQ itr2, $10
 -	JNE  openAVX2Tail256LoopB
 -
@@ -5558,7 +6312,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y4, 96(BP)
 +	VMOVDQA Y1, 128(BP)
 +	VMOVDQA Y2, 160(BP)
-
+ 
  	// Compute the number of iterations that will hash two blocks of data
 -	MOVQ    inl, tmpStoreAVX2
 -	MOVQ    inl, itr1
@@ -5622,7 +6376,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	LEAQ  16(BX), BX
-
+ 
  openAVX2Tail384LoopA:
 -	chachaQR_AVX2(AA0, BB0, CC0, DD0, TT0); chachaQR_AVX2(AA1, BB1, CC1, DD1, TT0); chachaQR_AVX2(AA2, BB2, CC2, DD2, TT0)
 -	VPALIGNR $4, BB0, BB0, BB0; VPALIGNR $4, BB1, BB1, BB1; VPALIGNR $4, BB2, BB2, BB2
@@ -5805,7 +6559,7 @@ index 731d2ac6..fd5ee845 100644
 +	SUBQ     SI, BX
 +	MOVQ     BX, CX
 +	MOVQ     224(BP), BX
-
+ 
  openAVX2Tail384Hash:
 -	ADDQ $16, itr1
 -	CMPQ itr1, inl
@@ -5915,7 +6669,7 @@ index 731d2ac6..fd5ee845 100644
 +	LEAQ       256(DI), DI
 +	SUBQ       $0x00000100, BX
  	JMP        openAVX2TailLoop
-
+ 
 -// ----------------------------------------------------------------------------
 -// Special optimization for the last 512 bytes of ciphertext
  openAVX2Tail512:
@@ -5949,7 +6703,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y3, 192(BP)
 +	XORQ    CX, CX
 +	MOVQ    SI, R9
-
+ 
  openAVX2Tail512LoopB:
 -	polyAdd(0(itr2))
 -	polyMulAVX2
@@ -5989,7 +6743,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	LEAQ  16(R9), R9
-
+ 
  openAVX2Tail512LoopA:
 -	VPADDD   BB0, AA0, AA0; VPADDD BB1, AA1, AA1; VPADDD BB2, AA2, AA2; VPADDD BB3, AA3, AA3
 -	VPXOR    AA0, DD0, DD0; VPXOR AA1, DD1, DD1; VPXOR AA2, DD2, DD2; VPXOR AA3, DD3, DD3
@@ -6292,7 +7046,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVQ     BX, CX
 +	SUBQ     $0x00000180, CX
 +	ANDQ     $-16, CX
-
+ 
  openAVX2Tail512HashLoop:
 -	TESTQ itr1, itr1
 +	TESTQ CX, CX
@@ -6338,7 +7092,7 @@ index 731d2ac6..fd5ee845 100644
 +	LEAQ  16(R9), R9
 +	SUBQ  $0x10, CX
  	JMP   openAVX2Tail512HashLoop
-
+ 
  openAVX2Tail512HashEnd:
 -	VPADDD     ·chacha20Constants<>(SB), AA0, AA0; VPADDD ·chacha20Constants<>(SB), AA1, AA1; VPADDD ·chacha20Constants<>(SB), AA2, AA2; VPADDD ·chacha20Constants<>(SB), AA3, AA3
 -	VPADDD     state1StoreAVX2, BB0, BB0; VPADDD state1StoreAVX2, BB1, BB1; VPADDD state1StoreAVX2, BB2, BB2; VPADDD state1StoreAVX2, BB3, BB3
@@ -6526,13 +7280,13 @@ index 731d2ac6..fd5ee845 100644
 +	MOVQ ad_base+72(FP), CX
 +	CMPB ·useAVX2+0(SB), $0x01
  	JE   chacha20Poly1305Seal_AVX2
-
+ 
  	// Special optimization, for very short buffers
 -	CMPQ inl, $128
 -	JBE  sealSSE128 // About 15% faster
 +	CMPQ BX, $0x80
 +	JBE  sealSSE128
-
+ 
  	// In the seal case - prepare the poly key + 3 blocks of stream in the first iteration
 -	MOVOU ·chacha20Constants<>(SB), A0
 -	MOVOU (1*16)(keyp), B0
@@ -6542,13 +7296,13 @@ index 731d2ac6..fd5ee845 100644
 +	MOVOU 16(R8), X3
 +	MOVOU 32(R8), X6
 +	MOVOU 48(R8), X9
-
+ 
  	// Store state on stack for future use
 -	MOVO B0, state1Store
 -	MOVO C0, state2Store
 +	MOVO X3, 32(BP)
 +	MOVO X6, 48(BP)
-
+ 
  	// Load state, increment counter blocks
 -	MOVO A0, A1; MOVO B0, B1; MOVO C0, C1; MOVO D0, D1; PADDL ·sseIncMask<>(SB), D1
 -	MOVO A1, A2; MOVO B1, B2; MOVO C1, C2; MOVO D1, D2; PADDL ·sseIncMask<>(SB), D2
@@ -6568,7 +7322,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO  X8, X14
 +	MOVO  X11, X15
 +	PADDL ·sseIncMask<>+0(SB), X15
-
+ 
  	// Store counters
 -	MOVO D0, ctr0Store; MOVO D1, ctr1Store; MOVO D2, ctr2Store; MOVO D3, ctr3Store
 -	MOVQ $10, itr2
@@ -6577,7 +7331,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO X11, 112(BP)
 +	MOVO X15, 128(BP)
 +	MOVQ $0x0000000a, R9
-
+ 
  sealSSEIntroLoop:
 -	MOVO         C3, tmpStore
 -	chachaQR(A0, B0, C0, D0, C3); chachaQR(A1, B1, C1, D1, C3); chachaQR(A2, B2, C2, D2, C3)
@@ -6912,7 +7666,7 @@ index 731d2ac6..fd5ee845 100644
 +	BYTE  $0x04
 +	DECQ  R9
 +	JNE   sealSSEIntroLoop
-
+ 
  	// Add in the state
 -	PADDD ·chacha20Constants<>(SB), A0; PADDD ·chacha20Constants<>(SB), A1; PADDD ·chacha20Constants<>(SB), A2; PADDD ·chacha20Constants<>(SB), A3
 -	PADDD state1Store, B0; PADDD state1Store, B1; PADDD state1Store, B2; PADDD state1Store, B3
@@ -6932,7 +7686,7 @@ index 731d2ac6..fd5ee845 100644
 +	PADDD 96(BP), X10
 +	PADDD 112(BP), X11
 +	PADDD 128(BP), X15
-
+ 
  	// Clamp and store the key
 -	PAND ·polyClampMask<>(SB), A0
 -	MOVO A0, rStore
@@ -6940,7 +7694,7 @@ index 731d2ac6..fd5ee845 100644
 +	PAND ·polyClampMask<>+0(SB), X0
 +	MOVO X0, (BP)
 +	MOVO X3, 16(BP)
-
+ 
  	// Hash AAD
 -	MOVQ ad_len+80(FP), itr2
 -	CALL polyHashADInternal<>(SB)
@@ -7036,7 +7790,7 @@ index 731d2ac6..fd5ee845 100644
 +	JBE   sealSSETail128
 +	CMPQ  BX, $0xc0
 +	JBE   sealSSETail192
-
+ 
  sealSSEMainLoop:
  	// Load state, increment counter blocks
 -	MOVO ·chacha20Constants<>(SB), A0; MOVO state1Store, B0; MOVO state2Store, C0; MOVO ctr3Store, D0; PADDL ·sseIncMask<>(SB), D0
@@ -7063,14 +7817,14 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO  X8, X14
 +	MOVO  X11, X15
 +	PADDL ·sseIncMask<>+0(SB), X15
-
+ 
  	// Store counters
 -	MOVO D0, ctr0Store; MOVO D1, ctr1Store; MOVO D2, ctr2Store; MOVO D3, ctr3Store
 +	MOVO X9, 80(BP)
 +	MOVO X10, 96(BP)
 +	MOVO X11, 112(BP)
 +	MOVO X15, 128(BP)
-
+ 
  sealSSEInnerLoop:
 -	MOVO          C3, tmpStore
 -	chachaQR(A0, B0, C0, D0, C3); chachaQR(A1, B1, C1, D1, C3); chachaQR(A2, B2, C2, D2, C3)
@@ -7501,7 +8255,7 @@ index 731d2ac6..fd5ee845 100644
 +	LEAQ  16(DI), DI
 +	DECQ  CX
 +	JG    sealSSEInnerLoop
-
+ 
  	// Add in the state
 -	PADDD ·chacha20Constants<>(SB), A0; PADDD ·chacha20Constants<>(SB), A1; PADDD ·chacha20Constants<>(SB), A2; PADDD ·chacha20Constants<>(SB), A3
 -	PADDD state1Store, B0; PADDD state1Store, B1; PADDD state1Store, B2; PADDD state1Store, B3
@@ -7525,7 +8279,7 @@ index 731d2ac6..fd5ee845 100644
 +	PADDD 112(BP), X11
 +	PADDD 128(BP), X15
 +	MOVO  X15, 64(BP)
-
+ 
  	// Load - xor - store
 -	MOVOU (0*16)(inp), D3; PXOR D3, A0
 -	MOVOU (1*16)(inp), D3; PXOR D3, B0
@@ -7638,7 +8392,7 @@ index 731d2ac6..fd5ee845 100644
 +	CMPQ  BX, $0x80
  	JBE   sealSSETail128
  	JMP   sealSSETail192
-
+ 
 -// ----------------------------------------------------------------------------
 -// Special optimization for the last 64 bytes of plaintext
  sealSSETail64:
@@ -7655,7 +8409,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO  128(BP), X10
 +	PADDL ·sseIncMask<>+0(SB), X10
 +	MOVO  X10, 80(BP)
-
+ 
  sealSSETail64LoopA:
 -	// Perform ChaCha rounds, while hashing the previously encrypted ciphertext
 -	polyAdd(0(oup))
@@ -7703,7 +8457,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	LEAQ  16(DI), DI
-
+ 
  sealSSETail64LoopB:
 -	chachaQR(A1, B1, C1, D1, T1)
 -	shiftB1Left;  shiftC1Left; shiftD1Left
@@ -7846,7 +8600,7 @@ index 731d2ac6..fd5ee845 100644
 +	PADDL 48(BP), X7
 +	PADDL 80(BP), X10
 +	JMP   sealSSE128Seal
-
+ 
 -	JMP sealSSE128Seal
 -
 -// ----------------------------------------------------------------------------
@@ -7867,7 +8621,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO  X9, X10
 +	PADDL ·sseIncMask<>+0(SB), X10
 +	MOVO  X10, 96(BP)
-
+ 
  sealSSETail128LoopA:
 -	// Perform ChaCha rounds, while hashing the previously encrypted ciphertext
 -	polyAdd(0(oup))
@@ -7915,7 +8669,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	LEAQ  16(DI), DI
-
+ 
  sealSSETail128LoopB:
 -	chachaQR(A0, B0, C0, D0, T0); chachaQR(A1, B1, C1, D1, T0)
 -	shiftB0Left;  shiftC0Left; shiftD0Left
@@ -8192,7 +8946,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO  X10, X11
 +	PADDL ·sseIncMask<>+0(SB), X11
 +	MOVO  X11, 112(BP)
-
+ 
  sealSSETail192LoopA:
 -	// Perform ChaCha rounds, while hashing the previously encrypted ciphertext
 -	polyAdd(0(oup))
@@ -8240,7 +8994,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	LEAQ  16(DI), DI
-
+ 
  sealSSETail192LoopB:
 -	chachaQR(A0, B0, C0, D0, T0); chachaQR(A1, B1, C1, D1, T0); chachaQR(A2, B2, C2, D2, T0)
 -	shiftB0Left; shiftC0Left; shiftD0Left
@@ -8626,7 +9380,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO  X6, X14
 +	MOVO  X10, X15
 +	MOVQ  $0x0000000a, R9
-
+ 
  sealSSE128InnerCipherLoop:
 -	chachaQR(A0, B0, C0, D0, T0); chachaQR(A1, B1, C1, D1, T0); chachaQR(A2, B2, C2, D2, T0)
 -	shiftB0Left;  shiftB1Left; shiftB2Left
@@ -8864,7 +9618,7 @@ index 731d2ac6..fd5ee845 100644
 +	BYTE  $0x04
 +	DECQ  R9
 +	JNE   sealSSE128InnerCipherLoop
-
+ 
  	// A0|B0 hold the Poly1305 32-byte key, C0,D0 can be discarded
 -	PADDL ·chacha20Constants<>(SB), A0; PADDL ·chacha20Constants<>(SB), A1; PADDL ·chacha20Constants<>(SB), A2
 -	PADDL T1, B0; PADDL T1, B1; PADDL T1, B2
@@ -8887,14 +9641,14 @@ index 731d2ac6..fd5ee845 100644
 +	PAND  ·polyClampMask<>+0(SB), X0
 +	MOVOU X0, (BP)
 +	MOVOU X3, 16(BP)
-
+ 
  	// Hash
 -	MOVQ ad_len+80(FP), itr2
 +	MOVQ ad_len+80(FP), R9
  	CALL polyHashADInternal<>(SB)
 -	XORQ itr1, itr1
 +	XORQ CX, CX
-
+ 
  sealSSE128SealHash:
 -	// itr1 holds the number of bytes encrypted but not yet hashed
 -	CMPQ itr1, $16
@@ -8952,14 +9706,14 @@ index 731d2ac6..fd5ee845 100644
 +	SUBQ  $0x10, CX
 +	ADDQ  $0x10, DI
 +	JMP   sealSSE128SealHash
-
+ 
  sealSSE128Seal:
 -	CMPQ inl, $16
 +	CMPQ BX, $0x10
  	JB   sealSSETail
 -	SUBQ $16, inl
 +	SUBQ $0x10, BX
-
+ 
  	// Load for decryption
 -	MOVOU (inp), T0
 -	PXOR  T0, A1
@@ -8971,7 +9725,7 @@ index 731d2ac6..fd5ee845 100644
 +	MOVOU X1, (DI)
 +	LEAQ  16(SI), SI
 +	LEAQ  16(DI), DI
-
+ 
  	// Extract for hashing
 -	MOVQ   A1, t0
 -	PSRLDQ $8, A1
@@ -9022,7 +9776,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ   R15, R10
 +	ADCQ   R8, R11
 +	ADCQ   $0x00, R12
-
+ 
  	// Shift the stream "left"
 -	MOVO B1, A1
 -	MOVO C1, B1
@@ -9039,12 +9793,12 @@ index 731d2ac6..fd5ee845 100644
 +	MOVO X8, X5
 +	MOVO X11, X8
  	JMP  sealSSE128Seal
-
+ 
  sealSSETail:
 -	TESTQ inl, inl
 +	TESTQ BX, BX
  	JE    sealSSEFinalize
-
+ 
  	// We can only load the PT one byte at a time to avoid read after end of buffer
 -	MOVQ inl, itr2
 -	SHLQ $4, itr2
@@ -9061,7 +9815,7 @@ index 731d2ac6..fd5ee845 100644
 +	XORQ R15, R15
 +	XORQ R8, R8
  	XORQ AX, AX
-
+ 
  sealSSETailLoadLoop:
 -	SHLQ $8, t2, t3
 -	SHLQ $8, t2
@@ -9140,7 +9894,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ   R8, R11
 +	ADCQ   $0x00, R12
 +	ADDQ   BX, DI
-
+ 
  sealSSEFinalize:
  	// Hash in the buffer lengths
 -	ADDQ ad_len+80(FP), acc0
@@ -9188,7 +9942,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ  R15, R10
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
-
+ 
  	// Final reduce
 -	MOVQ    acc0, t0
 -	MOVQ    acc1, t1
@@ -9208,20 +9962,20 @@ index 731d2ac6..fd5ee845 100644
 +	CMOVQCS R13, R10
 +	CMOVQCS R14, R11
 +	CMOVQCS R15, R12
-
+ 
  	// Add in the "s" part of the key
 -	ADDQ 0+sStore, acc0
 -	ADCQ 8+sStore, acc1
 +	ADDQ 16(BP), R10
 +	ADCQ 24(BP), R11
-
+ 
  	// Finally store the tag at the end of the message
 -	MOVQ acc0, (0*8)(oup)
 -	MOVQ acc1, (1*8)(oup)
 +	MOVQ R10, (DI)
 +	MOVQ R11, 8(DI)
  	RET
-
+ 
 -// ----------------------------------------------------------------------------
 -// ------------------------- AVX2 Code ----------------------------------------
  chacha20Poly1305Seal_AVX2:
@@ -9251,7 +10005,7 @@ index 731d2ac6..fd5ee845 100644
 +	BYTE    $0x60
 +	BYTE    $0x30
 +	VPADDD  ·avx2InitMask<>+0(SB), Y4, Y4
-
+ 
  	// Special optimizations, for very short buffers
 -	CMPQ inl, $192
 -	JBE  seal192AVX2 // 33% faster
@@ -9261,7 +10015,7 @@ index 731d2ac6..fd5ee845 100644
 +	JBE  seal192AVX2
 +	CMPQ BX, $0x00000140
 +	JBE  seal320AVX2
-
+ 
  	// For the general key prepare the key first - as a byproduct we have 64 bytes of cipher stream
 -	VMOVDQA AA0, AA1; VMOVDQA AA0, AA2; VMOVDQA AA0, AA3
 -	VMOVDQA BB0, BB1; VMOVDQA BB0, BB2; VMOVDQA BB0, BB3; VMOVDQA BB0, state1StoreAVX2
@@ -9290,7 +10044,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y2, 160(BP)
 +	VMOVDQA Y3, 192(BP)
 +	MOVQ    $0x0000000a, R9
-
+ 
  sealAVX2IntroLoop:
 -	VMOVDQA CC3, tmpStoreAVX2
 -	chachaQR_AVX2(AA0, BB0, CC0, DD0, CC3); chachaQR_AVX2(AA1, BB1, CC1, DD1, CC3); chachaQR_AVX2(AA2, BB2, CC2, DD2, CC3)
@@ -9507,18 +10261,18 @@ index 731d2ac6..fd5ee845 100644
 +	VPERM2I128 $0x13, Y12, Y4, Y12
 +	VPERM2I128 $0x02, Y0, Y14, Y4
 +	VPERM2I128 $0x13, Y0, Y14, Y0
-
+ 
  	// Clamp and store poly key
 -	VPAND   ·polyClampMask<>(SB), DD0, DD0
 -	VMOVDQA DD0, rsStoreAVX2
 +	VPAND   ·polyClampMask<>+0(SB), Y4, Y4
 +	VMOVDQA Y4, (BP)
-
+ 
  	// Hash AD
 -	MOVQ ad_len+80(FP), itr2
 +	MOVQ ad_len+80(FP), R9
  	CALL polyHashADInternal<>(SB)
-
+ 
  	// Can store at least 320 bytes
 -	VPXOR   (0*32)(inp), AA0, AA0
 -	VPXOR   (1*32)(inp), CC0, CC0
@@ -9612,7 +10366,7 @@ index 731d2ac6..fd5ee845 100644
 +	JBE        sealAVX2Tail384
 +	CMPQ       BX, $0x00000200
 +	JBE        sealAVX2Tail512
-
+ 
  	// We have 448 bytes to hash, but main loop hashes 512 bytes at a time - perform some rounds, before the main loop
 -	VMOVDQA ·chacha20Constants<>(SB), AA0; VMOVDQA AA0, AA1; VMOVDQA AA0, AA2; VMOVDQA AA0, AA3
 -	VMOVDQA state1StoreAVX2, BB0; VMOVDQA BB0, BB1; VMOVDQA BB0, BB2; VMOVDQA BB0, BB3
@@ -9877,7 +10631,7 @@ index 731d2ac6..fd5ee845 100644
 +	SUBQ     $0x10, DI
 +	MOVQ     $0x00000009, CX
 +	JMP      sealAVX2InternalLoopStart
-
+ 
  sealAVX2MainLoop:
 -	// Load state, increment counter blocks, store the incremented counters
 -	VMOVDQU ·chacha20Constants<>(SB), AA0; VMOVDQA AA0, AA1; VMOVDQA AA0, AA2; VMOVDQA AA0, AA3
@@ -9908,7 +10662,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y2, 160(BP)
 +	VMOVDQA Y3, 192(BP)
 +	MOVQ    $0x0000000a, CX
-
+ 
  sealAVX2InternalLoop:
 -	polyAdd(0*8(oup))
 -	VPADDD  BB0, AA0, AA0; VPADDD BB1, AA1, AA1; VPADDD BB2, AA2, AA2; VPADDD BB3, AA3, AA3
@@ -9994,7 +10748,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADDQ    R15, R10
 +	ADCQ    R8, R11
 +	ADCQ    $0x00, R12
-
+ 
  sealAVX2InternalLoopStart:
 -	VPADDD   BB0, AA0, AA0; VPADDD BB1, AA1, AA1; VPADDD BB2, AA2, AA2; VPADDD BB3, AA3, AA3
 -	VPXOR    AA0, DD0, DD0; VPXOR AA1, DD1, DD1; VPXOR AA2, DD2, DD2; VPXOR AA3, DD3, DD3
@@ -10267,7 +11021,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPADDD   160(BP), Y2, Y2
 +	VPADDD   192(BP), Y3, Y3
 +	VMOVDQA  Y15, 224(BP)
-
+ 
  	// We only hashed 480 of the 512 bytes available - hash the remaining 32 here
 -	polyAdd(0*8(oup))
 -	polyMulAVX2
@@ -10337,7 +11091,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQU    Y14, 160(DI)
 +	VMOVDQU    Y12, 192(DI)
 +	VMOVDQU    Y4, 224(DI)
-
+ 
  	// and here
 -	polyAdd(-2*8(oup))
 -	polyMulAVX2
@@ -10412,7 +11166,7 @@ index 731d2ac6..fd5ee845 100644
 +	SUBQ       $0x00000200, BX
 +	CMPQ       BX, $0x00000200
  	JG         sealAVX2MainLoop
-
+ 
  	// Tail can only hash 480 bytes
 -	polyAdd(0*8(oup))
 -	polyMulAVX2
@@ -10533,7 +11287,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y4, Y2
 +	VMOVDQA Y1, Y15
 +	MOVQ    $0x0000000a, R9
-
+ 
  sealAVX2192InnerCipherLoop:
 -	chachaQR_AVX2(AA0, BB0, CC0, DD0, TT0); chachaQR_AVX2(AA1, BB1, CC1, DD1, TT0)
 -	VPALIGNR   $4, BB0, BB0, BB0; VPALIGNR $4, BB1, BB1, BB1
@@ -10636,13 +11390,13 @@ index 731d2ac6..fd5ee845 100644
 +	VPADDD     Y2, Y4, Y4
 +	VPADDD     Y15, Y1, Y1
 +	VPERM2I128 $0x02, Y0, Y14, Y3
-
+ 
  	// Clamp and store poly key
 -	VPAND   ·polyClampMask<>(SB), TT0, TT0
 -	VMOVDQA TT0, rsStoreAVX2
 +	VPAND   ·polyClampMask<>+0(SB), Y3, Y3
 +	VMOVDQA Y3, (BP)
-
+ 
  	// Stream for up to 192 bytes
 -	VPERM2I128 $0x13, AA0, BB0, AA0
 -	VPERM2I128 $0x13, CC0, DD0, BB0
@@ -10656,7 +11410,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPERM2I128 $0x02, Y13, Y1, Y4
 +	VPERM2I128 $0x13, Y5, Y9, Y5
 +	VPERM2I128 $0x13, Y13, Y1, Y9
-
+ 
  sealAVX2ShortSeal:
  	// Hash aad
 -	MOVQ ad_len+80(FP), itr2
@@ -10664,7 +11418,7 @@ index 731d2ac6..fd5ee845 100644
  	CALL polyHashADInternal<>(SB)
 -	XORQ itr1, itr1
 +	XORQ CX, CX
-
+ 
  sealAVX2SealHash:
  	// itr1 holds the number of bytes encrypted but not yet hashed
 -	CMPQ itr1, $16
@@ -10720,14 +11474,14 @@ index 731d2ac6..fd5ee845 100644
 +	SUBQ  $0x10, CX
 +	ADDQ  $0x10, DI
 +	JMP   sealAVX2SealHash
-
+ 
  sealAVX2ShortSealLoop:
 -	CMPQ inl, $32
 +	CMPQ BX, $0x20
  	JB   sealAVX2ShortTail32
 -	SUBQ $32, inl
 +	SUBQ $0x20, BX
-
+ 
  	// Load for encryption
 -	VPXOR   (inp), AA0, AA0
 -	VMOVDQU AA0, (oup)
@@ -10735,7 +11489,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPXOR   (SI), Y0, Y0
 +	VMOVDQU Y0, (DI)
 +	LEAQ    32(SI), SI
-
+ 
  	// Now can hash
 -	polyAdd(0*8(oup))
 -	polyMulAVX2
@@ -10811,7 +11565,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	LEAQ  32(DI), DI
-
+ 
  	// Shift stream left
 -	VMOVDQA BB0, AA0
 -	VMOVDQA CC0, BB0
@@ -10832,7 +11586,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y6, Y1
 +	VMOVDQA Y10, Y6
  	JMP     sealAVX2ShortSealLoop
-
+ 
  sealAVX2ShortTail32:
 -	CMPQ    inl, $16
 -	VMOVDQA A0, A1
@@ -10842,7 +11596,7 @@ index 731d2ac6..fd5ee845 100644
 -
 -	SUBQ $16, inl
 +	SUBQ    $0x10, BX
-
+ 
  	// Load for encryption
 -	VPXOR   (inp), A0, T0
 -	VMOVDQU T0, (oup)
@@ -10850,7 +11604,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPXOR   (SI), X0, X12
 +	VMOVDQU X12, (DI)
 +	LEAQ    16(SI), SI
-
+ 
  	// Hash
 -	polyAdd(0*8(oup))
 -	polyMulAVX2
@@ -10894,11 +11648,11 @@ index 731d2ac6..fd5ee845 100644
 +	LEAQ       16(DI), DI
 +	VPERM2I128 $0x11, Y0, Y0, Y0
 +	VMOVDQA    X0, X1
-
+ 
  sealAVX2ShortDone:
  	VZEROUPPER
  	JMP sealSSETail
-
+ 
 -// ----------------------------------------------------------------------------
 -// Special optimization for buffers smaller than 321 bytes
  seal320AVX2:
@@ -10919,7 +11673,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y12, Y11
 +	VMOVDQA Y4, Y15
 +	MOVQ    $0x0000000a, R9
-
+ 
  sealAVX2320InnerCipherLoop:
 -	chachaQR_AVX2(AA0, BB0, CC0, DD0, TT0); chachaQR_AVX2(AA1, BB1, CC1, DD1, TT0); chachaQR_AVX2(AA2, BB2, CC2, DD2, TT0)
 -	VPALIGNR $4, BB0, BB0, BB0; VPALIGNR $4, BB1, BB1, BB1; VPALIGNR $4, BB2, BB2, BB2
@@ -11071,7 +11825,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPADDD   Y15, Y1, Y1
 +	VPADDD   Y3, Y15, Y15
 +	VPADDD   Y15, Y2, Y2
-
+ 
  	// Clamp and store poly key
 -	VPERM2I128 $0x02, AA0, BB0, TT0
 -	VPAND      ·polyClampMask<>(SB), TT0, TT0
@@ -11079,7 +11833,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPERM2I128 $0x02, Y0, Y14, Y3
 +	VPAND      ·polyClampMask<>+0(SB), Y3, Y3
 +	VMOVDQA    Y3, (BP)
-
+ 
  	// Stream for up to 320 bytes
 -	VPERM2I128 $0x13, AA0, BB0, AA0
 -	VPERM2I128 $0x13, CC0, DD0, BB0
@@ -11102,7 +11856,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPERM2I128 $0x13, Y6, Y10, Y6
 +	VPERM2I128 $0x13, Y8, Y2, Y10
  	JMP        sealAVX2ShortSeal
-
+ 
 -// ----------------------------------------------------------------------------
 -// Special optimization for the last 128 bytes of ciphertext
  sealAVX2Tail128:
@@ -11121,7 +11875,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA 192(BP), Y4
 +	VPADDD  ·avx2IncMask<>+0(SB), Y4, Y4
 +	VMOVDQA Y4, Y1
-
+ 
  sealAVX2Tail128LoopA:
 -	polyAdd(0(oup))
 -	polyMul
@@ -11168,7 +11922,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	LEAQ  16(DI), DI
-
+ 
  sealAVX2Tail128LoopB:
 -	chachaQR_AVX2(AA0, BB0, CC0, DD0, TT0)
 -	polyAdd(0(oup))
@@ -11331,7 +12085,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPERM2I128 $0x13, Y5, Y9, Y12
 +	VPERM2I128 $0x13, Y13, Y1, Y4
  	JMP        sealAVX2ShortSealLoop
-
+ 
 -// ----------------------------------------------------------------------------
 -// Special optimization for the last 256 bytes of ciphertext
  sealAVX2Tail256:
@@ -11357,7 +12111,7 @@ index 731d2ac6..fd5ee845 100644
 +	VPADDD  ·avx2IncMask<>+0(SB), Y4, Y1
 +	VMOVDQA Y4, Y7
 +	VMOVDQA Y1, Y11
-
+ 
  sealAVX2Tail256LoopA:
 -	polyAdd(0(oup))
 -	polyMul
@@ -11404,7 +12158,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	LEAQ  16(DI), DI
-
+ 
  sealAVX2Tail256LoopB:
 -	chachaQR_AVX2(AA0, BB0, CC0, DD0, TT0); chachaQR_AVX2(AA1, BB1, CC1, DD1, TT0)
 -	polyAdd(0(oup))
@@ -11664,7 +12418,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y4, Y7
 +	VMOVDQA Y1, Y11
 +	VMOVDQA Y2, Y15
-
+ 
  sealAVX2Tail384LoopA:
 -	polyAdd(0(oup))
 -	polyMul
@@ -11711,7 +12465,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	LEAQ  16(DI), DI
-
+ 
  sealAVX2Tail384LoopB:
 -	chachaQR_AVX2(AA0, BB0, CC0, DD0, TT0); chachaQR_AVX2(AA1, BB1, CC1, DD1, TT0); chachaQR_AVX2(AA2, BB2, CC2, DD2, TT0)
 -	polyAdd(0(oup))
@@ -12036,7 +12790,7 @@ index 731d2ac6..fd5ee845 100644
 +	VMOVDQA Y1, 128(BP)
 +	VMOVDQA Y2, 160(BP)
 +	VMOVDQA Y3, 192(BP)
-
+ 
  sealAVX2Tail512LoopA:
 -	polyAdd(0(oup))
 -	polyMul
@@ -12083,7 +12837,7 @@ index 731d2ac6..fd5ee845 100644
 +	ADCQ  R8, R11
 +	ADCQ  $0x00, R12
 +	LEAQ  16(DI), DI
-
+ 
  sealAVX2Tail512LoopB:
 -	VPADDD   BB0, AA0, AA0; VPADDD BB1, AA1, AA1; VPADDD BB2, AA2, AA2; VPADDD BB3, AA3, AA3
 -	VPXOR    AA0, DD0, DD0; VPXOR AA1, DD1, DD1; VPXOR AA2, DD2, DD2; VPXOR AA3, DD3, DD3
@@ -12488,12 +13242,12 @@ index 333da285..bd896bdc 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build (!amd64 && !ppc64le && !s390x) || !gc || purego
 +//go:build (!amd64 && !ppc64le && !ppc64 && !s390x) || !gc || purego
-
+ 
  package poly1305
-
+ 
 diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_amd64.s b/vendor/golang.org/x/crypto/internal/poly1305/sum_amd64.s
 index e0d3c647..13375738 100644
 --- a/vendor/golang.org/x/crypto/internal/poly1305/sum_amd64.s
@@ -12503,9 +13257,9 @@ index e0d3c647..13375738 100644
 -// Use of this source code is governed by a BSD-style
 -// license that can be found in the LICENSE file.
 +// Code generated by command: go run sum_amd64_asm.go -out ../sum_amd64.s -pkg poly1305. DO NOT EDIT.
-
+ 
  //go:build gc && !purego
-
+ 
 -#include "textflag.h"
 -
 -#define POLY1305_ADD(msg, h0, h1, h2) \
@@ -12577,14 +13331,14 @@ index e0d3c647..13375738 100644
 +	MOVQ 32(DI), R12
 +	CMPQ R15, $0x10
  	JB   bytes_between_0_and_15
-
+ 
  loop:
 -	POLY1305_ADD(SI, R8, R9, R10)
 +	ADDQ (SI), R8
 +	ADCQ 8(SI), R9
 +	ADCQ $0x01, R10
 +	LEAQ 16(SI), SI
-
+ 
  multiply:
 -	POLY1305_MUL(R8, R9, R10, R11, R12, BX, CX, R13, R14)
 -	SUBQ $16, R15
@@ -12631,7 +13385,7 @@ index e0d3c647..13375738 100644
 +	SUBQ  $0x10, R15
 +	CMPQ  R15, $0x10
 +	JAE   loop
-
+ 
  bytes_between_0_and_15:
  	TESTQ R15, R15
  	JZ    done
@@ -12640,7 +13394,7 @@ index e0d3c647..13375738 100644
  	XORQ  CX, CX
  	XORQ  R13, R13
  	ADDQ  R15, SI
-
+ 
  flush_buffer:
 -	SHLQ $8, BX, CX
 -	SHLQ $8, BX
@@ -12659,121 +13413,251 @@ index e0d3c647..13375738 100644
 +	ADCQ $0x00, R10
 +	MOVQ $0x00000010, R15
  	JMP  multiply
-
+ 
  done:
 -	MOVQ R8, 0(DI)
 +	MOVQ R8, (DI)
  	MOVQ R9, 8(DI)
  	MOVQ R10, 16(DI)
  	RET
-diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.go b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64x.go
-similarity index 95%
-rename from vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.go
-rename to vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64x.go
-index 4aec4874..1a1679aa 100644
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.go b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.go
+deleted file mode 100644
+index 4aec4874..00000000
 --- a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.go
-+++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64x.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
-
++++ /dev/null
+@@ -1,47 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
 -//go:build gc && !purego
-+//go:build gc && !purego && (ppc64 || ppc64le)
-
- package poly1305
-
-diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64x.s
-similarity index 89%
-rename from vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
-rename to vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64x.s
-index b3c1699b..6899a1da 100644
+-
+-package poly1305
+-
+-//go:noescape
+-func update(state *macState, msg []byte)
+-
+-// mac is a wrapper for macGeneric that redirects calls that would have gone to
+-// updateGeneric to update.
+-//
+-// Its Write and Sum methods are otherwise identical to the macGeneric ones, but
+-// using function pointers would carry a major performance cost.
+-type mac struct{ macGeneric }
+-
+-func (h *mac) Write(p []byte) (int, error) {
+-	nn := len(p)
+-	if h.offset > 0 {
+-		n := copy(h.buffer[h.offset:], p)
+-		if h.offset+n < TagSize {
+-			h.offset += n
+-			return nn, nil
+-		}
+-		p = p[n:]
+-		h.offset = 0
+-		update(&h.macState, h.buffer[:])
+-	}
+-	if n := len(p) - (len(p) % TagSize); n > 0 {
+-		update(&h.macState, p[:n])
+-		p = p[n:]
+-	}
+-	if len(p) > 0 {
+-		h.offset += copy(h.buffer[h.offset:], p)
+-	}
+-	return nn, nil
+-}
+-
+-func (h *mac) Sum(out *[16]byte) {
+-	state := h.macState
+-	if h.offset > 0 {
+-		update(&state, h.buffer[:h.offset])
+-	}
+-	finalize(out, &state.h, &state.s)
+-}
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+deleted file mode 100644
+index b3c1699b..00000000
 --- a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
-+++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64x.s
-@@ -2,15 +2,25 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
-
++++ /dev/null
+@@ -1,179 +0,0 @@
+-// Copyright 2019 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
 -//go:build gc && !purego
-+//go:build gc && !purego && (ppc64 || ppc64le)
-
- #include "textflag.h"
-
- // This was ported from the amd64 implementation.
-
-+#ifdef GOARCH_ppc64le
-+#define LE_MOVD MOVD
-+#define LE_MOVWZ MOVWZ
-+#define LE_MOVHZ MOVHZ
-+#else
-+#define LE_MOVD MOVDBR
-+#define LE_MOVWZ MOVWBR
-+#define LE_MOVHZ MOVHBR
-+#endif
-+
- #define POLY1305_ADD(msg, h0, h1, h2, t0, t1, t2) \
+-
+-#include "textflag.h"
+-
+-// This was ported from the amd64 implementation.
+-
+-#define POLY1305_ADD(msg, h0, h1, h2, t0, t1, t2) \
 -	MOVD (msg), t0;  \
 -	MOVD 8(msg), t1; \
-+	LE_MOVD (msg)( R0), t0; \
-+	LE_MOVD (msg)(R24), t1; \
- 	MOVD $1, t2;     \
- 	ADDC t0, h0, h0; \
- 	ADDE t1, h1, h1; \
-@@ -50,10 +60,6 @@
- 	ADDE   t3, h1, h1;  \
- 	ADDZE  h2
-
+-	MOVD $1, t2;     \
+-	ADDC t0, h0, h0; \
+-	ADDE t1, h1, h1; \
+-	ADDE t2, h2;     \
+-	ADD  $16, msg
+-
+-#define POLY1305_MUL(h0, h1, h2, r0, r1, t0, t1, t2, t3, t4, t5) \
+-	MULLD  r0, h0, t0;  \
+-	MULHDU r0, h0, t1;  \
+-	MULLD  r0, h1, t4;  \
+-	MULHDU r0, h1, t5;  \
+-	ADDC   t4, t1, t1;  \
+-	MULLD  r0, h2, t2;  \
+-	MULHDU r1, h0, t4;  \
+-	MULLD  r1, h0, h0;  \
+-	ADDE   t5, t2, t2;  \
+-	ADDC   h0, t1, t1;  \
+-	MULLD  h2, r1, t3;  \
+-	ADDZE  t4, h0;      \
+-	MULHDU r1, h1, t5;  \
+-	MULLD  r1, h1, t4;  \
+-	ADDC   t4, t2, t2;  \
+-	ADDE   t5, t3, t3;  \
+-	ADDC   h0, t2, t2;  \
+-	MOVD   $-4, t4;     \
+-	ADDZE  t3;          \
+-	RLDICL $0, t2, $62, h2; \
+-	AND    t2, t4, h0;  \
+-	ADDC   t0, h0, h0;  \
+-	ADDE   t3, t1, h1;  \
+-	SLD    $62, t3, t4; \
+-	SRD    $2, t2;      \
+-	ADDZE  h2;          \
+-	OR     t4, t2, t2;  \
+-	SRD    $2, t3;      \
+-	ADDC   t2, h0, h0;  \
+-	ADDE   t3, h1, h1;  \
+-	ADDZE  h2
+-
 -DATA ·poly1305Mask<>+0x00(SB)/8, $0x0FFFFFFC0FFFFFFF
 -DATA ·poly1305Mask<>+0x08(SB)/8, $0x0FFFFFFC0FFFFFFC
 -GLOBL ·poly1305Mask<>(SB), RODATA, $16
 -
- // func update(state *[7]uint64, msg []byte)
- TEXT ·update(SB), $0-32
- 	MOVD state+0(FP), R3
-@@ -66,6 +72,8 @@ TEXT ·update(SB), $0-32
- 	MOVD 24(R3), R11 // r0
- 	MOVD 32(R3), R12 // r1
-
-+	MOVD $8, R24
-+
- 	CMP R5, $16
- 	BLT bytes_between_0_and_15
-
-@@ -94,7 +102,7 @@ flush_buffer:
-
- 	// Greater than 8 -- load the rightmost remaining bytes in msg
- 	// and put into R17 (h1)
+-// func update(state *[7]uint64, msg []byte)
+-TEXT ·update(SB), $0-32
+-	MOVD state+0(FP), R3
+-	MOVD msg_base+8(FP), R4
+-	MOVD msg_len+16(FP), R5
+-
+-	MOVD 0(R3), R8   // h0
+-	MOVD 8(R3), R9   // h1
+-	MOVD 16(R3), R10 // h2
+-	MOVD 24(R3), R11 // r0
+-	MOVD 32(R3), R12 // r1
+-
+-	CMP R5, $16
+-	BLT bytes_between_0_and_15
+-
+-loop:
+-	POLY1305_ADD(R4, R8, R9, R10, R20, R21, R22)
+-
+-	PCALIGN $16
+-multiply:
+-	POLY1305_MUL(R8, R9, R10, R11, R12, R16, R17, R18, R14, R20, R21)
+-	ADD $-16, R5
+-	CMP R5, $16
+-	BGE loop
+-
+-bytes_between_0_and_15:
+-	CMP  R5, $0
+-	BEQ  done
+-	MOVD $0, R16 // h0
+-	MOVD $0, R17 // h1
+-
+-flush_buffer:
+-	CMP R5, $8
+-	BLE just1
+-
+-	MOVD $8, R21
+-	SUB  R21, R5, R21
+-
+-	// Greater than 8 -- load the rightmost remaining bytes in msg
+-	// and put into R17 (h1)
 -	MOVD (R4)(R21), R17
-+	LE_MOVD (R4)(R21), R17
- 	MOVD $16, R22
-
- 	// Find the offset to those bytes
-@@ -118,7 +126,7 @@ just1:
- 	BLT less8
-
- 	// Exactly 8
+-	MOVD $16, R22
+-
+-	// Find the offset to those bytes
+-	SUB R5, R22, R22
+-	SLD $3, R22
+-
+-	// Shift to get only the bytes in msg
+-	SRD R22, R17, R17
+-
+-	// Put 1 at high end
+-	MOVD $1, R23
+-	SLD  $3, R21
+-	SLD  R21, R23, R23
+-	OR   R23, R17, R17
+-
+-	// Remainder is 8
+-	MOVD $8, R5
+-
+-just1:
+-	CMP R5, $8
+-	BLT less8
+-
+-	// Exactly 8
 -	MOVD (R4), R16
-+	LE_MOVD (R4), R16
-
- 	CMP R17, $0
-
-@@ -133,7 +141,7 @@ less8:
- 	MOVD  $0, R22   // shift count
- 	CMP   R5, $4
- 	BLT   less4
+-
+-	CMP R17, $0
+-
+-	// Check if we've already set R17; if not
+-	// set 1 to indicate end of msg.
+-	BNE  carry
+-	MOVD $1, R17
+-	BR   carry
+-
+-less8:
+-	MOVD  $0, R16   // h0
+-	MOVD  $0, R22   // shift count
+-	CMP   R5, $4
+-	BLT   less4
 -	MOVWZ (R4), R16
-+	LE_MOVWZ (R4), R16
- 	ADD   $4, R4
- 	ADD   $-4, R5
- 	MOVD  $32, R22
-@@ -141,7 +149,7 @@ less8:
- less4:
- 	CMP   R5, $2
- 	BLT   less2
+-	ADD   $4, R4
+-	ADD   $-4, R5
+-	MOVD  $32, R22
+-
+-less4:
+-	CMP   R5, $2
+-	BLT   less2
 -	MOVHZ (R4), R21
-+	LE_MOVHZ (R4), R21
- 	SLD   R22, R21, R21
- 	OR    R16, R21, R16
- 	ADD   $16, R22
+-	SLD   R22, R21, R21
+-	OR    R16, R21, R16
+-	ADD   $16, R22
+-	ADD   $-2, R5
+-	ADD   $2, R4
+-
+-less2:
+-	CMP   R5, $0
+-	BEQ   insert1
+-	MOVBZ (R4), R21
+-	SLD   R22, R21, R21
+-	OR    R16, R21, R16
+-	ADD   $8, R22
+-
+-insert1:
+-	// Insert 1 at end of msg
+-	MOVD $1, R21
+-	SLD  R22, R21, R21
+-	OR   R16, R21, R16
+-
+-carry:
+-	// Add new values to h0, h1, h2
+-	ADDC  R16, R8
+-	ADDE  R17, R9
+-	ADDZE R10, R10
+-	MOVD  $16, R5
+-	ADD   R5, R4
+-	BR    multiply
+-
+-done:
+-	// Save h0, h1, h2 in state
+-	MOVD R8, 0(R3)
+-	MOVD R9, 8(R3)
+-	MOVD R10, 16(R3)
+-	RET
 diff --git a/vendor/golang.org/x/net/LICENSE b/vendor/golang.org/x/net/LICENSE
 index 6a66aea5..2a7cf70d 100644
 --- a/vendor/golang.org/x/net/LICENSE
@@ -12781,7 +13665,7 @@ index 6a66aea5..2a7cf70d 100644
 @@ -1,4 +1,4 @@
 -Copyright (c) 2009 The Go Authors. All rights reserved.
 +Copyright 2009 The Go Authors.
-
+ 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are
 @@ -10,7 +10,7 @@ notice, this list of conditions and the following disclaimer.
@@ -12792,13 +13676,13 @@ index 6a66aea5..2a7cf70d 100644
 +   * Neither the name of Google LLC nor the names of its
  contributors may be used to endorse or promote products derived from
  this software without specific prior written permission.
-
+ 
 diff --git a/vendor/golang.org/x/net/http2/client_conn_pool.go b/vendor/golang.org/x/net/http2/client_conn_pool.go
 index 780968d6..e81b73e6 100644
 --- a/vendor/golang.org/x/net/http2/client_conn_pool.go
 +++ b/vendor/golang.org/x/net/http2/client_conn_pool.go
 @@ -8,8 +8,8 @@ package http2
-
+ 
  import (
  	"context"
 -	"crypto/tls"
@@ -12819,231 +13703,14 @@ index 780968d6..e81b73e6 100644
 @@ -194,8 +194,8 @@ type addConnCall struct {
  	err  error
  }
-
+ 
 -func (c *addConnCall) run(t *Transport, key string, tc *tls.Conn) {
 -	cc, err := t.NewClientConn(tc)
 +func (c *addConnCall) run(t *Transport, key string, nc net.Conn) {
 +	cc, err := t.NewClientConn(nc)
-
+ 
  	p := c.p
  	p.mu.Lock()
-diff --git a/vendor/golang.org/x/net/http2/config.go b/vendor/golang.org/x/net/http2/config.go
-new file mode 100644
-index 00000000..de58dfb8
---- /dev/null
-+++ b/vendor/golang.org/x/net/http2/config.go
-@@ -0,0 +1,122 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+package http2
-+
-+import (
-+	"math"
-+	"net/http"
-+	"time"
-+)
-+
-+// http2Config is a package-internal version of net/http.HTTP2Config.
-+//
-+// http.HTTP2Config was added in Go 1.24.
-+// When running with a version of net/http that includes HTTP2Config,
-+// we merge the configuration with the fields in Transport or Server
-+// to produce an http2Config.
-+//
-+// Zero valued fields in http2Config are interpreted as in the
-+// net/http.HTTPConfig documentation.
-+//
-+// Precedence order for reconciling configurations is:
-+//
-+//   - Use the net/http.{Server,Transport}.HTTP2Config value, when non-zero.
-+//   - Otherwise use the http2.{Server.Transport} value.
-+//   - If the resulting value is zero or out of range, use a default.
-+type http2Config struct {
-+	MaxConcurrentStreams         uint32
-+	MaxDecoderHeaderTableSize    uint32
-+	MaxEncoderHeaderTableSize    uint32
-+	MaxReadFrameSize             uint32
-+	MaxUploadBufferPerConnection int32
-+	MaxUploadBufferPerStream     int32
-+	SendPingTimeout              time.Duration
-+	PingTimeout                  time.Duration
-+	WriteByteTimeout             time.Duration
-+	PermitProhibitedCipherSuites bool
-+	CountError                   func(errType string)
-+}
-+
-+// configFromServer merges configuration settings from
-+// net/http.Server.HTTP2Config and http2.Server.
-+func configFromServer(h1 *http.Server, h2 *Server) http2Config {
-+	conf := http2Config{
-+		MaxConcurrentStreams:         h2.MaxConcurrentStreams,
-+		MaxEncoderHeaderTableSize:    h2.MaxEncoderHeaderTableSize,
-+		MaxDecoderHeaderTableSize:    h2.MaxDecoderHeaderTableSize,
-+		MaxReadFrameSize:             h2.MaxReadFrameSize,
-+		MaxUploadBufferPerConnection: h2.MaxUploadBufferPerConnection,
-+		MaxUploadBufferPerStream:     h2.MaxUploadBufferPerStream,
-+		SendPingTimeout:              h2.ReadIdleTimeout,
-+		PingTimeout:                  h2.PingTimeout,
-+		WriteByteTimeout:             h2.WriteByteTimeout,
-+		PermitProhibitedCipherSuites: h2.PermitProhibitedCipherSuites,
-+		CountError:                   h2.CountError,
-+	}
-+	fillNetHTTPServerConfig(&conf, h1)
-+	setConfigDefaults(&conf, true)
-+	return conf
-+}
-+
-+// configFromServer merges configuration settings from h2 and h2.t1.HTTP2
-+// (the net/http Transport).
-+func configFromTransport(h2 *Transport) http2Config {
-+	conf := http2Config{
-+		MaxEncoderHeaderTableSize: h2.MaxEncoderHeaderTableSize,
-+		MaxDecoderHeaderTableSize: h2.MaxDecoderHeaderTableSize,
-+		MaxReadFrameSize:          h2.MaxReadFrameSize,
-+		SendPingTimeout:           h2.ReadIdleTimeout,
-+		PingTimeout:               h2.PingTimeout,
-+		WriteByteTimeout:          h2.WriteByteTimeout,
-+	}
-+
-+	// Unlike most config fields, where out-of-range values revert to the default,
-+	// Transport.MaxReadFrameSize clips.
-+	if conf.MaxReadFrameSize < minMaxFrameSize {
-+		conf.MaxReadFrameSize = minMaxFrameSize
-+	} else if conf.MaxReadFrameSize > maxFrameSize {
-+		conf.MaxReadFrameSize = maxFrameSize
-+	}
-+
-+	if h2.t1 != nil {
-+		fillNetHTTPTransportConfig(&conf, h2.t1)
-+	}
-+	setConfigDefaults(&conf, false)
-+	return conf
-+}
-+
-+func setDefault[T ~int | ~int32 | ~uint32 | ~int64](v *T, minval, maxval, defval T) {
-+	if *v < minval || *v > maxval {
-+		*v = defval
-+	}
-+}
-+
-+func setConfigDefaults(conf *http2Config, server bool) {
-+	setDefault(&conf.MaxConcurrentStreams, 1, math.MaxUint32, defaultMaxStreams)
-+	setDefault(&conf.MaxEncoderHeaderTableSize, 1, math.MaxUint32, initialHeaderTableSize)
-+	setDefault(&conf.MaxDecoderHeaderTableSize, 1, math.MaxUint32, initialHeaderTableSize)
-+	if server {
-+		setDefault(&conf.MaxUploadBufferPerConnection, initialWindowSize, math.MaxInt32, 1<<20)
-+	} else {
-+		setDefault(&conf.MaxUploadBufferPerConnection, initialWindowSize, math.MaxInt32, transportDefaultConnFlow)
-+	}
-+	if server {
-+		setDefault(&conf.MaxUploadBufferPerStream, 1, math.MaxInt32, 1<<20)
-+	} else {
-+		setDefault(&conf.MaxUploadBufferPerStream, 1, math.MaxInt32, transportDefaultStreamFlow)
-+	}
-+	setDefault(&conf.MaxReadFrameSize, minMaxFrameSize, maxFrameSize, defaultMaxReadFrameSize)
-+	setDefault(&conf.PingTimeout, 1, math.MaxInt64, 15*time.Second)
-+}
-+
-+// adjustHTTP1MaxHeaderSize converts a limit in bytes on the size of an HTTP/1 header
-+// to an HTTP/2 MAX_HEADER_LIST_SIZE value.
-+func adjustHTTP1MaxHeaderSize(n int64) int64 {
-+	// http2's count is in a slightly different unit and includes 32 bytes per pair.
-+	// So, take the net/http.Server value and pad it up a bit, assuming 10 headers.
-+	const perFieldOverhead = 32 // per http2 spec
-+	const typicalHeaders = 10   // conservative
-+	return n + typicalHeaders*perFieldOverhead
-+}
-diff --git a/vendor/golang.org/x/net/http2/config_go124.go b/vendor/golang.org/x/net/http2/config_go124.go
-new file mode 100644
-index 00000000..e3784123
---- /dev/null
-+++ b/vendor/golang.org/x/net/http2/config_go124.go
-@@ -0,0 +1,61 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build go1.24
-+
-+package http2
-+
-+import "net/http"
-+
-+// fillNetHTTPServerConfig sets fields in conf from srv.HTTP2.
-+func fillNetHTTPServerConfig(conf *http2Config, srv *http.Server) {
-+	fillNetHTTPConfig(conf, srv.HTTP2)
-+}
-+
-+// fillNetHTTPServerConfig sets fields in conf from tr.HTTP2.
-+func fillNetHTTPTransportConfig(conf *http2Config, tr *http.Transport) {
-+	fillNetHTTPConfig(conf, tr.HTTP2)
-+}
-+
-+func fillNetHTTPConfig(conf *http2Config, h2 *http.HTTP2Config) {
-+	if h2 == nil {
-+		return
-+	}
-+	if h2.MaxConcurrentStreams != 0 {
-+		conf.MaxConcurrentStreams = uint32(h2.MaxConcurrentStreams)
-+	}
-+	if h2.MaxEncoderHeaderTableSize != 0 {
-+		conf.MaxEncoderHeaderTableSize = uint32(h2.MaxEncoderHeaderTableSize)
-+	}
-+	if h2.MaxDecoderHeaderTableSize != 0 {
-+		conf.MaxDecoderHeaderTableSize = uint32(h2.MaxDecoderHeaderTableSize)
-+	}
-+	if h2.MaxConcurrentStreams != 0 {
-+		conf.MaxConcurrentStreams = uint32(h2.MaxConcurrentStreams)
-+	}
-+	if h2.MaxReadFrameSize != 0 {
-+		conf.MaxReadFrameSize = uint32(h2.MaxReadFrameSize)
-+	}
-+	if h2.MaxReceiveBufferPerConnection != 0 {
-+		conf.MaxUploadBufferPerConnection = int32(h2.MaxReceiveBufferPerConnection)
-+	}
-+	if h2.MaxReceiveBufferPerStream != 0 {
-+		conf.MaxUploadBufferPerStream = int32(h2.MaxReceiveBufferPerStream)
-+	}
-+	if h2.SendPingTimeout != 0 {
-+		conf.SendPingTimeout = h2.SendPingTimeout
-+	}
-+	if h2.PingTimeout != 0 {
-+		conf.PingTimeout = h2.PingTimeout
-+	}
-+	if h2.WriteByteTimeout != 0 {
-+		conf.WriteByteTimeout = h2.WriteByteTimeout
-+	}
-+	if h2.PermitProhibitedCipherSuites {
-+		conf.PermitProhibitedCipherSuites = true
-+	}
-+	if h2.CountError != nil {
-+		conf.CountError = h2.CountError
-+	}
-+}
-diff --git a/vendor/golang.org/x/net/http2/config_pre_go124.go b/vendor/golang.org/x/net/http2/config_pre_go124.go
-new file mode 100644
-index 00000000..060fd6c6
---- /dev/null
-+++ b/vendor/golang.org/x/net/http2/config_pre_go124.go
-@@ -0,0 +1,16 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build !go1.24
-+
-+package http2
-+
-+import "net/http"
-+
-+// Pre-Go 1.24 fallback.
-+// The Server.HTTP2 and Transport.HTTP2 config fields were added in Go 1.24.
-+
-+func fillNetHTTPServerConfig(conf *http2Config, srv *http.Server) {}
-+
-+func fillNetHTTPTransportConfig(conf *http2Config, tr *http.Transport) {}
 diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
 index 105c3b27..81faec7e 100644
 --- a/vendor/golang.org/x/net/http2/frame.go
@@ -13071,7 +13738,7 @@ index 6f2df281..c7601c90 100644
 --- a/vendor/golang.org/x/net/http2/http2.go
 +++ b/vendor/golang.org/x/net/http2/http2.go
 @@ -17,24 +17,28 @@ package http2 // import "golang.org/x/net/http2"
-
+ 
  import (
  	"bufio"
 +	"context"
@@ -13087,10 +13754,10 @@ index 6f2df281..c7601c90 100644
  	"strings"
  	"sync"
 +	"time"
-
+ 
  	"golang.org/x/net/http/httpguts"
  )
-
+ 
  var (
 -	VerboseLogs    bool
 -	logFrameWrites bool
@@ -13102,7 +13769,7 @@ index 6f2df281..c7601c90 100644
 +	inTests                        bool
 +	disableExtendedConnectProtocol bool
  )
-
+ 
  func init() {
 @@ -47,6 +51,9 @@ func init() {
  		logFrameWrites = true
@@ -13112,7 +13779,7 @@ index 6f2df281..c7601c90 100644
 +		disableExtendedConnectProtocol = true
 +	}
  }
-
+ 
  const (
 @@ -138,6 +145,10 @@ func (s Setting) Valid() error {
  		if s.Val < 16384 || s.Val > 1<<24-1 {
@@ -13127,7 +13794,7 @@ index 6f2df281..c7601c90 100644
  }
 @@ -147,21 +158,23 @@ func (s Setting) Valid() error {
  type SettingID uint16
-
+ 
  const (
 -	SettingHeaderTableSize      SettingID = 0x1
 -	SettingEnablePush           SettingID = 0x2
@@ -13143,7 +13810,7 @@ index 6f2df281..c7601c90 100644
 +	SettingMaxHeaderListSize     SettingID = 0x6
 +	SettingEnableConnectProtocol SettingID = 0x8
  )
-
+ 
  var settingName = map[SettingID]string{
 -	SettingHeaderTableSize:      "HEADER_TABLE_SIZE",
 -	SettingEnablePush:           "ENABLE_PUSH",
@@ -13159,12 +13826,12 @@ index 6f2df281..c7601c90 100644
 +	SettingMaxHeaderListSize:     "MAX_HEADER_LIST_SIZE",
 +	SettingEnableConnectProtocol: "ENABLE_CONNECT_PROTOCOL",
  }
-
+ 
  func (s SettingID) String() string {
 @@ -210,12 +223,6 @@ type stringWriter interface {
  	WriteString(s string) (n int, err error)
  }
-
+ 
 -// A gate lets two goroutines coordinate their activities.
 -type gate chan struct{}
 -
@@ -13173,7 +13840,7 @@ index 6f2df281..c7601c90 100644
 -
  // A closeWaiter is like a sync.WaitGroup but only goes 1 to 0 (open to closed).
  type closeWaiter chan struct{}
-
+ 
 @@ -241,13 +248,19 @@ func (cw closeWaiter) Wait() {
  // Its buffered writer is lazily allocated as needed, to minimize
  // idle memory usage with many connections.
@@ -13187,7 +13854,7 @@ index 6f2df281..c7601c90 100644
 +	bw          *bufio.Writer          // non-nil when data is buffered
 +	byteTimeout time.Duration          // immutable, WriteByteTimeout
  }
-
+ 
 -func newBufferedWriter(w io.Writer) *bufferedWriter {
 -	return &bufferedWriter{w: w}
 +func newBufferedWriter(group synctestGroupInterface, conn net.Conn, timeout time.Duration) *bufferedWriter {
@@ -13197,7 +13864,7 @@ index 6f2df281..c7601c90 100644
 +		byteTimeout: timeout,
 +	}
  }
-
+ 
  // bufWriterPoolBufferSize is the size of bufio.Writer's
 @@ -274,7 +287,7 @@ func (w *bufferedWriter) Available() int {
  func (w *bufferedWriter) Write(p []byte) (n int, err error) {
@@ -13211,7 +13878,7 @@ index 6f2df281..c7601c90 100644
 @@ -292,6 +305,38 @@ func (w *bufferedWriter) Flush() error {
  	return err
  }
-
+ 
 +type bufferedWriterTimeoutWriter bufferedWriter
 +
 +func (w *bufferedWriterTimeoutWriter) Write(p []byte) (n int, err error) {
@@ -13276,7 +13943,7 @@ index c5d08108..b55547ae 100644
  	"fmt"
 @@ -52,10 +53,14 @@ import (
  )
-
+ 
  const (
 -	prefaceTimeout         = 10 * time.Second
 -	firstSettingsTimeout   = 2 * time.Second // should be in-flight with preface anyway
@@ -13292,11 +13959,11 @@ index c5d08108..b55547ae 100644
 +	// the connection is closed to prevent memory exhaustion attacks.
  	maxQueuedControlFrames = 10000
  )
-
+ 
 @@ -127,6 +132,22 @@ type Server struct {
  	// If zero or negative, there is no timeout.
  	IdleTimeout time.Duration
-
+ 
 +	// ReadIdleTimeout is the timeout after which a health check using a ping
 +	// frame will be carried out if no frame is received on the connection.
 +	// If zero, no health check is performed.
@@ -13328,7 +13995,7 @@ index c5d08108..b55547ae 100644
 -	}
 -	return 1 << 20
 -}
-
+ 
 -func (s *Server) initialStreamRecvWindowSize() int32 {
 -	if s.MaxUploadBufferPerStream > 0 {
 -		return s.MaxUploadBufferPerStream
@@ -13338,7 +14005,7 @@ index c5d08108..b55547ae 100644
 +	// Outside of tests, this is nil.
 +	group synctestGroupInterface
  }
-
+ 
 -func (s *Server) maxReadFrameSize() uint32 {
 -	if v := s.MaxReadFrameSize; v >= minMaxFrameSize && v <= maxFrameSize {
 -		return v
@@ -13348,7 +14015,7 @@ index c5d08108..b55547ae 100644
  	}
 -	return defaultMaxReadFrameSize
  }
-
+ 
 -func (s *Server) maxConcurrentStreams() uint32 {
 -	if v := s.MaxConcurrentStreams; v > 0 {
 -		return v
@@ -13359,7 +14026,7 @@ index c5d08108..b55547ae 100644
 -	return defaultMaxStreams
 +	return time.Now()
  }
-
+ 
 -func (s *Server) maxDecoderHeaderTableSize() uint32 {
 -	if v := s.MaxDecoderHeaderTableSize; v > 0 {
 -		return v
@@ -13371,7 +14038,7 @@ index c5d08108..b55547ae 100644
 -	return initialHeaderTableSize
 +	return timeTimer{time.NewTimer(d)}
  }
-
+ 
 -func (s *Server) maxEncoderHeaderTableSize() uint32 {
 -	if v := s.MaxEncoderHeaderTableSize; v > 0 {
 -		return v
@@ -13392,7 +14059,7 @@ index c5d08108..b55547ae 100644
 -	return maxQueuedControlFrames
 +	return timeTimer{time.AfterFunc(d, f)}
  }
-
+ 
  type serverInternalState struct {
 @@ -303,7 +306,7 @@ func ConfigureServer(s *http.Server, conf *Server) error {
  	if s.TLSNextProto == nil {
@@ -13438,7 +14105,7 @@ index c5d08108..b55547ae 100644
 +	}
  	return nil
  }
-
+ 
 @@ -400,16 +422,22 @@ func (o *ServeConnOpts) handler() http.Handler {
  //
  // The opts parameter is optional. If nil, default values are used.
@@ -13449,7 +14116,7 @@ index c5d08108..b55547ae 100644
 +func (s *Server) serveConn(c net.Conn, opts *ServeConnOpts, newf func(*serverConn)) {
  	baseCtx, cancel := serverConnBaseContext(c, opts)
  	defer cancel()
-
+ 
 +	http1srv := opts.baseConfig()
 +	conf := configFromServer(http1srv, s)
  	sc := &serverConn{
@@ -13482,7 +14149,7 @@ index c5d08108..b55547ae 100644
 +	if newf != nil {
 +		newf(sc)
 +	}
-
+ 
  	s.state.registerConn(sc)
  	defer s.state.unregisterConn(sc)
 @@ -451,15 +485,15 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
@@ -13491,7 +14158,7 @@ index c5d08108..b55547ae 100644
  	sc.hpackEncoder = hpack.NewEncoder(&sc.headerWriteBuf)
 -	sc.hpackEncoder.SetMaxDynamicTableSizeLimit(s.maxEncoderHeaderTableSize())
 +	sc.hpackEncoder.SetMaxDynamicTableSizeLimit(conf.MaxEncoderHeaderTableSize)
-
+ 
  	fr := NewFramer(sc.bw, c)
 -	if s.CountError != nil {
 -		fr.countError = s.CountError
@@ -13504,12 +14171,12 @@ index c5d08108..b55547ae 100644
 -	fr.SetMaxReadFrameSize(s.maxReadFrameSize())
 +	fr.SetMaxReadFrameSize(conf.MaxReadFrameSize)
  	sc.framer = fr
-
+ 
  	if tc, ok := c.(connectionStater); ok {
 @@ -492,7 +526,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
  			// So for now, do nothing here again.
  		}
-
+ 
 -		if !s.PermitProhibitedCipherSuites && isBadCipher(sc.tlsState.CipherSuite) {
 +		if !conf.PermitProhibitedCipherSuites && isBadCipher(sc.tlsState.CipherSuite) {
  			// "Endpoints MAY choose to generate a connection error
@@ -13518,18 +14185,18 @@ index c5d08108..b55547ae 100644
 @@ -529,7 +563,7 @@ func (s *Server) ServeConn(c net.Conn, opts *ServeConnOpts) {
  		opts.UpgradeRequest = nil
  	}
-
+ 
 -	sc.serve()
 +	sc.serve(conf)
  }
-
+ 
  func serverConnBaseContext(c net.Conn, opts *ServeConnOpts) (ctx context.Context, cancel func()) {
 @@ -569,6 +603,7 @@ type serverConn struct {
  	tlsState         *tls.ConnectionState   // shared by all handlers, like net/http
  	remoteAddrStr    string
  	writeSched       WriteScheduler
 +	countErrorFunc   func(errType string)
-
+ 
  	// Everything following is owned by the serve loop; use serveG.check():
  	serveG                      goroutineLock // used to verify funcs are on serve()
 @@ -588,6 +623,7 @@ type serverConn struct {
@@ -13554,7 +14221,7 @@ index c5d08108..b55547ae 100644
 +	readIdleTimeout             time.Duration
 +	pingTimeout                 time.Duration
 +	readIdleTimer               timer // nil if unused
-
+ 
  	// Owned by the writeFrameAsync goroutine:
  	headerWriteBuf bytes.Buffer
 @@ -615,11 +656,7 @@ func (sc *serverConn) maxHeaderListSize() uint32 {
@@ -13568,7 +14235,7 @@ index c5d08108..b55547ae 100644
 -	return uint32(n + typicalHeaders*perFieldOverhead)
 +	return uint32(adjustHTTP1MaxHeaderSize(int64(n)))
  }
-
+ 
  func (sc *serverConn) curOpenStreams() uint32 {
 @@ -649,12 +686,12 @@ type stream struct {
  	flow             outflow // limits writing from Handler to client
@@ -13586,7 +14253,7 @@ index c5d08108..b55547ae 100644
 +	readDeadline     timer // nil if unused
 +	writeDeadline    timer // nil if unused
 +	closeErr         error // set before cw is closed
-
+ 
  	trailer    http.Header // accumulated trailers
  	reqTrailer http.Header // handler's Request.Trailer
 @@ -811,8 +848,9 @@ type readFrameResult struct {
@@ -13612,7 +14279,7 @@ index c5d08108..b55547ae 100644
 @@ -881,7 +920,7 @@ func (sc *serverConn) notePanic() {
  	}
  }
-
+ 
 -func (sc *serverConn) serve() {
 +func (sc *serverConn) serve(conf http2Config) {
  	sc.serveG.check()
@@ -13621,7 +14288,7 @@ index c5d08108..b55547ae 100644
 @@ -893,20 +932,24 @@ func (sc *serverConn) serve() {
  		sc.vlogf("http2: server connection from %v on %p", sc.conn.RemoteAddr(), sc.hs)
  	}
-
+ 
 +	settings := writeSettings{
 +		{SettingMaxFrameSize, conf.MaxReadFrameSize},
 +		{SettingMaxConcurrentStreams, sc.advMaxStreams},
@@ -13643,23 +14310,23 @@ index c5d08108..b55547ae 100644
 +		write: settings,
  	})
  	sc.unackedSettings++
-
+ 
  	// Each connection starts with initialWindowSize inflow tokens.
  	// If a higher value is configured, we add more tokens.
 -	if diff := sc.srv.initialConnRecvWindowSize() - initialWindowSize; diff > 0 {
 +	if diff := conf.MaxUploadBufferPerConnection - initialWindowSize; diff > 0 {
  		sc.sendWindowUpdate(nil, int(diff))
  	}
-
+ 
 @@ -922,15 +965,22 @@ func (sc *serverConn) serve() {
  	sc.setConnState(http.StateIdle)
-
+ 
  	if sc.srv.IdleTimeout > 0 {
 -		sc.idleTimer = time.AfterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
 +		sc.idleTimer = sc.srv.afterFunc(sc.srv.IdleTimeout, sc.onIdleTimer)
  		defer sc.idleTimer.Stop()
  	}
-
+ 
 +	if conf.SendPingTimeout > 0 {
 +		sc.readIdleTimeout = conf.SendPingTimeout
 +		sc.readIdleTimer = sc.srv.afterFunc(conf.SendPingTimeout, sc.onReadIdleTimer)
@@ -13667,11 +14334,11 @@ index c5d08108..b55547ae 100644
 +	}
 +
  	go sc.readFrames() // closed by defer sc.conn.Close above
-
+ 
 -	settingsTimer := time.AfterFunc(firstSettingsTimeout, sc.onSettingsTimer)
 +	settingsTimer := sc.srv.afterFunc(firstSettingsTimeout, sc.onSettingsTimer)
  	defer settingsTimer.Stop()
-
+ 
 +	lastFrameTime := sc.srv.now()
  	loopNum := 0
  	for {
@@ -13705,7 +14372,7 @@ index c5d08108..b55547ae 100644
 @@ -1013,12 +1066,39 @@ func (sc *serverConn) serve() {
  	}
  }
-
+ 
 +func (sc *serverConn) handlePingTimer(lastFrameReadTime time.Time) {
 +	if sc.pingSent {
 +		sc.vlogf("timeout waiting for PING response")
@@ -13733,7 +14400,7 @@ index c5d08108..b55547ae 100644
 +}
 +
  type serverMessage int
-
+ 
  // Message values sent to serveMsgCh.
  var (
  	settingsTimerMsg    = new(serverMessage)
@@ -13743,12 +14410,12 @@ index c5d08108..b55547ae 100644
  	gracefulShutdownMsg = new(serverMessage)
  	handlerDoneMsg      = new(serverMessage)
 @@ -1026,6 +1106,7 @@ var (
-
+ 
  func (sc *serverConn) onSettingsTimer() { sc.sendServeMsg(settingsTimerMsg) }
  func (sc *serverConn) onIdleTimer()     { sc.sendServeMsg(idleTimerMsg) }
 +func (sc *serverConn) onReadIdleTimer() { sc.sendServeMsg(readIdleTimerMsg) }
  func (sc *serverConn) onShutdownTimer() { sc.sendServeMsg(shutdownTimerMsg) }
-
+ 
  func (sc *serverConn) sendServeMsg(msg interface{}) {
 @@ -1057,10 +1138,10 @@ func (sc *serverConn) readPreface() error {
  			errc <- nil
@@ -13766,22 +14433,22 @@ index c5d08108..b55547ae 100644
 @@ -1278,6 +1359,10 @@ func (sc *serverConn) wroteFrame(res frameWriteResult) {
  	sc.writingFrame = false
  	sc.writingFrameAsync = false
-
+ 
 +	if res.err != nil {
 +		sc.conn.Close()
 +	}
 +
  	wr := res.wr
-
+ 
  	if writeEndsStream(wr.write) {
 @@ -1425,7 +1510,7 @@ func (sc *serverConn) goAway(code ErrCode) {
-
+ 
  func (sc *serverConn) shutDownIn(d time.Duration) {
  	sc.serveG.check()
 -	sc.shutdownTimer = time.AfterFunc(d, sc.onShutdownTimer)
 +	sc.shutdownTimer = sc.srv.afterFunc(d, sc.onShutdownTimer)
  }
-
+ 
  func (sc *serverConn) resetStream(se StreamError) {
 @@ -1552,6 +1637,11 @@ func (sc *serverConn) processFrame(f Frame) error {
  func (sc *serverConn) processPing(f *PingFrame) error {
@@ -13829,7 +14496,7 @@ index c5d08108..b55547ae 100644
 -		st.readDeadline = time.AfterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
 +		st.readDeadline = sc.srv.afterFunc(sc.hs.ReadTimeout, st.onReadTimeout)
  	}
-
+ 
  	return sc.scheduleHandler(id, rw, req, handler)
 @@ -2117,9 +2211,9 @@ func (sc *serverConn) newStream(id, pusherID uint32, state streamState) *stream
  	st.cw.Init()
@@ -13841,7 +14508,7 @@ index c5d08108..b55547ae 100644
 -		st.writeDeadline = time.AfterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
 +		st.writeDeadline = sc.srv.afterFunc(sc.hs.WriteTimeout, st.onWriteTimeout)
  	}
-
+ 
  	sc.streams[id] = st
 @@ -2144,11 +2238,17 @@ func (sc *serverConn) newWriterAndRequest(st *stream, f *MetaHeadersFrame) (*res
  		scheme:    f.PseudoValue("scheme"),
@@ -13854,7 +14521,7 @@ index c5d08108..b55547ae 100644
 +	if disableExtendedConnectProtocol && rp.protocol != "" {
 +		return nil, nil, sc.countError("bad_connect", streamError(f.StreamID, ErrCodeProtocol))
  	}
-
+ 
  	isConnect := rp.method == "CONNECT"
  	if isConnect {
 -		if rp.path != "" || rp.scheme != "" || rp.authority == "" {
@@ -13869,7 +14536,7 @@ index c5d08108..b55547ae 100644
 +	if rp.protocol != "" {
 +		rp.header.Set(":protocol", rp.protocol)
 +	}
-
+ 
  	rw, req, err := sc.newWriterAndRequestNoBody(st, rp)
  	if err != nil {
 @@ -2198,6 +2301,7 @@ func (sc *serverConn) newWriterAndRequest(st *stream, f *MetaHeadersFrame) (*res
@@ -13879,9 +14546,9 @@ index c5d08108..b55547ae 100644
 +	protocol                string
  	header                  http.Header
  }
-
+ 
 @@ -2239,7 +2343,7 @@ func (sc *serverConn) newWriterAndRequestNoBody(st *stream, rp requestParam) (*r
-
+ 
  	var url_ *url.URL
  	var requestURI string
 -	if rp.method == "CONNECT" {
@@ -13890,7 +14557,7 @@ index c5d08108..b55547ae 100644
  		requestURI = rp.authority // mimic HTTP/1 server behavior
  	} else {
 @@ -2343,6 +2447,7 @@ func (sc *serverConn) handlerDone() {
-
+ 
  // Run on its own goroutine.
  func (sc *serverConn) runHandler(rw *responseWriter, req *http.Request, handler func(http.ResponseWriter, *http.Request)) {
 +	sc.srv.markNewGoroutine()
@@ -13904,10 +14571,10 @@ index c5d08108..b55547ae 100644
 -			date = time.Now().UTC().Format(http.TimeFormat)
 +			date = rws.conn.srv.now().UTC().Format(http.TimeFormat)
  		}
-
+ 
  		for _, v := range rws.snapHeader["Trailer"] {
 @@ -2761,7 +2866,7 @@ func (rws *responseWriterState) promoteUndeclaredTrailers() {
-
+ 
  func (w *responseWriter) SetReadDeadline(deadline time.Time) error {
  	st := w.rws.stream
 -	if !deadline.IsZero() && deadline.Before(time.Now()) {
@@ -13928,7 +14595,7 @@ index c5d08108..b55547ae 100644
  	})
  	return nil
 @@ -2787,7 +2892,7 @@ func (w *responseWriter) SetReadDeadline(deadline time.Time) error {
-
+ 
  func (w *responseWriter) SetWriteDeadline(deadline time.Time) error {
  	st := w.rws.stream
 -	if !deadline.IsZero() && deadline.Before(time.Now()) {
@@ -13949,7 +14616,7 @@ index c5d08108..b55547ae 100644
  	})
  	return nil
  }
-
+ 
 +func (w *responseWriter) EnableFullDuplex() error {
 +	// We always support full duplex responses, so this is a no-op.
 +	return nil
@@ -14304,32 +14971,6 @@ index 61075bd1..00000000
 -	}
 -	return active
 -}
-diff --git a/vendor/golang.org/x/net/http2/timer.go b/vendor/golang.org/x/net/http2/timer.go
-new file mode 100644
-index 00000000..0b1c17b8
---- /dev/null
-+++ b/vendor/golang.org/x/net/http2/timer.go
-@@ -0,0 +1,20 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+package http2
-+
-+import "time"
-+
-+// A timer is a time.Timer, as an interface which can be replaced in tests.
-+type timer = interface {
-+	C() <-chan time.Time
-+	Reset(d time.Duration) bool
-+	Stop() bool
-+}
-+
-+// timeTimer adapts a time.Timer to the timer interface.
-+type timeTimer struct {
-+	*time.Timer
-+}
-+
-+func (t timeTimer) C() <-chan time.Time { return t.Timer.C }
 diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
 index 2fa49490..090d0e1b 100644
 --- a/vendor/golang.org/x/net/http2/transport.go
@@ -14345,11 +14986,11 @@ index 2fa49490..090d0e1b 100644
 @@ -185,42 +184,80 @@ type Transport struct {
  	connPoolOnce  sync.Once
  	connPoolOrDef ClientConnPool // non-nil version of ConnPool
-
+ 
 -	syncHooks *testSyncHooks
 +	*transportTestHooks
  }
-
+ 
 -func (t *Transport) maxHeaderListSize() uint32 {
 -	if t.MaxHeaderListSize == 0 {
 -		return 10 << 20
@@ -14377,7 +15018,7 @@ index 2fa49490..090d0e1b 100644
 -	return t.MaxHeaderListSize
 +	return time.Now()
  }
-
+ 
 -func (t *Transport) maxFrameReadSize() uint32 {
 -	if t.MaxReadFrameSize == 0 {
 -		return 0 // use the default provided by the peer
@@ -14408,7 +15049,7 @@ index 2fa49490..090d0e1b 100644
 -	return t.MaxReadFrameSize
 +	return timeTimer{time.AfterFunc(d, f)}
  }
-
+ 
 -func (t *Transport) disableCompression() bool {
 -	return t.DisableCompression || (t.t1 != nil && t.t1.DisableCompression)
 +func (t *Transport) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
@@ -14417,7 +15058,7 @@ index 2fa49490..090d0e1b 100644
 +	}
 +	return context.WithTimeout(ctx, d)
  }
-
+ 
 -func (t *Transport) pingTimeout() time.Duration {
 -	if t.PingTimeout == 0 {
 -		return 15 * time.Second
@@ -14438,11 +15079,11 @@ index 2fa49490..090d0e1b 100644
 +	}
 +	return uint32(n)
 +}
-
+ 
 +func (t *Transport) disableCompression() bool {
 +	return t.DisableCompression || (t.t1 != nil && t.t1.DisableCompression)
  }
-
+ 
  // ConfigureTransport configures a net/http HTTP/1 Transport to use HTTP/2.
 @@ -258,8 +295,8 @@ func configureTransports(t1 *http.Transport) (*Transport, error) {
  	if !strSliceContains(t1.TLSClientConfig.NextProtos, "http/1.1") {
@@ -14486,7 +15127,7 @@ index 2fa49490..090d0e1b 100644
  	}
  	return t2, nil
  }
-
+ 
 +// unencryptedTransport is a Transport with a RoundTrip method that
 +// always permits http:// URLs.
 +type unencryptedTransport Transport
@@ -14506,11 +15147,11 @@ index 2fa49490..090d0e1b 100644
 +	atomicReused  uint32               // whether conn is being reused; atomic
  	singleUse     bool                 // whether being used for a single http.Request
  	getConnCalled bool                 // used by clientConnPool
-
+ 
 @@ -312,31 +368,54 @@ type ClientConn struct {
  	idleTimeout time.Duration // or 0 for never
  	idleTimer   timer
-
+ 
 -	mu              sync.Mutex // guards following
 -	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
 -	flow            outflow    // our conn-level flow control quota (cs.outflow is per stream)
@@ -14583,7 +15224,7 @@ index 2fa49490..090d0e1b 100644
 +	// a PING response. This limits the number of requests we'll try to send to a
 +	// completely unresponsive connection.
 +	pendingResets int
-
+ 
  	// reqHeaderMu is a 1-element semaphore channel controlling access to sending new requests.
  	// Write to reqHeaderMu to lock it, read from it to unlock.
 @@ -352,60 +431,6 @@ type ClientConn struct {
@@ -14645,11 +15286,11 @@ index 2fa49490..090d0e1b 100644
 -	}
 -	return context.WithTimeout(ctx, d)
  }
-
+ 
  // clientStream is the state for a single HTTP/2 stream. One of these
 @@ -448,12 +473,12 @@ type clientStream struct {
  	sentHeaders   bool
-
+ 
  	// owned by clientConnReadLoop:
 -	firstByte    bool  // got the first response byte
 -	pastHeaders  bool  // got first MetaHeadersFrame (actual headers)
@@ -14663,7 +15304,7 @@ index 2fa49490..090d0e1b 100644
 +	readClosed      bool  // peer sent an END_STREAM flag
 +	readAborted     bool  // read loop reset the stream
 +	totalHeaderSize int64 // total size of 1xx headers seen
-
+ 
  	trailer    http.Header  // accumulated trailers
  	resTrailer *http.Header // client's Response.Trailer
 @@ -487,7 +512,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
@@ -14674,7 +15315,7 @@ index 2fa49490..090d0e1b 100644
 +		cs.cc.cond.Broadcast()
  	}
  }
-
+ 
 @@ -497,7 +522,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
  	defer cc.mu.Unlock()
  	if cs.reqBody != nil && cs.reqBodyClosed == nil {
@@ -14683,7 +15324,7 @@ index 2fa49490..090d0e1b 100644
 +		cc.cond.Broadcast()
  	}
  }
-
+ 
 @@ -507,13 +532,15 @@ func (cs *clientStream) closeReqBodyLocked() {
  	}
  	cs.reqBodyClosed = make(chan struct{})
@@ -14696,7 +15337,7 @@ index 2fa49490..090d0e1b 100644
 -	})
 +	}()
  }
-
+ 
  type stickyErrWriter struct {
 +	group   synctestGroupInterface
  	conn    net.Conn
@@ -14726,7 +15367,7 @@ index 2fa49490..090d0e1b 100644
 +	*sew.err = err
 +	return n, err
  }
-
+ 
  // noCachedConnError is the concrete type of ErrNoCachedConn, which
 @@ -569,6 +583,8 @@ type RoundTripOpt struct {
  	// no cached connection is available, RoundTripOpt
@@ -14735,10 +15376,10 @@ index 2fa49490..090d0e1b 100644
 +
 +	allowHTTP bool // allow http:// URLs
  }
-
+ 
  func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 @@ -601,7 +617,14 @@ func authorityAddr(scheme string, authority string) (addr string) {
-
+ 
  // RoundTripOpt is like RoundTrip, but takes options.
  func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
 -	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
@@ -14752,7 +15393,7 @@ index 2fa49490..090d0e1b 100644
 +	default:
  		return nil, errors.New("http2: unsupported scheme")
  	}
-
+ 
 @@ -612,7 +635,7 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
  			t.vlogf("http2: Transport failed to get client conn for %s: %v", addr, err)
  			return nil, err
@@ -14810,7 +15451,7 @@ index 2fa49490..090d0e1b 100644
  			return nil, err
 @@ -669,9 +694,10 @@ func (t *Transport) CloseIdleConnections() {
  }
-
+ 
  var (
 -	errClientConnClosed    = errors.New("http2: client conn is closed")
 -	errClientConnUnusable  = errors.New("http2: client conn not usable")
@@ -14820,11 +15461,11 @@ index 2fa49490..090d0e1b 100644
 +	errClientConnNotEstablished = errors.New("http2: client conn could not be established")
 +	errClientConnGotGoAway      = errors.New("http2: Transport received Server's graceful shutdown GOAWAY")
  )
-
+ 
  // shouldRetryRequest is called by RoundTrip when a request fails to get
 @@ -725,8 +751,8 @@ func canRetryError(err error) bool {
  }
-
+ 
  func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
 -	if t.syncHooks != nil {
 -		return t.newClientConn(nil, singleUse, t.syncHooks)
@@ -14840,12 +15481,12 @@ index 2fa49490..090d0e1b 100644
 -	return t.newClientConn(tconn, singleUse, nil)
 +	return t.newClientConn(tconn, singleUse)
  }
-
+ 
  func (t *Transport) newTLSConfig(host string) *tls.Config {
 @@ -787,48 +813,38 @@ func (t *Transport) expectContinueTimeout() time.Duration {
  	return t.t1.ExpectContinueTimeout
  }
-
+ 
 -func (t *Transport) maxDecoderHeaderTableSize() uint32 {
 -	if v := t.MaxDecoderHeaderTableSize; v > 0 {
 -		return v
@@ -14864,7 +15505,7 @@ index 2fa49490..090d0e1b 100644
 -	return t.newClientConn(c, t.disableKeepAlives(), nil)
 +	return t.newClientConn(c, t.disableKeepAlives())
  }
-
+ 
 -func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
 +func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
 +	conf := configFromTransport(t)
@@ -14941,12 +15582,12 @@ index 2fa49490..090d0e1b 100644
 +	maxHeaderTableSize := conf.MaxDecoderHeaderTableSize
  	cc.fr.ReadMetaHeaders = hpack.NewDecoder(maxHeaderTableSize, nil)
  	cc.fr.MaxHeaderListSize = t.maxHeaderListSize()
-
+ 
  	cc.henc = hpack.NewEncoder(&cc.hbuf)
 -	cc.henc.SetMaxDynamicTableSizeLimit(t.maxEncoderHeaderTableSize())
 +	cc.henc.SetMaxDynamicTableSizeLimit(conf.MaxEncoderHeaderTableSize)
  	cc.peerMaxHeaderTableSize = initialHeaderTableSize
-
+ 
 -	if t.AllowHTTP {
 -		cc.nextStreamID = 3
 -	}
@@ -14955,7 +15596,7 @@ index 2fa49490..090d0e1b 100644
  		state := cs.ConnectionState()
  		cc.tlsState = &state
 @@ -871,11 +882,9 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHoo
-
+ 
  	initialSettings := []Setting{
  		{ID: SettingEnablePush, Val: 0},
 -		{ID: SettingInitialWindowSize, Val: transportDefaultStreamFlow},
@@ -14969,7 +15610,7 @@ index 2fa49490..090d0e1b 100644
  		initialSettings = append(initialSettings, Setting{ID: SettingMaxHeaderListSize, Val: max})
  	}
 @@ -885,23 +894,29 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHoo
-
+ 
  	cc.bw.Write(clientPreface)
  	cc.fr.WriteSettings(initialSettings...)
 -	cc.fr.WriteWindowUpdate(0, transportDefaultConnFlow)
@@ -14981,7 +15622,7 @@ index 2fa49490..090d0e1b 100644
  		cc.Close()
  		return nil, cc.werr
  	}
-
+ 
 -	cc.goRun(cc.readLoop)
 +	// Start the idle timer after the connection is fully initialized.
 +	if d := t.idleConnTimeout(); d != 0 {
@@ -14992,7 +15633,7 @@ index 2fa49490..090d0e1b 100644
 +	go cc.readLoop()
  	return cc, nil
  }
-
+ 
  func (cc *ClientConn) healthCheck() {
 -	pingTimeout := cc.t.pingTimeout()
 +	pingTimeout := cc.pingTimeout
@@ -15025,7 +15666,7 @@ index 2fa49490..090d0e1b 100644
 +		// is less than the concurrency limit.
 +		maxConcurrentOkay = cc.currentRequestCountLocked() < int(cc.maxConcurrentStreams)
  	}
-
+ 
  	st.canTakeNewRequest = cc.goAway == nil && !cc.closed && !cc.closing && maxConcurrentOkay &&
  		!cc.doNotReuse &&
  		int64(cc.nextStreamID)+2*int64(cc.pendingRequests) < math.MaxInt32 &&
@@ -15042,7 +15683,7 @@ index 2fa49490..090d0e1b 100644
 +
  	return
  }
-
+ 
 +// currentRequestCountLocked reports the number of concurrency slots currently in use,
 +// including active streams, reserved slots, and reset streams waiting for acknowledgement.
 +func (cc *ClientConn) currentRequestCountLocked() int {
@@ -15059,7 +15700,7 @@ index 2fa49490..090d0e1b 100644
 -	return cc.idleTimeout != 0 && !cc.lastIdle.IsZero() && time.Since(cc.lastIdle.Round(0)) > cc.idleTimeout
 +	return cc.idleTimeout != 0 && !cc.lastIdle.IsZero() && cc.t.timeSince(cc.lastIdle.Round(0)) > cc.idleTimeout
  }
-
+ 
  // onIdleTimeout is called from a time.AfterFunc goroutine. It will
 @@ -1144,7 +1181,8 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
  	// Wait for all in-flight streams to complete or connection to close
@@ -15130,7 +15771,7 @@ index 2fa49490..090d0e1b 100644
 +	}
 +
 +	go cs.doRequest(req, streamf)
-
+ 
  	waitDone := func() error {
 -		if cc.syncHooks != nil {
 -			cc.syncHooks.blockUntil(func() bool {
@@ -15150,7 +15791,7 @@ index 2fa49490..090d0e1b 100644
 @@ -1398,24 +1443,7 @@ func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream))
  		return err
  	}
-
+ 
 -	if streamf != nil {
 -		streamf(cs)
 -	}
@@ -15183,7 +15824,7 @@ index 2fa49490..090d0e1b 100644
 +	err := cs.writeRequest(req, streamf)
  	cs.cleanupWriteRequest(err)
  }
-
+ 
 +var errExtendedConnectNotSupported = errors.New("net/http: extended connect not supported by peer")
 +
  // writeRequest sends a request.
@@ -15197,11 +15838,11 @@ index 2fa49490..090d0e1b 100644
 +func (cs *clientStream) writeRequest(req *http.Request, streamf func(*clientStream)) (err error) {
  	cc := cs.cc
  	ctx := cs.ctx
-
+ 
 @@ -1465,26 +1496,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
  		return err
  	}
-
+ 
 +	// wait for setting frames to be received, a server can change this value later,
 +	// but we just wait for the first settings frame
 +	var isExtendedConnect bool
@@ -15245,7 +15886,7 @@ index 2fa49490..090d0e1b 100644
 @@ -1510,28 +1545,8 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
  	}
  	cc.mu.Unlock()
-
+ 
 -	if newStreamHook != nil {
 -		newStreamHook(cs)
 -	}
@@ -15271,7 +15912,7 @@ index 2fa49490..090d0e1b 100644
 +	if streamf != nil {
 +		streamf(cs)
  	}
-
+ 
  	continueTimeout := cc.t.expectContinueTimeout()
 @@ -1594,7 +1609,7 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
  	var respHeaderTimer <-chan time.Time
@@ -15393,7 +16034,7 @@ index 2fa49490..090d0e1b 100644
 +		cc.cond.Wait()
  	}
  }
-
+ 
  func validateHeaders(hdrs http.Header) string {
  	for k, vv := range hdrs {
 -		if !httpguts.ValidHeaderFieldName(k) {
@@ -15402,9 +16043,9 @@ index 2fa49490..090d0e1b 100644
  		}
  		for _, v := range vv {
 @@ -2050,6 +2084,10 @@ func validateHeaders(hdrs http.Header) string {
-
+ 
  var errNilRequestURL = errors.New("http2: Request.URI is nil")
-
+ 
 +func isNormalConnect(req *http.Request) bool {
 +	return req.Method == "CONNECT" && req.Header.Get(":protocol") == ""
 +}
@@ -15414,7 +16055,7 @@ index 2fa49490..090d0e1b 100644
  	cc.hbuf.Reset()
 @@ -2070,7 +2108,7 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
  	}
-
+ 
  	var path string
 -	if req.Method != "CONNECT" {
 +	if !isNormalConnect(req) {
@@ -15454,11 +16095,11 @@ index 2fa49490..090d0e1b 100644
  	// wake up RoundTrip if there is a pending request.
 -	cc.condBroadcast()
 +	cc.cond.Broadcast()
-
+ 
  	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
  	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
 @@ -2333,6 +2371,7 @@ type clientConnReadLoop struct {
-
+ 
  // readLoop runs in its own goroutine and reads and dispatches frames.
  func (cc *ClientConn) readLoop() {
 +	cc.t.markNewGoroutine()
@@ -15466,17 +16107,17 @@ index 2fa49490..090d0e1b 100644
  	defer rl.cleanup()
  	cc.readerErr = rl.run()
 @@ -2366,7 +2405,6 @@ func isEOFOrNetReadError(err error) bool {
-
+ 
  func (rl *clientConnReadLoop) cleanup() {
  	cc := rl.cc
 -	cc.t.connPool().MarkDead(cc)
  	defer cc.closeConn()
  	defer close(cc.readerDone)
-
+ 
 @@ -2390,6 +2428,24 @@ func (rl *clientConnReadLoop) cleanup() {
  	}
  	cc.closed = true
-
+ 
 +	// If the connection has never been used, and has been open for only a short time,
 +	// leave it in the connection pool for a little while.
 +	//
@@ -15506,7 +16147,7 @@ index 2fa49490..090d0e1b 100644
 +	cc.cond.Broadcast()
  	cc.mu.Unlock()
  }
-
+ 
 @@ -2433,10 +2489,10 @@ func (cc *ClientConn) countReadFrameError(err error) {
  func (rl *clientConnReadLoop) run() error {
  	cc := rl.cc
@@ -15540,7 +16181,7 @@ index 2fa49490..090d0e1b 100644
  		}
  	}
  }
-
+ 
  func (rl *clientConnReadLoop) processHeaders(f *MetaHeadersFrame) error {
 -	cs := rl.streamByID(f.StreamID)
 +	cs := rl.streamByID(f.StreamID, headerOrDataFrame)
@@ -15588,7 +16229,7 @@ index 2fa49490..090d0e1b 100644
  		if statusCode == 100 {
  			traceGot100Continue(cs.trace)
 @@ -2809,7 +2887,7 @@ func (b transportResponseBody) Close() error {
-
+ 
  func (rl *clientConnReadLoop) processData(f *DataFrame) error {
  	cc := rl.cc
 -	cs := rl.streamByID(f.StreamID)
@@ -15599,7 +16240,7 @@ index 2fa49490..090d0e1b 100644
 @@ -2944,9 +3022,22 @@ func (rl *clientConnReadLoop) endStreamError(cs *clientStream, err error) {
  	cs.abortStream(err)
  }
-
+ 
 -func (rl *clientConnReadLoop) streamByID(id uint32) *clientStream {
 +// Constants passed to streamByID for documentation purposes.
 +const (
@@ -15626,7 +16267,7 @@ index 2fa49490..090d0e1b 100644
  			}
 -			cc.condBroadcast()
 +			cc.cond.Broadcast()
-
+ 
  			cc.initialWindowSize = s.Val
  		case SettingHeaderTableSize:
  			cc.henc.SetMaxDynamicTableSize(s.Val)
@@ -15656,9 +16297,9 @@ index 2fa49490..090d0e1b 100644
 +		close(cc.seenSettingsChan)
  		cc.seenSettings = true
  	}
-
+ 
 @@ -3065,7 +3172,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
-
+ 
  func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
  	cc := rl.cc
 -	cs := rl.streamByID(f.StreamID)
@@ -15667,14 +16308,14 @@ index 2fa49490..090d0e1b 100644
  		return nil
  	}
 @@ -3089,12 +3196,12 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
-
+ 
  		return ConnectionError(ErrCodeFlowControl)
  	}
 -	cc.condBroadcast()
 +	cc.cond.Broadcast()
  	return nil
  }
-
+ 
  func (rl *clientConnReadLoop) processResetStream(f *RSTStreamFrame) error {
 -	cs := rl.streamByID(f.StreamID)
 +	cs := rl.streamByID(f.StreamID, notHeaderOrDataFrame)
@@ -15729,7 +16370,7 @@ index 2fa49490..090d0e1b 100644
 @@ -3203,13 +3304,20 @@ func (rl *clientConnReadLoop) processPushPromise(f *PushPromiseFrame) error {
  	return ConnectionError(ErrCodeProtocol)
  }
-
+ 
 -func (cc *ClientConn) writeStreamReset(streamID uint32, code ErrCode, err error) {
 +// writeStreamReset sends a RST_STREAM frame.
 +// When ping is true, it also sends a PING frame with a random payload.
@@ -15756,53 +16397,15 @@ index 2fa49490..090d0e1b 100644
 +		ci.IdleTime = cc.t.timeSince(cc.lastActive)
  	}
  	cc.mu.Unlock()
-
-diff --git a/vendor/golang.org/x/net/http2/unencrypted.go b/vendor/golang.org/x/net/http2/unencrypted.go
-new file mode 100644
-index 00000000..b2de2116
---- /dev/null
-+++ b/vendor/golang.org/x/net/http2/unencrypted.go
-@@ -0,0 +1,32 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+package http2
-+
-+import (
-+	"crypto/tls"
-+	"errors"
-+	"net"
-+)
-+
-+const nextProtoUnencryptedHTTP2 = "unencrypted_http2"
-+
-+// unencryptedNetConnFromTLSConn retrieves a net.Conn wrapped in a *tls.Conn.
-+//
-+// TLSNextProto functions accept a *tls.Conn.
-+//
-+// When passing an unencrypted HTTP/2 connection to a TLSNextProto function,
-+// we pass a *tls.Conn with an underlying net.Conn containing the unencrypted connection.
-+// To be extra careful about mistakes (accidentally dropping TLS encryption in a place
-+// where we want it), the tls.Conn contains a net.Conn with an UnencryptedNetConn method
-+// that returns the actual connection we want to use.
-+func unencryptedNetConnFromTLSConn(tc *tls.Conn) (net.Conn, error) {
-+	conner, ok := tc.NetConn().(interface {
-+		UnencryptedNetConn() net.Conn
-+	})
-+	if !ok {
-+		return nil, errors.New("http2: TLS conn unexpectedly found in unencrypted handoff")
-+	}
-+	return conner.UnencryptedNetConn(), nil
-+}
+ 
 diff --git a/vendor/golang.org/x/net/http2/write.go b/vendor/golang.org/x/net/http2/write.go
 index 33f61398..6ff6bee7 100644
 --- a/vendor/golang.org/x/net/http2/write.go
 +++ b/vendor/golang.org/x/net/http2/write.go
 @@ -131,6 +131,16 @@ func (se StreamError) writeFrame(ctx writeContext) error {
-
+ 
  func (se StreamError) staysWithinBuffer(max int) bool { return frameHeaderLen+4 <= max }
-
+ 
 +type writePing struct {
 +	data [8]byte
 +}
@@ -15814,7 +16417,7 @@ index 33f61398..6ff6bee7 100644
 +func (w writePing) staysWithinBuffer(max int) bool { return frameHeaderLen+len(w.data) <= max }
 +
  type writePingAck struct{ pf *PingFrame }
-
+ 
  func (w writePingAck) writeFrame(ctx writeContext) error {
 diff --git a/vendor/golang.org/x/net/http2/writesched_priority.go b/vendor/golang.org/x/net/http2/writesched_priority.go
 index 0a242c66..f6783339 100644
@@ -15822,7 +16425,7 @@ index 0a242c66..f6783339 100644
 +++ b/vendor/golang.org/x/net/http2/writesched_priority.go
 @@ -443,8 +443,8 @@ func (ws *priorityWriteScheduler) addClosedOrIdleNode(list *[]*priorityNode, max
  }
-
+ 
  func (ws *priorityWriteScheduler) removeNode(n *priorityNode) {
 -	for k := n.kids; k != nil; k = k.next {
 -		k.setParent(n.parent)
@@ -15837,14 +16440,14 @@ index cebde763..3c9576e2 100644
 +++ b/vendor/golang.org/x/net/internal/socket/zsys_openbsd_ppc64.go
 @@ -4,27 +4,27 @@
  package socket
-
+ 
  type iovec struct {
 -	Base	*byte
 -	Len	uint64
 +	Base *byte
 +	Len  uint64
  }
-
+ 
  type msghdr struct {
 -	Name		*byte
 -	Namelen		uint32
@@ -15861,7 +16464,7 @@ index cebde763..3c9576e2 100644
 +	Controllen uint32
 +	Flags      int32
  }
-
+ 
  type cmsghdr struct {
 -	Len	uint32
 -	Level	int32
@@ -15870,7 +16473,7 @@ index cebde763..3c9576e2 100644
 +	Level int32
 +	Type  int32
  }
-
+ 
  const (
 -	sizeofIovec	= 0x10
 -	sizeofMsghdr	= 0x30
@@ -15883,14 +16486,14 @@ index cebde763..3c9576e2 100644
 +++ b/vendor/golang.org/x/net/internal/socket/zsys_openbsd_riscv64.go
 @@ -4,27 +4,27 @@
  package socket
-
+ 
  type iovec struct {
 -	Base	*byte
 -	Len	uint64
 +	Base *byte
 +	Len  uint64
  }
-
+ 
  type msghdr struct {
 -	Name		*byte
 -	Namelen		uint32
@@ -15907,7 +16510,7 @@ index cebde763..3c9576e2 100644
 +	Controllen uint32
 +	Flags      int32
  }
-
+ 
  type cmsghdr struct {
 -	Len	uint32
 -	Level	int32
@@ -15916,7 +16519,7 @@ index cebde763..3c9576e2 100644
 +	Level int32
 +	Type  int32
  }
-
+ 
  const (
 -	sizeofIovec	= 0x10
 -	sizeofMsghdr	= 0x30
@@ -15939,7 +16542,7 @@ index 573fe79e..d7d4b8b6 100644
  		zone = "." + zone
  	}
 @@ -148,8 +146,6 @@ func (p *PerHost) AddZone(zone string) {
-
+ 
  // AddHost specifies a host name that will use the bypass proxy.
  func (p *PerHost) AddHost(host string) {
 -	if strings.HasSuffix(host, ".") {
@@ -15955,7 +16558,7 @@ index 6a66aea5..2a7cf70d 100644
 @@ -1,4 +1,4 @@
 -Copyright (c) 2009 The Go Authors. All rights reserved.
 +Copyright 2009 The Go Authors.
-
+ 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are
 @@ -10,7 +10,7 @@ notice, this list of conditions and the following disclaimer.
@@ -15966,7 +16569,7 @@ index 6a66aea5..2a7cf70d 100644
 +   * Neither the name of Google LLC nor the names of its
  contributors may be used to endorse or promote products derived from
  this software without specific prior written permission.
-
+ 
 diff --git a/vendor/golang.org/x/sys/LICENSE b/vendor/golang.org/x/sys/LICENSE
 index 6a66aea5..2a7cf70d 100644
 --- a/vendor/golang.org/x/sys/LICENSE
@@ -15974,7 +16577,7 @@ index 6a66aea5..2a7cf70d 100644
 @@ -1,4 +1,4 @@
 -Copyright (c) 2009 The Go Authors. All rights reserved.
 +Copyright 2009 The Go Authors.
-
+ 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are
 @@ -10,7 +10,7 @@ notice, this list of conditions and the following disclaimer.
@@ -15985,30 +16588,7 @@ index 6a66aea5..2a7cf70d 100644
 +   * Neither the name of Google LLC nor the names of its
  contributors may be used to endorse or promote products derived from
  this software without specific prior written permission.
-
-diff --git a/vendor/golang.org/x/sys/cpu/asm_darwin_x86_gc.s b/vendor/golang.org/x/sys/cpu/asm_darwin_x86_gc.s
-new file mode 100644
-index 00000000..ec2acfe5
---- /dev/null
-+++ b/vendor/golang.org/x/sys/cpu/asm_darwin_x86_gc.s
-@@ -0,0 +1,17 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build darwin && amd64 && gc
-+
-+#include "textflag.h"
-+
-+TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
-+	JMP	libc_sysctl(SB)
-+GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
-+DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
-+
-+TEXT libc_sysctlbyname_trampoline<>(SB),NOSPLIT,$0-0
-+	JMP	libc_sysctlbyname(SB)
-+GLOBL	·libc_sysctlbyname_trampoline_addr(SB), RODATA, $8
-+DATA	·libc_sysctlbyname_trampoline_addr(SB)/8, $libc_sysctlbyname_trampoline<>(SB)
+ 
 diff --git a/vendor/golang.org/x/sys/cpu/cpu.go b/vendor/golang.org/x/sys/cpu/cpu.go
 index 8fa707aa..02609d5b 100644
 --- a/vendor/golang.org/x/sys/cpu/cpu.go
@@ -16021,11 +16601,11 @@ index 8fa707aa..02609d5b 100644
 +	HasI8MM     bool // Advanced SIMD Int8 matrix multiplication instructions
  	_           CacheLinePad
  }
-
+ 
 @@ -199,6 +201,25 @@ var S390X struct {
  	_         CacheLinePad
  }
-
+ 
 +// RISCV64 contains the supported CPU features and performance characteristics for riscv64
 +// platforms. The booleans in RISCV64, with the exception of HasFastMisaligned, indicate
 +// the presence of RISC-V extensions.
@@ -16060,11 +16640,11 @@ index 0e27a21e..af2aa99f 100644
 +		{Name: "i8mm", Feature: &ARM64.HasI8MM},
  	}
  }
-
+ 
 @@ -145,6 +147,11 @@ func parseARM64SystemRegisters(isar0, isar1, pfr0 uint64) {
  		ARM64.HasLRCPC = true
  	}
-
+ 
 +	switch extractBits(isar1, 52, 55) {
 +	case 1:
 +		ARM64.HasI8MM = true
@@ -16074,7 +16654,7 @@ index 0e27a21e..af2aa99f 100644
  	switch extractBits(pfr0, 16, 19) {
  	case 0:
 @@ -168,6 +175,11 @@ func parseARM64SystemRegisters(isar0, isar1, pfr0 uint64) {
-
+ 
  		parseARM64SVERegister(getzfr0())
  	}
 +
@@ -16083,108 +16663,25 @@ index 0e27a21e..af2aa99f 100644
 +		ARM64.HasDIT = true
 +	}
  }
-
+ 
  func parseARM64SVERegister(zfr0 uint64) {
-diff --git a/vendor/golang.org/x/sys/cpu/cpu_darwin_x86.go b/vendor/golang.org/x/sys/cpu/cpu_darwin_x86.go
-new file mode 100644
-index 00000000..b838cb9e
---- /dev/null
-+++ b/vendor/golang.org/x/sys/cpu/cpu_darwin_x86.go
-@@ -0,0 +1,61 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build darwin && amd64 && gc
-+
-+package cpu
-+
-+// darwinSupportsAVX512 checks Darwin kernel for AVX512 support via sysctl
-+// call (see issue 43089). It also restricts AVX512 support for Darwin to
-+// kernel version 21.3.0 (MacOS 12.2.0) or later (see issue 49233).
-+//
-+// Background:
-+// Darwin implements a special mechanism to economize on thread state when
-+// AVX512 specific registers are not in use. This scheme minimizes state when
-+// preempting threads that haven't yet used any AVX512 instructions, but adds
-+// special requirements to check for AVX512 hardware support at runtime (e.g.
-+// via sysctl call or commpage inspection). See issue 43089 and link below for
-+// full background:
-+// https://github.com/apple-oss-distributions/xnu/blob/xnu-11215.1.10/osfmk/i386/fpu.c#L214-L240
-+//
-+// Additionally, all versions of the Darwin kernel from 19.6.0 through 21.2.0
-+// (corresponding to MacOS 10.15.6 - 12.1) have a bug that can cause corruption
-+// of the AVX512 mask registers (K0-K7) upon signal return. For this reason
-+// AVX512 is considered unsafe to use on Darwin for kernel versions prior to
-+// 21.3.0, where a fix has been confirmed. See issue 49233 for full background.
-+func darwinSupportsAVX512() bool {
-+	return darwinSysctlEnabled([]byte("hw.optional.avx512f\x00")) && darwinKernelVersionCheck(21, 3, 0)
-+}
-+
-+// Ensure Darwin kernel version is at least major.minor.patch, avoiding dependencies
-+func darwinKernelVersionCheck(major, minor, patch int) bool {
-+	var release [256]byte
-+	err := darwinOSRelease(&release)
-+	if err != nil {
-+		return false
-+	}
-+
-+	var mmp [3]int
-+	c := 0
-+Loop:
-+	for _, b := range release[:] {
-+		switch {
-+		case b >= '0' && b <= '9':
-+			mmp[c] = 10*mmp[c] + int(b-'0')
-+		case b == '.':
-+			c++
-+			if c > 2 {
-+				return false
-+			}
-+		case b == 0:
-+			break Loop
-+		default:
-+			return false
-+		}
-+	}
-+	if c != 2 {
-+		return false
-+	}
-+	return mmp[0] > major || mmp[0] == major && (mmp[1] > minor || mmp[1] == minor && mmp[2] >= patch)
-+}
 diff --git a/vendor/golang.org/x/sys/cpu/cpu_gc_x86.go b/vendor/golang.org/x/sys/cpu/cpu_gc_x86.go
 index 910728fb..32a44514 100644
 --- a/vendor/golang.org/x/sys/cpu/cpu_gc_x86.go
 +++ b/vendor/golang.org/x/sys/cpu/cpu_gc_x86.go
 @@ -6,10 +6,10 @@
-
+ 
  package cpu
-
+ 
 -// cpuid is implemented in cpu_x86.s for gc compiler
 +// cpuid is implemented in cpu_gc_x86.s for gc compiler
  // and in cpu_gccgo.c for gccgo.
  func cpuid(eaxArg, ecxArg uint32) (eax, ebx, ecx, edx uint32)
-
+ 
 -// xgetbv with ecx = 0 is implemented in cpu_x86.s for gc compiler
 +// xgetbv with ecx = 0 is implemented in cpu_gc_x86.s for gc compiler
  // and in cpu_gccgo.c for gccgo.
  func xgetbv() (eax, edx uint32)
-diff --git a/vendor/golang.org/x/sys/cpu/cpu_x86.s b/vendor/golang.org/x/sys/cpu/cpu_gc_x86.s
-similarity index 94%
-rename from vendor/golang.org/x/sys/cpu/cpu_x86.s
-rename to vendor/golang.org/x/sys/cpu/cpu_gc_x86.s
-index 7d7ba33e..ce208ce6 100644
---- a/vendor/golang.org/x/sys/cpu/cpu_x86.s
-+++ b/vendor/golang.org/x/sys/cpu/cpu_gc_x86.s
-@@ -18,7 +18,7 @@ TEXT ·cpuid(SB), NOSPLIT, $0-24
- 	RET
-
- // func xgetbv() (eax, edx uint32)
--TEXT ·xgetbv(SB),NOSPLIT,$0-8
-+TEXT ·xgetbv(SB), NOSPLIT, $0-8
- 	MOVL $0, CX
- 	XGETBV
- 	MOVL AX, eax+0(FP)
 diff --git a/vendor/golang.org/x/sys/cpu/cpu_gccgo_x86.go b/vendor/golang.org/x/sys/cpu/cpu_gccgo_x86.go
 index 99c60fe9..170d21dd 100644
 --- a/vendor/golang.org/x/sys/cpu/cpu_gccgo_x86.go
@@ -16208,23 +16705,23 @@ index 3d386d0f..f1caf0f7 100644
  	hwcap_SVE      = 1 << 22
  	hwcap_ASIMDFHM = 1 << 23
 +	hwcap_DIT      = 1 << 24
-
+ 
  	hwcap2_SVE2 = 1 << 1
 +	hwcap2_I8MM = 1 << 13
  )
-
+ 
  // linuxKernelCanEmulateCPUID reports whether we're running
 @@ -106,9 +108,11 @@ func doinit() {
  	ARM64.HasSHA512 = isSet(hwCap, hwcap_SHA512)
  	ARM64.HasSVE = isSet(hwCap, hwcap_SVE)
  	ARM64.HasASIMDFHM = isSet(hwCap, hwcap_ASIMDFHM)
 +	ARM64.HasDIT = isSet(hwCap, hwcap_DIT)
-
+ 
  	// HWCAP2 feature bits
  	ARM64.HasSVE2 = isSet(hwCap2, hwcap2_SVE2)
 +	ARM64.HasI8MM = isSet(hwCap2, hwcap2_I8MM)
  }
-
+ 
  func isSet(hwc uint, value uint) bool {
 diff --git a/vendor/golang.org/x/sys/cpu/cpu_linux_noinit.go b/vendor/golang.org/x/sys/cpu/cpu_linux_noinit.go
 index cd63e733..7d902b68 100644
@@ -16233,180 +16730,20 @@ index cd63e733..7d902b68 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build linux && !arm && !arm64 && !mips64 && !mips64le && !ppc64 && !ppc64le && !s390x
 +//go:build linux && !arm && !arm64 && !mips64 && !mips64le && !ppc64 && !ppc64le && !s390x && !riscv64
-
+ 
  package cpu
-
-diff --git a/vendor/golang.org/x/sys/cpu/cpu_linux_riscv64.go b/vendor/golang.org/x/sys/cpu/cpu_linux_riscv64.go
-new file mode 100644
-index 00000000..cb4a0c57
---- /dev/null
-+++ b/vendor/golang.org/x/sys/cpu/cpu_linux_riscv64.go
-@@ -0,0 +1,137 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+package cpu
-+
-+import (
-+	"syscall"
-+	"unsafe"
-+)
-+
-+// RISC-V extension discovery code for Linux. The approach here is to first try the riscv_hwprobe
-+// syscall falling back to HWCAP to check for the C extension if riscv_hwprobe is not available.
-+//
-+// A note on detection of the Vector extension using HWCAP.
-+//
-+// Support for the Vector extension version 1.0 was added to the Linux kernel in release 6.5.
-+// Support for the riscv_hwprobe syscall was added in 6.4. It follows that if the riscv_hwprobe
-+// syscall is not available then neither is the Vector extension (which needs kernel support).
-+// The riscv_hwprobe syscall should then be all we need to detect the Vector extension.
-+// However, some RISC-V board manufacturers ship boards with an older kernel on top of which
-+// they have back-ported various versions of the Vector extension patches but not the riscv_hwprobe
-+// patches. These kernels advertise support for the Vector extension using HWCAP. Falling
-+// back to HWCAP to detect the Vector extension, if riscv_hwprobe is not available, or simply not
-+// bothering with riscv_hwprobe at all and just using HWCAP may then seem like an attractive option.
-+//
-+// Unfortunately, simply checking the 'V' bit in AT_HWCAP will not work as this bit is used by
-+// RISC-V board and cloud instance providers to mean different things. The Lichee Pi 4A board
-+// and the Scaleway RV1 cloud instances use the 'V' bit to advertise their support for the unratified
-+// 0.7.1 version of the Vector Specification. The Banana Pi BPI-F3 and the CanMV-K230 board use
-+// it to advertise support for 1.0 of the Vector extension. Versions 0.7.1 and 1.0 of the Vector
-+// extension are binary incompatible. HWCAP can then not be used in isolation to populate the
-+// HasV field as this field indicates that the underlying CPU is compatible with RVV 1.0.
-+//
-+// There is a way at runtime to distinguish between versions 0.7.1 and 1.0 of the Vector
-+// specification by issuing a RVV 1.0 vsetvli instruction and checking the vill bit of the vtype
-+// register. This check would allow us to safely detect version 1.0 of the Vector extension
-+// with HWCAP, if riscv_hwprobe were not available. However, the check cannot
-+// be added until the assembler supports the Vector instructions.
-+//
-+// Note the riscv_hwprobe syscall does not suffer from these ambiguities by design as all of the
-+// extensions it advertises support for are explicitly versioned. It's also worth noting that
-+// the riscv_hwprobe syscall is the only way to detect multi-letter RISC-V extensions, e.g., Zba.
-+// These cannot be detected using HWCAP and so riscv_hwprobe must be used to detect the majority
-+// of RISC-V extensions.
-+//
-+// Please see https://docs.kernel.org/arch/riscv/hwprobe.html for more information.
-+
-+// golang.org/x/sys/cpu is not allowed to depend on golang.org/x/sys/unix so we must
-+// reproduce the constants, types and functions needed to make the riscv_hwprobe syscall
-+// here.
-+
-+const (
-+	// Copied from golang.org/x/sys/unix/ztypes_linux_riscv64.go.
-+	riscv_HWPROBE_KEY_IMA_EXT_0   = 0x4
-+	riscv_HWPROBE_IMA_C           = 0x2
-+	riscv_HWPROBE_IMA_V           = 0x4
-+	riscv_HWPROBE_EXT_ZBA         = 0x8
-+	riscv_HWPROBE_EXT_ZBB         = 0x10
-+	riscv_HWPROBE_EXT_ZBS         = 0x20
-+	riscv_HWPROBE_KEY_CPUPERF_0   = 0x5
-+	riscv_HWPROBE_MISALIGNED_FAST = 0x3
-+	riscv_HWPROBE_MISALIGNED_MASK = 0x7
-+)
-+
-+const (
-+	// sys_RISCV_HWPROBE is copied from golang.org/x/sys/unix/zsysnum_linux_riscv64.go.
-+	sys_RISCV_HWPROBE = 258
-+)
-+
-+// riscvHWProbePairs is copied from golang.org/x/sys/unix/ztypes_linux_riscv64.go.
-+type riscvHWProbePairs struct {
-+	key   int64
-+	value uint64
-+}
-+
-+const (
-+	// CPU features
-+	hwcap_RISCV_ISA_C = 1 << ('C' - 'A')
-+)
-+
-+func doinit() {
-+	// A slice of key/value pair structures is passed to the RISCVHWProbe syscall. The key
-+	// field should be initialised with one of the key constants defined above, e.g.,
-+	// RISCV_HWPROBE_KEY_IMA_EXT_0. The syscall will set the value field to the appropriate value.
-+	// If the kernel does not recognise a key it will set the key field to -1 and the value field to 0.
-+
-+	pairs := []riscvHWProbePairs{
-+		{riscv_HWPROBE_KEY_IMA_EXT_0, 0},
-+		{riscv_HWPROBE_KEY_CPUPERF_0, 0},
-+	}
-+
-+	// This call only indicates that extensions are supported if they are implemented on all cores.
-+	if riscvHWProbe(pairs, 0) {
-+		if pairs[0].key != -1 {
-+			v := uint(pairs[0].value)
-+			RISCV64.HasC = isSet(v, riscv_HWPROBE_IMA_C)
-+			RISCV64.HasV = isSet(v, riscv_HWPROBE_IMA_V)
-+			RISCV64.HasZba = isSet(v, riscv_HWPROBE_EXT_ZBA)
-+			RISCV64.HasZbb = isSet(v, riscv_HWPROBE_EXT_ZBB)
-+			RISCV64.HasZbs = isSet(v, riscv_HWPROBE_EXT_ZBS)
-+		}
-+		if pairs[1].key != -1 {
-+			v := pairs[1].value & riscv_HWPROBE_MISALIGNED_MASK
-+			RISCV64.HasFastMisaligned = v == riscv_HWPROBE_MISALIGNED_FAST
-+		}
-+	}
-+
-+	// Let's double check with HWCAP if the C extension does not appear to be supported.
-+	// This may happen if we're running on a kernel older than 6.4.
-+
-+	if !RISCV64.HasC {
-+		RISCV64.HasC = isSet(hwCap, hwcap_RISCV_ISA_C)
-+	}
-+}
-+
-+func isSet(hwc uint, value uint) bool {
-+	return hwc&value != 0
-+}
-+
-+// riscvHWProbe is a simplified version of the generated wrapper function found in
-+// golang.org/x/sys/unix/zsyscall_linux_riscv64.go. We simplify it by removing the
-+// cpuCount and cpus parameters which we do not need. We always want to pass 0 for
-+// these parameters here so the kernel only reports the extensions that are present
-+// on all cores.
-+func riscvHWProbe(pairs []riscvHWProbePairs, flags uint) bool {
-+	var _zero uintptr
-+	var p0 unsafe.Pointer
-+	if len(pairs) > 0 {
-+		p0 = unsafe.Pointer(&pairs[0])
-+	} else {
-+		p0 = unsafe.Pointer(&_zero)
-+	}
-+
-+	_, _, e1 := syscall.Syscall6(sys_RISCV_HWPROBE, uintptr(p0), uintptr(len(pairs)), uintptr(0), uintptr(0), uintptr(flags), 0)
-+	return e1 == 0
-+}
-diff --git a/vendor/golang.org/x/sys/cpu/cpu_other_x86.go b/vendor/golang.org/x/sys/cpu/cpu_other_x86.go
-new file mode 100644
-index 00000000..a0fd7e2f
---- /dev/null
-+++ b/vendor/golang.org/x/sys/cpu/cpu_other_x86.go
-@@ -0,0 +1,11 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build 386 || amd64p32 || (amd64 && (!darwin || !gc))
-+
-+package cpu
-+
-+func darwinSupportsAVX512() bool {
-+	panic("only implemented for gc && amd64 && darwin")
-+}
+ 
 diff --git a/vendor/golang.org/x/sys/cpu/cpu_riscv64.go b/vendor/golang.org/x/sys/cpu/cpu_riscv64.go
 index 7f0c79c0..aca3199c 100644
 --- a/vendor/golang.org/x/sys/cpu/cpu_riscv64.go
 +++ b/vendor/golang.org/x/sys/cpu/cpu_riscv64.go
 @@ -8,4 +8,13 @@ package cpu
-
+ 
  const cacheLineSize = 64
-
+ 
 -func initOptions() {}
 +func initOptions() {
 +	options = []option{
@@ -16424,7 +16761,7 @@ index c29f5e4c..600a6807 100644
 +++ b/vendor/golang.org/x/sys/cpu/cpu_x86.go
 @@ -92,10 +92,8 @@ func archInit() {
  		osSupportsAVX = isSet(1, eax) && isSet(2, eax)
-
+ 
  		if runtime.GOOS == "darwin" {
 -			// Darwin doesn't save/restore AVX-512 mask registers correctly across signal handlers.
 -			// Since users can't rely on mask register contents, let's not advertise AVX-512 support.
@@ -16435,123 +16772,51 @@ index c29f5e4c..600a6807 100644
  		} else {
  			// Check if OPMASK and ZMM registers have OS support.
  			osSupportsAVX512 = osSupportsAVX && isSet(5, eax) && isSet(6, eax) && isSet(7, eax)
-diff --git a/vendor/golang.org/x/sys/cpu/syscall_darwin_x86_gc.go b/vendor/golang.org/x/sys/cpu/syscall_darwin_x86_gc.go
-new file mode 100644
-index 00000000..4d0888b0
---- /dev/null
-+++ b/vendor/golang.org/x/sys/cpu/syscall_darwin_x86_gc.go
-@@ -0,0 +1,98 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// Minimal copy of x/sys/unix so the cpu package can make a
-+// system call on Darwin without depending on x/sys/unix.
-+
-+//go:build darwin && amd64 && gc
-+
-+package cpu
-+
-+import (
-+	"syscall"
-+	"unsafe"
-+)
-+
-+type _C_int int32
-+
-+// adapted from unix.Uname() at x/sys/unix/syscall_darwin.go L419
-+func darwinOSRelease(release *[256]byte) error {
-+	// from x/sys/unix/zerrors_openbsd_amd64.go
-+	const (
-+		CTL_KERN       = 0x1
-+		KERN_OSRELEASE = 0x2
-+	)
-+
-+	mib := []_C_int{CTL_KERN, KERN_OSRELEASE}
-+	n := unsafe.Sizeof(*release)
-+
-+	return sysctl(mib, &release[0], &n, nil, 0)
-+}
-+
-+type Errno = syscall.Errno
-+
-+var _zero uintptr // Single-word zero for use when we need a valid pointer to 0 bytes.
-+
-+// from x/sys/unix/zsyscall_darwin_amd64.go L791-807
-+func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) error {
-+	var _p0 unsafe.Pointer
-+	if len(mib) > 0 {
-+		_p0 = unsafe.Pointer(&mib[0])
-+	} else {
-+		_p0 = unsafe.Pointer(&_zero)
-+	}
-+	if _, _, err := syscall_syscall6(
-+		libc_sysctl_trampoline_addr,
-+		uintptr(_p0),
-+		uintptr(len(mib)),
-+		uintptr(unsafe.Pointer(old)),
-+		uintptr(unsafe.Pointer(oldlen)),
-+		uintptr(unsafe.Pointer(new)),
-+		uintptr(newlen),
-+	); err != 0 {
-+		return err
-+	}
-+
-+	return nil
-+}
-+
-+var libc_sysctl_trampoline_addr uintptr
-+
-+// adapted from internal/cpu/cpu_arm64_darwin.go
-+func darwinSysctlEnabled(name []byte) bool {
-+	out := int32(0)
-+	nout := unsafe.Sizeof(out)
-+	if ret := sysctlbyname(&name[0], (*byte)(unsafe.Pointer(&out)), &nout, nil, 0); ret != nil {
-+		return false
-+	}
-+	return out > 0
-+}
-+
-+//go:cgo_import_dynamic libc_sysctl sysctl "/usr/lib/libSystem.B.dylib"
-+
-+var libc_sysctlbyname_trampoline_addr uintptr
-+
-+// adapted from runtime/sys_darwin.go in the pattern of sysctl() above, as defined in x/sys/unix
-+func sysctlbyname(name *byte, old *byte, oldlen *uintptr, new *byte, newlen uintptr) error {
-+	if _, _, err := syscall_syscall6(
-+		libc_sysctlbyname_trampoline_addr,
-+		uintptr(unsafe.Pointer(name)),
-+		uintptr(unsafe.Pointer(old)),
-+		uintptr(unsafe.Pointer(oldlen)),
-+		uintptr(unsafe.Pointer(new)),
-+		uintptr(newlen),
-+		0,
-+	); err != 0 {
-+		return err
-+	}
-+
-+	return nil
-+}
-+
-+//go:cgo_import_dynamic libc_sysctlbyname sysctlbyname "/usr/lib/libSystem.B.dylib"
-+
-+// Implemented in the runtime package (runtime/sys_darwin.go)
-+func syscall_syscall6(fn, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err Errno)
-+
-+//go:linkname syscall_syscall6 syscall.syscall6
+diff --git a/vendor/golang.org/x/sys/cpu/cpu_x86.s b/vendor/golang.org/x/sys/cpu/cpu_x86.s
+deleted file mode 100644
+index 7d7ba33e..00000000
+--- a/vendor/golang.org/x/sys/cpu/cpu_x86.s
++++ /dev/null
+@@ -1,26 +0,0 @@
+-// Copyright 2018 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build (386 || amd64 || amd64p32) && gc
+-
+-#include "textflag.h"
+-
+-// func cpuid(eaxArg, ecxArg uint32) (eax, ebx, ecx, edx uint32)
+-TEXT ·cpuid(SB), NOSPLIT, $0-24
+-	MOVL eaxArg+0(FP), AX
+-	MOVL ecxArg+4(FP), CX
+-	CPUID
+-	MOVL AX, eax+8(FP)
+-	MOVL BX, ebx+12(FP)
+-	MOVL CX, ecx+16(FP)
+-	MOVL DX, edx+20(FP)
+-	RET
+-
+-// func xgetbv() (eax, edx uint32)
+-TEXT ·xgetbv(SB),NOSPLIT,$0-8
+-	MOVL $0, CX
+-	XGETBV
+-	MOVL AX, eax+0(FP)
+-	MOVL DX, edx+4(FP)
+-	RET
 diff --git a/vendor/golang.org/x/sys/unix/README.md b/vendor/golang.org/x/sys/unix/README.md
 index 7d3c060e..6e08a76a 100644
 --- a/vendor/golang.org/x/sys/unix/README.md
 +++ b/vendor/golang.org/x/sys/unix/README.md
 @@ -156,7 +156,7 @@ from the generated architecture-specific files listed below, and merge these
  into a common file for each OS.
-
+ 
  The merge is performed in the following steps:
 -1. Construct the set of common code that is idential in all architecture-specific files.
 +1. Construct the set of common code that is identical in all architecture-specific files.
  2. Write this common code to the merged file.
  3. Remove the common code from all architecture-specific files.
-
+ 
 diff --git a/vendor/golang.org/x/sys/unix/ioctl_linux.go b/vendor/golang.org/x/sys/unix/ioctl_linux.go
 index dbe680ea..7ca4fa12 100644
 --- a/vendor/golang.org/x/sys/unix/ioctl_linux.go
@@ -16559,7 +16824,7 @@ index dbe680ea..7ca4fa12 100644
 @@ -58,6 +58,102 @@ func IoctlGetEthtoolDrvinfo(fd int, ifname string) (*EthtoolDrvinfo, error) {
  	return &value, err
  }
-
+ 
 +// IoctlGetEthtoolTsInfo fetches ethtool timestamping and PHC
 +// association for the network device specified by ifname.
 +func IoctlGetEthtoolTsInfo(fd int, ifname string) (*EthtoolTsInfo, error) {
@@ -16674,7 +16939,7 @@ index 4ed2e488..6ab02b6c 100644
 @@ -157,6 +158,16 @@ includes_Linux='
  #endif
  #define _GNU_SOURCE
-
+ 
 +// See the description in unix/linux/types.go
 +#if defined(__ARM_EABI__) || \
 +	(defined(__mips__) && (_MIPS_SIM == _ABIO32)) || \
@@ -16720,7 +16985,7 @@ index 4ed2e488..6ab02b6c 100644
 +	grep -E -v '(SIGSTKSIZE|SIGSTKSZ|SIGRT|SIGMAX64)' |
  	sort
  )
-
+ 
 @@ -664,7 +678,7 @@ echo '#include <errno.h>' | $CC -x c - -E -dM $ccflags |
  	sort >_error.grep
  echo '#include <signal.h>' | $CC -x c - -E -dM $ccflags |
@@ -16728,7 +16993,7 @@ index 4ed2e488..6ab02b6c 100644
 -	grep -v 'SIGSTKSIZE\|SIGSTKSZ\|SIGRT\|SIGMAX64' |
 +	grep -E -v '(SIGSTKSIZE|SIGSTKSZ|SIGRT|SIGMAX64)' |
  	sort >_signal.grep
-
+ 
  echo '// mkerrors.sh' "$@"
 diff --git a/vendor/golang.org/x/sys/unix/syscall_aix.go b/vendor/golang.org/x/sys/unix/syscall_aix.go
 index 67ce6cef..6f15ba1e 100644
@@ -16750,7 +17015,7 @@ index 4cc7b005..099867de 100644
 @@ -402,6 +402,18 @@ func IoctlSetIfreqMTU(fd int, ifreq *IfreqMTU) error {
  	return ioctlPtr(fd, SIOCSIFMTU, unsafe.Pointer(ifreq))
  }
-
+ 
 +//sys	renamexNp(from string, to string, flag uint32) (err error)
 +
 +func RenamexNp(from string, to string, flag uint32) (err error) {
@@ -16764,12 +17029,12 @@ index 4cc7b005..099867de 100644
 +}
 +
  //sys	sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) = SYS_SYSCTL
-
+ 
  func Uname(uname *Utsname) error {
 @@ -554,6 +566,43 @@ func PthreadFchdir(fd int) (err error) {
  	return pthread_fchdir_np(fd)
  }
-
+ 
 +// Connectx calls connectx(2) to initiate a connection on a socket.
 +//
 +// srcIf, srcAddr, and dstAddr are filled into a [SaEndpoints] struct and passed as the endpoints argument.
@@ -16808,7 +17073,7 @@ index 4cc7b005..099867de 100644
 +
 +//sys	connectx(fd int, endpoints *SaEndpoints, associd SaeAssocID, flags uint32, iov []Iovec, n *uintptr, connid *SaeConnID) (err error)
  //sys	sendfile(infd int, outfd int, offset int64, len *int64, hdtr unsafe.Pointer, flags int) (err error)
-
+ 
  //sys	shmat(id int, addr uintptr, flag int) (ret uintptr, err error)
 diff --git a/vendor/golang.org/x/sys/unix/syscall_hurd.go b/vendor/golang.org/x/sys/unix/syscall_hurd.go
 index ba46651f..a6a2d2fc 100644
@@ -16819,7 +17084,7 @@ index ba46651f..a6a2d2fc 100644
  */
  import "C"
 +import "unsafe"
-
+ 
  func ioctl(fd int, req uint, arg uintptr) (err error) {
  	r0, er := C.ioctl(C.int(fd), C.ulong(req), C.uintptr_t(arg))
 diff --git a/vendor/golang.org/x/sys/unix/syscall_linux.go b/vendor/golang.org/x/sys/unix/syscall_linux.go
@@ -16829,7 +17094,7 @@ index 5682e262..230a9454 100644
 @@ -1295,6 +1295,48 @@ func GetsockoptTCPInfo(fd, level, opt int) (*TCPInfo, error) {
  	return &value, err
  }
-
+ 
 +// GetsockoptTCPCCVegasInfo returns algorithm specific congestion control information for a socket using the "vegas"
 +// algorithm.
 +//
@@ -16913,7 +17178,7 @@ index 5682e262..230a9454 100644
  //sysnb	Gettid() (tid int)
 @@ -2592,3 +2654,4 @@ func SchedGetAttr(pid int, flags uint) (*SchedAttr, error) {
  }
-
+ 
  //sys	Cachestat(fd uint, crange *CachestatRange, cstat *Cachestat_t, flags uint) (err error)
 +//sys	Mseal(b []byte, flags uint) (err error)
 diff --git a/vendor/golang.org/x/sys/unix/syscall_linux_arm64.go b/vendor/golang.org/x/sys/unix/syscall_linux_arm64.go
@@ -16965,7 +17230,7 @@ index 312ae6ac..7bf5c04b 100644
 @@ -768,6 +768,15 @@ func Munmap(b []byte) (err error) {
  	return mapper.Munmap(b)
  }
-
+ 
 +func MmapPtr(fd int, offset int64, addr unsafe.Pointer, length uintptr, prot int, flags int) (ret unsafe.Pointer, err error) {
 +	xaddr, err := mapper.mmap(uintptr(addr), length, prot, flags, fd, offset)
 +	return unsafe.Pointer(xaddr), err
@@ -16990,7 +17255,7 @@ index 312ae6ac..7bf5c04b 100644
 +		{'S', 'Y', 'S', 'N', 'A', 'M', 'E', '/'},
 +		{'S', 'Y', 'S', 'S', 'Y', 'M', 'R', '/'},
 +		{'S', 'Y', 'S', 'S', 'Y', 'M', 'A', '/'}}
-
+ 
  	var i, j int
  	for i = 0; i < len(special); i++ {
 @@ -3115,3 +3124,90 @@ func legacy_Mkfifoat(dirfd int, path string, mode uint32) (err error) {
@@ -17083,42 +17348,6 @@ index 312ae6ac..7bf5c04b 100644
 +		}
 +	}
 +	return n2, nil
-+}
-diff --git a/vendor/golang.org/x/sys/unix/vgetrandom_linux.go b/vendor/golang.org/x/sys/unix/vgetrandom_linux.go
-new file mode 100644
-index 00000000..07ac8e09
---- /dev/null
-+++ b/vendor/golang.org/x/sys/unix/vgetrandom_linux.go
-@@ -0,0 +1,13 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build linux && go1.24
-+
-+package unix
-+
-+import _ "unsafe"
-+
-+//go:linkname vgetrandom runtime.vgetrandom
-+//go:noescape
-+func vgetrandom(p []byte, flags uint32) (ret int, supported bool)
-diff --git a/vendor/golang.org/x/sys/unix/vgetrandom_unsupported.go b/vendor/golang.org/x/sys/unix/vgetrandom_unsupported.go
-new file mode 100644
-index 00000000..297e97bc
---- /dev/null
-+++ b/vendor/golang.org/x/sys/unix/vgetrandom_unsupported.go
-@@ -0,0 +1,11 @@
-+// Copyright 2024 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build !linux || !go1.24
-+
-+package unix
-+
-+func vgetrandom(p []byte, flags uint32) (ret int, supported bool) {
-+	return -1, false
 +}
 diff --git a/vendor/golang.org/x/sys/unix/zerrors_darwin_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_darwin_amd64.go
 index e40fa852..d73c4652 100644
@@ -18598,16 +18827,16 @@ index da08b2ab..1ec2b140 100644
 +	ST_RDONLY                       = 1
 +	ST_NOSUID                       = 2
  )
-
+ 
  const (
 diff --git a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
 index 07642c30..24b346e1 100644
 --- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
 +++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go
 @@ -740,6 +740,54 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 +func renamexNp(from string, to string, flag uint32) (err error) {
 +	var _p0 *byte
 +	_p0, err = BytePtrFromString(from)
@@ -18660,9 +18889,9 @@ index 07642c30..24b346e1 100644
  	var _p0 unsafe.Pointer
  	if len(mib) > 0 {
 @@ -793,6 +841,26 @@ var libc_pthread_fchdir_np_trampoline_addr uintptr
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 +func connectx(fd int, endpoints *SaEndpoints, associd SaeAssocID, flags uint32, iov []Iovec, n *uintptr, connid *SaeConnID) (err error) {
 +	var _p0 unsafe.Pointer
 +	if len(iov) > 0 {
@@ -18693,7 +18922,7 @@ index 923e08cb..ebd21310 100644
 @@ -223,6 +223,16 @@ TEXT libc_ioctl_trampoline<>(SB),NOSPLIT,$0-0
  GLOBL	·libc_ioctl_trampoline_addr(SB), RODATA, $8
  DATA	·libc_ioctl_trampoline_addr(SB)/8, $libc_ioctl_trampoline<>(SB)
-
+ 
 +TEXT libc_renamex_np_trampoline<>(SB),NOSPLIT,$0-0
 +	JMP	libc_renamex_np(SB)
 +GLOBL	·libc_renamex_np_trampoline_addr(SB), RODATA, $8
@@ -18710,7 +18939,7 @@ index 923e08cb..ebd21310 100644
 @@ -238,6 +248,11 @@ TEXT libc_pthread_fchdir_np_trampoline<>(SB),NOSPLIT,$0-0
  GLOBL	·libc_pthread_fchdir_np_trampoline_addr(SB), RODATA, $8
  DATA	·libc_pthread_fchdir_np_trampoline_addr(SB)/8, $libc_pthread_fchdir_np_trampoline<>(SB)
-
+ 
 +TEXT libc_connectx_trampoline<>(SB),NOSPLIT,$0-0
 +	JMP	libc_connectx(SB)
 +GLOBL	·libc_connectx_trampoline_addr(SB), RODATA, $8
@@ -18724,9 +18953,9 @@ index 7d73dda6..824b9c2d 100644
 --- a/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
 +++ b/vendor/golang.org/x/sys/unix/zsyscall_darwin_arm64.go
 @@ -740,6 +740,54 @@ func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 +func renamexNp(from string, to string, flag uint32) (err error) {
 +	var _p0 *byte
 +	_p0, err = BytePtrFromString(from)
@@ -18779,9 +19008,9 @@ index 7d73dda6..824b9c2d 100644
  	var _p0 unsafe.Pointer
  	if len(mib) > 0 {
 @@ -793,6 +841,26 @@ var libc_pthread_fchdir_np_trampoline_addr uintptr
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 +func connectx(fd int, endpoints *SaEndpoints, associd SaeAssocID, flags uint32, iov []Iovec, n *uintptr, connid *SaeConnID) (err error) {
 +	var _p0 unsafe.Pointer
 +	if len(iov) > 0 {
@@ -18812,7 +19041,7 @@ index 05770011..4f178a22 100644
 @@ -223,6 +223,16 @@ TEXT libc_ioctl_trampoline<>(SB),NOSPLIT,$0-0
  GLOBL	·libc_ioctl_trampoline_addr(SB), RODATA, $8
  DATA	·libc_ioctl_trampoline_addr(SB)/8, $libc_ioctl_trampoline<>(SB)
-
+ 
 +TEXT libc_renamex_np_trampoline<>(SB),NOSPLIT,$0-0
 +	JMP	libc_renamex_np(SB)
 +GLOBL	·libc_renamex_np_trampoline_addr(SB), RODATA, $8
@@ -18829,7 +19058,7 @@ index 05770011..4f178a22 100644
 @@ -238,6 +248,11 @@ TEXT libc_pthread_fchdir_np_trampoline<>(SB),NOSPLIT,$0-0
  GLOBL	·libc_pthread_fchdir_np_trampoline_addr(SB), RODATA, $8
  DATA	·libc_pthread_fchdir_np_trampoline_addr(SB)/8, $libc_pthread_fchdir_np_trampoline<>(SB)
-
+ 
 +TEXT libc_connectx_trampoline<>(SB),NOSPLIT,$0-0
 +	JMP	libc_connectx(SB)
 +GLOBL	·libc_connectx_trampoline_addr(SB), RODATA, $8
@@ -18843,9 +19072,9 @@ index 87d8612a..5cc1e8eb 100644
 --- a/vendor/golang.org/x/sys/unix/zsyscall_linux.go
 +++ b/vendor/golang.org/x/sys/unix/zsyscall_linux.go
 @@ -592,6 +592,16 @@ func ClockGettime(clockid int32, time *Timespec) (err error) {
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 +func ClockSettime(clockid int32, time *Timespec) (err error) {
 +	_, _, e1 := Syscall(SYS_CLOCK_SETTIME, uintptr(clockid), uintptr(unsafe.Pointer(time)), 0)
 +	if e1 != 0 {
@@ -18860,9 +19089,9 @@ index 87d8612a..5cc1e8eb 100644
  	_, _, e1 := Syscall6(SYS_CLOCK_NANOSLEEP, uintptr(clockid), uintptr(flags), uintptr(unsafe.Pointer(request)), uintptr(unsafe.Pointer(remain)), 0, 0)
  	if e1 != 0 {
 @@ -971,23 +981,6 @@ func Getpriority(which int, who int) (prio int, err error) {
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 -func Getrandom(buf []byte, flags int) (n int, err error) {
 -	var _p0 unsafe.Pointer
 -	if len(buf) > 0 {
@@ -18908,9 +19137,9 @@ index 9dc42410..1851df14 100644
 --- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
 +++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_386.go
 @@ -1493,6 +1493,30 @@ var libc_mknodat_trampoline_addr uintptr
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 +func Mount(fsType string, dir string, flags int, data unsafe.Pointer) (err error) {
 +	var _p0 *byte
 +	_p0, err = BytePtrFromString(fsType)
@@ -18945,7 +19174,7 @@ index 41b56173..0b43c693 100644
 @@ -463,6 +463,11 @@ TEXT libc_mknodat_trampoline<>(SB),NOSPLIT,$0-0
  GLOBL	·libc_mknodat_trampoline_addr(SB), RODATA, $4
  DATA	·libc_mknodat_trampoline_addr(SB)/4, $libc_mknodat_trampoline<>(SB)
-
+ 
 +TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
 +	JMP	libc_mount(SB)
 +GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $4
@@ -18959,9 +19188,9 @@ index 0d3a0751..e1ec0dbe 100644
 --- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
 +++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_amd64.go
 @@ -1493,6 +1493,30 @@ var libc_mknodat_trampoline_addr uintptr
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 +func Mount(fsType string, dir string, flags int, data unsafe.Pointer) (err error) {
 +	var _p0 *byte
 +	_p0, err = BytePtrFromString(fsType)
@@ -18996,7 +19225,7 @@ index 4019a656..880c6d6e 100644
 @@ -463,6 +463,11 @@ TEXT libc_mknodat_trampoline<>(SB),NOSPLIT,$0-0
  GLOBL	·libc_mknodat_trampoline_addr(SB), RODATA, $8
  DATA	·libc_mknodat_trampoline_addr(SB)/8, $libc_mknodat_trampoline<>(SB)
-
+ 
 +TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
 +	JMP	libc_mount(SB)
 +GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
@@ -19010,9 +19239,9 @@ index c39f7776..7c8452a6 100644
 --- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
 +++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm.go
 @@ -1493,6 +1493,30 @@ var libc_mknodat_trampoline_addr uintptr
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 +func Mount(fsType string, dir string, flags int, data unsafe.Pointer) (err error) {
 +	var _p0 *byte
 +	_p0, err = BytePtrFromString(fsType)
@@ -19047,7 +19276,7 @@ index ac4af24f..b8ef95b0 100644
 @@ -463,6 +463,11 @@ TEXT libc_mknodat_trampoline<>(SB),NOSPLIT,$0-0
  GLOBL	·libc_mknodat_trampoline_addr(SB), RODATA, $4
  DATA	·libc_mknodat_trampoline_addr(SB)/4, $libc_mknodat_trampoline<>(SB)
-
+ 
 +TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
 +	JMP	libc_mount(SB)
 +GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $4
@@ -19061,9 +19290,9 @@ index 57571d07..2ffdf861 100644
 --- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
 +++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_arm64.go
 @@ -1493,6 +1493,30 @@ var libc_mknodat_trampoline_addr uintptr
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 +func Mount(fsType string, dir string, flags int, data unsafe.Pointer) (err error) {
 +	var _p0 *byte
 +	_p0, err = BytePtrFromString(fsType)
@@ -19098,7 +19327,7 @@ index f77d5321..2af3b5c7 100644
 @@ -463,6 +463,11 @@ TEXT libc_mknodat_trampoline<>(SB),NOSPLIT,$0-0
  GLOBL	·libc_mknodat_trampoline_addr(SB), RODATA, $8
  DATA	·libc_mknodat_trampoline_addr(SB)/8, $libc_mknodat_trampoline<>(SB)
-
+ 
 +TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
 +	JMP	libc_mount(SB)
 +GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
@@ -19112,9 +19341,9 @@ index e62963e6..1da08d52 100644
 --- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
 +++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_mips64.go
 @@ -1493,6 +1493,30 @@ var libc_mknodat_trampoline_addr uintptr
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 +func Mount(fsType string, dir string, flags int, data unsafe.Pointer) (err error) {
 +	var _p0 *byte
 +	_p0, err = BytePtrFromString(fsType)
@@ -19149,7 +19378,7 @@ index fae140b6..b7a25135 100644
 @@ -463,6 +463,11 @@ TEXT libc_mknodat_trampoline<>(SB),NOSPLIT,$0-0
  GLOBL	·libc_mknodat_trampoline_addr(SB), RODATA, $8
  DATA	·libc_mknodat_trampoline_addr(SB)/8, $libc_mknodat_trampoline<>(SB)
-
+ 
 +TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
 +	JMP	libc_mount(SB)
 +GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
@@ -19163,9 +19392,9 @@ index 00831354..6e85b0aa 100644
 --- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
 +++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_ppc64.go
 @@ -1493,6 +1493,30 @@ var libc_mknodat_trampoline_addr uintptr
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 +func Mount(fsType string, dir string, flags int, data unsafe.Pointer) (err error) {
 +	var _p0 *byte
 +	_p0, err = BytePtrFromString(fsType)
@@ -19200,7 +19429,7 @@ index 9d1e0ff0..f15dadf0 100644
 @@ -555,6 +555,12 @@ TEXT libc_mknodat_trampoline<>(SB),NOSPLIT,$0-0
  GLOBL	·libc_mknodat_trampoline_addr(SB), RODATA, $8
  DATA	·libc_mknodat_trampoline_addr(SB)/8, $libc_mknodat_trampoline<>(SB)
-
+ 
 +TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
 +	CALL	libc_mount(SB)
 +	RET
@@ -19215,9 +19444,9 @@ index 79029ed5..28b487df 100644
 --- a/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
 +++ b/vendor/golang.org/x/sys/unix/zsyscall_openbsd_riscv64.go
 @@ -1493,6 +1493,30 @@ var libc_mknodat_trampoline_addr uintptr
-
+ 
  // THIS FILE IS GENERATED BY THE COMMAND AT THE TOP; DO NOT EDIT
-
+ 
 +func Mount(fsType string, dir string, flags int, data unsafe.Pointer) (err error) {
 +	var _p0 *byte
 +	_p0, err = BytePtrFromString(fsType)
@@ -19252,7 +19481,7 @@ index da115f9a..1e7f321e 100644
 @@ -463,6 +463,11 @@ TEXT libc_mknodat_trampoline<>(SB),NOSPLIT,$0-0
  GLOBL	·libc_mknodat_trampoline_addr(SB), RODATA, $8
  DATA	·libc_mknodat_trampoline_addr(SB)/8, $libc_mknodat_trampoline<>(SB)
-
+ 
 +TEXT libc_mount_trampoline<>(SB),NOSPLIT,$0-0
 +	JMP	libc_mount(SB)
 +GLOBL	·libc_mount_trampoline_addr(SB), RODATA, $8
@@ -19451,9 +19680,9 @@ index 091d107f..17c53bd9 100644
 --- a/vendor/golang.org/x/sys/unix/ztypes_darwin_amd64.go
 +++ b/vendor/golang.org/x/sys/unix/ztypes_darwin_amd64.go
 @@ -306,6 +306,19 @@ type XVSockPgen struct {
-
+ 
  type _Socklen uint32
-
+ 
 +type SaeAssocID uint32
 +
 +type SaeConnID uint32
@@ -19471,7 +19700,7 @@ index 091d107f..17c53bd9 100644
  	Version uint32
  	Uid     uint32
 @@ -449,11 +462,14 @@ type FdSet struct {
-
+ 
  const (
  	SizeofIfMsghdr    = 0x70
 +	SizeofIfMsghdr2   = 0xa0
@@ -19484,11 +19713,11 @@ index 091d107f..17c53bd9 100644
 +	SizeofRtMsghdr2   = 0x5c
  	SizeofRtMetrics   = 0x38
  )
-
+ 
 @@ -467,6 +483,20 @@ type IfMsghdr struct {
  	Data    IfData
  }
-
+ 
 +type IfMsghdr2 struct {
 +	Msglen     uint16
 +	Version    uint8
@@ -19509,7 +19738,7 @@ index 091d107f..17c53bd9 100644
 @@ -499,6 +529,34 @@ type IfData struct {
  	Reserved2  uint32
  }
-
+ 
 +type IfData64 struct {
 +	Type       uint8
 +	Typelen    uint8
@@ -19544,7 +19773,7 @@ index 091d107f..17c53bd9 100644
 @@ -544,6 +602,21 @@ type RtMsghdr struct {
  	Rmx     RtMetrics
  }
-
+ 
 +type RtMsghdr2 struct {
 +	Msglen      uint16
 +	Version     uint8
@@ -19568,9 +19797,9 @@ index 28ff4ef7..2392226a 100644
 --- a/vendor/golang.org/x/sys/unix/ztypes_darwin_arm64.go
 +++ b/vendor/golang.org/x/sys/unix/ztypes_darwin_arm64.go
 @@ -306,6 +306,19 @@ type XVSockPgen struct {
-
+ 
  type _Socklen uint32
-
+ 
 +type SaeAssocID uint32
 +
 +type SaeConnID uint32
@@ -19588,7 +19817,7 @@ index 28ff4ef7..2392226a 100644
  	Version uint32
  	Uid     uint32
 @@ -449,11 +462,14 @@ type FdSet struct {
-
+ 
  const (
  	SizeofIfMsghdr    = 0x70
 +	SizeofIfMsghdr2   = 0xa0
@@ -19601,11 +19830,11 @@ index 28ff4ef7..2392226a 100644
 +	SizeofRtMsghdr2   = 0x5c
  	SizeofRtMetrics   = 0x38
  )
-
+ 
 @@ -467,6 +483,20 @@ type IfMsghdr struct {
  	Data    IfData
  }
-
+ 
 +type IfMsghdr2 struct {
 +	Msglen     uint16
 +	Version    uint8
@@ -19626,7 +19855,7 @@ index 28ff4ef7..2392226a 100644
 @@ -499,6 +529,34 @@ type IfData struct {
  	Reserved2  uint32
  }
-
+ 
 +type IfData64 struct {
 +	Type       uint8
 +	Typelen    uint8
@@ -19661,7 +19890,7 @@ index 28ff4ef7..2392226a 100644
 @@ -544,6 +602,21 @@ type RtMsghdr struct {
  	Rmx     RtMetrics
  }
-
+ 
 +type RtMsghdr2 struct {
 +	Msglen      uint16
 +	Version     uint8
@@ -19690,7 +19919,7 @@ index 6cbd094a..51e13eb0 100644
  	POLLWRNORM   = 0x4
 +	POLLRDHUP    = 0x4000
  )
-
+ 
  type CapRights struct {
 diff --git a/vendor/golang.org/x/sys/unix/ztypes_freebsd_amd64.go b/vendor/golang.org/x/sys/unix/ztypes_freebsd_amd64.go
 index 7c03b6ee..d002d8ef 100644
@@ -19702,7 +19931,7 @@ index 7c03b6ee..d002d8ef 100644
  	POLLWRNORM   = 0x4
 +	POLLRDHUP    = 0x4000
  )
-
+ 
  type CapRights struct {
 diff --git a/vendor/golang.org/x/sys/unix/ztypes_freebsd_arm.go b/vendor/golang.org/x/sys/unix/ztypes_freebsd_arm.go
 index 422107ee..3f863d89 100644
@@ -19714,7 +19943,7 @@ index 422107ee..3f863d89 100644
  	POLLWRNORM   = 0x4
 +	POLLRDHUP    = 0x4000
  )
-
+ 
  type CapRights struct {
 diff --git a/vendor/golang.org/x/sys/unix/ztypes_freebsd_arm64.go b/vendor/golang.org/x/sys/unix/ztypes_freebsd_arm64.go
 index 505a12ac..61c72931 100644
@@ -19726,7 +19955,7 @@ index 505a12ac..61c72931 100644
  	POLLWRNORM   = 0x4
 +	POLLRDHUP    = 0x4000
  )
-
+ 
  type CapRights struct {
 diff --git a/vendor/golang.org/x/sys/unix/ztypes_freebsd_riscv64.go b/vendor/golang.org/x/sys/unix/ztypes_freebsd_riscv64.go
 index cc986c79..b5d17414 100644
@@ -19738,7 +19967,7 @@ index cc986c79..b5d17414 100644
  	POLLWRNORM   = 0x4
 +	POLLRDHUP    = 0x4000
  )
-
+ 
  type CapRights struct {
 diff --git a/vendor/golang.org/x/sys/unix/ztypes_linux.go b/vendor/golang.org/x/sys/unix/ztypes_linux.go
 index 4740b834..5537148d 100644
@@ -19746,7 +19975,7 @@ index 4740b834..5537148d 100644
 +++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
 @@ -87,30 +87,35 @@ type StatxTimestamp struct {
  }
-
+ 
  type Statx_t struct {
 -	Mask             uint32
 -	Blksize          uint32
@@ -19802,12 +20031,12 @@ index 4740b834..5537148d 100644
 +	_                         [1]uint32
 +	_                         [9]uint64
  }
-
+ 
  type Fsid struct {
 @@ -515,6 +520,29 @@ type TCPInfo struct {
  	Total_rto_time       uint32
  }
-
+ 
 +type TCPVegasInfo struct {
 +	Enabled uint32
 +	Rttcnt  uint32
@@ -19891,7 +20120,7 @@ index 4740b834..5537148d 100644
 @@ -1948,6 +1976,15 @@ const (
  	IFLA_DSA_MASTER                            = 0x1
  )
-
+ 
 +const (
 +	NETKIT_NEXT     = -0x1
 +	NETKIT_PASS     = 0x0
@@ -19916,12 +20145,12 @@ index 4740b834..5537148d 100644
 @@ -2557,8 +2594,8 @@ const (
  	SOF_TIMESTAMPING_BIND_PHC     = 0x8000
  	SOF_TIMESTAMPING_OPT_ID_TCP   = 0x10000
-
+ 
 -	SOF_TIMESTAMPING_LAST = 0x10000
 -	SOF_TIMESTAMPING_MASK = 0x1ffff
 +	SOF_TIMESTAMPING_LAST = 0x20000
 +	SOF_TIMESTAMPING_MASK = 0x3ffff
-
+ 
  	SCM_TSTAMP_SND   = 0x0
  	SCM_TSTAMP_SCHED = 0x1
 @@ -3473,7 +3510,7 @@ const (
@@ -19931,7 +20160,7 @@ index 4740b834..5537148d 100644
 -	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x5
 +	DEVLINK_PORT_FUNCTION_ATTR_MAX                     = 0x6
  )
-
+ 
  type FsverityDigest struct {
 @@ -3504,7 +3541,7 @@ type Nhmsg struct {
  type NexthopGrp struct {
@@ -19941,7 +20170,7 @@ index 4740b834..5537148d 100644
 +	High   uint8
  	Resvd2 uint16
  }
-
+ 
 @@ -3765,7 +3802,7 @@ const (
  	ETHTOOL_MSG_PSE_GET                       = 0x24
  	ETHTOOL_MSG_PSE_SET                       = 0x25
@@ -20004,7 +20233,7 @@ index 4740b834..5537148d 100644
 @@ -4078,6 +4118,107 @@ type EthtoolDrvinfo struct {
  	Regdump_len  uint32
  }
-
+ 
 +type EthtoolTsInfo struct {
 +	Cmd             uint32
 +	So_timestamping uint32
@@ -20115,7 +20344,7 @@ index 4740b834..5537148d 100644
  	Access_net uint64
 +	Scoped     uint64
  }
-
+ 
  type LandlockPathBeneathAttr struct {
 @@ -4605,7 +4747,7 @@ const (
  	NL80211_ATTR_MAC_HINT                                   = 0xc8
@@ -20191,7 +20420,7 @@ index d9a13af4..2e5d5a44 100644
 @@ -377,6 +377,12 @@ type Flock_t struct {
  	Pid    int32
  }
-
+ 
 +type F_cnvrt struct {
 +	Cvtcmd int32
 +	Pccsid int16
@@ -20208,7 +20437,7 @@ index 115341fb..4e613cf6 100644
 @@ -65,7 +65,7 @@ func LoadDLL(name string) (dll *DLL, err error) {
  	return d, nil
  }
-
+ 
 -// MustLoadDLL is like LoadDLL but panics if load operation failes.
 +// MustLoadDLL is like LoadDLL but panics if load operation fails.
  func MustLoadDLL(name string) *DLL {
@@ -20220,11 +20449,11 @@ index 97651b5b..b6e1ab76 100644
 +++ b/vendor/golang.org/x/sys/windows/security_windows.go
 @@ -1179,7 +1179,7 @@ type OBJECTS_AND_NAME struct {
  //sys	makeSelfRelativeSD(absoluteSD *SECURITY_DESCRIPTOR, selfRelativeSD *SECURITY_DESCRIPTOR, selfRelativeSDSize *uint32) (err error) = advapi32.MakeSelfRelativeSD
-
+ 
  //sys	setEntriesInAcl(countExplicitEntries uint32, explicitEntries *EXPLICIT_ACCESS, oldACL *ACL, newACL **ACL) (ret error) = advapi32.SetEntriesInAclW
 -//sys	GetAce(acl *ACL, aceIndex uint32, pAce **ACCESS_ALLOWED_ACE) (ret error) = advapi32.GetAce
 +//sys	GetAce(acl *ACL, aceIndex uint32, pAce **ACCESS_ALLOWED_ACE) (err error) = advapi32.GetAce
-
+ 
  // Control returns the security descriptor control bits.
  func (sd *SECURITY_DESCRIPTOR) Control() (control SECURITY_DESCRIPTOR_CONTROL, revision uint32, err error) {
 diff --git a/vendor/golang.org/x/sys/windows/syscall_windows.go b/vendor/golang.org/x/sys/windows/syscall_windows.go
@@ -20234,14 +20463,14 @@ index 6525c62f..4a325438 100644
 @@ -17,8 +17,10 @@ import (
  	"unsafe"
  )
-
+ 
 -type Handle uintptr
 -type HWND uintptr
 +type (
 +	Handle uintptr
 +	HWND   uintptr
 +)
-
+ 
  const (
  	InvalidHandle = ^Handle(0)
 @@ -166,6 +168,8 @@ func NewCallbackCDecl(fn interface{}) uintptr {
@@ -20277,7 +20506,7 @@ index 6525c62f..4a325438 100644
  //sys	resizePseudoConsole(pconsole Handle, size uint32) (hr error) = kernel32.ResizePseudoConsole
 @@ -715,20 +727,12 @@ func DurationSinceBoot() time.Duration {
  }
-
+ 
  func Ftruncate(fd Handle, length int64) (err error) {
 -	curoffset, e := Seek(fd, 0, 1)
 -	if e != nil {
@@ -20299,7 +20528,7 @@ index 6525c62f..4a325438 100644
 +	info.EndOfFile = length
 +	return SetFileInformationByHandle(fd, FileEndOfFileInfo, (*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info)))
  }
-
+ 
  func Gettimeofday(tv *Timeval) (err error) {
 @@ -884,6 +888,11 @@ const socket_error = uintptr(^uint32(0))
  //sys	GetACP() (acp uint32) = kernel32.GetACP
@@ -20310,7 +20539,7 @@ index 6525c62f..4a325438 100644
 +//sys   NotifyIpInterfaceChange(family uint16, callback uintptr, callerContext unsafe.Pointer, initialNotification bool, notificationHandle *Handle) (errcode error) = iphlpapi.NotifyIpInterfaceChange
 +//sys   NotifyUnicastIpAddressChange(family uint16, callback uintptr, callerContext unsafe.Pointer, initialNotification bool, notificationHandle *Handle) (errcode error) = iphlpapi.NotifyUnicastIpAddressChange
 +//sys   CancelMibChangeNotify2(notificationHandle Handle) (errcode error) = iphlpapi.CancelMibChangeNotify2
-
+ 
  // For testing: clients can set this flag to force
  // creation of IPv6 sockets to return EAFNOSUPPORT.
 @@ -1368,9 +1377,11 @@ func SetsockoptLinger(fd Handle, level, opt int, l *Linger) (err error) {
@@ -20344,7 +20573,7 @@ index 6525c62f..4a325438 100644
 +		Buffer:        &s16[0],
 +	}, nil
  }
-
+ 
  // Slice returns a uint16 slice that aliases the data in the NTUnicodeString.
 diff --git a/vendor/golang.org/x/sys/windows/types_windows.go b/vendor/golang.org/x/sys/windows/types_windows.go
 index d8cb71db..9d138de5 100644
@@ -20352,7 +20581,7 @@ index d8cb71db..9d138de5 100644
 +++ b/vendor/golang.org/x/sys/windows/types_windows.go
 @@ -176,6 +176,7 @@ const (
  	WAIT_FAILED    = 0xFFFFFFFF
-
+ 
  	// Access rights for process.
 +	PROCESS_ALL_ACCESS                = 0xFFFF
  	PROCESS_CREATE_PROCESS            = 0x0080
@@ -20363,13 +20592,13 @@ index d8cb71db..9d138de5 100644
  	SIO_KEEPALIVE_VALS                 = IOC_IN | IOC_VENDOR | 4
  	SIO_UDP_CONNRESET                  = IOC_IN | IOC_VENDOR | 12
 +	SIO_UDP_NETRESET                   = IOC_IN | IOC_VENDOR | 15
-
+ 
  	// cf. http://support.microsoft.com/default.aspx?scid=kb;en-us;257460
-
+ 
 @@ -2003,7 +2005,21 @@ const (
  	MOVEFILE_FAIL_IF_NOT_TRACKABLE = 0x20
  )
-
+ 
 -const GAA_FLAG_INCLUDE_PREFIX = 0x00000010
 +// Flags for GetAdaptersAddresses, see
 +// https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses.
@@ -20386,13 +20615,13 @@ index d8cb71db..9d138de5 100644
 +	GAA_FLAG_INCLUDE_ALL_COMPARTMENTS    = 0x200
 +	GAA_FLAG_INCLUDE_TUNNEL_BINDINGORDER = 0x400
 +)
-
+ 
  const (
  	IF_TYPE_OTHER              = 1
 @@ -2017,6 +2033,50 @@ const (
  	IF_TYPE_IEEE1394           = 144
  )
-
+ 
 +// Enum NL_PREFIX_ORIGIN for [IpAdapterUnicastAddress], see
 +// https://learn.microsoft.com/en-us/windows/win32/api/nldef/ne-nldef-nl_prefix_origin
 +const (
@@ -20443,7 +20672,7 @@ index d8cb71db..9d138de5 100644
 @@ -2144,6 +2204,132 @@ const (
  	IfOperStatusLowerLayerDown = 7
  )
-
+ 
 +const (
 +	IF_MAX_PHYS_ADDRESS_LENGTH = 32
 +	IF_MAX_STRING_SIZE         = 256
@@ -20572,7 +20801,7 @@ index d8cb71db..9d138de5 100644
 +
  // Console related constants used for the mode parameter to SetConsoleMode. See
  // https://docs.microsoft.com/en-us/windows/console/setconsolemode for details.
-
+ 
 @@ -3404,3 +3590,14 @@ type DCB struct {
  	EvtChar    byte
  	wReserved1 uint16
@@ -20660,7 +20889,7 @@ index eba76101..01c0716c 100644
 @@ -789,6 +804,14 @@ func FreeSid(sid *SID) (err error) {
  	return
  }
-
+ 
 +func GetAce(acl *ACL, aceIndex uint32, pAce **ACCESS_ALLOWED_ACE) (err error) {
 +	r1, _, e1 := syscall.Syscall(procGetAce.Addr(), 3, uintptr(unsafe.Pointer(acl)), uintptr(aceIndex), uintptr(unsafe.Pointer(pAce)))
 +	if r1 == 0 {
@@ -20675,7 +20904,7 @@ index eba76101..01c0716c 100644
 @@ -1225,14 +1248,6 @@ func setEntriesInAcl(countExplicitEntries uint32, explicitEntries *EXPLICIT_ACCE
  	return
  }
-
+ 
 -func GetAce(acl *ACL, aceIndex uint32, pAce **ACCESS_ALLOWED_ACE) (ret error) {
 -	r0, _, _ := syscall.Syscall(procGetAce.Addr(), 3, uintptr(unsafe.Pointer(acl)), uintptr(aceIndex), uintptr(unsafe.Pointer(pAce)))
 -	if r0 == 0 {
@@ -20690,7 +20919,7 @@ index eba76101..01c0716c 100644
 @@ -1598,6 +1613,14 @@ func DwmSetWindowAttribute(hwnd HWND, attribute uint32, value unsafe.Pointer, si
  	return
  }
-
+ 
 +func CancelMibChangeNotify2(notificationHandle Handle) (errcode error) {
 +	r0, _, _ := syscall.Syscall(procCancelMibChangeNotify2.Addr(), 1, uintptr(notificationHandle), 0, 0)
 +	if r0 != 0 {
@@ -20705,7 +20934,7 @@ index eba76101..01c0716c 100644
 @@ -1630,6 +1653,46 @@ func GetIfEntry(pIfRow *MibIfRow) (errcode error) {
  	return
  }
-
+ 
 +func GetIfEntry2Ex(level uint32, row *MibIfRow2) (errcode error) {
 +	r0, _, _ := syscall.Syscall(procGetIfEntry2Ex.Addr(), 2, uintptr(level), uintptr(unsafe.Pointer(row)), 0)
 +	if r0 != 0 {
@@ -20752,7 +20981,7 @@ index eba76101..01c0716c 100644
 @@ -2158,6 +2221,15 @@ func GetComputerName(buf *uint16, n *uint32) (err error) {
  	return
  }
-
+ 
 +func GetConsoleCP() (cp uint32, err error) {
 +	r0, _, e1 := syscall.Syscall(procGetConsoleCP.Addr(), 0, 0, 0, 0)
 +	cp = uint32(r0)
@@ -20768,7 +20997,7 @@ index eba76101..01c0716c 100644
 @@ -2166,6 +2238,15 @@ func GetConsoleMode(console Handle, mode *uint32) (err error) {
  	return
  }
-
+ 
 +func GetConsoleOutputCP() (cp uint32, err error) {
 +	r0, _, e1 := syscall.Syscall(procGetConsoleOutputCP.Addr(), 0, 0, 0, 0)
 +	cp = uint32(r0)
@@ -20784,7 +21013,7 @@ index eba76101..01c0716c 100644
 @@ -2367,6 +2448,14 @@ func GetModuleHandleEx(flags uint32, moduleName *uint16, module *Handle) (err er
  	return
  }
-
+ 
 +func GetNamedPipeClientProcessId(pipe Handle, clientProcessID *uint32) (err error) {
 +	r1, _, e1 := syscall.Syscall(procGetNamedPipeClientProcessId.Addr(), 2, uintptr(pipe), uintptr(unsafe.Pointer(clientProcessID)), 0)
 +	if r1 == 0 {
@@ -20799,7 +21028,7 @@ index eba76101..01c0716c 100644
 @@ -2383,6 +2472,14 @@ func GetNamedPipeInfo(pipe Handle, flags *uint32, outSize *uint32, inSize *uint3
  	return
  }
-
+ 
 +func GetNamedPipeServerProcessId(pipe Handle, serverProcessID *uint32) (err error) {
 +	r1, _, e1 := syscall.Syscall(procGetNamedPipeServerProcessId.Addr(), 2, uintptr(pipe), uintptr(unsafe.Pointer(serverProcessID)), 0)
 +	if r1 == 0 {
@@ -20814,7 +21043,7 @@ index eba76101..01c0716c 100644
 @@ -3034,6 +3131,14 @@ func SetCommTimeouts(handle Handle, timeouts *CommTimeouts) (err error) {
  	return
  }
-
+ 
 +func SetConsoleCP(cp uint32) (err error) {
 +	r1, _, e1 := syscall.Syscall(procSetConsoleCP.Addr(), 1, uintptr(cp), 0, 0)
 +	if r1 == 0 {
@@ -20829,7 +21058,7 @@ index eba76101..01c0716c 100644
 @@ -3050,6 +3155,14 @@ func SetConsoleMode(console Handle, mode uint32) (err error) {
  	return
  }
-
+ 
 +func SetConsoleOutputCP(cp uint32) (err error) {
 +	r1, _, e1 := syscall.Syscall(procSetConsoleOutputCP.Addr(), 1, uintptr(cp), 0, 0)
 +	if r1 == 0 {
@@ -20844,7 +21073,7 @@ index eba76101..01c0716c 100644
 @@ -4082,6 +4195,12 @@ func GetGUIThreadInfo(thread uint32, info *GUIThreadInfo) (err error) {
  	return
  }
-
+ 
 +func GetKeyboardLayout(tid uint32) (hkl Handle) {
 +	r0, _, _ := syscall.Syscall(procGetKeyboardLayout.Addr(), 1, uintptr(tid), 0, 0)
 +	hkl = Handle(r0)
@@ -20857,7 +21086,7 @@ index eba76101..01c0716c 100644
 @@ -4115,6 +4234,15 @@ func IsWindowVisible(hwnd HWND) (isVisible bool) {
  	return
  }
-
+ 
 +func LoadKeyboardLayout(name *uint16, flags uint32) (hkl Handle, err error) {
 +	r0, _, e1 := syscall.Syscall(procLoadKeyboardLayoutW.Addr(), 2, uintptr(unsafe.Pointer(name)), uintptr(flags), 0)
 +	hkl = Handle(r0)
@@ -20873,7 +21102,7 @@ index eba76101..01c0716c 100644
 @@ -4124,6 +4252,20 @@ func MessageBox(hwnd HWND, text *uint16, caption *uint16, boxtype uint32) (ret i
  	return
  }
-
+ 
 +func ToUnicodeEx(vkey uint32, scancode uint32, keystate *byte, pwszBuff *uint16, cchBuff int32, flags uint32, hkl Handle) (ret int32) {
 +	r0, _, _ := syscall.Syscall9(procToUnicodeEx.Addr(), 7, uintptr(vkey), uintptr(scancode), uintptr(unsafe.Pointer(keystate)), uintptr(unsafe.Pointer(pwszBuff)), uintptr(cchBuff), uintptr(flags), uintptr(hkl), 0, 0)
 +	ret = int32(r0)
@@ -20898,7 +21127,7 @@ index 6a66aea5..2a7cf70d 100644
 @@ -1,4 +1,4 @@
 -Copyright (c) 2009 The Go Authors. All rights reserved.
 +Copyright 2009 The Go Authors.
-
+ 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are
 @@ -10,7 +10,7 @@ notice, this list of conditions and the following disclaimer.
@@ -20909,28 +21138,28 @@ index 6a66aea5..2a7cf70d 100644
 +   * Neither the name of Google LLC nor the names of its
  contributors may be used to endorse or promote products derived from
  this software without specific prior written permission.
-
+ 
 diff --git a/vendor/golang.org/x/term/README.md b/vendor/golang.org/x/term/README.md
 index d03d0aef..05ff623f 100644
 --- a/vendor/golang.org/x/term/README.md
 +++ b/vendor/golang.org/x/term/README.md
 @@ -4,16 +4,13 @@
-
+ 
  This repository provides Go terminal and console support packages.
-
+ 
 -## Download/Install
 -
 -The easiest way to install is to run `go get -u golang.org/x/term`. You can
 -also manually git clone the repository to `$GOPATH/src/golang.org/x/term`.
 -
  ## Report Issues / Send Patches
-
+ 
  This repository uses Gerrit for code changes. To learn how to submit changes to
 -this repository, see https://golang.org/doc/contribute.html.
 +this repository, see https://go.dev/doc/contribute.
 +
 +The git repository is https://go.googlesource.com/term.
-
+ 
  The main issue tracker for the term repository is located at
 -https://github.com/golang/go/issues. Prefix your issue with "x/term:" in the
 +https://go.dev/issues. Prefix your issue with "x/term:" in the
@@ -20954,7 +21183,7 @@ index 6a66aea5..2a7cf70d 100644
 @@ -1,4 +1,4 @@
 -Copyright (c) 2009 The Go Authors. All rights reserved.
 +Copyright 2009 The Go Authors.
-
+ 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are
 @@ -10,7 +10,7 @@ notice, this list of conditions and the following disclaimer.
@@ -20965,11 +21194,20 @@ index 6a66aea5..2a7cf70d 100644
 +   * Neither the name of Google LLC nor the names of its
  contributors may be used to endorse or promote products derived from
  this software without specific prior written permission.
-
+ 
 diff --git a/vendor/modules.txt b/vendor/modules.txt
-index c14c0460..71f9b367 100644
+index c14c0460..96673f57 100644
 --- a/vendor/modules.txt
 +++ b/vendor/modules.txt
+@@ -245,7 +245,7 @@ github.com/gogo/protobuf/gogoproto
+ github.com/gogo/protobuf/proto
+ github.com/gogo/protobuf/protoc-gen-gogo/descriptor
+ github.com/gogo/protobuf/sortkeys
+-# github.com/golang-jwt/jwt/v4 v4.5.0
++# github.com/golang-jwt/jwt/v4 v4.5.1
+ ## explicit; go 1.16
+ github.com/golang-jwt/jwt/v4
+ # github.com/golang/glog v1.1.0 => github.com/kubermatic/glog-gokit v0.0.0-20181129151237-8ab7e4c2d352
 @@ -673,7 +673,7 @@ go.uber.org/atomic
  ## explicit; go 1.13
  go.uber.org/goleak
@@ -21012,5 +21250,3 @@ index c14c0460..71f9b367 100644
  ## explicit; go 1.18
  golang.org/x/text/secure/bidirule
  golang.org/x/text/transform
---
-2.47.0

--- a/modules/300-prometheus/images/promxy/patches/0001-update-crypto-net-cve.patch
+++ b/modules/300-prometheus/images/promxy/patches/0001-update-crypto-net-cve.patch
@@ -203,32 +203,186 @@ index c0a6f692..9dd36e5a 100644
  // ParseUnverified parses the token but doesn't validate the signature.
 diff --git a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_intermediate_cert.der b/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_intermediate_cert.der
 deleted file mode 100644
-index 958f3cfa..00000000
-Binary files a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_intermediate_cert.der and /dev/null differ
+index 958f3cfaddf3645fa6c0578b5b6955d65ac4c172..0000000000000000000000000000000000000000
+GIT binary patch
+literal 0
+HcmV?d00001
+
+literal 998
+zcmXqLVt!=M#B^!_GZP~dlZfxTkgMw#Mx5CteAhsdS=K*t&xAY!UN%mxHjlRNyo`+8
+ztPBQ??S|Y2oNUaYENsF|p}{Z?2M?38qoI(207!<Nhcmb|FR!vJF(=hfz<>`V#>K<#
+zoS$2em{(~iXuuB=;pX9R$t=q(&dkp<6f+P32{H5V78@nTm!uY##3!c~l^9AHNWiV<
+zWEA7BsH}1TV!h=2Tmw0AULzv|Gec7&Lt`^z^C)p%6J+ina%mHz5^^vyvNA9?G4eAQ
+zG%<29H8C<W9Nt&6Og&yK;BEQ+&)lC6TkJXAv2-f0Nr{K_j%4;<{u$jO6aNcHY8t(~
+zqy9y&-1Lzs?~BsEkFGl8R8RP>nfQWlH+Myj<F(Sn!hQWyYraPcCEBrtXFWTArbgzD
+zm5IZ{bD=fd*)4ZeK5z9e=XhyZ+3(MM(MSL5oWy@hr_^6Rn|+8eIXzO*Cp*6;N>Tjz
+z2Bjk+Ub9TzT(Z$!`+w1f9a{SYn?h^$U$mDJKK^KOurlxGlhf8coXvjW^}bgt-rFjD
+znHJ|Xo9Wew;}%JlW_Kjsthc+chb^XXpU3LOdy_KCS4OTntgUFd?YsGkV{8gPCrIUU
+z7xZ1<|6Oe5g44&3J$ODp>G5YKW=00a#V!U;2J*mEAgjzGVIbBZvce&_^W7!+r|T*d
+zavIkkZ(n>dQ`LY6q(GR3)qt6i@xOr}h$qOxWx&zImXe>Fn2DZTf#J-^uui3sYst!#
+z{ImS~I{#0uS#WDz%!i-3yIxOGkAC<p^jwU<)XyikaNa8oiP79sW{{liX=%#*`SJI8
+zMcYgrntF|<A2Po$Z~L`udV^0!W9`!87p^3hsecxJ7d1D__DG4$xz}g@S(q)=657eI
+zRakm`-?5C8>KhN$DyM2L{LbrkL@xJCpY3crHP)J~LHEx;nsZlX$z1Na++S~*x&F8L
+zSHsIX`Pf;-7fz4f$yxWfRV}c$Te2$X#22gkrUlwjtNp9{IiD}~zjo}z)1J=iJoj~z
+zPFk$n)~eK8B%5+0@w1g$N8H(l+-H4!LOMmyS_+%b`$^TD`}g=z?!9=Gts-l=GE2@y
+HTP6bly#{pd
+
 diff --git a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_leaf_cert.der b/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_leaf_cert.der
 deleted file mode 100644
-index d2817641..00000000
-Binary files a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_leaf_cert.der and /dev/null differ
+index d2817641bafb022339926786ab85b545f40ac665..0000000000000000000000000000000000000000
+GIT binary patch
+literal 0
+HcmV?d00001
+
+literal 1147
+zcmXqLVktLhVvb+H%*4pVB*OPMYW498DSV5WgVNVW|Jr8oCgimNFB_*;n@8JsUPeZ4
+zRtAH{c0+ChPB!LH7B*p~&|nycgNMo4(NM@h03^fC!x>zfmseSqn3HNKV890w<Kkg=
+z&d)7K%&RmMG~fq`aPx4uWR_(XXXfV_iW!K2gqV4Fi;WWFOHzwV;*(R0N(`k8B;eL_
+zGKz6mR8~0vv0ie1u7R95uaS{~nW3qXp^2fPag;c(2{LyOxwMH<2{{-USs9p{82K3t
+zni#p5niv@wo;*yPCCXlYe?^B-(;DHW%6oSHT^;mIIyZa%%0}@fp3IN`n3U=!8oYmC
+zx$Bx#esbWw!c%jdQ)h2XXzh~a-c}{E)#88C^IglkPyd|owRl08L`B~JwZ4vz-YZX7
+zv)Ce6;FhjT*5j|PsSB=h^Bd2ec&K!u5=Zc_35w@VJ#yyRmHBj^jY_lT!^g4v8)Z{&
+zrj~|YSf1kBW!8JC{`HU5msIM4=9xBV3EoX;JHkB6EoRyG>6yxnyM_06xZQcZ?W<Su
+zO^scC0W1Ifow;&jPR_ckj7N?Jt}ry&qVQ_v_NEP`5+}F*Uw>@M4y!->Y40>Qzg1y0
+z&gNQpqF{|c>D+ZZ(rFIKEL_n{%!~|-iyLnkG+s4m+z3nvvdS!tD-9Z#Eo|&v(%3b4
+zVzNoZ_g%=<^$R1;>=M3fAjvH2AGv2jo&gWY$-*qG2F#3%{|y8|JV6#N1CA!Pl>FSp
+z%sk}C2j(GQ<TElTpY@M^tCo8#OWd4A>()!XwH^ngbB~t_{rh@w&h5|n>_#Tt3odjy
+zuPCdY_u)fF^#8=jc^^+Q{aqN5`$@Gm({I-q6VU_LtQOD6naL>j(`V|D&;QI6%^$Dc
+z@$uH$=blqSKTV1FFaEpmVP=>@<Nv4E^jE8jxIUOsm|y+YPIku{xm}zZ;ymZ3En<+r
+ze0yiM+SH!gGfiI2V)$EU-5^uEV1L#G8<(&WFQa{D>vvi*Y`l|mqO|ORNA0oIS8nOI
+z?NiA8%5=ljL@D29-OKpueEYz|zv5rHb554&taa#n7142tpUKWU?R-O_r^0)6j>G3Y
+aOB;Xxy<$H9NT-Uzt(mu6i*GEf3IzZ)c%0q<
+
 diff --git a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_root_cert.der b/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_root_cert.der
 deleted file mode 100644
-index d8c3710c..00000000
-Binary files a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/client_root_cert.der and /dev/null differ
+index d8c3710c85f9ff41ddfc709924c866350a727a4f..0000000000000000000000000000000000000000
+GIT binary patch
+literal 0
+HcmV?d00001
+
+literal 1013
+zcmXqLV*Y5*#B_53GZP~dlZa+<DywMROZSz%tV%tN{wd=1kCqwmvT<s)d9;1!Wn|=L
+zWiV)LH{>?pWMd9xVH0Kw4Tf<zc$l0W4TTH@Kr-w+oWZ4ed6i{}IjM#M27DkfE*^I0
+z{M>@Xyh=ks1AdSQHxGwPW?5!&W`3Tbn1KjLh?$4C*eEf+B(=CCJ~_3h#8ApW0&YDg
+zqZoHZWt9UE>m}#s8pw(B8W|aw8XFoJ7#JIxMv3#90J%nHQ0^ddX%nLoaxgNoGB7tW
+z@-rATF>*0AF)}hdZr#y6M}F(|x(>G^%gcAlKWcTb*S((Se#vIyuMojqJ6T@W9G$-N
+zZ|C3aC}V-ru$PA$a>||`V5!;WvLO9;#Z4xLTYkS~Q%%)mH+DGbsA<2rr@8F$Psyk!
+zC02_czBy5RY)XCG=Yl1DX=(>VSrdJ-C#|hK7^zn?b35awX<K}+vVPvN>)f$Ntvf$$
+zcUg9sL1fPSDbXqWt6$VVZu~MYZrj`2y}fI?80UuXsujC8ao09pzRe<Bw;hfu$Qhop
+zchzEJ&%VmpUZ?MM>SEFH3&Hjk;!&j?yPw^7|NHlfMLseyY=TyHB}&&4U!T;kt&%Ic
+z-@@f=`1w!pGyVU%zJI$PWGYXZ;?Bg($iTQb*dWkA7MKcT`B=nQL{>NicfPwM|8!l2
+zLQdoQ<L!$tW~v&<gQS&NBn-qFuqyy1ELmYj#{Vp=2FySTIoN@z7Z~h}4F12&IEtO8
+zzk97xB~UcG{~OPm@Zh%#mp`jr!}#xmdhKZ?iB>tUFt($qvv(cdI=i6tz3tUW`|a0C
+z&5N-8^H(H$?psgMz!}<?=eS*uc<N)`vF62T!8ej=XMIv1aC^+(al1<W$U&js>^;s&
+z=?+d?)Hkg%emvc~QLj+DwRvTMu)Tl4_m}{_7kTC1{xNsF-p9krsM-B)Ge_#Kiu#~{
+zd67^5U(N6lVcaug+5}Tw2V+f_-BCNQyG;7WAZ_<^`6QjCrOhu7&ztq4tdo7t^%&>)
+zT<y)NGjrG(I^DL<%h_YG%;0fd{;U~)n&$qEY`gxqr`BI{wMf|2<hvV^>R0VF*I2Sr
+HHQW{e5x{wf
+
 diff --git a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_intermediate_cert.der b/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_intermediate_cert.der
 deleted file mode 100644
-index dae619c0..00000000
-Binary files a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_intermediate_cert.der and /dev/null differ
+index dae619c097512f20d09d2054c63fc0f715d7be24..0000000000000000000000000000000000000000
+GIT binary patch
+literal 0
+HcmV?d00001
+
+literal 998
+zcmXqLVt!=M#B^!_GZP~dlZZk6mxvepr#-!NVoqOL*`yn*LOZ7#@Un4gwRyCC=VfH%
+zW@RvFY&YaK;ACSCWnmL$3Jr#FICz+x9SwyH1VA$EJe<L$d3lv(i8-l;0tS2_F)ki<
+z=ltA)#JoyFK?8n}2saOhOJ-SSab|v=p_qXPNQjw-x7a8#z9hA{BtAK{sKijpKmu+(
+zC!-j5MP-!(5bGu9=Nia~^BNf$m>HTH8JZfJT11KSnjmurkxQExm5_sxk(GhDiIJbd
+zpox)-sfm%1VO{t`EzVyWX$3+}`kJnrGQY>^=jnZyz4d%;|IQeuB_Gcfo1a{_>B5Fg
+zXYbI=4K*7QZdjc*51-)~EjRzyir2SPA5Z@zcTLeXV*g^*2f0P(7p>c<z3aD;l~DF-
+z&y#Bf+eN<I+xS*y8W(fvK_;!G(z3m4|C#Kb9Pou@(IH8%FE=m7OPTD5QT~77iSK^n
+zj?mc?Ig0vzyqYN4#&<SiohMgM?Dt+@*6v*6oEHh_p1eC{%)E7#x1FVt+=r@^WjxM8
+zW%EyEH!b#_{r32dR#^#;1N%=sP8KS(uV2~rZtk&H%Pp6?9b0gk#Wua^Sp3nLmF_Fr
+z^{Q6{3P}Dei<=kX_FPV0XQCk!Gb01zViyA^19@O7kX2@pFc51H;hEsb-IKY0Mj+Q>
+z?c<>#uh>H(ryKBq6bQ4h8Za|5{x=W=@dR183^<zDQu1>XGxLzc8JJvw;mpWjp+5Pu
+z!*l<vg@Hn^|6H3WFE%rH_O6Mx$4~F}75{kIX^Q{N_aEEtdi^dfyYuqN153{c9<x(*
+zYdJSpoI8JDrlP)M@bsM5GdX^7^2B_v?%Pq_uy)Rp40V~)ZM&xLxg&orKe$?SmHfLW
+zM+@(Y>q#5Sb^i@`a>klJNjzx%iu)2*?h3yy-gEL(;p^g~mZo#n!wzh9Qua5C+wfRd
+ztarh_l9E{Oro7&WNVTl@3-~vy&EDU;)-f|r-8<&mQ>C=;``&D2+5V0(pW(g3o1}Sj
+z^gY793Mi&+ntK1`1tm%ENt=U{rb%k1PtbRHEhYTylqR?8HqOeuvA1fBY>pc~NUFTR
+KZE!sDzAgX``fm0B
+
 diff --git a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_leaf_cert.der b/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_leaf_cert.der
 deleted file mode 100644
-index ce7f8d31..00000000
-Binary files a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_leaf_cert.der and /dev/null differ
+index ce7f8d31d6802c7e68c188af8797c3a063894857..0000000000000000000000000000000000000000
+GIT binary patch
+literal 0
+HcmV?d00001
+
+literal 1147
+zcmXqLVktLhVvb+H%*4pVB%&$)xidhT`$ARBi)~L`p2_<Bs<SiTW#iOp^Jx3d%gD&h
+z%3#pgZpdxG$;KSY!Y0fV8Vuub@Gv<$8VVT*fMnQtID<>`@+!*`b5acj4ER7|Ts-W~
+z`MCv&d6kBO2K*oqZXOPo%(Bel%=|n<F#{2h5Hk;Nu~A}tNosLPd~#}0iJ_E%1l)Q~
+zMltS+$|?sS)=SRMHINhMH8L_VGc*N~2F8|A;=Crv+(G2hCPpRXU}R)vU~XdMXE11D
+z<YH=KWMnwdp|;EFuK1za(r!=pH!pdapOn20ODNE9)SoP}k&l0M<Yt4fD{D3!e!kB@
+zc<t7$<tvSK%O@U~a`;wH_zxp@;pdC=Rpbo!KR+&YDrLj=eQ#&lY&#_t*TZ!uqu`wW
+z!G_X(FZVpWbXz6QaV@ia%<J<jF1Ng0@MMN>TUzhK>3dC_Z(le%bCn$9moio9jI@8{
+zd;5%c{XT!(ig$;5K+$bpwI6ChVmse+UV1r`!RY5*U#A%ppFJxS>PX#w$sz7*X_R~A
+zg!|$g&z66XI$)aW-TrxDio@fp!U<u!W?ji&nY8lfa`lt@jKrIsRbE{6F}h`%#kDZ!
+zd!LiH?o+UrI(7BuhhCZaq4rG7j0}v68*dmiUNvak2uujF$}Ej54H}m%Z0udq*fn@!
+zvPs0C{!7G*{nMUaIx(j&t!&bbRiT|z4R}CK7G_~JU}j|eZy*Tb39@h*a5S-{<mV=4
+z<{?KuFb@GEpOGOu^N;8i_bKT<dl^?bw^j;Yn9^@AZr#e#TcxkMRoadBAxnGj&t(^#
+z4l?$opGm9R@@vcG*RxwDMPHH#kiIDAAQ*8<t2CVRO;97(@t$R#-z=}Gyz<!o^x9e5
+zb=T!hE#=<3r7UUvxhU%8_W8O+jv8uR_S<Ck?B_nyoho`$<ih#;Px=xk{W+poY+Lel
+z+AcQpgJ+(^1(!Y*nei^cK*_`V@Y3Z!Em!BYGcT-={bt=_-1yCIN}6r@fyN+<o6^i`
+zi*_!%BgnkrSm1{3b%w{L7j>^sS#+*GdHMB|H?BTf!^g~J_=D$Y-Ot{~xpTg~G+{k6
+Zdr{DieczoQDL-a%Ib3(Tsv+bGCjf+Ap-TV&
+
 diff --git a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_root_cert.der b/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_root_cert.der
 deleted file mode 100644
-index 04b0d736..00000000
-Binary files a/vendor/github.com/google/s2a-go/internal/v2/certverifier/testdata/server_root_cert.der and /dev/null differ
+index 04b0d73600b72f80a03943d41973b279db9e8b32..0000000000000000000000000000000000000000
+GIT binary patch
+literal 0
+HcmV?d00001
+
+literal 1013
+zcmXqLV*Y5*#B_53GZP~dlZb{E^N!s~snriRh?%)HJiGKl>CAisUN%mxHjlRNyo`+8
+ztPBQ??S|Y2oNUaYENsF|p}{Z?2M?38qoI(207!<Nhcmb|FR!vJF(=hfz<>`V#>K<#
+zoS$2em{(~iXuuB=;pX9R$t=q(&dkp<6f+P32{H5V78@nTm!uY##3!c~l^9AHNWiV<
+zWEA7BsH}1TV!h=2Tmw0AULzv|Q)5FT0|N^q(<pIX6Cl^f49XouE^T5|LJmeoRtDxK
+zMt%l^CPpr%CPqevMO%MAzV7_kyv>aL-(RkWjuO*nCZC(^b4{<TlG&~yN@J19pEn;a
+zWz7h#JIf!hf8K}VIE(lB)-1neDdIJgBhJ~#aQ(1)CH894|9yW$ZgvD6*ig3MoTKrN
+z5YLr%E~_{06xp-kn$GoWZ;EX0y=8E15#qbI>cp%V+e53*PfoZW)2DU5BJN^Jypf0+
+z%dyqB7eAAEDfH_&Z*6C3aP8^9M)sYbgC^`~v;4F5#oepTLYl5+2bdY(i!-?My>4G)
+z&8u+L`?_9LxQB1$HP?fpd*5i(-|SJJ!`sZHa8UZu(QeP3Dc(Yr8?G#iY20z>);Fh$
+zMQ>DZHkC%KUBdEb&cYv;1sHCx@Vv~#%*epFIM^W2Ko*z^WcgUcSVVXxICA%7?w=9J
+zwOIRjXviz}kjUu<@*rtt76}8f2J8wz2}@R(k?}tZs{u2RLJoFd>IDWnBZI}4y?mP{
+zW+WALO{`uTY0T-O8uy=9`&z_;*e^$wYu3!Wz-Re-&a7vV%g_8h++q8CMf&zxTFdl~
+zp5i+{-R9L&+mdUFEBoKr@u=5M->UQ>MNWJ7BRi)4^M4~B*uKhe`J%yAbG&-Thr?bk
+zCap<joG92Ab~%`p;q(Xph%cKxrj_-3$828a&2wkQxk)>+`USuL4V}qf=6kBV_EFAN
+zmIn*31Qb`P{oxd|=2o5l$|&AdTJ_-*k&5oDQvTTOiN8OjczyHyta<w9_es3h)~)%z
+z&sP2UiroQq_v`0ApCc*mlF9S=tYWC6Yrt7^ud93ynYaCXy0?8#+xAHp9!)yGM(r3c
+JpX9EclL5Omdg1^8
+
 diff --git a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_cert.der b/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_cert.der
 deleted file mode 100644
-index d8c3710c..00000000
-Binary files a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_cert.der and /dev/null differ
+index d8c3710c85f9ff41ddfc709924c866350a727a4f..0000000000000000000000000000000000000000
+GIT binary patch
+literal 0
+HcmV?d00001
+
+literal 1013
+zcmXqLV*Y5*#B_53GZP~dlZa+<DywMROZSz%tV%tN{wd=1kCqwmvT<s)d9;1!Wn|=L
+zWiV)LH{>?pWMd9xVH0Kw4Tf<zc$l0W4TTH@Kr-w+oWZ4ed6i{}IjM#M27DkfE*^I0
+z{M>@Xyh=ks1AdSQHxGwPW?5!&W`3Tbn1KjLh?$4C*eEf+B(=CCJ~_3h#8ApW0&YDg
+zqZoHZWt9UE>m}#s8pw(B8W|aw8XFoJ7#JIxMv3#90J%nHQ0^ddX%nLoaxgNoGB7tW
+z@-rATF>*0AF)}hdZr#y6M}F(|x(>G^%gcAlKWcTb*S((Se#vIyuMojqJ6T@W9G$-N
+zZ|C3aC}V-ru$PA$a>||`V5!;WvLO9;#Z4xLTYkS~Q%%)mH+DGbsA<2rr@8F$Psyk!
+zC02_czBy5RY)XCG=Yl1DX=(>VSrdJ-C#|hK7^zn?b35awX<K}+vVPvN>)f$Ntvf$$
+zcUg9sL1fPSDbXqWt6$VVZu~MYZrj`2y}fI?80UuXsujC8ao09pzRe<Bw;hfu$Qhop
+zchzEJ&%VmpUZ?MM>SEFH3&Hjk;!&j?yPw^7|NHlfMLseyY=TyHB}&&4U!T;kt&%Ic
+z-@@f=`1w!pGyVU%zJI$PWGYXZ;?Bg($iTQb*dWkA7MKcT`B=nQL{>NicfPwM|8!l2
+zLQdoQ<L!$tW~v&<gQS&NBn-qFuqyy1ELmYj#{Vp=2FySTIoN@z7Z~h}4F12&IEtO8
+zzk97xB~UcG{~OPm@Zh%#mp`jr!}#xmdhKZ?iB>tUFt($qvv(cdI=i6tz3tUW`|a0C
+z&5N-8^H(H$?psgMz!}<?=eS*uc<N)`vF62T!8ej=XMIv1aC^+(al1<W$U&js>^;s&
+z=?+d?)Hkg%emvc~QLj+DwRvTMu)Tl4_m}{_7kTC1{xNsF-p9krsM-B)Ge_#Kiu#~{
+zd67^5U(N6lVcaug+5}Tw2V+f_-BCNQyG;7WAZ_<^`6QjCrOhu7&ztq4tdo7t^%&>)
+zT<y)NGjrG(I^DL<%h_YG%;0fd{;U~)n&$qEY`gxqr`BI{wMf|2<hvV^>R0VF*I2Sr
+HHQW{e5x{wf
+
 diff --git a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_cert.pem b/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/client_cert.pem
 deleted file mode 100644
 index 493a5a26..00000000
@@ -294,8 +448,30 @@ index 55a7f10c..00000000
 ------END RSA PRIVATE KEY-----
 diff --git a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_cert.der b/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_cert.der
 deleted file mode 100644
-index 04b0d736..00000000
-Binary files a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_cert.der and /dev/null differ
+index 04b0d73600b72f80a03943d41973b279db9e8b32..0000000000000000000000000000000000000000
+GIT binary patch
+literal 0
+HcmV?d00001
+
+literal 1013
+zcmXqLV*Y5*#B_53GZP~dlZb{E^N!s~snriRh?%)HJiGKl>CAisUN%mxHjlRNyo`+8
+ztPBQ??S|Y2oNUaYENsF|p}{Z?2M?38qoI(207!<Nhcmb|FR!vJF(=hfz<>`V#>K<#
+zoS$2em{(~iXuuB=;pX9R$t=q(&dkp<6f+P32{H5V78@nTm!uY##3!c~l^9AHNWiV<
+zWEA7BsH}1TV!h=2Tmw0AULzv|Q)5FT0|N^q(<pIX6Cl^f49XouE^T5|LJmeoRtDxK
+zMt%l^CPpr%CPqevMO%MAzV7_kyv>aL-(RkWjuO*nCZC(^b4{<TlG&~yN@J19pEn;a
+zWz7h#JIf!hf8K}VIE(lB)-1neDdIJgBhJ~#aQ(1)CH894|9yW$ZgvD6*ig3MoTKrN
+z5YLr%E~_{06xp-kn$GoWZ;EX0y=8E15#qbI>cp%V+e53*PfoZW)2DU5BJN^Jypf0+
+z%dyqB7eAAEDfH_&Z*6C3aP8^9M)sYbgC^`~v;4F5#oepTLYl5+2bdY(i!-?My>4G)
+z&8u+L`?_9LxQB1$HP?fpd*5i(-|SJJ!`sZHa8UZu(QeP3Dc(Yr8?G#iY20z>);Fh$
+zMQ>DZHkC%KUBdEb&cYv;1sHCx@Vv~#%*epFIM^W2Ko*z^WcgUcSVVXxICA%7?w=9J
+zwOIRjXviz}kjUu<@*rtt76}8f2J8wz2}@R(k?}tZs{u2RLJoFd>IDWnBZI}4y?mP{
+zW+WALO{`uTY0T-O8uy=9`&z_;*e^$wYu3!Wz-Re-&a7vV%g_8h++q8CMf&zxTFdl~
+zp5i+{-R9L&+mdUFEBoKr@u=5M->UQ>MNWJ7BRi)4^M4~B*uKhe`J%yAbG&-Thr?bk
+zCap<joG92Ab~%`p;q(Xph%cKxrj_-3$828a&2wkQxk)>+`USuL4V}qf=6kBV_EFAN
+zmIn*31Qb`P{oxd|=2o5l$|&AdTJ_-*k&5oDQvTTOiN8OjczyHyta<w9_es3h)~)%z
+z&sP2UiroQq_v`0ApCc*mlF9S=tYWC6Yrt7^ud93ynYaCXy0?8#+xAHp9!)yGM(r3c
+JpX9EclL5Omdg1^8
+
 diff --git a/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_cert.pem b/vendor/github.com/google/s2a-go/internal/v2/remotesigner/testdata/server_cert.pem
 deleted file mode 100644
 index 0f98322c..00000000
@@ -769,72 +945,42 @@ index db42e667..c709b728 100644
  
  package chacha20
  
-diff --git a/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.go b/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.go
-deleted file mode 100644
-index 3a4287f9..00000000
+diff --git a/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.go b/vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.go
+similarity index 89%
+rename from vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.go
+rename to vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.go
+index 3a4287f9..bd183d9b 100644
 --- a/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.go
-+++ /dev/null
-@@ -1,16 +0,0 @@
--// Copyright 2019 The Go Authors. All rights reserved.
--// Use of this source code is governed by a BSD-style
--// license that can be found in the LICENSE file.
--
++++ b/vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
 -//go:build gc && !purego
--
--package chacha20
--
--const bufSize = 256
--
--//go:noescape
--func chaCha20_ctr32_vsx(out, inp *byte, len int, key *[8]uint32, counter *uint32)
--
--func (c *Cipher) xorKeyStreamBlocks(dst, src []byte) {
--	chaCha20_ctr32_vsx(&dst[0], &src[0], len(src), &c.key, &c.counter)
--}
-diff --git a/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.s b/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.s
-deleted file mode 100644
-index c672ccf6..00000000
++//go:build gc && !purego && (ppc64 || ppc64le)
+ 
+ package chacha20
+ 
+diff --git a/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.s b/vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.s
+similarity index 76%
+rename from vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.s
+rename to vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.s
+index c672ccf6..a660b411 100644
 --- a/vendor/golang.org/x/crypto/chacha20/chacha_ppc64le.s
-+++ /dev/null
-@@ -1,443 +0,0 @@
--// Copyright 2019 The Go Authors. All rights reserved.
--// Use of this source code is governed by a BSD-style
--// license that can be found in the LICENSE file.
--
--// Based on CRYPTOGAMS code with the following comment:
--// # ====================================================================
--// # Written by Andy Polyakov <appro@openssl.org> for the OpenSSL
--// # project. The module is, however, dual licensed under OpenSSL and
--// # CRYPTOGAMS licenses depending on where you obtain it. For further
--// # details see http://www.openssl.org/~appro/cryptogams/.
--// # ====================================================================
--
--// Code for the perl script that generates the ppc64 assembler
--// can be found in the cryptogams repository at the link below. It is based on
--// the original from openssl.
--
--// https://github.com/dot-asm/cryptogams/commit/a60f5b50ed908e91
--
--// The differences in this and the original implementation are
--// due to the calling conventions and initialization of constants.
--
++++ b/vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.s
+@@ -19,7 +19,7 @@
+ // The differences in this and the original implementation are
+ // due to the calling conventions and initialization of constants.
+ 
 -//go:build gc && !purego
--
--#include "textflag.h"
--
--#define OUT  R3
--#define INP  R4
--#define LEN  R5
--#define KEY  R6
--#define CNT  R7
--#define TMP  R15
--
--#define CONSTBASE  R16
--#define BLOCKS R17
--
--// for VPERMXOR
--#define MASK  R18
--
++//go:build gc && !purego && (ppc64 || ppc64le)
+ 
+ #include "textflag.h"
+ 
+@@ -36,32 +36,68 @@
+ // for VPERMXOR
+ #define MASK  R18
+ 
 -DATA consts<>+0x00(SB)/8, $0x3320646e61707865
 -DATA consts<>+0x08(SB)/8, $0x6b20657479622d32
 -DATA consts<>+0x10(SB)/8, $0x0000000000000001
@@ -859,387 +1005,150 @@ index c672ccf6..00000000
 -DATA consts<>+0xa8(SB)/8, $0xddeeffcc99aabb88
 -DATA consts<>+0xb0(SB)/8, $0x6677445522330011
 -DATA consts<>+0xb8(SB)/8, $0xeeffccddaabb8899
--GLOBL consts<>(SB), RODATA, $0xc0
--
--//func chaCha20_ctr32_vsx(out, inp *byte, len int, key *[8]uint32, counter *uint32)
--TEXT ·chaCha20_ctr32_vsx(SB),NOSPLIT,$64-40
--	MOVD out+0(FP), OUT
--	MOVD inp+8(FP), INP
--	MOVD len+16(FP), LEN
--	MOVD key+24(FP), KEY
--	MOVD counter+32(FP), CNT
--
--	// Addressing for constants
--	MOVD $consts<>+0x00(SB), CONSTBASE
--	MOVD $16, R8
--	MOVD $32, R9
--	MOVD $48, R10
--	MOVD $64, R11
--	SRD $6, LEN, BLOCKS
--	// for VPERMXOR
--	MOVD $consts<>+0xa0(SB), MASK
--	MOVD $16, R20
--	// V16
--	LXVW4X (CONSTBASE)(R0), VS48
--	ADD $80,CONSTBASE
--
--	// Load key into V17,V18
--	LXVW4X (KEY)(R0), VS49
--	LXVW4X (KEY)(R8), VS50
--
--	// Load CNT, NONCE into V19
--	LXVW4X (CNT)(R0), VS51
--
--	// Clear V27
--	VXOR V27, V27, V27
--
--	// V28
--	LXVW4X (CONSTBASE)(R11), VS60
--
--	// Load mask constants for VPERMXOR
--	LXVW4X (MASK)(R0), V20
--	LXVW4X (MASK)(R20), V21
--
--	// splat slot from V19 -> V26
--	VSPLTW $0, V19, V26
--
--	VSLDOI $4, V19, V27, V19
--	VSLDOI $12, V27, V19, V19
--
--	VADDUWM V26, V28, V26
--
--	MOVD $10, R14
--	MOVD R14, CTR
--	PCALIGN $16
--loop_outer_vsx:
--	// V0, V1, V2, V3
--	LXVW4X (R0)(CONSTBASE), VS32
--	LXVW4X (R8)(CONSTBASE), VS33
--	LXVW4X (R9)(CONSTBASE), VS34
--	LXVW4X (R10)(CONSTBASE), VS35
--
--	// splat values from V17, V18 into V4-V11
--	VSPLTW $0, V17, V4
--	VSPLTW $1, V17, V5
--	VSPLTW $2, V17, V6
--	VSPLTW $3, V17, V7
--	VSPLTW $0, V18, V8
--	VSPLTW $1, V18, V9
--	VSPLTW $2, V18, V10
--	VSPLTW $3, V18, V11
--
--	// VOR
--	VOR V26, V26, V12
--
--	// splat values from V19 -> V13, V14, V15
--	VSPLTW $1, V19, V13
--	VSPLTW $2, V19, V14
--	VSPLTW $3, V19, V15
--
--	// splat   const values
--	VSPLTISW $-16, V27
--	VSPLTISW $12, V28
--	VSPLTISW $8, V29
--	VSPLTISW $7, V30
--	PCALIGN $16
--loop_vsx:
--	VADDUWM V0, V4, V0
--	VADDUWM V1, V5, V1
--	VADDUWM V2, V6, V2
--	VADDUWM V3, V7, V3
--
--	VPERMXOR V12, V0, V21, V12
--	VPERMXOR V13, V1, V21, V13
--	VPERMXOR V14, V2, V21, V14
--	VPERMXOR V15, V3, V21, V15
--
--	VADDUWM V8, V12, V8
--	VADDUWM V9, V13, V9
--	VADDUWM V10, V14, V10
--	VADDUWM V11, V15, V11
--
--	VXOR V4, V8, V4
--	VXOR V5, V9, V5
--	VXOR V6, V10, V6
--	VXOR V7, V11, V7
--
--	VRLW V4, V28, V4
--	VRLW V5, V28, V5
--	VRLW V6, V28, V6
--	VRLW V7, V28, V7
--
--	VADDUWM V0, V4, V0
--	VADDUWM V1, V5, V1
--	VADDUWM V2, V6, V2
--	VADDUWM V3, V7, V3
--
--	VPERMXOR V12, V0, V20, V12
--	VPERMXOR V13, V1, V20, V13
--	VPERMXOR V14, V2, V20, V14
--	VPERMXOR V15, V3, V20, V15
--
--	VADDUWM V8, V12, V8
--	VADDUWM V9, V13, V9
--	VADDUWM V10, V14, V10
--	VADDUWM V11, V15, V11
--
--	VXOR V4, V8, V4
--	VXOR V5, V9, V5
--	VXOR V6, V10, V6
--	VXOR V7, V11, V7
--
--	VRLW V4, V30, V4
--	VRLW V5, V30, V5
--	VRLW V6, V30, V6
--	VRLW V7, V30, V7
--
--	VADDUWM V0, V5, V0
--	VADDUWM V1, V6, V1
--	VADDUWM V2, V7, V2
--	VADDUWM V3, V4, V3
--
--	VPERMXOR V15, V0, V21, V15
--	VPERMXOR V12, V1, V21, V12
--	VPERMXOR V13, V2, V21, V13
--	VPERMXOR V14, V3, V21, V14
--
--	VADDUWM V10, V15, V10
--	VADDUWM V11, V12, V11
--	VADDUWM V8, V13, V8
--	VADDUWM V9, V14, V9
--
--	VXOR V5, V10, V5
--	VXOR V6, V11, V6
--	VXOR V7, V8, V7
--	VXOR V4, V9, V4
--
--	VRLW V5, V28, V5
--	VRLW V6, V28, V6
--	VRLW V7, V28, V7
--	VRLW V4, V28, V4
--
--	VADDUWM V0, V5, V0
--	VADDUWM V1, V6, V1
--	VADDUWM V2, V7, V2
--	VADDUWM V3, V4, V3
--
--	VPERMXOR V15, V0, V20, V15
--	VPERMXOR V12, V1, V20, V12
--	VPERMXOR V13, V2, V20, V13
--	VPERMXOR V14, V3, V20, V14
--
--	VADDUWM V10, V15, V10
--	VADDUWM V11, V12, V11
--	VADDUWM V8, V13, V8
--	VADDUWM V9, V14, V9
--
--	VXOR V5, V10, V5
--	VXOR V6, V11, V6
--	VXOR V7, V8, V7
--	VXOR V4, V9, V4
--
--	VRLW V5, V30, V5
--	VRLW V6, V30, V6
--	VRLW V7, V30, V7
--	VRLW V4, V30, V4
--	BDNZ   loop_vsx
--
--	VADDUWM V12, V26, V12
--
--	VMRGEW V0, V1, V27
--	VMRGEW V2, V3, V28
--
--	VMRGOW V0, V1, V0
--	VMRGOW V2, V3, V2
--
--	VMRGEW V4, V5, V29
--	VMRGEW V6, V7, V30
--
--	XXPERMDI VS32, VS34, $0, VS33
--	XXPERMDI VS32, VS34, $3, VS35
--	XXPERMDI VS59, VS60, $0, VS32
--	XXPERMDI VS59, VS60, $3, VS34
--
--	VMRGOW V4, V5, V4
--	VMRGOW V6, V7, V6
--
--	VMRGEW V8, V9, V27
--	VMRGEW V10, V11, V28
--
--	XXPERMDI VS36, VS38, $0, VS37
--	XXPERMDI VS36, VS38, $3, VS39
--	XXPERMDI VS61, VS62, $0, VS36
--	XXPERMDI VS61, VS62, $3, VS38
--
--	VMRGOW V8, V9, V8
--	VMRGOW V10, V11, V10
--
--	VMRGEW V12, V13, V29
--	VMRGEW V14, V15, V30
--
--	XXPERMDI VS40, VS42, $0, VS41
--	XXPERMDI VS40, VS42, $3, VS43
--	XXPERMDI VS59, VS60, $0, VS40
--	XXPERMDI VS59, VS60, $3, VS42
--
--	VMRGOW V12, V13, V12
--	VMRGOW V14, V15, V14
--
--	VSPLTISW $4, V27
--	VADDUWM V26, V27, V26
--
--	XXPERMDI VS44, VS46, $0, VS45
--	XXPERMDI VS44, VS46, $3, VS47
--	XXPERMDI VS61, VS62, $0, VS44
--	XXPERMDI VS61, VS62, $3, VS46
--
--	VADDUWM V0, V16, V0
--	VADDUWM V4, V17, V4
--	VADDUWM V8, V18, V8
--	VADDUWM V12, V19, V12
--
--	CMPU LEN, $64
--	BLT tail_vsx
--
--	// Bottom of loop
--	LXVW4X (INP)(R0), VS59
--	LXVW4X (INP)(R8), VS60
--	LXVW4X (INP)(R9), VS61
--	LXVW4X (INP)(R10), VS62
--
--	VXOR V27, V0, V27
--	VXOR V28, V4, V28
--	VXOR V29, V8, V29
--	VXOR V30, V12, V30
--
--	STXVW4X VS59, (OUT)(R0)
--	STXVW4X VS60, (OUT)(R8)
--	ADD     $64, INP
--	STXVW4X VS61, (OUT)(R9)
--	ADD     $-64, LEN
--	STXVW4X VS62, (OUT)(R10)
--	ADD     $64, OUT
--	BEQ     done_vsx
--
--	VADDUWM V1, V16, V0
--	VADDUWM V5, V17, V4
--	VADDUWM V9, V18, V8
--	VADDUWM V13, V19, V12
--
--	CMPU  LEN, $64
--	BLT   tail_vsx
--
--	LXVW4X (INP)(R0), VS59
--	LXVW4X (INP)(R8), VS60
--	LXVW4X (INP)(R9), VS61
--	LXVW4X (INP)(R10), VS62
++DATA consts<>+0x00(SB)/4, $0x61707865
++DATA consts<>+0x04(SB)/4, $0x3320646e
++DATA consts<>+0x08(SB)/4, $0x79622d32
++DATA consts<>+0x0c(SB)/4, $0x6b206574
++DATA consts<>+0x10(SB)/4, $0x00000001
++DATA consts<>+0x14(SB)/4, $0x00000000
++DATA consts<>+0x18(SB)/4, $0x00000000
++DATA consts<>+0x1c(SB)/4, $0x00000000
++DATA consts<>+0x20(SB)/4, $0x00000004
++DATA consts<>+0x24(SB)/4, $0x00000000
++DATA consts<>+0x28(SB)/4, $0x00000000
++DATA consts<>+0x2c(SB)/4, $0x00000000
++DATA consts<>+0x30(SB)/4, $0x0e0f0c0d
++DATA consts<>+0x34(SB)/4, $0x0a0b0809
++DATA consts<>+0x38(SB)/4, $0x06070405
++DATA consts<>+0x3c(SB)/4, $0x02030001
++DATA consts<>+0x40(SB)/4, $0x0d0e0f0c
++DATA consts<>+0x44(SB)/4, $0x090a0b08
++DATA consts<>+0x48(SB)/4, $0x05060704
++DATA consts<>+0x4c(SB)/4, $0x01020300
++DATA consts<>+0x50(SB)/4, $0x61707865
++DATA consts<>+0x54(SB)/4, $0x61707865
++DATA consts<>+0x58(SB)/4, $0x61707865
++DATA consts<>+0x5c(SB)/4, $0x61707865
++DATA consts<>+0x60(SB)/4, $0x3320646e
++DATA consts<>+0x64(SB)/4, $0x3320646e
++DATA consts<>+0x68(SB)/4, $0x3320646e
++DATA consts<>+0x6c(SB)/4, $0x3320646e
++DATA consts<>+0x70(SB)/4, $0x79622d32
++DATA consts<>+0x74(SB)/4, $0x79622d32
++DATA consts<>+0x78(SB)/4, $0x79622d32
++DATA consts<>+0x7c(SB)/4, $0x79622d32
++DATA consts<>+0x80(SB)/4, $0x6b206574
++DATA consts<>+0x84(SB)/4, $0x6b206574
++DATA consts<>+0x88(SB)/4, $0x6b206574
++DATA consts<>+0x8c(SB)/4, $0x6b206574
++DATA consts<>+0x90(SB)/4, $0x00000000
++DATA consts<>+0x94(SB)/4, $0x00000001
++DATA consts<>+0x98(SB)/4, $0x00000002
++DATA consts<>+0x9c(SB)/4, $0x00000003
++DATA consts<>+0xa0(SB)/4, $0x11223300
++DATA consts<>+0xa4(SB)/4, $0x55667744
++DATA consts<>+0xa8(SB)/4, $0x99aabb88
++DATA consts<>+0xac(SB)/4, $0xddeeffcc
++DATA consts<>+0xb0(SB)/4, $0x22330011
++DATA consts<>+0xb4(SB)/4, $0x66774455
++DATA consts<>+0xb8(SB)/4, $0xaabb8899
++DATA consts<>+0xbc(SB)/4, $0xeeffccdd
+ GLOBL consts<>(SB), RODATA, $0xc0
+ 
++#ifdef GOARCH_ppc64
++#define BE_XXBRW_INIT() \
++		LVSL (R0)(R0), V24 \
++		VSPLTISB $3, V25   \
++		VXOR V24, V25, V24 \
++
++#define BE_XXBRW(vr) VPERM vr, vr, V24, vr
++#else
++#define BE_XXBRW_INIT()
++#define BE_XXBRW(vr)
++#endif
++
+ //func chaCha20_ctr32_vsx(out, inp *byte, len int, key *[8]uint32, counter *uint32)
+ TEXT ·chaCha20_ctr32_vsx(SB),NOSPLIT,$64-40
+ 	MOVD out+0(FP), OUT
+@@ -94,6 +130,8 @@ TEXT ·chaCha20_ctr32_vsx(SB),NOSPLIT,$64-40
+ 	// Clear V27
+ 	VXOR V27, V27, V27
+ 
++	BE_XXBRW_INIT()
++
+ 	// V28
+ 	LXVW4X (CONSTBASE)(R11), VS60
+ 
+@@ -299,6 +337,11 @@ loop_vsx:
+ 	VADDUWM V8, V18, V8
+ 	VADDUWM V12, V19, V12
+ 
++	BE_XXBRW(V0)
++	BE_XXBRW(V4)
++	BE_XXBRW(V8)
++	BE_XXBRW(V12)
++
+ 	CMPU LEN, $64
+ 	BLT tail_vsx
+ 
+@@ -327,6 +370,11 @@ loop_vsx:
+ 	VADDUWM V9, V18, V8
+ 	VADDUWM V13, V19, V12
+ 
++	BE_XXBRW(V0)
++	BE_XXBRW(V4)
++	BE_XXBRW(V8)
++	BE_XXBRW(V12)
++
+ 	CMPU  LEN, $64
+ 	BLT   tail_vsx
+ 
+@@ -334,8 +382,8 @@ loop_vsx:
+ 	LXVW4X (INP)(R8), VS60
+ 	LXVW4X (INP)(R9), VS61
+ 	LXVW4X (INP)(R10), VS62
 -	VXOR   V27, V0, V27
--
--	VXOR V28, V4, V28
--	VXOR V29, V8, V29
--	VXOR V30, V12, V30
--
--	STXVW4X VS59, (OUT)(R0)
--	STXVW4X VS60, (OUT)(R8)
--	ADD     $64, INP
--	STXVW4X VS61, (OUT)(R9)
--	ADD     $-64, LEN
--	STXVW4X VS62, (OUT)(V10)
--	ADD     $64, OUT
--	BEQ     done_vsx
--
--	VADDUWM V2, V16, V0
--	VADDUWM V6, V17, V4
--	VADDUWM V10, V18, V8
--	VADDUWM V14, V19, V12
--
--	CMPU LEN, $64
--	BLT  tail_vsx
--
--	LXVW4X (INP)(R0), VS59
--	LXVW4X (INP)(R8), VS60
--	LXVW4X (INP)(R9), VS61
--	LXVW4X (INP)(R10), VS62
--
--	VXOR V27, V0, V27
--	VXOR V28, V4, V28
--	VXOR V29, V8, V29
--	VXOR V30, V12, V30
--
--	STXVW4X VS59, (OUT)(R0)
--	STXVW4X VS60, (OUT)(R8)
--	ADD     $64, INP
--	STXVW4X VS61, (OUT)(R9)
--	ADD     $-64, LEN
--	STXVW4X VS62, (OUT)(R10)
--	ADD     $64, OUT
--	BEQ     done_vsx
--
--	VADDUWM V3, V16, V0
--	VADDUWM V7, V17, V4
--	VADDUWM V11, V18, V8
--	VADDUWM V15, V19, V12
--
--	CMPU  LEN, $64
--	BLT   tail_vsx
--
--	LXVW4X (INP)(R0), VS59
--	LXVW4X (INP)(R8), VS60
--	LXVW4X (INP)(R9), VS61
--	LXVW4X (INP)(R10), VS62
--
--	VXOR V27, V0, V27
--	VXOR V28, V4, V28
--	VXOR V29, V8, V29
--	VXOR V30, V12, V30
--
--	STXVW4X VS59, (OUT)(R0)
--	STXVW4X VS60, (OUT)(R8)
--	ADD     $64, INP
--	STXVW4X VS61, (OUT)(R9)
--	ADD     $-64, LEN
--	STXVW4X VS62, (OUT)(R10)
--	ADD     $64, OUT
--
--	MOVD $10, R14
--	MOVD R14, CTR
--	BNE  loop_outer_vsx
--
--done_vsx:
--	// Increment counter by number of 64 byte blocks
+ 
++	VXOR V27, V0, V27
+ 	VXOR V28, V4, V28
+ 	VXOR V29, V8, V29
+ 	VXOR V30, V12, V30
+@@ -354,6 +402,11 @@ loop_vsx:
+ 	VADDUWM V10, V18, V8
+ 	VADDUWM V14, V19, V12
+ 
++	BE_XXBRW(V0)
++	BE_XXBRW(V4)
++	BE_XXBRW(V8)
++	BE_XXBRW(V12)
++
+ 	CMPU LEN, $64
+ 	BLT  tail_vsx
+ 
+@@ -381,6 +434,11 @@ loop_vsx:
+ 	VADDUWM V11, V18, V8
+ 	VADDUWM V15, V19, V12
+ 
++	BE_XXBRW(V0)
++	BE_XXBRW(V4)
++	BE_XXBRW(V8)
++	BE_XXBRW(V12)
++
+ 	CMPU  LEN, $64
+ 	BLT   tail_vsx
+ 
+@@ -408,9 +466,9 @@ loop_vsx:
+ 
+ done_vsx:
+ 	// Increment counter by number of 64 byte blocks
 -	MOVD (CNT), R14
--	ADD  BLOCKS, R14
++	MOVWZ (CNT), R14
+ 	ADD  BLOCKS, R14
 -	MOVD R14, (CNT)
--	RET
--
--tail_vsx:
--	ADD  $32, R1, R11
--	MOVD LEN, CTR
--
--	// Save values on stack to copy from
--	STXVW4X VS32, (R11)(R0)
--	STXVW4X VS36, (R11)(R8)
--	STXVW4X VS40, (R11)(R9)
--	STXVW4X VS44, (R11)(R10)
--	ADD $-1, R11, R12
--	ADD $-1, INP
--	ADD $-1, OUT
--	PCALIGN $16
--looptail_vsx:
--	// Copying the result to OUT
--	// in bytes.
--	MOVBZU 1(R12), KEY
--	MOVBZU 1(INP), TMP
--	XOR    KEY, TMP, KEY
--	MOVBU  KEY, 1(OUT)
--	BDNZ   looptail_vsx
--
--	// Clear the stack values
--	STXVW4X VS48, (R11)(R0)
--	STXVW4X VS48, (R11)(R8)
--	STXVW4X VS48, (R11)(R9)
--	STXVW4X VS48, (R11)(R10)
--	BR      done_vsx
++	MOVWZ R14, (CNT)
+ 	RET
+ 
+ tail_vsx:
 diff --git a/vendor/golang.org/x/crypto/chacha20poly1305/chacha20poly1305_amd64.s b/vendor/golang.org/x/crypto/chacha20poly1305/chacha20poly1305_amd64.s
 index 731d2ac6..fd5ee845 100644
 --- a/vendor/golang.org/x/crypto/chacha20poly1305/chacha20poly1305_amd64.s
@@ -13420,244 +13329,114 @@ index e0d3c647..13375738 100644
  	MOVQ R9, 8(DI)
  	MOVQ R10, 16(DI)
  	RET
-diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.go b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.go
-deleted file mode 100644
-index 4aec4874..00000000
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.go b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64x.go
+similarity index 95%
+rename from vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.go
+rename to vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64x.go
+index 4aec4874..1a1679aa 100644
 --- a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.go
-+++ /dev/null
-@@ -1,47 +0,0 @@
--// Copyright 2019 The Go Authors. All rights reserved.
--// Use of this source code is governed by a BSD-style
--// license that can be found in the LICENSE file.
--
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64x.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
 -//go:build gc && !purego
--
--package poly1305
--
--//go:noescape
--func update(state *macState, msg []byte)
--
--// mac is a wrapper for macGeneric that redirects calls that would have gone to
--// updateGeneric to update.
--//
--// Its Write and Sum methods are otherwise identical to the macGeneric ones, but
--// using function pointers would carry a major performance cost.
--type mac struct{ macGeneric }
--
--func (h *mac) Write(p []byte) (int, error) {
--	nn := len(p)
--	if h.offset > 0 {
--		n := copy(h.buffer[h.offset:], p)
--		if h.offset+n < TagSize {
--			h.offset += n
--			return nn, nil
--		}
--		p = p[n:]
--		h.offset = 0
--		update(&h.macState, h.buffer[:])
--	}
--	if n := len(p) - (len(p) % TagSize); n > 0 {
--		update(&h.macState, p[:n])
--		p = p[n:]
--	}
--	if len(p) > 0 {
--		h.offset += copy(h.buffer[h.offset:], p)
--	}
--	return nn, nil
--}
--
--func (h *mac) Sum(out *[16]byte) {
--	state := h.macState
--	if h.offset > 0 {
--		update(&state, h.buffer[:h.offset])
--	}
--	finalize(out, &state.h, &state.s)
--}
-diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
-deleted file mode 100644
-index b3c1699b..00000000
++//go:build gc && !purego && (ppc64 || ppc64le)
+ 
+ package poly1305
+ 
+diff --git a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64x.s
+similarity index 89%
+rename from vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
+rename to vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64x.s
+index b3c1699b..6899a1da 100644
 --- a/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64le.s
-+++ /dev/null
-@@ -1,179 +0,0 @@
--// Copyright 2019 The Go Authors. All rights reserved.
--// Use of this source code is governed by a BSD-style
--// license that can be found in the LICENSE file.
--
++++ b/vendor/golang.org/x/crypto/internal/poly1305/sum_ppc64x.s
+@@ -2,15 +2,25 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
 -//go:build gc && !purego
--
--#include "textflag.h"
--
--// This was ported from the amd64 implementation.
--
--#define POLY1305_ADD(msg, h0, h1, h2, t0, t1, t2) \
++//go:build gc && !purego && (ppc64 || ppc64le)
+ 
+ #include "textflag.h"
+ 
+ // This was ported from the amd64 implementation.
+ 
++#ifdef GOARCH_ppc64le
++#define LE_MOVD MOVD
++#define LE_MOVWZ MOVWZ
++#define LE_MOVHZ MOVHZ
++#else
++#define LE_MOVD MOVDBR
++#define LE_MOVWZ MOVWBR
++#define LE_MOVHZ MOVHBR
++#endif
++
+ #define POLY1305_ADD(msg, h0, h1, h2, t0, t1, t2) \
 -	MOVD (msg), t0;  \
 -	MOVD 8(msg), t1; \
--	MOVD $1, t2;     \
--	ADDC t0, h0, h0; \
--	ADDE t1, h1, h1; \
--	ADDE t2, h2;     \
--	ADD  $16, msg
--
--#define POLY1305_MUL(h0, h1, h2, r0, r1, t0, t1, t2, t3, t4, t5) \
--	MULLD  r0, h0, t0;  \
--	MULHDU r0, h0, t1;  \
--	MULLD  r0, h1, t4;  \
--	MULHDU r0, h1, t5;  \
--	ADDC   t4, t1, t1;  \
--	MULLD  r0, h2, t2;  \
--	MULHDU r1, h0, t4;  \
--	MULLD  r1, h0, h0;  \
--	ADDE   t5, t2, t2;  \
--	ADDC   h0, t1, t1;  \
--	MULLD  h2, r1, t3;  \
--	ADDZE  t4, h0;      \
--	MULHDU r1, h1, t5;  \
--	MULLD  r1, h1, t4;  \
--	ADDC   t4, t2, t2;  \
--	ADDE   t5, t3, t3;  \
--	ADDC   h0, t2, t2;  \
--	MOVD   $-4, t4;     \
--	ADDZE  t3;          \
--	RLDICL $0, t2, $62, h2; \
--	AND    t2, t4, h0;  \
--	ADDC   t0, h0, h0;  \
--	ADDE   t3, t1, h1;  \
--	SLD    $62, t3, t4; \
--	SRD    $2, t2;      \
--	ADDZE  h2;          \
--	OR     t4, t2, t2;  \
--	SRD    $2, t3;      \
--	ADDC   t2, h0, h0;  \
--	ADDE   t3, h1, h1;  \
--	ADDZE  h2
--
++	LE_MOVD (msg)( R0), t0; \
++	LE_MOVD (msg)(R24), t1; \
+ 	MOVD $1, t2;     \
+ 	ADDC t0, h0, h0; \
+ 	ADDE t1, h1, h1; \
+@@ -50,10 +60,6 @@
+ 	ADDE   t3, h1, h1;  \
+ 	ADDZE  h2
+ 
 -DATA ·poly1305Mask<>+0x00(SB)/8, $0x0FFFFFFC0FFFFFFF
 -DATA ·poly1305Mask<>+0x08(SB)/8, $0x0FFFFFFC0FFFFFFC
 -GLOBL ·poly1305Mask<>(SB), RODATA, $16
 -
--// func update(state *[7]uint64, msg []byte)
--TEXT ·update(SB), $0-32
--	MOVD state+0(FP), R3
--	MOVD msg_base+8(FP), R4
--	MOVD msg_len+16(FP), R5
--
--	MOVD 0(R3), R8   // h0
--	MOVD 8(R3), R9   // h1
--	MOVD 16(R3), R10 // h2
--	MOVD 24(R3), R11 // r0
--	MOVD 32(R3), R12 // r1
--
--	CMP R5, $16
--	BLT bytes_between_0_and_15
--
--loop:
--	POLY1305_ADD(R4, R8, R9, R10, R20, R21, R22)
--
--	PCALIGN $16
--multiply:
--	POLY1305_MUL(R8, R9, R10, R11, R12, R16, R17, R18, R14, R20, R21)
--	ADD $-16, R5
--	CMP R5, $16
--	BGE loop
--
--bytes_between_0_and_15:
--	CMP  R5, $0
--	BEQ  done
--	MOVD $0, R16 // h0
--	MOVD $0, R17 // h1
--
--flush_buffer:
--	CMP R5, $8
--	BLE just1
--
--	MOVD $8, R21
--	SUB  R21, R5, R21
--
--	// Greater than 8 -- load the rightmost remaining bytes in msg
--	// and put into R17 (h1)
+ // func update(state *[7]uint64, msg []byte)
+ TEXT ·update(SB), $0-32
+ 	MOVD state+0(FP), R3
+@@ -66,6 +72,8 @@ TEXT ·update(SB), $0-32
+ 	MOVD 24(R3), R11 // r0
+ 	MOVD 32(R3), R12 // r1
+ 
++	MOVD $8, R24
++
+ 	CMP R5, $16
+ 	BLT bytes_between_0_and_15
+ 
+@@ -94,7 +102,7 @@ flush_buffer:
+ 
+ 	// Greater than 8 -- load the rightmost remaining bytes in msg
+ 	// and put into R17 (h1)
 -	MOVD (R4)(R21), R17
--	MOVD $16, R22
--
--	// Find the offset to those bytes
--	SUB R5, R22, R22
--	SLD $3, R22
--
--	// Shift to get only the bytes in msg
--	SRD R22, R17, R17
--
--	// Put 1 at high end
--	MOVD $1, R23
--	SLD  $3, R21
--	SLD  R21, R23, R23
--	OR   R23, R17, R17
--
--	// Remainder is 8
--	MOVD $8, R5
--
--just1:
--	CMP R5, $8
--	BLT less8
--
--	// Exactly 8
++	LE_MOVD (R4)(R21), R17
+ 	MOVD $16, R22
+ 
+ 	// Find the offset to those bytes
+@@ -118,7 +126,7 @@ just1:
+ 	BLT less8
+ 
+ 	// Exactly 8
 -	MOVD (R4), R16
--
--	CMP R17, $0
--
--	// Check if we've already set R17; if not
--	// set 1 to indicate end of msg.
--	BNE  carry
--	MOVD $1, R17
--	BR   carry
--
--less8:
--	MOVD  $0, R16   // h0
--	MOVD  $0, R22   // shift count
--	CMP   R5, $4
--	BLT   less4
++	LE_MOVD (R4), R16
+ 
+ 	CMP R17, $0
+ 
+@@ -133,7 +141,7 @@ less8:
+ 	MOVD  $0, R22   // shift count
+ 	CMP   R5, $4
+ 	BLT   less4
 -	MOVWZ (R4), R16
--	ADD   $4, R4
--	ADD   $-4, R5
--	MOVD  $32, R22
--
--less4:
--	CMP   R5, $2
--	BLT   less2
++	LE_MOVWZ (R4), R16
+ 	ADD   $4, R4
+ 	ADD   $-4, R5
+ 	MOVD  $32, R22
+@@ -141,7 +149,7 @@ less8:
+ less4:
+ 	CMP   R5, $2
+ 	BLT   less2
 -	MOVHZ (R4), R21
--	SLD   R22, R21, R21
--	OR    R16, R21, R16
--	ADD   $16, R22
--	ADD   $-2, R5
--	ADD   $2, R4
--
--less2:
--	CMP   R5, $0
--	BEQ   insert1
--	MOVBZ (R4), R21
--	SLD   R22, R21, R21
--	OR    R16, R21, R16
--	ADD   $8, R22
--
--insert1:
--	// Insert 1 at end of msg
--	MOVD $1, R21
--	SLD  R22, R21, R21
--	OR   R16, R21, R16
--
--carry:
--	// Add new values to h0, h1, h2
--	ADDC  R16, R8
--	ADDE  R17, R9
--	ADDZE R10, R10
--	MOVD  $16, R5
--	ADD   R5, R4
--	BR    multiply
--
--done:
--	// Save h0, h1, h2 in state
--	MOVD R8, 0(R3)
--	MOVD R9, 8(R3)
--	MOVD R10, 16(R3)
--	RET
++	LE_MOVHZ (R4), R21
+ 	SLD   R22, R21, R21
+ 	OR    R16, R21, R16
+ 	ADD   $16, R22
 diff --git a/vendor/golang.org/x/net/LICENSE b/vendor/golang.org/x/net/LICENSE
 index 6a66aea5..2a7cf70d 100644
 --- a/vendor/golang.org/x/net/LICENSE
@@ -13711,6 +13490,223 @@ index 780968d6..e81b73e6 100644
  
  	p := c.p
  	p.mu.Lock()
+diff --git a/vendor/golang.org/x/net/http2/config.go b/vendor/golang.org/x/net/http2/config.go
+new file mode 100644
+index 00000000..de58dfb8
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/config.go
+@@ -0,0 +1,122 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package http2
++
++import (
++	"math"
++	"net/http"
++	"time"
++)
++
++// http2Config is a package-internal version of net/http.HTTP2Config.
++//
++// http.HTTP2Config was added in Go 1.24.
++// When running with a version of net/http that includes HTTP2Config,
++// we merge the configuration with the fields in Transport or Server
++// to produce an http2Config.
++//
++// Zero valued fields in http2Config are interpreted as in the
++// net/http.HTTPConfig documentation.
++//
++// Precedence order for reconciling configurations is:
++//
++//   - Use the net/http.{Server,Transport}.HTTP2Config value, when non-zero.
++//   - Otherwise use the http2.{Server.Transport} value.
++//   - If the resulting value is zero or out of range, use a default.
++type http2Config struct {
++	MaxConcurrentStreams         uint32
++	MaxDecoderHeaderTableSize    uint32
++	MaxEncoderHeaderTableSize    uint32
++	MaxReadFrameSize             uint32
++	MaxUploadBufferPerConnection int32
++	MaxUploadBufferPerStream     int32
++	SendPingTimeout              time.Duration
++	PingTimeout                  time.Duration
++	WriteByteTimeout             time.Duration
++	PermitProhibitedCipherSuites bool
++	CountError                   func(errType string)
++}
++
++// configFromServer merges configuration settings from
++// net/http.Server.HTTP2Config and http2.Server.
++func configFromServer(h1 *http.Server, h2 *Server) http2Config {
++	conf := http2Config{
++		MaxConcurrentStreams:         h2.MaxConcurrentStreams,
++		MaxEncoderHeaderTableSize:    h2.MaxEncoderHeaderTableSize,
++		MaxDecoderHeaderTableSize:    h2.MaxDecoderHeaderTableSize,
++		MaxReadFrameSize:             h2.MaxReadFrameSize,
++		MaxUploadBufferPerConnection: h2.MaxUploadBufferPerConnection,
++		MaxUploadBufferPerStream:     h2.MaxUploadBufferPerStream,
++		SendPingTimeout:              h2.ReadIdleTimeout,
++		PingTimeout:                  h2.PingTimeout,
++		WriteByteTimeout:             h2.WriteByteTimeout,
++		PermitProhibitedCipherSuites: h2.PermitProhibitedCipherSuites,
++		CountError:                   h2.CountError,
++	}
++	fillNetHTTPServerConfig(&conf, h1)
++	setConfigDefaults(&conf, true)
++	return conf
++}
++
++// configFromServer merges configuration settings from h2 and h2.t1.HTTP2
++// (the net/http Transport).
++func configFromTransport(h2 *Transport) http2Config {
++	conf := http2Config{
++		MaxEncoderHeaderTableSize: h2.MaxEncoderHeaderTableSize,
++		MaxDecoderHeaderTableSize: h2.MaxDecoderHeaderTableSize,
++		MaxReadFrameSize:          h2.MaxReadFrameSize,
++		SendPingTimeout:           h2.ReadIdleTimeout,
++		PingTimeout:               h2.PingTimeout,
++		WriteByteTimeout:          h2.WriteByteTimeout,
++	}
++
++	// Unlike most config fields, where out-of-range values revert to the default,
++	// Transport.MaxReadFrameSize clips.
++	if conf.MaxReadFrameSize < minMaxFrameSize {
++		conf.MaxReadFrameSize = minMaxFrameSize
++	} else if conf.MaxReadFrameSize > maxFrameSize {
++		conf.MaxReadFrameSize = maxFrameSize
++	}
++
++	if h2.t1 != nil {
++		fillNetHTTPTransportConfig(&conf, h2.t1)
++	}
++	setConfigDefaults(&conf, false)
++	return conf
++}
++
++func setDefault[T ~int | ~int32 | ~uint32 | ~int64](v *T, minval, maxval, defval T) {
++	if *v < minval || *v > maxval {
++		*v = defval
++	}
++}
++
++func setConfigDefaults(conf *http2Config, server bool) {
++	setDefault(&conf.MaxConcurrentStreams, 1, math.MaxUint32, defaultMaxStreams)
++	setDefault(&conf.MaxEncoderHeaderTableSize, 1, math.MaxUint32, initialHeaderTableSize)
++	setDefault(&conf.MaxDecoderHeaderTableSize, 1, math.MaxUint32, initialHeaderTableSize)
++	if server {
++		setDefault(&conf.MaxUploadBufferPerConnection, initialWindowSize, math.MaxInt32, 1<<20)
++	} else {
++		setDefault(&conf.MaxUploadBufferPerConnection, initialWindowSize, math.MaxInt32, transportDefaultConnFlow)
++	}
++	if server {
++		setDefault(&conf.MaxUploadBufferPerStream, 1, math.MaxInt32, 1<<20)
++	} else {
++		setDefault(&conf.MaxUploadBufferPerStream, 1, math.MaxInt32, transportDefaultStreamFlow)
++	}
++	setDefault(&conf.MaxReadFrameSize, minMaxFrameSize, maxFrameSize, defaultMaxReadFrameSize)
++	setDefault(&conf.PingTimeout, 1, math.MaxInt64, 15*time.Second)
++}
++
++// adjustHTTP1MaxHeaderSize converts a limit in bytes on the size of an HTTP/1 header
++// to an HTTP/2 MAX_HEADER_LIST_SIZE value.
++func adjustHTTP1MaxHeaderSize(n int64) int64 {
++	// http2's count is in a slightly different unit and includes 32 bytes per pair.
++	// So, take the net/http.Server value and pad it up a bit, assuming 10 headers.
++	const perFieldOverhead = 32 // per http2 spec
++	const typicalHeaders = 10   // conservative
++	return n + typicalHeaders*perFieldOverhead
++}
+diff --git a/vendor/golang.org/x/net/http2/config_go124.go b/vendor/golang.org/x/net/http2/config_go124.go
+new file mode 100644
+index 00000000..e3784123
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/config_go124.go
+@@ -0,0 +1,61 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build go1.24
++
++package http2
++
++import "net/http"
++
++// fillNetHTTPServerConfig sets fields in conf from srv.HTTP2.
++func fillNetHTTPServerConfig(conf *http2Config, srv *http.Server) {
++	fillNetHTTPConfig(conf, srv.HTTP2)
++}
++
++// fillNetHTTPServerConfig sets fields in conf from tr.HTTP2.
++func fillNetHTTPTransportConfig(conf *http2Config, tr *http.Transport) {
++	fillNetHTTPConfig(conf, tr.HTTP2)
++}
++
++func fillNetHTTPConfig(conf *http2Config, h2 *http.HTTP2Config) {
++	if h2 == nil {
++		return
++	}
++	if h2.MaxConcurrentStreams != 0 {
++		conf.MaxConcurrentStreams = uint32(h2.MaxConcurrentStreams)
++	}
++	if h2.MaxEncoderHeaderTableSize != 0 {
++		conf.MaxEncoderHeaderTableSize = uint32(h2.MaxEncoderHeaderTableSize)
++	}
++	if h2.MaxDecoderHeaderTableSize != 0 {
++		conf.MaxDecoderHeaderTableSize = uint32(h2.MaxDecoderHeaderTableSize)
++	}
++	if h2.MaxConcurrentStreams != 0 {
++		conf.MaxConcurrentStreams = uint32(h2.MaxConcurrentStreams)
++	}
++	if h2.MaxReadFrameSize != 0 {
++		conf.MaxReadFrameSize = uint32(h2.MaxReadFrameSize)
++	}
++	if h2.MaxReceiveBufferPerConnection != 0 {
++		conf.MaxUploadBufferPerConnection = int32(h2.MaxReceiveBufferPerConnection)
++	}
++	if h2.MaxReceiveBufferPerStream != 0 {
++		conf.MaxUploadBufferPerStream = int32(h2.MaxReceiveBufferPerStream)
++	}
++	if h2.SendPingTimeout != 0 {
++		conf.SendPingTimeout = h2.SendPingTimeout
++	}
++	if h2.PingTimeout != 0 {
++		conf.PingTimeout = h2.PingTimeout
++	}
++	if h2.WriteByteTimeout != 0 {
++		conf.WriteByteTimeout = h2.WriteByteTimeout
++	}
++	if h2.PermitProhibitedCipherSuites {
++		conf.PermitProhibitedCipherSuites = true
++	}
++	if h2.CountError != nil {
++		conf.CountError = h2.CountError
++	}
++}
+diff --git a/vendor/golang.org/x/net/http2/config_pre_go124.go b/vendor/golang.org/x/net/http2/config_pre_go124.go
+new file mode 100644
+index 00000000..060fd6c6
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/config_pre_go124.go
+@@ -0,0 +1,16 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !go1.24
++
++package http2
++
++import "net/http"
++
++// Pre-Go 1.24 fallback.
++// The Server.HTTP2 and Transport.HTTP2 config fields were added in Go 1.24.
++
++func fillNetHTTPServerConfig(conf *http2Config, srv *http.Server) {}
++
++func fillNetHTTPTransportConfig(conf *http2Config, tr *http.Transport) {}
 diff --git a/vendor/golang.org/x/net/http2/frame.go b/vendor/golang.org/x/net/http2/frame.go
 index 105c3b27..81faec7e 100644
 --- a/vendor/golang.org/x/net/http2/frame.go
@@ -14971,6 +14967,32 @@ index 61075bd1..00000000
 -	}
 -	return active
 -}
+diff --git a/vendor/golang.org/x/net/http2/timer.go b/vendor/golang.org/x/net/http2/timer.go
+new file mode 100644
+index 00000000..0b1c17b8
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/timer.go
+@@ -0,0 +1,20 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++package http2
++
++import "time"
++
++// A timer is a time.Timer, as an interface which can be replaced in tests.
++type timer = interface {
++	C() <-chan time.Time
++	Reset(d time.Duration) bool
++	Stop() bool
++}
++
++// timeTimer adapts a time.Timer to the timer interface.
++type timeTimer struct {
++	*time.Timer
++}
++
++func (t timeTimer) C() <-chan time.Time { return t.Timer.C }
 diff --git a/vendor/golang.org/x/net/http2/transport.go b/vendor/golang.org/x/net/http2/transport.go
 index 2fa49490..090d0e1b 100644
 --- a/vendor/golang.org/x/net/http2/transport.go
@@ -16398,6 +16420,44 @@ index 2fa49490..090d0e1b 100644
  	}
  	cc.mu.Unlock()
  
+diff --git a/vendor/golang.org/x/net/http2/unencrypted.go b/vendor/golang.org/x/net/http2/unencrypted.go
+new file mode 100644
+index 00000000..b2de2116
+--- /dev/null
++++ b/vendor/golang.org/x/net/http2/unencrypted.go
+@@ -0,0 +1,32 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package http2
++
++import (
++	"crypto/tls"
++	"errors"
++	"net"
++)
++
++const nextProtoUnencryptedHTTP2 = "unencrypted_http2"
++
++// unencryptedNetConnFromTLSConn retrieves a net.Conn wrapped in a *tls.Conn.
++//
++// TLSNextProto functions accept a *tls.Conn.
++//
++// When passing an unencrypted HTTP/2 connection to a TLSNextProto function,
++// we pass a *tls.Conn with an underlying net.Conn containing the unencrypted connection.
++// To be extra careful about mistakes (accidentally dropping TLS encryption in a place
++// where we want it), the tls.Conn contains a net.Conn with an UnencryptedNetConn method
++// that returns the actual connection we want to use.
++func unencryptedNetConnFromTLSConn(tc *tls.Conn) (net.Conn, error) {
++	conner, ok := tc.NetConn().(interface {
++		UnencryptedNetConn() net.Conn
++	})
++	if !ok {
++		return nil, errors.New("http2: TLS conn unexpectedly found in unencrypted handoff")
++	}
++	return conner.UnencryptedNetConn(), nil
++}
 diff --git a/vendor/golang.org/x/net/http2/write.go b/vendor/golang.org/x/net/http2/write.go
 index 33f61398..6ff6bee7 100644
 --- a/vendor/golang.org/x/net/http2/write.go
@@ -16589,6 +16649,29 @@ index 6a66aea5..2a7cf70d 100644
  contributors may be used to endorse or promote products derived from
  this software without specific prior written permission.
  
+diff --git a/vendor/golang.org/x/sys/cpu/asm_darwin_x86_gc.s b/vendor/golang.org/x/sys/cpu/asm_darwin_x86_gc.s
+new file mode 100644
+index 00000000..ec2acfe5
+--- /dev/null
++++ b/vendor/golang.org/x/sys/cpu/asm_darwin_x86_gc.s
+@@ -0,0 +1,17 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build darwin && amd64 && gc
++
++#include "textflag.h"
++
++TEXT libc_sysctl_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_sysctl(SB)
++GLOBL	·libc_sysctl_trampoline_addr(SB), RODATA, $8
++DATA	·libc_sysctl_trampoline_addr(SB)/8, $libc_sysctl_trampoline<>(SB)
++
++TEXT libc_sysctlbyname_trampoline<>(SB),NOSPLIT,$0-0
++	JMP	libc_sysctlbyname(SB)
++GLOBL	·libc_sysctlbyname_trampoline_addr(SB), RODATA, $8
++DATA	·libc_sysctlbyname_trampoline_addr(SB)/8, $libc_sysctlbyname_trampoline<>(SB)
 diff --git a/vendor/golang.org/x/sys/cpu/cpu.go b/vendor/golang.org/x/sys/cpu/cpu.go
 index 8fa707aa..02609d5b 100644
 --- a/vendor/golang.org/x/sys/cpu/cpu.go
@@ -16665,6 +16748,73 @@ index 0e27a21e..af2aa99f 100644
  }
  
  func parseARM64SVERegister(zfr0 uint64) {
+diff --git a/vendor/golang.org/x/sys/cpu/cpu_darwin_x86.go b/vendor/golang.org/x/sys/cpu/cpu_darwin_x86.go
+new file mode 100644
+index 00000000..b838cb9e
+--- /dev/null
++++ b/vendor/golang.org/x/sys/cpu/cpu_darwin_x86.go
+@@ -0,0 +1,61 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build darwin && amd64 && gc
++
++package cpu
++
++// darwinSupportsAVX512 checks Darwin kernel for AVX512 support via sysctl
++// call (see issue 43089). It also restricts AVX512 support for Darwin to
++// kernel version 21.3.0 (MacOS 12.2.0) or later (see issue 49233).
++//
++// Background:
++// Darwin implements a special mechanism to economize on thread state when
++// AVX512 specific registers are not in use. This scheme minimizes state when
++// preempting threads that haven't yet used any AVX512 instructions, but adds
++// special requirements to check for AVX512 hardware support at runtime (e.g.
++// via sysctl call or commpage inspection). See issue 43089 and link below for
++// full background:
++// https://github.com/apple-oss-distributions/xnu/blob/xnu-11215.1.10/osfmk/i386/fpu.c#L214-L240
++//
++// Additionally, all versions of the Darwin kernel from 19.6.0 through 21.2.0
++// (corresponding to MacOS 10.15.6 - 12.1) have a bug that can cause corruption
++// of the AVX512 mask registers (K0-K7) upon signal return. For this reason
++// AVX512 is considered unsafe to use on Darwin for kernel versions prior to
++// 21.3.0, where a fix has been confirmed. See issue 49233 for full background.
++func darwinSupportsAVX512() bool {
++	return darwinSysctlEnabled([]byte("hw.optional.avx512f\x00")) && darwinKernelVersionCheck(21, 3, 0)
++}
++
++// Ensure Darwin kernel version is at least major.minor.patch, avoiding dependencies
++func darwinKernelVersionCheck(major, minor, patch int) bool {
++	var release [256]byte
++	err := darwinOSRelease(&release)
++	if err != nil {
++		return false
++	}
++
++	var mmp [3]int
++	c := 0
++Loop:
++	for _, b := range release[:] {
++		switch {
++		case b >= '0' && b <= '9':
++			mmp[c] = 10*mmp[c] + int(b-'0')
++		case b == '.':
++			c++
++			if c > 2 {
++				return false
++			}
++		case b == 0:
++			break Loop
++		default:
++			return false
++		}
++	}
++	if c != 2 {
++		return false
++	}
++	return mmp[0] > major || mmp[0] == major && (mmp[1] > minor || mmp[1] == minor && mmp[2] >= patch)
++}
 diff --git a/vendor/golang.org/x/sys/cpu/cpu_gc_x86.go b/vendor/golang.org/x/sys/cpu/cpu_gc_x86.go
 index 910728fb..32a44514 100644
 --- a/vendor/golang.org/x/sys/cpu/cpu_gc_x86.go
@@ -16682,6 +16832,22 @@ index 910728fb..32a44514 100644
 +// xgetbv with ecx = 0 is implemented in cpu_gc_x86.s for gc compiler
  // and in cpu_gccgo.c for gccgo.
  func xgetbv() (eax, edx uint32)
+diff --git a/vendor/golang.org/x/sys/cpu/cpu_x86.s b/vendor/golang.org/x/sys/cpu/cpu_gc_x86.s
+similarity index 94%
+rename from vendor/golang.org/x/sys/cpu/cpu_x86.s
+rename to vendor/golang.org/x/sys/cpu/cpu_gc_x86.s
+index 7d7ba33e..ce208ce6 100644
+--- a/vendor/golang.org/x/sys/cpu/cpu_x86.s
++++ b/vendor/golang.org/x/sys/cpu/cpu_gc_x86.s
+@@ -18,7 +18,7 @@ TEXT ·cpuid(SB), NOSPLIT, $0-24
+ 	RET
+ 
+ // func xgetbv() (eax, edx uint32)
+-TEXT ·xgetbv(SB),NOSPLIT,$0-8
++TEXT ·xgetbv(SB), NOSPLIT, $0-8
+ 	MOVL $0, CX
+ 	XGETBV
+ 	MOVL AX, eax+0(FP)
 diff --git a/vendor/golang.org/x/sys/cpu/cpu_gccgo_x86.go b/vendor/golang.org/x/sys/cpu/cpu_gccgo_x86.go
 index 99c60fe9..170d21dd 100644
 --- a/vendor/golang.org/x/sys/cpu/cpu_gccgo_x86.go
@@ -16736,6 +16902,166 @@ index cd63e733..7d902b68 100644
  
  package cpu
  
+diff --git a/vendor/golang.org/x/sys/cpu/cpu_linux_riscv64.go b/vendor/golang.org/x/sys/cpu/cpu_linux_riscv64.go
+new file mode 100644
+index 00000000..cb4a0c57
+--- /dev/null
++++ b/vendor/golang.org/x/sys/cpu/cpu_linux_riscv64.go
+@@ -0,0 +1,137 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package cpu
++
++import (
++	"syscall"
++	"unsafe"
++)
++
++// RISC-V extension discovery code for Linux. The approach here is to first try the riscv_hwprobe
++// syscall falling back to HWCAP to check for the C extension if riscv_hwprobe is not available.
++//
++// A note on detection of the Vector extension using HWCAP.
++//
++// Support for the Vector extension version 1.0 was added to the Linux kernel in release 6.5.
++// Support for the riscv_hwprobe syscall was added in 6.4. It follows that if the riscv_hwprobe
++// syscall is not available then neither is the Vector extension (which needs kernel support).
++// The riscv_hwprobe syscall should then be all we need to detect the Vector extension.
++// However, some RISC-V board manufacturers ship boards with an older kernel on top of which
++// they have back-ported various versions of the Vector extension patches but not the riscv_hwprobe
++// patches. These kernels advertise support for the Vector extension using HWCAP. Falling
++// back to HWCAP to detect the Vector extension, if riscv_hwprobe is not available, or simply not
++// bothering with riscv_hwprobe at all and just using HWCAP may then seem like an attractive option.
++//
++// Unfortunately, simply checking the 'V' bit in AT_HWCAP will not work as this bit is used by
++// RISC-V board and cloud instance providers to mean different things. The Lichee Pi 4A board
++// and the Scaleway RV1 cloud instances use the 'V' bit to advertise their support for the unratified
++// 0.7.1 version of the Vector Specification. The Banana Pi BPI-F3 and the CanMV-K230 board use
++// it to advertise support for 1.0 of the Vector extension. Versions 0.7.1 and 1.0 of the Vector
++// extension are binary incompatible. HWCAP can then not be used in isolation to populate the
++// HasV field as this field indicates that the underlying CPU is compatible with RVV 1.0.
++//
++// There is a way at runtime to distinguish between versions 0.7.1 and 1.0 of the Vector
++// specification by issuing a RVV 1.0 vsetvli instruction and checking the vill bit of the vtype
++// register. This check would allow us to safely detect version 1.0 of the Vector extension
++// with HWCAP, if riscv_hwprobe were not available. However, the check cannot
++// be added until the assembler supports the Vector instructions.
++//
++// Note the riscv_hwprobe syscall does not suffer from these ambiguities by design as all of the
++// extensions it advertises support for are explicitly versioned. It's also worth noting that
++// the riscv_hwprobe syscall is the only way to detect multi-letter RISC-V extensions, e.g., Zba.
++// These cannot be detected using HWCAP and so riscv_hwprobe must be used to detect the majority
++// of RISC-V extensions.
++//
++// Please see https://docs.kernel.org/arch/riscv/hwprobe.html for more information.
++
++// golang.org/x/sys/cpu is not allowed to depend on golang.org/x/sys/unix so we must
++// reproduce the constants, types and functions needed to make the riscv_hwprobe syscall
++// here.
++
++const (
++	// Copied from golang.org/x/sys/unix/ztypes_linux_riscv64.go.
++	riscv_HWPROBE_KEY_IMA_EXT_0   = 0x4
++	riscv_HWPROBE_IMA_C           = 0x2
++	riscv_HWPROBE_IMA_V           = 0x4
++	riscv_HWPROBE_EXT_ZBA         = 0x8
++	riscv_HWPROBE_EXT_ZBB         = 0x10
++	riscv_HWPROBE_EXT_ZBS         = 0x20
++	riscv_HWPROBE_KEY_CPUPERF_0   = 0x5
++	riscv_HWPROBE_MISALIGNED_FAST = 0x3
++	riscv_HWPROBE_MISALIGNED_MASK = 0x7
++)
++
++const (
++	// sys_RISCV_HWPROBE is copied from golang.org/x/sys/unix/zsysnum_linux_riscv64.go.
++	sys_RISCV_HWPROBE = 258
++)
++
++// riscvHWProbePairs is copied from golang.org/x/sys/unix/ztypes_linux_riscv64.go.
++type riscvHWProbePairs struct {
++	key   int64
++	value uint64
++}
++
++const (
++	// CPU features
++	hwcap_RISCV_ISA_C = 1 << ('C' - 'A')
++)
++
++func doinit() {
++	// A slice of key/value pair structures is passed to the RISCVHWProbe syscall. The key
++	// field should be initialised with one of the key constants defined above, e.g.,
++	// RISCV_HWPROBE_KEY_IMA_EXT_0. The syscall will set the value field to the appropriate value.
++	// If the kernel does not recognise a key it will set the key field to -1 and the value field to 0.
++
++	pairs := []riscvHWProbePairs{
++		{riscv_HWPROBE_KEY_IMA_EXT_0, 0},
++		{riscv_HWPROBE_KEY_CPUPERF_0, 0},
++	}
++
++	// This call only indicates that extensions are supported if they are implemented on all cores.
++	if riscvHWProbe(pairs, 0) {
++		if pairs[0].key != -1 {
++			v := uint(pairs[0].value)
++			RISCV64.HasC = isSet(v, riscv_HWPROBE_IMA_C)
++			RISCV64.HasV = isSet(v, riscv_HWPROBE_IMA_V)
++			RISCV64.HasZba = isSet(v, riscv_HWPROBE_EXT_ZBA)
++			RISCV64.HasZbb = isSet(v, riscv_HWPROBE_EXT_ZBB)
++			RISCV64.HasZbs = isSet(v, riscv_HWPROBE_EXT_ZBS)
++		}
++		if pairs[1].key != -1 {
++			v := pairs[1].value & riscv_HWPROBE_MISALIGNED_MASK
++			RISCV64.HasFastMisaligned = v == riscv_HWPROBE_MISALIGNED_FAST
++		}
++	}
++
++	// Let's double check with HWCAP if the C extension does not appear to be supported.
++	// This may happen if we're running on a kernel older than 6.4.
++
++	if !RISCV64.HasC {
++		RISCV64.HasC = isSet(hwCap, hwcap_RISCV_ISA_C)
++	}
++}
++
++func isSet(hwc uint, value uint) bool {
++	return hwc&value != 0
++}
++
++// riscvHWProbe is a simplified version of the generated wrapper function found in
++// golang.org/x/sys/unix/zsyscall_linux_riscv64.go. We simplify it by removing the
++// cpuCount and cpus parameters which we do not need. We always want to pass 0 for
++// these parameters here so the kernel only reports the extensions that are present
++// on all cores.
++func riscvHWProbe(pairs []riscvHWProbePairs, flags uint) bool {
++	var _zero uintptr
++	var p0 unsafe.Pointer
++	if len(pairs) > 0 {
++		p0 = unsafe.Pointer(&pairs[0])
++	} else {
++		p0 = unsafe.Pointer(&_zero)
++	}
++
++	_, _, e1 := syscall.Syscall6(sys_RISCV_HWPROBE, uintptr(p0), uintptr(len(pairs)), uintptr(0), uintptr(0), uintptr(flags), 0)
++	return e1 == 0
++}
+diff --git a/vendor/golang.org/x/sys/cpu/cpu_other_x86.go b/vendor/golang.org/x/sys/cpu/cpu_other_x86.go
+new file mode 100644
+index 00000000..a0fd7e2f
+--- /dev/null
++++ b/vendor/golang.org/x/sys/cpu/cpu_other_x86.go
+@@ -0,0 +1,11 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build 386 || amd64p32 || (amd64 && (!darwin || !gc))
++
++package cpu
++
++func darwinSupportsAVX512() bool {
++	panic("only implemented for gc && amd64 && darwin")
++}
 diff --git a/vendor/golang.org/x/sys/cpu/cpu_riscv64.go b/vendor/golang.org/x/sys/cpu/cpu_riscv64.go
 index 7f0c79c0..aca3199c 100644
 --- a/vendor/golang.org/x/sys/cpu/cpu_riscv64.go
@@ -16772,38 +17098,110 @@ index c29f5e4c..600a6807 100644
  		} else {
  			// Check if OPMASK and ZMM registers have OS support.
  			osSupportsAVX512 = osSupportsAVX && isSet(5, eax) && isSet(6, eax) && isSet(7, eax)
-diff --git a/vendor/golang.org/x/sys/cpu/cpu_x86.s b/vendor/golang.org/x/sys/cpu/cpu_x86.s
-deleted file mode 100644
-index 7d7ba33e..00000000
---- a/vendor/golang.org/x/sys/cpu/cpu_x86.s
-+++ /dev/null
-@@ -1,26 +0,0 @@
--// Copyright 2018 The Go Authors. All rights reserved.
--// Use of this source code is governed by a BSD-style
--// license that can be found in the LICENSE file.
--
--//go:build (386 || amd64 || amd64p32) && gc
--
--#include "textflag.h"
--
--// func cpuid(eaxArg, ecxArg uint32) (eax, ebx, ecx, edx uint32)
--TEXT ·cpuid(SB), NOSPLIT, $0-24
--	MOVL eaxArg+0(FP), AX
--	MOVL ecxArg+4(FP), CX
--	CPUID
--	MOVL AX, eax+8(FP)
--	MOVL BX, ebx+12(FP)
--	MOVL CX, ecx+16(FP)
--	MOVL DX, edx+20(FP)
--	RET
--
--// func xgetbv() (eax, edx uint32)
--TEXT ·xgetbv(SB),NOSPLIT,$0-8
--	MOVL $0, CX
--	XGETBV
--	MOVL AX, eax+0(FP)
--	MOVL DX, edx+4(FP)
--	RET
+diff --git a/vendor/golang.org/x/sys/cpu/syscall_darwin_x86_gc.go b/vendor/golang.org/x/sys/cpu/syscall_darwin_x86_gc.go
+new file mode 100644
+index 00000000..4d0888b0
+--- /dev/null
++++ b/vendor/golang.org/x/sys/cpu/syscall_darwin_x86_gc.go
+@@ -0,0 +1,98 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Minimal copy of x/sys/unix so the cpu package can make a
++// system call on Darwin without depending on x/sys/unix.
++
++//go:build darwin && amd64 && gc
++
++package cpu
++
++import (
++	"syscall"
++	"unsafe"
++)
++
++type _C_int int32
++
++// adapted from unix.Uname() at x/sys/unix/syscall_darwin.go L419
++func darwinOSRelease(release *[256]byte) error {
++	// from x/sys/unix/zerrors_openbsd_amd64.go
++	const (
++		CTL_KERN       = 0x1
++		KERN_OSRELEASE = 0x2
++	)
++
++	mib := []_C_int{CTL_KERN, KERN_OSRELEASE}
++	n := unsafe.Sizeof(*release)
++
++	return sysctl(mib, &release[0], &n, nil, 0)
++}
++
++type Errno = syscall.Errno
++
++var _zero uintptr // Single-word zero for use when we need a valid pointer to 0 bytes.
++
++// from x/sys/unix/zsyscall_darwin_amd64.go L791-807
++func sysctl(mib []_C_int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) error {
++	var _p0 unsafe.Pointer
++	if len(mib) > 0 {
++		_p0 = unsafe.Pointer(&mib[0])
++	} else {
++		_p0 = unsafe.Pointer(&_zero)
++	}
++	if _, _, err := syscall_syscall6(
++		libc_sysctl_trampoline_addr,
++		uintptr(_p0),
++		uintptr(len(mib)),
++		uintptr(unsafe.Pointer(old)),
++		uintptr(unsafe.Pointer(oldlen)),
++		uintptr(unsafe.Pointer(new)),
++		uintptr(newlen),
++	); err != 0 {
++		return err
++	}
++
++	return nil
++}
++
++var libc_sysctl_trampoline_addr uintptr
++
++// adapted from internal/cpu/cpu_arm64_darwin.go
++func darwinSysctlEnabled(name []byte) bool {
++	out := int32(0)
++	nout := unsafe.Sizeof(out)
++	if ret := sysctlbyname(&name[0], (*byte)(unsafe.Pointer(&out)), &nout, nil, 0); ret != nil {
++		return false
++	}
++	return out > 0
++}
++
++//go:cgo_import_dynamic libc_sysctl sysctl "/usr/lib/libSystem.B.dylib"
++
++var libc_sysctlbyname_trampoline_addr uintptr
++
++// adapted from runtime/sys_darwin.go in the pattern of sysctl() above, as defined in x/sys/unix
++func sysctlbyname(name *byte, old *byte, oldlen *uintptr, new *byte, newlen uintptr) error {
++	if _, _, err := syscall_syscall6(
++		libc_sysctlbyname_trampoline_addr,
++		uintptr(unsafe.Pointer(name)),
++		uintptr(unsafe.Pointer(old)),
++		uintptr(unsafe.Pointer(oldlen)),
++		uintptr(unsafe.Pointer(new)),
++		uintptr(newlen),
++		0,
++	); err != 0 {
++		return err
++	}
++
++	return nil
++}
++
++//go:cgo_import_dynamic libc_sysctlbyname sysctlbyname "/usr/lib/libSystem.B.dylib"
++
++// Implemented in the runtime package (runtime/sys_darwin.go)
++func syscall_syscall6(fn, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err Errno)
++
++//go:linkname syscall_syscall6 syscall.syscall6
 diff --git a/vendor/golang.org/x/sys/unix/README.md b/vendor/golang.org/x/sys/unix/README.md
 index 7d3c060e..6e08a76a 100644
 --- a/vendor/golang.org/x/sys/unix/README.md
@@ -17348,6 +17746,42 @@ index 312ae6ac..7bf5c04b 100644
 +		}
 +	}
 +	return n2, nil
++}
+diff --git a/vendor/golang.org/x/sys/unix/vgetrandom_linux.go b/vendor/golang.org/x/sys/unix/vgetrandom_linux.go
+new file mode 100644
+index 00000000..07ac8e09
+--- /dev/null
++++ b/vendor/golang.org/x/sys/unix/vgetrandom_linux.go
+@@ -0,0 +1,13 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build linux && go1.24
++
++package unix
++
++import _ "unsafe"
++
++//go:linkname vgetrandom runtime.vgetrandom
++//go:noescape
++func vgetrandom(p []byte, flags uint32) (ret int, supported bool)
+diff --git a/vendor/golang.org/x/sys/unix/vgetrandom_unsupported.go b/vendor/golang.org/x/sys/unix/vgetrandom_unsupported.go
+new file mode 100644
+index 00000000..297e97bc
+--- /dev/null
++++ b/vendor/golang.org/x/sys/unix/vgetrandom_unsupported.go
+@@ -0,0 +1,11 @@
++// Copyright 2024 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !linux || !go1.24
++
++package unix
++
++func vgetrandom(p []byte, flags uint32) (ret int, supported bool) {
++	return -1, false
 +}
 diff --git a/vendor/golang.org/x/sys/unix/zerrors_darwin_amd64.go b/vendor/golang.org/x/sys/unix/zerrors_darwin_amd64.go
 index e40fa852..d73c4652 100644
@@ -21250,3 +21684,5 @@ index c14c0460..96673f57 100644
  ## explicit; go 1.18
  golang.org/x/text/secure/bidirule
  golang.org/x/text/transform
+-- 
+2.47.0


### PR DESCRIPTION
## Description

Add patch to fix CVE-2024-51744 
`go: upgraded github.com/golang-jwt/jwt/v4 v4.5.0 => v4.5.1`

## Why do we need it, and what problem does it solve?
- Security compliance.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: chore
summary: Fix Promxy CVE-2024-51744
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
