### PR TITLE
[global] Disable automountServiceAccountToken for all sa, enable if necessary

### DIFF
--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -220,9 +220,10 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			},
 		},
 		Spec: apiv1.PodSpec{
-			HostNetwork:        true,
-			DNSPolicy:          apiv1.DNSDefault,
-			ServiceAccountName: "deckhouse",
+			HostNetwork:                  true,
+			DNSPolicy:                    apiv1.DNSDefault,
+			ServiceAccountName:           "deckhouse",
+			AutomountServiceAccountToken: ptr.To(true),
 			SecurityContext: &apiv1.PodSecurityContext{
 				RunAsUser:    ptr.To(int64(0)),
 				RunAsNonRoot: ptr.To(false),
@@ -459,6 +460,7 @@ func DeckhouseServiceAccount() *apiv1.ServiceAccount {
 				"meta.helm.sh/release-namespace": "d8-system",
 			},
 		},
+		AutomountServiceAccountToken: ptr.To(false),
 	}
 }
 

--- a/ee/be/modules/140-user-authz/templates/webhook/daemonset.yaml
+++ b/ee/be/modules/140-user-authz/templates/webhook/daemonset.yaml
@@ -48,6 +48,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       hostNetwork: true

--- a/ee/be/modules/140-user-authz/templates/webhook/rbac-for-us.yaml
+++ b/ee/be/modules/140-user-authz/templates/webhook/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: webhook
   namespace: d8-user-authz
   {{- include "helm_lib_module_labels" (list . (dict "app" "webhook")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/be/modules/350-node-local-dns/templates/daemonset.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/daemonset.yaml
@@ -59,6 +59,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
 {{- if not (.Values.global.enabledModules | has "cni-cilium" )}}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
 {{- end }}

--- a/ee/be/modules/350-node-local-dns/templates/daemonset.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/daemonset.yaml
@@ -59,11 +59,11 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
 {{- if not (.Values.global.enabledModules | has "cni-cilium" )}}
-      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
       serviceAccountName: d8-node-local-dns
+      automountServiceAccountToken: true
 {{- if (.Values.global.enabledModules | has "cni-cilium") }}
       initContainers:
       {{- include "helm_lib_module_init_container_check_linux_kernel" (tuple . ">= 5.7") | nindent 6 }}

--- a/ee/be/modules/350-node-local-dns/templates/rbac-for-us.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: d8-node-local-dns
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "node-local-dns")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/ee/be/modules/350-node-local-dns/templates/stale-dns-connections-cleaner/daemonset.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/stale-dns-connections-cleaner/daemonset.yaml
@@ -46,8 +46,8 @@ spec:
     spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      # could be run as not root, but, in the first place, a way of setting file capabilities for binaries in distroless images must be developed
-      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:

--- a/ee/be/modules/350-node-local-dns/templates/stale-dns-connections-cleaner/rbac-for-us.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/stale-dns-connections-cleaner/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: stale-dns-connections-cleaner
   namespace: kube-system
   {{ include "helm_lib_module_labels" (list . (dict "app" "stale-dns-connections-cleaner")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/ee/modules/015-admission-policy-engine/templates/ratify/deployment.yaml
+++ b/ee/modules/015-admission-policy-engine/templates/ratify/deployment.yaml
@@ -52,6 +52,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "ratify")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
         - name: deckhouse-registry
       serviceAccountName: ratify

--- a/ee/modules/015-admission-policy-engine/templates/ratify/rbac-for-us.yaml
+++ b/ee/modules/015-admission-policy-engine/templates/ratify/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "ratify" "app.kubernetes.io/part-of" "gatekeeper")) | nindent 2 }}
   name: ratify
   namespace: d8-{{ .Chart.Name }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/025-static-routing-manager/templates/agent/daemonset.yaml
+++ b/ee/modules/025-static-routing-manager/templates/agent/daemonset.yaml
@@ -46,6 +46,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:

--- a/ee/modules/025-static-routing-manager/templates/agent/rbac-for-us.yaml
+++ b/ee/modules/025-static-routing-manager/templates/agent/rbac-for-us.yaml
@@ -4,6 +4,7 @@ metadata:
   name: agent
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "agent")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/ee/modules/030-cloud-provider-dynamix/templates/capd-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/capd-controller-manager/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "capd-controller-manager")) | nindent 6 }}
       serviceAccountName: capd-controller-manager
+      automountServiceAccountToken: true
       imagePullSecrets:
         - name: deckhouse-registry
       terminationGracePeriodSeconds: 10

--- a/ee/modules/030-cloud-provider-dynamix/templates/capd-controller-manager/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/capd-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: capd-controller-manager
   namespace: d8-cloud-provider-dynamix
   {{- include "helm_lib_module_labels" (list . (dict "app" "capd-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/030-cloud-provider-dynamix/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/cloud-controller-manager/deployment.yaml
@@ -61,6 +61,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}

--- a/ee/modules/030-cloud-provider-dynamix/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-controller-manager
   namespace: d8-cloud-provider-dynamix
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/030-cloud-provider-dynamix/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/cloud-data-discoverer/deployment.yaml
@@ -64,6 +64,7 @@ spec:
         kubectl.kubernetes.io/default-logs-container: cloud-data-discoverer
         checksum/config: {{ printf "%s%s" (include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | toString) | sha256sum }}
     spec:
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}

--- a/ee/modules/030-cloud-provider-dynamix/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-dynamix
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/deployment.yaml
@@ -68,6 +68,7 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "caphc-controller-manager")) | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: caphc-controller-manager
       imagePullSecrets:
         - name: deckhouse-registry

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: caphc-controller-manager
   namespace: d8-cloud-provider-huaweicloud
   {{- include "helm_lib_module_labels" (list . (dict "app" "caphc-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/deployment.yaml
@@ -68,6 +68,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: Default
       serviceAccountName: cloud-controller-manager

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-controller-manager
   namespace: d8-cloud-provider-huaweicloud
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-data-discoverer/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: cloud-data-discoverer
       containers:
       - name: cloud-data-discoverer

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-huaweicloud
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: Default
       serviceAccountName: cloud-controller-manager

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-controller-manager
   namespace: d8-cloud-provider-openstack
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: cloud-data-discoverer
       containers:
       - name: cloud-data-discoverer

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-openstack
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/deployment.yaml
@@ -91,6 +91,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "capcd-controller-manager")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: capcd-controller-manager

--- a/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/rbac-for-us.yaml
@@ -5,7 +5,7 @@ metadata:
   name: capcd-controller-manager
   namespace:  d8-cloud-provider-vcd
   {{- include "helm_lib_module_labels" (list . (dict "app" "capcd-controller-manager")) | nindent 2 }}
-
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/deployment.yaml
@@ -77,6 +77,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: Default
       serviceAccountName: cloud-controller-manager

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-controller-manager
   namespace: d8-cloud-provider-vcd
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-data-discoverer/deployment.yaml
@@ -77,6 +77,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: cloud-data-discoverer
       containers:
       - name: cloud-data-discoverer

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-vcd
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
@@ -53,6 +53,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       serviceAccountName: alliance-ingressgateway
+      automountServiceAccountToken: true
   {{- if $.Values.istio.alliance.ingressGateway.nodeSelector }}
       nodeSelector:
         {{- $.Values.istio.alliance.ingressGateway.nodeSelector | toYaml | nindent 8 }}

--- a/ee/modules/110-istio/templates/alliance/ingressgateway/rbac-for-us.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: alliance-ingressgateway
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "ingressgateway")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/ee/modules/110-istio/templates/alliance/metadata-exporter/deployment.yaml
+++ b/ee/modules/110-istio/templates/alliance/metadata-exporter/deployment.yaml
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "metadata-exporter")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: alliance-metadata-exporter
       imagePullSecrets:
       - name: deckhouse-registry

--- a/ee/modules/110-istio/templates/alliance/metadata-exporter/rbac-for-us.yaml
+++ b/ee/modules/110-istio/templates/alliance/metadata-exporter/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: alliance-metadata-exporter
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "metadata-exporter")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/110-istio/templates/multicluster/api-proxy/deployment.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/deployment.yaml
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "api-proxy")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: multicluster-api-proxy
       imagePullSecrets:
       - name: deckhouse-registry

