### PR TITLE
Trivy import reports to defectDojo

### DIFF
--- a/.github/ci_templates/cve_tests.yaml
+++ b/.github/ci_templates/cve_tests.yaml
@@ -1,0 +1,79 @@
+{!{ define "cve_tests_base_images" }!}
+# <template: cve_tests_base_images>
+- name: Run base images CVE tests on ${{env.TAG}}
+  env:
+    TRIVY_TOKEN: ${{secrets.FOX_ACCESS_TOKEN}}
+    DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
+    DEFECTDOJO_HOST: ${{secrets.DEFECTDOJO_HOST}}
+    DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
+    TRIVY_PROJECT_ID: "2181"
+    TRIVY_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2 
+    TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-java-db:1
+    TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-bdu:1
+  run: |
+    echo "⚓️ 🏎 Running CVE tests on ${TAG}..."
+    make cve-base-images
+# </template: cve_tests_base_images>
+{!{- end -}!}
+
+{!{ define "cve_tests_deckhouse_images" }!}
+# <template: cve_tests_deckhouse_images>
+- name: Run Deckhouse images CVE tests on ${{env.TAG}}
+  env:
+    TRIVY_TOKEN: ${{secrets.FOX_ACCESS_TOKEN}}
+    DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
+    DEFECTDOJO_HOST: ${{secrets.DEFECTDOJO_HOST}}
+    DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
+    TRIVY_PROJECT_ID: "2181"
+    TRIVY_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2 
+    TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-java-db:1
+    TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-bdu:1
+  run: |
+    echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
+    make cve-report
+# </template: cve_tests_deckhouse_images>
+{!{- end -}!}
+
+{!{ define "cve_tests_upload_reports_artifacts" }!}
+# <template: cve_tests_upload_reports_artifacts>
+- name: Archive report artifacts
+  if: success()
+  run: |
+    tar -zcvf out/trivy_json_reports.tar.gz out/json
+- name: Create fail artifact
+  if: failure()
+  run: |
+    echo "Trivy tests for ${TAG} have failed." > "out/${TAG}_test-failed.txt"
+- name: Upload report artifacts
+  if: success()
+  uses: {!{ index (ds "actions") "actions/upload-artifact" }!}
+  with:
+    name: cve-reports
+    path: |
+      out/trivy_json_reports.tar.gz
+- name: Upload fail artifact
+  if: failure()
+  uses: {!{ index (ds "actions") "actions/upload-artifact" }!}
+  with:
+    name: cve-reports
+    path: |
+      out/${{ env.TAG }}_test-failed.txt
+# </template: cve_tests_upload_reports_artifacts>
+{!{- end -}!}
+
+{!{ define "defectdojo_dev_tests_rotator" }!}
+# <template: defectdojo_dev_tests_rotator>
+- name: Set up Python
+  uses: actions/setup-python@v4
+  with:
+    python-version: ${{ env.PYTHON_VERSION }}
+- name: DefectDojo rotate dev tests
+  env:
+    DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
+    DEFECTDOJO_HOST: ${{secrets.DEFECTDOJO_HOST}}
+    DEFECTDOJO_DEV_TESTS_ROTATION_DAYS: 7
+  shell: bash
+  run: |
+    python .github/scripts/python/defectdojo_dev_tests_rotator.py
+# </template: defectdojo_dev_tests_rotator>
+{!{- end -}!}

--- a/.github/scripts/python/defectdojo_dev_tests_rotator.py
+++ b/.github/scripts/python/defectdojo_dev_tests_rotator.py
@@ -32,7 +32,7 @@ current_date=datetime.now().date()
 
 def get_old_tests():
     engage_id = requests.get(defectdojo_api_url+"engagements", headers=headers, params={"name": defectdojo_deckhouse_images_engagement}).json()["results"][0]["id"]
-    old_dev_tests = requests.get(defectdojo_api_url+"tests", headers=headers, params={"engagement": engage_id, "not_tag": "main"}).json()["results"]
+    old_dev_tests = requests.get(defectdojo_api_url+"tests", headers=headers, params={"engagement": engage_id, "limit": "10000", "not_tag": "main"}).json()["results"]
     return old_dev_tests
 
 def remove_old_tests(old_dev_tests):

--- a/.github/scripts/python/defectdojo_dev_tests_rotator.py
+++ b/.github/scripts/python/defectdojo_dev_tests_rotator.py
@@ -1,5 +1,5 @@
 
