### PR TITLE
[dhctl] chore: dhctl for installer

### DIFF
--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// FIXME(dhctl-for-installer): fix connection-config, converge and check options
+
 package main
 
 import (


### PR DESCRIPTION
## Description

This PR is not intended for merge and only needed to test dhctl in installer.