--- a/ee/modules/110-istio/templates/multicluster/api-proxy/rbac-for-us.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: multicluster-api-proxy
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "api-proxy")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 # This rules were copied from original istio charts for role istio-reader with value .Values.global.externalIstiod = false
 apiVersion: rbac.authorization.k8s.io/v1

--- a/ee/modules/380-metallb/templates/controller/deployment.yaml
+++ b/ee/modules/380-metallb/templates/controller/deployment.yaml
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
         - name: deckhouse-registry
       containers:

--- a/ee/modules/380-metallb/templates/controller/rbac-for-us.yaml
+++ b/ee/modules/380-metallb/templates/controller/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: controller
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "controller")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/380-metallb/templates/speaker/daemonset.yaml
+++ b/ee/modules/380-metallb/templates/speaker/daemonset.yaml
@@ -57,6 +57,7 @@ spec:
         {{- if .Values.metallb.speaker.tolerations }}
         {{- .Values.metallb.speaker.tolerations | toYaml | nindent 6 }}
         {{- end }}
+      automountServiceAccountToken: true
       imagePullSecrets:
         - name: deckhouse-registry
       volumes:

--- a/ee/modules/380-metallb/templates/speaker/rbac-for-us.yaml
+++ b/ee/modules/380-metallb/templates/speaker/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: speaker
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "speaker")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/500-operator-trivy/templates/rbac-for-us.yaml
+++ b/ee/modules/500-operator-trivy/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: operator-trivy
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/ee/modules/500-operator-trivy/templates/report-updater/rbac-for-us.yaml
+++ b/ee/modules/500-operator-trivy/templates/report-updater/rbac-for-us.yaml
@@ -6,4 +6,5 @@ metadata:
   name: report-updater
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "report-updater")) | nindent 2 }}
+automountServiceAccountToken: false
 {{- end }}

--- a/ee/modules/610-service-with-healthchecks/templates/agent/daemonset.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/agent/daemonset.yaml
@@ -49,6 +49,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
         - name: deckhouse-registry
       containers:

--- a/ee/modules/610-service-with-healthchecks/templates/agent/rbac-for-us.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/agent/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: agent
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "agent")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/610-service-with-healthchecks/templates/controller/deployment.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/controller/deployment.yaml
@@ -63,6 +63,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "controller")) | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
         - name: deckhouse-registry
       containers:

--- a/ee/modules/610-service-with-healthchecks/templates/controller/rbac-for-us.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/controller/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: controller
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "controller")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -62,6 +62,7 @@ spec:
     spec:
       imagePullSecrets:
       - name: deckhouse-registry
+      automountServiceAccountToken: true
       serviceAccountName: {{ $.Chart.Name }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}

--- a/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/deployment.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/deployment.yaml
@@ -63,6 +63,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: k8s-metacollector
       imagePullSecrets:
       - name: deckhouse-registry

--- a/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/rbac-for-us.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: k8s-metacollector
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/modules/650-runtime-audit-engine/templates/rbac-for-us.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: runtime-audit-engine
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-agent/daemonset.yaml
+++ b/ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-agent/daemonset.yaml
@@ -50,6 +50,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "with-cloud-provider-uninitialized" "with-storage-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      automountServiceAccountToken: true
       nodeSelector:
         egress-gateway.network.deckhouse.io/member: ""
       terminationGracePeriodSeconds: 1

