### PR TITLE
[docs] Fix yaml example in metallb module

### DIFF
--- a/ee/se/modules/380-metallb/docs/EXAMPLES.md
+++ b/ee/se/modules/380-metallb/docs/EXAMPLES.md
@@ -80,7 +80,14 @@ Below is a small step-by-step guide on how to enable the metallb module, create 
          - effect: NoExecute
            key: dedicated.deckhouse.io
            operator: Equal
-           value: metallb
+           value: frontend
+       nodeSelector:
+         node-role.deckhouse.io/metallb: ""
+       tolerations:
+       - effect: NoExecute
+         key: dedicated.deckhouse.io
+         operator: Equal
+         value: frontend    
    ```
 
 1. Deploy the application (nginx) and Service on port `8080`:

--- a/ee/se/modules/380-metallb/docs/EXAMPLES_RU.md
+++ b/ee/se/modules/380-metallb/docs/EXAMPLES_RU.md
@@ -82,6 +82,13 @@ Metallb можно использовать в статических класт
            key: dedicated.deckhouse.io
            operator: Equal
            value: frontend
+       nodeSelector:
+         node-role.deckhouse.io/metallb: ""
+       tolerations:
+       - effect: NoExecute
+         key: dedicated.deckhouse.io
+         operator: Equal
+         value: frontend    
    ```
 
 1. Установите приложение (nginx) и опубликуйте на порту `8080`:


### PR DESCRIPTION
## Description
Fix yaml example in metallb module.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix
summary: Fix yaml example in metallb module.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
