### PR TITLE
[CI] update flow deploy release

### DIFF
--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -74,10 +74,20 @@ env:
 
 jobs:
 {!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if triggered by a tag
+        run: |
+          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
+            echo "Workflow can only be triggered from release tags!"
+            exit 1
+          fi
 
   detect_editions:
     name: Detect editions
     runs-on: ubuntu-latest
+    needs: check_branch
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
       DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}

--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -79,11 +79,11 @@ jobs:
     steps:
       - name: Check if triggered by a tag
         run: |
-          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
-            echo "Workflow can only be triggered from release tags!"
+          TAG="${{ github.ref }}"
+          if [[ ! "$TAG" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Workflow can only be triggered from release tags (vX.Y.Z)!"
             exit 1
           fi
-
   detect_editions:
     name: Detect editions
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -138,11 +138,11 @@ jobs:
     steps:
       - name: Check if triggered by a tag
         run: |
-          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
-            echo "Workflow can only be triggered from release tags!"
+          TAG="${{ github.ref }}"
+          if [[ ! "$TAG" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Workflow can only be triggered from release tags (vX.Y.Z)!"
             exit 1
           fi
-
   detect_editions:
     name: Detect editions
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -133,10 +133,20 @@ jobs:
             core.setCommandEcho(false)
 
   # </template: git_info_job>
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if triggered by a tag
+        run: |
+          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
+            echo "Workflow can only be triggered from release tags!"
+            exit 1
+          fi
 
   detect_editions:
     name: Detect editions
     runs-on: ubuntu-latest
+    needs: check_branch
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
       DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -138,11 +138,11 @@ jobs:
     steps:
       - name: Check if triggered by a tag
         run: |
-          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
-            echo "Workflow can only be triggered from release tags!"
+          TAG="${{ github.ref }}"
+          if [[ ! "$TAG" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Workflow can only be triggered from release tags (vX.Y.Z)!"
             exit 1
           fi
-
   detect_editions:
     name: Detect editions
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -133,10 +133,20 @@ jobs:
             core.setCommandEcho(false)
 
   # </template: git_info_job>
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if triggered by a tag
+        run: |
+          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
+            echo "Workflow can only be triggered from release tags!"
+            exit 1
+          fi
 
   detect_editions:
     name: Detect editions
     runs-on: ubuntu-latest
+    needs: check_branch
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
       DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -138,11 +138,11 @@ jobs:
     steps:
       - name: Check if triggered by a tag
         run: |
-          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
-            echo "Workflow can only be triggered from release tags!"
+          TAG="${{ github.ref }}"
+          if [[ ! "$TAG" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Workflow can only be triggered from release tags (vX.Y.Z)!"
             exit 1
           fi
-
   detect_editions:
     name: Detect editions
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -133,10 +133,20 @@ jobs:
             core.setCommandEcho(false)
 
   # </template: git_info_job>
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if triggered by a tag
+        run: |
+          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
+            echo "Workflow can only be triggered from release tags!"
+            exit 1
+          fi
 
   detect_editions:
     name: Detect editions
     runs-on: ubuntu-latest
+    needs: check_branch
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
       DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -138,11 +138,11 @@ jobs:
     steps:
       - name: Check if triggered by a tag
         run: |
-          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
-            echo "Workflow can only be triggered from release tags!"
+          TAG="${{ github.ref }}"
+          if [[ ! "$TAG" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Workflow can only be triggered from release tags (vX.Y.Z)!"
             exit 1
           fi
-
   detect_editions:
     name: Detect editions
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -133,10 +133,20 @@ jobs:
             core.setCommandEcho(false)
 
   # </template: git_info_job>
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if triggered by a tag
+        run: |
+          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
+            echo "Workflow can only be triggered from release tags!"
+            exit 1
+          fi
 
   detect_editions:
     name: Detect editions
     runs-on: ubuntu-latest
+    needs: check_branch
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
       DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -138,11 +138,11 @@ jobs:
     steps:
       - name: Check if triggered by a tag
         run: |
-          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
-            echo "Workflow can only be triggered from release tags!"
+          TAG="${{ github.ref }}"
+          if [[ ! "$TAG" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Workflow can only be triggered from release tags (vX.Y.Z)!"
             exit 1
           fi
-
   detect_editions:
     name: Detect editions
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -133,10 +133,20 @@ jobs:
             core.setCommandEcho(false)
 
   # </template: git_info_job>
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if triggered by a tag
+        run: |
+          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
+            echo "Workflow can only be triggered from release tags!"
+            exit 1
+          fi
 
   detect_editions:
     name: Detect editions
     runs-on: ubuntu-latest
+    needs: check_branch
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
       DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}


### PR DESCRIPTION
## Description
- Implemented validation to ensure the workflow runs only for release tags in the format `vX.Y.Z` (e.g., `v1.67.9`).
- The workflow now verifies that the `github.ref` matches `refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$` before proceeding.
- If the tag does not match the required format, the workflow exits with an error.

## Why do we need it, and what problem does it solve?
- To prevent accidental workflow execution on incorrect tags.
- Ensures that only proper release tags trigger the deployment process.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: updated flow deploy release
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
