### PR TITLE
[deckhouse-controller] Skip requirement if not registered

### DIFF
--- a/go_lib/dependency/requirements/requirements.go
+++ b/go_lib/dependency/requirements/requirements.go
@@ -76,9 +76,9 @@ func CheckRequirement(key, value string, enabledModules ...set.Set) (bool, error
 		return true, nil
 	}
 
-	fs, err := defaultRegistry.GetChecksByKey(key)
-	if err != nil {
-		return false, err
+	fs := defaultRegistry.GetChecksByKey(key)
+	if fs == nil {
+		return true, nil
 	}
 
 	for _, f := range fs {
@@ -156,7 +156,7 @@ type ValueGetter interface {
 
 type requirementsResolver interface {
 	RegisterCheck(key string, f CheckFunc)
-	GetChecksByKey(key string) ([]CheckFunc, error)
+	GetChecksByKey(key string) []CheckFunc
 
 	RegisterDisruption(key string, f DisruptionFunc)
 	GetDisruptionByKey(key string) (DisruptionFunc, error)
@@ -182,13 +182,13 @@ func (r *requirementsRegistry) RegisterDisruption(key string, f DisruptionFunc) 
 	r.disruptions[key] = f
 }
 
-func (r *requirementsRegistry) GetChecksByKey(key string) ([]CheckFunc, error) {
+func (r *requirementsRegistry) GetChecksByKey(key string) []CheckFunc {
 	f, ok := r.checkers[key]
 	if !ok {
-		return nil, errors.Wrap(ErrNotRegistered, fmt.Sprintf("requirement with a key: %s", key))
+		return nil
 	}
 
-	return f, nil
+	return f
 }
 
 func (r *requirementsRegistry) GetDisruptionByKey(key string) (DisruptionFunc, error) {


### PR DESCRIPTION
## Description
Skip DeckhouseRelease requirement if not registered

## Why do we need it, and what problem does it solve?
Skip requirements from modules, which are not included in the edition (CE for example)

## Why do we need it in the patch release (if we do)?

This will unblock 1.66 CE release version

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Skip DeckhouseRelease requirement if it's not registered.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
