### PR TITLE
[dhctl] Fix Stronghold pv delete 

### DIFF
--- a/dhctl/pkg/operations/destroy/deckhouse.go
+++ b/dhctl/pkg/operations/destroy/deckhouse.go
@@ -152,6 +152,11 @@ func (g *DeckhouseDestroyer) deleteEntities(kubeCl *client.KubernetesClient) err
 		return err
 	}
 
+	err = deckhouse.DeletePV(kubeCl)
+	if err != nil {
+		return err
+	}
+
 	err = deckhouse.WaitForPVDeletion(kubeCl)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This pr allow delete persistentVolumes provided manually or contain reclaimPolicy other than Delete when dhctl destroy.
```
│ ┌ Delete PersistentVolumes provided manually or contain reclaimPolicy other than Delete.
│ │ d8-stronghold-data-0
│ │ pvc-006cc8f6-8d10-4129-bb9d-bac3587f1697
│ │ pvc-8d319b7e-f6b2-4191-aa3f-0a33d70c7600
│ │ pvc-dfa34b0b-d93b-43d9-b078-417210aee694
│ │ 🎉 Succeeded!
│ └ Delete PersistentVolumes provided manually or contain reclaimPolicy other than Delete. (0.06 seconds)
│
│ ┌ Wait for PersistentVolumes deletion
│ │ ️⛱️️ Attempt #1 of 45 |
│ │     Wait for PersistentVolumes deletion failed, next attempt will be in 15s"
│ │     2 PersistentVolumes with reclaimPolicy other than Delete in the cluster. Set their reclaim policy to Delete or remove them manually
│ │             pvc-8d319b7e-f6b2-4191-aa3f-0a33d70c7600 | Released
│ │             pvc-dfa34b0b-d93b-43d9-b078-417210aee694 | Released
│ │
│ │ All PersistentVolumes are deleted from the cluster
│ │ 🎉 Succeeded!
│ └ Wait for PersistentVolumes deletion (15.04 seconds)
```


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This solve https://github.com/deckhouse/deckhouse/issues/11065.
e.g. Stronghold deploy pv manually created.
```
stronghold/templates/stronghold/pvc.yaml
---
apiVersion: v1
kind: PersistentVolume
metadata:
  name: d8-stronghold-data-{{ $i }}
...
  storageClassName: local-storage
  local:
    path: /var/lib/deckhouse/stronghold
...
{{- end }}
---
```
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary:  stronghold pv delete fix
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
