### PR TITLE
[admission-policy-engine] bump deps version to fix cves

### DIFF
--- a/ee/modules/015-admission-policy-engine/images/ratify/patches/02-go-mod.patch
+++ b/ee/modules/015-admission-policy-engine/images/ratify/patches/02-go-mod.patch
@@ -1,5 +1,5 @@
 diff --git a/go.mod b/go.mod
-index 9531e39..d4c36c2 100644
+index 9531e39..58a3329 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -28,8 +28,8 @@ require (
@@ -31,15 +31,17 @@ index 9531e39..d4c36c2 100644
  	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 // indirect
  	github.com/sagikazarmark/locafero v0.4.0 // indirect
  	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
-@@ -171,7 +171,7 @@ require (
+@@ -171,8 +171,8 @@ require (
  	github.com/go-openapi/swag v0.23.0 // indirect
  	github.com/go-openapi/validate v0.24.0 // indirect
  	github.com/gogo/protobuf v1.3.2 // indirect
 -	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+-	github.com/golang/glog v1.2.1 // indirect
 +	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
- 	github.com/golang/glog v1.2.1 // indirect
++	github.com/golang/glog v1.2.4 // indirect
  	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
  	github.com/golang/snappy v0.0.4 // indirect
+ 	github.com/google/certificate-transparency-go v1.1.8 // indirect
 @@ -222,7 +222,7 @@ require (
  	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
  	github.com/transparency-dev/merkle v0.0.2 // indirect
@@ -71,10 +73,10 @@ index 9531e39..d4c36c2 100644
  	gomodules.xyz/jsonpatch/v2 v2.3.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
 diff --git a/go.sum b/go.sum
-index 2817a08..5275e01 100644
+index 2817a08..40c0311 100644
 --- a/go.sum
 +++ b/go.sum
-@@ -331,8 +331,9 @@ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
+@@ -331,13 +331,14 @@ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
  github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
  github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
  github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
@@ -85,6 +87,13 @@ index 2817a08..5275e01 100644
  github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
  github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
  github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+-github.com/golang/glog v1.2.1 h1:OptwRhECazUx5ix5TTWC3EZhsZEHWcYWY4FQHTIubm4=
+-github.com/golang/glog v1.2.1/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
++github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
++github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 @@ -516,14 +517,14 @@ github.com/mozillazg/docker-credential-acr-helper v0.3.0/go.mod h1:cZlu3tof523uj
  github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
  github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=

--- a/modules/015-admission-policy-engine/images/gatekeeper/patches/001-go-mod.patch
+++ b/modules/015-admission-policy-engine/images/gatekeeper/patches/001-go-mod.patch
@@ -1,5 +1,5 @@
 diff --git a/go.mod b/go.mod
-index 33df7a3ab..1fc57c00f 100644
+index 33df7a3..0662de7 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -31,7 +31,7 @@ require (
@@ -11,10 +11,30 @@ index 33df7a3ab..1fc57c00f 100644
  	golang.org/x/oauth2 v0.21.0
  	golang.org/x/sync v0.10.0
  	golang.org/x/time v0.6.0
+@@ -94,7 +94,7 @@ require (
+ 	github.com/go-openapi/swag v0.23.0 // indirect
+ 	github.com/gobwas/glob v0.2.3 // indirect
+ 	github.com/gogo/protobuf v1.3.2 // indirect
+-	github.com/golang/glog v1.2.1 // indirect
++	github.com/golang/glog v1.2.4 // indirect
+ 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+ 	github.com/google/cel-go v0.17.8 // indirect
+ 	github.com/google/gnostic-models v0.6.8 // indirect
 diff --git a/go.sum b/go.sum
-index f34d55235..c57f37f99 100644
+index f34d552..1489735 100644
 --- a/go.sum
 +++ b/go.sum
+@@ -173,8 +173,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
+ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
+ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+-github.com/golang/glog v1.2.1 h1:OptwRhECazUx5ix5TTWC3EZhsZEHWcYWY4FQHTIubm4=
+-github.com/golang/glog v1.2.1/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
++github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
++github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+ github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 @@ -445,8 +445,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
  golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Bump golang deps version to fix cves.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Vulnerability fixes.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessary.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: chore
summary: bump deps version to fix cves
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
