### PR TITLE
[testing] Removing explicitly specified mc for cni in Static layout.

### DIFF
--- a/testing/cloud_layouts/Static/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Static/configuration.tpl.yaml
@@ -35,14 +35,6 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
-  name: cni-cilium
-spec:
-  version: 1
-  enabled: true
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
   name: global
 spec:
   enabled: true


### PR DESCRIPTION
## Description

Removing explicitly specified mc for CNI in Static layout. 
mc for CNI will be created automatically by dhctl.

An additional fix for #10517.

## Why do we need it, and what problem does it solve?

We need to check how `dhctl` selects and configures CNI if it has not been explicitly specified.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: testing
type: chore
summary: Removing explicitly specified mc for cni in Static layout.
impact_level: low
```

