### PR TITLE
[istio] Fix alliance.ingressGateway.advertise option address in api item

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -81,9 +81,9 @@ properties:
             x-examples: [[{"ip": "172.16.0.5", "port": 15443}]]
             items:
               type: object
-              required: ["ip", "port"]
+              required: ["address", "port"]
               properties:
-                ip:
+                address:
                   type: string
                   example: "172.16.0.5"
                   pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$'


### PR DESCRIPTION
## Description
Wrong `ip` option in `alliance.ingressGateway.advertise` MC section.

## Why do we need it, and what problem does it solve?
The `alliance.ingressGateway.advertise` did not work correctly when specifying the `ip` option to change the communication address between clusters in the federation and multicluster. The correct option is `address`.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: fix
summary: Wrong `ip` option in `alliance.ingressGateway.advertise` MC section.
impact_level: low
```