### PR TITLE
[cilium] Adding a new dashboard for cilium.

### DIFF
--- a/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-ping-nodes.json
+++ b/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-ping-nodes.json
@@ -790,7 +790,7 @@
     ]
   },
   "timezone": "",
-  "title": "Cilium Nodes Connectivity Latency",
+  "title": "Cilium Nodes Connectivity Status&Latency",
   "uid": "vtuWtdunt",
   "version": 1,
   "weekStart": ""

--- a/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-ping-nodes.json
+++ b/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-ping-nodes.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": 36,
@@ -766,8 +766,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
-      "10s",
       "30s",
       "1m",
       "5m",

--- a/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-ping-nodes.json
+++ b/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-ping-nodes.json
@@ -127,7 +127,7 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "avg_over_time(cilium_node_connectivity_status{type=\"node\"}[$__range]) * 100",
+          "expr": "avg_over_time(cilium_node_connectivity_status{type=\"node\",source_node_name=~\"${source_node:regex}\",target_node_name=~\"${destination_node:regex}\"}[$__range]) * 100",
           "format": "table",
           "legendFormat": "__auto",
           "range": true,

--- a/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-ping-nodes.json
+++ b/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-ping-nodes.json
@@ -83,7 +83,7 @@
       },
       "gridPos": {
         "h": 17,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 1
       },
@@ -115,7 +115,7 @@
           "mode": "single",
           "sort": "none"
         },
-        "txtLength": 50,
+        "txtLength": 25,
         "txtSize": 10,
         "value": "Value",
         "valueText": "Value"
@@ -135,6 +135,106 @@
         }
       ],
       "title": "Node Connectivity Status Matrix",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "esnet-matrix-panel"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 17,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 793,
