### PR TITLE
[docs] New badges in the sidebar

### DIFF
--- a/docs/documentation/_includes/sidebar_entry.html
+++ b/docs/documentation/_includes/sidebar_entry.html
@@ -40,7 +40,8 @@
 
 {%- if entry.folders %}
 <li class="{{ folder_entry_class }}">
-    <a href="#">{{ entry.title[page.lang] }}
+    <a href="#">
+      <span class="sidebar__submenu-title">{{ entry.title[page.lang] }}</span>
     {%- if entry.featureStatus %}<span class="sidebar__badge sidebar__badge_{{ entry.featureStatus }}" title="{{ site.data.i18n.features[entry.featureStatus][page.lang] | lstrip | strip_html | regex_replace: '.$', '' }}">
         {%- if entry.featureStatus == "experimental" %}
           Exp

--- a/docs/documentation/_includes/sidebar_entry.html
+++ b/docs/documentation/_includes/sidebar_entry.html
@@ -43,19 +43,19 @@
     <a href="#">{{ entry.title[page.lang] }}
     {%- if entry.featureStatus %}<span class="sidebar__badge sidebar__badge_{{ entry.featureStatus }}" title="{{ site.data.i18n.features[entry.featureStatus][page.lang] | lstrip | strip_html | regex_replace: '.$', '' }}">
         {%- if entry.featureStatus == "experimental" %}
-          Experimental
+          Exp
         {%- elsif entry.featureStatus == "deprecated" %}
-          Deprecated
+          Dep
         {%- elsif entry.featureStatus == "temporaryDeprecated" %}
           Temporary deprecated
         {%- elsif entry.featureStatus == "proprietaryOkmeter" %}
-          Proprietary
+          Prop
         {%- else %}
           NEW!
         {%- endif %}
       </span>
     {%- endif %}
-    {%- if entry.d8Revision and entry.d8Revision != "ce" %}<span class="sidebar__badge sidebar__badge_{{ entry.d8Revision }}" title="{{ site.data.i18n.features[entry.d8Revision][page.lang] | strip_html | regex_replace: '.$', '' }}">EE Only</span>
+    {%- if entry.d8Revision and entry.d8Revision != "ce" %}<span class="sidebar__badge sidebar__badge_{{ entry.d8Revision }}" title="{{ site.data.i18n.features[entry.d8Revision][page.lang] | strip_html | regex_replace: '.$', '' }}">&#8381;</span>
     {%- endif %}
     </a>
     <ul class="sidebar__submenu">

