### PR TITLE
[docs] fix/registry watcher resp err handle

### DIFF
--- a/docs/site/backends/registry-modules-watcher/cmd/main.go
+++ b/docs/site/backends/registry-modules-watcher/cmd/main.go
@@ -80,12 +80,12 @@ func main() {
 		logger.Fatal("no registries to watch")
 	}
 
-	registryScaner := registryscaner.New(logger, clients...)
+	registryScaner := registryscaner.New(logger.Named("registry-scanner"), clients...)
 	registryScaner.Subscribe(ctx, *scanInterval)
 
 	// * * * * * * * * *
 	// New sender
-	sender := sender.New(logger)
+	sender := sender.New(logger.Named("sender"))
 
 	// * * * * * * * * *
 	// New backends service
@@ -106,7 +106,7 @@ func main() {
 	// * * * * * * * * *
 	// Watch lease
 	namespace := os.Getenv("POD_NAMESPACE")
-	wather := watcher.New(kClient, namespace, logger)
+	wather := watcher.New(kClient, namespace, logger.Named("watcher"))
 	wather.Watch(ctx, backends.Add, backends.Delete)
 
 	<-ctx.Done()

--- a/docs/site/backends/registry-modules-watcher/internal/backends/backends.go
+++ b/docs/site/backends/registry-modules-watcher/internal/backends/backends.go
@@ -16,6 +16,7 @@ package backends
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 
@@ -84,6 +85,7 @@ func (b *backends) Add(backend string) {
 
 	b.listBackends[backend] = struct{}{}
 	state := b.registryScaner.GetState()
+
 	err := b.sender.Send(context.Background(), map[string]struct{}{backend: {}}, state)
 	if err != nil {
 		b.logger.Fatal("sending docs to new backend", log.Err(err))
@@ -108,7 +110,7 @@ func (b *backends) updateHandler(versions []Version) error {
 
 	err := b.sender.Send(context.Background(), b.listBackends, versions)
 	if err != nil {
-		return err
+		return fmt.Errorf("send: %w", err)
 	}
 
 	return nil

--- a/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scaner/process.go
+++ b/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scaner/process.go
@@ -142,7 +142,7 @@ func (s *registryscaner) extractDocumentation(image v1.Image) ([]byte, error) {
 	})
 	if err != nil {
 		s.logger.Error("write header", log.Err(err))
-		return nil, err
+		return nil, fmt.Errorf("write header: %w", err)
 	}
 
 	// "openapi" directory
@@ -153,7 +153,7 @@ func (s *registryscaner) extractDocumentation(image v1.Image) ([]byte, error) {
 	})
 	if err != nil {
 		s.logger.Error("write header", log.Err(err))
-		return nil, err
+		return nil, fmt.Errorf("write header: %w", err)
 	}
 
 	// "crds" directory
@@ -164,7 +164,7 @@ func (s *registryscaner) extractDocumentation(image v1.Image) ([]byte, error) {
 	})
 	if err != nil {
 		s.logger.Error("write header", log.Err(err))
-		return nil, err
+		return nil, fmt.Errorf("write header: %w", err)
 	}
 
 	for {
@@ -174,7 +174,7 @@ func (s *registryscaner) extractDocumentation(image v1.Image) ([]byte, error) {
 				return tarFile.Bytes(), nil
 			}
 
-			return nil, err
+			return nil, fmt.Errorf("tar reader next: %w", err)
 		}
 
 		// TODO: short duplicate
@@ -233,7 +233,7 @@ func extractVersionFromImage(releaseImage v1.Image) (string, error) {
 
 	readCloser, err := cr.Extract(releaseImage)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("extract image: %w", err)
 	}
 	defer readCloser.Close()
 
@@ -245,18 +245,18 @@ func extractVersionFromImage(releaseImage v1.Image) (string, error) {
 				return "", fmt.Errorf("version is not set")
 			}
 
-			return "", err
+			return "", fmt.Errorf("tar reader next: %w", err)
 		}
 
 		if hdr.Typeflag == tar.TypeReg && hdr.Name == "version.json" {
 			buf := bytes.NewBuffer(nil)
 			if _, err = io.Copy(buf, tarReader); err != nil {
-				return "", err
+				return "", fmt.Errorf("copy: %w", err)
 			}
 
 			v := versionJSON{}
 			if err := json.Unmarshal(buf.Bytes(), &v); err != nil {
-				return "", err
+				return "", fmt.Errorf("unmarshal: %w", err)
 			}
 
 			if v.Version != "" {
@@ -268,10 +268,12 @@ func extractVersionFromImage(releaseImage v1.Image) (string, error) {
 
 func filterReleaseChannelsFromTags(tags []string) []string {
 	releaseChannels := make([]string, 0)
+
 	for _, tag := range tags {
 		if _, ok := releaseChannelsTags[tag]; ok {
 			releaseChannels = append(releaseChannels, tag)
 		}
 	}
+
 	return releaseChannels
 }

--- a/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scaner/registry-scaner.go
+++ b/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scaner/registry-scaner.go
@@ -82,12 +82,15 @@ func (s *registryscaner) Subscribe(ctx context.Context, scanInterval time.Durati
 			select {
 			case <-ticker.C:
 				s.processRegistries(ctx)
+
 				state := s.cache.GetRange()
 				if len(state) > 0 {
 					s.logger.Info("module versions changed in registry")
+
 					if err := s.updateHandler(state); err != nil {
 						s.logger.Error("updateHandler", log.Err(err))
 					}
+
 					s.cache.ResetRange()
 				}
 

--- a/docs/site/backends/registry-modules-watcher/internal/backends/pkg/sender/sender.go
+++ b/docs/site/backends/registry-modules-watcher/internal/backends/pkg/sender/sender.go
@@ -17,6 +17,7 @@ package sender
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -60,28 +61,25 @@ func (s *sender) Send(ctx context.Context, listBackends map[string]struct{}, ver
 		go func(backend string) {
 			for _, version := range versions {
 				if version.ToDelete {
-					err := s.delete(ctx, backend, version.Module, version.ReleaseChannels)
+					err := s.delete(ctx, backend, version)
 					if err != nil {
-						s.logger.Error("send delete", log.Err(err))
+						s.logger.Error("send delete docs", log.Err(err))
 					}
 
 					continue
 				}
 
-				url := "http://" + backend + "/api/v1/doc/" + version.Module + "/" + version.Version + "?channels=" + strings.Join(version.ReleaseChannels, ",")
-
-				err := s.loadDocArchive(ctx, url, version.TarFile)
+				err := s.upload(ctx, backend, version)
 				if err != nil {
-					s.logger.Error("send docs", log.Err(err))
+					s.logger.Error("send upload docs", log.Err(err))
 				}
 			}
 
-			url := "http://" + backend + "/api/v1/build"
-
-			err := s.build(ctx, url)
+			err := s.build(ctx, backend)
 			if err != nil {
-				s.logger.Error("build docs", log.Err(err))
+				s.logger.Error("send build docs", log.Err(err))
 			}
+
 			<-syncChan
 		}(backend)
 	}
@@ -89,15 +87,20 @@ func (s *sender) Send(ctx context.Context, listBackends map[string]struct{}, ver
 	return nil
 }
 
-func (s *sender) delete(_ context.Context, backend, moduleName string, releaseChannels []string) error {
-	url := fmt.Sprintf("http://%s/api/v1/doc/%s", backend, moduleName)
-	if len(releaseChannels) > 0 {
+var ErrBadStatusCode = errors.New("bad status code")
+
+func (s *sender) delete(ctx context.Context, backend string, version backends.Version) error {
+	url := fmt.Sprintf("http://%s/api/v1/doc/%s", backend, version.Module)
+
+	s.logger.Info("delete documentation", slog.String("url", url))
+
+	if len(version.ReleaseChannels) > 0 {
 		params := url2.Values{}
-		params.Add("channels", strings.Join(releaseChannels, ","))
+		params.Add("channels", strings.Join(version.ReleaseChannels, ","))
 		url += "?" + params.Encode()
 	}
 
-	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return fmt.Errorf("client: could not create request: %s", err)
 	}
@@ -108,7 +111,12 @@ func (s *sender) delete(_ context.Context, backend, moduleName string, releaseCh
 			return fmt.Errorf("client: error making http request: %s", err)
 		}
 
-		// TODO: add >=300 status code handling
+		if resp.StatusCode != http.StatusNoContent {
+			s.logger.Warn("delete response", slog.Int("status_code", resp.StatusCode))
+
+			return fmt.Errorf("%w: %s", ErrBadStatusCode, resp.Status)
+		}
+
 		s.logger.Info("delete response", slog.Int("status_code", resp.StatusCode))
 
 		return nil
@@ -116,17 +124,21 @@ func (s *sender) delete(_ context.Context, backend, moduleName string, releaseCh
 
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = maxElapsedTime * time.Minute
+
 	err = backoff.Retry(operation, backoff.WithMaxRetries(b, maxRetries))
 	if err != nil {
-		return err
+		return fmt.Errorf("send request: %w", err)
 	}
 
 	return nil
 }
 
-func (s *sender) loadDocArchive(_ context.Context, url string, tarFile []byte) error {
-	s.logger.Info("send loadDoc", slog.String("url", url))
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(tarFile))
+func (s *sender) upload(ctx context.Context, backend string, version backends.Version) error {
+	url := "http://" + backend + "/api/v1/doc/" + version.Module + "/" + version.Version + "?channels=" + strings.Join(version.ReleaseChannels, ",")
+
+	s.logger.Info("upload archive", slog.String("url", url))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(version.TarFile))
 	if err != nil {
 		return fmt.Errorf("client: could not create request: %s", err)
 	}
@@ -139,7 +151,12 @@ func (s *sender) loadDocArchive(_ context.Context, url string, tarFile []byte) e
 			return fmt.Errorf("client: error making http request: %s", err)
 		}
 
-		// TODO: add >=300 status code handling
+		if resp.StatusCode != http.StatusCreated {
+			s.logger.Warn("send archive response", slog.Int("status_code", resp.StatusCode))
+
+			return fmt.Errorf("%w: %s", ErrBadStatusCode, resp.Status)
+		}
+
 		s.logger.Info("send archive response", slog.Int("status_code", resp.StatusCode))
 
 		return nil
@@ -147,18 +164,21 @@ func (s *sender) loadDocArchive(_ context.Context, url string, tarFile []byte) e
 
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = maxElapsedTime * time.Minute
+
 	err = backoff.Retry(operation, backoff.WithMaxRetries(b, maxRetries))
 	if err != nil {
-		return err
+		return fmt.Errorf("send request: %w", err)
 	}
 
 	return nil
 }
 
-func (s *sender) build(_ context.Context, url string) error {
+func (s *sender) build(ctx context.Context, backend string) error {
+	url := "http://" + backend + "/api/v1/build"
+
 	s.logger.Info("send build", slog.String("url", url))
 
-	req, err := http.NewRequest(http.MethodPost, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	if err != nil {
 		return fmt.Errorf("client: could not create request: %s", err)
 	}
@@ -171,17 +191,23 @@ func (s *sender) build(_ context.Context, url string) error {
 			return fmt.Errorf("client: error making http request: %s", err)
 		}
 
-		// TODO: add >=300 status code handling
-		s.logger.Info("send build response", slog.Int("status_code", resp.StatusCode))
+		if resp.StatusCode != http.StatusOK {
+			s.logger.Warn("build response", slog.Int("status_code", resp.StatusCode))
+
+			return fmt.Errorf("%w: %s", ErrBadStatusCode, resp.Status)
+		}
+
+		s.logger.Info("build response", slog.Int("status_code", resp.StatusCode))
 
 		return nil
 	}
 
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = maxElapsedTime * time.Minute
+
 	err = backoff.Retry(operation, backoff.WithMaxRetries(b, maxRetries))
 	if err != nil {
-		return err
+		return fmt.Errorf("send request: %w", err)
 	}
 
 	return nil

--- a/docs/site/backends/registry-modules-watcher/pkg/registry-client/helpers.go
+++ b/docs/site/backends/registry-modules-watcher/pkg/registry-client/helpers.go
@@ -16,6 +16,7 @@ package registryclient
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -26,13 +27,13 @@ import (
 func readAuthConfig(repo, dockerCfg string) (authn.AuthConfig, error) {
 	r, err := parse(repo)
 	if err != nil {
-		return authn.AuthConfig{}, err
+		return authn.AuthConfig{}, fmt.Errorf("parse: %w", err)
 	}
 
 	var auths dockercfgAuths
 	err = json.Unmarshal([]byte(dockerCfg), &auths)
 	if err != nil {
-		return authn.AuthConfig{}, err
+		return authn.AuthConfig{}, fmt.Errorf("json unmarshal: %w", err)
 	}
 
 	// The config should have at least one .auths.* entry
@@ -42,7 +43,7 @@ func readAuthConfig(repo, dockerCfg string) (authn.AuthConfig, error) {
 		}
 	}
 
-	return authn.AuthConfig{}, fmt.Errorf("no auth data")
+	return authn.AuthConfig{}, errors.New("no auth data")
 }
 
 type dockercfgAuths struct {
@@ -55,5 +56,6 @@ func parse(rawURL string) (*url.URL, error) {
 	if strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://") {
 		return url.ParseRequestURI(rawURL)
 	}
+
 	return url.Parse("//" + rawURL)
 }

--- a/docs/site/backends/registry-modules-watcher/pkg/registry-client/registry-client.go
+++ b/docs/site/backends/registry-modules-watcher/pkg/registry-client/registry-client.go
@@ -54,8 +54,9 @@ func NewClient(repo string, options ...Option) (registryscaner.Client, error) {
 	if !opts.withoutAuth {
 		authConfig, err := readAuthConfig(repo, opts.dockerCfg)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read auth config: %w", err)
 		}
+
 		client.authConfig = authConfig
 	}
 
@@ -83,7 +84,7 @@ func (c *client) image(imageURL string) (v1.Image, error) {
 
 	ref, err := name.ParseReference(imageURL, nameOpts...) // parse options available: weak validation, etc.
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse reference: %w", err)
 	}
 
 	imageOptions := make([]remote.Option, 0)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed behavior, when watcher ignored status codes from docs builder

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: add handle status codes from builder 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
