### PR TITLE
[registrypackages] Containerd hosts path rewrite & auth configuration changes without service restart

### DIFF
--- a/modules/007-registrypackages/images/containerd/patches/containerd/002-hosts-rewrite.patch
+++ b/modules/007-registrypackages/images/containerd/patches/containerd/002-hosts-rewrite.patch
@@ -1,0 +1,129 @@
+diff --git a/remotes/docker/config/hosts.go b/remotes/docker/config/hosts.go
+index c138c952e..ce655a587 100644
+--- a/remotes/docker/config/hosts.go
++++ b/remotes/docker/config/hosts.go
+@@ -28,6 +28,7 @@ import (
+ 	"os"
+ 	"path"
+ 	"path/filepath"
++	"regexp"
+ 	"sort"
+ 	"strings"
+ 	"time"
+@@ -55,9 +56,16 @@ type hostConfig struct {
+ 
+ 	header http.Header
+ 
++	rewrites []hostPathRewrite
++
+ 	// TODO: Add credential configuration (domain alias, username)
+ }
+ 
++type hostPathRewrite struct {
++	regexp      *regexp.Regexp
++	replacement string
++}
++
+ // HostOptions is used to configure registry hosts
+ type HostOptions struct {
+ 	HostDir       func(string) (string, error)
+@@ -266,6 +274,16 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
+ 			rhosts[i].Path = host.path
+ 			rhosts[i].Capabilities = host.capabilities
+ 			rhosts[i].Header = host.header
++
++			if len(host.rewrites) > 0 {
++				rhosts[i].RepoRewrites = make([]docker.RegistryHostRepoRewrite, len(host.rewrites))
++				for ri, rewrite := range host.rewrites {
++					rhosts[i].RepoRewrites[ri] = docker.RegistryHostRepoRewrite{
++						Regex:       rewrite.regexp,
++						Replacement: rewrite.replacement,
++					}
++				}
++			}
+ 		}
+ 
+ 		return rhosts, nil
+@@ -355,6 +373,11 @@ type hostFileConfig struct {
+ 	// API root endpoint.
+ 	OverridePath bool `toml:"override_path"`
+ 
++	Rewrites []struct {
++		Regex       string `toml:"regex"`
++		Replacement string `toml:"replace"`
++	} `toml:"rewrite"`
++
+ 	// TODO: Credentials: helper? name? username? alternate domain? token?
+ }
+ 
+@@ -524,6 +547,23 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
+ 		result.header = header
+ 	}
+ 
++	if len(config.Rewrites) > 0 {
++		result.rewrites = make([]hostPathRewrite, len(config.Rewrites))
++
++		for i, item := range config.Rewrites {
++			re, err := regexp.Compile(item.Regex)
++			if err != nil {
++				return hostConfig{}, fmt.Errorf(
++					"failed to compile rewrite regex %q for %q, error: %w",
++					item.Regex, server, err,
++				)
++			}
++
++			result.rewrites[i].regexp = re
++			result.rewrites[i].replacement = item.Replacement
++		}
++	}
++
+ 	return result, nil
+ }
+ 
+diff --git a/remotes/docker/registry.go b/remotes/docker/registry.go
+index 98cafcd06..25458671a 100644
+--- a/remotes/docker/registry.go
++++ b/remotes/docker/registry.go
+@@ -20,6 +20,7 @@ import (
+ 	"errors"
+ 	"net"
+ 	"net/http"
++	"regexp"
+ )
+ 
+ // HostCapabilities represent the capabilities of the registry
+@@ -74,6 +75,12 @@ type RegistryHost struct {
+ 	Path         string
+ 	Capabilities HostCapabilities
+ 	Header       http.Header
++	RepoRewrites []RegistryHostRepoRewrite
++}
++
++type RegistryHostRepoRewrite struct {
++	Regex       *regexp.Regexp
++	Replacement string
+ }
+ 
+ func (h RegistryHost) isProxy(refhost string) bool {
+diff --git a/remotes/docker/resolver.go b/remotes/docker/resolver.go
+index 8ce4cccc0..3911f11f7 100644
+--- a/remotes/docker/resolver.go
++++ b/remotes/docker/resolver.go
+@@ -487,7 +487,16 @@ func (r *dockerBase) request(host RegistryHost, method string, ps ...string) *re
+ 	for key, value := range host.Header {
+ 		header[key] = append(header[key], value...)
+ 	}
+-	parts := append([]string{"/", host.Path, r.repository}, ps...)
++
++	repo := r.repository
++	for _, rewrite := range host.RepoRewrites {
++		if rewrite.Regex.MatchString(repo) {
++			repo = rewrite.Regex.ReplaceAllString(repo, rewrite.Replacement)
++			break
++		}
++	}
++
++	parts := append([]string{"/", host.Path, repo}, ps...)
+ 	p := path.Join(parts...)
+ 	// Join strips trailing slash, re-add ending "/" if included
+ 	if len(parts) > 0 && strings.HasSuffix(parts[len(parts)-1], "/") {

--- a/modules/007-registrypackages/images/containerd/patches/containerd/003-hosts-auth.patch
+++ b/modules/007-registrypackages/images/containerd/patches/containerd/003-hosts-auth.patch
@@ -1,0 +1,204 @@
+diff --git a/cmd/ctr/commands/resolver.go b/cmd/ctr/commands/resolver.go
+index 28bc4d43b..4802fa253 100644
+--- a/cmd/ctr/commands/resolver.go
++++ b/cmd/ctr/commands/resolver.go
+@@ -85,10 +85,12 @@ func GetResolver(ctx gocontext.Context, clicontext *cli.Context) (remotes.Resolv
+ 	}
+ 
+ 	hostOptions := config.HostOptions{}
+-	hostOptions.Credentials = func(host string) (string, string, error) {
+-		// If host doesn't match...
+-		// Only one host
+-		return username, secret, nil
++	if username != "" && secret != "" {
++		hostOptions.Credentials = func(host string) (string, string, error) {
++			// If host doesn't match...
++			// Only one host
++			return username, secret, nil
++		}
+ 	}
+ 	if clicontext.Bool("plain-http") {
+ 		hostOptions.DefaultScheme = "http"
+diff --git a/pkg/cri/sbserver/image_pull.go b/pkg/cri/sbserver/image_pull.go
+index e8dead03f..cb1301295 100644
+--- a/pkg/cri/sbserver/image_pull.go
++++ b/pkg/cri/sbserver/image_pull.go
+@@ -425,15 +425,11 @@ func (c *criService) registryHosts(ctx context.Context, auth *runtime.AuthConfig
+ 		hostOptions := config.HostOptions{
+ 			UpdateClient: updateClientFn,
+ 		}
+-		hostOptions.Credentials = func(host string) (string, string, error) {
+-			hostauth := auth
+-			if hostauth == nil {
+-				config := c.config.Registry.Configs[host]
+-				if config.Auth != nil {
+-					hostauth = toRuntimeAuthConfig(*config.Auth)
+-				}
++
++		if auth != nil {
++			hostOptions.Credentials = func(host string) (string, string, error) {
++				return ParseAuth(auth, host)
+ 			}
+-			return ParseAuth(hostauth, host)
+ 		}
+ 		hostOptions.HostDir = hostDirFromRoots(paths)
+ 
+diff --git a/pkg/cri/server/image_pull.go b/pkg/cri/server/image_pull.go
+index 6b321515b..e76d09bc1 100644
+--- a/pkg/cri/server/image_pull.go
++++ b/pkg/cri/server/image_pull.go
+@@ -427,15 +427,10 @@ func (c *criService) registryHosts(ctx context.Context, auth *runtime.AuthConfig
+ 		hostOptions := config.HostOptions{
+ 			UpdateClient: updateClientFn,
+ 		}
+-		hostOptions.Credentials = func(host string) (string, string, error) {
+-			hostauth := auth
+-			if hostauth == nil {
+-				config := c.config.Registry.Configs[host]
+-				if config.Auth != nil {
+-					hostauth = toRuntimeAuthConfig(*config.Auth)
+-				}
++		if auth != nil {
++			hostOptions.Credentials = func(host string) (string, string, error) {
++				return ParseAuth(auth, host)
+ 			}
+-			return ParseAuth(hostauth, host)
+ 		}
+ 		hostOptions.HostDir = hostDirFromRoots(paths)
+ 
+diff --git a/remotes/docker/config/hosts.go b/remotes/docker/config/hosts.go
+index ce655a587..31df545c5 100644
+--- a/remotes/docker/config/hosts.go
++++ b/remotes/docker/config/hosts.go
+@@ -20,6 +20,7 @@ package config
+ import (
+ 	"context"
+ 	"crypto/tls"
++	"encoding/base64"
+ 	"errors"
+ 	"fmt"
+ 	"net"
+@@ -58,9 +59,18 @@ type hostConfig struct {
+ 
+ 	rewrites []hostPathRewrite
+ 
++	auth authConfig
++
+ 	// TODO: Add credential configuration (domain alias, username)
+ }
+ 
++type authConfig struct {
++	userName      string
++	password      string
++	auth          string
++	identityToken string
++}
++
+ type hostPathRewrite struct {
+ 	regexp      *regexp.Regexp
+ 	replacement string
+@@ -176,18 +186,22 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
+ 			}
+ 		}
+ 
+-		authOpts := []docker.AuthorizerOpt{docker.WithAuthClient(client)}
+-		if options.Credentials != nil {
+-			authOpts = append(authOpts, docker.WithAuthCreds(options.Credentials))
+-		}
+-		authOpts = append(authOpts, options.AuthorizerOpts...)
+-		authorizer := docker.NewDockerAuthorizer(authOpts...)
+-
+ 		rhosts := make([]docker.RegistryHost, len(hosts))
+ 		for i, host := range hosts {
+ 			// Allow setting for each host as well
+ 			explicitTLS := tlsConfigured
+ 
++			authOpts := []docker.AuthorizerOpt{docker.WithAuthClient(client)}
++			if options.Credentials != nil {
++				authOpts = append(authOpts, docker.WithAuthCreds(options.Credentials))
++			} else {
++				hostAuth := host.auth // copy to local variable from loop variable
++				authOpts = append(authOpts, docker.WithAuthCreds(func(s string) (string, string, error) {
++					return parseAuth(&hostAuth)
++				}))
++			}
++			authOpts = append(authOpts, options.AuthorizerOpts...)
++
+ 			if host.caCerts != nil || host.clientPairs != nil || host.skipVerify != nil {
+ 				explicitTLS = true
+ 				tr := defaultTransport.Clone()
+@@ -251,7 +265,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
+ 				rhosts[i].Authorizer = docker.NewDockerAuthorizer(append(authOpts, docker.WithAuthClient(&c))...)
+ 			} else {
+ 				rhosts[i].Client = client
+-				rhosts[i].Authorizer = authorizer
++				rhosts[i].Authorizer = docker.NewDockerAuthorizer(authOpts...)
+ 			}
+ 
+ 			// When TLS has been configured for the operation or host and
+@@ -378,6 +392,19 @@ type hostFileConfig struct {
+ 		Replacement string `toml:"replace"`
+ 	} `toml:"rewrite"`
+ 
++	Auth struct {
++		// Username is the username to login the registry.
++		Username string `toml:"username" json:"username"`
++		// Password is the password to login the registry.
++		Password string `toml:"password" json:"password"`
++		// Auth is a base64 encoded string from the concatenation of the username,
++		// a colon, and the password.
++		Auth string `toml:"auth" json:"auth"`
++		// IdentityToken is used to authenticate the user and get
++		// an access token for the registry.
++		IdentityToken string `toml:"identitytoken" json:"identitytoken"`
++	} `toml:"auth"`
++
+ 	// TODO: Credentials: helper? name? username? alternate domain? token?
+ }
+ 
+@@ -564,6 +591,13 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
+ 		}
+ 	}
+ 
++	result.auth = authConfig{
++		userName:      config.Auth.Username,
++		password:      config.Auth.Password,
++		auth:          config.Auth.Auth,
++		identityToken: config.Auth.IdentityToken,
++	}
++
+ 	return result, nil
+ }
+ 
+@@ -651,3 +685,31 @@ func loadCertFiles(ctx context.Context, certsDir string) ([]hostConfig, error) {
+ 	}
+ 	return hosts, nil
+ }
++
++// parseAuth parses AuthConfig and returns username and password/secret required by containerd.
++func parseAuth(auth *authConfig) (string, string, error) {
++	if auth == nil {
++		return "", "", nil
++	}
++	if auth.userName != "" {
++		return auth.userName, auth.password, nil
++	}
++	if auth.identityToken != "" {
++		return "", auth.identityToken, nil
++	}
++	if auth.auth != "" {
++		decLen := base64.StdEncoding.DecodedLen(len(auth.auth))
++		decoded := make([]byte, decLen)
++		_, err := base64.StdEncoding.Decode(decoded, []byte(auth.auth))
++		if err != nil {
++			return "", "", err
++		}
++		user, passwd, ok := strings.Cut(string(decoded), ":")
++		if !ok {
++			return "", "", fmt.Errorf("invalid decoded auth: %q", decoded)
++		}
++		return user, strings.Trim(passwd, "\x00"), nil
++	}
++
++	return "", "", nil
++}

--- a/modules/007-registrypackages/images/containerd/patches/containerd/README.md
+++ b/modules/007-registrypackages/images/containerd/patches/containerd/README.md
@@ -1,0 +1,116 @@
+# Patches
+
+## 002-hosts-rewrite.patch
+Adds ability to rewrite path (repository) part for mirror defined in containerd [host](https://github.com/containerd/containerd/blob/v1.7.24/docs/hosts.md) configuration.
+Configuration will be applied wihout containerd service restart.
+
+To use this support of dynamic hosts configuration must be enabled in containerd by specifying following setting:
+
+```toml
+[plugins."io.containerd.grpc.v1.cri".registry]
+config_path = "/etc/containerd/registry.d"
+```
+
+*Warning: after specify this setting you will disable [deprecated legacy mirrors](https://github.com/containerd/containerd/blob/v1.7.24/docs/cri/registry.md#configure-registry-endpoint) defined by `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]`*
+
+
+Usage example:
+
+`/etc/containerd/registry.d/registry.deckhouse.local/hosts.toml`
+```toml
+server = "https://dev-registry.deckhouse.io"
+capabilities = ["pull", "push", "resolve"]
+
+# first rewrite with regex match will be applied
+# check will be in order as defined in this configuration file
+[[rewrite]]
+regex = "^/system/deckhouse"
+replace = "/sys/deckhouse-oss"
+
+# repos starts with /system/deckhouse will be matched by previous rewrite
+# so it will be not handled by this rewrite 
+[[rewrite]]
+regex = "^/system/"
+replace = "/sys-other/"
+
+# Capture groups can be used in replace in 
+# form specified in https://pkg.go.dev/regexp#Regexp.Expand
+[[rewrite]]
+regex = "^/test/(.+)"
+replace = "/other/${1}/service"
+
+[host]
+
+  # Also it may be configured if multiple hosts specified
+  [host."dev-registry2.deckhouse.io"]
+  capabilities = ["pull", "resolve"]
+
+    [[host."dev-registry2.deckhouse.io".rewrite]]
+    regex = "^/system/"
+    replace = "/sys-registy2/"
+
+    [[host."dev-registry2.deckhouse.io".rewrite]]
+    regex = "^/system/"
+    replace = "/sys-other2/"
+
+  [host."dev-registry3.deckhouse.io"]
+  capabilities = ["pull", "resolve"]
+
+    [[host."dev-registry3.deckhouse.io".rewrite]]
+    regex = "^/system/"
+    replace = "/sys-registy3/"
+
+    [[host."dev-registry3.deckhouse.io".rewrite]]
+    regex = "^/system/"
+    replace = "/sys-other3/"
+
+```
+
+## 003-hosts-auth.patch
+
+Adds ability to specify authentication credentials for mirror defined in containerd [host](https://github.com/containerd/containerd/blob/v1.7.24/docs/hosts.md) configuration.
+Configuration will be applied wihout containerd service restart.
+
+To use this support of dynamic hosts configuration must be enabled in containerd by specifying following setting:
+
+```toml
+[plugins."io.containerd.grpc.v1.cri".registry]
+config_path = "/etc/containerd/registry.d"
+```
+
+*Warning:*
+- *after specify this setting you will disable [deprecated legacy mirrors](https://github.com/containerd/containerd/blob/v1.7.24/docs/cri/registry.md#configure-registry-endpoint) defined by `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]`*
+- *it also will disable usage of the [deprecated `registry.configs.*.auth`](https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials) sections in main config file **(it is differs from standart containerd behavior)***
+
+Usage example:
+
+`/etc/containerd/registry.d/registry.deckhouse.local/hosts.toml`
+```toml
+server = "https://dev-registry.deckhouse.io"
+capabilities = ["pull", "push", "resolve"]
+
+# Auth for top-level mirror
+[auth]
+username = "license-token"
+password = "<my-registry-token>
+
+[host]
+
+  # Also it may be configured for fallback hosts
+  [host."dev-registry2.deckhouse.io"]
+  capabilities = ["pull", "resolve"]
+
+    [host."dev-registry2.deckhouse.io".auth]
+    username = "license-token"
+    password = "<my-registry-token2>
+
+  [host."dev-registry3.deckhouse.io"]
+  capabilities = ["pull", "resolve"]
+
+    [host."dev-registry3.deckhouse.io".auth]
+    username = "license-token"
+    password = "<my-registry-token2>
+
+```
+
+Any options supported by [deprecated `registry.configs.*.auth`](https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials) are supported in `[auth]` section


### PR DESCRIPTION
## Description
This PR adds ability to fully (re)configure hosts (aka mirrors) in **containerd** without service restart.

Implementation extends existent [hosts](https://github.com/containerd/containerd/blob/v1.7.24/docs/hosts.md) mechanic already present in containerd by adding support for settings which required to fully configure mirrors without service restart:
- mirror's authentication configuration
- ability to rewrite `repository` part of the docker image

This setting supported in both `CRI` and `crt` interfaces.

**Change affects critical cluster component: containerd**

PR is includes 2 patches (same also described in included README)

### Patches

#### 002-hosts-rewrite.patch
Adds ability to rewrite path (repository) part for mirror defined in containerd [host](https://github.com/containerd/containerd/blob/v1.7.24/docs/hosts.md) configuration.
Configuration will be applied wihout containerd service restart.

To use this support of dynamic hosts configuration must be enabled in containerd by specifying following setting:

```toml
[plugins."io.containerd.grpc.v1.cri".registry]
config_path = "/etc/containerd/registry.d"
```

*Warning: after specify this setting you will disable [deprecated legacy mirrors](https://github.com/containerd/containerd/blob/v1.7.24/docs/cri/registry.md#configure-registry-endpoint) defined by `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]`*


Usage example:

`/etc/containerd/registry.d/registry.deckhouse.local/hosts.toml`
```toml
server = "https://dev-registry.deckhouse.io"
capabilities = ["pull", "push", "resolve"]

# first rewrite with regex match will be applied
# check will be in order as defined in this configuration file
[[rewrite]]
regex = "^/system/deckhouse"
replace = "/sys/deckhouse-oss"

# repos starts with /system/deckhouse will be matched by previous rewrite
# so it will be not handled by this rewrite 
[[rewrite]]
regex = "^/system/"
replace = "/sys-other/"

# Capture groups can be used in replace in 
# form specified in https://pkg.go.dev/regexp#Regexp.Expand
[[rewrite]]
regex = "^/test/(.+)"
replace = "/other/${1}/service"

[host]

  # Also it may be configured if multiple hosts specified
  [host."dev-registry2.deckhouse.io"]
  capabilities = ["pull", "resolve"]

    [[host."dev-registry2.deckhouse.io".rewrite]]
    regex = "^/system/"
    replace = "/sys-registy2/"

    [[host."dev-registry2.deckhouse.io".rewrite]]
    regex = "^/system/"
    replace = "/sys-other2/"

  [host."dev-registry3.deckhouse.io"]
  capabilities = ["pull", "resolve"]

    [[host."dev-registry3.deckhouse.io".rewrite]]
    regex = "^/system/"
    replace = "/sys-registy3/"

    [[host."dev-registry3.deckhouse.io".rewrite]]
    regex = "^/system/"
    replace = "/sys-other3/"

```

#### 003-hosts-auth.patch

Adds ability to specify authentication credentials for mirror defined in containerd [host](https://github.com/containerd/containerd/blob/v1.7.24/docs/hosts.md) configuration.
Configuration will be applied wihout containerd service restart.

To use this support of dynamic hosts configuration must be enabled in containerd by specifying following setting:

```toml
[plugins."io.containerd.grpc.v1.cri".registry]
config_path = "/etc/containerd/registry.d"
```

*Warning:*
- *after specify this setting you will disable [deprecated legacy mirrors](https://github.com/containerd/containerd/blob/v1.7.24/docs/cri/registry.md#configure-registry-endpoint) defined by `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]`*
- *it also will disable usage of the [deprecated `registry.configs.*.auth`](https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials) sections in main config file **(it is differs from standart containerd behavior)***

Usage example:

`/etc/containerd/registry.d/registry.deckhouse.local/hosts.toml`
```toml
server = "https://dev-registry.deckhouse.io"
capabilities = ["pull", "push", "resolve"]

# Auth for top-level mirror
[auth]
username = "license-token"
password = "<my-registry-token>

[host]

  # Also it may be configured for fallback hosts
  [host."dev-registry2.deckhouse.io"]
  capabilities = ["pull", "resolve"]

    [host."dev-registry2.deckhouse.io".auth]
    username = "license-token"
    password = "<my-registry-token2>

  [host."dev-registry3.deckhouse.io"]
  capabilities = ["pull", "resolve"]

    [host."dev-registry3.deckhouse.io".auth]
    username = "license-token"
    password = "<my-registry-token2>

```

Any options supported by [deprecated `registry.configs.*.auth`](https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials) are supported in `[auth]` section


## Why do we need it, and what problem does it solve?
This change will add ability to:
1. (re) configure registry mirrors without containerd restarts
2. have _stable internal_ registry address and path for deckhouse components (for example `deckhouse-registry.deckhouse.local/sys/deckhouse`) in clusters and change _real_ registry address and path without containerd restarts and changes in deployments, daemonsets and other k8s primitives. Will also make transition between direct / embedded registry more seamless.

This change was initiated by @sample

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: feature
summary: containerd hosts path rewrite & auth configuration changes without service restart
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