-# Copyright 2024 Flant JSC
+# Copyright 2025 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/scripts/python/defectdojo_dev_tests_rotator.py
+++ b/.github/scripts/python/defectdojo_dev_tests_rotator.py
@@ -1,0 +1,41 @@
+
+import os
+import requests
+from datetime import datetime
+
+# Env vars
+defectdojo_host = os.getenv('DEFECTDOJO_HOST')
+defectdojo_token = os.getenv('DEFECTDOJO_API_TOKEN')
+days_to_keep = os.getenv('DEFECTDOJO_DEV_TESTS_ROTATION_DAYS', 7)
+
+# Static vars
+defectdojo_proto = "https://"
+defectdojo_api_url = defectdojo_proto+defectdojo_host+"/api/v2/"
+defectdojo_deckhouse_images_engagement = "CVE Test: Deckhouse Images"
+headers = {"accept": "application/json", "Content-Type": "application/json", "Authorization": "Token "+defectdojo_token}
+current_date=datetime.now().date()
+
+
+def get_old_tests():
+    engage_id = requests.get(defectdojo_api_url+"engagements", headers=headers, params={"name": defectdojo_deckhouse_images_engagement}).json()["results"][0]["id"]
+    old_dev_tests = requests.get(defectdojo_api_url+"tests", headers=headers, params={"engagement": engage_id, "not_tag": "main"}).json()["results"]
+    return old_dev_tests
+
+def remove_old_tests(old_dev_tests):
+    old_tests_counter = 0
+    for test in old_dev_tests:
+        if (current_date - datetime.fromisoformat(test["created"]).date()).days > days_to_keep:
+            deleted_result = requests.delete(defectdojo_api_url+"tests/"+str(test["id"])+"/", headers=headers)
+            if deleted_result.status_code == 204:
+                old_tests_counter += 1
+                print("Test: "+str(test["id"])+" "+str(test["title"])+" was successfully removed")
+            else:
+                print("Test: "+str(test["id"])+" "+str(test["title"])+" was NOT REMOVED, response code: "+str(deleted_result.status_code))
+    if old_tests_counter > 0:
+        print("Dev tests were removed: "+str(old_tests_counter))
+    else:
+        print("Nothing to remove as there are no dev tests older than "+str(days_to_keep)+" days")
+
+
+if __name__ == "__main__":
+    remove_old_tests(get_old_tests())

--- a/.github/scripts/python/defectdojo_dev_tests_rotator.py
+++ b/.github/scripts/python/defectdojo_dev_tests_rotator.py
@@ -1,4 +1,18 @@
 
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import requests
 from datetime import datetime

--- a/.github/workflow_templates/cve-dev-test-rotator.yml
+++ b/.github/workflow_templates/cve-dev-test-rotator.yml
@@ -1,0 +1,40 @@
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{!{- $workflowName              := "Weekly DefectDojo Dev Tests Rotator" -}!}
+{!{- $enableWorkflowOnTestRepos := true -}!}
+
+
+{!{- $ctx := . }!}
+
+name: '{!{ $workflowName }!}'
+on:
+  schedule:
+  - cron: '0 22 * * 0'
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: '3.12'
+
+# Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  defectdojo-rotate-dev-tests:
+    runs-on: ubuntu-latest
+    steps:
+{!{ tmpl.Exec "defectdojo_dev_tests_rotator"      | strings.Indent 6 }!}
+

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }} || ( ${{ github.event.label.name != 'security/cve' }} && contains(github.event.pull_request.labels.*.name, 'security/cve'))
+    if: contains(github.event.pull_request.labels.*.name, 'security/cve')
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -1,0 +1,45 @@
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{!{- $workflowName              := "Trivy CVE scan on PR" -}!}
+{!{- $enableWorkflowOnTestRepos := true -}!}
+
+
+{!{- $ctx := . }!}
+
+name: '{!{ $workflowName }!}'
+on:
+  pull_request:
+    types: [ labeled ]
+
+# Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test_cve_report_main:
+    name: Trivy scan dev images
+    if: ${{ github.event.label.name == 'cve/trivy' }}
+    runs-on: [ self-hosted, regular, selectel ]
+    env:
+      IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"
+      TAG: pr${{ github.event.number }}
+    steps:
+{!{ tmpl.Exec "checkout_full_step"           $ctx | strings.Indent 6 }!}
+{!{ tmpl.Exec "login_dev_registry_step"      $ctx | strings.Indent 6 }!}
+{!{ tmpl.Exec "link_bin_step"                     | strings.Indent 6 }!}
+{!{ tmpl.Exec "cve_tests_deckhouse_images"        | strings.Indent 6 }!}
+{!{ tmpl.Exec "cve_tests_upload_reports_artifacts"| strings.Indent 6 }!}
+{!{ tmpl.Exec "unlink_bin_step"                   | strings.Indent 6 }!}

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -23,7 +23,6 @@ on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
 
