### PR TITLE
feat: update dmtlint configuration and bump DMT version to 0.0.29

### DIFF
--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -1,6 +1,7 @@
 warnings-only:
   - images
   - conversions
+  - k8s-resources
 linters-settings:
   probes:
     probes-excludes:

--- a/.dmtlint.yaml
+++ b/.dmtlint.yaml
@@ -1,5 +1,6 @@
 warnings-only:
   - images
+  - conversions
 linters-settings:
   probes:
     probes-excludes:

--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-DMT_VERSION=0.0.28
+DMT_VERSION=0.0.29
 
 function install_dmt() {
   platform_name=$(uname -m)


### PR DESCRIPTION
## Description

Updated dmt lint to version 0.0.29, added new linters. Which are added in warning-only mode.

## Why do we need it, and what problem does it solve?

Adding new checks and improving the operation of the linter

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: chore
summary: update dmtlint configuration and bump DMT version to 0.0.29
impact_level: low
```
