### PR TITLE
chore: migrate build tools

### DIFF
--- a/modules/021-cni-cilium/images/base-cilium-dev/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/base-cilium-dev/werf.inc.yaml
@@ -4,13 +4,11 @@
 {{- $bazelVersions := "3.7.0 3.7.1 3.7.2 6.3.2" }}
 #
 {{- $source := "https://github.com" }}
+{{- $sourceraw := "https://raw.githubusercontent.com" }}
 {{- if $.DistroPackagesProxy }}
   {{- $source = printf "http://%s/repository/github-com" $.DistroPackagesProxy }}
-{{- end }}
-  {{- $sourceraw := "https://raw.githubusercontent.com" }}
-  {{- if $.DistroPackagesProxy }}
   {{- $sourceraw = printf "http://%s/repository/githubusercontent" $.DistroPackagesProxy }}
-  {{- end }}
+{{- end }}
 
 ---
 # #####################################################################
@@ -38,21 +36,6 @@ image: {{ .ModuleName }}/golang-artifact
 from: {{ .Images.BASE_GOLANG_23_ALPINE }}
 final: false
 ---
-image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
-final: false
-shell:
-  install:
-  - git clone --depth 1 --branch cmd/protoc-gen-go-grpc/v1.3.0 {{ $.SOURCE_REPO }}/grpc/grpc-go.git /src/grpc-go
-  - rm -rf /src/grpc-go/.git /src/grpc-go/examples /src/grpc-go/gcp /src/grpc-go/security /src/grpc-go/stats /src/grpc-go/test
-  - git clone --depth 1 --branch v1.30.0 {{ $.SOURCE_REPO }}/protocolbuffers/protobuf-go.git /src/protobuf-go
-  - rm -rf /src/protobuf-go/.git
-  - git clone --depth 1 --branch v1.1.0 {{ $.SOURCE_REPO }}/mitchellh/protoc-gen-go-json.git /src/protoc-gen-go-json
-  - rm -rf /src/protoc-gen-go-json/.git
-  - git clone --depth 1 --branch v1.5.1 {{ $.SOURCE_REPO }}/pseudomuto/protoc-gen-doc.git /src/protoc-gen-doc
-  - rm -rf /src/protoc-gen-doc/.git
-
----
 image: {{ .ModuleName }}/base-cilium-dev
 fromImage: common/alt-p11-artifact
 final: false
@@ -63,15 +46,6 @@ import:
 - image: {{ .ModuleName }}/golang-artifact
   add: /usr/local/go
   to: /usr/local/go
-  before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-  add: /src
-  to: /src
-  includePaths:
-  - grpc-go
-  - protobuf-go
-  - protoc-gen-go-json
-  - protoc-gen-doc
   before: install
 shell:
   beforeInstall:
@@ -102,7 +76,7 @@ shell:
     sudo \
     libcap-devel libpcap-devel \
     clang17.0 clang17.0-tools lldb17.0 lld17.0 llvm17.0-devel \
-    libcxxabi-devel \
+    libcxxabi-devel git
   install:
   # Install Go
   - export GOROOT=/usr/local/go GOPATH=/go
@@ -115,10 +89,20 @@ shell:
   - unzip /tmp/protoc.zip -x readme.txt -d /usr/local && rm /tmp/protoc.zip
   - chmod o+rx /usr/local/bin/protoc && chmod o+rX -R /usr/local/include/google/
   # 8ba23be9613c672d40ae261d2a1335d639bdd59b == tag: cmd/protoc-gen-go-grpc/v1.3.0
+  - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
+  - git clone --depth 1 --branch cmd/protoc-gen-go-grpc/v1.3.0 {{ $.SOURCE_REPO }}/grpc/grpc-go.git /src/grpc-go
+  - git clone --depth 1 --branch v1.30.0 {{ $.SOURCE_REPO }}/protocolbuffers/protobuf-go.git /src/protobuf-go
+  - git clone --depth 1 --branch v1.1.0 {{ $.SOURCE_REPO }}/mitchellh/protoc-gen-go-json.git /src/protoc-gen-go-json
+  - git clone --depth 1 --branch v1.5.1 {{ $.SOURCE_REPO }}/pseudomuto/protoc-gen-doc.git /src/protoc-gen-doc
   - cd /src/grpc-go/cmd/protoc-gen-go-grpc && go install
   - cd /src/protobuf-go/cmd/protoc-gen-go && go install
   - cd /src/protoc-gen-go-json && go install
   - cd /src/protoc-gen-doc/cmd/protoc-gen-doc && go install