-
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }} || contains(github.event.pull_request.labels.*.name, 'security/cve')
+    if: ${{ github.event.label.name == 'security/cve' }} || ( ${{ github.event.label.name != 'security/cve' }} && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }} || ( github.event.pull_request.labeled == false && contains(github.event.pull_request.labels.*.name, 'security/cve'))
+    if: ${{ github.event.label.name == 'security/cve' }} || ( github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'cve/trivy' }}
+    if: ${{ github.event.label.name == 'security/cve' }}
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }}
+    if: contains(github.event.pull_request.labels.*.name, 'security/cve')
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -21,7 +21,7 @@
 name: '{!{ $workflowName }!}'
 on:
   pull_request:
-    types: [opened, reopened, labeled, unlabeled, synchronize]
+    types: [opened, reopened, labeled, synchronize]
 
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -32,7 +32,9 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }} || ( ${{ github.event.action != 'labeled' }} && contains(github.event.pull_request.labels.*.name, 'security/cve'))
+    if: |
+      github.event.label.name == 'security/cve' ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -21,7 +21,7 @@
 name: '{!{ $workflowName }!}'
 on:
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -19,7 +19,10 @@
 {!{- $ctx := . }!}
 
 name: '{!{ $workflowName }!}'
-on: pull_request
+on:
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
+
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
 concurrency:
@@ -29,7 +32,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: contains(github.event.pull_request.labels.*.name, 'security/cve')
+    if: ${{ github.event.label.name == 'security/cve' }} || contains(github.event.pull_request.labels.*.name, 'security/cve')
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -19,9 +19,7 @@
 {!{- $ctx := . }!}
 
 name: '{!{ $workflowName }!}'
