### PR TITLE
[deckhouse, multitenancy-manager] fix affinity rules

### DIFF
--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -74,14 +74,12 @@ spec:
         kubectl.kubernetes.io/default-container: deckhouse
     spec:
       affinity:
-        {{- if and (include "helm_lib_ha_enabled" .) .Values.global.clusterIsBootstrapped }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
                 app: deckhouse
             topologyKey: kubernetes.io/hostname
-        {{- end }}
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - preference:

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
         checksum/registry: {{ include (print $.Template.BasePath "/registry-secret.yaml") . | sha256sum }}
         kubectl.kubernetes.io/default-container: deckhouse
     spec:
-      affinity:
+      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "deckhouse")) | nindent 6 }}
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - preference:
@@ -83,19 +83,6 @@ spec:
                   values:
                   - "true"
               weight: 100
-{{- if and (include "helm_lib_ha_enabled" .) .Values.global.clusterIsBootstrapped }}
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - deckhouse
-                topologyKey: kubernetes.io/hostname
-              weight: 100
-{{- end }}
 {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
 {{- if .Values.deckhouse.nodeSelector }}
       nodeSelector:

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -73,7 +73,15 @@ spec:
         checksum/registry: {{ include (print $.Template.BasePath "/registry-secret.yaml") . | sha256sum }}
         kubectl.kubernetes.io/default-container: deckhouse
     spec:
-      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "deckhouse")) | nindent 6 }}
+      affinity:
+        {{- if and (include "helm_lib_ha_enabled" .) .Values.global.clusterIsBootstrapped }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: deckhouse
+            topologyKey: kubernetes.io/hostname
+        {{- end }}
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - preference:

--- a/modules/015-admission-policy-engine/templates/README.md
+++ b/modules/015-admission-policy-engine/templates/README.md
@@ -1,2 +1,0 @@
-repo: https://github.com/open-policy-agent/gatekeeper
-version: 3.10.0

--- a/modules/160-multitenancy-manager/templates/multitenancy-manager/controller.yaml
+++ b/modules/160-multitenancy-manager/templates/multitenancy-manager/controller.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "multitenancy-manager")) | nindent 2 }}
 spec:
-  {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}
+  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/modules/160-multitenancy-manager/templates/multitenancy-manager/controller.yaml
+++ b/modules/160-multitenancy-manager/templates/multitenancy-manager/controller.yaml
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "multitenancy-manager")) | nindent 6 }}
       imagePullSecrets:
         - name: deckhouse-registry
       terminationGracePeriodSeconds: 60


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixes anti-affinity rules for the deckhouse and multitenancy-manager modules.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

When the `high availability` setting is set to true, there is a possibility that more than one deckhouse or multitenancy-manager pods could be scheduled on a single node, breaking the rule of highly available deployment.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse,multitenancy-manager
type: chore
summary: Fix affinity rules.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