+      "options": {
+        "addUrl": false,
+        "cellPadding": 5,
+        "cellSize": 15,
+        "colWidth": 0.8,
+        "defaultColor": "#E6E6E6",
+        "destination": "target_name",
+        "inputList": false,
+        "legend": {
+          "displayMode": "list",
+          "height": 500,
+          "placement": "bottom",
+          "showLegend": true,
+          "width": 700
+        },
+        "nullColor": "#E6E6E6",
+        "rowHeight": 0.7,
+        "showValue": "never",
+        "source": "source_name",
+        "sourceField": "source_node_name",
+        "sourceText": "From",
+        "targetField": "target_node_name",
+        "targetText": "To",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "txtLength": 25,
+        "txtSize": 10,
+        "value": "Value",
+        "valueText": "Value"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(cilium_node_connectivity_status{type=\"endpoint\",source_node_name=~\"${source_node:regex}\",target_node_name=~\"${destination_node:regex}\"}[$__range]) * 100",
+          "format": "table",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Endpoint Connectivity Status Matrix",
       "transformations": [
         {
           "id": "organize",

--- a/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-ping-nodes.json
+++ b/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-ping-nodes.json
@@ -1,0 +1,697 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 36,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 777,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "From all nodes",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 17,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 778,
+      "options": {
+        "addUrl": false,
+        "cellPadding": 5,
+        "cellSize": 15,
+        "colWidth": 0.8,
+        "defaultColor": "#E6E6E6",
+        "destination": "target_name",
+        "inputList": false,
+        "legend": {
+          "displayMode": "list",
+          "height": 500,
+          "placement": "bottom",
+          "showLegend": true,
+          "width": 700
+        },
+        "nullColor": "#E6E6E6",
+        "rowHeight": 0.7,
+        "showValue": "never",
+        "source": "source_name",
+        "sourceField": "source_node_name",
+        "sourceText": "From",
+        "targetField": "target_node_name",
+        "targetText": "To",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "txtLength": 50,
+        "txtSize": 10,
+        "value": "Value",
+        "valueText": "Value"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(cilium_node_connectivity_status{type=\"node\"}[$__range]) * 100",
+          "format": "table",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Node Connectivity Status Matrix",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "esnet-matrix-panel"
+    },
+    {
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 17,
+      "panels": [
+        {
+          "datasource": {
+            "uid": "$ds_prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 3,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 779,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "avg by (target_node_name) (cilium_node_connectivity_latency_seconds{source_node_name=~\"$source_node\", target_node_name=~\"$destination_node\", type=\"node\", protocol=\"icmp\"})",
+              "legendFormat": "{{target_node_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Node ICMP Latency",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "uid": "$ds_prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 3,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "id": 780,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "avg by (target_node_name) (cilium_node_connectivity_latency_seconds{source_node_name=~\"$source_node\", target_node_name=~\"$destination_node\", type=\"node\", protocol=\"http\"})",
+              "legendFormat": "{{target_node_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Node HTTP Latency",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "uid": "$ds_prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 3,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "id": 781,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "avg by (target_node_name) (cilium_node_connectivity_latency_seconds{source_node_name=~\"$source_node\", target_node_name=~\"$destination_node\", type=\"endpoint\", protocol=\"icmp\"})",
+              "legendFormat": "{{target_node_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Endpoint ICMP Latency",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "uid": "$ds_prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 3,
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 25
+          },
+          "id": 782,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "avg by (target_node_name) (cilium_node_connectivity_latency_seconds{source_node_name=~\"$source_node\", target_node_name=~\"$destination_node\", type=\"endpoint\", protocol=\"http\"})",
+              "legendFormat": "{{target_node_name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Endpoint HTTP Latency",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": "source_node",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "From $source_node",
+      "type": "row"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "nodes"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "main",
+          "value": "$ds_prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Source",
+        "multi": true,
+        "name": "source_node",
+        "options": [],
+        "query": "label_values(cilium_node_connectivity_latency_seconds, source_node_name)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "definition": "label_values(cilium_node_connectivity_latency_seconds, target_node_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Destination",
+        "multi": true,
+        "name": "destination_node",
+        "options": [],
+        "query": "label_values(cilium_node_connectivity_latency_seconds, target_node_name)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "definition": "label_values(cilium_node_connectivity_latency_seconds, protocol)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Protocol",
+        "multi": true,
+        "name": "protocol",
+        "options": [],
+        "query": "label_values(cilium_node_connectivity_latency_seconds, protocol)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "filters": [],
+        "hide": 0,
+        "name": "Filters",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Cilium Nodes Connectivity Latency",
+  "uid": "vtuWtdunt",
+  "version": 1,
+  "weekStart": ""
+}

--- a/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
+++ b/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 {{ $grafanaVersion := "10.4.15" }}
-{{ $bundledPlugins := "petrslavotinek-carpetplot-panel,vonage-status-panel,btplc-status-dot-panel,natel-plotly-panel,savantly-heatmap-panel,grafana-piechart-panel,grafana-worldmap-panel" }}
+{{ $bundledPlugins := "petrslavotinek-carpetplot-panel,vonage-status-panel,btplc-status-dot-panel,natel-plotly-panel,savantly-heatmap-panel,grafana-piechart-panel,grafana-worldmap-panel,esnet-matrix-panel" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
 final: false

--- a/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
+++ b/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
@@ -19,8 +19,13 @@ shell:
   - cd /usr/src/app
   - git clone --depth 1 --branch v{{ $grafanaVersion }} {{ $.SOURCE_REPO }}/grafana/grafana.git .
   - git clone --depth 1 --branch v{{ $grafanaVersion }} {{ $.SOURCE_REPO }}/grafana/grafana-deps.git /grafana-public
-  - git clone --depth 1 {{ $.SOURCE_REPO }}/grafana/grafana-plugins.git /grafana-plugins
   - find /patches -name '*.patch' -exec git apply {} \;
+  - mkdir -p /grafana-plugins
+  - cd /grafana-plugins
+  - git init
+  - git remote add origin {{ $.SOURCE_REPO }}/grafana/grafana-plugins.git
+  - git fetch origin 2184f7ebebe08585f0a1fd9ff7b2bca3bedcc5a6
+  - git reset --hard FETCH_HEAD
   - rm -rf /usr/src/app/.git /grafana-public/.git /grafana-plugins/.git /src/wire/.git
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-go-builder

--- a/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
+++ b/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
@@ -19,13 +19,8 @@ shell:
   - cd /usr/src/app
   - git clone --depth 1 --branch v{{ $grafanaVersion }} {{ $.SOURCE_REPO }}/grafana/grafana.git .
   - git clone --depth 1 --branch v{{ $grafanaVersion }} {{ $.SOURCE_REPO }}/grafana/grafana-deps.git /grafana-public
+  - git clone --depth 1 {{ $.SOURCE_REPO }}/grafana/grafana-plugins.git /grafana-plugins
   - find /patches -name '*.patch' -exec git apply {} \;
-  - mkdir -p /grafana-plugins
-  - cd /grafana-plugins
-  - git init
-  - git remote add origin {{ $.SOURCE_REPO }}/grafana/grafana-plugins.git
-  - git fetch origin 2184f7ebebe08585f0a1fd9ff7b2bca3bedcc5a6
-  - git reset --hard FETCH_HEAD
   - rm -rf /usr/src/app/.git /grafana-public/.git /grafana-plugins/.git /src/wire/.git
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-go-builder


### PR DESCRIPTION
## Description

We have added a new dashboard to help quickly identify any connectivity issues between nodes in the cluster. 
This dashboard is similar to the periodic execution of the `cilium-health status` command on all the nodes in the cluster.

![image](https://github.com/user-attachments/assets/2a00dccc-e0de-453d-9a92-c6ea864623f1)

## Why do we need it, and what problem does it solve?

This dashboard is very useful, as it allows you to quickly identify connection issues between nodes. In addition, all the necessary metrics are already available in Prometheus.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: feature 
summary: Added new dashboard "Cilium Nodes Connectivity Status&Latency"
impact_level: default
---
section: prometheus
type: feature 
summary: Added new grafana plugin `esnet-matrix-panel`.
impact_level: default
```