-on:
-  pull_request:
-    types: [ labeled ]
+on: pull_request
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
 concurrency:

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }} || ( github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
+    if: ${{ github.event.label.name == 'security/cve' }} || ( ${{ github.event.action != 'labeled' }} && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }} || ( github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
+    if: ${{ github.event.label.name == 'security/cve' }} || ( github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: contains(github.event.pull_request.labels.*.name, 'security/cve')
+    if: ${{ github.event.label.name == 'security/cve' }} || ( github.event.pull_request.labeled == false && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflow_templates/cve-weekly.yml
+++ b/.github/workflow_templates/cve-weekly.yml
@@ -17,77 +17,15 @@
 {!{- $testAllReleaseChannels    := false -}!}
 
 
-{!{ define "cve_tests" }!}
-# <template: cve_tests>
-- name: Run base images CVE tests on ${{env.TAG}}
-  env:
-    TRIVY_TOKEN: ${{secrets.FOX_ACCESS_TOKEN}}
-    DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
-    TRIVY_PROJECT_ID: "2181"
-    TRIVY_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2 
-    TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-java-db:1
-    TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-bdu:1
-  run: |
-    echo "⚓️ 🏎 Running CVE tests on ${TAG}..."
-    make cve-base-images
-- name: Run Deckhouse images CVE tests on ${{env.TAG}}
-  env:
-    TRIVY_TOKEN: ${{secrets.FOX_ACCESS_TOKEN}}
-    DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
-    TRIVY_PROJECT_ID: "2181"
-    TRIVY_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2 
-    TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-java-db:1
-    TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-bdu:1
-  run: |
-    echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
-    make cve-report
-- name: Send report
-  if: success()
-  env:
-    LOOP_TOKEN: ${{secrets.LOOP_CVE_REPORTS_SEND_TOKEN}}
-    LOOP_CHANNEL_ID: ${{secrets.LOOP_CVE_CHANEL_ID}}
-  run: |
-    bash ./.github/scripts/send-trivy-report.sh
-- name: Send fail report
-  if: failure()
-  env:
-    LOOP_TOKEN: ${{secrets.LOOP_CVE_REPORTS_SEND_TOKEN}}
-    LOOP_CHANNEL_ID: ${{secrets.LOOP_CVE_CHANEL_ID}}
-  run: |
-    bash ./.github/scripts/send-trivy-report.sh --failure
-- name: Rename report artifacts
-  if: success()
-  run: |
-    mv "out/base-images.html" "out/${TAG}_base-images.html"
-    mv "out/d8-images.html" "out/${TAG}_d8-images.html"
-- name: Create fail artifact
-  if: failure()
-  run: |
-    echo "Trivy tests for ${TAG} have failed." > "out/${TAG}_test-failed.txt"
-- name: Upload report artifacts
-  if: success()
-  uses: {!{ index (ds "actions") "actions/upload-artifact" }!}
-  with:
-    name: cve-reports
-    path: |
-      out/${{ env.TAG }}_base-images.html
-      out/${{ env.TAG }}_d8-images.html
-- name: Upload fail artifact
-  if: failure()
-  uses: {!{ index (ds "actions") "actions/upload-artifact" }!}
-  with:
-    name: cve-reports
-    path: |
-      out/${{ env.TAG }}_test-failed.txt
-# </template: cve_tests>
-{!{- end -}!}
-
 {!{- $ctx := . }!}
 
 name: '{!{ $workflowName }!}'
 on:
+  push:
+    branches:
+      - main
   schedule:
-  - cron: '0 23 * * 5'
+  - cron: '0 23 * * 0,3'
   workflow_dispatch:
 
 concurrency:
@@ -128,7 +66,9 @@ jobs:
 {!{ tmpl.Exec "login_dev_registry_step"      $ctx | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_readonly_registry_step" $ctx | strings.Indent 6 }!}
 {!{ tmpl.Exec "link_bin_step"                     | strings.Indent 6 }!}
-{!{ tmpl.Exec "cve_tests"                         | strings.Indent 6 }!}
+{!{ tmpl.Exec "cve_tests_base_images"             | strings.Indent 6 }!}
+{!{ tmpl.Exec "cve_tests_deckhouse_images"        | strings.Indent 6 }!}
+{!{ tmpl.Exec "cve_tests_upload_reports_artifacts"| strings.Indent 6 }!}
 {!{ tmpl.Exec "unlink_bin_step"                   | strings.Indent 6 }!}
 
 {!{ if $testAllReleaseChannels }!}

--- a/.github/workflow_templates/cve-weekly.yml
+++ b/.github/workflow_templates/cve-weekly.yml
@@ -27,15 +27,13 @@ on:
   schedule:
   - cron: '0 23 * * 0,3'
   workflow_dispatch:
+    inputs:
+      release_branch:
+        description: 'release branch name, example: release-1.68'
+        required: false
 
 concurrency:
   group: cve-daily
-
-inputs:
-  release_branch:
-    description: 'release branch name, example: release-1.68'
-    required: false
-    default: ''
 
 jobs:
   skip_tests_repos:

--- a/.github/workflow_templates/cve-weekly.yml
+++ b/.github/workflow_templates/cve-weekly.yml
@@ -31,6 +31,12 @@ on:
 concurrency:
   group: cve-daily
 
+inputs:
+  release_branch:
+    description: 'release branch name, example: release-1.68'
+    required: false
+    default: ''
+
 jobs:
   skip_tests_repos:
     name: Skip tests repos
@@ -60,7 +66,7 @@ jobs:
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"
-      TAG: "main"
+      TAG: ${{ github.event.inputs.release_branch || 'main' }}
     steps:
 {!{ tmpl.Exec "checkout_full_step"           $ctx | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_dev_registry_step"      $ctx | strings.Indent 6 }!}

--- a/.github/workflows/cve-dev-test-rotator.yml
+++ b/.github/workflows/cve-dev-test-rotator.yml
@@ -1,0 +1,52 @@
+#
+# THIS FILE IS GENERATED, PLEASE DO NOT EDIT.
+#
+
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Weekly DefectDojo Dev Tests Rotator'
+on:
+  schedule:
+  - cron: '0 22 * * 0'
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: '3.12'
+
+# Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  defectdojo-rotate-dev-tests:
+    runs-on: ubuntu-latest
+    steps:
+
+      # <template: defectdojo_dev_tests_rotator>
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: DefectDojo rotate dev tests
+        env:
+          DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
+          DEFECTDOJO_HOST: ${{secrets.DEFECTDOJO_HOST}}
+          DEFECTDOJO_DEV_TESTS_ROTATION_DAYS: 7
+        shell: bash
+        run: |
+          python .github/scripts/python/defectdojo_dev_tests_rotator.py
+      # </template: defectdojo_dev_tests_rotator>
+

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -17,7 +17,10 @@
 # limitations under the License.
 
 name: 'Trivy CVE scan on PR'
-on: pull_request
+on:
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
+
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
 concurrency:
@@ -27,7 +30,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: contains(github.event.pull_request.labels.*.name, 'security/cve')
+    if: ${{ github.event.label.name == 'security/cve' }} || contains(github.event.pull_request.labels.*.name, 'security/cve')
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: contains(github.event.pull_request.labels.*.name, 'security/cve')
+    if: ${{ github.event.label.name == 'security/cve' }} || ( github.event.pull_request.labeled == false && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -1,0 +1,120 @@
+#
+# THIS FILE IS GENERATED, PLEASE DO NOT EDIT.
+#
+
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Trivy CVE scan on PR'
+on:
+  pull_request:
+    types: [ labeled ]
+
+# Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test_cve_report_main:
+    name: Trivy scan dev images
+    if: ${{ github.event.label.name == 'cve/trivy' }}
+    runs-on: [ self-hosted, regular, selectel ]
+    env:
+      IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"
+      TAG: pr${{ github.event.number }}
+    steps:
+
+      # <template: checkout_full_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+        with:
+          fetch-depth: 0
+      # </template: checkout_full_step>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "has_credentials=true" >> $GITHUB_OUTPUT
+            echo "web_registry_path=${{secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/deckhouse/site" >> $GITHUB_OUTPUT
+          fi
+      - name: Login to dev registry
+        uses: docker/login-action@v2.1.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: link_bin_step>
+      - name: Link binary cache
+        id: link_bin_step
+        run: |
+          ln -s ~/deckhouse-bin-cache bin
+      # </template: link_bin_step>
+
+      # <template: cve_tests_deckhouse_images>
+      - name: Run Deckhouse images CVE tests on ${{env.TAG}}
+        env:
+          TRIVY_TOKEN: ${{secrets.FOX_ACCESS_TOKEN}}
+          DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
+          DEFECTDOJO_HOST: ${{secrets.DEFECTDOJO_HOST}}
+          DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
+          TRIVY_PROJECT_ID: "2181"
+          TRIVY_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2 
+          TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-java-db:1
+          TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-bdu:1
+        run: |
+          echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
+          make cve-report
+      # </template: cve_tests_deckhouse_images>
+
+      # <template: cve_tests_upload_reports_artifacts>
+      - name: Archive report artifacts
+        if: success()
+        run: |
+          tar -zcvf out/trivy_json_reports.tar.gz out/json
+      - name: Create fail artifact
+        if: failure()
+        run: |
+          echo "Trivy tests for ${TAG} have failed." > "out/${TAG}_test-failed.txt"
+      - name: Upload report artifacts
+        if: success()
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: cve-reports
+          path: |
+            out/trivy_json_reports.tar.gz
+      - name: Upload fail artifact
+        if: failure()
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: cve-reports
+          path: |
+            out/${{ env.TAG }}_test-failed.txt
+      # </template: cve_tests_upload_reports_artifacts>
+
+      # <template: unlink_bin_step>
+      - name: Unlink binary cache
+        id: unlink_bin_step
+        if: always()
+        run: |
+          rm bin
+      # </template: unlink_bin_step>

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }}
+    if: contains(github.event.pull_request.labels.*.name, 'security/cve')
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -19,7 +19,7 @@
 name: 'Trivy CVE scan on PR'
 on:
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }} || ( github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
+    if: ${{ github.event.label.name == 'security/cve' }} || ( ${{ github.event.action != 'labeled' }} && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }} || ( github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
+    if: ${{ github.event.label.name == 'security/cve' }} || ( github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }} || ( github.event.pull_request.labeled == false && contains(github.event.pull_request.labels.*.name, 'security/cve'))
+    if: ${{ github.event.label.name == 'security/cve' }} || ( github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }} || contains(github.event.pull_request.labels.*.name, 'security/cve')
+    if: ${{ github.event.label.name == 'security/cve' }} || ( ${{ github.event.label.name != 'security/cve' }} && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }} || ( ${{ github.event.label.name != 'security/cve' }} && contains(github.event.pull_request.labels.*.name, 'security/cve'))
+    if: contains(github.event.pull_request.labels.*.name, 'security/cve')
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -17,9 +17,7 @@
 # limitations under the License.
 
 name: 'Trivy CVE scan on PR'
-on:
-  pull_request:
-    types: [ labeled ]
+on: pull_request
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
 concurrency:

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -19,7 +19,7 @@
 name: 'Trivy CVE scan on PR'
 on:
   pull_request:
-    types: [opened, reopened, labeled, unlabeled, synchronize]
+    types: [opened, reopened, labeled, synchronize]
 
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -30,7 +30,9 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'security/cve' }} || ( ${{ github.event.action != 'labeled' }} && contains(github.event.pull_request.labels.*.name, 'security/cve'))
+    if: |
+      github.event.label.name == 'security/cve' ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ github.event.label.name == 'cve/trivy' }}
+    if: ${{ github.event.label.name == 'security/cve' }}
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -21,7 +21,6 @@ on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
 
