### PR TITLE
[deckhouse-controller] Recreate missing deployed release

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -28,6 +28,7 @@ import (
 	sh_debug "github.com/flant/shell-operator/pkg/debug"
 	"gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/debug"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/registry"
@@ -58,6 +59,7 @@ const (
 func main() {
 	sh_app.Version = ShellOperatorVersion
 	ad_app.Version = AddonOperatorVersion
+	controller.DeckhouseVersion = DeckhouseVersion
 
 	FileName := filepath.Base(os.Args[0])
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
@@ -169,6 +169,16 @@ func (in *DeckhouseRelease) GetNotificationShift() bool {
 	return ok && v == "true"
 }
 
+func (in *DeckhouseRelease) GetDryRun() bool {
+	v, ok := in.Annotations[DeckhouseReleaseAnnotationDryrun]
+	return ok && v == "true"
+}
+
+func (in *DeckhouseRelease) GetTriggeredByDryRun() bool {
+	v, ok := in.Annotations[DeckhouseReleaseAnnotationTriggeredByDryrun]
+	return ok && v == "true"
+}
+
 func (in *DeckhouseRelease) GetModuleName() string {
 	return ""
 }

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
@@ -42,6 +42,7 @@ const (
 	DeckhouseReleaseAnnotationNotificationTimeShift = "release.deckhouse.io/notification-time-shift"
 	DeckhouseReleaseAnnotationDryrun                = "dryrun"
 	DeckhouseReleaseAnnotationTriggeredByDryrun     = "triggered_by_dryrun"
+	DeckhouseReleaseAnnotationCurrentRestored       = "release.deckhouse.io/current-restored"
 
 	// TODO: remove in entire code
 	DeckhouseReleaseAnnotationCooldown = "release.deckhouse.io/cooldown"
@@ -176,6 +177,11 @@ func (in *DeckhouseRelease) GetDryRun() bool {
 
 func (in *DeckhouseRelease) GetTriggeredByDryRun() bool {
 	v, ok := in.Annotations[DeckhouseReleaseAnnotationTriggeredByDryrun]
+	return ok && v == "true"
+}
+
+func (in *DeckhouseRelease) GetCurrentRestored() bool {
+	v, ok := in.Annotations[DeckhouseReleaseAnnotationCurrentRestored]
 	return ok && v == "true"
 }
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
@@ -40,6 +40,8 @@ const (
 	DeckhouseReleaseAnnotationForce                 = "release.deckhouse.io/force"
 	DeckhouseReleaseAnnotationSuspended             = "release.deckhouse.io/suspended"
 	DeckhouseReleaseAnnotationNotificationTimeShift = "release.deckhouse.io/notification-time-shift"
+	DeckhouseReleaseAnnotationDryrun                = "dryrun"
+	DeckhouseReleaseAnnotationTriggeredByDryrun     = "triggered_by_dryrun"
 
 	// TODO: remove in entire code
 	DeckhouseReleaseAnnotationCooldown = "release.deckhouse.io/cooldown"

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -62,6 +62,8 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
+var DeckhouseVersion string
+
 const (
 	docsLeaseLabel = "deckhouse.io/documentation-builder-sync"
 
@@ -225,7 +227,7 @@ func NewDeckhouseController(ctx context.Context, version string, operator *addon
 	loader := moduleloader.New(runtimeManager.GetClient(), version, operator.ModuleManager.ModulesDir, operator.ModuleManager.GlobalHooksDir, dc, embeddedPolicy, logger.Named("module-loader"))
 	operator.ModuleManager.SetModuleLoader(loader)
 
-	err = deckhouserelease.NewDeckhouseReleaseController(ctx, runtimeManager, dc, operator.ModuleManager, settingsContainer, operator.MetricStorage, preflightCountDown, logger.Named("deckhouse-release-controller"))
+	err = deckhouserelease.NewDeckhouseReleaseController(ctx, runtimeManager, dc, operator.ModuleManager, settingsContainer, operator.MetricStorage, preflightCountDown, DeckhouseVersion, logger.Named("deckhouse-release-controller"))
 	if err != nil {
 		return nil, fmt.Errorf("create deckhouse release controller: %w", err)
 	}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"path"
 	"regexp"
 	"sort"
@@ -55,9 +56,6 @@ const (
 
 func (r *deckhouseReleaseReconciler) checkDeckhouseReleaseLoop(ctx context.Context) {
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
-		if r.updateSettings.Get().ReleaseChannel == "" {
-			return
-		}
 		err := r.checkDeckhouseRelease(ctx)
 		if err != nil {
 			r.logger.Errorf("check Deckhouse release: %s", err)
@@ -67,7 +65,7 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseReleaseLoop(ctx context.Conte
 
 func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) error {
 	if r.updateSettings.Get().ReleaseChannel == "" {
-		r.logger.Debug("Release channel does not set.")
+		r.logger.Debug("Release channel isn't set.")
 		return nil
 	}
 
@@ -112,6 +110,34 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 		return err
 	}
 
+	var (
+		releases               v1alpha1.DeckhouseReleaseList
+		currentDeployedRelease *v1alpha1.DeckhouseRelease
+	)
+	err = r.client.List(ctx, &releases)
+	if err != nil {
+		return fmt.Errorf("get deckhouse releases: %w", err)
+	}
+
+	pointerReleases := make([]*v1alpha1.DeckhouseRelease, 0, len(releases.Items))
+	for _, r := range releases.Items {
+		if r.GetPhase() == v1alpha1.DeckhouseReleasePhaseDeployed {
+			// no deployed release was found or there is more than one deployed release (get the latest)
+			if currentDeployedRelease == nil || r.GetVersion().GreaterThan(currentDeployedRelease.GetVersion()) {
+				currentDeployedRelease = &r
+			}
+		}
+		pointerReleases = append(pointerReleases, &r)
+	}
+	sort.Sort(sort.Reverse(updater.ByVersion[*v1alpha1.DeckhouseRelease](pointerReleases)))
+
+	// restore current deployed release if no deployed releases found
+	if currentDeployedRelease == nil {
+		if err := r.restoreCurrentDeployedRelease(ctx, releaseChecker, r.deckhouseVersion); err != nil {
+			return fmt.Errorf("restore current deployed release: %w", err)
+		}
+	}
+
 	// no new image found
 	if newImageHash == "" {
 		return nil
@@ -131,18 +157,6 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 		return fmt.Errorf("parse semver: %w", err)
 	}
 	r.releaseVersionImageHash = newImageHash
-
-	var releases v1alpha1.DeckhouseReleaseList
-	err = r.client.List(ctx, &releases)
-	if err != nil {
-		return fmt.Errorf("get deckhouse releases: %w", err)
-	}
-
-	pointerReleases := make([]*v1alpha1.DeckhouseRelease, 0, len(releases.Items))
-	for _, r := range releases.Items {
-		pointerReleases = append(pointerReleases, &r)
-	}
-	sort.Sort(sort.Reverse(updater.ByVersion[*v1alpha1.DeckhouseRelease](pointerReleases)))
 	r.metricStorage.Grouped().ExpireGroupMetrics(metricUpdatingFailedGroup)
 
 	for _, release := range pointerReleases {
@@ -234,13 +248,67 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 		}
 	}
 
-	// if there are no releases in the cluster, we apply the latest release
-	if len(pointerReleases) == 0 {
-		err = r.createRelease(ctx, releaseChecker, cooldownUntil, notificationShiftTime)
-		if err != nil {
-			return fmt.Errorf("create release %s: %w", releaseChecker.releaseMetadata.Version, err)
+	return nil
+}
+
+func (r *deckhouseReleaseReconciler) restoreCurrentDeployedRelease(ctx context.Context, releaseChecker *DeckhouseReleaseChecker, tag string) error {
+	var releaseMetadata *ReleaseMetadata
+
+	if image, err := releaseChecker.registryClient.Image(ctx, tag); err != nil {
+		r.logger.Warn("couldn't get current deployed release's image from registry", slog.String("image", tag), log.Err(err))
+	} else {
+		if releaseMetadata, err = releaseChecker.fetchReleaseMetadata(image); err != nil {
+			r.logger.Warn("couldn't fetch current deployed release's image metadata", slog.String("image", tag), log.Err(err))
 		}
 	}
+
+	release := &v1alpha1.DeckhouseRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DeckhouseRelease",
+			APIVersion: "deckhouse.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: tag,
+			Annotations: map[string]string{
+				v1alpha1.DeckhouseReleaseAnnotationIsUpdating: "false",
+				v1alpha1.DeckhouseReleaseAnnotationNotified:   "false",
+				v1alpha1.DeckhouseReleaseAnnotationDryrun:     "true",
+			},
+			Labels: map[string]string{
+				"heritage": "deckhouse",
+			},
+		},
+		Spec: v1alpha1.DeckhouseReleaseSpec{
+			Version: tag,
+		},
+		Approved: true,
+	}
+
+	if releaseMetadata != nil {
+		release.Spec.Requirements = releaseMetadata.Requirements
+		release.Spec.ChangelogLink = fmt.Sprintf("https://github.com/deckhouse/deckhouse/releases/tag/%s", releaseMetadata.Version)
+	}
+
+	if err := r.client.Create(ctx, release); err != nil {
+		// proceed with patching only if the object was created by the execution
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("create current deployed release: %w", err)
+	}
+
+	patchBytes, _ := json.Marshal(map[string]interface{}{
+		"status": map[string]interface{}{
+			"approved":       true,
+			"phase":          v1alpha1.DeckhouseReleasePhaseDeployed,
+			"transitionTime": r.dc.GetClock().Now().UTC(),
+			"message":        "Release object was restored",
+		},
+	})
+	if err := r.client.Status().Patch(ctx, release, client.RawPatch(types.MergePatchType, patchBytes)); err != nil {
+		return fmt.Errorf("patch current deployed release: %w", err)
+	}
+
 	return nil
 }
 
@@ -285,6 +353,9 @@ func (r *deckhouseReleaseReconciler) createRelease(ctx context.Context, releaseC
 			Annotations: map[string]string{
 				v1alpha1.DeckhouseReleaseAnnotationIsUpdating: "false",
 				v1alpha1.DeckhouseReleaseAnnotationNotified:   "false",
+			},
+			Labels: map[string]string{
+				"heritage": "deckhouse",
 			},
 		},
 		Spec: v1alpha1.DeckhouseReleaseSpec{

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
@@ -70,19 +70,28 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	}
 }`
 
+	var testDeckhouseVersionImage = &fake.FakeImage{
+		ManifestStub: ManifestStub,
+		LayersStub: func() ([]v1.Layer, error) {
+			return []v1.Layer{&fakeLayer{}, &fakeLayer{
+				FilesContent: map[string]string{
+					"version.json": fmt.Sprintf("{`version`: `%s`}", testDeckhouseVersion),
+				}}}, nil
+		}}
+
 	suite.Run("Have new deckhouse image", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(
-			&fake.FakeImage{
-				ManifestStub: ManifestStub,
-				LayersStub: func() ([]v1.Layer, error) {
-					return []v1.Layer{&fakeLayer{}, &fakeLayer{
-						FilesContent: map[string]string{`version.json`: `{"version": "v1.25.3"}`}},
-					}, nil
-				},
-				DigestStub: func() (v1.Hash, error) {
-					return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b777")
-				},
-			}, nil,
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{
+					FilesContent: map[string]string{`version.json`: `{"version": "v1.25.3"}`}},
+				}, nil
+			},
+			DigestStub: func() (v1.Hash, error) {
+				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b777")
+			},
+		}, nil,
 		)
 
 		suite.setupController("have-new-deckhouse-image.yaml", initValues, embeddedMUP)
@@ -91,20 +100,19 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("Have canary release wave 0", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(
-			&fake.FakeImage{
-				ManifestStub: ManifestStub,
-				LayersStub: func() ([]v1.Layer, error) {
-					return []v1.Layer{&fakeLayer{}, &fakeLayer{
-						FilesContent: map[string]string{
-							`version.json`: `{"version": "v1.25.0", "canary": {"stable": {"enabled": true, "waves": 5, "interval": "6m"}}}`,
-						}}}, nil
-				},
-				DigestStub: func() (v1.Hash, error) {
-					return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
-				},
-			}, nil,
-		)
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{
+					FilesContent: map[string]string{
+						`version.json`: `{"version": "v1.25.0", "canary": {"stable": {"enabled": true, "waves": 5, "interval": "6m"}}}`,
+					}}}, nil
+			},
+			DigestStub: func() (v1.Hash, error) {
+				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+			},
+		}, nil)
 
 		suite.setupController("have-canary-release-wave-0.yaml", initValues, embeddedMUP)
 		err := suite.ctr.checkDeckhouseRelease(ctx)
@@ -112,7 +120,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("Have canary release wave 4", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
@@ -130,7 +139,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("Existed release suspended", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
@@ -163,7 +173,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("New release suspended", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
@@ -180,7 +191,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("Resume suspended release", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
@@ -197,7 +209,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("Image hash not changed", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
@@ -215,7 +228,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("Release has requirements", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
@@ -234,7 +248,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("Release has canary", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
@@ -262,7 +277,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			"v1.33.0",
 			"v1.33.1",
 		}, nil)
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{
@@ -287,7 +303,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("Inherit release cooldown", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{
@@ -312,7 +329,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("Patch release has own cooldown", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{
@@ -337,7 +355,8 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 	})
 
 	suite.Run("Release has disruptions", func() {
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{
@@ -380,7 +399,8 @@ global:
 
 		changelog := fmt.Sprintf(changelogTemplate, "`control-plane`") // global.features[0].description
 
-		dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
+		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{

--- a/deckhouse-controller/pkg/controller/deckhouse-release/cleanup_deckhouse_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/cleanup_deckhouse_release.go
@@ -65,13 +65,13 @@ func (r *deckhouseReleaseReconciler) cleanupDeckhouseRelease(ctx context.Context
 
 	for i, release := range pointerReleases {
 		switch release.Status.Phase {
-		case v1alpha1.ModuleReleasePhasePending:
+		case v1alpha1.DeckhouseReleasePhasePending:
 			pendingReleasesIndexes = append(pendingReleasesIndexes, i)
 
-		case v1alpha1.ModuleReleasePhaseDeployed:
+		case v1alpha1.DeckhouseReleasePhaseDeployed:
 			deployedReleasesIndexes = append(deployedReleasesIndexes, i)
 
-		case v1alpha1.ModuleReleasePhaseSuperseded, v1alpha1.ModuleReleasePhaseSkipped, v1alpha1.ModuleReleasePhaseSuspended:
+		case v1alpha1.DeckhouseReleasePhaseSuperseded, v1alpha1.DeckhouseReleasePhaseSkipped, v1alpha1.DeckhouseReleasePhaseSuspended:
 			outdatedReleasesIndexes = append(outdatedReleasesIndexes, i)
 		}
 	}
@@ -79,7 +79,7 @@ func (r *deckhouseReleaseReconciler) cleanupDeckhouseRelease(ctx context.Context
 	if len(deployedReleasesIndexes) > 1 {
 		// cleanup releases stacked in Deployed status
 		sp, _ := json.Marshal(d8updater.StatusPatch{
-			Phase:          v1alpha1.ModuleReleasePhaseSuperseded,
+			Phase:          v1alpha1.DeckhouseReleasePhaseSuperseded,
 			TransitionTime: metav1.NewTime(now),
 		})
 		// everything except the last Deployed release
@@ -110,7 +110,7 @@ func (r *deckhouseReleaseReconciler) cleanupDeckhouseRelease(ctx context.Context
 	if len(deployedReleasesIndexes) > 0 && len(pendingReleasesIndexes) > 0 {
 		lastDeployed := deployedReleasesIndexes[0] // releases are reversed, that's why we have to take the first one (latest Deployed release)
 		sp, _ := json.Marshal(d8updater.StatusPatch{
-			Phase:          v1alpha1.ModuleReleasePhaseSkipped,
+			Phase:          v1alpha1.DeckhouseReleasePhaseSkipped,
 			Message:        "Skipped by cleanup hook",
 			TransitionTime: metav1.NewTime(now),
 		})

--- a/deckhouse-controller/pkg/controller/deckhouse-release/client_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/client_test.go
@@ -43,6 +43,8 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
+var testDeckhouseVersion = "v1.15.0"
+
 func setupFakeController(
 	t *testing.T,
 	filename, values string,
@@ -94,13 +96,14 @@ func setupControllerSettings(
 	dc := dependency.NewDependencyContainer()
 
 	rec := &deckhouseReleaseReconciler{
-		client:         cl,
-		dc:             dc,
-		logger:         log.NewNop(),
-		moduleManager:  stubModulesManager{},
-		updateSettings: helpers.NewDeckhouseSettingsContainer(ds),
-		metricStorage:  metricstorage.NewMetricStorage(context.Background(), "", true, log.NewNop()),
-		metricsUpdater: d8updater.NewMetricsUpdater(metricstorage.NewMetricStorage(context.Background(), "", true, log.NewNop())),
+		client:           cl,
+		deckhouseVersion: testDeckhouseVersion,
+		dc:               dc,
+		logger:           log.NewNop(),
+		moduleManager:    stubModulesManager{},
+		updateSettings:   helpers.NewDeckhouseSettingsContainer(ds),
+		metricStorage:    metricstorage.NewMetricStorage(context.Background(), "", true, log.NewNop()),
+		metricsUpdater:   d8updater.NewMetricsUpdater(metricstorage.NewMetricStorage(context.Background(), "", true, log.NewNop())),
 	}
 	rec.clusterUUID = rec.getClusterUUID(context.Background())
 

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -221,7 +221,7 @@ func (r *deckhouseReleaseReconciler) createOrUpdateReconcile(ctx context.Context
 				return res, err
 			}
 
-			return ctrl.Result{Requeue: false}, nil
+			return ctrl.Result{}, nil
 		}
 
 		// initial state

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -654,9 +654,8 @@ func (r *deckhouseReleaseReconciler) bumpDeckhouseDeployment(ctx context.Context
 	}
 
 	// dryrun for testing purpose
-	val, ok := dr.GetAnnotations()[v1alpha1.DeckhouseReleaseAnnotationDryrun]
-	if ok && val == "true" {
-		dryrun = true
+	dryrun = dr.GetDryRun()
+	if dryrun {
 		go func() {
 			r.logger.Debug("dryrun start soon...")
 

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/existed-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/existed-release-suspended.yaml
@@ -1,5 +1,26 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
+approved: true
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    dryrun: "true"
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
+spec:
+  version: v1.15.0
+status:
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/existed-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/existed-release-suspended.yaml
@@ -4,21 +4,20 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1
 approved: false

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
@@ -1,18 +1,21 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
-approved: false
+approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    dryrun: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  name: v1.25.0
-  resourceVersion: "1"
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.25.0
-  version: v1.25.0
+  version: v1.15.0
 status:
-  approved: false
-  message: ""
-  transitionTime: null
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
@@ -4,18 +4,17 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
@@ -1,19 +1,21 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
-approved: false
+approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    dryrun: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  name: v1.25.5
-  resourceVersion: "1"
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
 spec:
-  applyAfter: "2019-10-17T16:33:00Z"
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.25.5
-  version: v1.25.5
+  version: v1.15.0
 status:
-  approved: false
-  message: ""
-  transitionTime: null
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
@@ -4,18 +4,17 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
@@ -4,18 +4,17 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
@@ -1,18 +1,21 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
-approved: false
+approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    dryrun: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  name: v1.25.3
-  resourceVersion: "1"
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.25.3
-  version: v1.25.3
+  version: v1.15.0
 status:
-  approved: false
-  message: ""
-  transitionTime: null
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/image-hash-not-changed.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/image-hash-not-changed.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: true
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    dryrun: "true"
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
+spec:
+  version: v1.15.0
+status:
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/image-hash-not-changed.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/image-hash-not-changed.yaml
@@ -4,18 +4,17 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
@@ -1,19 +1,21 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
-approved: false
+approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    release.deckhouse.io/cooldown: "2026-06-06T16:16:16Z"
+    dryrun: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  name: v1.31.1
-  resourceVersion: "1"
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.1
-  version: v1.31.1
+  version: v1.15.0
 status:
-  approved: false
-  message: ""
-  transitionTime: null
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
@@ -4,18 +4,17 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
@@ -1,19 +1,21 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
-approved: false
+approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    dryrun: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
-    release.deckhouse.io/suspended: "true"
   creationTimestamp: null
-  name: v1.25.0
-  resourceVersion: "1"
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.25.0
-  version: v1.25.0
+  version: v1.15.0
 status:
-  approved: false
-  message: ""
-  transitionTime: null
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
@@ -4,18 +4,17 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
@@ -1,19 +1,21 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
-approved: false
+approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    release.deckhouse.io/cooldown: "2030-05-05T15:15:15Z"
+    dryrun: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  name: v1.31.2
-  resourceVersion: "1"
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.2
-  version: v1.31.2
+  version: v1.15.0
 status:
-  approved: false
-  message: ""
-  transitionTime: null
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
@@ -4,18 +4,17 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
@@ -1,19 +1,21 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
-approved: false
+approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    dryrun: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  name: v1.31.0
-  resourceVersion: "1"
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
 spec:
-  applyAfter: "2019-10-17T17:03:00Z"
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.0
-  version: v1.31.0
+  version: v1.15.0
 status:
-  approved: false
-  message: ""
-  transitionTime: null
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
@@ -4,18 +4,17 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
@@ -1,19 +1,21 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
-approved: false
+approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    release.deckhouse.io/cooldown: "2026-06-06T16:16:16Z"
+    dryrun: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  name: v1.31.0
-  resourceVersion: "1"
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.0
-  version: v1.31.0
+  version: v1.15.0
 status:
-  approved: false
-  message: ""
-  transitionTime: null
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
@@ -4,18 +4,17 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
@@ -1,20 +1,21 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
-approved: false
+approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    dryrun: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  name: v1.32.0
-  resourceVersion: "1"
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.32.0
-  disruptions:
-  - ingressNginx
-  version: v1.32.0
+  version: v1.15.0
 status:
-  approved: false
-  message: ""
-  transitionTime: null
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
@@ -4,18 +4,17 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
@@ -1,21 +1,21 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
-approved: false
+approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    dryrun: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  name: v1.30.0
-  resourceVersion: "1"
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.30.0
-  requirements:
-    k8s: "1.19"
-    req1: dep1
-  version: v1.30.0
+  version: v1.15.0
 status:
-  approved: false
-  message: ""
-  transitionTime: null
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
@@ -4,18 +4,17 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
@@ -1,38 +1,21 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
-approved: false
+approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    dryrun: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  name: v1.31.0
-  resourceVersion: "1"
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
 spec:
-  changelog:
-    cert-manager:
-      fixes:
-      - pull_request: https://github.com/deckhouse/deckhouse/pull/999
-        summary: Remove D8CertmanagerOrphanSecretsWithoutCorrespondingCertificateResources
-    global:
-      features:
-      - description: All master nodes will have `control-plane` role in new exist
-          clusters.
-        note: Add migration for adding role. Bashible steps will be rerunned on master
-          nodes.
-        pull_request: https://github.com/deckhouse/deckhouse/pull/562
-      - description: Update Kubernetes patch versions.
-        pull_request: https://github.com/deckhouse/deckhouse/pull/558
-      fixes:
-      - description: Fix parsing deckhouse images repo if there is the sha256 sum
-          in the image name
-        pull_request: https://github.com/deckhouse/deckhouse/pull/527
-      - description: Fix serialization of empty strings in secrets
-        pull_request: https://github.com/deckhouse/deckhouse/pull/523
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.0
-  version: v1.31.0
+  version: v1.15.0
 status:
-  approved: false
-  message: ""
-  transitionTime: null
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
@@ -4,18 +4,17 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/restore-absent-releases-from-registry.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/restore-absent-releases-from-registry.yaml
@@ -22,6 +22,8 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
+  labels:
+    heritage: deckhouse
   name: v1.58.1
   resourceVersion: "1"
 spec:
@@ -40,6 +42,8 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
+  labels:
+    heritage: deckhouse
   name: v1.59.3
   resourceVersion: "1"
 spec:
@@ -58,6 +62,8 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
+  labels:
+    heritage: deckhouse
   name: v1.60.2
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/resume-suspended-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/resume-suspended-release.yaml
@@ -1,5 +1,26 @@
 ---
 apiVersion: deckhouse.io/v1alpha1
+approved: true
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    dryrun: "true"
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.15.0
+  resourceVersion: "2"
+spec:
+  version: v1.15.0
+status:
+  approved: true
+  message: Release object was restored
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/resume-suspended-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/resume-suspended-release.yaml
@@ -4,21 +4,20 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
-    dryrun: "true"
+    release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "2"
+  resourceVersion: "1"
 spec:
   version: v1.15.0
 status:
-  approved: true
-  message: Release object was restored
-  phase: Deployed
-  transitionTime: "2019-10-17T15:33:00Z"
+  approved: false
+  message: ""
+  transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1
 approved: false

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-update-successfully.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-update-successfully.yaml
@@ -22,6 +22,8 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
+  labels:
+    heritage: deckhouse
   name: v1.32.3
   resourceVersion: "1"
 spec:
@@ -40,6 +42,8 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
+  labels:
+    heritage: deckhouse
   name: v1.33.1
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/updater/update_task_calculator.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/updater/update_task_calculator.go
@@ -69,6 +69,7 @@ type ReleaseInfo struct {
 }
 
 var ErrReleasePhaseIsNotPending = errors.New("release phase is not pending")
+var ErrReleaseIsAlreadyDeployed = errors.New("release is already deployed")
 
 // CalculatePendingReleaseOrder calculate task with information about current reconcile
 //
@@ -118,6 +119,11 @@ func (p *TaskCalculator) CalculatePendingReleaseOrder(ctx context.Context, dr *v
 			return &Task{
 				TaskType: Skip,
 			}, nil
+		}
+
+		// if we patch between reconcile start and calculating
+		if deployedReleaseInfo.Version.Equal(dr.GetVersion()) {
+			return nil, ErrReleaseIsAlreadyDeployed
 		}
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Implements the idea that having a deployed DeckhouseRelease object in the cluster is mandatory.
Closes #11596 
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Always having a deployed DeckhouseRelease object in the cluster facilitates:
- understanding which version the cluster is running on (from the users' point of view);
- calculating which deckhouse release should be applied next (from the controller's point of view).

If there is no deployed DeckhouseRelease in the cluster, it's recreated either using the corresponding release metadata from the registry or the current version of the deckhouse controller, in case the corresponding metadata can't be fetched.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: Recreate missing deployed release.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
