### PR TITLE
[candi] Add sudoer group

### DIFF
--- a/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
@@ -168,16 +168,50 @@ function put_user_ssh_key() {
   fi
 }
 
+# $1 - group name
+function add_sudoer_group() {
+    local path="/etc/sudoers"
+    local groupname="$1"
+    sudoers_filename="30-deckhouse-nodeadmins"
+    local sudoersd_path=$(cat $path |egrep "[@#]includedir" |awk '{ print $2}')
+
+    if [[ -z $sudoersd_path ]]
+      then
+        mkdir -p ${root}etc/sudoers.d
+        echo "" >> $path
+        echo "#includedir ${root}etc/sudoers.d" >> $path
+        sudoersd_path="${root}etc/sudoers.d"
+    fi
+
+    local sudoers_file="$sudoersd_path/$sudoers_filename"
+    
+    if getent group $groupname >/dev/null
+      then
+	      continue
+      else
+        groupadd $groupname
+    fi
+
+    # Discover sudoer groups
+    groups=($(cat $path |egrep "^%[a-z][-a-zA-Z0-9._]*\s+.+" |awk '{print $1}' |cut -c2-))
+    additional_groups=$(cat $sudoersd_path/* |egrep "^%[a-z][-a-zA-Z0-9._]*\s+.+" |awk '{print $1}' |cut -c2-)
+    groups+=($additional_groups)
+
+    if [[ ! " ${groups[*]} " =~ [[:space:]]${groupname}[[:space:]] ]]
+      then
+        if [[ ! -f $sudoers_file ]]
+          then
+            echo "# Group rules for deckhouse users" > $sudoers_file
+            echo "%${groupname} ALL=(ALL) ALL" >> $sudoers_file
+          else
+            echo "%${groupname} ALL=(ALL) ALL" >> $sudoers_file
+        fi
+    fi
+}
+
 function main() {
-  if getent group sudo >/dev/null; then
-    sudo_group="sudo"
-  elif getent group wheel >/dev/null; then
-    sudo_group="wheel"
-  else
-    bb-log-error "Cannot find sudo group"
-    nodeuser_add_error "${user_name}" "Cannot find sudo group"
-    return
-  fi
+  sudo_group="nodeadmin"
+  add_sudoer_group $sudo_group
 
   main_group="100" # users
   home_base_path="/home/deckhouse"


### PR DESCRIPTION
## Description

Change logic of add NodeUser to sudoers: instead of looking for `sudo`/`wheel` group, create a new group and add it to `/etc/sudoers.d/`

## Why do we need it, and what problem does it solve?

If `sudo`/`wheel` group is not present on machine, we cannot add NodeUser to sudoer.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Add new group nodeadmin and include it to /etc/sudoers.d for NodeUser with isSudoer set to true.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