-
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -18,8 +18,11 @@
 
 name: 'Weekly CVE tests'
 on:
+  push:
+    branches:
+      - main
   schedule:
-  - cron: '0 23 * * 5'
+  - cron: '0 23 * * 0,3'
   workflow_dispatch:
 
 concurrency:
@@ -116,10 +119,12 @@ jobs:
           ln -s ~/deckhouse-bin-cache bin
       # </template: link_bin_step>
 
-      # <template: cve_tests>
+      # <template: cve_tests_base_images>
       - name: Run base images CVE tests on ${{env.TAG}}
         env:
           TRIVY_TOKEN: ${{secrets.FOX_ACCESS_TOKEN}}
+          DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
+          DEFECTDOJO_HOST: ${{secrets.DEFECTDOJO_HOST}}
           DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
           TRIVY_PROJECT_ID: "2181"
           TRIVY_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2 
@@ -128,9 +133,14 @@ jobs:
         run: |
           echo "⚓️ 🏎 Running CVE tests on ${TAG}..."
           make cve-base-images
+      # </template: cve_tests_base_images>
+
+      # <template: cve_tests_deckhouse_images>
       - name: Run Deckhouse images CVE tests on ${{env.TAG}}
         env:
           TRIVY_TOKEN: ${{secrets.FOX_ACCESS_TOKEN}}
