### PR TITLE
[monitoring-deckhouse] Add wide descrition for `ModuleHasDeprecatedUpdatePolicy` alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4248,7 +4248,8 @@ alerts:
       description: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
 
-        Please specify the proper update policy in the module configuration to continue get updates.
+        Please specify the update policy for the corresponding module in the ModuleConfig `spec.updatePolicy` parameter.
+        Execute the following command to delete deprecated fields: `kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io '{{ $labels.moduleName }}' --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'`.
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.
       severity: "4"

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -202,6 +202,7 @@
       description: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
 
-        Please specify the proper update policy in the module configuration to continue get updates.
+        Please specify the update policy for the corresponding module in the ModuleConfig `spec.updatePolicy` parameter.
+        Execute the following command to delete deprecated fields: `kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io '{{ $labels.moduleName }}' --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'`.
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.


### PR DESCRIPTION
## Description
Add wide descrition for `ModuleHasDeprecatedUpdatePolicy` alert
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
At the moment, the description of the alert does not fully show the solution on how to fix this alert.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: 
type: fix
summary: Add detailed info about `ModuleHasDeprecatedUpdatePolicy` alert
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
