### PR TITLE
[extended-monitoring] Separate alert of DeploymentReplicasUnavailable for Standby-Holder

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4759,9 +4759,9 @@ alerts:
       moduleUrl: 040-node-manager
       module: node-manager
       edition: ce
-      description: Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
+      description: Deckhouse has detected that there are no available replicas remaining in deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager.
       summary: |
-        Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
+        No available replicas remaining in deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager.
       severity: "5"
       markupFormat: markdown
     - name: StatefulSetAuthenticationFailure

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4754,6 +4754,19 @@ alerts:
         At least one object violates the configured cluster security policies.
       severity: "7"
       markupFormat: markdown
+    - name: StandbyHolderDeploymentReplicasUnavailable
+      sourceFile: modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+      moduleUrl: 340-extended-monitoring
+      module: extended-monitoring
+      edition: ce
+      description: |-
+        Count of available replicas in Deployment {{$labels.namespace}}/{{$labels.deployment}} is at zero.
+
+        List of unavailable Pod(s): {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"Deployment\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.deployment | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
+      summary: |
+        Count of available replicas in Deployment {{$labels.namespace}}/{{$labels.deployment}} is at zero.
+      severity: "5"
+      markupFormat: markdown
     - name: StatefulSetAuthenticationFailure
       sourceFile: modules/340-extended-monitoring/monitoring/prometheus-rules/image-checks.tpl
       moduleUrl: 340-extended-monitoring

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4759,9 +4759,9 @@ alerts:
       moduleUrl: 040-node-manager
       module: node-manager
       edition: ce
-      description: Deckhouse has detected that there are no available replicas remaining in deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager.
+      description: Deckhouse has detected that there are no available replicas remaining in Deployment `standby-holder-{{$labels.node_group_name}}` in namespace `d8-cloud-instance-manager`.
       summary: |
-        No available replicas remaining in deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager.
+        No available replicas remaining in Deployment `standby-holder-{{$labels.node_group_name}}` in namespace `d8-cloud-instance-manager`.
       severity: "5"
       markupFormat: markdown
     - name: StatefulSetAuthenticationFailure

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4761,7 +4761,7 @@ alerts:
       edition: ce
       description: Deckhouse has detected that there are no available replicas remaining in Deployment `standby-holder-{{$labels.node_group_name}}` in namespace `d8-cloud-instance-manager`.
       summary: |
-        No available replicas remaining in Deployment `standby-holder-{{$labels.node_group_name}}` in namespace `d8-cloud-instance-manager`.
+        No available replicas remaining in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager.
       severity: "5"
       markupFormat: markdown
     - name: StatefulSetAuthenticationFailure

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4759,12 +4759,9 @@ alerts:
       moduleUrl: 340-extended-monitoring
       module: extended-monitoring
       edition: ce
-      description: |-
-        Count of available replicas in Deployment {{$labels.namespace}}/{{$labels.deployment}} is at zero.
-
-        List of unavailable Pod(s): {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"Deployment\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.deployment | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
+      description: Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
       summary: |
-        Count of available replicas in Deployment {{$labels.namespace}}/{{$labels.deployment}} is at zero.
+        Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
       severity: "5"
       markupFormat: markdown
     - name: StatefulSetAuthenticationFailure

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4755,9 +4755,9 @@ alerts:
       severity: "7"
       markupFormat: markdown
     - name: StandbyHolderDeploymentReplicasUnavailable
-      sourceFile: modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
-      moduleUrl: 340-extended-monitoring
-      module: extended-monitoring
+      sourceFile: modules/040-node-manager/monitoring/prometheus-rules/standby-deployment-unavailable.yaml
+      moduleUrl: 040-node-manager
+      module: node-manager
       edition: ce
       description: Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
       summary: |

--- a/modules/040-node-manager/monitoring/prometheus-rules/standby-deployment-unavailable.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/standby-deployment-unavailable.yaml
@@ -32,6 +32,6 @@
       plk_create_group_if_not_exists__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,node_group_name={{ $labels.node_group_name }},kubernetes=~kubernetes"
       plk_grouped_by__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,node_group_name={{ $labels.node_group_name }},kubernetes=~kubernetes"
       summary: |-
-        No available replicas remaining in deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager.
+        No available replicas remaining in Deployment `standby-holder-{{$labels.node_group_name}}` in namespace `d8-cloud-instance-manager`.
       description: |-
-        Deckhouse has detected that there are no available replicas remaining in deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager.
+        Deckhouse has detected that there are no available replicas remaining in Deployment `standby-holder-{{$labels.node_group_name}}` in namespace `d8-cloud-instance-manager`.

--- a/modules/040-node-manager/monitoring/prometheus-rules/standby-deployment-unavailable.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/standby-deployment-unavailable.yaml
@@ -22,7 +22,7 @@
             "standby-holder-(.+)"
           )
       * on (node_group_name)
-        d8_node_group_standby{node_group_name=~".+"}
+        d8_node_group_standby{node_group_name=~".+"} > 0
     for: 5m
     labels:
       severity_level: "5"

--- a/modules/040-node-manager/monitoring/prometheus-rules/standby-deployment-unavailable.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/standby-deployment-unavailable.yaml
@@ -1,0 +1,37 @@
+- name: d8.standby-deployment-unavailable
+  rules:
+  - alert: StandbyHolderDeploymentReplicasUnavailable
+    expr: |
+      (
+              min_over_time(
+                (
+                    kube_deployment_spec_replicas{deployment=~"standby-holder-.+"}
+                  -
+                    kube_deployment_status_replicas_available{deployment=~"standby-holder-.+"}
+                )[5m:]
+              )
+            >
+              0
+          )
+        * on (namespace, deployment) group_left (node_group_name)
+          label_replace(
+            kube_deployment_spec_replicas{deployment=~"standby-holder-.+"},
+            "node_group_name",
+            "$1",
+            "deployment",
+            "standby-holder-(.+)"
+          )
+      * on (node_group_name)
+        d8_node_group_standby{node_group_name=~".+"}
+    for: 5m
+    labels:
+      severity_level: "5"
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,node_group_name={{ $labels.node_group_name }},kubernetes=~kubernetes"
+      plk_grouped_by__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,node_group_name={{ $labels.node_group_name }},kubernetes=~kubernetes"
+      summary: |-
+        Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
+      description: |-
+        Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.

--- a/modules/040-node-manager/monitoring/prometheus-rules/standby-deployment-unavailable.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/standby-deployment-unavailable.yaml
@@ -32,6 +32,6 @@
       plk_create_group_if_not_exists__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,node_group_name={{ $labels.node_group_name }},kubernetes=~kubernetes"
       plk_grouped_by__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,node_group_name={{ $labels.node_group_name }},kubernetes=~kubernetes"
       summary: |-
-        Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
+        No available replicas remaining in deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager.
       description: |-
-        Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
+        Deckhouse has detected that there are no available replicas remaining in deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager.

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -30,7 +30,7 @@
   - alert: KubernetesDeploymentReplicasUnavailable
     expr: |
       (
-        (kube_deployment_status_replicas_available == 0) * (kube_deployment_spec_replicas != 0)
+        (kube_deployment_status_replicas_available{deployment!~"standby-holder-.+"} == 0) * (kube_deployment_spec_replicas{deployment!~"standby-holder-.+"} != 0)
       )
       * on (namespace, deployment)
       (
@@ -50,6 +50,38 @@
         Count of available replicas in Deployment {{$labels.namespace}}/{{$labels.deployment}} is at zero.
 
         List of unavailable Pod(s): {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"Deployment\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.deployment | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
+
+  - alert: StandbyHolderDeploymentReplicasUnavailable
+    expr: |
+      (
+        (kube_deployment_status_replicas_available{deployment=~"standby-holder-.+"} == 0)
+        * (kube_deployment_spec_replicas{deployment=~"standby-holder-.+"} != 0)
+      )
+      * on (namespace, deployment)
+      (
+        max by (namespace, deployment) (extended_monitoring_deployment_threshold{threshold="replicas-not-ready"})
+      )
+      * on (namespace, node_group_name)
+      (
+        label_replace(d8_node_group_ready, "node_group_name", "$1", "deployment", "standby-holder-(.+)")
+        !=
+        label_replace(d8_node_group_max, "node_group_name", "$1", "deployment", "standby-holder-(.+)")
+      )
+    for: 5m
+    labels:
+      severity_level: "5"
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,namespace={{ $labels.namespace }},kubernetes=~kubernetes"
+      plk_grouped_by__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,namespace={{ $labels.namespace }},kubernetes=~kubernetes"
+      summary: |-
+        Count of available replicas in Deployment {{$labels.namespace}}/{{$labels.deployment}} is at zero.
+      description: |-
+        Count of available replicas in Deployment {{$labels.namespace}}/{{$labels.deployment}} is at zero.
+
+        List of unavailable Pod(s): {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"Deployment\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.deployment | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
+
 
   - alert:  KubernetesDaemonSetReplicasUnavailable
     expr: |

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -57,16 +57,16 @@
         (kube_deployment_status_replicas_available{deployment=~"standby-holder-.+"} == 0)
         * (kube_deployment_spec_replicas{deployment=~"standby-holder-.+"} != 0)
       )
-      * on (namespace, deployment)
-      (
-        max by (namespace, deployment) (extended_monitoring_deployment_threshold{threshold="replicas-not-ready"})
-      )
-      * on (namespace, node_group_name)
-      (
-        label_replace(d8_node_group_ready, "node_group_name", "$1", "deployment", "standby-holder-(.+)")
-        !=
-        label_replace(d8_node_group_max, "node_group_name", "$1", "deployment", "standby-holder-(.+)")
-      )
+      * on(namespace, deployment) group_left(node_group_name)
+        label_replace(
+          kube_deployment_spec_replicas{deployment=~"standby-holder-.+"},
+          "node_group_name",
+          "$1",
+          "deployment",
+          "standby-holder-(.+)"
+        )
+      * on (node_group_name)
+        (d8_node_group_ready{node_group_name=~".+"} != d8_node_group_max{node_group_name=~".+"})
     for: 5m
     labels:
       severity_level: "5"

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -54,19 +54,26 @@
   - alert: StandbyHolderDeploymentReplicasUnavailable
     expr: |
       (
-        (kube_deployment_status_replicas_available{deployment=~"standby-holder-.+"} == 0)
-        * (kube_deployment_spec_replicas{deployment=~"standby-holder-.+"} != 0)
-      )
-      * on(namespace, deployment) group_left(node_group_name)
-        label_replace(
-          kube_deployment_spec_replicas{deployment=~"standby-holder-.+"},
-          "node_group_name",
-          "$1",
-          "deployment",
-          "standby-holder-(.+)"
-        )
+              min_over_time(
+                (
+                    kube_deployment_spec_replicas{deployment=~"standby-holder-.+"}
+                  -
+                    kube_deployment_status_replicas_available{deployment=~"standby-holder-.+"}
+                )[5m:]
+              )
+            >
+              0
+          )
+        * on (namespace, deployment) group_left (node_group_name)
+          label_replace(
+            kube_deployment_spec_replicas{deployment=~"standby-holder-.+"},
+            "node_group_name",
+            "$1",
+            "deployment",
+            "standby-holder-(.+)"
+          )
       * on (node_group_name)
-        (d8_node_group_ready{node_group_name=~".+"} != d8_node_group_max{node_group_name=~".+"})
+        d8_node_group_standby{node_group_name=~".+"}
     for: 5m
     labels:
       severity_level: "5"
@@ -76,12 +83,9 @@
       plk_create_group_if_not_exists__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,namespace={{ $labels.namespace }},kubernetes=~kubernetes"
       plk_grouped_by__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,namespace={{ $labels.namespace }},kubernetes=~kubernetes"
       summary: |-
-        Count of available replicas in Deployment {{$labels.namespace}}/{{$labels.deployment}} is at zero.
+        Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
       description: |-
-        Count of available replicas in Deployment {{$labels.namespace}}/{{$labels.deployment}} is at zero.
-
-        List of unavailable Pod(s): {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"Deployment\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.deployment | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
-
+        Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
 
   - alert:  KubernetesDaemonSetReplicasUnavailable
     expr: |

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -80,8 +80,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,namespace={{ $labels.namespace }},kubernetes=~kubernetes"
-      plk_grouped_by__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,namespace={{ $labels.namespace }},kubernetes=~kubernetes"
+      plk_create_group_if_not_exists__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,node_group_name={{ $labels.node_group_name }},kubernetes=~kubernetes"
+      plk_grouped_by__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,node_group_name={{ $labels.node_group_name }},kubernetes=~kubernetes"
       summary: |-
         Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
       description: |-

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -30,7 +30,7 @@
   - alert: KubernetesDeploymentReplicasUnavailable
     expr: |
       (
-        (kube_deployment_status_replicas_available{deployment!~"standby-holder-.+"} == 0) * (kube_deployment_spec_replicas{deployment!~"standby-holder-.+"} != 0)
+        (kube_deployment_status_replicas_available == 0) * (kube_deployment_spec_replicas != 0)
       )
       * on (namespace, deployment)
       (

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -51,42 +51,6 @@
 
         List of unavailable Pod(s): {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"Deployment\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.deployment | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
 
-  - alert: StandbyHolderDeploymentReplicasUnavailable
-    expr: |
-      (
-              min_over_time(
-                (
-                    kube_deployment_spec_replicas{deployment=~"standby-holder-.+"}
-                  -
-                    kube_deployment_status_replicas_available{deployment=~"standby-holder-.+"}
-                )[5m:]
-              )
-            >
-              0
-          )
-        * on (namespace, deployment) group_left (node_group_name)
-          label_replace(
-            kube_deployment_spec_replicas{deployment=~"standby-holder-.+"},
-            "node_group_name",
-            "$1",
-            "deployment",
-            "standby-holder-(.+)"
-          )
-      * on (node_group_name)
-        d8_node_group_standby{node_group_name=~".+"}
-    for: 5m
-    labels:
-      severity_level: "5"
-    annotations:
-      plk_protocol_version: "1"
-      plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,node_group_name={{ $labels.node_group_name }},kubernetes=~kubernetes"
-      plk_grouped_by__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,node_group_name={{ $labels.node_group_name }},kubernetes=~kubernetes"
-      summary: |-
-        Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
-      description: |-
-        Count of available replicas in Deployment standby-holder-{{$labels.node_group_name}} in namespace d8-cloud-instance-manager is at zero.
-
   - alert:  KubernetesDaemonSetReplicasUnavailable
     expr: |
       kube_daemonset_status_number_unavailable


### PR DESCRIPTION
## Description
When we reach max nodes in node group we can recieve KubernetesControllersMalfunctioningInNamespace alert for standby-holder. It is false positive alert.

## Why do we need it, and what problem does it solve?
To receive correct alerts for standby-holder deployments. 

## Why do we need it in the patch release (if we do)?
Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: chore
summary: Separate alert of DeploymentReplicasUnavailable for Standby-Holder
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