+          DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
+          DEFECTDOJO_HOST: ${{secrets.DEFECTDOJO_HOST}}
           DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
           TRIVY_PROJECT_ID: "2181"
           TRIVY_DB_URL: ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-db:2 
@@ -139,25 +149,13 @@ jobs:
         run: |
           echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
           make cve-report
-      - name: Send report
-        if: success()
-        env:
-          LOOP_TOKEN: ${{secrets.LOOP_CVE_REPORTS_SEND_TOKEN}}
-          LOOP_CHANNEL_ID: ${{secrets.LOOP_CVE_CHANEL_ID}}
-        run: |
-          bash ./.github/scripts/send-trivy-report.sh
-      - name: Send fail report
-        if: failure()
-        env:
-          LOOP_TOKEN: ${{secrets.LOOP_CVE_REPORTS_SEND_TOKEN}}
-          LOOP_CHANNEL_ID: ${{secrets.LOOP_CVE_CHANEL_ID}}
-        run: |
-          bash ./.github/scripts/send-trivy-report.sh --failure
-      - name: Rename report artifacts
+      # </template: cve_tests_deckhouse_images>
+
+      # <template: cve_tests_upload_reports_artifacts>
+      - name: Archive report artifacts
         if: success()
         run: |
-          mv "out/base-images.html" "out/${TAG}_base-images.html"
-          mv "out/d8-images.html" "out/${TAG}_d8-images.html"
+          tar -zcvf out/trivy_json_reports.tar.gz out/json
       - name: Create fail artifact
         if: failure()
         run: |
@@ -168,8 +166,7 @@ jobs:
         with:
           name: cve-reports
           path: |
-            out/${{ env.TAG }}_base-images.html
-            out/${{ env.TAG }}_d8-images.html
+            out/trivy_json_reports.tar.gz
       - name: Upload fail artifact
         if: failure()
         uses: actions/upload-artifact@v4.4.0
@@ -177,7 +174,7 @@ jobs:
           name: cve-reports
           path: |
             out/${{ env.TAG }}_test-failed.txt
-      # </template: cve_tests>
+      # </template: cve_tests_upload_reports_artifacts>
 
       # <template: unlink_bin_step>
       - name: Unlink binary cache

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -28,6 +28,12 @@ on:
 concurrency:
   group: cve-daily
 
