### PR TITLE
[multitenancy-manager] add resource labels/annotations

### DIFF
--- a/modules/160-multitenancy-manager/crds/doc-ru-projects.yaml
+++ b/modules/160-multitenancy-manager/crds/doc-ru-projects.yaml
@@ -39,9 +39,9 @@ spec:
                 resourceLabels:
                   description: |
                     Метки которые будут применены ко всем ресурсам созданным для этого проекта.
-                  resourceAnnotations:
-                    description: |
-                      Аннотации которые будут применены ко всем ресурсам созданным для этого проекта.
+                resourceAnnotations:
+                  description: |
+                    Аннотации которые будут применены ко всем ресурсам созданным для этого проекта.
                 projectTemplateName:
                   description: |
                     Имя ресурса [ProjectTemplate](cr.html#projecttemplate), который определяет, какие ресурсы будут созданы в проекте.

--- a/modules/160-multitenancy-manager/crds/doc-ru-projects.yaml
+++ b/modules/160-multitenancy-manager/crds/doc-ru-projects.yaml
@@ -36,6 +36,12 @@ spec:
                 description:
                   description: |
                     Произвольное описание назначения проекта. Укажите пустую строку, если описание не требуется.
+                resourceLabels:
+                  description: |
+                    Метки которые будут применены ко всем ресурсам созданным для этого проекта.
+                  resourceAnnotations:
+                    description: |
+                      Аннотации которые будут применены ко всем ресурсам созданным для этого проекта.
                 projectTemplateName:
                   description: |
                     Имя ресурса [ProjectTemplate](cr.html#projecttemplate), который определяет, какие ресурсы будут созданы в проекте.

--- a/modules/160-multitenancy-manager/crds/projects.yaml
+++ b/modules/160-multitenancy-manager/crds/projects.yaml
@@ -93,6 +93,18 @@ spec:
                   description: |
                     Arbitrary description of the project's purpose. Specify an empty string if no description is required.
                   type: string
+                resourceLabels:
+                  description: |
+                    Labels to be applied to all resources created by the project.
+                  type: object
+                  additionalProperties:
+                    type: string
+                  resourceAnnotations:
+                    description: |
+                      Annotations to be applied to all resources created by the project.
+                    type: object
+                    additionalProperties:
+                      type: string
                 projectTemplateName:
                   description: |
                     The name of the [ProjectTemplate](cr.html#projecttemplate) resource that defines which resources will be created in the project.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/apis/deckhouse.io/v1alpha2/project.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/apis/deckhouse.io/v1alpha2/project.go
@@ -17,11 +17,12 @@ limitations under the License.
 package v1alpha2
 
 import (
+	"slices"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"slices"
 )
 
 const (

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/apis/deckhouse.io/v1alpha2/project.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/apis/deckhouse.io/v1alpha2/project.go
@@ -116,6 +116,12 @@ type ProjectSpec struct {
 	// Description of the Project
 	Description string `json:"description,omitempty"`
 
+	// Labels that will be set for all project resources
+	ResourceLabels map[string]string `json:"resourceLabels,omitempty"`
+
+	// Annotations that will be set for all project resources
+	ResourceAnnotations map[string]string `json:"resourceAnnotations,omitempty"`
+
 	// Name of ProjectTemplate to use to create Project
 	ProjectTemplateName string `json:"projectTemplateName,omitempty"`
 
@@ -135,11 +141,23 @@ func (p *ProjectSpec) DeepCopy() *ProjectSpec {
 }
 func (p *ProjectSpec) DeepCopyInto(newObj *ProjectSpec) {
 	*newObj = *p
-	newObj.Description = p.Description
-	newObj.ProjectTemplateName = p.ProjectTemplateName
 	newObj.Parameters = make(map[string]interface{})
 	for key, value := range p.Parameters {
 		newObj.Parameters[key] = value
+	}
+	if p.ResourceLabels != nil {
+		in, out := &p.ResourceLabels, &newObj.ResourceLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if p.ResourceAnnotations != nil {
+		in, out := &p.ResourceAnnotations, &newObj.ResourceAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 }
 

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/client.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/client.go
@@ -261,6 +261,9 @@ func buildValues(project *v1alpha2.Project, template *v1alpha1.ProjectTemplate) 
 	return map[string]interface{}{
 		"projectTemplate": structs.Map(template.Spec),
 		"project":         structs.Map(preparedProject),
+		// this helps to trigger project rendering when resource labels/annotations changed
+		"_projectLabels":      structs.Map(project.Spec.ResourceLabels),
+		"_projectAnnotations": structs.Map(project.Spec.ResourceAnnotations),
 	}
 }
 

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/client.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/client.go
@@ -262,8 +262,8 @@ func buildValues(project *v1alpha2.Project, template *v1alpha1.ProjectTemplate) 
 		"projectTemplate": structs.Map(template.Spec),
 		"project":         structs.Map(preparedProject),
 		// this helps to trigger project rendering when resource labels/annotations changed
-		"_projectLabels":      structs.Map(project.Spec.ResourceLabels),
-		"_projectAnnotations": structs.Map(project.Spec.ResourceAnnotations),
+		"_projectLabels":      project.Spec.ResourceLabels,
+		"_projectAnnotations": project.Spec.ResourceAnnotations,
 	}
 }
 

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/project.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/project.yaml
@@ -3,6 +3,10 @@ kind: Project
 metadata:
   name: test
 spec:
+  resourceLabels:
+    key: val
+  resourceAnnotations:
+    key: val
   description: This is an example from the Deckhouse documentation.
   projectTemplateName: default
   parameters:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
@@ -3,8 +3,11 @@
 apiVersion: deckhouse.io/v1alpha1
 kind: AuthorizationRule
 metadata:
+  annotations:
+    key: val
   labels:
     heritage: multitenancy-manager
+    key: val
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: default
   name: user-gmail.com
@@ -19,8 +22,11 @@ spec:
 apiVersion: v1
 kind: ResourceQuota
 metadata:
+  annotations:
+    key: val
   labels:
     heritage: multitenancy-manager
+    key: val
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: default
   name: all-pods
@@ -34,8 +40,11 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    key: val
   labels:
     heritage: multitenancy-manager
+    key: val
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: default
   name: isolated
@@ -80,8 +89,11 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: OperationPolicy
 metadata:
+  annotations:
+    key: val
   labels:
     heritage: multitenancy-manager
+    key: val
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: default
   name: required-requests-9f86d081
@@ -102,9 +114,12 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    key: val
   labels:
     extended-monitoring.deckhouse.io/enabled: ""
     heritage: multitenancy-manager
+    key: val
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: default
     security.deckhouse.io/pod-policy: baseline

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/project.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/project.yaml
@@ -3,6 +3,10 @@ kind: Project
 metadata:
   name: test
 spec:
+  resourceLabels:
+    "my": "key"
+  resourceAnnotations:
+    "my": "key"
   description: This is an example from the Deckhouse documentation.
   projectTemplateName: without_ns
   parameters:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
@@ -3,9 +3,12 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    my: key
   creationTimestamp: null
   labels:
     heritage: multitenancy-manager
+    my: key
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: without_ns
   name: test
@@ -16,8 +19,11 @@ status: {}
 apiVersion: deckhouse.io/v1alpha1
 kind: AuthorizationRule
 metadata:
+  annotations:
+    my: key
   labels:
     heritage: multitenancy-manager
+    my: key
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: without_ns
   name: user-gmail.com
@@ -32,8 +38,11 @@ spec:
 apiVersion: v1
 kind: ResourceQuota
 metadata:
+  annotations:
+    my: key
   labels:
     heritage: multitenancy-manager
+    my: key
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: without_ns
   name: all-pods
@@ -47,8 +56,11 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    my: key
   labels:
     heritage: multitenancy-manager
+    my: key
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: without_ns
   name: isolated
@@ -74,15 +86,15 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: d8-monitoring
-        podSelector:
-          matchLabels:
-            app.kubernetes.io/name: prometheus
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: d8-ingress-nginx
-        podSelector:
-          matchLabels:
-            app: controller
+      podSelector:
+        matchLabels:
+          app: controller
   podSelector:
     matchLabels: {}
   policyTypes:
@@ -93,8 +105,11 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: OperationPolicy
 metadata:
+  annotations:
+    my: key
   labels:
     heritage: multitenancy-manager
+    my: key
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: without_ns
   name: required-requests-9f86d081

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
@@ -133,9 +133,10 @@ spec:
     spec:
       accessLevel: Admin
       subjects:
-      - kind: {{ $administrator.subject }}
-        name: {{ $administrator.name }}
+        - kind: {{ $administrator.subject }}
+          name: {{ $administrator.name }}
     {{- end }}
+
     ---
     # Max requests and limits for resource and storage consumption for all pods in a namespace.
     # Refer to https://kubernetes.io/docs/concepts/policy/resource-quotas/
@@ -156,6 +157,7 @@ spec:
             {{ with .memory }}limits.memory: {{ . }}{{ end }}
           {{ end }}
         {{ end }}
+
     {{- if eq .parameters.networkPolicy "Isolated" }}
     ---
     # Deny all network traffic by default except namespaced traffic and dns.
@@ -180,31 +182,32 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-monitoring"
-                podSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: prometheus
+              podSelector:
+                matchLabels:
+                  app.kubernetes.io/name: prometheus
             # Ingress nginx traffic.
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-ingress-nginx"
-                podSelector:
-                  matchLabels:
-                    app: controller
-      egress:
-        # Traffic within the project is allowed.
-        - to:
-            - namespaceSelector:
+              podSelector:
                 matchLabels:
-                  kubernetes.io/metadata.name: "{{ .projectName }}"
+                  app: controller
+      egress:
+        - to:
+          # Traffic within the project is allowed.
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: "{{ .projectName }}"
         # Allow DNS traffic (both kube-dns and nodelocaldns).
         - to:
-            - namespaceSelector:
-                matchLabels:
-                  kubernetes.io/metadata.name: kube-system
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: kube-system
           ports:
             - protocol: UDP
               port: 53
     {{- end }}
+
     {{- with .parameters.clusterLogDestinationName }}
     ---
     # Refer to https://deckhouse.io/documentation/v1/modules/460-log-shipper/
@@ -216,6 +219,7 @@ spec:
       clusterDestinationRefs:
         - {{ . }}
     {{- end }}
+
     ---
     # Referer to https://deckhouse.io/documentation/v1/modules/015-admission-policy-engine/
     apiVersion: deckhouse.io/v1alpha1


### PR DESCRIPTION
## Description
It adds resource labels and annotations.

## Why do we need it, and what problem does it solve?
It allows to set labels/annotations to all resource that will be created for the project, and also a good hack to trigger project resources to rerender.

## Example

Project:
```
apiVersion: deckhouse.io/v1alpha2
kind: Project
metadata:
  name: test1
spec:
  resourceLabels:
    "my": "val"
  resourceAnnotations:
    "my": "val"
  description: This is example.
  parameters:
    administrators:
      - name: user@gmail.com
        subject: User
    resourceQuota:
      limits:
        memory: 20Gi
      requests:
        cpu: 2
        memory: 10Gi
  projectTemplateName: default
```

Rendered resource:
```
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    meta.helm.sh/release-name: test1
    meta.helm.sh/release-namespace: ""
    my: val
  creationTimestamp: "2025-02-06T21:00:12Z"
  labels:
    app.kubernetes.io/managed-by: Helm
    extended-monitoring.deckhouse.io/enabled: ""
    heritage: multitenancy-manager
    kubernetes.io/metadata.name: test1
    my: val
    projects.deckhouse.io/project: test1
    projects.deckhouse.io/project-template: default
    security.deckhouse.io/pod-policy: baseline
  name: test1
  resourceVersion: "298804392"
  uid: c7208b73-2a92-4c0e-bea6-1bdfc5841c32
spec:
  finalizers:
  - kubernetes
status:
  phase: Active
```

If we remove resourceLabels the project is rerendered without the label:
```
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    meta.helm.sh/release-name: test1
    meta.helm.sh/release-namespace: ""
  creationTimestamp: "2025-02-06T21:00:12Z"
  labels:
    app.kubernetes.io/managed-by: Helm
    extended-monitoring.deckhouse.io/enabled: ""
    heritage: multitenancy-manager
    kubernetes.io/metadata.name: test1
    my: val
    projects.deckhouse.io/project: test1
    projects.deckhouse.io/project-template: default
    security.deckhouse.io/pod-policy: baseline
  name: test1
  resourceVersion: "298804392"
  uid: c7208b73-2a92-4c0e-bea6-1bdfc5841c32
spec:
  finalizers:
  - kubernetes
status:
  phase: Active
```

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: feature
summary: Add resource label/annotations.
```