### PR TITLE
[registrypackages] added static resize2fs in e2fsprogs

### DIFF
--- a/candi/bashible/common-steps/all/003_install_mandatory_packages.sh.tpl
+++ b/candi/bashible/common-steps/all/003_install_mandatory_packages.sh.tpl
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bb-package-install "jq:{{ .images.registrypackages.jq171 }}" "curl:{{ .images.registrypackages.d8Curl891 }}" "virt-what:{{ .images.registrypackages.virtWhat125 }}" "socat:{{ .images.registrypackages.socat1734 }}" "e2fsprogs:{{ .images.registrypackages.e2fsprogs1470 }}" "netcat:{{ .images.registrypackages.netcat110481 }}" "iptables:{{ .images.registrypackages.iptables189 }}" "growpart:{{ .images.registrypackages.growpart033 }}" "lsblk:{{- index .images.registrypackages "lsblk2402" }}"
+bb-package-install "jq:{{ .images.registrypackages.jq171 }}" "curl:{{ .images.registrypackages.d8Curl891 }}" "virt-what:{{ .images.registrypackages.virtWhat125 }}" "socat:{{ .images.registrypackages.socat1734 }}" "e2fsprogs:{{ .images.registrypackages.e2fsprogs1472 }}" "netcat:{{ .images.registrypackages.netcat110481 }}" "iptables:{{ .images.registrypackages.iptables189 }}" "growpart:{{ .images.registrypackages.growpart033 }}" "lsblk:{{- index .images.registrypackages "lsblk2402" }}"

--- a/modules/007-registrypackages/images/e2fsprogs/scripts/install
+++ b/modules/007-registrypackages/images/e2fsprogs/scripts/install
@@ -19,3 +19,4 @@ cp -f mke2fs /opt/deckhouse/bin
 ln -sf /opt/deckhouse/bin/mke2fs /opt/deckhouse/bin/mkfs.ext4
 ln -sf /opt/deckhouse/bin/mke2fs /opt/deckhouse/bin/mkfs.ext3
 cp -f fsck /opt/deckhouse/bin
+cp -f resize2fs /opt/deckhouse/bin

--- a/modules/007-registrypackages/images/e2fsprogs/scripts/uninstall
+++ b/modules/007-registrypackages/images/e2fsprogs/scripts/uninstall
@@ -18,3 +18,4 @@ rm -f /opt/deckhouse/bin/mkfs.ext4
 rm -f /opt/deckhouse/bin/mkfs.ext3
 rm -f /opt/deckhouse/bin/fsck
 rm -f /opt/deckhouse/bin/mke2fs
+rm -f /opt/deckhouse/bin/resize2fs

--- a/modules/007-registrypackages/images/e2fsprogs/werf.inc.yaml
+++ b/modules/007-registrypackages/images/e2fsprogs/werf.inc.yaml
@@ -1,11 +1,11 @@
-{{- $version := "1.47.0" }}
+{{- $version := "1.47.2" }}
 {{- $image_version := $version | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
 fromImage: common/src-artifact
 git:
-- add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+- add: /{{ .ModulePath }}/modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/scripts
   to: /src/scripts
   stageDependencies:
     install:
@@ -19,13 +19,19 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ $.Images.BASE_SCRATCH }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
-  add: /
+  add: /src/scripts
+  to: /
+  includePaths:
+  - install
+  - uninstall
+  before: setup
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
+  add: /relocate/sbin
   to: /
   includePaths:
   - mke2fs
   - fsck
-  - install
-  - uninstall
+  - resize2fs
   before: setup
 docker:
   LABEL:
@@ -33,6 +39,7 @@ docker:
     version: all
     mke2fs: {{ $version }}
     fsck: {{ $version }}
+    resize2fs: {{ $version }}
   USER: 64535
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
@@ -48,10 +55,9 @@ shell:
   {{- include "alpine packages proxy" . | nindent 2 }}
   - apk add --no-cache make gettext-dev autoconf automake libtool flex bison clang binutils g++ linux-headers
   setup:
+  - mkdir /relocate
   - cd /src/e2fsprogs
   - CFLAGS='-static' LDFLAGS="-static" ./configure
   - make
-  - strip ./misc/mke2fs && strip ./misc/fsck
-  - mv ./misc/mke2fs /mke2fs && mv ./misc/fsck /fsck
-  - mv /src/scripts/* /
-  - chmod +x /mke2fs /fsck  /install /uninstall
+  - make DESTDIR=/relocate install
+  - make clean

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -428,7 +428,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"d8Curl891":                 "imageHash-registrypackages-d8Curl891",
 		"dockerRegistry283":         "imageHash-registrypackages-dockerRegistry283",
 		"drbd":                      "imageHash-registrypackages-drbd",
-		"e2fsprogs1470":             "imageHash-registrypackages-e2fsprogs1470",
+		"e2fsprogs1472":             "imageHash-registrypackages-e2fsprogs1472",
 		"ec2DescribeTagsV001Flant2": "imageHash-registrypackages-ec2DescribeTagsV001Flant2",
 		"ecrCredentialProvider127":  "imageHash-registrypackages-ecrCredentialProvider127",
 		"ecrCredentialProvider128":  "imageHash-registrypackages-ecrCredentialProvider128",


### PR DESCRIPTION
## Description
added static resize2fs in e2fsprogs
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Mandatory to be accepted in 1.68.0
https://github.com/deckhouse/deckhouse/pull/11585
https://github.com/deckhouse/deckhouse/pull/11634
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: chore
summary: added static resize2fs in e2fsprogs
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
