### PR TITLE
[prometheus] Add missing monaco library to grafana-v10 image for CSE

### DIFF
--- a/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
+++ b/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
@@ -5,6 +5,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
 final: false
 from: {{ $.Images.BASE_ALPINE_DEV }}
+fromCacheVersion: 20250122
 git:
 - add: /{{ $.ModulePath }}modules/300-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches


### PR DESCRIPTION
## Description
The `prometheus/grafana-v10-src-files` image imports precompiled static assets from a git repository. Monaco library was not committed to that repo due to a `.gitignore` in `public/lib` thus the library is missing from the final image. 

## Why do we need it, and what problem does it solve?
The lack of the monaco library causes the query editor to malfunction. We have to rebuild the grafana image.

## Why do we need it in the patch release (if we do)?
This bug has leaked to the 1.67 release and has to be fixed in the nearest patch release.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: fix
summary: add the missing monaco JS library to the grafana image
impact: grafana deployment pods will be rollout restarted
impact_level: default
```