### PR TITLE
[monitoring-kubernetes] Patch kube-state-metrics with tolerations dedup fix

### DIFF
--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/patches/README.md
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/patches/README.md
@@ -1,0 +1,9 @@
+## Patches
+
+### go-mod
+
+Fix CVEs
+
+###  fix-kube_pod_tolerations-deduplicate.patch
+
+Fixes issues  related to duplicated [samples](https://github.com/kubernetes/kube-state-metrics/issues/2390). Must be removed after [fix](https://github.com/kubernetes/kube-state-metrics/pull/2559/files) lands into release version.

--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/patches/fix-kube_pod_tolerations-deduplicate.patch
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/patches/fix-kube_pod_tolerations-deduplicate.patch
@@ -1,0 +1,40 @@
+diff --git a/internal/store/pod.go b/internal/store/pod.go
+index d597667e..d9ad4afa 100644
+--- a/internal/store/pod.go
++++ b/internal/store/pod.go
+@@ -1642,6 +1642,21 @@ func createPodStatusUnschedulableFamilyGenerator() generator.FamilyGenerator {
+ 	)
+ }
+ 
++// getUniqueTolerations takes an array
++func getUniqueTolerations(tolerations []v1.Toleration) []v1.Toleration {
++	uniqueTolerationsMap := make(map[v1.Toleration]struct{})
++	var uniqueTolerations []v1.Toleration
++
++	for _, toleration := range tolerations {
++		_, exists := uniqueTolerationsMap[toleration]
++		if !exists {
++			uniqueTolerationsMap[toleration] = struct{}{}
++			uniqueTolerations = append(uniqueTolerations, toleration)
++		}
++	}
++	return uniqueTolerations
++}
++
+ func createPodTolerationsFamilyGenerator() generator.FamilyGenerator {
+ 	return *generator.NewFamilyGeneratorWithStability(
+ 		"kube_pod_tolerations",
+@@ -1651,8 +1666,9 @@ func createPodTolerationsFamilyGenerator() generator.FamilyGenerator {
+ 		"",
+ 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
+ 			var ms []*metric.Metric
++			uniqueTolerations := getUniqueTolerations(p.Spec.Tolerations)
+ 
+-			for _, t := range p.Spec.Tolerations {
++			for _, t := range uniqueTolerations {
+ 				var key, operator, value, effect, tolerationSeconds string
+ 
+ 				key = t.Key
+-- 
+2.47.0
+


### PR DESCRIPTION
## Description
- Applies [this](https://github.com/kubernetes/kube-state-metrics/pull/2559/files) changes as patch, until it is included in the release version. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

-  Deduplicate metrics that currently create warnings in the logs of prometheus. 

## Why do we need it in the patch release (if we do)?


<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: fix 
summary: kube-state-metrics minor improvements
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
