### PR TITLE
[docs] Fix 1.65 changelog

### DIFF
--- a/CHANGELOG/CHANGELOG-v1.65.md
+++ b/CHANGELOG/CHANGELOG-v1.65.md
@@ -1,13 +1,5 @@
 # Changelog v1.65
 
-## [MALFORMED]
-
-
- - #9966 unknown section "cloud-provider-vsphere"
- - #9966 unknown section "cloud-provider-zvirt"
- - #10035 unknown section "cloud-provider-zvirt"
- - #10236 unknown section "cloud-provider-zvirt"
-
 ## Know before update
 
 
@@ -73,6 +65,8 @@
  - **[cloud-provider-aws]** revert "Added the ability to specify your IAM role" [#10435](https://github.com/deckhouse/deckhouse/pull/10435)
  - **[cloud-provider-vcd]** Fix vCloudDirector catalogs sharing. [#9802](https://github.com/deckhouse/deckhouse/pull/9802)
  - **[cloud-provider-yandex]** Add support a hybrid cluster in yandex CSI driver [#9861](https://github.com/deckhouse/deckhouse/pull/9861)
+ - **[cloud-provider-zvirt]** Add to the instance a status about zvirtinstance. [#10236](https://github.com/deckhouse/deckhouse/pull/10236)
+ - **[cloud-provider-zvirt]** 401 Unauthorized error fixed in zvirt csi-node. [#10035](https://github.com/deckhouse/deckhouse/pull/10035)
  - **[cni-cilium]** Fixed `excludedCIDRs` option in EgressGatewayPolicies [#10493](https://github.com/deckhouse/deckhouse/pull/10493)
  - **[cni-cilium]** Disable the metrics server in the "egress-gateway-agent" because we don't use it. [#10208](https://github.com/deckhouse/deckhouse/pull/10208)
     The pods of the egress-gateway-agent will be restarted.


### PR DESCRIPTION
## Description
Fix 1.65 changelog.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix 1.65 changelog.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
