### PR TITLE
[cni] Reducing the severity of alerts regarding incorrect CNI configurations.

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -571,7 +571,7 @@ alerts:
         To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
       summary: |
         The settings from the secret d8-cni-configuration and the ModuleConfig contradict each other.
-      severity: "3"
+      severity: "5"
       markupFormat: markdown
     - name: D8CNIMisconfigured
       sourceFile: modules/035-cni-flannel/monitoring/prometheus-rules/cni-checks.yaml
@@ -584,7 +584,7 @@ alerts:
         To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
       summary: |
         The settings from the secret d8-cni-configuration and the ModuleConfig contradict each other.
-      severity: "3"
+      severity: "5"
       markupFormat: markdown
     - name: D8CNIMisconfigured
       sourceFile: modules/035-cni-simple-bridge/monitoring/prometheus-rules/cni-checks.yaml
@@ -597,7 +597,7 @@ alerts:
         To do this, please run the following command: `kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml`.
       summary: |
         The settings from the secret d8-cni-configuration and the ModuleConfig contradict each other.
-      severity: "3"
+      severity: "5"
       markupFormat: markdown
     - name: D8ControlPlaneManagerPodNotRunning
       sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml

--- a/modules/021-cni-cilium/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/cni-checks.yaml
@@ -4,7 +4,7 @@
       expr: max(cniMisconfigured{}) by(cni, module) == 1
       for: 5m
       labels:
-        severity_level: "3"
+        severity_level: "5"
         tier: cluster
       annotations:
         plk_markup_format: "markdown"

--- a/modules/035-cni-flannel/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/035-cni-flannel/monitoring/prometheus-rules/cni-checks.yaml
@@ -4,7 +4,7 @@
       expr: max(cniMisconfigured{}) by(cni, module) == 1
       for: 5m
       labels:
-        severity_level: "3"
+        severity_level: "5"
         tier: cluster
       annotations:
         plk_markup_format: "markdown"

--- a/modules/035-cni-simple-bridge/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/035-cni-simple-bridge/monitoring/prometheus-rules/cni-checks.yaml
@@ -4,7 +4,7 @@
       expr: max(cniMisconfigured{}) by(cni, module) == 1
       for: 5m
       labels:
-        severity_level: "3"
+        severity_level: "5"
         tier: cluster
       annotations:
         plk_markup_format: "markdown"


### PR DESCRIPTION
## Description

Reducing the severity of alerts regarding incorrect CNI configurations.

## Why do we need it, and what problem does it solve?

The previously configured severity for the CNI misconfiguration alert was too high.

## Why do we need it in the patch release (if we do)?

A high-priority alert has been triggered in a significant number of clusters, which may cause confusion

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-flannel
type: chore
summary: The severity of alerts regarding incorrect CNI configurations has been reduced.
impact_level: low
```
```changes
section: cni-cilium
type: chore
summary: The severity of alerts regarding incorrect CNI configurations has been reduced.
impact_level: low
```
```changes
section: cni-simple-bridge
type: chore
summary: The severity of alerts regarding incorrect CNI configurations has been reduced.
impact_level: low
```

