### PR TITLE
[common][kube-rbac-proxy] stale cache request timeout

### DIFF
--- a/modules/000-common/images/kube-rbac-proxy/patches/001-stale-cache.patch
+++ b/modules/000-common/images/kube-rbac-proxy/patches/001-stale-cache.patch
@@ -1,12 +1,8 @@
-Index: README.md
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/README.md b/README.md
---- a/README.md	(revision fa09bd61bfd7fd1b6312aac131a1f65e5cf01296)
-+++ b/README.md	(revision c094da33d0a5c86fb230fbc8db951542868e461f)
-@@ -56,6 +56,7 @@
+index ce09dca7..cfe900b7 100644
+--- a/README.md
++++ b/README.md
+@@ -56,6 +56,7 @@ Usage of _output/kube-rbac-proxy:
        --secure-listen-address string                The address the kube-rbac-proxy HTTPs server should listen on.
        --skip_headers                                If true, avoid header prefixes in the log messages
        --skip_log_headers                            If true, avoid headers when opening log files
@@ -14,48 +10,67 @@ diff --git a/README.md b/README.md
        --stderrthreshold severity                    logs at or above this threshold go to stderr (default 2)
        --tls-cert-file string                        File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert)
        --tls-cipher-suites strings                   Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used
-Index: main.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/main.go b/main.go
---- a/main.go	(revision fa09bd61bfd7fd1b6312aac131a1f65e5cf01296)
-+++ b/main.go	(revision c094da33d0a5c86fb230fbc8db951542868e461f)
-@@ -63,6 +63,7 @@
+index 6812e746..15e5f25e 100644
+--- a/main.go
++++ b/main.go
+@@ -52,6 +52,8 @@ import (
+ 	rbac_proxy_tls "github.com/brancz/kube-rbac-proxy/pkg/tls"
+ )
+ 
++var kubeClientDefaultTimeout = 5 * time.Second
++
+ type config struct {
+ 	insecureListenAddress string
+ 	secureListenAddress   string
+@@ -63,6 +65,7 @@ type config struct {
  	kubeconfigLocation    string
  	allowPaths            []string
  	ignorePaths           []string
 +	staleCacheTTL         time.Duration
  }
-
+ 
  type tlsConfig struct {
-@@ -107,6 +108,7 @@
+@@ -107,6 +110,7 @@ func main() {
  	flagset.StringVar(&configFileName, "config-file", "", "Configuration file to configure kube-rbac-proxy.")
  	flagset.StringSliceVar(&cfg.allowPaths, "allow-paths", nil, "Comma-separated list of paths against which kube-rbac-proxy matches the incoming request. If the request doesn't match, kube-rbac-proxy responds with a 404 status code. If omitted, the incoming request path isn't checked. Cannot be used with --ignore-paths.")
  	flagset.StringSliceVar(&cfg.ignorePaths, "ignore-paths", nil, "Comma-separated list of paths against which kube-rbac-proxy will proxy without performing an authentication or authorization check. Cannot be used with --allow-paths.")
 +	flagset.DurationVar(&cfg.staleCacheTTL, "stale-cache-interval", 0*time.Minute, "The interval to keep auth request review results for in case of unavailability of kube-apiserver.")
-
+ 
  	// TLS flags
  	flagset.StringVar(&cfg.tls.certFile, "tls-cert-file", "", "File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert)")
-@@ -206,7 +208,7 @@
+@@ -206,7 +210,7 @@ func main() {
  		sarAuthorizer,
  	)
-
+ 
 -	auth, err := proxy.New(kubeClient, cfg.auth, authorizer, authenticator)
 +	auth, err := proxy.New(kubeClient, cfg.auth, authorizer, authenticator, cfg.staleCacheTTL)
-
+ 
  	if err != nil {
  		klog.Fatalf("Failed to create rbac-proxy: %v", err)
-Index: pkg/proxy/cache.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
+@@ -413,6 +417,9 @@ func initKubeConfig(kcLocation string) *rest.Config {
+ 		if err != nil {
+ 			klog.Fatalf("unable to build rest config based on provided path to kubeconfig file: %v", err)
+ 		}
++
++		kubeConfig.Timeout = kubeClientDefaultTimeout
++
+ 		return kubeConfig
+ 	}
+ 
+@@ -421,5 +428,7 @@ func initKubeConfig(kcLocation string) *rest.Config {
+ 		klog.Fatalf("cannot find Service Account in pod to build in-cluster rest config: %v", err)
+ 	}
+ 
++	kubeConfig.Timeout = kubeClientDefaultTimeout
++
+ 	return kubeConfig
+ }
 diff --git a/pkg/proxy/cache.go b/pkg/proxy/cache.go
 new file mode 100644
---- /dev/null	(revision c094da33d0a5c86fb230fbc8db951542868e461f)
-+++ b/pkg/proxy/cache.go	(revision c094da33d0a5c86fb230fbc8db951542868e461f)
+index 00000000..08a77ca9
+--- /dev/null
++++ b/pkg/proxy/cache.go
 @@ -0,0 +1,65 @@
 +/*
 +Copyright 2017 Frederic Branczyk All rights reserved.
@@ -122,26 +137,22 @@ new file mode 100644
 +func (*fakeCache) Add(_ string, _ *authenticator.Response)      {}
 +func (*fakeCache) Remove(_ string)                              {}
 +func (*fakeCache) Get(_ string) (*authenticator.Response, bool) { return nil, false }
-Index: pkg/proxy/proxy.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/pkg/proxy/proxy.go b/pkg/proxy/proxy.go
---- a/pkg/proxy/proxy.go	(revision fa09bd61bfd7fd1b6312aac131a1f65e5cf01296)
-+++ b/pkg/proxy/proxy.go	(revision c094da33d0a5c86fb230fbc8db951542868e461f)
-@@ -22,6 +22,7 @@
+index aaac103c..988fd632 100644
+--- a/pkg/proxy/proxy.go
++++ b/pkg/proxy/proxy.go
+@@ -22,6 +22,7 @@ import (
  	"net/http"
  	"strings"
  	"text/template"
 +	"time"
-
+ 
  	"github.com/brancz/kube-rbac-proxy/pkg/authn"
  	"github.com/brancz/kube-rbac-proxy/pkg/authz"
-@@ -32,6 +33,12 @@
+@@ -32,6 +33,12 @@ import (
  	"k8s.io/klog/v2"
  )
-
+ 
 +// Prefixes to differentiate authentication methods to save them to the same cache
 +var (
 +	tokenPrefix       = "token:"
@@ -151,7 +162,7 @@ diff --git a/pkg/proxy/proxy.go b/pkg/proxy/proxy.go
  // Config holds proxy authorization and authentication settings
  type Config struct {
  	Authentication *authn.AuthnConfig
-@@ -45,17 +52,29 @@
+@@ -45,17 +52,29 @@ type kubeRBACProxy struct {
  	authorizer.Authorizer
  	// authorizerAttributesGetter implements retrieving authorization attributes for a respective request.
  	authorizerAttributesGetter *krpAuthorizerAttributesGetter
@@ -161,7 +172,7 @@ diff --git a/pkg/proxy/proxy.go b/pkg/proxy/proxy.go
 +	// StaleCache for caching auth response
 +	StaleCache authResponseCache
  }
-
+ 
 -func new(authenticator authenticator.Request, authorizer authorizer.Authorizer, config Config) *kubeRBACProxy {
 -	return &kubeRBACProxy{authenticator, authorizer, newKubeRBACProxyAuthorizerAttributesGetter(config.Authorization), config}
 +func new(authenticator authenticator.Request, authorizer authorizer.Authorizer, config Config, staleCacheTTL time.Duration) *kubeRBACProxy {
@@ -177,19 +188,19 @@ diff --git a/pkg/proxy/proxy.go b/pkg/proxy/proxy.go
 +	}
 +	return &proxy
  }
-
+ 
  // New creates an authenticator, an authorizer, and a matching authorizer attributes getter compatible with the kube-rbac-proxy
 -func New(client clientset.Interface, config Config, authorizer authorizer.Authorizer, authenticator authenticator.Request) (*kubeRBACProxy, error) {
 -	return new(authenticator, authorizer, config), nil
 +func New(_ clientset.Interface, config Config, authorizer authorizer.Authorizer, authenticator authenticator.Request, staleCacheTTL time.Duration) (*kubeRBACProxy, error) {
 +	return new(authenticator, authorizer, config, staleCacheTTL), nil
  }
-
+ 
  // Handle authenticates the client and authorizes the request.
-@@ -67,24 +86,37 @@
+@@ -67,24 +86,37 @@ func (h *kubeRBACProxy) Handle(w http.ResponseWriter, req *http.Request) bool {
  		req = req.WithContext(ctx)
  	}
-
+ 
 +	userIdentity := tokenPrefix + getTokenFromRequest(req)
 +
  	// Authenticate
@@ -210,7 +221,7 @@ diff --git a/pkg/proxy/proxy.go b/pkg/proxy/proxy.go
 +		h.StaleCache.Remove(userIdentity)
  		return false
  	}
-
+ 
 +	// If no token was specified in request, use the user name (cn) from x509 authentication instead with the prefix
 +	if userIdentity == tokenPrefix {
 +		userIdentity = certificatePrefix + u.User.GetName()
@@ -226,8 +237,8 @@ diff --git a/pkg/proxy/proxy.go b/pkg/proxy/proxy.go
 +		h.StaleCache.Remove(userIdentity)
  		return false
  	}
-
-@@ -92,19 +124,33 @@
+ 
+@@ -92,19 +124,33 @@ func (h *kubeRBACProxy) Handle(w http.ResponseWriter, req *http.Request) bool {
  		// Authorize
  		authorized, reason, err := h.Authorize(ctx, attrs)
  		if err != nil {
@@ -258,14 +269,14 @@ diff --git a/pkg/proxy/proxy.go b/pkg/proxy/proxy.go
  			return false
  		}
  	}
-
+ 
 +	// cache successfully authorized responses only
 +	h.StaleCache.Add(userIdentity, u)
 +
  	if h.Config.Authentication.Header.Enabled {
  		// Seemingly well-known headers to tell the upstream about user's identity
  		// so that the upstream can achieve the original goal of delegating RBAC authn/authz to kube-rbac-proxy
-@@ -210,6 +256,11 @@
+@@ -210,6 +256,11 @@ func (n krpAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http
  		}
  		allAttrs = append(allAttrs, attrs)
  	}
@@ -276,8 +287,8 @@ diff --git a/pkg/proxy/proxy.go b/pkg/proxy/proxy.go
 +
  	return allAttrs
  }
-
-@@ -265,3 +316,15 @@
+ 
+@@ -265,3 +316,15 @@ func templateWithValue(templateString, value string) string {
  	}
  	return out.String()
  }
@@ -293,16 +304,12 @@ diff --git a/pkg/proxy/proxy.go b/pkg/proxy/proxy.go
 +	}
 +	return parts[1]
 +}
-Index: pkg/proxy/proxy_test.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/pkg/proxy/proxy_test.go b/pkg/proxy/proxy_test.go
---- a/pkg/proxy/proxy_test.go	(revision fa09bd61bfd7fd1b6312aac131a1f65e5cf01296)
-+++ b/pkg/proxy/proxy_test.go	(revision c094da33d0a5c86fb230fbc8db951542868e461f)
-@@ -18,10 +18,12 @@
-
+index d5afc362..0e596e25 100644
+--- a/pkg/proxy/proxy_test.go
++++ b/pkg/proxy/proxy_test.go
+@@ -18,10 +18,12 @@ package proxy
+ 
  import (
  	"context"
 +	"fmt"
@@ -311,31 +318,31 @@ diff --git a/pkg/proxy/proxy_test.go b/pkg/proxy/proxy_test.go
  	"strings"
  	"testing"
 +	"time"
-
+ 
  	"github.com/brancz/kube-rbac-proxy/pkg/authn"
  	"github.com/brancz/kube-rbac-proxy/pkg/authz"
-@@ -49,7 +51,7 @@
+@@ -49,7 +51,7 @@ func TestProxyWithOIDCSupport(t *testing.T) {
  	}
-
+ 
  	fakeUser := user.DefaultInfo{Name: "Foo Bar", Groups: []string{"foo-bars"}}
 -	authenticator := fakeOIDCAuthenticator(t, &fakeUser)
 +	fakeAuth := fakeAuthenticator(&fakeUser)
-
+ 
  	scenario := setupTestScenario()
  	for _, v := range scenario {
-@@ -57,7 +59,7 @@
+@@ -57,7 +59,7 @@ func TestProxyWithOIDCSupport(t *testing.T) {
  		t.Run(v.description, func(t *testing.T) {
-
+ 
  			w := httptest.NewRecorder()
 -			proxy, err := New(kc, cfg, v.authorizer, authenticator)
 +			proxy, err := New(kc, cfg, v.authorizer, fakeAuth, 0)
-
+ 
  			if err != nil {
  				t.Fatalf("Failed to instantiate test proxy. Details : %s", err.Error())
-@@ -237,6 +239,103 @@
+@@ -237,6 +239,103 @@ func TestGeneratingAuthorizerAttributes(t *testing.T) {
  	}
  }
-
+ 
 +func TestProxyCacheSupport(t *testing.T) {
 +	kc := testclient.NewSimpleClientset()
 +	cfg := Config{
@@ -436,10 +443,10 @@ diff --git a/pkg/proxy/proxy_test.go b/pkg/proxy/proxy_test.go
  func createRequest(queryParams, headers map[string]string) *http.Request {
  	r := httptest.NewRequest("GET", "/accounts", nil)
  	if queryParams != nil {
-@@ -296,13 +395,16 @@
+@@ -296,13 +395,16 @@ func fakeJWTRequest(method, path, token string) *http.Request {
  	return req
  }
-
+ 
 -func fakeOIDCAuthenticator(t *testing.T, fakeUser *user.DefaultInfo) authenticator.Request {
 -
 +func fakeAuthenticator(fakeUser *user.DefaultInfo) authenticator.Request {
@@ -448,20 +455,19 @@ diff --git a/pkg/proxy/proxy_test.go b/pkg/proxy/proxy_test.go
 +		switch token {
 +		case "INVALID":
  			return nil, false, nil
--		}
--		return &authenticator.Response{User: fakeUser}, true, nil
 +		case "ERROR":
 +			return nil, false, fmt.Errorf("error occured while authenticating")
 +		default:
 +			return &authenticator.Response{User: fakeUser}, true, nil
-+		}
+ 		}
+-		return &authenticator.Response{User: fakeUser}, true, nil
  	}))
  	return auth
  }
-@@ -319,6 +421,14 @@
+@@ -319,6 +421,14 @@ func (a approver) Authorize(ctx context.Context, auth authorizer.Attributes) (au
  	return authorizer.DecisionAllow, "user allowed", nil
  }
-
+ 
 +type failer struct{}
 +
 +func (e failer) Authorize(ctx context.Context, auth authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {


### PR DESCRIPTION
## Description

We use `kube-rbac-proxy` to access prom exporters. ~~Earlier we added staleCache mechanism which caches authorization permission in case kuve-api is unavailable.
Now we added backoff mechanism that blocks access to kube-api with exponential timeout in case kube-api is unavailable. So, if kube-rbac-proxy fails to connect to kube-api, the next 5 seconds of attempts will be blocked and authorization permission will be taken from cache at once. If the attempt fails again, the timeout will be extended. Maximum timeout is 5 minutes~~

Previously there was a long timeout in kube-api client, which caused prom exporters to become unavailable if kube-api became unavailable. Now timeout is set to 3 seconds, after that stale cache will be used.


## Why do we need it, and what problem does it solve?

~~Before this change, kube-rbac-proxy tried to access kube-api every time and only after failure it tried to access the cache. This causes heavy slowdown of requests if control-plane is disabled.
Finally it breaks monitoring in case control-plane is disabled~~

Before this change kube-rbac-proxy tried to access kube-api and in case of its unavailability only after a long timeout tried to use cache. 
This led to broken monitoring in case control-plane was disabled

## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

Case 1: kube-api is down

![kube-apiserver-down](https://github.com/user-attachments/assets/94bcc6f4-8cc1-4ce0-93dd-a0ee1951c069)
![metrics-still-working-1](https://github.com/user-attachments/assets/93736ba5-852d-423a-b7a5-799324b9e4a2)

Case 2: master VM is down
![master-vm-down](https://github.com/user-attachments/assets/0dcff039-a57b-4f7e-bed7-70cfba3fe039)
![metrics-still-working-2](https://github.com/user-attachments/assets/52e5afbb-7ba8-44c0-aa74-f7344be82b79)

In both cases grafana is unavailable after some time (for different reasons), but the metrics are still collected. After recovery we see that the metrics are still there

```
I0213 09:42:26.143980       1 proxy.go:120] Backoff mode active: blocking kube-api request until 2025-02-13 09:42:45.822985014 +0000 UTC m=+628.305458219. Using cached credentials for token:eyJh… (truncated).
I0213 09:42:26.144839       1 proxy.go:120] Backoff mode active: blocking kube-api request until 2025-02-13 09:42:45.822985014 +0000 UTC m=+628.305458219. Using cached credentials for token:eyJh… (truncated).
I0213 09:42:26.162042       1 proxy.go:120] Backoff mode active: blocking kube-api request until 2025-02-13 09:42:45.822985014 +0000 UTC m=+628.305458219. Using cached credentials for token:eyJh… (truncated).
I0213 09:42:26.162193       1 proxy.go:120] Backoff mode active: blocking kube-api request until 2025-02-13 09:42:45.822985014 +0000 UTC m=+628.305458219. Using cached credentials for token:eyJh… (truncated).
```



```changes
section: prometheus
type: fix
summary: kube-rbac-proxy stale cache request timeout
impact: all components using kube-rbac-proxy will be restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