--- a/docs/site/_assets/css/docs.scss
+++ b/docs/site/_assets/css/docs.scss
@@ -475,21 +475,32 @@ a.comparison-table__module::after {
 
 .sidebar__badge {
   display: inline-flex;
-  vertical-align: middle;
-  font-size: 8px;
-  font-weight: 700;
-  line-height: 16px;
+  margin-right: 4px;
+  padding: 4px 5px;
+  border: 1px solid #bbb;
+  border-radius: 16px;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 7px;
   letter-spacing: 1px;
-  color: #fff;
-  margin-right: 10px;
-  padding: 0 4px;
-  background: #0066FF;
-  border-radius: 4px;
+  color: $color-text-secondary;
+  text-transform: uppercase;
   white-space: nowrap;
+  background: $background-blue;
+
+  &:nth-child(2) {
+    margin-left: 10px;
+  }
 }
 
-.sidebar__badge:nth-child(2) {
-  margin-left: 10px;
+.sidebar__badge_ee {
+  padding: 3px 3px 4px 5px;
+  border: none;
+  font-weight: 400;
+  font-size: 12px;
+  text-align: center;
+  color: $white;
+  background-color: $color-text-secondary;
 }
 
 a.comparison-table__module {

--- a/docs/site/_assets/css/docs.scss
+++ b/docs/site/_assets/css/docs.scss
@@ -473,6 +473,10 @@ a.comparison-table__module::after {
     white-space: nowrap;
 }
 
+.sidebar__submenu-title {
+  margin-right: 10px;
+}
+
 .sidebar__badge {
   display: inline-flex;
   margin-right: 4px;
@@ -487,10 +491,6 @@ a.comparison-table__module::after {
   text-transform: uppercase;
   white-space: nowrap;
   background: $background-blue;
-
-  &:nth-child(2) {
-    margin-left: 10px;
-  }
 }
 
 .sidebar__badge_ee {

--- a/docs/site/_includes/sidebar_entry.html
+++ b/docs/site/_includes/sidebar_entry.html
@@ -48,7 +48,7 @@
     <a href="#">{{ entry.title[page.lang] }}
     {%- if entry.featureStatus %}<span class="sidebar__badge sidebar__badge_{{ entry.featureStatus }}" title="{{ site.data.i18n.features[entry.featureStatus][page.lang] | lstrip | strip_html | regex_replace: '.$', '' }}">
         {%- if entry.featureStatus == "experimental" %}
-        Exp
+          Exp
         {%- elsif entry.featureStatus == "deprecated" %}
           Dep
         {%- elsif entry.featureStatus == "temporaryDeprecated" %}

--- a/docs/site/_includes/sidebar_entry.html
+++ b/docs/site/_includes/sidebar_entry.html
@@ -48,19 +48,19 @@
     <a href="#">{{ entry.title[page.lang] }}
     {%- if entry.featureStatus %}<span class="sidebar__badge sidebar__badge_{{ entry.featureStatus }}" title="{{ site.data.i18n.features[entry.featureStatus][page.lang] | lstrip | strip_html | regex_replace: '.$', '' }}">
         {%- if entry.featureStatus == "experimental" %}
-          Experimental
+        Exp
         {%- elsif entry.featureStatus == "deprecated" %}
-          Deprecated
+          Dep
         {%- elsif entry.featureStatus == "temporaryDeprecated" %}
           Temporary deprecated
         {%- elsif entry.featureStatus == "proprietaryOkmeter" %}
-          Proprietary
+          Prop
         {%- else %}
           NEW!
         {%- endif %}
       </span>
     {%- endif %}
-    {%- if entry.d8Revision and entry.d8Revision != "ce" %}<span class="sidebar__badge sidebar__badge_{{ entry.d8Revision }}" title="{{ site.data.i18n.features[entry.d8Revision][page.lang] | strip_html | regex_replace: '.$', '' }}">EE Only</span>
+    {%- if entry.d8Revision and entry.d8Revision != "ce" %}<span class="sidebar__badge sidebar__badge_{{ entry.d8Revision }}" title="{{ site.data.i18n.features[entry.d8Revision][page.lang] | strip_html | regex_replace: '.$', '' }}">&#8381;</span>
     {%- endif %}
     </a>
     <ul class="sidebar__submenu">

--- a/docs/site/_includes/sidebar_entry.html
+++ b/docs/site/_includes/sidebar_entry.html
@@ -45,7 +45,8 @@
 
 {%- if entry.folders %}
 <li class="{{ folder_entry_class }}">
-    <a href="#">{{ entry.title[page.lang] }}
+    <a href="#">
+      <span class="sidebar__submenu-title">{{ entry.title[page.lang] }}</span>
     {%- if entry.featureStatus %}<span class="sidebar__badge sidebar__badge_{{ entry.featureStatus }}" title="{{ site.data.i18n.features[entry.featureStatus][page.lang] | lstrip | strip_html | regex_replace: '.$', '' }}">
         {%- if entry.featureStatus == "experimental" %}
           Exp

--- a/docs/site/backends/docs-builder-template/layouts/partials/sidebar.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/sidebar.html
@@ -69,7 +69,7 @@
             <li class="sidebar__item sidebar__item_parent{{ if $sidebarItem.isActive }} active{{ end }}">
                 <a href='#'>
                   {{- $sidebarItem.title }}
-                  {{- if ne $sidebarItem.d8Edition "ce" }}<span class="sidebar__badge sidebar__badge_{{ lower $sidebarItem.d8Edition }}">EE Only</span>{{ end }} 
+                  {{- if ne $sidebarItem.d8Edition "ce" }}<span class="sidebar__badge sidebar__badge_{{ lower $sidebarItem.d8Edition }}">EE Only</span>{{ end }}
                   {{- if $sidebarItem.moduleStatus -}}
                     <span class="sidebar__badge sidebar__badge_{{ lower $sidebarItem.moduleStatus }}" title='{{ (T (printf "module_alert_%s" (lower $sidebarItem.moduleStatus ))) }}'>{{ humanize $sidebarItem.moduleStatus }}</span>
                   {{ end }}

--- a/docs/site/backends/docs-builder-template/layouts/partials/sidebar.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/sidebar.html
@@ -69,7 +69,7 @@
             <li class="sidebar__item sidebar__item_parent{{ if $sidebarItem.isActive }} active{{ end }}">
                 <a href='#'>
                   {{- $sidebarItem.title }}
-                  {{- if ne $sidebarItem.d8Edition "ce" }}<span class="sidebar__badge sidebar__badge_{{ lower $sidebarItem.d8Edition }}">EE Only</span>{{ end }}
+                  {{- if ne $sidebarItem.d8Edition "ce" }}<span class="sidebar__badge sidebar__badge_{{ lower $sidebarItem.d8Edition }}">EE Only</span>{{ end }} 
                   {{- if $sidebarItem.moduleStatus -}}
                     <span class="sidebar__badge sidebar__badge_{{ lower $sidebarItem.moduleStatus }}" title='{{ (T (printf "module_alert_%s" (lower $sidebarItem.moduleStatus ))) }}'>{{ humanize $sidebarItem.moduleStatus }}</span>
                   {{ end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Changing badges in the sidebar.

Ref #11502 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix the tooltip.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
