### PR TITLE
[prometheus] Add init container and switcher for prom longterm

### DIFF
--- a/ee/fe/modules/300-prometheus/.build.yaml
+++ b/ee/fe/modules/300-prometheus/.build.yaml
@@ -1,1 +1,2 @@
 templates/prometheus/prometheus.yaml
+templates/prometheus/longterm/prometheus.yaml

--- a/ee/fe/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/ee/fe/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -63,7 +63,7 @@ spec:
   version: v2.53.2
 {{- else }}
   image: {{ include "helm_lib_module_image" (list . "prometheus") }}
-  version: v2.45.2
+  version: v2.55.1
 {{- end }}
   imagePullSecrets:
   - name: deckhouse-registry
@@ -87,7 +87,7 @@ spec:
     - "walpp"
     {{- end }}
     volumeMounts:
-    - name: prometheus-main-db
+    - name: prometheus-longterm-db
       mountPath: /prometheus
       subPath: prometheus-db
       securityContext:

--- a/ee/fe/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/ee/fe/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -1,0 +1,230 @@
+{{- define "longterm_prometheus_resources" }} # for reference see modules/300-prometheus/hooks/detect_vpa_max.go
+cpu: 50m
+memory: 500Mi
+{{- end }}
+
+{{- define "longterm_config_reloader_resources" }}
+cpu: 10m
+memory: 25Mi
+{{- end }}
+
+{{- define "prompp-context" -}}
+{{- $values := deepCopy .Values | merge dict }}
+{{- $_ := set $values.global.modulesImages.registry "base" (printf "%s/modules/prompp" .Values.global.modulesImages.registry.base) }}
+{{- $ctx := dict "Chart" (dict "Name" "prompp") "Values" $values }}
+{{- $ctx | toYaml }}
+{{- end }}
+
+{{- if .Values.prometheus.longtermRetentionDays }}
+{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: prometheus-longterm
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus")) | nindent 2 }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: StatefulSet
+    name: prometheus-longterm
+  updatePolicy:
+    updateMode: {{ .Values.prometheus.vpa.updateMode | quote }}
+  resourcePolicy:
+    containerPolicies:
+    - containerName: "prometheus"
+      minAllowed:
+        {{- include "longterm_prometheus_resources" . | nindent 8 }}
+      maxAllowed:
+        cpu: {{ .Values.prometheus.vpa.longtermMaxCPU | default .Values.prometheus.internal.vpa.longtermMaxCPU | quote }}
+        memory: {{ .Values.prometheus.vpa.longtermMaxMemory | default .Values.prometheus.internal.vpa.longtermMaxMemory | quote }}
+    - containerName: config-reloader
+      minAllowed:
+        {{- include "longterm_config_reloader_resources" . | nindent 8 }}
+      maxAllowed:
+        memory: 50Mi
+        cpu: 20m
+    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
+{{- end }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: longterm
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus")) | nindent 2 }}
+spec:
+  replicas: 1
+  retention: {{ .Values.prometheus.longtermRetentionDays }}d
+  retentionSize: {{ .Values.prometheus.internal.prometheusLongterm.retentionGigabytes }}GB
+{{- if (.Values.global.enabledModules | has "prompp") }}
+  image: {{ include "helm_lib_module_image" (list (include "prompp-context" . | fromYaml) "prompp") }}
+  version: v2.53.2
+{{- else }}
+  image: {{ include "helm_lib_module_image" (list . "prometheus") }}
+  version: v2.45.2
+{{- end }}
+  imagePullSecrets:
+  - name: deckhouse-registry
+  listenLocal: true
+  query:
+    maxSamples: 100000000
+  additionalArgs:
+    - name: scrape.timestamp-tolerance
+      value: 10ms
+{{- if hasKey .Values.global.modulesImages.digests "prompp" }}
+  initContainers:
+  - name: prompptool
+    image: {{ include "helm_lib_module_image" (list (include "prompp-context" . | fromYaml) "prompptool") }}
+    command:
+    - /bin/prompptool
+    - "--working-dir=/prometheus"
+    - "--verbose"
+    {{- if (.Values.global.enabledModules | has "prompp") }}
+    - "walvanilla"
+    {{- else }}
+    - "walpp"
+    {{- end }}
+    volumeMounts:
+    - name: prometheus-main-db
+      mountPath: /prometheus
+      subPath: prometheus-db
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
+    resources:
+      requests:
+        {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
+{{- end }}
+  containers:
+  - name: prometheus
+    startupProbe:
+      failureThreshold: 300
+{{- if (.Values.global.enabledModules | has "prompp") }}
+    envFrom:
+      - configMapRef:
+          name: prometheus-pp-envs
+{{- end }}
+  - name: kube-rbac-proxy
+    {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 4 }}
+    image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
+    args:
+    - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):9090"
+    - "--client-ca-file=/etc/kube-rbac-proxy/ca.crt"
+    - "--v=2"
+    - "--logtostderr=true"
+    - "--stale-cache-interval=1h30m"
+    ports:
+    - containerPort: 9090
+      name: https
+    env:
+    - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: KUBE_RBAC_PROXY_CONFIG
+      value: |
+        upstreams:
+        - upstream: http://127.0.0.1:9090/
+          path: /
+          authorization:
+            resourceAttributes:
+              namespace: d8-monitoring
+              apiGroup: monitoring.coreos.com
+              apiVersion: v1
+              resource: prometheuses
+              subresource: http
+              name: longterm
+    resources:
+      requests:
+        {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 8 }}
+  {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+        {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 8 }}
+  {{- end }}
+    volumeMounts:
+    - name: kube-rbac-proxy-ca
+      mountPath: /etc/kube-rbac-proxy
+  - name: config-reloader
+    resources:
+      requests:
+        {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 20 | nindent 8 }}
+  {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+        {{- include "longterm_config_reloader_resources" . | nindent 8 }}
+  {{- end }}
+  affinity:
+    podAntiAffinity:
+      {{- if eq .Values.prometheus.longtermPodAntiAffinity "Required" }}
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+              prometheus: main
+          topologyKey: kubernetes.io/hostname
+      {{- else }}
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: prometheus
+                prometheus: main
+            topologyKey: kubernetes.io/hostname
+      {{- end }}
+  scrapeInterval: {{ .Values.prometheus.longtermScrapeInterval | default "5m" }}
+  evaluationInterval: {{ .Values.prometheus.longtermScrapeInterval | default "5m" }}
+{{- if .Values.global.modules.publicDomainTemplate }}
+  externalUrl: {{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "grafana") }}/prometheus/longterm/
+{{- end }}
+  {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 2 }}
+    fsGroup: 64535
+  serviceAccountName: prometheus
+  podMetadata:
+    labels:
+      threshold.extended-monitoring.deckhouse.io/disk-bytes-warning: "94"
+      threshold.extended-monitoring.deckhouse.io/disk-bytes-critical: "96"
+    annotations:
+      checksum/kube-rbac-proxy: {{ include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "") | sha256sum }}
+  secrets:
+  - prometheus-api-client-tls
+  {{- if .Values.prometheus.longtermNodeSelector }}
+  nodeSelector:
+    {{ .Values.prometheus.longtermNodeSelector | toYaml }}
+  {{- else }}
+    {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 2}}
+  {{- end }}
+  {{- if .Values.prometheus.longtermTolerations }}
+  tolerations:
+    {{ .Values.prometheus.longtermTolerations | toYaml | nindent 2}}
+  {{- else }}
+    {{- include "helm_lib_tolerations" (tuple . "monitoring" "without-storage-problems") | nindent 2 }}
+  {{- end }}
+
+  {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 2 }}
+  {{- $storageClass := .Values.prometheus.internal.prometheusLongterm.effectiveStorageClass }}
+  {{- if $storageClass }}
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.prometheus.internal.prometheusLongterm.diskSizeGigabytes }}Gi
+        storageClassName: {{ $storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 100 | nindent 6 }}
+  {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+      {{- include "longterm_prometheus_resources" . | nindent 6 }}
+  {{- end }}
+  volumes:
+  - name: kube-rbac-proxy-ca
+    configMap:
+      defaultMode: 420
+      name: kube-rbac-proxy-ca.crt
+{{- end }}

--- a/ee/fe/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/ee/fe/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -62,7 +62,7 @@ spec:
   version: v2.53.2
 {{- else }}
   image: {{ include "helm_lib_module_image" (list . "prometheus") }}
-  version: v2.45.2
+  version: v2.55.1
 {{- end }}
   enableRemoteWriteReceiver: true
   enableFeatures:

--- a/ee/fe/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/ee/fe/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -62,7 +62,7 @@ spec:
   version: v2.53.2
 {{- else }}
   image: {{ include "helm_lib_module_image" (list . "prometheus") }}
-  version: v2.55.1
+  version: v2.45.2
 {{- end }}
   enableRemoteWriteReceiver: true
   enableFeatures:
@@ -91,7 +91,7 @@ spec:
     - "walpp"
     {{- end }}
     volumeMounts:
-    - name: prometheus-longterm-db
+    - name: prometheus-main-db
       mountPath: /prometheus
       subPath: prometheus-db
       securityContext:

--- a/ee/fe/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/ee/fe/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -91,7 +91,7 @@ spec:
     - "walpp"
     {{- end }}
     volumeMounts:
-    - name: prometheus-main-db
+    - name: prometheus-longterm-db
       mountPath: /prometheus
       subPath: prometheus-db
       securityContext:

--- a/tools/build_includes/modules-FE.yaml
+++ b/tools/build_includes/modules-FE.yaml
@@ -344,6 +344,11 @@
   stageDependencies:
     setup:
         - '**/*'
+- add: /ee/fe/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+  to: /deckhouse/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/fe/modules/340-monitoring-applications
   to: /deckhouse/modules/340-monitoring-applications
   stageDependencies:

--- a/tools/build_includes/modules-with-dependencies-FE.yaml
+++ b/tools/build_includes/modules-with-dependencies-FE.yaml
@@ -1046,6 +1046,11 @@
   stageDependencies:
     setup:
         - '**/*'
+- add: /ee/fe/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+  to: /deckhouse/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/fe/modules/340-monitoring-applications
   to: /deckhouse/modules/340-monitoring-applications
   excludePaths:

--- a/tools/build_includes/modules-with-exclude-FE.yaml
+++ b/tools/build_includes/modules-with-exclude-FE.yaml
@@ -585,6 +585,11 @@
   stageDependencies:
     setup:
         - '**/*'
+- add: /ee/fe/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+  to: /deckhouse/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/fe/modules/340-monitoring-applications
   to: /deckhouse/modules/340-monitoring-applications
   excludePaths:


### PR DESCRIPTION
## Description
This PR marks the third phase of the migration from Prometheus to Prom++. We are moving prometheus longterm to Prom++ image, focusing on a complete switch to Prom++. Prom++ has been externalized into a separate module, and it is now possible to run Prom++ as a replacement for Prometheus longterm.

An initContainer has been added to the Prometheus longterm pod to ensure smooth data transitions. It performs data conservation and format conversion between Prometheus and Prom++ (both ways), ensuring compatibility and data integrity during the switch. If the Prom++ external module is enabled, Prom++ will be deployed; otherwise, Prometheus will be used as before.

## Why do we need it, and what problem does it solve?
This change is a critical step in the transition to Prom++. It provides users with the ability to consciously choose their monitoring system, allowing them to adopt the new system at their own pace. By making the switch to Prom++ controllable and predictable, this PR ensures a smooth and manageable migration process without disrupting existing workflows or monitoring operations.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: chore
summary:  Add init container and switcher for prom longterm
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
