### PR TITLE
[caps] Rewrite `StaticInstance` adoption

### DIFF
--- a/candi/bashible/common-steps/all/098_update_node_annotations.sh.tpl
+++ b/candi/bashible/common-steps/all/098_update_node_annotations.sh.tpl
@@ -1,0 +1,27 @@
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function kubectl_exec() {
+  kubectl --request-timeout 60s --kubeconfig=/etc/kubernetes/kubelet.conf ${@}
+}
+
+{{- if hasKey .nodeGroup "staticInstances" }}
+if [[ -f /var/lib/bashible/node-spec-provider-id ]]; then
+  PROVIDER_ID="$( kubectl_exec get no "$D8_NODE_HOSTNAME" -o json | jq -r '.spec.providerID' )"
+
+  if [[ "${PROVIDER_ID}" == "static://" ]]; then
+    kubectl_exec annotate node "${D8_NODE_HOSTNAME}" node.deckhouse.io/provider-id="$(cat /var/lib/bashible/node-spec-provider-id)"
+  fi
+fi
+{{- end }}

--- a/modules/040-node-manager/images/capi-controller-manager/patches/002-search-node-by-provider-id-annotation.patch
+++ b/modules/040-node-manager/images/capi-controller-manager/patches/002-search-node-by-provider-id-annotation.patch
@@ -1,0 +1,47 @@
+Subject: [PATCH] Add support for searching nodes using the `node.deckhouse.io/provider-id` annotation
+---
+Index: internal/controllers/machine/machine_controller_noderef.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/internal/controllers/machine/machine_controller_noderef.go b/internal/controllers/machine/machine_controller_noderef.go
+--- a/internal/controllers/machine/machine_controller_noderef.go	(revision 6dbd0ecc76f0b1996d351d5bef8730f4768bf4f8)
++++ b/internal/controllers/machine/machine_controller_noderef.go	(date 1743591323436)
+@@ -236,6 +236,14 @@
+ 			}
+ 
+ 			for _, node := range nl.Items {
++				if node.Spec.ProviderID == "static://" {
++					providerID := node.Annotations["node.deckhouse.io/provider-id"]
++
++					if providerID != "" {
++						node.Spec.ProviderID = providerID
++					}
++				}
++
+ 				if providerID == node.Spec.ProviderID {
+ 					return &node, nil
+ 				}
+Index: api/v1beta1/index/node.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/api/v1beta1/index/node.go b/api/v1beta1/index/node.go
+--- a/api/v1beta1/index/node.go	(revision 6dbd0ecc76f0b1996d351d5bef8730f4768bf4f8)
++++ b/api/v1beta1/index/node.go	(date 1743591323428)
+@@ -40,5 +40,13 @@
+ 		return nil
+ 	}
+ 
++	if node.Spec.ProviderID == "static://" {
++		providerID := node.Annotations["node.deckhouse.io/provider-id"]
++
++		if providerID != "" {
++			node.Spec.ProviderID = providerID
++		}
++	}
++
+ 	return []string{node.Spec.ProviderID}
+ }

--- a/modules/040-node-manager/images/capi-controller-manager/patches/README.md
+++ b/modules/040-node-manager/images/capi-controller-manager/patches/README.md
@@ -3,3 +3,7 @@
 ### 001-go-mod.patch
 
 Bump libraries versions to resolve CVE