+  - cd /src
+  - rm -rf /src/grpc-go
+  - rm -rf /src/protobuf-go
+  - rm -rf /src/protoc-gen-go-json
+  - rm -rf /src/protoc-gen-doc
   # Install multiversion bazel
   - bazel_versions=({{ $bazelVersions }})
   # install bazel wrapper script in the path, it automatically recognises `.bazelversion` and `USE_BAZEL_VERSIONS`, if neither are set it picks latest

--- a/modules/021-cni-cilium/images/base-cilium-dev/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/base-cilium-dev/werf.inc.yaml
@@ -1,15 +1,16 @@
 # src of image BASE_ALT_DEV_CILIUM in candi/image_versions.yml
 {{- $goVersion := "1.23.1" }}
-{{- $protocVersion := "22.3" }}
-{{- $bazelVersions := "3.7.0 3.7.1 3.7.2 6.3.2" }}
-#
-{{- $source := "https://github.com" }}
-{{- $sourceraw := "https://raw.githubusercontent.com" }}
-{{- if $.DistroPackagesProxy }}
+  {{- $protocVersion := "22.3" }}
+  {{- $bazelVersions := "3.7.0 3.7.1 3.7.2 6.3.2" }}
+  #
+  {{- $source := "https://github.com" }}
+  {{- if $.DistroPackagesProxy }}
   {{- $source = printf "http://%s/repository/github-com" $.DistroPackagesProxy }}
+  {{- end }}
+  {{- $sourceraw := "https://raw.githubusercontent.com" }}
+  {{- if $.DistroPackagesProxy }}
   {{- $sourceraw = printf "http://%s/repository/githubusercontent" $.DistroPackagesProxy }}
-{{- end }}
-
+  {{- end }}
 ---
 # #####################################################################
 # BASE_DEV image for build binaries of all cilium components (based on Ubuntu)

--- a/modules/021-cni-cilium/images/base-cilium-dev/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/base-cilium-dev/werf.inc.yaml
@@ -1,16 +1,17 @@
 # src of image BASE_ALT_DEV_CILIUM in candi/image_versions.yml
 {{- $goVersion := "1.23.1" }}
-  {{- $protocVersion := "22.3" }}
-  {{- $bazelVersions := "3.7.0 3.7.1 3.7.2 6.3.2" }}
-  #
-  {{- $source := "https://github.com" }}
-  {{- if $.DistroPackagesProxy }}
+{{- $protocVersion := "22.3" }}
+{{- $bazelVersions := "3.7.0 3.7.1 3.7.2 6.3.2" }}
+#
+{{- $source := "https://github.com" }}
+{{- if $.DistroPackagesProxy }}
   {{- $source = printf "http://%s/repository/github-com" $.DistroPackagesProxy }}
-  {{- end }}
+{{- end }}
   {{- $sourceraw := "https://raw.githubusercontent.com" }}
   {{- if $.DistroPackagesProxy }}
   {{- $sourceraw = printf "http://%s/repository/githubusercontent" $.DistroPackagesProxy }}
   {{- end }}
+
 ---
 # #####################################################################
 # BASE_DEV image for build binaries of all cilium components (based on Ubuntu)

--- a/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
@@ -234,15 +234,6 @@ import:
   add: /usr/local/go
   to: /usr/local/go
   before: install
-- image: cni-cilium/base-cilium-dev-src-artifact
-  add: /src
-  to: /src
-  includePaths:
-  - grpc-go
-  - protobuf-go
-  - protoc-gen-go-json
-  - protoc-gen-doc
-  before: install
 shell:
   beforeInstall:
   - export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
@@ -269,7 +260,7 @@ shell:
     libcap-devel libpcap-devel \
     clang14.0 clang14.0-tools lld14.0 llvm14.0-devel \
     libcxxabi-devel \
-    libcxx libcxx-static libcxxabi-static lld14.0
+    libcxx libcxx-static libcxxabi-static lld14.0 git
   # apt clean
   - apt-get autoclean && apt-get clean
   install:
