### PR TITLE
chore: Add block e2e tests during dev image build

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -336,6 +336,7 @@ check_e2e_labels:
     - check_e2e_labels
 {!{- end }!}
     - git_info
+    - block-e2e-until-image-is-not-ready
 {!{- if coll.Has $ctx "manualRun" }!}
   if: needs.check_e2e_labels.outputs.run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!} == 'true'
 {!{- end }!}
@@ -386,6 +387,7 @@ check_e2e_labels:
         INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
         MANUAL_RUN: {!{ coll.Has $ctx "manualRun" | conv.ToString | strings.Quote }!}
         MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+        WAIT_IMAGE_TIME: 300 # 5 minutes
       run: |
         # Calculate unique prefix for e2e test.
         # GITHUB_RUN_ID is a unique number for each workflow run.

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -98,6 +98,93 @@ git_info:
 # </template: git_info_job>
 {!{- end -}!}
 
+{!{ define "block-e2e-until-image-is-not-ready" }!}
+# </template: block-e2e-until-image-is-not-ready>
+{!{- $ctx := . }!}
+block-e2e-until-image-is-not-ready:
+  name: Block e2e until the docker image is not ready
+  runs-on: ubuntu-latest
+  if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
+  steps:
+    - id: block-e2e
+      name: Block e2e until the docker image is not ready
+      uses: {!{ index (ds "actions") "actions/github-script" }!}
+      with:
+        script: |
+          const WORKFLOW_NAME = 'Build and test for dev branches';
+          const WORKFLOW_STATUS_RUNNING = 'in_progress';
+          const WORKFLOW_STATUS_COMPLETED = 'completed';
+          const MAX_ATTEMPTS = 60;
+          const TIMEOUT_BETWEEN_ATTEMPT = 1000 * 30; // 10 second
+          const MAX_ITEMS_PER_PAGE = 100;
+
+          /**
+          * @param {string} branch 
+          * @returns {Promise<boolean>}
+          */
+          async function isReadyToE2E(branch) {
+            try {
+              const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch: branch,
+                per_page: MAX_ITEMS_PER_PAGE,
+              });
+
+              // Checking for active workflow 'Build and test for dev branches'
+              const activeRuns = data.workflow_runs.filter(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_RUNNING);
+              if (activeRuns.length > 0) {
+                console.log(`There are active '${WORKFLOW_NAME}' jobs, wait for them to complete.`);
+                return false;
+              }
+
+              // Checking the status of the first task 'Build and test for dev branches'
+              console.log(`No active jobs '${WORKFLOW_NAME}' were found, checking status first job.`);
+              const completedRun = data.workflow_runs.find(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_COMPLETED);
+              
+              if (completedRun) {
+                if (completedRun.conclusion === 'success') {
+                  console.log('The first job was completed successfully.');
+                  return true;
+                } else {
+                  console.error('The first job ended with an error.');
+                  core.setFailed('There is no current image; the first job finished with an error.');
+                  return false;
+                }
+              } else {
+                core.setFailed('Job not found');
+                return false;
+              }
+            } catch (error) {
+              core.setFailed(error.message);
+              return false;
+            }
+          }
+
+          const branchName = context.payload.inputs.ci_commit_ref_name;
+          const prNum = context.payload.inputs.issue_number;
+          console.log(`Run check for branch: ${branchName} PR: ${context.payload.repository.html_url}/pull/${prNum}`);
+
+          function sleep(ms) {
+              return new Promise(resolve => setTimeout(resolve, ms));
+          }
+
+          async function isWorkflowReadyToE2E() {
+            for (let i = 0; i < MAX_ATTEMPTS; i++) {
+              console.log(`Attempt number ${i + 1} of ${MAX_ATTEMPTS}`);
+              const isReady = await isReadyToE2E(branchName);
+              if (isReady) {
+                return;
+              }
+              await sleep(TIMEOUT_BETWEEN_ATTEMPT);
+            }
+            core.setFailed('Failed to wait for the job to complete within the allowed number of attempts.');
+          };
+
+          await isWorkflowReadyToE2E()
+
+# </template: block-e2e-until-image-is-not-ready>
+{!{- end -}!}
 
 # Check pull request state on push or pull_request_target events:
 # - find PR info on push event

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -119,6 +119,8 @@ jobs:
 
 {!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
 
+{!{ tmpl.Exec "block-e2e-until-image-is-not-ready" . | strings.Indent 2 }!}
+
 {!{ tmpl.Exec "check_e2e_labels_job" $ctx | strings.Indent 2 }!}
 
 {!{/* Jobs for each CRI and Kubernetes version */}!}

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -167,6 +167,92 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
+    steps:
+      - id: block-e2e
+        name: Block e2e until the docker image is not ready
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const WORKFLOW_NAME = 'Build and test for dev branches';
+            const WORKFLOW_STATUS_RUNNING = 'in_progress';
+            const WORKFLOW_STATUS_COMPLETED = 'completed';
+            const MAX_ATTEMPTS = 60;
+            const TIMEOUT_BETWEEN_ATTEMPT = 1000 * 30; // 10 second
+            const MAX_ITEMS_PER_PAGE = 100;
+
+            /**
+            * @param {string} branch 
+            * @returns {Promise<boolean>}
+            */
+            async function isReadyToE2E(branch) {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  branch: branch,
+                  per_page: MAX_ITEMS_PER_PAGE,
+                });
+
+                // Checking for active workflow 'Build and test for dev branches'
+                const activeRuns = data.workflow_runs.filter(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_RUNNING);
+                if (activeRuns.length > 0) {
+                  console.log(`There are active '${WORKFLOW_NAME}' jobs, wait for them to complete.`);
+                  return false;
+                }
+
+                // Checking the status of the first task 'Build and test for dev branches'
+                console.log(`No active jobs '${WORKFLOW_NAME}' were found, checking status first job.`);
+                const completedRun = data.workflow_runs.find(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_COMPLETED);
+
+                if (completedRun) {
+                  if (completedRun.conclusion === 'success') {
+                    console.log('The first job was completed successfully.');
+                    return true;
+                  } else {
+                    console.error('The first job ended with an error.');
+                    core.setFailed('There is no current image; the first job finished with an error.');
+                    return false;
+                  }
+                } else {
+                  core.setFailed('Job not found');
+                  return false;
+                }
+              } catch (error) {
+                core.setFailed(error.message);
+                return false;
+              }
+            }
+
+            const branchName = context.payload.inputs.ci_commit_ref_name;
+            const prNum = context.payload.inputs.issue_number;
+            console.log(`Run check for branch: ${branchName} PR: ${context.payload.repository.html_url}/pull/${prNum}`);
+
+            function sleep(ms) {
+                return new Promise(resolve => setTimeout(resolve, ms));
+            }
+
+            async function isWorkflowReadyToE2E() {
+              for (let i = 0; i < MAX_ATTEMPTS; i++) {
+                console.log(`Attempt number ${i + 1} of ${MAX_ATTEMPTS}`);
+                const isReady = await isReadyToE2E(branchName);
+                if (isReady) {
+                  return;
+                }
+                await sleep(TIMEOUT_BETWEEN_ATTEMPT);
+              }
+              core.setFailed('Failed to wait for the job to complete within the allowed number of attempts.');
+            };
+
+            await isWorkflowReadyToE2E()
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -209,6 +295,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -327,6 +414,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -704,6 +792,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_27 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -822,6 +911,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1199,6 +1289,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1317,6 +1408,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1694,6 +1786,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1812,6 +1905,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2189,6 +2283,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2307,6 +2402,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2684,6 +2780,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2802,6 +2899,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -3179,6 +3277,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3297,6 +3396,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -167,6 +167,92 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
+    steps:
+      - id: block-e2e
+        name: Block e2e until the docker image is not ready
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const WORKFLOW_NAME = 'Build and test for dev branches';
+            const WORKFLOW_STATUS_RUNNING = 'in_progress';
+            const WORKFLOW_STATUS_COMPLETED = 'completed';
+            const MAX_ATTEMPTS = 60;
+            const TIMEOUT_BETWEEN_ATTEMPT = 1000 * 30; // 10 second
+            const MAX_ITEMS_PER_PAGE = 100;
+
+            /**
+            * @param {string} branch 
+            * @returns {Promise<boolean>}
+            */
+            async function isReadyToE2E(branch) {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  branch: branch,
+                  per_page: MAX_ITEMS_PER_PAGE,
+                });
+
+                // Checking for active workflow 'Build and test for dev branches'
+                const activeRuns = data.workflow_runs.filter(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_RUNNING);
+                if (activeRuns.length > 0) {
+                  console.log(`There are active '${WORKFLOW_NAME}' jobs, wait for them to complete.`);
+                  return false;
+                }
+
+                // Checking the status of the first task 'Build and test for dev branches'
+                console.log(`No active jobs '${WORKFLOW_NAME}' were found, checking status first job.`);
+                const completedRun = data.workflow_runs.find(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_COMPLETED);
+
+                if (completedRun) {
+                  if (completedRun.conclusion === 'success') {
+                    console.log('The first job was completed successfully.');
+                    return true;
+                  } else {
+                    console.error('The first job ended with an error.');
+                    core.setFailed('There is no current image; the first job finished with an error.');
+                    return false;
+                  }
+                } else {
+                  core.setFailed('Job not found');
+                  return false;
+                }
+              } catch (error) {
+                core.setFailed(error.message);
+                return false;
+              }
+            }
+
+            const branchName = context.payload.inputs.ci_commit_ref_name;
+            const prNum = context.payload.inputs.issue_number;
+            console.log(`Run check for branch: ${branchName} PR: ${context.payload.repository.html_url}/pull/${prNum}`);
+
+            function sleep(ms) {
+                return new Promise(resolve => setTimeout(resolve, ms));
+            }
+
+            async function isWorkflowReadyToE2E() {
+              for (let i = 0; i < MAX_ATTEMPTS; i++) {
+                console.log(`Attempt number ${i + 1} of ${MAX_ATTEMPTS}`);
+                const isReady = await isReadyToE2E(branchName);
+                if (isReady) {
+                  return;
+                }
+                await sleep(TIMEOUT_BETWEEN_ATTEMPT);
+              }
+              core.setFailed('Failed to wait for the job to complete within the allowed number of attempts.');
+            };
+
+            await isWorkflowReadyToE2E()
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -209,6 +295,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -327,6 +414,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -712,6 +800,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_27 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -830,6 +919,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1215,6 +1305,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1333,6 +1424,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1718,6 +1810,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1836,6 +1929,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2221,6 +2315,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2339,6 +2434,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2724,6 +2820,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2842,6 +2939,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -3227,6 +3325,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3345,6 +3444,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -138,6 +138,7 @@ jobs:
     name: "AWS, Containerd, Kubernetes 1.29"
     needs:
       - git_info
