### PR TITLE
[prometheus] Grafana v8 deprecation hook

### DIFF
--- a/modules/300-prometheus/hooks/grafana_v8_cleanup.go
+++ b/modules/300-prometheus/hooks/grafana_v8_cleanup.go
@@ -33,7 +33,7 @@ type GrafanaV8Resource struct {
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	Queue: "/modules/prometheus/grafana_v8_deprecation",
+	Queue: "/modules/prometheus/grafana_v8_cleanup",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "grafana-v8-deployments",

--- a/modules/300-prometheus/hooks/grafana_v8_deprecation.go
+++ b/modules/300-prometheus/hooks/grafana_v8_deprecation.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type GrafanaV8Resource struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Metadata   struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/prometheus/grafana_v8_deprecation",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "grafana-v8-deployments",
+			ApiVersion: "apps/v1",
+			Kind:       "Deployment",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-monitoring"},
+				},
+			},
+			NameSelector: &types.NameSelector{MatchNames: []string{
+				"grafana",
+				"grafana-v8-dex-authenticator",
+			}},
+			FilterFunc: filterResources,
+		},
+		{
+			Name:       "grafana-v8-services",
+			ApiVersion: "v1",
+			Kind:       "Service",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-monitoring"},
+				},
+			},
+			NameSelector: &types.NameSelector{MatchNames: []string{
+				"grafana",
+				"grafana-v8-dex-authenticator",
+			}},
+			FilterFunc: filterResources,
+		},
+		{
+			Name:       "grafana-v8-ingresses",
+			ApiVersion: "networking.k8s.io/v1",
+			Kind:       "Ingress",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-monitoring"},
+				},
+			},
+			NameSelector: &types.NameSelector{MatchNames: []string{
+				"grafana",
+				"grafana-v8-dex-authenticator",
+				"grafana-v8-dex-authenticator-sign-out",
+			}},
+			FilterFunc: filterResources,
+		},
+	},
+}, grafanaV8ResourcesHandler)
+
+func filterResources(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var resource GrafanaV8Resource
+
+	err := sdk.FromUnstructured(obj, &resource)
+	if err != nil {
+		return nil, err
+	}
+
+	resource.APIVersion = obj.GetAPIVersion()
+	resource.Metadata.Name = obj.GetName()
+	resource.Metadata.Namespace = obj.GetNamespace()
+	resource.Kind = obj.GetKind()
+
+	return resource, nil
+}
+
+func grafanaV8ResourcesHandler(input *go_hook.HookInput) error {
+	deployments := input.Snapshots["grafana-v8-deployments"]
+	services := input.Snapshots["grafana-v8-services"]
+	ingresses := input.Snapshots["grafana-v8-ingresses"]
+
+	for _, snap := range [][]go_hook.FilterResult{deployments, services, ingresses} {
+		for _, s := range snap {
+			resource := s.(GrafanaV8Resource)
+			input.PatchCollector.Delete(resource.APIVersion, resource.Kind, resource.Metadata.Namespace, resource.Metadata.Name)
+		}
+	}
+
+	return nil
+}

--- a/modules/300-prometheus/hooks/grafana_v8_deprecation.go
+++ b/modules/300-prometheus/hooks/grafana_v8_deprecation.go
@@ -81,6 +81,34 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			}},
 			FilterFunc: filterResources,
 		},
+		{
+			Name:       "grafana-v8-pdb",
+			ApiVersion: "policy/v1",
+			Kind:       "PodDisruptionBudget",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-monitoring"},
+				},
+			},
+			NameSelector: &types.NameSelector{MatchNames: []string{
+				"grafana-v8-dex-authenticator",
+			}},
+			FilterFunc: filterResources,
+		},
+		{
+			Name:       "grafana-v8-dexauth",
+			ApiVersion: "deckhouse.io/v1",
+			Kind:       "DexAuthenticator",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-monitoring"},
+				},
+			},
+			NameSelector: &types.NameSelector{MatchNames: []string{
+				"grafana-v8",
+			}},
+			FilterFunc: filterResources,
+		},
 	},
 }, grafanaV8ResourcesHandler)
 
@@ -104,8 +132,10 @@ func grafanaV8ResourcesHandler(input *go_hook.HookInput) error {
 	deployments := input.Snapshots["grafana-v8-deployments"]
 	services := input.Snapshots["grafana-v8-services"]
 	ingresses := input.Snapshots["grafana-v8-ingresses"]
+	pdb := input.Snapshots["grafana-v8-ingresses"]
+	dexAuth := input.Snapshots["grafana-v8-ingresses"]
 
-	for _, snap := range [][]go_hook.FilterResult{deployments, services, ingresses} {
+	for _, snap := range [][]go_hook.FilterResult{deployments, services, ingresses, pdb, dexAuth} {
 		for _, s := range snap {
 			resource := s.(GrafanaV8Resource)
 			input.PatchCollector.Delete(resource.APIVersion, resource.Kind, resource.Metadata.Namespace, resource.Metadata.Name)


### PR DESCRIPTION
## Description
This hook cleanup old unused Grafana V8 resources. The following Kubernetes resources in the d8-monitoring namespace will be delete:

Deployments:
- grafana
- grafana-v8-dex-authenticator

Services:
- grafana
- grafana-v8-dex-authenticator

Ingresses:
- grafana
- grafana-v8-dex-authenticator
- grafana-v8-dex-authenticator-sign-out

#### Testing
This hook was tested manually, as unit tests are not functioning correctly due to FieldSelector/NameSelector adding incorrect resources to the snapshots (known bug), causing test failures.

## Why do we need it, and what problem does it solve?
Cleanup unused resources.

## Why do we need it in the patch release (if we do)?
- 
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: chore
summary: Cleanup after grafana v8 deprecation
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
