### PR TITLE
fix: ValidatingAdmissionPolicy for exclude-restartedAt

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -52,16 +52,18 @@ spec:
     - name: 'exclude-kinds'
       expression: '!(has(request.kind) && ["StorageClass"].exists(e, (e == request.kind.kind)))'
     - name: 'exclude-restartedAt'
-      expression: '!((!has(oldObject.spec.template.metadata.annotations) && has(object.spec.template.metadata.annotations)
-                    && "kubectl.kubernetes.io/restartedAt" in object.spec.template.metadata.annotations)
-                    || (has(oldObject.spec.template.metadata.annotations) && has(object.spec.template.metadata.annotations)
-                    && !("kubectl.kubernetes.io/restartedAt" in oldObject.spec.template.metadata.annotations)
-                    && "kubectl.kubernetes.io/restartedAt" in object.spec.template.metadata.annotations)
-                    || (has(oldObject.spec.template.metadata.annotations) && has(object.spec.template.metadata.annotations)
-                    && "kubectl.kubernetes.io/restartedAt" in oldObject.spec.template.metadata.annotations
-                    && "kubectl.kubernetes.io/restartedAt" in object.spec.template.metadata.annotations
-                    && oldObject.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"]
-                    != object.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"]))'
+      expression: '!((has(object.spec) && has(object.spec.template) && has(object.spec.template.metadata)
+          && has(oldObject.spec) && has(oldObject.spec.template) && has(oldObject.spec.template.metadata))
+          && ((!has(oldObject.spec.template.metadata.annotations) && has(object.spec.template.metadata.annotations)
+          && "kubectl.kubernetes.io/restartedAt" in object.spec.template.metadata.annotations)
+          || (has(oldObject.spec.template.metadata.annotations) && has(object.spec.template.metadata.annotations)
+          && !("kubectl.kubernetes.io/restartedAt" in oldObject.spec.template.metadata.annotations)
+          && "kubectl.kubernetes.io/restartedAt" in object.spec.template.metadata.annotations)
+          || (has(oldObject.spec.template.metadata.annotations) && has(object.spec.template.metadata.annotations)
+          && "kubectl.kubernetes.io/restartedAt" in oldObject.spec.template.metadata.annotations
+          && "kubectl.kubernetes.io/restartedAt" in object.spec.template.metadata.annotations
+          && oldObject.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"]
+          != object.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"])))'
   validations:
     - expression: 'request.userInfo.username.startsWith("system:serviceaccount:d8-")'
       reason: Forbidden


### PR DESCRIPTION
## Description

Relate error changes in ValidatingAdmissionPolicy for exceptions in exclude-restartedAt.

## Why do we need it, and what problem does it solve?

CSE release must be working

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: ValidatingAdmissionPolicy for exclude-restartedAt
impact_level: default
```