--- a/ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-agent/rbac-for-us.yaml
+++ b/ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-agent/rbac-for-us.yaml
@@ -4,6 +4,7 @@ metadata:
   name: egress-gateway-agent
   namespace: d8-{{ .Chart.Name }}
   {{ include "helm_lib_module_labels" (list . (dict "app" "egress-gateway-agent")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-controller-manager/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: Default
       serviceAccountName: cloud-controller-manager

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-controller-manager
   namespace: d8-cloud-provider-vsphere
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: cloud-data-discoverer
       containers:
       - name: cloud-data-discoverer

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-vsphere
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/templates/capz-controller-manager/deployment.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/templates/capz-controller-manager/deployment.yaml
@@ -69,6 +69,7 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "capz-controller-manager")) | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: capz-controller-manager
       imagePullSecrets:
         - name: deckhouse-registry

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/templates/capz-controller-manager/rbac-for-us.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/templates/capz-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: capz-controller-manager
   namespace: d8-cloud-provider-zvirt
   {{- include "helm_lib_module_labels" (list . (dict "app" "capz-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/templates/cloud-controller-manager/deployment.yaml
@@ -68,6 +68,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: Default
       serviceAccountName: cloud-controller-manager

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-controller-manager
   namespace: d8-cloud-provider-zvirt
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/templates/cloud-data-discoverer/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: cloud-data-discoverer
       containers:
       - name: cloud-data-discoverer

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-zvirt
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/se/modules/380-metallb/templates/l2lb/controller/deployment.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/controller/deployment.yaml
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
         - name: deckhouse-registry
       containers:

--- a/ee/se/modules/380-metallb/templates/l2lb/controller/rbac-for-us.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/controller/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: l2lb-controller
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "l2lb-controller")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/ee/se/modules/380-metallb/templates/l2lb/speaker/daemonset.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/speaker/daemonset.yaml
@@ -48,6 +48,7 @@ spec:
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      automountServiceAccountToken: true
       nodeSelector:
         l2-load-balancer.network.deckhouse.io/member: ""
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-storage-problems") | nindent 6 }}

--- a/ee/se/modules/380-metallb/templates/l2lb/speaker/rbac-for-us.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/speaker/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: l2lb-speaker
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "l2lb-speaker")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_monitoring_grafana_dashboards.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_monitoring_grafana_dashboards.tpl
@@ -73,14 +73,29 @@
   {{- $resourceName := index . 1 }}  {{- /* Dashboard name */ -}}
   {{- $folder := index . 2 }}        {{- /* Folder */ -}}
   {{- $definition := index . 3 }}    {{/* Dashboard definition */}}
+  {{- $propagated := contains "-propagated-" $resourceName }}
+  {{- $resourceName = $resourceName | replace "-propagated-" "-" }}
 ---
 apiVersion: deckhouse.io/v1
 kind: GrafanaDashboardDefinition
 metadata:
   name: d8-{{ $resourceName }}
-  {{- include "helm_lib_module_labels" (list $context (dict "prometheus.deckhouse.io/grafana-dashboard" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $context (dict "prometheus.deckhouse.io/grafana-dashboard" "" "observability.deckhouse.io/skip-dashboard-conversion" "")) | nindent 2 }}
 spec:
-  folder: "{{ $folder }}"
+  folder: {{ $folder | quote }}
   definition: |
     {{- $definition | nindent 4 }}
+  {{- if $context.Values.global.enabledModules | has "observability" }}
+---
+apiVersion: observability.deckhouse.io/v1alpha1
+kind: {{ $propagated | ternary "ClusterObservabilityPropagatedDashboard" "ClusterObservabilityDashboard" }}
+metadata:
+  annotations:
+    metadata.deckhouse.io/category: {{ $folder | quote }}
+  name: d8-{{ $resourceName }}
+  {{- include "helm_lib_module_labels" (list $context (dict "observability.deckhouse.io/dashboard-origin" "module")) | nindent 2 }}
+spec:
+  definition: |
+    {{- $definition | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_monitoring_grafana_dashboards.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_monitoring_grafana_dashboards.tpl
@@ -73,29 +73,14 @@
   {{- $resourceName := index . 1 }}  {{- /* Dashboard name */ -}}
   {{- $folder := index . 2 }}        {{- /* Folder */ -}}
   {{- $definition := index . 3 }}    {{/* Dashboard definition */}}
-  {{- $propagated := contains "-propagated-" $resourceName }}
-  {{- $resourceName = $resourceName | replace "-propagated-" "-" }}
 ---
 apiVersion: deckhouse.io/v1
 kind: GrafanaDashboardDefinition
 metadata:
   name: d8-{{ $resourceName }}
-  {{- include "helm_lib_module_labels" (list $context (dict "prometheus.deckhouse.io/grafana-dashboard" "" "observability.deckhouse.io/skip-dashboard-conversion" "")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $context (dict "prometheus.deckhouse.io/grafana-dashboard" "")) | nindent 2 }}
 spec:
-  folder: {{ $folder | quote }}
+  folder: "{{ $folder }}"
   definition: |
     {{- $definition | nindent 4 }}
-  {{- if $context.Values.global.enabledModules | has "observability" }}
----
-apiVersion: observability.deckhouse.io/v1alpha1
-kind: {{ $propagated | ternary "ClusterObservabilityPropagatedDashboard" "ClusterObservabilityDashboard" }}
-metadata:
-  annotations:
-    metadata.deckhouse.io/category: {{ $folder | quote }}
-  name: d8-{{ $resourceName }}
-  {{- include "helm_lib_module_labels" (list $context (dict "observability.deckhouse.io/dashboard-origin" "module")) | nindent 2 }}
-spec:
-  definition: |
-    {{- $definition | nindent 4 }}
-  {{- end }}
 {{- end }}

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -344,6 +344,7 @@ spec:
       dnsPolicy: Default
 {{- end}}
       serviceAccountName: deckhouse
+      automountServiceAccountToken: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/modules/002-deckhouse/templates/rbac-for-us.yaml
+++ b/modules/002-deckhouse/templates/rbac-for-us.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: false
 metadata:
   name: deckhouse
   namespace: d8-system

--- a/modules/002-deckhouse/templates/rbac-for-us.yaml
+++ b/modules/002-deckhouse/templates/rbac-for-us.yaml
@@ -1,14 +1,13 @@
 ---
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: false
 metadata:
   name: deckhouse
   namespace: d8-system
   annotations:
     helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-
+automountServiceAccountToken: false
 # RBAC for bashible - access to registry secret
 ---
 kind: Role

--- a/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
@@ -59,6 +59,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "webhook-handler")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: webhook-handler
       imagePullSecrets:
       - name: deckhouse-registry

--- a/modules/002-deckhouse/templates/webhook-handler/rbac-for-us.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: webhook-handler
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "webhook-handler")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/015-admission-policy-engine/templates/audit-deployment.yaml
+++ b/modules/015-admission-policy-engine/templates/audit-deployment.yaml
@@ -61,6 +61,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       containers:
       - image: {{ include "helm_lib_module_image" (list . "gatekeeper") }}
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}

--- a/modules/015-admission-policy-engine/templates/gatekeeper-deployment.yaml
+++ b/modules/015-admission-policy-engine/templates/gatekeeper-deployment.yaml
@@ -56,6 +56,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "gatekeeper" "control-plane" "controller-manager")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       containers:
       - image: {{ include "helm_lib_module_image" (list . "gatekeeper") }}
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}

--- a/modules/015-admission-policy-engine/templates/rbac-for-us.yaml
+++ b/modules/015-admission-policy-engine/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "gatekeeper.sh/system" "yes" "app" "gatekeeper")) | nindent 2 }}
   name: admission-policy-engine
   namespace: d8-{{ .Chart.Name }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -32,6 +32,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple $context "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple $context "any-node" "with-uninitialized" "with-cloud-provider-uninitialized" "with-storage-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" $context | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       containers:

--- a/modules/021-cni-cilium/templates/agent/rbac-for-us.yaml
+++ b/modules/021-cni-cilium/templates/agent/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: agent
   namespace: d8-{{ .Chart.Name }}
   {{ include "helm_lib_module_labels" (list . (dict "app" "agent")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/021-cni-cilium/templates/operator/deployment.yaml
+++ b/modules/021-cni-cilium/templates/operator/deployment.yaml
@@ -53,6 +53,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "operator")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       containers:

--- a/modules/021-cni-cilium/templates/operator/rbac-for-us.yaml
+++ b/modules/021-cni-cilium/templates/operator/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: operator
   namespace: d8-{{ .Chart.Name }}
   {{ include "helm_lib_module_labels" (list . (dict "app" "operator")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/021-cni-cilium/templates/safe-agent-updater/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/safe-agent-updater/daemonset.yaml
@@ -45,6 +45,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "with-cloud-provider-uninitialized" "with-storage-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       terminationGracePeriodSeconds: 1
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/modules/021-cni-cilium/templates/safe-agent-updater/rbac-for-us.yaml
+++ b/modules/021-cni-cilium/templates/safe-agent-updater/rbac-for-us.yaml
@@ -4,6 +4,7 @@ metadata:
   name: safe-agent-updater
   namespace: d8-{{ .Chart.Name }}
   {{ include "helm_lib_module_labels" (list . (dict "app" "safe-agent-updater")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/030-cloud-provider-aws/templates/cloud-controller-manager/deployment.yaml
+++ b/modules/030-cloud-provider-aws/templates/cloud-controller-manager/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: Default
       serviceAccountName: cloud-controller-manager

--- a/modules/030-cloud-provider-aws/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-aws/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-controller-manager
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/deployment.yaml
+++ b/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: cloud-data-discoverer
       containers:
       - name: cloud-data-discoverer

--- a/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-aws
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/030-cloud-provider-aws/templates/node-termination-handler/daemonset.yaml
+++ b/modules/030-cloud-provider-aws/templates/node-termination-handler/daemonset.yaml
@@ -58,6 +58,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: node-termination-handler
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/modules/030-cloud-provider-aws/templates/node-termination-handler/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-aws/templates/node-termination-handler/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: node-termination-handler
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "node-termination-handler")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/030-cloud-provider-azure/templates/cloud-controller-manager/deployment.yaml
+++ b/modules/030-cloud-provider-azure/templates/cloud-controller-manager/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: Default
       serviceAccountName: cloud-controller-manager

--- a/modules/030-cloud-provider-azure/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-azure/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-controller-manager
   namespace: d8-cloud-provider-azure
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/deployment.yaml
+++ b/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: cloud-data-discoverer
       containers:
       - name: cloud-data-discoverer

--- a/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-azure
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/030-cloud-provider-gcp/templates/cloud-controller-manager/deployment.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cloud-controller-manager/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: Default
       serviceAccountName: cloud-controller-manager

--- a/modules/030-cloud-provider-gcp/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-controller-manager
   namespace: d8-cloud-provider-gcp
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/deployment.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/deployment.yaml
@@ -70,6 +70,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: cloud-data-discoverer
       containers:
       - name: cloud-data-discoverer

--- a/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-gcp
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
-automountServiceAccountToken: true
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-gcp
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+automountServiceAccountToken: true
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/030-cloud-provider-yandex/templates/cloud-controller-manager/deployment.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-controller-manager/deployment.yaml
@@ -61,6 +61,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}

--- a/modules/030-cloud-provider-yandex/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-controller-manager
   namespace: d8-cloud-provider-yandex
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/030-cloud-provider-yandex/templates/cloud-data-discoverer/deployment.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-data-discoverer/deployment.yaml
@@ -64,6 +64,7 @@ spec:
         kubectl.kubernetes.io/default-logs-container: cloud-data-discoverer
         checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}

--- a/modules/030-cloud-provider-yandex/templates/cloud-data-discoverer/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-data-discoverer/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cloud-data-discoverer
   namespace: d8-cloud-provider-yandex
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/030-cloud-provider-yandex/templates/cloud-metrics-exporter/deployment.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-metrics-exporter/deployment.yaml
@@ -50,6 +50,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/cloud-metrics-exporter/secret-exporter-creds.yaml") . | sha256sum }}
     spec:
       serviceAccountName: cloud-metrics-exporter
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}

--- a/modules/030-cloud-provider-yandex/templates/cloud-metrics-exporter/rbac-for-us.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-metrics-exporter/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: cloud-metrics-exporter
   namespace: d8-cloud-provider-yandex
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-metrics-exporter")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/031-local-path-provisioner/templates/deployment.yaml
+++ b/modules/031-local-path-provisioner/templates/deployment.yaml
@@ -68,6 +68,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple $context "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple $context "wildcard") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       hostNetwork: true

--- a/modules/031-local-path-provisioner/templates/rbac-for-us.yaml
+++ b/modules/031-local-path-provisioner/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Chart.Name }}
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "local-path-provisioner")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/035-cni-flannel/templates/daemonset.yaml
+++ b/modules/035-cni-flannel/templates/daemonset.yaml
@@ -56,6 +56,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ .Chart.Name }}