@@ -287,10 +278,20 @@ shell:
   - curl --fail --show-error --silent --location "{{ $source }}/protocolbuffers/protobuf/releases/download/v{{ $protocVersion }}/protoc-{{ $protocVersion }}-linux-x86_64.zip" --output /tmp/protoc.zip
   - unzip /tmp/protoc.zip -x readme.txt -d /usr/local && rm /tmp/protoc.zip
   - chmod o+rx /usr/local/bin/protoc && chmod o+rX -R /usr/local/include/google/
+  - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
+  - git clone --depth 1 --branch cmd/protoc-gen-go-grpc/v1.3.0 {{ $.SOURCE_REPO }}/grpc/grpc-go.git /src/grpc-go
+  - git clone --depth 1 --branch v1.30.0 {{ $.SOURCE_REPO }}/protocolbuffers/protobuf-go.git /src/protobuf-go
+  - git clone --depth 1 --branch v1.1.0 {{ $.SOURCE_REPO }}/mitchellh/protoc-gen-go-json.git /src/protoc-gen-go-json
+  - git clone --depth 1 --branch v1.5.1 {{ $.SOURCE_REPO }}/pseudomuto/protoc-gen-doc.git /src/protoc-gen-doc
   - cd /src/grpc-go/cmd/protoc-gen-go-grpc && go install
   - cd /src/protobuf-go/cmd/protoc-gen-go && go install
   - cd /src/protoc-gen-go-json && go install
   - cd /src/protoc-gen-doc/cmd/protoc-gen-doc && go install
+  - cd /src
+  - rm -rf /src/grpc-go
+  - rm -rf /src/protobuf-go
+  - rm -rf /src/protoc-gen-go-json
+  - rm -rf /src/protoc-gen-doc
   # Install multiversion bazel
   - bazel_versions=({{ $bazelVersions }})
   # install bazel wrapper script in the path, it automatically recognises `.bazelversion` and `USE_BAZEL_VERSIONS`, if neither are set it picks latest

--- a/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
+++ b/modules/300-prometheus/images/grafana-v10/werf.inc.yaml
@@ -20,7 +20,6 @@ shell:
   - git clone --depth 1 --branch v{{ $grafanaVersion }} {{ $.SOURCE_REPO }}/grafana/grafana.git .
   - git clone --depth 1 --branch v{{ $grafanaVersion }} {{ $.SOURCE_REPO }}/grafana/grafana-deps.git /grafana-public
   - git clone --depth 1 {{ $.SOURCE_REPO }}/grafana/grafana-plugins.git /grafana-plugins
-  - git clone --depth 1 --branch v0.6.0 {{ $.SOURCE_REPO }}/google/wire.git /src/wire
   - find /patches -name '*.patch' -exec git apply {} \;
   - rm -rf /usr/src/app/.git /grafana-public/.git /grafana-plugins/.git /src/wire/.git
 ---
@@ -35,17 +34,16 @@ import:
   add: /usr/src/app
   to: /usr/src/app
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-files
-  add: /src/wire
-  to: /src/wire
-  before: install
 shell:
   beforeInstall:
   {{- include "debian packages proxy" . | nindent 2 }}
-  - apt-get -y --no-install-recommends install gcc musl musl-tools
+  - apt-get -y --no-install-recommends install gcc musl musl-tools git
+  - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
+  - git clone --depth 1 --branch v0.6.0 {{ $.SOURCE_REPO }}/google/wire.git /src/wire
   install:
   - export GOPROXY={{ $.GOPROXY }} CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC=/usr/bin/musl-gcc
   - cd /src/wire/cmd/wire && go install
+  - rm -rf /src/wire
   - cd /usr/src/app
   - /go/bin/wire gen -tags oss ./pkg/server
   - go build -ldflags -w -ldflags "-X main.version={{ $grafanaVersion }} -linkmode external -extldflags -static" -tags netgo -o ./bin/linux-amd64/grafana ./pkg/cmd/grafana


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
The src-artifact image contains utilities that are not the source code of the platform components
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Moving problematic utilities from src-artifact to artifact
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not related to release
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: chore
summary: Moving problematic utilities from src-artifact to artifact
impact_level: low
---
section: cni-cilium
type: chore
summary: Moving problematic utilities from src-artifact to artifact
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
