### PR TITLE
[docs] Fix the display of the list in the header

### DIFF
--- a/docs/site/_assets/css/components/_header.scss
+++ b/docs/site/_assets/css/components/_header.scss
@@ -77,8 +77,6 @@ font-family: 'Noto Sans', sans-serif;
 
 &__nav {
   &.nav {
-    display: none;
-
     @include min-w(xl) {
       display: flex;
       gap: .75rem .95rem;
@@ -272,10 +270,6 @@ font-family: 'Noto Sans', sans-serif;
   gap: .5rem;
   align-items: center;
 
-  @include max-w(l) {
-    display: none;
-  }
-
   @include min-w(xl) {
     gap: 1rem;
   }
@@ -294,7 +288,7 @@ font-family: 'Noto Sans', sans-serif;
     font-size: .875rem;
     font-weight: 400;
 
-    @include min-w(l) {
+    @include min-w(m) {
       padding: .25rem .4rem;
       font-size: .635rem;
     }
@@ -487,10 +481,7 @@ font-family: 'Noto Sans', sans-serif;
     display: flex;
     gap: 1.25rem 2.1rem;
     flex-direction: column;
-
-    @include min-w(l) {
-      flex-direction: row;
-    }
+    flex-direction: row;
   }
 
   &-logo {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed the display of the list in the header.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix the display of the list in the header.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