--- a/modules/035-cni-flannel/templates/rbac-for-us.yaml
+++ b/modules/035-cni-flannel/templates/rbac-for-us.yaml
@@ -47,3 +47,4 @@ metadata:
   name: {{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "flannel")) | nindent 2 }}
   namespace: d8-{{ .Chart.Name }}
+automountServiceAccountToken: false

--- a/modules/035-cni-simple-bridge/templates/daemonset.yaml
+++ b/modules/035-cni-simple-bridge/templates/daemonset.yaml
@@ -52,6 +52,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ .Chart.Name }}

--- a/modules/035-cni-simple-bridge/templates/rbac-for-us.yaml
+++ b/modules/035-cni-simple-bridge/templates/rbac-for-us.yaml
@@ -33,3 +33,4 @@ metadata:
   name: {{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list $ (dict "app" "simple-bridge")) | nindent 2 }}
   namespace: d8-{{ .Chart.Name }}
+automountServiceAccountToken: false

--- a/modules/036-kube-proxy/templates/daemonset.yaml
+++ b/modules/036-kube-proxy/templates/daemonset.yaml
@@ -55,6 +55,7 @@ spec:
       {{- /* kube-proxy must start before any other components, so we tolerate nodes uninitialized by cloud provider (cloud provider pods requires kube-proxy to work). */ -}}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "with-cloud-provider-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      automountServiceAccountToken: true
       initContainers:
       - name: nodeport-bind-address
         {{- include "helm_lib_module_container_security_context_not_allow_privilege_escalation" . | nindent 8 }}

--- a/modules/036-kube-proxy/templates/rbac-for-us.yaml
+++ b/modules/036-kube-proxy/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: d8-kube-proxy
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/modules/039-registry-packages-proxy/templates/deployment.yaml
+++ b/modules/039-registry-packages-proxy/templates/deployment.yaml
@@ -63,6 +63,7 @@ spec:
     spec:
       # registry-packages-proxy runs in the hostNetwork on the bootstrap phase due to this component should work
       # when is cni plugin is absent
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:

--- a/modules/039-registry-packages-proxy/templates/rbac-for-us.yaml
+++ b/modules/039-registry-packages-proxy/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: registry-packages-proxy
   namespace: d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "registry-packages-proxy")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/040-control-plane-manager/hooks/audit_policy_basic_targets_generated.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_basic_targets_generated.go
@@ -148,7 +148,6 @@ var auditPolicyBasicServiceAccounts = []string{
 	"system:serviceaccount:d8-snapshot-controller:snapshot-controller",
 	"system:serviceaccount:d8-static-routing-manager:agent",
 	"system:serviceaccount:d8-system:d8-kube-dns",
-	"system:serviceaccount:d8-system:deckhouse-tools",
 	"system:serviceaccount:d8-system:documentation",
 	"system:serviceaccount:d8-system:network-policy-engine",
 	"system:serviceaccount:d8-system:terraform-auto-converger",

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -217,6 +217,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "any-node" "uninitialized") | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
+      automountServiceAccountToken: true
       serviceAccountName: d8-control-plane-manager
       containers:
       - name: control-plane-manager

--- a/modules/040-control-plane-manager/templates/rbac-for-us.yaml
+++ b/modules/040-control-plane-manager/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: d8-control-plane-manager
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "d8-control-plane-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
@@ -62,6 +62,7 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" .   | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "bashible-apiserver"))  | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: bashible-apiserver
       imagePullSecrets:
         - name: deckhouse-registry

--- a/modules/040-node-manager/templates/bashible-apiserver/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: bashible-apiserver
   namespace: d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "bashible-apiserver")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
@@ -68,6 +68,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: capi-controller-manager
       terminationGracePeriodSeconds: 10
       hostNetwork: true

