### PR TITLE
[metall] Fix controller panic

### DIFF
--- a/ee/se/modules/380-metallb/images/l2lb/patches/002-l2lb-service-custom-resource.patch
+++ b/ee/se/modules/380-metallb/images/l2lb/patches/002-l2lb-service-custom-resource.patch
@@ -371,7 +371,7 @@ index 15489c3f..4e1c5c09 100644
  		return ForAddresses(svc.Spec.ClusterIPs)
  	}
 diff --git a/internal/k8s/controllers/service_controller.go b/internal/k8s/controllers/service_controller.go
-index a804ee76..9391ac59 100644
+index a804ee76..8daadda4 100644
 --- a/internal/k8s/controllers/service_controller.go
 +++ b/internal/k8s/controllers/service_controller.go
 @@ -19,6 +19,8 @@ package controllers
@@ -414,7 +414,7 @@ index a804ee76..9391ac59 100644
  		return ctrl.Result{}, nil
  	}
  
-+	if service.Spec.ServiceRef == nil {
++	if service == nil {
 +		level.Error(r.Logger).Log("controller", "ServiceReconciler", "message", "serviceRef is not valid", "service", req.NamespacedName)
 +		return ctrl.Result{}, nil
 +	}

--- a/ee/se/modules/380-metallb/images/l2lb/patches/002-l2lb-service-custom-resource.patch
+++ b/ee/se/modules/380-metallb/images/l2lb/patches/002-l2lb-service-custom-resource.patch
@@ -1,6 +1,6 @@
 diff --git a/api/v1alpha1/l2lbservice.go b/api/v1alpha1/l2lbservice.go
 new file mode 100644
-index 00000000..090001a9
+index 00000000..48ba7e03
 --- /dev/null
 +++ b/api/v1alpha1/l2lbservice.go
 @@ -0,0 +1,155 @@
@@ -31,7 +31,7 @@ index 00000000..090001a9
 +
 +type SDNInternalL2LBServiceSpec struct {
 +	v1.ServiceSpec `json:",inline"`
-+	ServiceRef     SDNInternalL2LBServiceReference `json:"serviceRef"`
++	ServiceRef     *SDNInternalL2LBServiceReference `json:"serviceRef"`
 +}
 +
 +type SDNInternalL2LBServiceReference struct {
@@ -371,7 +371,7 @@ index 15489c3f..4e1c5c09 100644
  		return ForAddresses(svc.Spec.ClusterIPs)
  	}
 diff --git a/internal/k8s/controllers/service_controller.go b/internal/k8s/controllers/service_controller.go
-index a804ee76..fb1f2083 100644
+index a804ee76..9391ac59 100644
 --- a/internal/k8s/controllers/service_controller.go
 +++ b/internal/k8s/controllers/service_controller.go
 @@ -19,6 +19,8 @@ package controllers
@@ -410,10 +410,15 @@ index a804ee76..fb1f2083 100644
  
  	if !r.initialLoadPerformed {
  		level.Debug(r.Logger).Log("controller", "ServiceReconciler", "message", "filtered service, still waiting for the initial load to be performed")
-@@ -83,9 +83,14 @@ func (r *ServiceReconciler) reconcileService(ctx context.Context, req ctrl.Reque
+@@ -83,9 +83,19 @@ func (r *ServiceReconciler) reconcileService(ctx context.Context, req ctrl.Reque
  		return ctrl.Result{}, nil
  	}
  
++	if service.Spec.ServiceRef == nil {
++		level.Error(r.Logger).Log("controller", "ServiceReconciler", "message", "serviceRef is not valid", "service", req.NamespacedName)
++		return ctrl.Result{}, nil
++	}
++
 +	if service.Spec.ServiceRef.Name == "" || service.Spec.ServiceRef.Namespace == "" {
 +		level.Error(r.Logger).Log("controller", "ServiceReconciler", "message", "serviceRef.Name or serviceRef.Namespace is empty", "service", req.NamespacedName)
 +		return ctrl.Result{}, nil
@@ -426,7 +431,7 @@ index a804ee76..fb1f2083 100644
  		if err != nil {
  			level.Error(r.Logger).Log("controller", "ServiceReconciler", "message", "failed to get endpoints", "service", req.NamespacedName, "error", err)
  			return ctrl.Result{}, err
-@@ -118,7 +123,7 @@ func (r *ServiceReconciler) reconcileService(ctx context.Context, req ctrl.Reque
+@@ -118,7 +128,7 @@ func (r *ServiceReconciler) reconcileService(ctx context.Context, req ctrl.Reque
  func (r *ServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
  	if r.Endpoints {
  		return ctrl.NewControllerManagedBy(mgr).
@@ -435,7 +440,7 @@ index a804ee76..fb1f2083 100644
  			Watches(&discovery.EndpointSlice{},
  				handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
  					epSlice, ok := obj.(*discovery.EndpointSlice)
-@@ -132,20 +137,39 @@ func (r *ServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+@@ -132,20 +142,39 @@ func (r *ServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
  						return []reconcile.Request{}
  					}
  					level.Debug(r.Logger).Log("controller", "ServiceReconciler", "enqueueing", serviceName, "epslice", dumpResource(epSlice))
@@ -479,7 +484,7 @@ index a804ee76..fb1f2083 100644
  	err := r.Get(ctx, name, &res)
  	if apierrors.IsNotFound(err) { // in case of delete, get fails and we need to pass nil to the handler
  		return nil, nil
-@@ -156,7 +180,7 @@ func (r *ServiceReconciler) serviceFor(ctx context.Context, name types.Namespace
+@@ -156,7 +185,7 @@ func (r *ServiceReconciler) serviceFor(ctx context.Context, name types.Namespace
  	return &res, nil
  }
  


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