+
+### 002-search-node-by-provider-id-annotation.patch
+
+Add support for searching nodes using the `node.deckhouse.io/provider-id` annotation

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/staticinstance_annotations.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/staticinstance_annotations.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+const SkipBootstrapPhaseAnnotation = "static.node.deckhouse.io/skip-bootstrap-phase"

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/staticinstance_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/staticinstance_webhook.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"errors"
+	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -68,6 +69,11 @@ func (r *StaticInstance) ValidateUpdate(old runtime.Object) (admission.Warnings,
 	oldStaticInstance := old.(*StaticInstance)
 	if oldStaticInstance.Spec.Address != r.Spec.Address {
 		return nil, field.Forbidden(field.NewPath("spec", "address"), "StaticInstance address is immutable")
+	}
+
+	_, ok := r.Annotations[SkipBootstrapPhaseAnnotation]
+	if ok && r.Status.CurrentStatus.Phase != StaticInstanceStatusCurrentStatusPhasePending {
+		return nil, field.Forbidden(field.NewPath("metadata", "annotations"), fmt.Sprintf("Annotation '%s' can be set only when StaticInstance is in Pending phase", SkipBootstrapPhaseAnnotation))
 	}
 
 	return nil, nil

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/client/adopt.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/client/adopt.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha1"
+	"caps-controller-manager/internal/providerid"
+	"caps-controller-manager/internal/scope"
+	"caps-controller-manager/internal/ssh"
+)
+
+func (c *Client) AdoptStaticInstance(ctx context.Context, instanceScope *scope.InstanceScope) (ctrl.Result, error) {
+	instanceScope.Logger.Info(
+		fmt.Sprintf("adopting node for StaticInstance with '%s' annotation", deckhousev1.SkipBootstrapPhaseAnnotation),
+	)
+
+	if instanceScope.MachineScope.StaticMachine.Spec.ProviderID == "" {
+		providerID := providerid.GenerateProviderID(instanceScope.Instance.Name)
+
+		instanceScope.MachineScope.StaticMachine.Spec.ProviderID = providerID
+
+		err := instanceScope.MachineScope.Patch(ctx)
+		if err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to set StaticMachine provider id to '%s'", providerID)
+		}
+	}
+
+	instanceScope.Instance.Status.MachineRef = &corev1.ObjectReference{
+		APIVersion: instanceScope.MachineScope.StaticMachine.APIVersion,
+		Kind:       instanceScope.MachineScope.StaticMachine.Kind,
+		Namespace:  instanceScope.MachineScope.StaticMachine.Namespace,
+		Name:       instanceScope.MachineScope.StaticMachine.Name,
+		UID:        instanceScope.MachineScope.StaticMachine.UID,
+	}
+
+	err := instanceScope.Patch(ctx)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to patch StaticInstance MachineRef")
+	}
+
+	ok, err := c.adoptStaticInstance(instanceScope)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to adopt StaticInstance")
+	}
+	if !ok {
+		return ctrl.Result{}, nil
+	}
+
+	delete(instanceScope.Instance.Annotations, deckhousev1.SkipBootstrapPhaseAnnotation)
+
+	err = c.setStaticInstancePhaseToRunning(ctx, instanceScope)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to set StaticInstance phase to Running")
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (c *Client) adoptStaticInstance(instanceScope *scope.InstanceScope) (bool, error) {
+	done := c.adoptTaskManager.spawn(taskID(instanceScope.MachineScope.StaticMachine.Spec.ProviderID), func() bool {
+		data, err := ssh.ExecSSHCommandToString(instanceScope,
+			fmt.Sprintf("mkdir -p /var/lib/bashible && echo '%s' > /var/lib/bashible/node-spec-provider-id && echo '%s' > /var/lib/bashible/machine-name",
+				instanceScope.MachineScope.StaticMachine.Spec.ProviderID, instanceScope.MachineScope.Machine.Name))
+		if err != nil {
+			scanner := bufio.NewScanner(strings.NewReader(data))
+			for scanner.Scan() {
+				str := scanner.Text()
+				if strings.Contains(str, "debug1: Exit status 2") {
+					return true
+				}
+			}
+			// If Node reboots, the ssh connection will close, and we will get an error.
+			instanceScope.Logger.Error(err, "Failed to adopt StaticInstance: failed to exec ssh command")
+			return false
+		}
+
+		return true
+	})
+	if done == nil || !*done {
+		instanceScope.Logger.Info("Adopting is not finished yet, waiting...")
+		return false, nil
+	}
+
+	c.recorder.SendNormalEvent(instanceScope.Instance, instanceScope.MachineScope.StaticMachine.Labels["node-group"], "AdoptionScriptSucceeded", "Adoption script executed successfully")
+
+	return true, nil
+}

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/client/bootstrap.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/client/bootstrap.go
@@ -238,9 +238,9 @@ func (c *Client) setStaticInstancePhaseToBootstrapping(ctx context.Context, inst
 
 // setStaticInstancePhaseToRunning finishes the bootstrap process by waiting for bootstrapping Node to appear and patching StaticMachine and StaticInstance.
 func (c *Client) setStaticInstancePhaseToRunning(ctx context.Context, instanceScope *scope.InstanceScope) error {
-	node, err := waitForNode(ctx, instanceScope)
+	node, err := getNodeByProviderID(ctx, instanceScope)
 	if err != nil {
-		return errors.Wrap(err, "failed to wait for Node to appear")
+		return errors.Wrap(err, "failed to get Node by provider id")
 	}
 
 	c.recorder.SendNormalEvent(instanceScope.Instance, instanceScope.MachineScope.StaticMachine.Labels["node-group"], "NodeBootstrappingSucceeded", "Node successfully bootstrapped")
@@ -275,8 +275,8 @@ func (c *Client) setStaticInstancePhaseToRunning(ctx context.Context, instanceSc
 	return nil
 }
 
-// waitForNode waits for the node to appear and checks that it has 'node.deckhouse.io/configuration-checksum' annotation.
-func waitForNode(ctx context.Context, instanceScope *scope.InstanceScope) (*corev1.Node, error) {
+// getNodeByProviderID returns the Node with the provider id from the StaticMachine's spec.
+func getNodeByProviderID(ctx context.Context, instanceScope *scope.InstanceScope) (*corev1.Node, error) {
 	nodes := &corev1.NodeList{}
 	nodeSelector := fields.OneTermEqualSelector("spec.providerID", string(instanceScope.MachineScope.StaticMachine.Spec.ProviderID))
 

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/client/client.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/client/client.go
@@ -30,6 +30,7 @@ type Client struct {
 	checkTaskManager     *taskManager
 	bootstrapTaskManager *taskManager
 	cleanupTaskManager   *taskManager
+	adoptTaskManager     *taskManager
 	tcpCheckTaskManager  *taskManager
 	tcpCheckRateLimiter  workqueue.RateLimiter
 
@@ -42,6 +43,7 @@ func NewClient(recorder *event.Recorder) *Client {
 		checkTaskManager:     newTaskManager(),
 		bootstrapTaskManager: newTaskManager(),
 		cleanupTaskManager:   newTaskManager(),
+		adoptTaskManager:     newTaskManager(),
 		tcpCheckTaskManager:  newTaskManager(),
 		tcpCheckRateLimiter:  workqueue.NewItemExponentialFailureRateLimiter(250*time.Millisecond, time.Minute),
 		recorder:             recorder,

--- a/testing/cloud_layouts/Static/resources.tpl.yaml
+++ b/testing/cloud_layouts/Static/resources.tpl.yaml
@@ -2,6 +2,47 @@
 apiVersion: deckhouse.io/v1
 kind: NodeGroup
 metadata:
+  name: master
+spec:
+  nodeTemplate:
+    labels:
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+    taints:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+  nodeType: Static
+  staticInstances:
+    count: 1
+    labelSelector:
+      matchLabels:
+        role: master
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SSHCredentials
+metadata:
+  name: caps-master
+spec:
+  privateSSHKey: '${b64_SSH_KEY}'
+  user: '${MASTER_USER}'
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: master
+  annotations:
+    static.node.deckhouse.io/skip-bootstrap-phase: ""
+  labels:
+    role: master
+spec:
+  address: '${MASTER_IP}'
+  credentialsRef:
+    kind: SSHCredentials
+    name: caps-master
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
   name: system
 spec:
   nodeType: Static


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

To fix static node adoption, the following changes have been made:  
- Added a `bashible` step that assigns the `node.deckhouse.io/provider-id` annotation to nodes with a `static://` provider ID
- Implemented special logic in the `CAPS` controller for adopting static nodes
- Applied a patch to the Cluster API Controller to enable node searches using the `node.deckhouse.io/provider-id` annotation

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In the previous implementation, a `StaticInstance` with the `static.node.deckhouse.io/skip-bootstrap-phase` annotation was cleaned up and moved to a failed state.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Added a `bashible` step that assigns the `node.deckhouse.io/provider-id` annotation to nodes with a `static://` provider ID
impact_level: default
---
section: node-manager
type: fix
summary: Rewrite static Node adoption for `CAPS`
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