--- a/modules/040-node-manager/templates/capi-controller-manager/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
   name: capi-controller-manager
   namespace: d8-cloud-instance-manager
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/modules/040-node-manager/templates/caps-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/caps-controller-manager/deployment.yaml
@@ -69,6 +69,7 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "caps-controller-manager")) | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: caps-controller-manager
       imagePullSecrets:
         - name: deckhouse-registry

--- a/modules/040-node-manager/templates/caps-controller-manager/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/caps-controller-manager/rbac-for-us.yaml
@@ -6,7 +6,7 @@ metadata:
   name: caps-controller-manager
   namespace: d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "caps-controller-manager")) | nindent 2 }}
-
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml
@@ -93,6 +93,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: cluster-autoscaler
       terminationGracePeriodSeconds: 5
       imagePullSecrets:

--- a/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
@@ -8,6 +8,7 @@ metadata:
   name: cluster-autoscaler
   namespace: d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "cluster-autoscaler")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/modules/040-node-manager/templates/early-oom/daemonset.yaml
+++ b/modules/040-node-manager/templates/early-oom/daemonset.yaml
@@ -53,6 +53,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: early-oom
       containers:
       - name: psi-monitor

--- a/modules/040-node-manager/templates/early-oom/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/early-oom/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: early-oom
   namespace: d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "early-oom")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/040-node-manager/templates/fencing-agent/daemonset.yaml
+++ b/modules/040-node-manager/templates/fencing-agent/daemonset.yaml
@@ -56,6 +56,7 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       nodeSelector:
         node.deckhouse.io/group: {{ $ng.name }}
+      automountServiceAccountToken: true
       serviceAccountName: fencing-agent
       containers:
         - name: fencing-agent

--- a/modules/040-node-manager/templates/fencing-agent/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/fencing-agent/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: fencing-agent
   namespace: d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "fencing-agent")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/040-node-manager/templates/machine-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/deployment.yaml
@@ -53,6 +53,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: machine-controller-manager
       hostNetwork: true
       dnsPolicy: Default

--- a/modules/040-node-manager/templates/machine-controller-manager/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/rbac-for-us.yaml
@@ -7,6 +7,7 @@ metadata:
   name: machine-controller-manager
   namespace: d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "machine-controller-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
@@ -57,6 +57,7 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
+      automountServiceAccountToken: true
       serviceAccountName: terraform-auto-converger
       {{- if has .Values.global.clusterConfiguration.cloud.provider (list "Yandex") }}
       initContainers:

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/rbac-for-us.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 automountServiceAccountToken: false
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/rbac-for-us.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/rbac-for-us.yaml
@@ -5,7 +5,7 @@ metadata:
   name: terraform-auto-converger
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
----
+automountServiceAccountToken: false
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
@@ -55,6 +55,7 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
+      automountServiceAccountToken: true
       serviceAccountName: terraform-state-exporter
       containers:
       - name: exporter

--- a/modules/040-terraform-manager/templates/terraform-state-exporter/rbac-for-us.yaml
+++ b/modules/040-terraform-manager/templates/terraform-state-exporter/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: terraform-state-exporter
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/modules/042-kube-dns/templates/deployment.yaml
+++ b/modules/042-kube-dns/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
       - name: deckhouse-registry
       # hardcoded, because kube-dns is a critical component and system-cluster-critical priority class exists by default
       priorityClassName: system-cluster-critical
+      automountServiceAccountToken: true
       serviceAccountName: d8-kube-dns
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-no-csi") | nindent 6 }}
       containers:

--- a/modules/042-kube-dns/templates/rbac-for-us.yaml
+++ b/modules/042-kube-dns/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: d8-kube-dns
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/045-snapshot-controller/templates/snapshot-controller/deployment.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-controller/deployment.yaml
@@ -66,6 +66,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "snapshot-controller")) | nindent 6 }}
+      automountServiceAccountToken: true
       containers:
       - name: snapshot-controller
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}

--- a/modules/045-snapshot-controller/templates/snapshot-controller/rbac-for-us.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-controller/rbac-for-us.yaml
@@ -5,7 +5,7 @@ metadata:
   name: snapshot-controller
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "snapshot-controller")) | nindent 2 }}
-automountServiceAccountToken: true
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/045-snapshot-controller/templates/snapshot-controller/rbac-for-us.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-controller/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: snapshot-controller
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "snapshot-controller")) | nindent 2 }}
+automountServiceAccountToken: true
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/045-snapshot-controller/templates/snapshot-validation-webhook/deployment.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-validation-webhook/deployment.yaml
@@ -67,6 +67,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "snapshot-validation-webhook")) | nindent 6 }}
+      automountServiceAccountToken: true
       containers:
       - name: snapshot-validation
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}

--- a/modules/050-network-policy-engine/templates/daemonset.yaml
+++ b/modules/050-network-policy-engine/templates/daemonset.yaml
@@ -47,6 +47,7 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
+      automountServiceAccountToken: true
       serviceAccountName: network-policy-engine
       containers:
       - name: kube-router

--- a/modules/050-network-policy-engine/templates/rbac-for-us.yaml
+++ b/modules/050-network-policy-engine/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: network-policy-engine
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "kube-router")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/101-cert-manager/templates/cainjector/deployment.yaml
+++ b/modules/101-cert-manager/templates/cainjector/deployment.yaml
@@ -47,6 +47,7 @@ spec:
         app: cainjector
     spec:
       serviceAccountName: cainjector
+      automountServiceAccountToken: true
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "cainjector")) | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}

--- a/modules/101-cert-manager/templates/cainjector/rbac-for-us.yaml
+++ b/modules/101-cert-manager/templates/cainjector/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: cainjector
   namespace: d8-cert-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "cainjector")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/101-cert-manager/templates/cert-manager/deployment.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/deployment.yaml
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "cert-manager")) | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: cert-manager
       imagePullSecrets:
       - name: deckhouse-registry

--- a/modules/101-cert-manager/templates/cert-manager/rbac-for-us.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: cert-manager
   namespace: d8-cert-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "cert-manager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/101-cert-manager/templates/webhook/deployment.yaml
+++ b/modules/101-cert-manager/templates/webhook/deployment.yaml
@@ -49,6 +49,7 @@ spec:
         app: webhook
     spec:
       serviceAccountName: webhook
+      automountServiceAccountToken: true
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "webhook")) | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}

--- a/modules/101-cert-manager/templates/webhook/rbac-for-us.yaml
+++ b/modules/101-cert-manager/templates/webhook/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: webhook
   namespace: d8-cert-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "webhook")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/110-istio/templates/cni/daemonset.yaml
+++ b/modules/110-istio/templates/cni/daemonset.yaml
@@ -61,6 +61,7 @@ spec:
     spec:
       imagePullSecrets:
       - name: deckhouse-registry
+      automountServiceAccountToken: true
       containers:
         - name: install-cni
           args:

