### PR TITLE
[ingress-nginx] Fix ds_eviction_annotation in ingress-nginx controllers pods

### DIFF
--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -128,12 +128,12 @@ spec:
       {{- end }}
         app: controller
         name: {{ $name }}
-      {{- if $crd.spec.enableIstioSidecar }}
       annotations:
+        {{ include "helm_lib_prevent_ds_eviction_annotation" . | nindent 8 }}
+      {{- if $crd.spec.enableIstioSidecar }}
         traffic.sidecar.istio.io/includeInboundPorts: ""
         traffic.sidecar.istio.io/includeOutboundIPRanges: {{ $context.Values.global.discovery.serviceSubnet | quote }}
         inject.istio.io/templates: "sidecar,d8-hold-istio-proxy-termination-until-application-stops"
-        {{ include "helm_lib_prevent_ds_eviction_annotation" . | nindent 8 }}
       {{- end }}
     spec:
   {{- if $crd.spec.nodeSelector }}


### PR DESCRIPTION
## Description

The annotations section of the Helm-template for the ingress-controller has been corrected.

## Why do we need it, and what problem does it solve?

An error was made in pr8609, which resulted in the graceful shutdown for the ingress controller only working if Istio was additionally configured.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: fix
summary: Fixed graceful shutdown for the ingress-controller pods.
impact: Pods of ingress-nginx controllers will be restarted.
impact_level: default
```


