### PR TITLE
defectDojo to auto close old findings

### DIFF
--- a/tools/cve/base-images.sh
+++ b/tools/cve/base-images.sh
@@ -101,7 +101,8 @@ function __main__() {
       -F "active=true" \
       -F "verified=true" \
       -F "scan_type=Trivy Scan" \
-      -F "close_old_findings=false" \
+      -F "close_old_findings=true" \
+      -F "do_not_reactivate=false" \
       -F "push_to_jira=false" \
       -F "file=@out/json/base_image_${IMAGE_NAME}_report.json" \
       -F "product_type_name=Deckhouse images" \

--- a/tools/cve/d8-images.sh
+++ b/tools/cve/d8-images.sh
@@ -121,7 +121,8 @@ function __main__() {
         -F "active=true" \
         -F "verified=true" \
         -F "scan_type=Trivy Scan" \
-        -F "close_old_findings=false" \
+        -F "close_old_findings=true" \
+        -F "do_not_reactivate=false" \
         -F "push_to_jira=false" \
         -F "file=@out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" \
         -F "product_type_name=Deckhouse images" \


### PR DESCRIPTION
## Description
defectDojo will auto close old findings on reimport if vulnerability is absent in the report

## Why do we need it, and what problem does it solve?
currently defectDojo not updates report

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


```changes
section: ci
type: fix
summary: none
impact: none
impact_level: low
```