--- a/modules/110-istio/templates/cni/rbac-for-us.yaml
+++ b/modules/110-istio/templates/cni/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: cni
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list $ (dict "app"  "istio-cni-node")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/110-istio/templates/ingress-gateway-controller/daemonset.yaml
+++ b/modules/110-istio/templates/ingress-gateway-controller/daemonset.yaml
@@ -64,6 +64,7 @@ spec:
     spec:
       {{- include "helm_lib_priority_class" (tuple $ "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: ingress-gateway-controller
   {{- if $controller.spec.nodeSelector }}
       nodeSelector:

--- a/modules/110-istio/templates/ingress-gateway-controller/rbac-for-us.yaml
+++ b/modules/110-istio/templates/ingress-gateway-controller/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: ingress-gateway-controller
   namespace: d8-ingress-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list $ (dict "app"  "ingress-gateway-controller")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/modules/110-istio/templates/kiali/deployment.yaml
+++ b/modules/110-istio/templates/kiali/deployment.yaml
@@ -55,6 +55,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "kiali")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_custom" (list . 1000 1000) | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: kiali
       imagePullSecrets:
       - name: deckhouse-registry

--- a/modules/110-istio/templates/kiali/rbac-for-us.yaml
+++ b/modules/110-istio/templates/kiali/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kiali
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "kiali")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/110-istio/templates/operator/deployment.yaml
+++ b/modules/110-istio/templates/operator/deployment.yaml
@@ -73,6 +73,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple $ "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple $ "cluster-low") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" $ | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: operator
       imagePullSecrets:
       - name: deckhouse-registry

--- a/modules/110-istio/templates/operator/rbac-for-us.yaml
+++ b/modules/110-istio/templates/operator/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   name: operator
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/150-user-authn/templates/dex/deployment.yaml
+++ b/modules/150-user-authn/templates/dex/deployment.yaml
@@ -57,6 +57,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "dex")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: dex

--- a/modules/150-user-authn/templates/dex/rbac-for-us.yaml
+++ b/modules/150-user-authn/templates/dex/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: dex
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "dex")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/160-multitenancy-manager/templates/multitenancy-manager/controller.yaml
+++ b/modules/160-multitenancy-manager/templates/multitenancy-manager/controller.yaml
@@ -52,6 +52,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "multitenancy-manager")) | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
         - name: deckhouse-registry
       terminationGracePeriodSeconds: 60

--- a/modules/160-multitenancy-manager/templates/multitenancy-manager/rbac-for-us.yaml
+++ b/modules/160-multitenancy-manager/templates/multitenancy-manager/rbac-for-us.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/200-operator-prometheus/templates/operator.yaml
+++ b/modules/200-operator-prometheus/templates/operator.yaml
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       containers:
       - args:
         - --kubelet-service=d8-monitoring/kubelet

--- a/modules/200-operator-prometheus/templates/rbac-for-us.yaml
+++ b/modules/200-operator-prometheus/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: operator-prometheus
   namespace: d8-operator-prometheus
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/300-prometheus/templates/aggregating-proxy/deployment.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/deployment.yaml
@@ -66,6 +66,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "aggregating-proxy")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: aggregating-proxy
       initContainers:
         - name: wait-memcached

--- a/modules/300-prometheus/templates/aggregating-proxy/rbac-for-us.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: aggregating-proxy
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "aggregating-proxy")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/300-prometheus/templates/alertmanager/internal/alertmanager.yaml
+++ b/modules/300-prometheus/templates/alertmanager/internal/alertmanager.yaml
@@ -16,6 +16,7 @@ spec:
   - name: deckhouse-registry
   listenLocal: true
   serviceAccountName: alertmanager-internal
+  automountServiceAccountToken: true
   volumes:
   - name: kube-rbac-proxy-ca
     configMap:

--- a/modules/300-prometheus/templates/alertmanager/internal/rbac-for-us.yaml
+++ b/modules/300-prometheus/templates/alertmanager/internal/rbac-for-us.yaml
@@ -4,6 +4,7 @@ metadata:
   name: alertmanager-internal
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "alertmanager")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/300-prometheus/templates/alerts-receiver/deployment.yaml
+++ b/modules/300-prometheus/templates/alerts-receiver/deployment.yaml
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple $ "monitoring") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple $ "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" $ | nindent 6 }}
+      automountServiceAccountToken: true
       containers:
       - name: alerts-receiver
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" $ | nindent 8 }}

--- a/modules/300-prometheus/templates/alerts-receiver/rbac-for-us.yaml
+++ b/modules/300-prometheus/templates/alerts-receiver/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: alerts-receiver
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "alerts-receiver")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/300-prometheus/templates/grafana/deployment-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment-v10.yaml
@@ -72,6 +72,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "grafana-v10")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: grafana
       imagePullSecrets:
       - name: deckhouse-registry

--- a/modules/300-prometheus/templates/grafana/rbac-for-us.yaml
+++ b/modules/300-prometheus/templates/grafana/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: grafana
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "grafana")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/300-prometheus/templates/trickster/deployment.yaml
+++ b/modules/300-prometheus/templates/trickster/deployment.yaml
@@ -54,6 +54,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "trickster")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: trickster
       containers:
       - name: trickster

--- a/modules/300-prometheus/templates/trickster/rbac-for-us.yaml
+++ b/modules/300-prometheus/templates/trickster/rbac-for-us.yaml
@@ -4,6 +4,7 @@ metadata:
   name: trickster
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "trickster")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
@@ -65,6 +65,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: prometheus-metrics-adapter
       imagePullSecrets:
       - name: deckhouse-registry

--- a/modules/301-prometheus-metrics-adapter/templates/rbac-for-us.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: prometheus-metrics-adapter
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/modules/302-vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
@@ -50,6 +50,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: d8-vertical-pod-autoscaler-admission-controller
       imagePullSecrets:
       - name: deckhouse-registry

--- a/modules/302-vertical-pod-autoscaler/templates/admission-controller/rbac-for-us.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/admission-controller/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: d8-vertical-pod-autoscaler-admission-controller
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "vpa-admission-controller")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/302-vertical-pod-autoscaler/templates/recommender/deployment.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/recommender/deployment.yaml
@@ -46,6 +46,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: d8-vertical-pod-autoscaler-recommender
       imagePullSecrets:
       - name: deckhouse-registry

--- a/modules/302-vertical-pod-autoscaler/templates/recommender/rbac-for-us.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/recommender/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: d8-vertical-pod-autoscaler-recommender
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "vpa-recommender")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/302-vertical-pod-autoscaler/templates/updater/deployment.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/updater/deployment.yaml
@@ -46,6 +46,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: d8-vertical-pod-autoscaler-updater
       imagePullSecrets:
       - name: deckhouse-registry

--- a/modules/302-vertical-pod-autoscaler/templates/updater/rbac-for-us.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/updater/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: d8-vertical-pod-autoscaler-updater
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "vpa-updater")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/340-extended-monitoring/templates/events-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/events-exporter/deployment.yaml
@@ -55,6 +55,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: events-exporter

--- a/modules/340-extended-monitoring/templates/events-exporter/rbac-for-us.yaml
+++ b/modules/340-extended-monitoring/templates/events-exporter/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: events-exporter
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/340-extended-monitoring/templates/extended-monitoring-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/extended-monitoring-exporter/deployment.yaml
@@ -54,6 +54,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: extended-monitoring-exporter

