### PR TITLE
[deckhouse] fix overridden stuck in source

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -265,6 +265,7 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 		for _, available := range source.Status.AvailableModules {
 			if available.Name == moduleName {
 				availableModule = available
+				break
 			}
 		}
 
@@ -301,6 +302,9 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 			availableModules = append(availableModules, availableModule)
 			continue
 		}
+
+		// clear overridden
+		availableModule.Overridden = false
 
 		var cachedChecksum = availableModule.Checksum
 


### PR DESCRIPTION
## Description
It unsets overridden if MPO does not exist.

## Why do we need it, and what problem does it solve?
After deleting MPO, modules still have overridden in the module source.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Unset overridden in module source.
impact_level: low
```
