### PR TITLE
[docs] Fixed reference to SSHCredentials in StaticInstance description

### DIFF
--- a/modules/040-node-manager/crds/doc-ru-staticinstance.yaml
+++ b/modules/040-node-manager/crds/doc-ru-staticinstance.yaml
@@ -21,7 +21,7 @@ spec:
                     IP-адрес сервера (виртуальной машины) для подключения.
                 credentialsRef:
                   description: |
-                    Ссылка на ресурс [SSHCredentials](cr.html#sshcredentials).
+                    Ссылка на ресурс [SSHCredentials](../../../kubernetes-platform/documentation/v1/modules/node-manager/cr.html#sshcredentials).
                   properties:
                     apiVersion:
                       description: Версия API ресурса.


### PR DESCRIPTION
## Description
Fixed link to SSHCredentials in StaticInstance description

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
section: docs
type: fix
summary: Fix update policy docs.
impact_level: low
