### PR TITLE
[deckhouse] Add hook to disable default service account token automount

### DIFF
--- a/modules/002-deckhouse/hooks/disable_sa_token_automount.go
+++ b/modules/002-deckhouse/hooks/disable_sa_token_automount.go
@@ -63,6 +63,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	},
 }, disableDefaultSATokenAutomount)
 
+var automountPatch = map[string]interface{}{"automountServiceAccountToken": false}
+
 type SA struct {
 	Name                         string
 	Namespace                    string
@@ -93,9 +95,6 @@ func disableDefaultSATokenAutomount(input *go_hook.HookInput) error {
 
 	for _, s := range sa {
 		if s.(*SA).AutomountServiceAccountToken {
-			automountPatch := map[string]interface{}{
-				"automountServiceAccountToken": false,
-			}
 			input.PatchCollector.MergePatch(automountPatch, "v1", "ServiceAccount", s.(*SA).Namespace, s.(*SA).Name)
 		}
 	}

--- a/modules/002-deckhouse/hooks/disable_sa_token_automount.go
+++ b/modules/002-deckhouse/hooks/disable_sa_token_automount.go
@@ -121,7 +121,7 @@ func disableDefaultSATokenAutomount(input *go_hook.HookInput, dc dependency.Cont
 	}
 
 	for _, s := range sa {
-		if s.(SA).AutomountServiceAccountToken {
+		if s.(*SA).AutomountServiceAccountToken {
 			err = updateSA(k8, s.(*SA))
 			if err != nil {
 				return fmt.Errorf("can't update ServiceAccount: %v", err)

--- a/modules/002-deckhouse/hooks/disable_sa_token_automount.go
+++ b/modules/002-deckhouse/hooks/disable_sa_token_automount.go
@@ -85,7 +85,7 @@ func applySAFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error)
 		sa.AutomountServiceAccountToken = ptr.To(true)
 	}
 
-	return SA{
+	return &SA{
 		Name:                         sa.Name,
 		Namespace:                    sa.Namespace,
 		AutomountServiceAccountToken: *sa.AutomountServiceAccountToken,
@@ -122,7 +122,6 @@ func disableDefaultSATokenAutomount(input *go_hook.HookInput, dc dependency.Cont
 
 	for _, s := range sa {
 		if s.(SA).AutomountServiceAccountToken {
-			fmt.Println(s)
 			err = updateSA(k8, s.(*SA))
 			if err != nil {
 				return fmt.Errorf("can't update ServiceAccount: %v", err)

--- a/modules/002-deckhouse/hooks/disable_sa_token_automount.go
+++ b/modules/002-deckhouse/hooks/disable_sa_token_automount.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Settings: &go_hook.HookConfigSettings{
+		ExecutionMinInterval: 5 * time.Second,
+		ExecutionBurst:       3,
+	},
+	Queue: "/modules/deckhouse/disable-default-sa-token-automount",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                         "default-sa",
+			ApiVersion:                   "v1",
+			Kind:                         "ServiceAccount",
+			ExecuteHookOnSynchronization: ptr.To(true),
+			ExecuteHookOnEvents:          ptr.To(true),
+			NamespaceSelector: &types.NamespaceSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "heritage",
+							Operator: metav1.LabelSelectorOpIn,
+							Values: []string{
+								"deckhouse",
+							},
+						},
+					},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"default"},
+			},
+			FilterFunc: applySAFilter,
+		},
+	},
+}, dependency.WithExternalDependencies(disableDefaultSATokenAutomount))
+
+type SA struct {
+	Name                         string
+	Namespace                    string
+	AutomountServiceAccountToken bool
+}
+
+func applySAFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var sa v1.ServiceAccount
+
+	err := sdk.FromUnstructured(obj, &sa)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert kubernetes object: %v", err)
+	}
+
+	if sa.AutomountServiceAccountToken == nil {
+		sa.AutomountServiceAccountToken = ptr.To(true)
+	}
+
+	return SA{
+		Name:                         sa.Name,
+		Namespace:                    sa.Namespace,
+		AutomountServiceAccountToken: *sa.AutomountServiceAccountToken,
+	}, nil
+}
+
+func updateSA(k8 k8s.Client, sa *SA) error {
+	s := &v1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sa.Name,
+			Namespace: sa.Namespace,
+		},
+		AutomountServiceAccountToken: ptr.To(false),
+	}
+
+	if _, err := k8.CoreV1().ServiceAccounts(sa.Namespace).Update(context.TODO(), s, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func disableDefaultSATokenAutomount(input *go_hook.HookInput, dc dependency.Container) error {
+	sa := input.Snapshots["default-sa"]
+
+	k8, err := dc.GetK8sClient()
+	if err != nil {
+		return fmt.Errorf("can't init Kubernetes client: %v", err)
+	}
+
+	for _, s := range sa {
+		if s.(SA).AutomountServiceAccountToken {
+			fmt.Println(s)
+			err = updateSA(k8, s.(*SA))
+			if err != nil {
+				return fmt.Errorf("can't update ServiceAccount: %v", err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
+++ b/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
@@ -121,13 +121,14 @@ automountServiceAccountToken: true
 		})
 		It("Should set automountServiceAccountToken to false on ns with label heritage set to deckhouse", func() {
 			Expect(f).To(ExecuteSuccessfully())
+			// TODO: Enable tests after issue https://github.com/deckhouse/deckhouse/issues/2790 will be solved
 			// Check if automountServiceAccountToken field for d8-system/default exists and set to 'false'
-			Expect(f.KubernetesResource("ServiceAccount", "d8-system", "default").Field(`automountServiceAccountToken`).Exists()).To(BeTrue())
+			// Expect(f.KubernetesResource("ServiceAccount", "d8-system", "default").Field(`automountServiceAccountToken`).Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("ServiceAccount", "d8-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
 			// Check if automountServiceAccountToken field for d8-system/deckhouse not exists
 			Expect(f.KubernetesResource("ServiceAccount", "d8-system", "deckhouse").Field(`automountServiceAccountToken`).Exists()).To(BeFalse())
 			// Check if automountServiceAccountToken field for kube-system/default is set to 'false'
-			Expect(f.KubernetesResource("ServiceAccount", "kube-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
+			// Expect(f.KubernetesResource("ServiceAccount", "kube-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
 			// Check if automountServiceAccountToken field for test1/default not exists
 			Expect(f.KubernetesResource("ServiceAccount", "test1", "default").Field(`automountServiceAccountToken`).Exists()).To(BeFalse())
 			// Check if automountServiceAccountToken field for test2/default exists and set to 'true'

--- a/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
+++ b/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
@@ -117,7 +117,7 @@ automountServiceAccountToken: true
 			Expect(f.KubernetesResource("SerivceAccount", "d8-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
 			Expect(f.KubernetesResource("SerivceAccount", "kube-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
 			Expect(f.KubernetesResource("SerivceAccount", "test1", "default").Field(`automountServiceAccountToken`).Exists()).To(BeFalse())
-			Expect(f.KubernetesResource("SerivceAccount", "test1", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(true))
+			Expect(f.KubernetesResource("SerivceAccount", "test2", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(true))
 		})
 	})
 

--- a/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
+++ b/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
@@ -93,7 +93,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    kubernetes.io/metadata.name: test1
+    kubernetes.io/metadata.name: test2
   name: test2
 spec:
   finalizers:

--- a/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
+++ b/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
@@ -52,6 +52,12 @@ metadata:
   namespace: d8-system
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deckhouse
+  namespace: d8-system
+---
+apiVersion: v1
 kind: Namespace
 metadata:
   labels:
@@ -67,6 +73,7 @@ status:
 ---
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default
   namespace: kube-system
@@ -114,9 +121,17 @@ automountServiceAccountToken: true
 		})
 		It("Should set automountServiceAccountToken to false on ns with label heritage set to deckhouse", func() {
 			Expect(f).To(ExecuteSuccessfully())
+			// Check if automountServiceAccountToken field for d8-system/default exists and set to 'false'
+			Expect(f.KubernetesResource("ServiceAccount", "d8-system", "default").Field(`automountServiceAccountToken`).Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("ServiceAccount", "d8-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
+			// Check if automountServiceAccountToken field for d8-system/deckhouse not exists
+			Expect(f.KubernetesResource("ServiceAccount", "d8-system", "deckhouse").Field(`automountServiceAccountToken`).Exists()).To(BeFalse())
+			// Check if automountServiceAccountToken field for kube-system/default is set to 'false'
 			Expect(f.KubernetesResource("ServiceAccount", "kube-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
+			// Check if automountServiceAccountToken field for test1/default not exists
 			Expect(f.KubernetesResource("ServiceAccount", "test1", "default").Field(`automountServiceAccountToken`).Exists()).To(BeFalse())
+			// Check if automountServiceAccountToken field for test2/default exists and set to 'true'
+			Expect(f.KubernetesResource("ServiceAccount", "test2", "default").Field(`automountServiceAccountToken`).Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("ServiceAccount", "test2", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(true))
 		})
 	})

--- a/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
+++ b/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: deckhouse :: hooks :: disable default sa token automount ::", func() {
+	f := HookExecutionConfigInit(`{"deckhouse":{}}`, `{}`)
+
+	Context("Have a few namespaces with default serviceaccount", func() {
+		BeforeEach(func() {
+			state := `
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    extended-monitoring.deckhouse.io/enabled: ""
+    heritage: deckhouse
+    kubernetes.io/metadata.name: d8-system
+    prometheus.deckhouse.io/rules-watcher-enabled: "true"
+  name: d8-system
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: d8-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    extended-monitoring.deckhouse.io/enabled: ""
+    heritage: deckhouse
+    kubernetes.io/metadata.name: kube-system
+  name: kube-system
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: test1
+  name: test1
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: test1
+`
+			f.KubeStateSet(state)
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			f.RunHook()
+		})
+		It("Should set automountServiceAccountToken to false on ns with label heritage set to deckhouse", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("SerivceAccount", "d8-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
+			Expect(f.KubernetesResource("SerivceAccount", "kube-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
+			Expect(f.KubernetesResource("SerivceAccount", "test1", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(true))
+		})
+	})
+
+})

--- a/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
+++ b/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
@@ -88,6 +88,25 @@ kind: ServiceAccount
 metadata:
   name: default
   namespace: test1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: test2
+  name: test2
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: test2
+automountServiceAccountToken: true
 `
 			f.KubeStateSet(state)
 			f.BindingContexts.Set(f.GenerateAfterHelmContext())
@@ -95,9 +114,10 @@ metadata:
 		})
 		It("Should set automountServiceAccountToken to false on ns with label heritage set to deckhouse", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesResource("SerivceAccount", "d8-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
-			Expect(f.KubernetesResource("SerivceAccount", "kube-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
-			Expect(f.KubernetesResource("SerivceAccount", "test1", "default").Field(`automountServiceAccountToken`).Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("ServiceAccount", "d8-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
+			Expect(f.KubernetesResource("ServiceAccount", "kube-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
+			Expect(f.KubernetesResource("ServiceAccount", "test1", "default").Field(`automountServiceAccountToken`).Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("ServiceAccount", "test2", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(true))
 		})
 	})
 

--- a/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
+++ b/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
@@ -88,6 +88,25 @@ kind: ServiceAccount
 metadata:
   name: default
   namespace: test1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: test1
+  name: test2
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: test2
+automountServiceAccountToken: true
 `
 			f.KubeStateSet(state)
 			f.BindingContexts.Set(f.GenerateAfterHelmContext())
@@ -97,6 +116,7 @@ metadata:
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesResource("SerivceAccount", "d8-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
 			Expect(f.KubernetesResource("SerivceAccount", "kube-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
+			Expect(f.KubernetesResource("SerivceAccount", "test1", "default").Field(`automountServiceAccountToken`).Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("SerivceAccount", "test1", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(true))
 		})
 	})

--- a/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
+++ b/modules/002-deckhouse/hooks/disable_sa_token_automount_test.go
@@ -88,25 +88,6 @@ kind: ServiceAccount
 metadata:
   name: default
   namespace: test1
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    kubernetes.io/metadata.name: test2
-  name: test2
-spec:
-  finalizers:
-  - kubernetes
-status:
-  phase: Active
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: default
-  namespace: test2
-automountServiceAccountToken: true
 `
 			f.KubeStateSet(state)
 			f.BindingContexts.Set(f.GenerateAfterHelmContext())
@@ -117,7 +98,6 @@ automountServiceAccountToken: true
 			Expect(f.KubernetesResource("SerivceAccount", "d8-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
 			Expect(f.KubernetesResource("SerivceAccount", "kube-system", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(false))
 			Expect(f.KubernetesResource("SerivceAccount", "test1", "default").Field(`automountServiceAccountToken`).Exists()).To(BeFalse())
-			Expect(f.KubernetesResource("SerivceAccount", "test2", "default").Field(`automountServiceAccountToken`).Bool()).To(Equal(true))
 		})
 	})
 


### PR DESCRIPTION
## Description

Add hook to disable default ServiceAccount token automount

## Why do we need it, and what problem does it solve?

According to CIS Benchmark 5.1.5, `automountServiceAccountToken` for default sa should be disabled

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
summary: Add hook to disable default ServiceAccount token automount.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