--- a/modules/340-extended-monitoring/templates/extended-monitoring-exporter/rbac-for-us.yaml
+++ b/modules/340-extended-monitoring/templates/extended-monitoring-exporter/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: extended-monitoring-exporter
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
@@ -55,6 +55,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: image-availability-exporter

--- a/modules/340-extended-monitoring/templates/image-availability-exporter/rbac-for-us.yaml
+++ b/modules/340-extended-monitoring/templates/image-availability-exporter/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: image-availability-exporter
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/340-extended-monitoring/templates/x509-certificate-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/x509-certificate-exporter/deployment.yaml
@@ -55,6 +55,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       restartPolicy: Always

--- a/modules/340-extended-monitoring/templates/x509-certificate-exporter/rbac-for-us.yaml
+++ b/modules/340-extended-monitoring/templates/x509-certificate-exporter/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: x509-certificate-exporter
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/daemonset.yaml
@@ -44,6 +44,7 @@ spec:
         app: control-plane-proxy
     spec:
       serviceAccountName: control-plane-proxy
+      automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}

--- a/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/rbac-for-us.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: control-plane-proxy
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "control-plane-proxy")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/340-monitoring-kubernetes/templates/ebpf-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/ebpf-exporter/daemonset.yaml
@@ -54,6 +54,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       serviceAccountName: ebpf-exporter
+      automountServiceAccountToken: true
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}

--- a/modules/340-monitoring-kubernetes/templates/ebpf-exporter/rbac-for-us.yaml
+++ b/modules/340-monitoring-kubernetes/templates/ebpf-exporter/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: ebpf-exporter
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "ebpf-exporter")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/deployment.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/deployment.yaml
@@ -49,6 +49,7 @@ spec:
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: kube-state-metrics
+      automountServiceAccountToken: true
       {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}

--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/rbac-for-us.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kube-state-metrics
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "kube-state-metrics")) | nindent 2 }}
+automountServiceAccountToken: true
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/rbac-for-us.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/rbac-for-us.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kube-state-metrics
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "kube-state-metrics")) | nindent 2 }}
-automountServiceAccountToken: true
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -66,6 +66,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       serviceAccountName: node-exporter
+      automountServiceAccountToken: true
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . | nindent 6 }}

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/rbac-for-us.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/rbac-for-us.yaml
@@ -45,3 +45,4 @@ metadata:
   name: node-exporter
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "node-exporter")) | nindent 2 }}
+automountServiceAccountToken: false

--- a/modules/340-monitoring-ping/templates/daemonset.yaml
+++ b/modules/340-monitoring-ping/templates/daemonset.yaml
@@ -54,6 +54,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: monitoring-ping
       containers:
       - image: {{ include "helm_lib_module_image" (list . "monitoringPing") }}

--- a/modules/340-monitoring-ping/templates/rbac-for-us.yaml
+++ b/modules/340-monitoring-ping/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: monitoring-ping
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "monitoring-ping")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/400-descheduler/templates/deployment.yaml
+++ b/modules/400-descheduler/templates/deployment.yaml
@@ -62,6 +62,7 @@ spec:
         checksum/config: {{ $.Values.descheduler.internal.deschedulers | toJson | sha256sum }}
     spec:
       serviceAccountName: descheduler
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       {{- include "helm_lib_node_selector" (tuple $ "system") | nindent 6 }}

--- a/modules/400-descheduler/templates/rbac-for-us.yaml
+++ b/modules/400-descheduler/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: descheduler
   namespace: d8-descheduler
   {{- include "helm_lib_module_labels" (list . (dict "app" "descheduler")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -154,6 +154,7 @@ spec:
   {{- end }}
 {{- include "helm_lib_priority_class" (tuple $context "system-cluster-critical") | nindent 6 }}
       serviceAccountName: ingress-nginx
+      automountServiceAccountToken: true
       terminationGracePeriodSeconds: 420
   {{- if and (eq $crd.spec.inlet "HostWithFailover") (not $failover) }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/modules/402-ingress-nginx/templates/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/templates/controller/hpa.yaml
@@ -64,6 +64,7 @@ spec:
         app: hpa-scaler
         name: {{ $name }}
     spec:
+      automountServiceAccountToken: true
       {{- if $crd.spec.nodeSelector }}
       nodeSelector:
       {{ $crd.spec.nodeSelector | toYaml | nindent 8 }}

--- a/modules/402-ingress-nginx/templates/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/templates/controller/hpa.yaml
@@ -64,7 +64,6 @@ spec:
         app: hpa-scaler
         name: {{ $name }}
     spec:
-      automountServiceAccountToken: true
       {{- if $crd.spec.nodeSelector }}
       nodeSelector:
       {{ $crd.spec.nodeSelector | toYaml | nindent 8 }}

--- a/modules/402-ingress-nginx/templates/failover/daemonset.yaml
+++ b/modules/402-ingress-nginx/templates/failover/daemonset.yaml
@@ -58,6 +58,7 @@ spec:
         app: proxy-failover
         name: {{ $crd.name }}
     spec:
+      automountServiceAccountToken: true
   {{- if $crd.spec.nodeSelector }}
       nodeSelector:
         {{- $crd.spec.nodeSelector | toYaml | nindent 8 }}

--- a/modules/402-ingress-nginx/templates/kruise/manager.yaml
+++ b/modules/402-ingress-nginx/templates/kruise/manager.yaml
@@ -79,6 +79,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
         - name: deckhouse-registry
       containers:

--- a/modules/402-ingress-nginx/templates/kruise/rbac-for-us.yaml
+++ b/modules/402-ingress-nginx/templates/kruise/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: kruise
   namespace: d8-ingress-nginx
   {{- include "helm_lib_module_labels" (list . ) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/402-ingress-nginx/templates/rbac-for-us.yaml
+++ b/modules/402-ingress-nginx/templates/rbac-for-us.yaml
@@ -42,6 +42,7 @@ metadata:
   name: ingress-nginx
   namespace: d8-ingress-nginx
   {{- include "helm_lib_module_labels" (list . ) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/460-log-shipper/templates/daemonset.yaml
+++ b/modules/460-log-shipper/templates/daemonset.yaml
@@ -49,6 +49,7 @@ spec:
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: {{ $.Chart.Name }}
+      automountServiceAccountToken: true
       shareProcessNamespace: true
       {{- with .Values.logShipper.nodeSelector }}
       nodeSelector:

--- a/modules/460-log-shipper/templates/rbac-for-us.yaml
+++ b/modules/460-log-shipper/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ $.Chart.Name }}
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/modules/462-loki/templates/rbac-for-us.yaml
+++ b/modules/462-loki/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Chart.Name }}
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/462-loki/templates/statefulset.yaml
+++ b/modules/462-loki/templates/statefulset.yaml
@@ -37,6 +37,7 @@ spec:
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: {{ .Chart.Name }}
+      automountServiceAccountToken: true
       terminationGracePeriodSeconds: 4800
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}

--- a/modules/465-pod-reloader/templates/deployment.yaml
+++ b/modules/465-pod-reloader/templates/deployment.yaml
@@ -61,6 +61,7 @@ spec:
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: {{ $.Chart.Name }}
+      automountServiceAccountToken: true
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}

--- a/modules/465-pod-reloader/templates/rbac-for-us.yaml
+++ b/modules/465-pod-reloader/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ $.Chart.Name }}
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -107,6 +107,7 @@ spec:
                 - master
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: chrony-exporter
+      automountServiceAccountToken: true
       hostNetwork: true
       imagePullSecrets:
       - name: deckhouse-registry
