### PR TITLE
[deckhouse] enrich deprecated update policy alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4249,11 +4249,6 @@ alerts:
       edition: ce
       description: |
         The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
-
-        Please specify the proper update policy in the module config to continue get updates:
-        ```
-        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | quote }}}}'
-        ```
       summary: |
         The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy.
       severity: "4"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4252,7 +4252,7 @@ alerts:
 
         Please specify the proper update policy in the module config to continue get updates:
         ```
-        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": "{{ $labels.updatePolicy }}" }}'
+        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | toJson }} }}'
         ```
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4252,7 +4252,7 @@ alerts:
 
         Please specify the proper update policy in the module config to continue get updates:
         ```
-        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | toJson }} }}'
+        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy }} }}'
         ```
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4252,7 +4252,7 @@ alerts:
 
         Please specify the proper update policy in the module config to continue get updates:
         ```
-        kubectl patch mc '{{ $labels.moduleName }}' --type=merge -p '{"spec": {"updatePolicy": '{{ $labels.updatePolicy }}'}}'
+        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": "{{ $labels.updatePolicy }}" }}'
         ```
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4248,9 +4248,12 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        The '{{ $labels.moduleName }}' module has a deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
+        The '{{ $labels.moduleName }}' module matched by deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
 
-        Please specify the proper update policy in the module configuration to continue get updates.
+        Please specify the proper update policy in the module config to continue get updates:
+        ```
+        kubectl patch mc '{{ $labels.moduleName }}' --type=merge -p '{"spec": {"updatePolicy": '{{ $labels.updatePolicy }}'}}'
+        ```
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.
       severity: "4"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4248,7 +4248,17 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
+        The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy, the policy`s v1alpha1 has selector that no longer works.
+        
+        Specify the update policy in the module config by following command:
+        ```
+        kubectl patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
+        ```
+        
+        After all alerts are solved, use this command to clear selector in the update policy:
+        ```
+        kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
+        ```
       summary: |
         The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy.
       severity: "4"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4254,8 +4254,13 @@ alerts:
         ```
         kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | quote }}}}'
         ```
+        
+        When all modules updated, patch the v1alpha1 update policy to get rid of the alert:
+        ```
+        kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
+        ```
       summary: |
-        The '{{ $labels.moduleName }}' module has a deprecated module update policy.
+        The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy.
       severity: "4"
       markupFormat: markdown
     - name: ModuleReleaseIsBlockedByRequirements

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4248,19 +4248,19 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy, the policy`s v1alpha1 has selector that no longer works.
+        The '{{ $labels.moduleName }}' module is matched by the '{{ $labels.updatePolicy }}' deprecated module update policy. The policy`s v1alpha1 has a selector that no longer works.
 
-        Specify the update policy in the module config by following command:
+        Specify the update policy in the module config by running the following command:
         ```
         kubectl patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
         ```
 
-        After solving all alerts for the '{{ $labels.updatePolicy }}' update policy, use this command to clear selector:
+        After solving all alerts for the '{{ $labels.updatePolicy }}' update policy, use this command to clear the selector:
         ```
         kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
         ```
       summary: |
-        The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy.
+        The '{{ $labels.moduleName }}' module is matched by the '{{ $labels.updatePolicy }}' deprecated module update policy.
       severity: "4"
       markupFormat: markdown
     - name: ModuleReleaseIsBlockedByRequirements

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4255,7 +4255,7 @@ alerts:
         kubectl patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
         ```
 
-        After all alerts are solved, use this command to clear selector in the update policy:
+        After solving all alerts for the '{{ $labels.updatePolicy }}' update policy, use this command to clear selector:
         ```
         kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
         ```

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4248,11 +4248,11 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        The '{{ $labels.moduleName }}' module matched by deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
+        The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
 
         Please specify the proper update policy in the module config to continue get updates:
         ```
-        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy }} }}'
+        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | quote }}}}'
         ```
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4249,12 +4249,12 @@ alerts:
       edition: ce
       description: |
         The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy, the policy`s v1alpha1 has selector that no longer works.
-        
+
         Specify the update policy in the module config by following command:
         ```
         kubectl patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
         ```
-        
+
         After all alerts are solved, use this command to clear selector in the update policy:
         ```
         kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4254,7 +4254,7 @@ alerts:
         ```
         kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | quote }}}}'
         ```