+      - block-e2e-until-image-is-not-ready
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
       ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
@@ -240,6 +241,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "false"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -600,6 +602,7 @@ jobs:
     name: "EKS, Containerd, Kubernetes 1.29"
     needs:
       - git_info
+      - block-e2e-until-image-is-not-ready
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
       ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
@@ -702,6 +705,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "false"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1107,6 +1111,7 @@ jobs:
     name: "Azure, Containerd, Kubernetes 1.29"
     needs:
       - git_info
+      - block-e2e-until-image-is-not-ready
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
       ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
@@ -1209,6 +1214,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "false"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1577,6 +1583,7 @@ jobs:
     name: "GCP, Containerd, Kubernetes 1.29"
     needs:
       - git_info
+      - block-e2e-until-image-is-not-ready
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
       ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
@@ -1679,6 +1686,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "false"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2035,6 +2043,7 @@ jobs:
     name: "Yandex.Cloud, Containerd, Kubernetes 1.29"
     needs:
       - git_info
+      - block-e2e-until-image-is-not-ready
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
       ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
@@ -2137,6 +2146,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "false"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2501,6 +2511,7 @@ jobs:
     name: "OpenStack, Containerd, Kubernetes 1.29"
     needs:
       - git_info
+      - block-e2e-until-image-is-not-ready
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
       ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
