### PR TITLE
[docs] Fix typos in DVP virtual machines documentation

### DIFF
--- a/docs/site/pages/virtualization-platform/documentation/user/resource-managment/VM.md
+++ b/docs/site/pages/virtualization-platform/documentation/user/resource-managment/VM.md
@@ -707,7 +707,7 @@ After deleting the virtual machine, `the vmip` resource will persist and can be 
 
 ```yaml
 spec:
-  virtualMachineIPAdressName: linux-vm-7prpx
+  virtualMachineIPAddressName: linux-vm-7prpx
 ```
 
 Even if the `vmip` resource is deleted, it remains leased to the current project/namespace for another 10 minutes, and there is an option to re-lease it upon request:

--- a/docs/site/pages/virtualization-platform/documentation/user/resource-managment/VM_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/user/resource-managment/VM_RU.md
@@ -42,7 +42,7 @@ spec:
         - nginx
         - qemu-guest-agent
       run_cmd:
-        - systemctl daemon-relaod
+        - systemctl daemon-reload
         - systemctl enable --now nginx.service
         - systemctl enable --now qemu-guest-agent.service
       ssh_pwauth: True
@@ -432,7 +432,7 @@ spec:
 
 ![virtualMachineAndPodAffinity](/images/virtualization-platform/placement-vm-affinity.ru.png)
 
-В этом примере виртуальная машина будет размещена, если будет такая возможность (так как используется метка `preffered`), только на узлах на которых присутствует виртуальная машина с меткой `server` и значением `database`.
+В этом примере виртуальная машина будет размещена, если будет такая возможность (так как используется метка `preferred`), только на узлах на которых присутствует виртуальная машина с меткой `server` и значением `database`.
 
 ### Избежание совместного размещения — AntiAffinity
 
@@ -659,7 +659,7 @@ linux-vm-7prpx   10.66.10.14   Attached   linux-vm   12h
 
 По умолчанию IP-адрес для виртуальной машины назначается автоматически, из подсетей, определенных в модуле, и закрепляется за ней до её удаления. После удаления виртуальной машины ресурс `vmip` также удаляется, но IP-адрес временно остается закрепленным за проектом/пространством имен и может быть повторно запрошен.
 
-## Как запросить требуемый ip-адрес?
+## Как запросить требуемый IP-адрес?
 
 Создайте ресурс `vmip`:
 
@@ -679,7 +679,7 @@ EOF
 
 ```yaml
 spec:
-  virtualMachineIPAdressName: linux-vm-custom-ip
+  virtualMachineIPAddressName: linux-vm-custom-ip
 ```
 
 ## Как сохранить присвоенный виртуальной машине IP-адрес?
@@ -708,7 +708,7 @@ d8 k patch vmip linux-vm-7prpx --type=merge --patch '{"metadata":{"ownerReferenc
 
 ```yaml
 spec:
-  virtualMachineIPAdressName: linux-vm-7prpx
+  virtualMachineIPAddressName: linux-vm-7prpx
 ```
 
 Даже если ресурс `vmip` будет удален, он остается арендованным для текущего проекта/пространства имен еще 10 минут и существует возможность вновь его занять по запросу:


### PR DESCRIPTION
## Description
Fix typos in DVP virtual machines documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix
summary: Fix typos in DVP virtual machines documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
