### PR TITLE
[prometheus] Improve prometheus rolling update

### DIFF
--- a/ee/fe/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/ee/fe/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -8,6 +8,12 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
+{{- define "toSeconds" -}}
+{{- $duration := . }}
+{{- $now := now }}
+{{- sub ($now | unixEpoch) ($now |  date_modify (printf "-%s" $duration) | unixEpoch) }}
+{{- end }}
+
 {{- define "prompp-context" -}}
 {{- $values := deepCopy .Values | merge dict }}
 {{- $_ := set $values.global.modulesImages.registry "base" (printf "%s/modules/prompp" .Values.global.modulesImages.registry.base) }}
@@ -179,6 +185,7 @@ spec:
 {{- end }}
   scrapeInterval: {{ .Values.prometheus.scrapeInterval | default "30s"}}
   evaluationInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
+  minReadySeconds: {{ mul (include "toSeconds" .Values.prometheus.scrapeInterval) 2 }}
   # Empty field because when scraping metrics via the Federation API,
   # labels from externalLabels are being added,
   # which makes the series in long-term storage and regular Prometheus different

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -8,6 +8,12 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
+{{- define "toSeconds" -}}
+{{- $duration := . }}
+{{- $now := now }}
+{{- sub ($now | unixEpoch) ($now |  date_modify (printf "-%s" $duration) | unixEpoch) }}
+{{- end }}
+
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -78,6 +84,17 @@ spec:
     - "--v=2"
     - "--logtostderr=true"
     - "--stale-cache-interval=1h30m"
+    lifecycle:
+      preStop:
+        {{- if semverCompare ">=1.30" .Values.global.clusterConfiguration.kubernetesVersion }}
+        sleep:
+          seconds: {{ mul (include "toSeconds" .Values.prometheus.scrapeInterval) 2 }}
+        {{- else }}
+        exec:
+          command:
+          - sleep
+          - {{ mul (include "toSeconds" .Values.prometheus.scrapeInterval) 2 }}
+        {{- end }}
     ports:
     - containerPort: 9090
       name: https

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -84,17 +84,6 @@ spec:
     - "--v=2"
     - "--logtostderr=true"
     - "--stale-cache-interval=1h30m"
-    lifecycle:
-      preStop:
-        {{- if semverCompare ">=1.30" .Values.global.clusterConfiguration.kubernetesVersion }}
-        sleep:
-          seconds: {{ mul (include "toSeconds" .Values.prometheus.scrapeInterval) 2 }}
-        {{- else }}
-        exec:
-          command:
-          - sleep
-          - {{ mul (include "toSeconds" .Values.prometheus.scrapeInterval) 2 }}
-        {{- end }}
     ports:
     - containerPort: 9090
       name: https
@@ -152,6 +141,7 @@ spec:
 {{- end }}
   scrapeInterval: {{ .Values.prometheus.scrapeInterval | default "30s"}}
   evaluationInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
+  minReadySeconds: {{ mul (include "toSeconds" .Values.prometheus.scrapeInterval) 2 }}
   # Empty field because when scraping metrics via the Federation API,
   # labels from externalLabels are being added,
   # which makes the series in long-term storage and regular Prometheus different


### PR DESCRIPTION
## Description
Deckhouse prefers to run two Prometheus replicas when possible. In conjunction with the aggregation proxy, it gives some redundancy. It delivers the end user gapless charts in a cluster's Grafana even if one Prometheus replica is down for some period.

## Why do we need it, and what problem does it solve?
When the Prometheus StatefulSets is being rollout-restarted gaps can still occur.
The Prometheus readiness probe only checks if it can serve the requests: when one replica is ready, Kubernetes can terminate the other immediately. So we end up in the situation where the first replica has just started but never scraped any targets and the other one is being terminated and already has stopped the scraping process, hence having scraping gaps.

We should postpone the second replica stop until the first replica scrapes all the targets. The simplest approach is to employ a `minReadySeconds` feature. Waiting for two scrape intervals should be enough.

## Why do we need it in the patch release (if we do)?
We don't

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: avoid gaps in charts when Prometheus StatefulSet is being rollout restarted
impact: Prometheus StatefulSet will be rollout restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
