### PR TITLE
[monitoring] Allow to create/update/delete objects with heritage label for observability SA.

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -48,7 +48,7 @@ spec:
     - name: 'exclude-groups'
       expression: '!(["system:nodes", "system:serviceaccounts:kube-system", "system:serviceaccounts:d8-system"].exists(e, (e in request.userInfo.groups)))'
     - name: 'exclude-users'
-      expression: '!(["system:apiserver", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler", "dhctl"].exists(e, (e == request.userInfo.username)))'
+      expression: '!(["system:apiserver", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler", "dhctl", "observability"].exists(e, (e == request.userInfo.username)))'
     - name: 'exclude-kinds'
       expression: '!(has(request.kind) && ["StorageClass"].exists(e, (e == request.kind.kind)))'
     - name: 'exclude-restartedAt'


### PR DESCRIPTION
## Description
This changes makes possible operating with objects containing `heritage: deckhouse` label for `observability` `ServiceAccount`.

## Why do we need it, and what problem does it solve?
We need this change, because observability controller must have possibility to create/update/delete objects with `heritage: deckhouse`.

## Why do we need it in the patch release (if we do)?
-

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Allow observability module to operating Deckhouse objects.

```changes
section: prometheus
type: fix | feature | chore
summary: Allow to create/update/delete objects with heritage label for observability SA
impact_level: low
```