@@ -305,6 +306,7 @@ spec:
                 - master
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: chrony-exporter-master
+      automountServiceAccountToken: true
       hostNetwork: true
       imagePullSecrets:
       - name: deckhouse-registry

--- a/modules/470-chrony/templates/rbac-for-us.yaml
+++ b/modules/470-chrony/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: chrony-exporter-master
   namespace: d8-chrony
   {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-exporter")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -12,6 +13,7 @@ metadata:
   name: chrony-exporter
   namespace: d8-chrony
   {{- include "helm_lib_module_labels" (list . (dict "app" "chrony-exporter")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/500-cilium-hubble/templates/relay/rbac-for-us.yaml
+++ b/modules/500-cilium-hubble/templates/relay/rbac-for-us.yaml
@@ -4,3 +4,4 @@ metadata:
   name: "relay"
   namespace: d8-cni-cilium
   {{- include "helm_lib_module_labels" (list . (dict "app" "hubble-relay")) | nindent 2 }}
+automountServiceAccountToken: false

--- a/modules/500-cilium-hubble/templates/ui/deployment.yaml
+++ b/modules/500-cilium-hubble/templates/ui/deployment.yaml
@@ -68,6 +68,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . | nindent 6 }}
+      automountServiceAccountToken: true
       serviceAccountName: "ui"
       imagePullSecrets:
         - name: deckhouse-registry

--- a/modules/500-cilium-hubble/templates/ui/rbac-for-us.yaml
+++ b/modules/500-cilium-hubble/templates/ui/rbac-for-us.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "ui"
   namespace: d8-cni-cilium
   {{- include "helm_lib_module_labels" (list . (dict "app" "hubble-ui")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/500-dashboard/templates/api/deployment.yaml
+++ b/modules/500-dashboard/templates/api/deployment.yaml
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "api")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       containers:

--- a/modules/500-dashboard/templates/api/rbac-for-us.yaml
+++ b/modules/500-dashboard/templates/api/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: api
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "api")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/500-dashboard/templates/auth/deployment.yaml
+++ b/modules/500-dashboard/templates/auth/deployment.yaml
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "auth")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       containers:

--- a/modules/500-dashboard/templates/auth/rbac-for-us.yaml
+++ b/modules/500-dashboard/templates/auth/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: auth
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "auth")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/500-dashboard/templates/metrics-scraper/deployment.yaml
+++ b/modules/500-dashboard/templates/metrics-scraper/deployment.yaml
@@ -52,6 +52,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "metrics-scraper")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       containers:

--- a/modules/500-dashboard/templates/metrics-scraper/rbac-for-us.yaml
+++ b/modules/500-dashboard/templates/metrics-scraper/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: metrics-scraper
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "metrics-scraper")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/500-dashboard/templates/web/deployment.yaml
+++ b/modules/500-dashboard/templates/web/deployment.yaml
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "web")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       containers:

--- a/modules/500-dashboard/templates/web/rbac-for-us.yaml
+++ b/modules/500-dashboard/templates/web/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: web
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "web")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/500-openvpn/templates/openvpn/statefulset.yaml
+++ b/modules/500-openvpn/templates/openvpn/statefulset.yaml
@@ -105,6 +105,7 @@ spec:
       imagePullSecrets:
       - name: deckhouse-registry
       terminationGracePeriodSeconds: 5
+      automountServiceAccountToken: true
       serviceAccountName: openvpn
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}

--- a/modules/500-openvpn/templates/rbac-for-us.yaml
+++ b/modules/500-openvpn/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: openvpn
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/500-upmeter/templates/smoke-mini/rbac-for-us.yaml
+++ b/modules/500-upmeter/templates/smoke-mini/rbac-for-us.yaml
@@ -6,6 +6,7 @@ metadata:
   name: smoke-mini
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "smoke-mini")) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/500-upmeter/templates/smoke-mini/statefulsets.yaml
+++ b/modules/500-upmeter/templates/smoke-mini/statefulsets.yaml
@@ -60,6 +60,7 @@ spec:
         app: smoke-mini
         smoke-mini: {{ $k }}
     spec:
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       terminationGracePeriodSeconds: 30

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -49,6 +49,7 @@ spec:
         - name: deckhouse-registry
       terminationGracePeriodSeconds: 5
       serviceAccountName: upmeter-agent
+      automountServiceAccountToken: true
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}

--- a/modules/500-upmeter/templates/upmeter-agent/rbac-for-us.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: upmeter-agent
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/500-upmeter/templates/upmeter/rbac-for-us.yaml
+++ b/modules/500-upmeter/templates/upmeter/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: upmeter
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -63,6 +63,7 @@ spec:
       terminationGracePeriodSeconds: 5
       enableServiceLinks: false
       serviceAccountName: upmeter
+      automountServiceAccountToken: true
       {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "monitoring" "without-storage-problems") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}

--- a/modules/800-deckhouse-tools/templates/deployment.yaml
+++ b/modules/800-deckhouse-tools/templates/deployment.yaml
@@ -23,8 +23,6 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
-      serviceAccountName: deckhouse-tools
-      automountServiceAccountToken: true
       containers:
       - name: web
         image: {{ include "helm_lib_module_image" (list $ "web") }}

--- a/modules/800-deckhouse-tools/templates/deployment.yaml
+++ b/modules/800-deckhouse-tools/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: deckhouse-tools
+      automountServiceAccountToken: true
       containers:
       - name: web
         image: {{ include "helm_lib_module_image" (list $ "web") }}

--- a/modules/800-deckhouse-tools/templates/rbac-for-us.yaml
+++ b/modules/800-deckhouse-tools/templates/rbac-for-us.yaml
@@ -5,3 +5,4 @@ metadata:
   name: deckhouse-tools
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false

--- a/modules/800-deckhouse-tools/templates/rbac-for-us.yaml
+++ b/modules/800-deckhouse-tools/templates/rbac-for-us.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: deckhouse-tools
-  namespace: d8-system
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-automountServiceAccountToken: false

--- a/modules/810-documentation/templates/deployment.yaml
+++ b/modules/810-documentation/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: documentation
+      automountServiceAccountToken: true
       containers:
       - name: web
         image: {{ include "helm_lib_module_image" (list $ "web") }}

--- a/modules/810-documentation/templates/rbac-for-us.yaml
+++ b/modules/810-documentation/templates/rbac-for-us.yaml
@@ -5,6 +5,7 @@ metadata:
   name: documentation
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
## Description

Disable `automountServiceAccountToken` for all ServiceAccounts, enable in PodSpecs if necessary

## Why do we need it, and what problem does it solve?

According to CIS Benchmark 5.1.6, `automountServiceAccountToken` should be set to `false` if Kubernetes API access is not required

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Disable `automountServiceAccountToken` for all ServiceAccounts, enable in PodSpecs if necessary.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
