### PR TITLE
[node-manager] Fix ngc enable-watchdog-for-nodegroup.sh

### DIFF
--- a/modules/040-node-manager/templates/fencing-agent/nodegroupconfiguration.yaml
+++ b/modules/040-node-manager/templates/fencing-agent/nodegroupconfiguration.yaml
@@ -52,7 +52,7 @@ spec:
     WD="/dev/watchdog"
 
     start_wd() {
-      if [ -d "${WD}" ]; then
+      if [ -e "${WD}" ]; then
         ls -lha /dev/watchdog* 2>/dev/null
         rm -rf "${WD}"
       fi


### PR DESCRIPTION
## Description
  Correct condition in bash script nodegroup-watchdog.sh.
<!---
  Correct condition in bash script.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Fix bash script nodegroup-watchdog.sh for case, when softdog was already turned on.
<!---
Fix bash script nodegroup-watchdog.sh for case, when softdog was already turned on.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
section: node-manager
type: fix
summary: "Script nodegroup-watchdog.sh for case, when softdog was already turned on, doesn't work correct."
impact_level: low

<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
    start_wd() {
      if [ -e "${WD}" ]; then
        ls -lha /dev/watchdog* 2>/dev/null
        rm -rf "${WD}"
        touch /root/on
      fi
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "node-manage

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