-        
+
         When all modules updated, patch the v1alpha1 update policy to get rid of the alert:
         ```
         kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4254,11 +4254,6 @@ alerts:
         ```
         kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | quote }}}}'
         ```
-
-        When all modules updated, patch the v1alpha1 update policy to get rid of the alert:
-        ```
-        kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
-        ```
       summary: |
         The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy.
       severity: "4"

--- a/global-hooks/migrate/migrate_update_policy.go
+++ b/global-hooks/migrate/migrate_update_policy.go
@@ -56,10 +56,11 @@ func mupFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	if mup.Spec.ModuleReleaseSelector.LabelSelector == nil {
 		return nil, nil
 	}
-	return &filteredMup{LabelSelector: mup.Spec.ModuleReleaseSelector.LabelSelector}, nil
+	return &filteredMup{Name: mup.Name, LabelSelector: mup.Spec.ModuleReleaseSelector.LabelSelector}, nil
 }
 
 type filteredMup struct {
+	Name          string
 	LabelSelector *metav1.LabelSelector
 }
 
@@ -112,7 +113,8 @@ func fireMupAlerts(input *go_hook.HookInput) error {
 
 			if selector.Matches(labelsSet) {
 				input.MetricsCollector.Set("d8_deprecated_update_policy", 1.0, map[string]string{
-					"moduleName": module.Name,
+					"moduleName":   module.Name,
+					"updatePolicy": policy.Name,
 				}, metrics.WithGroup("d8_update_policy"))
 				continue
 			}

--- a/global-hooks/migrate/migrate_update_policy.go
+++ b/global-hooks/migrate/migrate_update_policy.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
@@ -112,6 +113,7 @@ func fireMupAlerts(input *go_hook.HookInput) error {
 			}
 
 			if selector.Matches(labelsSet) {
+				fmt.Printf("[HOOK_DEBUG] update policy '%s'\n", policy.Name)
 				input.MetricsCollector.Set("d8_deprecated_update_policy", 1.0, map[string]string{
 					"moduleName":   module.Name,
 					"updatePolicy": policy.Name,

--- a/global-hooks/migrate/migrate_update_policy.go
+++ b/global-hooks/migrate/migrate_update_policy.go
@@ -17,7 +17,6 @@ limitations under the License.
 package hooks
 
 import (
-	"fmt"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
@@ -113,7 +112,6 @@ func fireMupAlerts(input *go_hook.HookInput) error {
 			}
 
 			if selector.Matches(labelsSet) {
-				fmt.Printf("[HOOK_DEBUG] update policy '%s'\n", policy.Name)
 				input.MetricsCollector.Set("d8_deprecated_update_policy", 1.0, map[string]string{
 					"moduleName":   module.Name,
 					"updatePolicy": policy.Name,

--- a/global-hooks/migrate/migrate_update_policy.go
+++ b/global-hooks/migrate/migrate_update_policy.go
@@ -17,7 +17,6 @@ limitations under the License.
 package hooks
 
 import (
-	"fmt"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
@@ -113,7 +112,6 @@ func fireMupAlerts(input *go_hook.HookInput) error {
 			}
 
 			if selector.Matches(labelsSet) {
-				fmt.Printf("[DEBUG HOOK] update policy %s", policy.Name)
 				input.MetricsCollector.Set("d8_deprecated_update_policy", 1.0, map[string]string{
 					"moduleName":   module.Name,
 					"updatePolicy": policy.Name,

--- a/global-hooks/migrate/migrate_update_policy.go
+++ b/global-hooks/migrate/migrate_update_policy.go
@@ -112,6 +112,7 @@ func fireMupAlerts(input *go_hook.HookInput) error {
 			}
 
 			if selector.Matches(labelsSet) {
+				input.Logger.Debugf("[DEBUG HOOK] update policy %s", policy.Name)
 				input.MetricsCollector.Set("d8_deprecated_update_policy", 1.0, map[string]string{
 					"moduleName":   module.Name,
 					"updatePolicy": policy.Name,

--- a/global-hooks/migrate/migrate_update_policy.go
+++ b/global-hooks/migrate/migrate_update_policy.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
@@ -112,7 +113,7 @@ func fireMupAlerts(input *go_hook.HookInput) error {
 			}
 
 			if selector.Matches(labelsSet) {
-				input.Logger.Debugf("[DEBUG HOOK] update policy %s", policy.Name)
+				fmt.Printf("[DEBUG HOOK] update policy %s", policy.Name)
 				input.MetricsCollector.Set("d8_deprecated_update_policy", 1.0, map[string]string{
 					"moduleName":   module.Name,
 					"updatePolicy": policy.Name,

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -204,7 +204,7 @@
 
         Please specify the proper update policy in the module config to continue get updates:
         ```
-        kubectl patch mc '{{ $labels.moduleName }}' --type=merge -p '{"spec": {"updatePolicy": '{{ $labels.updatePolicy }}'}}'
+        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": "{{ $labels.updatePolicy }}" }}'
         ```
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -200,8 +200,11 @@
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       description: |
-        The '{{ $labels.moduleName }}' module has a deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
+        The '{{ $labels.moduleName }}' module matched by deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
 
-        Please specify the proper update policy in the module configuration to continue get updates.
+        Please specify the proper update policy in the module config to continue get updates:
+        ```
+        kubectl patch mc '{{ $labels.moduleName }}' --type=merge -p '{"spec": {"updatePolicy": '{{ $labels.updatePolicy }}'}}'
+        ```
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -204,7 +204,7 @@
 
         Please specify the proper update policy in the module config to continue get updates:
         ```
-        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | toJson }} }}'
+        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy }} }}'
         ```
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -204,7 +204,7 @@
 
         Please specify the proper update policy in the module config to continue get updates:
         ```
