### PR TITLE
[deckhouse-controller] added check for enabled modules before getting debug logs

### DIFF
--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -136,7 +136,7 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "mcm-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules node-manager -o json | jq -r '.items[] | select(.status.phase == "Ready") | "kubectl -n d8-cloud-instance-manager logs -l app=machine-controller-manager --tail=3000 -c controller"' | bash`},
+			Args: []string{"-c", `kubectl get modules node-manager -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n d8-cloud-instance-manager logs -l app=machine-controller-manager --tail=3000 -c controller"' | bash`},
 		},
 		{
 			File: "ccm-logs.txt",
@@ -146,32 +146,32 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "cluster-autoscaler-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules node-manager -o json | jq -r '.items[] | select(.status.phase == "Ready") | "kubectl -n d8-cloud-instance-manager logs -l app=cluster-autoscaler --tail=3000 -c cluster-autoscaler"' | bash`},
+			Args: []string{"-c", `kubectl get modules node-manager -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n d8-cloud-instance-manager logs -l app=cluster-autoscaler --tail=3000 -c cluster-autoscaler"' | bash`},
 		},
 		{
 			File: "vpa-admission-controller-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules vertical-pod-autoscaler -o json | jq -r '.items[] | select(.status.phase == "Ready") | "kubectl -n kube-system logs -l app=vpa-admission-controller --tail=3000 -c admission-controller"' | bash`},
+			Args: []string{"-c", `kubectl get modules vertical-pod-autoscaler -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n kube-system logs -l app=vpa-admission-controller --tail=3000 -c admission-controller"' | bash`},
 		},
 		{
 			File: "vpa-recommender-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules vertical-pod-autoscaler -o json | jq -r '.items[] | select(.status.phase == "Ready") | "kubectl -n kube-system logs -l app=vpa-recommender --tail=3000 -c recommender"' | bash`},
+			Args: []string{"-c", `kubectl get modules vertical-pod-autoscaler -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n kube-system logs -l app=vpa-recommender --tail=3000 -c recommender"' | bash`},
 		},
 		{
 			File: "vpa-updater-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules vertical-pod-autoscaler -o json | jq -r '.items[] | select(.status.phase == "Ready") | "kubectl -n kube-system logs -l app=vpa-updater --tail=3000 -c updater"' | bash`},
+			Args: []string{"-c", `kubectl get modules vertical-pod-autoscaler -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n kube-system logs -l app=vpa-updater --tail=3000 -c updater"' | bash`},
 		},
 		{
 			File: "prometheus-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules prometheus -o json | jq -r '.items[] | select(.status.phase == "Ready") | "kubectl -n d8-monitoring logs -l prometheus=main --tail=3000 -c prometheus"' | bash`},
+			Args: []string{"-c", `kubectl get modules prometheus -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n d8-monitoring logs -l prometheus=main --tail=3000 -c prometheus"' | bash`},
 		},
 		{
 			File: "terraform-check.json",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl exec deploy/terraform-state-exporter -- dhctl terraform check --logger-type json -o json | jq -c '.terraform_plan[]?.variables.providerClusterConfiguration.value.provider = "REDACTED"'`},
+			Args: []string{"-c", `kubectl get modules terraform-manager -o json | jq -r 'select(.status.phase == "Ready") | "kubectl exec deploy/terraform-state-exporter -- dhctl terraform check --logger-type json -o json" | bash | jq -c '.terraform_plan[]?.variables.providerClusterConfiguration.value.provider = "REDACTED"'`},
 		},
 		{
 			File: "alerts.json",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -179,7 +179,7 @@ func createTarball() *bytes.Buffer {
 			Args: []string{"-c", `kubectl get clusteralerts.deckhouse.io -o json | jq '.items[]'`},
 		},
 		{
-			File: "pods.txt",
+			File: "bad-pods.txt",
 			Cmd:  "bash",
 			Args: []string{"-c", `kubectl get pod -A -owide | grep -Pv '\s+([1-9]+[\d]*)\/\1\s+' | grep -v 'Completed\|Evicted' | grep -E "^(d8-|kube-system)" || true`},
 		},

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -171,7 +171,7 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "terraform-check.json",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules terraform-manager -o json | jq -r 'select(.status.phase == "Ready") | "kubectl exec deploy/terraform-state-exporter -- dhctl terraform check --logger-type json -o json" | bash | jq -c '.terraform_plan[]?.variables.providerClusterConfiguration.value.provider = "REDACTED"'`},
+			Args: []string{"-c", `kubectl get modules terraform-manager -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n d8-system exec deploy/terraform-state-exporter -- dhctl terraform check --logger-type json -o json"' | bash | jq -c '.terraform_plan[]?.variables.providerClusterConfiguration.value.provider = "REDACTED"'`},
 		},
 		{
 			File: "alerts.json",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -141,32 +141,32 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "ccm-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", "kubectl -n $(kubectl get ns -o custom-columns=NAME:metadata.name | grep d8-cloud-provider) logs -l app=cloud-controller-manager --tail=3000"},
