### PR TITLE
[extended-monitoring] Fix x509-certificate-exporter metrics port

### DIFF
--- a/modules/340-extended-monitoring/templates/x509-certificate-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/x509-certificate-exporter/deployment.yaml
@@ -103,7 +103,7 @@ spec:
             excludePaths:
             - /healthz
             upstreams:
-            - upstream: http://127.0.0.1:9000/
+            - upstream: http://127.0.0.1:9793/
               path: /
               authorization:
                 resourceAttributes:

--- a/modules/340-extended-monitoring/templates/x509-certificate-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/x509-certificate-exporter/deployment.yaml
@@ -78,20 +78,17 @@ spec:
         - --max-cache-duration=3600s
         - --kube-api-rate-limit-qps=3
         - --kube-api-rate-limit-burst=5
-        - --listen-address=:9793
-        ports:
-        - name: metrics
-          containerPort: 9793
+        - --listen-address=127.0.0.1:9793
       - name: kube-rbac-proxy
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         args:
-        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):9001"
+        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):9793"
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
         ports:
-        - containerPort: 9001
+        - containerPort: 9793
           name: https-metrics
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS

--- a/modules/340-extended-monitoring/templates/x509-certificate-exporter/podmonitor.yaml
+++ b/modules/340-extended-monitoring/templates/x509-certificate-exporter/podmonitor.yaml
@@ -10,9 +10,13 @@ metadata:
 spec:
   jobLabel: app
   podMetricsEndpoints:
-  - port: metrics
-    interval: 60s
-    scheme: http
+  - port: https-metrics
+    scheme: https
+    bearerTokenSecret:
+      name: "prometheus-token"
+      key: "token"
+    tlsConfig:
+      insecureSkipVerify: true
     honorLabels: true
     scrapeTimeout: {{ include "helm_lib_prometheus_target_scrape_timeout_seconds" (list . 25) }}
   selector:


### PR DESCRIPTION
## Description

Switch x509-certificate-exporter podMonitor port from exporter container to kube-rbac-proxy.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: fix
summary: Minor x509-certificate-exporter improvements
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
