### PR TITLE
[deckhouse] cse 1.64 fix requirements

### DIFF
--- a/deckhouse-controller/pkg/controller/loader.go
+++ b/deckhouse-controller/pkg/controller/loader.go
@@ -125,7 +125,7 @@ func (dml *DeckhouseController) processModuleDefinition(def models.DeckhouseModu
 	}
 
 	// Load constrains
-	if err = extenders.AddConstraints(def.Name, def.Requirements); err != nil {
+	if err = extenders.AddConstraints(def.Name, def.GetRequirements()); err != nil {
 		return nil, err
 	}
 

--- a/deckhouse-controller/pkg/controller/models/definition.go
+++ b/deckhouse-controller/pkg/controller/models/definition.go
@@ -21,12 +21,27 @@ const (
 )
 
 type DeckhouseModuleDefinition struct {
-	Name         string            `yaml:"name"`
-	Weight       uint32            `yaml:"weight,omitempty"`
-	Tags         []string          `yaml:"tags"`
-	Stage        string            `yaml:"stage"`
-	Description  string            `yaml:"description"`
-	Requirements map[string]string `json:"requirements"`
+	Name         string                 `yaml:"name"`
+	Weight       uint32                 `yaml:"weight,omitempty"`
+	Tags         []string               `yaml:"tags"`
+	Stage        string                 `yaml:"stage"`
+	Description  string                 `yaml:"description"`
+	Requirements map[string]interface{} `json:"requirements"`
 
 	Path string `yaml:"-"`
+}
+
+func (d *DeckhouseModuleDefinition) GetRequirements() map[string]string {
+	requirements := make(map[string]string)
+	if len(d.Requirements) == 0 {
+		return requirements
+	}
+
+	for key, raw := range d.Requirements {
+		if value, ok := raw.(string); ok {
+			requirements[key] = value
+		}
+	}
+
+	return requirements
 }

--- a/deckhouse-controller/pkg/controller/models/definition.go
+++ b/deckhouse-controller/pkg/controller/models/definition.go
@@ -40,11 +40,11 @@ func (d *DeckhouseModuleDefinition) GetRequirements() map[string]string {
 	}
 
 	for key, raw := range d.Requirements {
-		if value, ok := raw.(string); ok {
-			requirements[key] = value
-		}
-		if value, ok := raw.(bool); ok {
-			requirements[key] = strconv.FormatBool(value)
+		switch v := raw.(type) {
+		case string:
+			requirements[key] = v
+		case bool:
+			requirements[key] = strconv.FormatBool(v)
 		}
 	}
 

--- a/deckhouse-controller/pkg/controller/models/definition.go
+++ b/deckhouse-controller/pkg/controller/models/definition.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package models
 
+import "strconv"
+
 const (
 	ModuleDefinitionFile = "module.yaml"
 )
@@ -40,6 +42,9 @@ func (d *DeckhouseModuleDefinition) GetRequirements() map[string]string {
 	for key, raw := range d.Requirements {
 		if value, ok := raw.(string); ok {
 			requirements[key] = value
+		}
+		if value, ok := raw.(bool); ok {
+			requirements[key] = strconv.FormatBool(value)
 		}
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -333,7 +333,7 @@ func (c *moduleSourceReconciler) createModuleRelease(ctx context.Context, ms *v1
 		},
 	}
 	if result.ModuleDefinition != nil {
-		rl.Spec.Requirements = result.ModuleDefinition.Requirements
+		rl.Spec.Requirements = result.ModuleDefinition.GetRequirements()
 	}
 
 	err := c.client.Create(ctx, rl)


### PR DESCRIPTION
## Description
It provides fix for the module requirements.

## Why do we need it, and what problem does it solve?
If a module has module dependency in requirements in the module def, it cannot be parsed, so the release is not created.  

## Why do we need it in the patch release (if we do)?
It needs for backward compatibility.

Module yaml:
```
name: test
weight: 901
requirements:
    kubernetes: ">= 1.26"
    modules:
        ingress-nginx: '> 1.0.0'
```

Module release:
```
root@dev-master-0:~# kubectl get mr test-v0.10.0 -oyaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleRelease
metadata:
  annotations:
    release.deckhouse.io/notified: "false"
  creationTimestamp: "2025-01-27T14:48:15Z"
  generation: 1
  labels:
    module: test
    modules.deckhouse.io/update-policy: alpha-auto
    release-checksum: 3fea2c3636591b1092127de869a3cae3
    source: test
  name: test-v0.10.0
  ownerReferences:
  - apiVersion: deckhouse.io/v1alpha1
    controller: true
    kind: ModuleSource
    name: test
    uid: b09fdc2a-8afa-4a73-a9b4-df419254f499
  resourceVersion: "285987318"
  uid: 04698877-39a4-412b-b284-41fe8599d083
spec:
  moduleName: test
  requirements:
    kubernetes: '>= 1.26'
  version: 0.10.0
  weight: 901
status:
  approved: false
  message: ""
  phase: Deployed
  pullDuration: 165.808816ms
  size: 5592678
  transitionTime: "2025-01-27T14:48:16Z"
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix module requirements parsing.
```

