### PR TITLE
[deckhouse] enrich deprecated update policy alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3764,9 +3764,12 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        The '{{ $labels.moduleName }}' module has a deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
+        The '{{ $labels.moduleName }}' module matched by deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
 
-        Please specify the proper update policy in the module configuration to continue get updates.
+        Please specify the proper update policy in the module config to continue get updates:
+        ```
+        kubectl patch mc '{{ $labels.moduleName }}' --type=merge -p '{"spec": {"updatePolicy": '{{ $labels.updatePolicy }}'}}'
+        ```
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.
       severity: "4"

--- a/global-hooks/migrate/migrate_update_policy.go
+++ b/global-hooks/migrate/migrate_update_policy.go
@@ -56,10 +56,11 @@ func mupFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	if mup.Spec.ModuleReleaseSelector.LabelSelector == nil {
 		return nil, nil
 	}
-	return &filteredMup{LabelSelector: mup.Spec.ModuleReleaseSelector.LabelSelector}, nil
+	return &filteredMup{Name: mup.Name, LabelSelector: mup.Spec.ModuleReleaseSelector.LabelSelector}, nil
 }
 
 type filteredMup struct {
+	Name          string
 	LabelSelector *metav1.LabelSelector
 }
 
@@ -112,7 +113,8 @@ func fireMupAlerts(input *go_hook.HookInput) error {
 
 			if selector.Matches(labelsSet) {
 				input.MetricsCollector.Set("d8_deprecated_update_policy", 1.0, map[string]string{
-					"moduleName": module.Name,
+					"moduleName":   module.Name,
+					"updatePolicy": policy.Name,
 				}, metrics.WithGroup("d8_update_policy"))
 				continue
 			}

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -200,8 +200,11 @@
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       description: |
-        The '{{ $labels.moduleName }}' module has a deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
+        The '{{ $labels.moduleName }}' module matched by deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
 
-        Please specify the proper update policy in the module configuration to continue get updates.
+        Please specify the proper update policy in the module config to continue get updates:
+        ```
+        kubectl patch mc '{{ $labels.moduleName }}' --type=merge -p '{"spec": {"updatePolicy": '{{ $labels.updatePolicy }}'}}'
+        ```
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.


### PR DESCRIPTION
## Description
It enriches deprecated update policy alert with a command to set the update policy to the module config

## Why do we need it, and what problem does it solve?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
