### PR TITLE
Fix/defectdojo tests rotator

### DIFF
--- a/.github/ci_templates/cve_tests.yaml
+++ b/.github/ci_templates/cve_tests.yaml
@@ -74,6 +74,6 @@
     DEFECTDOJO_DEV_TESTS_ROTATION_DAYS: 7
   shell: bash
   run: |
-    python .github/scripts/python/defectdojo_dev_tests_rotator.py
+    python ./.github/scripts/python/defectdojo_dev_tests_rotator.py
 # </template: defectdojo_dev_tests_rotator>
 {!{- end -}!}

--- a/.github/ci_templates/cve_tests.yaml
+++ b/.github/ci_templates/cve_tests.yaml
@@ -67,6 +67,8 @@
   uses: actions/setup-python@v4
   with:
     python-version: ${{ env.PYTHON_VERSION }}
+- name: Install dependencies
+  run: pip install requests
 - name: DefectDojo rotate dev tests
   env:
     DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}

--- a/.github/ci_templates/cve_tests.yaml
+++ b/.github/ci_templates/cve_tests.yaml
@@ -74,6 +74,6 @@
     DEFECTDOJO_DEV_TESTS_ROTATION_DAYS: 7
   shell: bash
   run: |
-    python ./.github/scripts/python/defectdojo_dev_tests_rotator.py
+    python .github/scripts/python/defectdojo_dev_tests_rotator.py
 # </template: defectdojo_dev_tests_rotator>
 {!{- end -}!}

--- a/.github/scripts/python/defectdojo_dev_tests_rotator.py
+++ b/.github/scripts/python/defectdojo_dev_tests_rotator.py
@@ -20,7 +20,7 @@ from datetime import datetime
 # Env vars
 defectdojo_host = os.getenv('DEFECTDOJO_HOST')
 defectdojo_token = os.getenv('DEFECTDOJO_API_TOKEN')
-days_to_keep = os.getenv('DEFECTDOJO_DEV_TESTS_ROTATION_DAYS', 7)
+days_to_keep = int(os.getenv('DEFECTDOJO_DEV_TESTS_ROTATION_DAYS', 7))
 
 # Static vars
 defectdojo_proto = "https://"

--- a/.github/workflow_templates/cve-dev-test-rotator.yml
+++ b/.github/workflow_templates/cve-dev-test-rotator.yml
@@ -36,5 +36,6 @@ jobs:
   defectdojo-rotate-dev-tests:
     runs-on: ubuntu-latest
     steps:
+{!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "defectdojo_dev_tests_rotator"      | strings.Indent 6 }!}
 

--- a/.github/workflows/cve-dev-test-rotator.yml
+++ b/.github/workflows/cve-dev-test-rotator.yml
@@ -46,6 +46,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install dependencies
+        run: pip install requests
       - name: DefectDojo rotate dev tests
         env:
           DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}

--- a/.github/workflows/cve-dev-test-rotator.yml
+++ b/.github/workflows/cve-dev-test-rotator.yml
@@ -35,6 +35,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+
+      # </template: checkout_step>
+
       # <template: defectdojo_dev_tests_rotator>
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
## Description
Fix for scheduled trigger to clean up dev tests in defectDojo

## Why do we need it, and what problem does it solve?
Trigger fails to run script

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: ci
type: fix
summary: none
impact: none
impact_level: low
```
