### PR TITLE
[ci] Increase limits for werf-cleanup

### DIFF
--- a/werf_cleanup.yaml
+++ b/werf_cleanup.yaml
@@ -19,7 +19,7 @@ cleanup:
       last: 1
   # keep 10 release builds
   - references:
-      tag: /v[0-9]+\.[0-9]+\.[0-9]+/
+      tag: /.*/
       limit:
         last: 10
     imagesPerReference:

--- a/werf_cleanup.yaml
+++ b/werf_cleanup.yaml
@@ -10,20 +10,23 @@ cleanup:
       branch: /.*/
       limit:
         in: 72h
-  # keep 3 pre-release builds
+  # keep 4 pre-release builds
   - references:
       branch: /release-.*/
       limit:
-        last: 3
-  # keep 3 release builds
+        last: 4
+    imagesPerReference:
+      last: 1
+  # keep 10 release builds
   - references:
-      tag: /.*/
+      tag: /v[0-9]+\.[0-9]+\.[0-9]+/
       limit:
-        last: 3
-  # Keep 14 days of all builds in main.
+        last: 10
+    imagesPerReference:
+      last: 1
+  # Keep 21 days of all builds in main.
   # This should reduce what needs to be built for pr after the branch is cleared after 3 days.
   - references:
       branch: main
     imagesPerReference:
-      last: -1
-      in: 336h
+      in: 504h


### PR DESCRIPTION
## Description
Increase limits for stored images in dev-registry:
- 21 days (from 14 days) for main branch;
- 4 latest release branches (from 3);
- 10 latest release tags (from 3).

Also limit number of stored versions for release branches and release tags to 1.

## Why do we need it, and what problem does it solve?
As available volume for stored built images was increased recently, we now want to keep more previous versions in dev-registry.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Increase limits for werf-cleanup.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