+			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.properties.state == "Enabled" and (.metadata.name | test("^cloud-provider"))) | "kubectl -n d8-"+.metadata.name+" logs -l app=cloud-controller-manager --tail=3000"' | bash`},
 		},
 		{
 			File: "cluster-autoscaler-logs.txt",
-			Cmd:  "kubectl",
-			Args: []string{"-n", "d8-cloud-instance-manager", "logs", "-l", "app=cluster-autoscaler", "--tail", "3000", "-c", "cluster-autoscaler"},
+			Cmd:  "bash",
+			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.properties.state == "Enabled" and .metadata.name == "node-manager") | "kubectl -n d8-cloud-instance-manager logs -l app=cluster-autoscaler --tail=3000 -c cluster-autoscaler"' | bash`},
 		},
 		{
 			File: "vpa-admission-controller-logs.txt",
-			Cmd:  "kubectl",
-			Args: []string{"-n", "kube-system", "logs", "-l", "app=vpa-admission-controller", "--tail", "3000", "-c", "admission-controller"},
+			Cmd:  "bash",
+			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.properties.state == "Enabled" and .metadata.name == "vertical-pod-autoscaler") | "kubectl -n kube-system logs -l app=vpa-admission-controller --tail=3000 -c admission-controller"' | bash`},
 		},
 		{
 			File: "vpa-recommender-logs.txt",
-			Cmd:  "kubectl",
-			Args: []string{"-n", "kube-system", "logs", "-l", "app=vpa-recommender", "--tail", "3000", "-c", "recommender"},
+			Cmd:  "bash",
+			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.properties.state == "Enabled" and .metadata.name == "vertical-pod-autoscaler") | "kubectl -n kube-system logs -l app=vpa-recommender --tail=3000 -c recommender"' | bash`},
 		},
 		{
 			File: "vpa-updater-logs.txt",
-			Cmd:  "kubectl",
-			Args: []string{"-n", "kube-system", "logs", "-l", "app=vpa-updater", "--tail", "3000", "-c", "updater"},
+			Cmd:  "bash",
+			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.properties.state == "Enabled" and .metadata.name == "vertical-pod-autoscaler") | "kubectl -n kube-system logs -l app=vpa-updater --tail=3000 -c updater"' | bash`},
 		},
 		{
 			File: "prometheus-logs.txt",
-			Cmd:  "kubectl",
-			Args: []string{"-n", "d8-monitoring", "logs", "-l", "prometheus=main", "--tail", "3000", "-c", "prometheus"},
+			Cmd:  "bash",
+			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.properties.state == "Enabled" and .metadata.name == "prometheus") | "kubectl -n d8-monitoring logs -l prometheus=main --tail=3000 -c prometheus"' | bash`},
 		},
 		{
 			File: "terraform-check.json",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -135,38 +135,38 @@ func createTarball() *bytes.Buffer {
 		},
 		{
 			File: "mcm-logs.txt",
-			Cmd:  "kubectl",
-			Args: []string{"-n", "d8-cloud-instance-manager", "logs", "-l", "app=machine-controller-manager", "--tail", "3000", "-c", "controller"},
+			Cmd:  "bash",
+			Args: []string{"-c", `kubectl get modules node-manager -o json | jq -r '.items[] | select(.status.phase == "Ready") | "kubectl -n d8-cloud-instance-manager logs -l app=machine-controller-manager --tail=3000 -c controller"' | bash`},
 		},
 		{
 			File: "ccm-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.properties.state == "Enabled" and (.metadata.name | test("^cloud-provider"))) | "kubectl -n d8-"+.metadata.name+" logs -l app=cloud-controller-manager --tail=3000"' | bash`},
+			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.status.phase == "Ready" and (.metadata.name | test("^cloud-provider"))) | "kubectl -n d8-"+.metadata.name+" logs -l app=cloud-controller-manager --tail=3000"' | bash`},
 		},
 		{
 			File: "cluster-autoscaler-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.properties.state == "Enabled" and .metadata.name == "node-manager") | "kubectl -n d8-cloud-instance-manager logs -l app=cluster-autoscaler --tail=3000 -c cluster-autoscaler"' | bash`},
+			Args: []string{"-c", `kubectl get modules node-manager -o json | jq -r '.items[] | select(.status.phase == "Ready") | "kubectl -n d8-cloud-instance-manager logs -l app=cluster-autoscaler --tail=3000 -c cluster-autoscaler"' | bash`},
 		},
 		{
 			File: "vpa-admission-controller-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.properties.state == "Enabled" and .metadata.name == "vertical-pod-autoscaler") | "kubectl -n kube-system logs -l app=vpa-admission-controller --tail=3000 -c admission-controller"' | bash`},
+			Args: []string{"-c", `kubectl get modules vertical-pod-autoscaler -o json | jq -r '.items[] | select(.status.phase == "Ready") | "kubectl -n kube-system logs -l app=vpa-admission-controller --tail=3000 -c admission-controller"' | bash`},
 		},
 		{
 			File: "vpa-recommender-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.properties.state == "Enabled" and .metadata.name == "vertical-pod-autoscaler") | "kubectl -n kube-system logs -l app=vpa-recommender --tail=3000 -c recommender"' | bash`},
+			Args: []string{"-c", `kubectl get modules vertical-pod-autoscaler -o json | jq -r '.items[] | select(.status.phase == "Ready") | "kubectl -n kube-system logs -l app=vpa-recommender --tail=3000 -c recommender"' | bash`},
 		},
 		{
 			File: "vpa-updater-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.properties.state == "Enabled" and .metadata.name == "vertical-pod-autoscaler") | "kubectl -n kube-system logs -l app=vpa-updater --tail=3000 -c updater"' | bash`},
+			Args: []string{"-c", `kubectl get modules vertical-pod-autoscaler -o json | jq -r '.items[] | select(.status.phase == "Ready") | "kubectl -n kube-system logs -l app=vpa-updater --tail=3000 -c updater"' | bash`},
 		},
 		{
 			File: "prometheus-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules -o json | jq -r '.items[] | select(.properties.state == "Enabled" and .metadata.name == "prometheus") | "kubectl -n d8-monitoring logs -l prometheus=main --tail=3000 -c prometheus"' | bash`},
+			Args: []string{"-c", `kubectl get modules prometheus -o json | jq -r '.items[] | select(.status.phase == "Ready") | "kubectl -n d8-monitoring logs -l prometheus=main --tail=3000 -c prometheus"' | bash`},
 		},
 		{
 			File: "terraform-check.json",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -145,8 +145,8 @@ func createTarball() *bytes.Buffer {
 		},
 		{
 			File: "cluster-autoscaler-logs.txt",
-			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules node-manager -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n d8-cloud-instance-manager logs -l app=cluster-autoscaler --tail=3000 -c cluster-autoscaler"' | bash`},
+			Cmd:  "kubectl",
+			Args: []string{"-n", "d8-cloud-instance-manager", "logs", "-l", "app=cluster-autoscaler", "--tail=3000", "-c", "cluster-autoscaler", "--ignore-errors=true"},
 		},
 		{
 			File: "vpa-admission-controller-logs.txt",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -135,8 +135,8 @@ func createTarball() *bytes.Buffer {
 		},
 		{
 			File: "mcm-logs.txt",
-			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules node-manager -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n d8-cloud-instance-manager logs -l app=machine-controller-manager --tail=3000 -c controller"' | bash`},
+			Cmd:  "kubectl",
+			Args: []string{"-n", "d8-cloud-instance-manager", "logs", "-l", "app=machine-controller-manager", "--tail=3000", "-c", "controller", "--ignore-errors=true"},
 		},
 		{
 			File: "ccm-logs.txt",
@@ -150,23 +150,23 @@ func createTarball() *bytes.Buffer {
 		},
 		{
 			File: "vpa-admission-controller-logs.txt",
-			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules vertical-pod-autoscaler -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n kube-system logs -l app=vpa-admission-controller --tail=3000 -c admission-controller"' | bash`},
+			Cmd:  "kubectl",
+			Args: []string{"-n", "kube-system", "logs", "-l", "app=vpa-admission-controller", "--tail=3000", "-c", "admission-controller", "--ignore-errors=true"},
 		},
 		{
 			File: "vpa-recommender-logs.txt",
-			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules vertical-pod-autoscaler -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n kube-system logs -l app=vpa-recommender --tail=3000 -c recommender"' | bash`},
+			Cmd:  "kubectl",
+			Args: []string{"-n", "kube-system", "logs", "-l", "app=vpa-recommender", "--tail=3000", "-c", "recommender", "--ignore-errors=true"},
 		},
 		{
 			File: "vpa-updater-logs.txt",
-			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules vertical-pod-autoscaler -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n kube-system logs -l app=vpa-updater --tail=3000 -c updater"' | bash`},
+			Cmd:  "kubectl",
+			Args: []string{"-n", "kube-system", "logs", "-l", "app=vpa-updater", "--tail=3000", "-c", "updater", "--ignore-errors=true"},
 		},
 		{
 			File: "prometheus-logs.txt",
-			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules prometheus -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n d8-monitoring logs -l prometheus=main --tail=3000 -c prometheus"' | bash`},
+			Cmd:  "kubectl",
+			Args: []string{"-n", "d8-monitoring", "logs", "-l", "prometheus=main", "--tail=3000", "-c", "prometheus", "--ignore-errors=true"},
 		},
 		{
 			File: "terraform-check.json",
@@ -181,7 +181,7 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "pods.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get pod -A -owide | grep -Pv '\s+([1-9]+[\d]*)\/\1\s+' | grep -v 'Completed\|Evicted' | grep -E "^(d8-|kube-system)"`},
+			Args: []string{"-c", `kubectl get pod -A -owide | grep -Pv '\s+([1-9]+[\d]*)\/\1\s+' | grep -v 'Completed\|Evicted' | grep -E "^(d8-|kube-system)" || true`},
 		},
 		{
 			File: "cluster-authorization-rules.json",


### PR DESCRIPTION
## Description
Added a check that the module is enabled before getting its logs.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Closed https://github.com/deckhouse/deckhouse/issues/11652 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: added check for enabled modules before getting debug logs
impact_level: low 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