+inputs:
+  release_branch:
+    description: 'release branch name, example: release-1.68'
+    required: false
+    default: ''
+
 jobs:
   skip_tests_repos:
     name: Skip tests repos
@@ -62,7 +68,7 @@ jobs:
     runs-on: [ self-hosted, regular, selectel ]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"
-      TAG: "main"
+      TAG: ${{ github.event.inputs.release_branch || 'main' }}
     steps:
 
       # <template: checkout_full_step>

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -24,15 +24,13 @@ on:
   schedule:
   - cron: '0 23 * * 0,3'
   workflow_dispatch:
+    inputs:
+      release_branch:
+        description: 'release branch name, example: release-1.68'
+        required: false
 
 concurrency:
   group: cve-daily
-
-inputs:
-  release_branch:
-    description: 'release branch name, example: release-1.68'
-    required: false
-    default: ''
 
 jobs:
   skip_tests_repos:

--- a/tools/cve/d8-images.sh
+++ b/tools/cve/d8-images.sh
@@ -48,16 +48,51 @@ function __main__() {
   docker pull "$IMAGE:$TAG"
   digests=$(docker run --rm "$IMAGE:$TAG" cat /deckhouse/modules/images_digests.json)
 
-  HTML_TEMP=$(mktemp -d)
   IMAGE_REPORT_NAME="deckhouse::$(echo "$IMAGE:$TAG" | sed 's/^.*\/\(.*\)/\1/')"
-  mkdir -p out/
-  htmlReportHeader > out/d8-images.html
-  trivyGetHTMLReportPartForImage -l "$IMAGE_REPORT_NAME" -i "$IMAGE" -t "$TAG" -s "$SEVERITY" --ignore out/.trivyignore >> out/d8-images.html
+  mkdir -p out/json
+
+  date_iso=$(date -I)
 
   for module in $(jq -rc 'to_entries[]' <<< "$digests"); do
     MODULE_NAME=$(jq -rc '.key' <<< "$module")
+    touch out/${MODULE_NAME}_report
     echo "=============================================="
     echo "🛰 Module: $MODULE_NAME"
+
+    # Get codeowners to fill defectDojo tags
+    CODEOWNERS_MODULE_NAME="$(echo $MODULE_NAME|sed -s 's/[A-Z]/-&/g')"
+    codeowner_tags=""
+    # Search module number if any
+    if ls -1 modules/ |grep -i "^[0-9]*-${CODEOWNERS_MODULE_NAME}$"; then
+      # As we know module number - lets search with it
+      CODEOWNERS_MODULE_NAME=$(ls -1 modules/ |grep -i "^[0-9]*-${CODEOWNERS_MODULE_NAME}$")
+      while IFS="\n" read -r line; do
+        search_pattern=$(echo "$line"| sed 's/^\///'|cut -d '/' -f 1)
+        if echo ${CODEOWNERS_MODULE_NAME} | grep -i -q "$search_pattern"; then
+          for owner_name in $(echo "${line#*@}"); do
+            codeowner_tags="${codeowner_tags},codeowner:${owner_name#*@}"
+          done
+          break
+        fi
+      done < .github/CODEOWNERS
+    else
+      # As we dont have module number - also cut it from search pattern
+      while IFS="\n" read -r line; do
+        # 'sed' will cut "/" before folder name if exist, 'cut' will get dirname that will be used as regexp for current module_name, then cut digits from module name
+        search_pattern=$(echo "$line"| sed 's/^\///'|cut -d '/' -f 1|sed 's/^[0-9]*-//')
+        if echo ${CODEOWNERS_MODULE_NAME} | grep -i -q "$search_pattern"; then
+          for owner_name in $(echo "${line#*@}"); do
+            codeowner_tags="${codeowner_tags},codeowner:${owner_name#*@}"
+          done
+          break
+        fi
+      done < .github/CODEOWNERS
+    fi
+
+    # Set default codeowner in case if not found in CODEOWNERS file
+    if [ -z "${codeowner_tags}" ]; then
+      codeowner_tags=",codeowner:RomanenkoDenys"
+    fi
 
     for module_image in $(jq -rc '.value | to_entries[]' <<<"$module"); do
       IMAGE_NAME=$(jq -rc '.key' <<< "$module_image")
@@ -70,12 +105,42 @@ function __main__() {
 
       IMAGE_HASH="$(jq -rc '.value' <<< "$module_image")"
       IMAGE_REPORT_NAME="$MODULE_NAME::$IMAGE_NAME"
-      trivyGetHTMLReportPartForImage  -l "$IMAGE_REPORT_NAME" -i "$IMAGE@$IMAGE_HASH" -s "$SEVERITY" --ignore out/.trivyignore >> out/d8-images.html
+
+      # Output reports per images
+      trivyGetJSONReportPartForImage -l "$IMAGE_REPORT_NAME" -i "$IMAGE@$IMAGE_HASH" -s "$SEVERITY" --ignore "out/.trivyignore" --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json"
+      echo ""
+      echo " Uploading trivy CVE report for image ${IMAGE_NAME} of ${MODULE_NAME} module"
+      echo ""
+      curl -s -X POST \
+        https://${DEFECTDOJO_HOST}/api/v2/reimport-scan/ \
+        -H "accept: application/json" \
+        -H "Content-Type: multipart/form-data"  \
+        -H "Authorization: Token ${DEFECTDOJO_API_TOKEN}" \
+        -F "auto_create_context=True" \
+        -F "minimum_severity=Info" \
+        -F "active=true" \
+        -F "verified=true" \
+        -F "scan_type=Trivy Scan" \
+        -F "close_old_findings=false" \
+        -F "push_to_jira=false" \
+        -F "file=@out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" \
+        -F "product_type_name=Deckhouse images" \
+        -F "product_name=Deckhouse" \
+        -F "scan_date=${date_iso}" \
+        -F "engagement_name=CVE Test: Deckhouse Images" \
+        -F "service=${MODULE_NAME} / ${IMAGE_NAME}" \
+        -F "group_by=component_name+component_version" \
+        -F "deduplication_on_engagement=false" \
+        -F "tags=deckhouse_image,module:${MODULE_NAME},image:${IMAGE_NAME},branch:${TAG}${codeowner_tags}" \
+        -F "test_title=[${MODULE_NAME}]: ${IMAGE_NAME}:${TAG}" \
+        -F "version=${TAG}" \
+        -F "build_id=${IMAGE_HASH}" \
+        -F "commit_hash=${GITHUB_SHA}" \
+        -F "branch_tag=${TAG}" \
+        -F "apply_tags_to_findings=true" \
+      > /dev/null
     done
   done
-
-  rm -r "$HTML_TEMP"
-  htmlReportFooter >> out/d8-images.html
 }
 
 __main__

--- a/tools/cve/trivy-wrapper.sh
+++ b/tools/cve/trivy-wrapper.sh
@@ -68,8 +68,13 @@ function prepareImageArgs() {
       shift
       shift
       ;;
+    -o | --output)
+      OUTPUT="$2"
+      shift
+      shift
+      ;;
     *)
