### PR TITLE
[docs]Changes the links in documentation about alerts from url to relative links

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -335,7 +335,7 @@ alerts:
 
         They must be moved from Deckhouse namespace to user-spec namespace (was not labeled as `heritage: deckhouse`).
 
-        The detailed description of the metric collecting process is available in the [documentation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html).
+        The detailed description of the metric collecting process is available in the [documentation](modules/prometheus/faq.html).
       summary: |
         There are PodMonitors in Deckhouse namespace that were not created by Deckhouse.
       severity: "9"
@@ -352,7 +352,7 @@ alerts:
 
         They must be moved from Deckhouse namespace to user-spec namespace (was not labeled as `heritage: deckhouse`).
 
-        The detailed description of the metric collecting process is available in the [documentation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html).
+        The detailed description of the metric collecting process is available in the [documentation](modules/prometheus/faq.html).
       summary: |
         There are ServiceMonitors in Deckhouse namespace that were not created by Deckhouse.
       severity: "9"
@@ -625,7 +625,7 @@ alerts:
 
         They must be abandoned and replaced with the `CustomPrometheusRules` object.
 
-        Please, refer to the [documentation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html#how-do-i-add-alerts-andor-recording-rules) for information about adding alerts and/or recording rules.
+        Please, refer to the [documentation](modules/prometheus/faq.html#how-do-i-add-alerts-andor-recording-rules) for information about adding alerts and/or recording rules.
       summary: |
         There are PrometheusRules in the cluster that were not created by Deckhouse.
       severity: "9"
@@ -1164,7 +1164,7 @@ alerts:
         ```
         max by (namespace, dataplane_pod) (d8_istio_dataplane_metadata{full_version="{{$labels.full_version}}"})
         ```
-        Also consider using the automatic istio data-plane update described in the documentation: https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/istio/examples.html#upgrading-istio
+        Also consider using the automatic istio data-plane update described in the [documentation](modules/istio/examples.html#upgrading-istio)
       summary: |
         There are Pods with data-plane version different from control-plane one.
       severity: "8"
@@ -1193,7 +1193,7 @@ alerts:
       description: |
         There is deprecated istio version `{{$labels.version}}` installed.
         Impact — version support will be removed in future deckhouse releases. The higher alert severity — the higher probability of support cancelling.
-        Read [documentation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/istio/examples.html#upgrading-istio) on upgrading Istio.
+        Read [documentation](modules/istio/examples.html#upgrading-istio) on upgrading Istio.
       summary: |
         There is deprecated istio version installed
       severity: undefined
@@ -1334,7 +1334,7 @@ alerts:
       description: |
         The current istio version `{{$labels.istio_version}}` may not work properly with the current k8s version `{{$labels.k8s_version}}`, because it is unsupported officially.
         Please upgrade istio as soon as possible.
-        Read [documentation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/istio/examples.html#upgrading-istio) on upgrading Istio.
+        Read [documentation](modules/istio/examples.html#upgrading-istio) on upgrading Istio.
       summary: |
         The installed istio version is incompatible with the k8s version
       severity: "3"
@@ -1373,11 +1373,11 @@ alerts:
       module: control-plane-manager
       edition: ce
       description: |-
-        The current Kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed in upcoming releases.
+        Current kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed within 6 months
 
         Please migrate to the next kubernetes version (at least 1.28)
 
-        Check how to update the Kubernetes version in the cluster here - https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster
+        Check how to update the Kubernetes version in the cluster here - platform/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster
       summary: |
         Kubernetes version &quot;{{ $labels.k8s_version }}&quot; is deprecated
       severity: "7"
@@ -1415,7 +1415,7 @@ alerts:
       edition: ce
       description: |-
         Found ClusterLogDestination resource {{$labels.resource_name}} without authorization params.
-        You should [add](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/log-shipper/faq.html#how-to-add-authorization-to-the-clusterlogdestination-resource) authorization params to the ClusterLogDestination resource.
+        You should [add](modules/log-shipper/faq.html#how-to-add-authorization-to-the-clusterlogdestination-resource) authorization params to the ClusterLogDestination resource.
       summary: |
         Required authorization params for ClusterLogDestination.
       severity: "9"
@@ -1762,7 +1762,7 @@ alerts:
       module: node-manager
       edition: ce
       description: |
-        The {{ $labels.node }} Node is not managed by the [node-manager](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/node-manager/) module.
+        The {{ $labels.node }} Node is not managed by the [node-manager](modules/node-manager/) module.
 
         The recommended actions are as follows:
         - Follow these instructions to clean up the node and add it to the cluster: https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/node-manager/faq.html#how-to-clean-up-a-node-for-adding-to-the-cluster
@@ -1803,7 +1803,7 @@ alerts:
 
         Note that the label format has changed. You need to change the `prometheus-custom-target` label to `prometheus.deckhouse.io/custom-target`.
 
-        For more information, refer to the [documentation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html).
+        For more information, refer to the [documentation](modules/prometheus/faq.html).
       summary: |
         Services with the prometheus-custom-target label are used to collect metrics in the cluster.
       severity: "9"
@@ -1940,7 +1940,7 @@ alerts:
         - reserved `metadata.labels` *node-role.deckhouse.io/* with ending not in `(system|frontend|monitoring|_deckhouse_module_name_)`
         - or reserved `spec.taints` *dedicated.deckhouse.io* with values not in `(system|frontend|monitoring|_deckhouse_module_name_)`
 
-        [Get instructions on how to fix it here](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).
+        [Get instructions on how to fix it here](modules/node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).
       summary: |
         Node {{ $labels.name }} needs fixing up
       severity: "6"
@@ -2818,18 +2818,12 @@ alerts:
       module: ingress-nginx
       edition: ce
       description: |-
-        There is an IngressNginxController and/or an Ingress object that utilize(s) Nginx GeoIPv1 module's variables. The module is deprecated and its support is discontinued from Ingess Nginx Controller of version 1.10 and higher. It's recommend to upgrade your configuration to use [GeoIPv2 module](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/ingress-nginx/cr.html#ingressnginxcontroller-v1-spec-geoip2).
+        There is an IngressNginxController and/or an Ingress object that utilize(s) Nginx GeoIPv1 module's variables. The module is deprecated and its support is discontinued from Ingess Nginx Controller of version 1.10 and higher. It's recommend to upgrade your configuration to use [GeoIPv2 module](modules/ingress-nginx/cr.html#ingressnginxcontroller-v1-spec-geoip2).
         Use the following command to get the list of the IngressNginxControllers that contain GeoIPv1 variables:
-
-        ```shell
-        kubectl  get ingressnginxcontrollers.deckhouse.io -o json | jq '.items[] | select(..|strings | test("\\$geoip_(country_(code3|code|name)|area_code|city_continent_code|city_country_(code3|code|name)|dma_code|latitude|longitude|region|region_name|city|postal_code|org)([^_a-zA-Z0-9]|$)+")) | .metadata.name'
-        ```
+        `kubectl  get ingressnginxcontrollers.deckhouse.io -o json | jq '.items[] | select(..|strings | test("\\$geoip_(country_(code3|code|name)|area_code|city_continent_code|city_country_(code3|code|name)|dma_code|latitude|longitude|region|region_name|city|postal_code|org)([^_a-zA-Z0-9]|$)+")) | .metadata.name'`
 
         Use the following command to get the list of the Ingress objects that contain GeoIPv1 variables:
-
-        ```shell
-        kubectl  get ingress -A -o json | jq '.items[] | select(..|strings | test("\\$geoip_(country_(code3|code|name)|area_code|city_continent_code|city_country_(code3|code|name)|dma_code|latitude|longitude|region|region_name|city|postal_code|org)([^_a-zA-Z0-9]|$)+")) | "\(.metadata.namespace)/\(.metadata.name)"' | sort | uniq
-        ```
+        `kubectl  get ingress -A -o json | jq '.items[] | select(..|strings | test("\\$geoip_(country_(code3|code|name)|area_code|city_continent_code|city_country_(code3|code|name)|dma_code|latitude|longitude|region|region_name|city|postal_code|org)([^_a-zA-Z0-9]|$)+")) | "\(.metadata.namespace)/\(.metadata.name)"' | sort | uniq`
       summary: |
         Deprecated GeoIP version 1 is being used in the cluster.
       severity: "9"
@@ -2877,7 +2871,7 @@ alerts:
           * CPU overloads and throttling of containers
           * 500 errors on ingress
           * Replicas quantity of controllers (alerts about the insufficient amount of replicas of  Deployment, StatefulSet, DaemonSet)
-          * And [others](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/extended-monitoring/)
+          * And [others](modules/extended-monitoring/)
 
         To debug, execute the following commands:
           1. `kubectl -n d8-monitoring describe deploy extended-monitoring-exporter`
@@ -3645,6 +3639,21 @@ alerts:
         Count of unavailable replicas in StatefulSet {{$labels.namespace}}/{{$labels.statefulset}} above threshold.
       severity: "6"
       markupFormat: markdown
+    - name: KubernetesVersionEndOfLife
+      sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+      moduleUrl: 040-control-plane-manager
+      module: control-plane-manager
+      edition: ce
+      description: |-
+        Current kubernetes version "{{ $labels.k8s_version }}" support will be removed in the next Deckhouse release (1.58).
+
+        Please migrate to the next kubernetes version (at least 1.24) as soon as possible.
+
+        Check how to update the Kubernetes version in the cluster here - https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster
+      summary: |
+        Kubernetes version &quot;{{ $labels.k8s_version }}&quot; has reached End Of Life.
+      severity: "4"
+      markupFormat: markdown
     - name: KubeStateMetricsDown
       sourceFile: modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kube-state-metrics.yaml
       moduleUrl: 340-monitoring-kubernetes
@@ -4378,9 +4387,9 @@ alerts:
         To resolve the time synchronization issues:
 
         - Fix network errors:
-          - Ensure the upstream time synchronization servers defined in the [chrony configuration](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/chrony/configuration.html) are available.
+          - Ensure the upstream time synchronization servers defined in the [chrony configuration](modules/chrony/configuration.html) are available.
           - Eliminate large packet loss and excessive latency to upstream time synchronization servers.
-        - Modify the NTP servers list defined in the [chrony configuration](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/chrony/configuration.html).
+        - Modify the NTP servers list defined in the [chrony configuration](modules/chrony/configuration.html).
       summary: |
         Clock on the node {{$labels.node}} is drifting.
       severity: "5"
@@ -4424,9 +4433,9 @@ alerts:
 
         3. Resolve the time synchronization issues:
            - Fix network errors:
-             - Ensure the upstream time synchronization servers defined in the [chrony configuration](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/chrony/configuration.html) are available.
+             - Ensure the upstream time synchronization servers defined in the [chrony configuration](modules/chrony/configuration.html) are available.
              - Eliminate large packet loss and excessive latency to upstream time synchronization servers.
-           - Modify the NTP servers list defined in the [chrony configuration](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/chrony/configuration.html).
+           - Modify the NTP servers list defined in the [chrony configuration](modules/chrony/configuration.html).
       summary: |
         NTP daemon on the node {{$labels.node}} haven't synchronized time for too long.
       severity: "5"
@@ -4569,7 +4578,7 @@ alerts:
         ```shell
         kubectl -n {{ $labels.namespace }} exec -ti {{ $labels.pod_name }} -c prometheus -- df -PBG /prometheus
         ```
-        Consider increasing it https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html#how-to-expand-disk-size
+        Consider increasing [it](modules/prometheus/faq.html#how-to-expand-disk-size)
       summary: |
         Prometheus disk is over 95% used.
       severity: "4"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
In the cluster, the links from the documentation page about alerts were not relative and were forwarded to the website.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In a closed environment cluster, the links in the alert documentation would direct users to the "deckhouse.io" website. However, if there is no internet access, these links would remain inactive. This could pose a challenge for users who rely on external resources for additional information and troubleshooting. It's important for such environments to have comprehensive offline documentation or an internal mirror of the necessary resources to ensure that users can access critical information without relying on an internet connection. This setup ensures that even in restricted environments, users can effectively manage alerts and maintain system operations.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix 
summary: Changes the links in documentation about alerts from url to relative links
impact: The documentation will be available to users even if there is no access to the network.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
