### PR TITLE
[control-plane-manager] Update k8s deprecation/eol prometheus rules

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1373,7 +1373,7 @@ alerts:
       module: control-plane-manager
       edition: ce
       description: |-
-        Current kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed within 6 months
+        Current kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed in next releases
 
         Please migrate to the next kubernetes version (at least 1.28)
 
@@ -3638,21 +3638,6 @@ alerts:
       summary: |
         Count of unavailable replicas in StatefulSet {{$labels.namespace}}/{{$labels.statefulset}} above threshold.
       severity: "6"
-      markupFormat: markdown
-    - name: KubernetesVersionEndOfLife
-      sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
-      moduleUrl: 040-control-plane-manager
-      module: control-plane-manager
-      edition: ce
-      description: |-
-        Current kubernetes version "{{ $labels.k8s_version }}" support will be removed in the next Deckhouse release (1.58).
-
-        Please migrate to the next kubernetes version (at least 1.24) as soon as possible.
-
-        Check how to update the Kubernetes version in the cluster here - https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster
-      summary: |
-        Kubernetes version &quot;{{ $labels.k8s_version }}&quot; has reached End Of Life.
-      severity: "4"
       markupFormat: markdown
     - name: KubeStateMetricsDown
       sourceFile: modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kube-state-metrics.yaml

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1373,7 +1373,7 @@ alerts:
       module: control-plane-manager
       edition: ce
       description: |-
-        Current kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed in next releases
+        The current Kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed in upcoming releases.
 
         Please migrate to the next kubernetes version (at least 1.28)
 

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -45,7 +45,7 @@
       plk_markup_format: "markdown"
       summary: Kubernetes version "{{ $labels.k8s_version }}" is deprecated
       description: |-
-        Current kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed in next releases
+        The current Kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed in upcoming releases.
 
         Please migrate to the next kubernetes version (at least 1.28)
 

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -36,7 +36,7 @@
 
   - alert: D8KubernetesVersionIsDeprecated
     for: 10m
-    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.26"}) == 1
+    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.27"}) == 1
     labels:
       severity_level: "7"
       tier: cluster
@@ -45,25 +45,9 @@
       plk_markup_format: "markdown"
       summary: Kubernetes version "{{ $labels.k8s_version }}" is deprecated
       description: |-
-        Current kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed within 6 months
+        Current kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed in next releases
 
         Please migrate to the next kubernetes version (at least 1.28)
 
         Check how to update the Kubernetes version in the cluster here - https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster
 
-  - alert: KubernetesVersionEndOfLife
-    for: 10m
-    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.23"}) == 1
-    labels:
-      severity_level: "4"
-      tier: cluster
-    annotations:
-      plk_protocol_version: "1"
-      plk_markup_format: "markdown"
-      summary: Kubernetes version "{{ $labels.k8s_version }}" has reached End Of Life.
-      description: |-
-        Current kubernetes version "{{ $labels.k8s_version }}" support will be removed in the next Deckhouse release (1.58).
-
-        Please migrate to the next kubernetes version (at least 1.24) as soon as possible.
-
-        Check how to update the Kubernetes version in the cluster here - https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster


### PR DESCRIPTION
## Description

Update deprecated version of Kubernetes in prometheus alert: 1.27 will be deprecated

## Why do we need it, and what problem does it solve?

Now Kubernetes 1.27 is in EOL status — we would like to deprecate it to inform customers to update to supported version

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: Update D8KubernetesVersionIsDeprecated alert to set k8s v1.27 deprecated.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