-      echo "Unknown option $1"
+      echo "Trivy-wrapper: Unknown option $1"
       exit 1
       ;;
     esac
@@ -94,6 +99,10 @@ function prepareImageArgs() {
   if [ -z "$SEVERITY" ]; then
     SEVERITY="CRITICAL,HIGH"
   fi
+
+  if [ -z "$OUTPUT" ]; then
+    OUTPUT="out/report.json"
+  fi
 }
 
 function trivyGetCVEListForImage() (
@@ -106,13 +115,9 @@ function htmlReportHeader() (
   cat tools/cve/html/header.tpl
 )
 
-function trivyGetHTMLReportPartForImage() (
+function trivyGetJSONReportPartForImage() (
   prepareImageArgs "$@"
   echo -n "    <h1>$LABEL</h1>"
-  bin/trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "$IGNORE" --format template --template "@tools/cve/html/body-part.tpl" --quiet "$IMAGE_ARGS"
+  bin/trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "$IGNORE" --format json --output $OUTPUT --quiet "$IMAGE_ARGS"
   echo -n "    <br/>"
-)
-
-function htmlReportFooter() (
-  cat tools/cve/html/footer.tpl
 )


### PR DESCRIPTION
## Description
  - CVE now imports report to defectDojo instead of html.
  - Each file report is per image and in .json format. (also accessible as action artifact)
  - Scheduler changed to run at Wed and Sun, also will be run on push to main branch.
  - Added ability to run cve test on PR
  - HTML report generation and loop notifications are removed as defectDojo became an only vulnerability storage.

## Why do we need it, and what problem does it solve?
  Use defectDojo as a single system to work with vulnerability reports
  No impact to users

## Why do we need it in the patch release (if we do)?
  none

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: chore
summary: no changes for a user
impact: no impact
impact_level:  low
```