-        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": "{{ $labels.updatePolicy }}" }}'
+        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | toJson }} }}'
         ```
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -201,10 +201,5 @@
       plk_protocol_version: "1"
       description: |
         The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
-
-        Please specify the proper update policy in the module config to continue get updates:
-        ```
-        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | quote }}}}'
-        ```
       summary: |
         The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -206,5 +206,10 @@
         ```
         kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | quote }}}}'
         ```
+        
+        When all modules updated, patch the v1alpha1 update policy to get rid of the alert:
+        ```
+        kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
+        ```
       summary: |
-        The '{{ $labels.moduleName }}' module has a deprecated module update policy.
+        The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -200,11 +200,11 @@
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       description: |
-        The '{{ $labels.moduleName }}' module matched by deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
+        The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
 
         Please specify the proper update policy in the module config to continue get updates:
         ```
-        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy }} }}'
+        kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | quote }}}}'
         ```
       summary: |
         The '{{ $labels.moduleName }}' module has a deprecated module update policy.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -200,16 +200,16 @@
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       description: |
-        The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy, the policy`s v1alpha1 has selector that no longer works.
+        The '{{ $labels.moduleName }}' module is matched by the '{{ $labels.updatePolicy }}' deprecated module update policy. The policy`s v1alpha1 has a selector that no longer works.
 
-        Specify the update policy in the module config by following command:
+        Specify the update policy in the module config by running the following command:
         ```
         kubectl patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
         ```
 
-        After solving all alerts for the '{{ $labels.updatePolicy }}' update policy, use this command to clear selector:
+        After solving all alerts for the '{{ $labels.updatePolicy }}' update policy, use this command to clear the selector:
         ```
         kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
         ```
       summary: |
-        The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy.
+        The '{{ $labels.moduleName }}' module is matched by the '{{ $labels.updatePolicy }}' deprecated module update policy.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -193,13 +193,23 @@
       summary: |
         ModuleConfig {{ $labels.name }} is outdated.
   - alert: ModuleHasDeprecatedUpdatePolicy
-    expr: max by (moduleName) (d8_deprecated_update_policy) >= 1
+    expr: max by (moduleName, updatePolicy) (d8_deprecated_update_policy) >= 1
     labels:
       severity_level: "4"
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       description: |
-        The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy, the policy selector does not work, and the module will use deckhouse update policy.
+        The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy, the policy`s v1alpha1 has selector that no longer works.
+        
+        Specify the update policy in the module config by following command:
+        ```
+        kubectl patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
+        ```
+        
+        After all alerts are solved, use this command to clear selector in the update policy:
+        ```
+        kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
+        ```
       summary: |
         The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -201,12 +201,12 @@
       plk_protocol_version: "1"
       description: |
         The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy, the policy`s v1alpha1 has selector that no longer works.
-        
+
         Specify the update policy in the module config by following command:
         ```
         kubectl patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
         ```
-        
+
         After all alerts are solved, use this command to clear selector in the update policy:
         ```
         kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -206,10 +206,5 @@
         ```
         kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | quote }}}}'
         ```
-
-        When all modules updated, patch the v1alpha1 update policy to get rid of the alert:
-        ```
-        kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
-        ```
       summary: |
         The '{{ $labels.moduleName }}' module matched by the '{{ $labels.updatePolicy }}' deprecated module update policy.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -206,7 +206,7 @@
         ```
         kubectl patch mc {{ $labels.moduleName }} --type=merge -p '{"spec": {"updatePolicy": {{ $labels.updatePolicy | quote }}}}'
         ```
-        
+
         When all modules updated, patch the v1alpha1 update policy to get rid of the alert:
         ```
         kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -207,7 +207,7 @@
         kubectl patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
         ```
 
-        After all alerts are solved, use this command to clear selector in the update policy:
+        After solving all alerts for the '{{ $labels.updatePolicy }}' update policy, use this command to clear selector:
         ```
         kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
         ```


### PR DESCRIPTION
## Description
It enriches the deprecated update policy alert with commands to set the update policy to the module config

## Why do we need it, and what problem does it solve?
To help people migrating.

```
root@dev-master-0:~# kubectl get clusteralert 76f555d6c3d29c67 -oyaml
alert:
  description: |
    The 'test' module matched by the 'alpha-auto' deprecated module update policy, the policy`s v1alpha1 has selector that no longer works.

    Specify the update policy in the module config by following command:
    ```
    kubectl patch moduleconfig test --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "alpha-auto"}]'
    ```

    After solving all alerts for the 'alpha-auto' update policy, use this command to clear selector:
    ```
    kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io alpha-auto --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
    ```
  labels:
    moduleName: test
    prometheus: deckhouse
    updatePolicy: alpha-auto
  name: ModuleHasDeprecatedUpdatePolicy
  severityLevel: "4"
  summary: |
    The 'test' module matched by the 'alpha-auto' deprecated module update policy.
```


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Enrich deprecated update policy alert
impact_level: low
```