### PR TITLE
[prometheus-rules] Change links in prometheus-rules when module documentation is enable.

### DIFF
--- a/modules/040-node-manager/monitoring/prometheus-rules/early-oom.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/early-oom.tpl
@@ -21,5 +21,5 @@
         Possible actions to resolve the problem:
         * Upgrade kernel to version 4.20 or higher.
         * Enable [Pressure Stall Information](https://docs.kernel.org/accounting/psi.html).
-        * [Disable]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}{{- else }}https://deckhouse.io{{- end }}/products/kubernetes-platform/documentation/v1/modules/node-manager/configuration.html#parameters-earlyoomenabled) early oom.
+        * [Disable]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation")}}/en/platform/modules{{- else }}https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules{{- end }}/node-manager/configuration.html#parameters-earlyoomenabled) early oom.
 {{- end }}

--- a/modules/110-istio/monitoring/prometheus-rules/versions.tpl
+++ b/modules/110-istio/monitoring/prometheus-rules/versions.tpl
@@ -8,7 +8,7 @@
           
           Support for this version will be removed in upcoming Deckhouse releases. The higher the alert severity, the greater the probability of support being discontinued.
 
-          To learn how to upgrade Istio, refer to the [upgrade guide]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/en/platform/modules{{- else }}https://deckhouse.io/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules{{- end }}/istio/examples.html#upgrading-istio).
+          To learn how to upgrade Istio, refer to the [upgrade guide]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}{{- else }}https://deckhouse.io{{- end }}/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules/istio/examples.html#upgrading-istio).
         plk_markup_format: markdown
         plk_labels_as_annotations: pod,instance
         plk_protocol_version: "1"
@@ -26,7 +26,7 @@
         description: |
           The installed Istio version `{{"{{$labels.istio_version}}"}}` may not work properly with the current Kubernetes version `{{"{{$labels.k8s_version}}"}}` because it's not supported officially.
 
-          To resolve the issue, upgrade Istio following the [guide]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/en/platform/modules{{- else }}https://deckhouse.io/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules{{- end }}/istio/examples.html#upgrading-istio).
+          To resolve the issue, upgrade Istio following the [guide]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}{{- else }}https://deckhouse.io{{- end }}/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules/istio/examples.html#upgrading-istio).
         plk_markup_format: markdown
         plk_labels_as_annotations: pod,instance
         plk_protocol_version: "1"

--- a/modules/110-istio/monitoring/prometheus-rules/versions.tpl
+++ b/modules/110-istio/monitoring/prometheus-rules/versions.tpl
@@ -8,7 +8,7 @@
           
           Support for this version will be removed in upcoming Deckhouse releases. The higher the alert severity, the greater the probability of support being discontinued.
 
-          To learn how to upgrade Istio, refer to the [upgrade guide]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}{{- else }}https://deckhouse.io{{- end }}/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules/istio/examples.html#upgrading-istio).
+          To learn how to upgrade Istio, refer to the [upgrade guide]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/en/platform/modules{{- else }}https://deckhouse.io/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules{{- end }}/istio/examples.html#upgrading-istio).
         plk_markup_format: markdown
         plk_labels_as_annotations: pod,instance
         plk_protocol_version: "1"
@@ -26,7 +26,7 @@
         description: |
           The installed Istio version `{{"{{$labels.istio_version}}"}}` may not work properly with the current Kubernetes version `{{"{{$labels.k8s_version}}"}}` because it's not supported officially.
 
-          To resolve the issue, upgrade Istio following the [guide]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}{{- else }}https://deckhouse.io{{- end }}/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules/istio/examples.html#upgrading-istio).
+          To resolve the issue, upgrade Istio following the [guide]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/en/platform/modules{{- else }}https://deckhouse.io/products/kubernetes-platform/documentation/{{ $.Values.global.deckhouseVersion }}/modules{{- end }}/istio/examples.html#upgrading-istio).
         plk_markup_format: markdown
         plk_labels_as_annotations: pod,instance
         plk_protocol_version: "1"

--- a/modules/340-monitoring-custom/monitoring/prometheus-rules/reserved-domain.tpl
+++ b/modules/340-monitoring-custom/monitoring/prometheus-rules/reserved-domain.tpl
@@ -18,4 +18,4 @@
         - reserved `metadata.labels` *node-role.deckhouse.io/* with ending not in `(system|frontend|monitoring|_deckhouse_module_name_)`
         - or reserved `spec.taints` *dedicated.deckhouse.io* with values not in `(system|frontend|monitoring|_deckhouse_module_name_)`
 
-        [Get instructions on how to fix it here]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}{{- else }}https://deckhouse.io{{- end }}/products/kubernetes-platform/documentation/v1/modules/node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).
+        [Get instructions on how to fix it here]({{ if .Values.global.modules.publicDomainTemplate }}{{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "documentation") }}/en/platform/modules{{- else }}https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules{{- end }}/node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Some alerts had incorrect link templates, and when the `documentation` module was enabled, the link followed the path of the documentation web page in deckhouse.io


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
If there is no Internet access and the `Documentation` module is enabled, this can create problems for users who turn to external resources for additional information and troubleshooting. For such environments, it is important to have complete offline documentation or an internal mirror of the necessary resources so that users can access important information without relying on an internet connection. This setting ensures that even in conditions of limited access, users will be able to effectively manage alerts and maintain the system.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus-rules
type: fix 
summary: Changes the links in alert's template about alerts from url to relative links
impact: The links in the alerts will be correct when the documentation module is enabled.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