@@ -2603,6 +2614,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "false"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2959,6 +2971,7 @@ jobs:
     name: "vSphere, Containerd, Kubernetes 1.29"
     needs:
       - git_info
+      - block-e2e-until-image-is-not-ready
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
       ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
@@ -3061,6 +3074,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "false"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -3421,6 +3435,7 @@ jobs:
     name: "VCD, Containerd, Kubernetes 1.29"
     needs:
       - git_info
+      - block-e2e-until-image-is-not-ready
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
       ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
@@ -3523,6 +3538,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "false"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -3895,6 +3911,7 @@ jobs:
     name: "Static, Containerd, Kubernetes 1.29"
     needs:
       - git_info
+      - block-e2e-until-image-is-not-ready
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
       ssh_bastion_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_bastion_connection_string }}
@@ -3997,6 +4014,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "false"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -167,6 +167,92 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
+    steps:
+      - id: block-e2e
+        name: Block e2e until the docker image is not ready
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const WORKFLOW_NAME = 'Build and test for dev branches';
+            const WORKFLOW_STATUS_RUNNING = 'in_progress';
+            const WORKFLOW_STATUS_COMPLETED = 'completed';
+            const MAX_ATTEMPTS = 60;
+            const TIMEOUT_BETWEEN_ATTEMPT = 1000 * 30; // 10 second
+            const MAX_ITEMS_PER_PAGE = 100;
+
+            /**
+            * @param {string} branch 
+            * @returns {Promise<boolean>}
+            */
+            async function isReadyToE2E(branch) {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  branch: branch,
+                  per_page: MAX_ITEMS_PER_PAGE,
+                });
+
+                // Checking for active workflow 'Build and test for dev branches'
+                const activeRuns = data.workflow_runs.filter(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_RUNNING);
+                if (activeRuns.length > 0) {
+                  console.log(`There are active '${WORKFLOW_NAME}' jobs, wait for them to complete.`);
+                  return false;
+                }
+
+                // Checking the status of the first task 'Build and test for dev branches'
+                console.log(`No active jobs '${WORKFLOW_NAME}' were found, checking status first job.`);
+                const completedRun = data.workflow_runs.find(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_COMPLETED);
+
+                if (completedRun) {
+                  if (completedRun.conclusion === 'success') {
+                    console.log('The first job was completed successfully.');
+                    return true;
+                  } else {
+                    console.error('The first job ended with an error.');
+                    core.setFailed('There is no current image; the first job finished with an error.');
+                    return false;
+                  }
+                } else {
+                  core.setFailed('Job not found');
+                  return false;
+                }
+              } catch (error) {
+                core.setFailed(error.message);
+                return false;
+              }
+            }
+
+            const branchName = context.payload.inputs.ci_commit_ref_name;
+            const prNum = context.payload.inputs.issue_number;
+            console.log(`Run check for branch: ${branchName} PR: ${context.payload.repository.html_url}/pull/${prNum}`);
+
+            function sleep(ms) {
+                return new Promise(resolve => setTimeout(resolve, ms));
+            }
+
+            async function isWorkflowReadyToE2E() {
+              for (let i = 0; i < MAX_ATTEMPTS; i++) {
+                console.log(`Attempt number ${i + 1} of ${MAX_ATTEMPTS}`);
+                const isReady = await isReadyToE2E(branchName);
+                if (isReady) {
+                  return;
+                }
+                await sleep(TIMEOUT_BETWEEN_ATTEMPT);
+              }
+              core.setFailed('Failed to wait for the job to complete within the allowed number of attempts.');
+            };
+
+            await isWorkflowReadyToE2E()
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -209,6 +295,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -327,6 +414,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -749,6 +837,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_27 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -867,6 +956,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1289,6 +1379,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1407,6 +1498,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1829,6 +1921,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1947,6 +2040,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2369,6 +2463,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2487,6 +2582,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2909,6 +3005,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3027,6 +3124,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -3449,6 +3547,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3567,6 +3666,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -167,6 +167,92 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
+    steps:
+      - id: block-e2e
+        name: Block e2e until the docker image is not ready
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const WORKFLOW_NAME = 'Build and test for dev branches';
+            const WORKFLOW_STATUS_RUNNING = 'in_progress';
+            const WORKFLOW_STATUS_COMPLETED = 'completed';
+            const MAX_ATTEMPTS = 60;
+            const TIMEOUT_BETWEEN_ATTEMPT = 1000 * 30; // 10 second
+            const MAX_ITEMS_PER_PAGE = 100;
+
+            /**
+            * @param {string} branch 
+            * @returns {Promise<boolean>}
+            */
+            async function isReadyToE2E(branch) {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  branch: branch,
+                  per_page: MAX_ITEMS_PER_PAGE,
+                });
+
+                // Checking for active workflow 'Build and test for dev branches'
+                const activeRuns = data.workflow_runs.filter(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_RUNNING);
+                if (activeRuns.length > 0) {
+                  console.log(`There are active '${WORKFLOW_NAME}' jobs, wait for them to complete.`);
+                  return false;
+                }
+
+                // Checking the status of the first task 'Build and test for dev branches'
+                console.log(`No active jobs '${WORKFLOW_NAME}' were found, checking status first job.`);
+                const completedRun = data.workflow_runs.find(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_COMPLETED);
+
+                if (completedRun) {
+                  if (completedRun.conclusion === 'success') {
+                    console.log('The first job was completed successfully.');
+                    return true;
+                  } else {
+                    console.error('The first job ended with an error.');
+                    core.setFailed('There is no current image; the first job finished with an error.');
+                    return false;
+                  }
+                } else {
+                  core.setFailed('Job not found');
+                  return false;
+                }
+              } catch (error) {
+                core.setFailed(error.message);
+                return false;
+              }
+            }
+
+            const branchName = context.payload.inputs.ci_commit_ref_name;
+            const prNum = context.payload.inputs.issue_number;
+            console.log(`Run check for branch: ${branchName} PR: ${context.payload.repository.html_url}/pull/${prNum}`);
+
+            function sleep(ms) {
+                return new Promise(resolve => setTimeout(resolve, ms));
+            }
+
+            async function isWorkflowReadyToE2E() {
+              for (let i = 0; i < MAX_ATTEMPTS; i++) {
+                console.log(`Attempt number ${i + 1} of ${MAX_ATTEMPTS}`);
+                const isReady = await isReadyToE2E(branchName);
+                if (isReady) {
+                  return;
+                }
+                await sleep(TIMEOUT_BETWEEN_ATTEMPT);
+              }
+              core.setFailed('Failed to wait for the job to complete within the allowed number of attempts.');
+            };
+
+            await isWorkflowReadyToE2E()
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -209,6 +295,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -327,6 +414,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -700,6 +788,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_27 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -818,6 +907,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1191,6 +1281,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1309,6 +1400,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1682,6 +1774,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1800,6 +1893,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2173,6 +2267,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2291,6 +2386,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2664,6 +2760,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2782,6 +2879,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -3155,6 +3253,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3273,6 +3372,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -167,6 +167,92 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
+    steps:
+      - id: block-e2e
+        name: Block e2e until the docker image is not ready
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const WORKFLOW_NAME = 'Build and test for dev branches';
+            const WORKFLOW_STATUS_RUNNING = 'in_progress';
+            const WORKFLOW_STATUS_COMPLETED = 'completed';
+            const MAX_ATTEMPTS = 60;
+            const TIMEOUT_BETWEEN_ATTEMPT = 1000 * 30; // 10 second
+            const MAX_ITEMS_PER_PAGE = 100;
+
+            /**
+            * @param {string} branch 
+            * @returns {Promise<boolean>}
+            */
+            async function isReadyToE2E(branch) {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  branch: branch,
+                  per_page: MAX_ITEMS_PER_PAGE,
+                });
+
+                // Checking for active workflow 'Build and test for dev branches'
+                const activeRuns = data.workflow_runs.filter(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_RUNNING);
+                if (activeRuns.length > 0) {
+                  console.log(`There are active '${WORKFLOW_NAME}' jobs, wait for them to complete.`);
+                  return false;
+                }
+
+                // Checking the status of the first task 'Build and test for dev branches'
+                console.log(`No active jobs '${WORKFLOW_NAME}' were found, checking status first job.`);
+                const completedRun = data.workflow_runs.find(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_COMPLETED);
+
+                if (completedRun) {
+                  if (completedRun.conclusion === 'success') {
+                    console.log('The first job was completed successfully.');
+                    return true;
+                  } else {
+                    console.error('The first job ended with an error.');
+                    core.setFailed('There is no current image; the first job finished with an error.');
+                    return false;
+                  }
+                } else {
+                  core.setFailed('Job not found');
+                  return false;
+                }
+              } catch (error) {
+                core.setFailed(error.message);
+                return false;
+              }
+            }
+
+            const branchName = context.payload.inputs.ci_commit_ref_name;
+            const prNum = context.payload.inputs.issue_number;
+            console.log(`Run check for branch: ${branchName} PR: ${context.payload.repository.html_url}/pull/${prNum}`);
+
+            function sleep(ms) {
+                return new Promise(resolve => setTimeout(resolve, ms));
+            }
+
+            async function isWorkflowReadyToE2E() {
+              for (let i = 0; i < MAX_ATTEMPTS; i++) {
+                console.log(`Attempt number ${i + 1} of ${MAX_ATTEMPTS}`);
+                const isReady = await isReadyToE2E(branchName);
+                if (isReady) {
+                  return;
+                }
+                await sleep(TIMEOUT_BETWEEN_ATTEMPT);
+              }
+              core.setFailed('Failed to wait for the job to complete within the allowed number of attempts.');
+            };
+
+            await isWorkflowReadyToE2E()
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -209,6 +295,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -327,6 +414,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -700,6 +788,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_27 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -818,6 +907,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1191,6 +1281,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1309,6 +1400,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1682,6 +1774,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1800,6 +1893,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2173,6 +2267,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2291,6 +2386,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2664,6 +2760,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2782,6 +2879,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -3155,6 +3253,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3273,6 +3372,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -167,6 +167,92 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
+    steps:
+      - id: block-e2e
+        name: Block e2e until the docker image is not ready
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const WORKFLOW_NAME = 'Build and test for dev branches';
+            const WORKFLOW_STATUS_RUNNING = 'in_progress';
+            const WORKFLOW_STATUS_COMPLETED = 'completed';
+            const MAX_ATTEMPTS = 60;
+            const TIMEOUT_BETWEEN_ATTEMPT = 1000 * 30; // 10 second
+            const MAX_ITEMS_PER_PAGE = 100;
+
+            /**
+            * @param {string} branch 
+            * @returns {Promise<boolean>}
+            */
+            async function isReadyToE2E(branch) {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  branch: branch,
+                  per_page: MAX_ITEMS_PER_PAGE,
+                });
+
+                // Checking for active workflow 'Build and test for dev branches'
+                const activeRuns = data.workflow_runs.filter(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_RUNNING);
+                if (activeRuns.length > 0) {
+                  console.log(`There are active '${WORKFLOW_NAME}' jobs, wait for them to complete.`);
+                  return false;
+                }
+
+                // Checking the status of the first task 'Build and test for dev branches'
+                console.log(`No active jobs '${WORKFLOW_NAME}' were found, checking status first job.`);
+                const completedRun = data.workflow_runs.find(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_COMPLETED);
+
+                if (completedRun) {
+                  if (completedRun.conclusion === 'success') {
+                    console.log('The first job was completed successfully.');
+                    return true;
+                  } else {
+                    console.error('The first job ended with an error.');
+                    core.setFailed('There is no current image; the first job finished with an error.');
+                    return false;
+                  }
+                } else {
+                  core.setFailed('Job not found');
+                  return false;
+                }
+              } catch (error) {
+                core.setFailed(error.message);
+                return false;
+              }
+            }
+
+            const branchName = context.payload.inputs.ci_commit_ref_name;
+            const prNum = context.payload.inputs.issue_number;
+            console.log(`Run check for branch: ${branchName} PR: ${context.payload.repository.html_url}/pull/${prNum}`);
+
+            function sleep(ms) {
+                return new Promise(resolve => setTimeout(resolve, ms));
+            }
+
+            async function isWorkflowReadyToE2E() {
+              for (let i = 0; i < MAX_ATTEMPTS; i++) {
+                console.log(`Attempt number ${i + 1} of ${MAX_ATTEMPTS}`);
+                const isReady = await isReadyToE2E(branchName);
+                if (isReady) {
+                  return;
+                }
+                await sleep(TIMEOUT_BETWEEN_ATTEMPT);
+              }
+              core.setFailed('Failed to wait for the job to complete within the allowed number of attempts.');
+            };
+
+            await isWorkflowReadyToE2E()
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -209,6 +295,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -327,6 +414,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -700,6 +788,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_27 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -818,6 +907,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1191,6 +1281,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1309,6 +1400,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1682,6 +1774,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1800,6 +1893,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2173,6 +2267,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2291,6 +2386,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2664,6 +2760,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2782,6 +2879,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -3155,6 +3253,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3273,6 +3372,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -167,6 +167,92 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
+    steps:
+      - id: block-e2e
+        name: Block e2e until the docker image is not ready
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const WORKFLOW_NAME = 'Build and test for dev branches';
+            const WORKFLOW_STATUS_RUNNING = 'in_progress';
+            const WORKFLOW_STATUS_COMPLETED = 'completed';
+            const MAX_ATTEMPTS = 60;
+            const TIMEOUT_BETWEEN_ATTEMPT = 1000 * 30; // 10 second
+            const MAX_ITEMS_PER_PAGE = 100;
+
+            /**
+            * @param {string} branch 
+            * @returns {Promise<boolean>}
+            */
+            async function isReadyToE2E(branch) {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  branch: branch,
+                  per_page: MAX_ITEMS_PER_PAGE,
+                });
+
+                // Checking for active workflow 'Build and test for dev branches'
+                const activeRuns = data.workflow_runs.filter(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_RUNNING);
+                if (activeRuns.length > 0) {
+                  console.log(`There are active '${WORKFLOW_NAME}' jobs, wait for them to complete.`);
+                  return false;
+                }
+
+                // Checking the status of the first task 'Build and test for dev branches'
+                console.log(`No active jobs '${WORKFLOW_NAME}' were found, checking status first job.`);
+                const completedRun = data.workflow_runs.find(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_COMPLETED);
+
+                if (completedRun) {
+                  if (completedRun.conclusion === 'success') {
+                    console.log('The first job was completed successfully.');
+                    return true;
+                  } else {
+                    console.error('The first job ended with an error.');
+                    core.setFailed('There is no current image; the first job finished with an error.');
+                    return false;
+                  }
+                } else {
+                  core.setFailed('Job not found');
+                  return false;
+                }
+              } catch (error) {
+                core.setFailed(error.message);
+                return false;
+              }
+            }
+
+            const branchName = context.payload.inputs.ci_commit_ref_name;
+            const prNum = context.payload.inputs.issue_number;
+            console.log(`Run check for branch: ${branchName} PR: ${context.payload.repository.html_url}/pull/${prNum}`);
+
+            function sleep(ms) {
+                return new Promise(resolve => setTimeout(resolve, ms));
+            }
+
+            async function isWorkflowReadyToE2E() {
+              for (let i = 0; i < MAX_ATTEMPTS; i++) {
+                console.log(`Attempt number ${i + 1} of ${MAX_ATTEMPTS}`);
+                const isReady = await isReadyToE2E(branchName);
+                if (isReady) {
+                  return;
+                }
+                await sleep(TIMEOUT_BETWEEN_ATTEMPT);
+              }
+              core.setFailed('Failed to wait for the job to complete within the allowed number of attempts.');
+            };
+
+            await isWorkflowReadyToE2E()
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -209,6 +295,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -327,6 +414,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -716,6 +804,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_27 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -834,6 +923,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1223,6 +1313,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1341,6 +1432,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1730,6 +1822,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1848,6 +1941,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2237,6 +2331,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2355,6 +2450,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2744,6 +2840,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2862,6 +2959,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -3251,6 +3349,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3369,6 +3468,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -167,6 +167,92 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
+    steps:
+      - id: block-e2e
+        name: Block e2e until the docker image is not ready
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const WORKFLOW_NAME = 'Build and test for dev branches';
+            const WORKFLOW_STATUS_RUNNING = 'in_progress';
+            const WORKFLOW_STATUS_COMPLETED = 'completed';
+            const MAX_ATTEMPTS = 60;
+            const TIMEOUT_BETWEEN_ATTEMPT = 1000 * 30; // 10 second
+            const MAX_ITEMS_PER_PAGE = 100;
+
+            /**
+            * @param {string} branch 
+            * @returns {Promise<boolean>}
+            */
+            async function isReadyToE2E(branch) {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  branch: branch,
+                  per_page: MAX_ITEMS_PER_PAGE,
+                });
+
+                // Checking for active workflow 'Build and test for dev branches'
+                const activeRuns = data.workflow_runs.filter(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_RUNNING);
+                if (activeRuns.length > 0) {
+                  console.log(`There are active '${WORKFLOW_NAME}' jobs, wait for them to complete.`);
+                  return false;
+                }
+
+                // Checking the status of the first task 'Build and test for dev branches'
+                console.log(`No active jobs '${WORKFLOW_NAME}' were found, checking status first job.`);
+                const completedRun = data.workflow_runs.find(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_COMPLETED);
+
+                if (completedRun) {
+                  if (completedRun.conclusion === 'success') {
+                    console.log('The first job was completed successfully.');
+                    return true;
+                  } else {
+                    console.error('The first job ended with an error.');
+                    core.setFailed('There is no current image; the first job finished with an error.');
+                    return false;
+                  }
+                } else {
+                  core.setFailed('Job not found');
+                  return false;
+                }
+              } catch (error) {
+                core.setFailed(error.message);
+                return false;
+              }
+            }
+
+            const branchName = context.payload.inputs.ci_commit_ref_name;
+            const prNum = context.payload.inputs.issue_number;
+            console.log(`Run check for branch: ${branchName} PR: ${context.payload.repository.html_url}/pull/${prNum}`);
+
+            function sleep(ms) {
+                return new Promise(resolve => setTimeout(resolve, ms));
+            }
+
+            async function isWorkflowReadyToE2E() {
+              for (let i = 0; i < MAX_ATTEMPTS; i++) {
+                console.log(`Attempt number ${i + 1} of ${MAX_ATTEMPTS}`);
+                const isReady = await isReadyToE2E(branchName);
+                if (isReady) {
+                  return;
+                }
+                await sleep(TIMEOUT_BETWEEN_ATTEMPT);
+              }
+              core.setFailed('Failed to wait for the job to complete within the allowed number of attempts.');
+            };
+
+            await isWorkflowReadyToE2E()
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -209,6 +295,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -327,6 +414,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -704,6 +792,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_27 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -822,6 +911,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1199,6 +1289,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1317,6 +1408,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1694,6 +1786,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1812,6 +1905,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2189,6 +2283,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2307,6 +2402,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2684,6 +2780,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2802,6 +2899,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -3179,6 +3277,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3297,6 +3396,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -167,6 +167,92 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
+    steps:
+      - id: block-e2e
+        name: Block e2e until the docker image is not ready
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const WORKFLOW_NAME = 'Build and test for dev branches';
+            const WORKFLOW_STATUS_RUNNING = 'in_progress';
+            const WORKFLOW_STATUS_COMPLETED = 'completed';
+            const MAX_ATTEMPTS = 60;
+            const TIMEOUT_BETWEEN_ATTEMPT = 1000 * 30; // 10 second
+            const MAX_ITEMS_PER_PAGE = 100;
+
+            /**
+            * @param {string} branch 
+            * @returns {Promise<boolean>}
+            */
+            async function isReadyToE2E(branch) {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  branch: branch,
+                  per_page: MAX_ITEMS_PER_PAGE,
+                });
+
+                // Checking for active workflow 'Build and test for dev branches'
+                const activeRuns = data.workflow_runs.filter(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_RUNNING);
+                if (activeRuns.length > 0) {
+                  console.log(`There are active '${WORKFLOW_NAME}' jobs, wait for them to complete.`);
+                  return false;
+                }
+
+                // Checking the status of the first task 'Build and test for dev branches'
+                console.log(`No active jobs '${WORKFLOW_NAME}' were found, checking status first job.`);
+                const completedRun = data.workflow_runs.find(run => run.name === WORKFLOW_NAME && run.status === WORKFLOW_STATUS_COMPLETED);
+
+                if (completedRun) {
+                  if (completedRun.conclusion === 'success') {
+                    console.log('The first job was completed successfully.');
+                    return true;
+                  } else {
+                    console.error('The first job ended with an error.');
+                    core.setFailed('There is no current image; the first job finished with an error.');
+                    return false;
+                  }
+                } else {
+                  core.setFailed('Job not found');
+                  return false;
+                }
+              } catch (error) {
+                core.setFailed(error.message);
+                return false;
+              }
+            }
+
+            const branchName = context.payload.inputs.ci_commit_ref_name;
+            const prNum = context.payload.inputs.issue_number;
+            console.log(`Run check for branch: ${branchName} PR: ${context.payload.repository.html_url}/pull/${prNum}`);
+
+            function sleep(ms) {
+                return new Promise(resolve => setTimeout(resolve, ms));
+            }
+
+            async function isWorkflowReadyToE2E() {
+              for (let i = 0; i < MAX_ATTEMPTS; i++) {
+                console.log(`Attempt number ${i + 1} of ${MAX_ATTEMPTS}`);
+                const isReady = await isReadyToE2E(branchName);
+                if (isReady) {
+                  return;
+                }
+                await sleep(TIMEOUT_BETWEEN_ATTEMPT);
+              }
+              core.setFailed('Failed to wait for the job to complete within the allowed number of attempts.');
+            };
+
+            await isWorkflowReadyToE2E()
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -209,6 +295,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_26 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -327,6 +414,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -708,6 +796,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_27 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -826,6 +915,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1207,6 +1297,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1325,6 +1416,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -1706,6 +1798,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1824,6 +1917,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2205,6 +2299,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2323,6 +2418,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -2704,6 +2800,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2822,6 +2919,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
@@ -3203,6 +3301,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3321,6 +3420,7 @@ jobs:
           INITIAL_REF_SLUG: ${{ github.event.inputs.initial_ref_slug }}
           MANUAL_RUN: "true"
           MULTIMASTER: ${{ needs.check_e2e_labels.outputs.multimaster }}
+          WAIT_IMAGE_TIME: 300 # 5 minutes
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.


### PR DESCRIPTION
## Description
Update CI
Block run e2e tests until the docker image is not ready

## Why do we need it, and what problem does it solve?
e2e tests may run before the corresponding image is built. it's stopping the test.

## Why do we need it in the patch release (if we do)?

## What is the expected result?
the test will not run until the image build workflow is complete

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: the test will not run until the image build workflow is complete
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
