### PR TITLE
[deckhouse] cse 1.67 fix requirements

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -194,7 +194,7 @@ func (r *reconciler) ensureModuleRelease(ctx context.Context, sourceUID types.UI
 			},
 		}
 		if meta.ModuleDefinition != nil {
-			release.Spec.Requirements = meta.ModuleDefinition.Requirements
+			release.Spec.Requirements = meta.ModuleDefinition.GetRequirements()
 		}
 
 		// if it's a first release for a Module, we have to install it immediately

--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -19,9 +19,9 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -200,7 +200,7 @@ func (l *Loader) processModuleDefinition(def *moduletypes.Definition) (*modulety
 	}
 
 	// load constrains
-	if err = extenders.AddConstraints(def.Name, def.Requirements); err != nil {
+	if err = extenders.AddConstraints(def.Name, def.GetRequirements()); err != nil {
 		return nil, fmt.Errorf("load constraints for the %q module: %w", def.Name, err)
 	}
 
@@ -309,7 +309,7 @@ func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, 
 						Description:  def.Description,
 						Stage:        def.Stage,
 						Source:       v1alpha1.ModuleSourceEmbedded,
-						Requirements: def.Requirements,
+						Requirements: def.GetRequirements(),
 					},
 				}
 				l.log.Debugf("the '%s' embedded module not found, create it", def.Name)
@@ -334,8 +334,8 @@ func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, 
 				needsUpdate = true
 			}
 
-			if !maps.Equal(module.Properties.Requirements, def.Requirements) {
-				module.Properties.Requirements = def.Requirements
+			if !reflect.DeepEqual(module.Properties.Requirements, def.Requirements) {
+				module.Properties.Requirements = def.GetRequirements()
 				needsUpdate = true
 			}
 

--- a/deckhouse-controller/pkg/controller/moduleloader/types/definition.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/types/definition.go
@@ -103,11 +103,11 @@ func (d *Definition) GetRequirements() map[string]string {
 	}
 
 	for key, raw := range d.Requirements {
-		if value, ok := raw.(string); ok {
-			requirements[key] = value
-		}
-		if value, ok := raw.(bool); ok {
-			requirements[key] = strconv.FormatBool(value)
+		switch v := raw.(type) {
+		case string:
+			requirements[key] = v
+		case bool:
+			requirements[key] = strconv.FormatBool(v)
 		}
 	}
 

--- a/deckhouse-controller/pkg/controller/moduleloader/types/definition.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/types/definition.go
@@ -32,12 +32,12 @@ const (
 )
 
 type Definition struct {
-	Name         string            `yaml:"name"`
-	Weight       uint32            `yaml:"weight,omitempty"`
-	Tags         []string          `yaml:"tags"`
-	Stage        string            `yaml:"stage"`
-	Description  string            `yaml:"description"`
-	Requirements map[string]string `json:"requirements"`
+	Name         string                 `yaml:"name"`
+	Weight       uint32                 `yaml:"weight,omitempty"`
+	Tags         []string               `yaml:"tags"`
+	Stage        string                 `yaml:"stage"`
+	Description  string                 `yaml:"description"`
+	Requirements map[string]interface{} `json:"requirements"`
 
 	DisableOptions DisableOptions `yaml:"disable"`
 
@@ -93,4 +93,19 @@ func (d *Definition) Validate(values addonutils.Values, logger *log.Logger) erro
 	}
 
 	return nil
+}
+
+func (d *Definition) GetRequirements() map[string]string {
+	requirements := make(map[string]string)
+	if len(d.Requirements) == 0 {
+		return requirements
+	}
+
+	for key, raw := range d.Requirements {
+		if value, ok := raw.(string); ok {
+			requirements[key] = value
+		}
+	}
+
+	return requirements
 }

--- a/deckhouse-controller/pkg/controller/moduleloader/types/definition.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/types/definition.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strconv"
 
 	addonmodules "github.com/flant/addon-operator/pkg/module_manager/models/modules"
 	addonutils "github.com/flant/addon-operator/pkg/utils"
@@ -104,6 +105,9 @@ func (d *Definition) GetRequirements() map[string]string {
 	for key, raw := range d.Requirements {
 		if value, ok := raw.(string); ok {
 			requirements[key] = value
+		}
+		if value, ok := raw.(bool); ok {
+			requirements[key] = strconv.FormatBool(value)
 		}
 	}
 


### PR DESCRIPTION
## Description
It provides fix for the module requirements.

## Why do we need it, and what problem does it solve?
If a module has module dependency in requirements in the module def, it cannot be parsed, so the release is not created.  

## Why do we need it in the patch release (if we do)?
It needs for backward compatibility.

Module yaml:
```
name: test
weight: 901
requirements:
    kubernetes: ">= 1.26"
    modules:
        ingress-nginx: '> 1.0.0'
```

Module release:
```
root@dev-master-0:~# kubectl get mr test-v0.10.0 -oyaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleRelease
metadata:
  annotations:
    release.deckhouse.io/notified: "false"
  creationTimestamp: "2025-01-27T14:48:15Z"
  generation: 1
  labels:
    module: test
    modules.deckhouse.io/update-policy: alpha-auto
    release-checksum: 3fea2c3636591b1092127de869a3cae3
    source: test
  name: test-v0.10.0
  ownerReferences:
  - apiVersion: deckhouse.io/v1alpha1
    controller: true
    kind: ModuleSource
    name: test
    uid: b09fdc2a-8afa-4a73-a9b4-df419254f499
  resourceVersion: "285987318"
  uid: 04698877-39a4-412b-b284-41fe8599d083
spec:
  moduleName: test
  requirements:
    kubernetes: '>= 1.26'
  version: 0.10.0
  weight: 901
status:
  approved: false
  message: ""
  phase: Deployed
  pullDuration: 165.808816ms
  size: 5592678
  transitionTime: "2025-01-27T14:48:16Z"
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix module requirements parsing.
```

