### PR TITLE
[docs] Update instructions for adding a root certificate

### DIFF
--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/OS.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/OS.md
@@ -155,7 +155,7 @@ You can add a root certificate as a NodeGroupConfiguration resource.
 The following example is for Ubuntu OS.
 The method of adding certificates to the store may differ depending on the OS.
 
-To adapt the script to a different OS, modify the [`bundles`](../../../../reference/cr/nodegroup.html#nodegroupconfiguration-v1alpha1-spec-bundles) parameter.
+To adapt the script to a different OS, modify the [`bundles`](../../../../reference/cr/nodegroupconfiguration.html#nodegroupconfiguration-v1alpha1-spec-bundles) and [content](../../../../reference/cr/nodegroupconfiguration.html#nodegroupconfiguration-v1alpha1-spec-content) parameters.
 {% endalert %}
 
 The script uses the following Bash Booster functions:

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/OS_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/OS_RU.md
@@ -148,7 +148,7 @@ spec:
 Данный пример приведен для ОС Ubuntu.  
 Способ обновления хранилища сертификатов может отличаться в зависимости от ОС.
 
-При адаптации скрипта под другую ОС измените параметр [bundles](../../../../reference/cr/nodegroup.html#nodegroupconfiguration-v1alpha1-spec-bundles).
+При адаптации скрипта под другую ОС измените параметры [bundles](../../../../reference/cr/nodegroupconfiguration.html#nodegroupconfiguration-v1alpha1-spec-bundles) и [content](../../../../reference/cr/nodegroupconfiguration.html#nodegroupconfiguration-v1alpha1-spec-content).
 {% endalert %}
 
 Скрипт использует следующие конструкции Bash Booster:

--- a/modules/040-node-manager/docs/EXAMPLES.md
+++ b/modules/040-node-manager/docs/EXAMPLES.md
@@ -436,7 +436,7 @@ spec:
 Example is given for Ubuntu OS.  
 The method of adding certificates to the store may differ depending on the OS.  
 
-Change the [bundles](cr.html#nodegroupconfiguration-v1alpha1-spec-bundles) parameter to adapt the script to a different OS.
+Change the [bundles](cr.html#nodegroupconfiguration-v1alpha1-spec-bundles) and [content](cr.html#nodegroupconfiguration-v1alpha1-spec-content) parameters to adapt the script to a different OS.
 {% endalert %}
 
 {% alert level="warning" %}

--- a/modules/040-node-manager/docs/EXAMPLES_RU.md
+++ b/modules/040-node-manager/docs/EXAMPLES_RU.md
@@ -442,7 +442,7 @@ spec:
 Данный пример приведен для ОС Ubuntu.  
 Способ добавления сертификатов в хранилище может отличаться в зависимости от ОС.
   
-При адаптации скрипта под другую ОС измените параметр [bundles](cr.html#nodegroupconfiguration-v1alpha1-spec-bundles).
+При адаптации скрипта под другую ОС измените параметры [bundles](cr.html#nodegroupconfiguration-v1alpha1-spec-bundles) и [content](cr.html#nodegroupconfiguration-v1alpha1-spec-content).
 {% endalert %}
 
 {% alert level="warning" %}
@@ -518,7 +518,7 @@ spec:
 Данный пример приведен для ОС Ubuntu.  
 Способ добавления сертификатов в хранилище может отличаться в зависимости от ОС.
   
-При адаптации скрипта под другую ОС измените параметр [bundles](cr.html#nodegroupconfiguration-v1alpha1-spec-bundles).
+При адаптации скрипта под другую ОС измените параметры [bundles](cr.html#nodegroupconfiguration-v1alpha1-spec-bundles) и [content](cr.html#nodegroupconfiguration-v1alpha1-spec-content).
 {% endalert %}
 
 {% alert level="info" %}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
It is necessary to supplement the instructions for adding the root certificate and correct one link
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The client added the certificate according to the [instructions from the official deckhouse website](https://deckhouse.io/products/virtualization-platform/documentation/admin/platform-management/node-management/os.html#adding-a-root-certificate).
He got confused because the `content` field, depending on the `OS`, may contain parameters that differ from those specified in the instructions.
For example, the `CERTS_FOLDER (/usr/local/share/ca-certificates)` is not present for `redos` and other `OS`, and their own are used.

I also found that the existing `bundles` link in the instruction leads to the [Custom resource NodeGroup](https://deckhouse.io/products/virtualization-platform/reference/cr/nodegroup.html#nodegroupconfiguration-v1alpha1-spec-bundles) page, but as I think it should go to the [Custom resource NodeGroupConfiguration](https://deckhouse.io/products/virtualization-platform/reference/cr/nodegroupconfiguration.html#nodegroupconfiguration-v1alpha1-spec-bundles)




## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: feature
summary: Update instructions for adding a root certificate.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
