### PR TITLE
fix: vsphere e2e bootsrap template

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -1,5 +1,5 @@
 warnings-only:
-  - images
+- images
 linters-settings:
   probes:
     probes-excludes:

--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -1,5 +1,5 @@
 warnings-only:
-- images
+  - images
 linters-settings:
   probes:
     probes-excludes:

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -336,7 +336,7 @@ function prepare_environment() {
         envsubst '${DECKHOUSE_DOCKERCFG} ${PREFIX} ${DEV_BRANCH} ${KUBERNETES_VERSION} ${CRI} ${VSPHERE_PASSWORD} ${VSPHERE_BASE_DOMAIN} ${MASTERS_COUNT}' \
         <"$cwd/configuration.tpl.yaml" >"$cwd/configuration.yaml"
 
-    ssh_user="ubuntu"
+    ssh_user="redos"
     ;;
 
 "VCD")

--- a/testing/cloud_layouts/vSphere/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/vSphere/Standard/configuration.tpl.yaml
@@ -37,7 +37,7 @@ masterNodeGroup:
   instanceClass:
     numCPUs: 4
     memory: 8192
-    template: vm-teamplates/ubuntu-24.04-cloudinit
+    template: vm-teamplates/redos8-cloudinit
     mainNetwork: DPortGroup-lab-vms
     datastore: vsan-spb-5-datastore
     rootDiskSize: 50

--- a/testing/cloud_layouts/vSphere/Standard/resources.yaml
+++ b/testing/cloud_layouts/vSphere/Standard/resources.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   numCPUs: 4
   memory: 8192
-  rootDiskSize: 20
+  rootDiskSize: 40
   mainNetwork: DPortGroup-lab-vms
   datastore: SPB-5/vsan-spb-5-datastore
 ---


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
The current template is unstable
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Change bootstrap template e2e vsphere
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not related to release
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Change bootstrap template e2e vsphere.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
