### PR TITLE
[cni-flannel] Fixing a faulty check in the `cni-flannel` module.

### DIFF
--- a/modules/035-cni-flannel/hooks/check_cni_configuration.go
+++ b/modules/035-cni-flannel/hooks/check_cni_configuration.go
@@ -220,15 +220,21 @@ func checkCni(input *go_hook.HookInput) error {
 		// Secret d8-cni-configuration exist, key "cni" eq "flannel" and key "flannel" does not empty.
 		// Let's compare secret with module configuration.
 		switch cniSecret.flannel.PodNetworkMode {
-		case "HostGW", "VXLAN":
+		case "host-gw":
 			value, ok := input.ConfigValues.GetOk("cniFlannel.podNetworkMode")
-			if !ok || value.String() != cniSecret.flannel.PodNetworkMode {
-				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = cniSecret.flannel.PodNetworkMode
+			if !ok || value.String() != "HostGW" {
+				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = "HostGW"
+				needUpdateMC = true
+			}
+		case "vxlan":
+			value, ok := input.ConfigValues.GetOk("cniFlannel.podNetworkMode")
+			if !ok || value.String() != "VXLAN" {
+				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = "VXLAN"
 				needUpdateMC = true
 			}
 		case "":
 			value, ok := input.ConfigValues.GetOk("cniFlannel.podNetworkMode")
-			if !ok || value.String() != "BPF" {
+			if !ok || value.String() != "HostGW" {
 				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = "HostGW"
 				needUpdateMC = true
 			}

--- a/modules/035-cni-flannel/hooks/check_cni_configuration_test.go
+++ b/modules/035-cni-flannel/hooks/check_cni_configuration_test.go
@@ -178,7 +178,7 @@ data:
 	Context("Cluster has cni secret, key `cni` eq `flannel`, but cni MC does not exist or it not explicitly enabled", func() {
 		BeforeEach(func() {
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "VXLAN"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -266,7 +266,7 @@ status:
 		BeforeEach(func() {
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "HostGW"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`),
 				cniMCYAML(cniName, pointer.Bool(true), v1alpha1.SettingsValues{
 					"podNetworkMode": "VXLAN",
 				}),
@@ -307,7 +307,7 @@ status:
 		BeforeEach(func() {
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "HostGW")
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "VXLAN"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`),
 				cniMCYAML(cniName, pointer.Bool(true), v1alpha1.SettingsValues{
 					"podNetworkMode": "HostGW",
 				}),
@@ -349,7 +349,7 @@ status:
 		BeforeEach(func() {
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "HostGWv"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "HostGW"}`),
 				cniMCYAML(cniName, pointer.Bool(true), v1alpha1.SettingsValues{
 					"podNetworkMode": "VXLAN",
 				}),
@@ -367,7 +367,7 @@ status:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 1.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
-			Expect(f.GoHookError.Error()).Should(ContainSubstring(`unknown flannel podNetworkMode HostGWv`))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`unknown flannel podNetworkMode HostGW`))
 		})
 	})
 
@@ -375,7 +375,7 @@ status:
 		BeforeEach(func() {
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "VXLAN"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`),
 				cniMCYAML(cniName, pointer.Bool(true), v1alpha1.SettingsValues{
 					"podNetworkMode": "VXLAN",
 				}),


### PR DESCRIPTION
## Description

Earlier (in [PR10640](https://github.com/deckhouse/deckhouse/pull/10640)), there was an error in the `check_cni_configuration` hook for the `cni-flannel` module. 
The values of the `PodNetworkMode` parameter in the secret `d8-cni-configuration` were expected to be uppercase, but they were actually in lowercase.
In this PR, we have corrected this issue

## Why do we need it, and what problem does it solve?

In clusters that use `cni-flannel`, this results in an error in the main `deckhouse` queue.

## Why do we need it in the patch release (if we do)?

A release containing this issue is starting to be deployed to client clusters, which may cause confusion.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-flannel
type: fix
summary: Fixed a bug in the `check_cni_configuration` hook that could cause the main queue in the `deckhouse` to stop.
impact_level: default
```
