### PR TITLE
[deckhouse-controller] Fix kubectl wrapper

### DIFF
--- a/deckhouse-controller/files/kubectl_wrapper.sh
+++ b/deckhouse-controller/files/kubectl_wrapper.sh
@@ -25,7 +25,7 @@ fi
 
 case "$kubernetes_version" in
   1.27.* | 1.28.* | 1.29.* )
-    kubectl_version="1.28"
+    kubectl_version="1.29"
     ;;
   1.30.* | 1.31.* | 1.32.* )
     kubectl_version="1.31"

--- a/werf.yaml
+++ b/werf.yaml
@@ -61,6 +61,7 @@ cleanup:
 
 {{- $_ := set . "CandiVersionMap" $versionMap }}
 
+# do not forget change /deckhouse-controller/files/kubectl_wrapper.sh
 {{- $_ := set . "kubectlForBaseComponents" (list "1.29" "1.31") }}
 ---
 # Terraform Versions


### PR DESCRIPTION
## Description
Forget change kubectl version in kubectl_wrapper in #11501

## Why do we need it, and what problem does it solve?
Kubectl does not work in deckhouse pod

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix kubectl wrapper
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
