### PR TITLE
[docs][chore] update Makefile to use local registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,19 +242,17 @@ cve-base-images-check-default-user: bin/trivy bin/jq ## Check CVE in our base im
 .PHONY: docs
 docs: ## Run containers with the documentation.
 	docker network inspect deckhouse 2>/dev/null 1>/dev/null || docker network create deckhouse
-	cd docs/documentation/; werf compose up --docker-compose-command-options='-d' --env local --repo ":local"
-	cd docs/site/; werf compose up --docker-compose-command-options='-d' --env local --repo ":local"
+	cd docs/documentation/; werf compose up --docker-compose-command-options='-d' --env local
+	cd docs/site/; werf compose up --docker-compose-command-options='-d' --env local
 	echo "Open http://localhost to access the documentation..."
 
 .PHONY: docs-dev
 docs-dev: ## Run containers with the documentation in the dev mode (allow uncommited files).
-	export WERF_REPO=:local
-	export SECONDARY_REPO=""
 	export DOC_API_URL=dev
 	export DOC_API_KEY=dev
 	docker network inspect deckhouse 2>/dev/null 1>/dev/null || docker network create deckhouse
-	cd docs/documentation/; werf compose up --docker-compose-command-options='-d' --dev --env development --repo ":local"
-	cd docs/site/; werf compose up --docker-compose-command-options='-d' --dev --env development --repo ":local"
+	cd docs/documentation/; werf compose up --docker-compose-command-options='-d' --dev --env development
+	cd docs/site/; werf compose up --docker-compose-command-options='-d' --dev --env development
 	echo "Open http://localhost to access the documentation..."
 
 .PHONY: docs-down

--- a/docs/documentation/Makefile
+++ b/docs/documentation/Makefile
@@ -8,13 +8,24 @@ all: up
 network:
 		docker network inspect deckhouse 2>&1 1>/dev/null || docker network create deckhouse
 
+.PHONY:
+registry:
+		@if ! docker ps | grep -q registry ; then \
+			docker rm -f registry 2>/dev/null 1>/dev/null; \
+			docker run -d -p 5000:5000 --restart=always --name registry registry:2 ; \
+		fi
+
+.PHONY:
+registry-down:
+		docker rm -f registry; docker volume prune -fa
+
 up: network
-		werf compose up --follow --docker-compose-command-options='-d' --env module
+		werf compose up --follow --docker-compose-command-options='-d' --env module --repo localhost:5000/docs
 
 down:
-		docker rm -f documentation
+		docker rm -f documentation 2>/dev/null
 
 dev: network
-		werf compose up --follow --docker-compose-command-options='-d' --dev --env development
+		werf compose up --follow --docker-compose-command-options='-d' --dev --env development  --repo localhost:5000/docs
 
 .PHONY: up dev

--- a/docs/site/Makefile
+++ b/docs/site/Makefile
@@ -5,19 +5,29 @@ endif
 
 all: up
 
-network:
+registry:
+		@if ! docker ps | grep -q registry ; then \
+			docker rm -f registry 2>/dev/null 1>/dev/null; \
+			docker run -d -p 5000:5000 --restart=always --name registry registry:2 ; \
+		fi
+
+.PHONY:
+registry-down:
+		docker rm -f registry; docker volume prune -fa
+
+network: registry
 		docker network inspect deckhouse 2>&1 1>/dev/null || docker network create deckhouse
 
 up: network
-		werf compose up --follow --docker-compose-command-options='-d --force-recreate' --env local
+		werf compose up --follow --docker-compose-command-options='-d --force-recreate' --env local --repo localhost:5000/docs
 
 down:
 		docker rm -f site-site-1 site-front-1 site_site_1 site_front_1 2>/dev/null; docker network rm deckhouse
 
 dev: network
-		werf compose up --follow --docker-compose-command-options='-d --force-recreate' --dev --env development
+		werf compose up --follow --docker-compose-command-options='-d --force-recreate' --dev --env development --repo localhost:5000/docs
 
 debug: network
-		werf compose up --config werf-debug.yaml --follow --docker-compose-command-options='-d --force-recreate' --docker-compose-options='-f docker-compose-debug.yml'  --dev --env development
+		werf compose up --config werf-debug.yaml --follow --docker-compose-command-options='-d --force-recreate' --docker-compose-options='-f docker-compose-debug.yml'  --dev --env development --repo localhost:5000/docs
 
 .PHONY: up dev


### PR DESCRIPTION
## Description
- Add registry and registry-down targets in Makefile for site and documentation
- Update werf compose commands to include '--repo localhost:5000/docs' flag
- Ensure registry is running before starting services

## Why do we need it, and what problem does it solve?

The new build rules use `imageSpec` werf parameter which can't be used with local repo.

Error:
```
Error: phase build on image docs/web stage imageSpec handler failed: unable to builde stage "imageSpec": local storage are not supported at the moment. Please provide repo with --repo flag or WERF_REPO env variable
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Update Makefile to use local registry.
impact_level: low
```
