### PR TITLE
[deckhouse] limit pulled modules

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -55,7 +55,7 @@ const (
 	maxConcurrentReconciles = 3
 	cacheSyncTimeout        = 3 * time.Minute
 
-	maxModulesLimit = 250
+	maxModulesLimit = 1500
 )
 
 var ErrSettingsNotChanged = errors.New("settings not changed")

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -54,6 +54,8 @@ const (
 
 	maxConcurrentReconciles = 3
 	cacheSyncTimeout        = 3 * time.Minute
+
+	maxModulesLimit = 250
 )
 
 var ErrSettingsNotChanged = errors.New("settings not changed")
@@ -223,6 +225,11 @@ func (r *reconciler) handleModuleSource(ctx context.Context, source *v1alpha1.Mo
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{RequeueAfter: defaultScanInterval}, nil
+	}
+
+	// limit pulled module
+	if len(pulledModules) > maxModulesLimit {
+		pulledModules = pulledModules[:maxModulesLimit]
 	}
 
 	// remove the source from available sources in deleted modules

--- a/go_lib/dependency/cr/cr.go
+++ b/go_lib/dependency/cr/cr.go
@@ -42,7 +42,7 @@ import (
 //go:generate minimock -i Client -o cr_mock.go
 
 const (
-	defaultTimeout = 90 * time.Second
+	defaultTimeout = 120 * time.Second
 )
 
 type Client interface {

--- a/go_lib/dependency/cr/cr.go
+++ b/go_lib/dependency/cr/cr.go
@@ -167,8 +167,6 @@ func (r *client) ListTags(ctx context.Context) ([]string, error) {
 		imageOptions = append(imageOptions, remote.WithContext(ctx))
 	}
 
-	imageOptions = append(imageOptions, remote.WithPageSize(250))
-
 	return remote.List(repo, imageOptions...)
 }
 

--- a/go_lib/dependency/cr/cr.go
+++ b/go_lib/dependency/cr/cr.go
@@ -167,6 +167,8 @@ func (r *client) ListTags(ctx context.Context) ([]string, error) {
 		imageOptions = append(imageOptions, remote.WithContext(ctx))
 	}
 
+	imageOptions = append(imageOptions, remote.WithPageSize(250))
+
 	return remote.List(repo, imageOptions...)
 }
 


### PR DESCRIPTION
## Description
It limits tags.

## Why do we need it, and what problem does it solve?
To avoid server overwhelming.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Limit pulled modules.
impact_level: low
```
