### PR TITLE
[user-authn] Dex-authenticator add redis connection retries

### DIFF
--- a/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
@@ -8,8 +8,8 @@ index 96ea6d4f..8614a60c 100644
         ctx := context.Background()
 -
 +       for i := 0; i < 5; i++ {
-+               tempErr := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
-+               if tempErr == nil {
++               err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
++               if err == nil {
 +                       break
 +               }
 +               time.Sleep(2 * time.Second)

--- a/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
@@ -1,0 +1,37 @@
+diff --git a/pkg/validation/sessions.go b/pkg/validation/sessions.go
+index 96ea6d4f..f14bcd84 100644
+--- a/pkg/validation/sessions.go
++++ b/pkg/validation/sessions.go
+@@ -64,19 +64,21 @@ func validateRedisSessionStore(o *options.Options) []string {
+ func sendRedisConnectionTest(client redis.Client, key string, val string) []string {
+        msgs := []string{}
+        ctx := context.Background()
+-
+-       err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
+-       if err != nil {
+-               msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))
+-       } else {
+-               gval, err := client.Get(ctx, key)
++       for i := 0; i < 5; i++ {
++               err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
+                if err != nil {
+-                       msgs = append(msgs,
+-                               fmt.Sprintf("unable to retrieve redis initialization key: %v", err))
+-               }
+-               if string(gval) != val {
+-                       msgs = append(msgs,
+-                               "the retrieved redis initialization key did not match the value we set")
++                       msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))
++               } else {
++                       gval, err := client.Get(ctx, key)
++                       if err != nil {
++                               msgs = append(msgs,
++                                       fmt.Sprintf("unable to retrieve redis initialization key: %v", err))
++                       }
++                       if string(gval) != val {
++                               msgs = append(msgs,
++                                       "the retrieved redis initialization key did not match the value we set")
++                       }
++                       break
+                }
+        }

--- a/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
@@ -1,24 +1,23 @@
 diff --git a/pkg/validation/sessions.go b/pkg/validation/sessions.go
-index 96ea6d4f..6cf8b035 100644
+index 96ea6d4f..60f8bb03 100644
 --- a/pkg/validation/sessions.go
 +++ b/pkg/validation/sessions.go
-@@ -64,10 +64,17 @@ func validateRedisSessionStore(o *options.Options) []string {
- func sendRedisConnectionTest(client redis.Client, key string, val string) []string {
-        msgs := []string{}
-        ctx := context.Background()
--
-+       for i := 0; i < 5; i++ {
-+               fmt.Println("Testing connection to redis...")
-+               err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
-+               if err == nil {
-+                       break
-+               }
-+               time.Sleep(2 * time.Second)
-+       }
-        err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
-        if err != nil {
--               msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))
-+               msgs = append(msgs, fmt.Sprintf("TEST unable to set a redis initialization key: %v", err))
-        } else {
-                gval, err := client.Get(ctx, key)
-                if err != nil {
+@@ -65,9 +65,17 @@ func sendRedisConnectionTest(client redis.Client, key string, val string) []stri
+ 	msgs := []string{}
+ 	ctx := context.Background()
+ 
++	for i := 0; i < 5; i++ {
++		fmt.Println("Testing connection to redis...")
++		err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
++		if err == nil {
++			break
++		}
++		time.Sleep(2 * time.Second)
++	}
+ 	err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
+ 	if err != nil {
+-		msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))
++		msgs = append(msgs, fmt.Sprintf("TEST unable to set a redis initialization key: %v", err))
+ 	} else {
+ 		gval, err := client.Get(ctx, key)
+ 		if err != nil {

--- a/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
@@ -1,14 +1,22 @@
 diff --git a/pkg/validation/sessions.go b/pkg/validation/sessions.go
-index 96ea6d4f..bde8284e 100644
+index 96ea6d4f..294c1a00 100644
 --- a/pkg/validation/sessions.go
 +++ b/pkg/validation/sessions.go
-@@ -64,7 +64,14 @@ func validateRedisSessionStore(o *options.Options) []string {
+@@ -8,6 +8,7 @@ import (
+
+        "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+        "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
++       "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+        "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/sessions/redis"
+ )
+
+@@ -64,7 +65,14 @@ func validateRedisSessionStore(o *options.Options) []string {
  func sendRedisConnectionTest(client redis.Client, key string, val string) []string {
         msgs := []string{}
         ctx := context.Background()
 -
 +       for i := 0; i < 5; i++ {
-+               fmt.Println("Testing connection to redis...")
++               logger.Printf("Testing connection to redis...")
 +               err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
 +               if err == nil {
 +                       break

--- a/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
@@ -1,13 +1,14 @@
 diff --git a/pkg/validation/sessions.go b/pkg/validation/sessions.go
-index 96ea6d4f..8614a60c 100644
+index 96ea6d4f..bde8284e 100644
 --- a/pkg/validation/sessions.go
 +++ b/pkg/validation/sessions.go
-@@ -64,7 +64,13 @@ func validateRedisSessionStore(o *options.Options) []string {
+@@ -64,7 +64,14 @@ func validateRedisSessionStore(o *options.Options) []string {
  func sendRedisConnectionTest(client redis.Client, key string, val string) []string {
         msgs := []string{}
         ctx := context.Background()
 -
 +       for i := 0; i < 5; i++ {
++               fmt.Println("Testing connection to redis...")
 +               err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
 +               if err == nil {
 +                       break

--- a/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
@@ -1,37 +1,19 @@
 diff --git a/pkg/validation/sessions.go b/pkg/validation/sessions.go
-index 96ea6d4f..f14bcd84 100644
+index 96ea6d4f..8614a60c 100644
 --- a/pkg/validation/sessions.go
 +++ b/pkg/validation/sessions.go
-@@ -64,19 +64,21 @@ func validateRedisSessionStore(o *options.Options) []string {
+@@ -64,7 +64,13 @@ func validateRedisSessionStore(o *options.Options) []string {
  func sendRedisConnectionTest(client redis.Client, key string, val string) []string {
         msgs := []string{}
         ctx := context.Background()
 -
--       err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
--       if err != nil {
--               msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))
--       } else {
--               gval, err := client.Get(ctx, key)
 +       for i := 0; i < 5; i++ {
-+               err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
-                if err != nil {
--                       msgs = append(msgs,
--                               fmt.Sprintf("unable to retrieve redis initialization key: %v", err))
--               }
--               if string(gval) != val {
--                       msgs = append(msgs,
--                               "the retrieved redis initialization key did not match the value we set")
-+                       msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))
-+               } else {
-+                       gval, err := client.Get(ctx, key)
-+                       if err != nil {
-+                               msgs = append(msgs,
-+                                       fmt.Sprintf("unable to retrieve redis initialization key: %v", err))
-+                       }
-+                       if string(gval) != val {
-+                               msgs = append(msgs,
-+                                       "the retrieved redis initialization key did not match the value we set")
-+                       }
++               tempErr := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
++               if tempErr == nil {
 +                       break
-                }
-        }
++               }
++               time.Sleep(2 * time.Second)
++       }
+        err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
+        if err != nil {
+                msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))

--- a/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
@@ -3,13 +3,13 @@ index 96ea6d4f..e35f2ab8 100644
 --- a/pkg/validation/sessions.go
 +++ b/pkg/validation/sessions.go
 @@ -8,6 +8,7 @@ import (
- 
+
  	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
  	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
 +	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
  	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/sessions/redis"
  )
- 
+
 @@ -64,13 +65,20 @@ func validateRedisSessionStore(o *options.Options) []string {
  func sendRedisConnectionTest(client redis.Client, key string, val string) []string {
  	msgs := []string{}
@@ -18,7 +18,7 @@ index 96ea6d4f..e35f2ab8 100644
 -	err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
 +	var err error
 +	for i := 0; i < 10; i++ {
-+		logger.Printf("testing connection to redis...", i)
++		logger.Printf("testing connection to redis...")
 +		err = client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
 +		if err == nil {
 +			break

--- a/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
@@ -1,5 +1,5 @@
 diff --git a/pkg/validation/sessions.go b/pkg/validation/sessions.go
-index 96ea6d4f..294c1a00 100644
+index 96ea6d4f..a71c4283 100644
 --- a/pkg/validation/sessions.go
 +++ b/pkg/validation/sessions.go
 @@ -8,6 +8,7 @@ import (
@@ -10,7 +10,7 @@ index 96ea6d4f..294c1a00 100644
         "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/sessions/redis"
  )
 
-@@ -64,7 +65,14 @@ func validateRedisSessionStore(o *options.Options) []string {
+@@ -64,10 +65,17 @@ func validateRedisSessionStore(o *options.Options) []string {
  func sendRedisConnectionTest(client redis.Client, key string, val string) []string {
         msgs := []string{}
         ctx := context.Background()
@@ -25,4 +25,8 @@ index 96ea6d4f..294c1a00 100644
 +       }
         err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
         if err != nil {
-                msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))
+-               msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))
++               msgs = append(msgs, fmt.Sprintf("TEST unable to set a redis initialization key: %v", err))
+        } else {
+                gval, err := client.Get(ctx, key)
+                if err != nil {

--- a/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
@@ -1,23 +1,37 @@
 diff --git a/pkg/validation/sessions.go b/pkg/validation/sessions.go
-index 96ea6d4f..60f8bb03 100644
+index 96ea6d4f..e35f2ab8 100644
 --- a/pkg/validation/sessions.go
 +++ b/pkg/validation/sessions.go
-@@ -65,9 +65,17 @@ func sendRedisConnectionTest(client redis.Client, key string, val string) []stri
+@@ -8,6 +8,7 @@ import (
+ 
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
++	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/sessions/redis"
+ )
+ 
+@@ -64,13 +65,20 @@ func validateRedisSessionStore(o *options.Options) []string {
+ func sendRedisConnectionTest(client redis.Client, key string, val string) []string {
  	msgs := []string{}
  	ctx := context.Background()
- 
-+	for i := 0; i < 5; i++ {
-+		fmt.Println("Testing connection to redis...")
-+		err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
+-
+-	err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
++	var err error
++	for i := 0; i < 10; i++ {
++		logger.Printf("testing connection to redis...", i)
++		err = client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
 +		if err == nil {
 +			break
 +		}
 +		time.Sleep(2 * time.Second)
 +	}
- 	err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
  	if err != nil {
--		msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))
-+		msgs = append(msgs, fmt.Sprintf("TEST unable to set a redis initialization key: %v", err))
+ 		msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))
  	} else {
- 		gval, err := client.Get(ctx, key)
- 		if err != nil {
+-		gval, err := client.Get(ctx, key)
+-		if err != nil {
++		gval, errGet := client.Get(ctx, key)
++		if errGet != nil {
+ 			msgs = append(msgs,
+ 				fmt.Sprintf("unable to retrieve redis initialization key: %v", err))
+ 		}

--- a/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/0004-add-redis-retries.patch
@@ -1,22 +1,14 @@
 diff --git a/pkg/validation/sessions.go b/pkg/validation/sessions.go
-index 96ea6d4f..a71c4283 100644
+index 96ea6d4f..6cf8b035 100644
 --- a/pkg/validation/sessions.go
 +++ b/pkg/validation/sessions.go
-@@ -8,6 +8,7 @@ import (
-
-        "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
-        "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
-+       "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
-        "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/sessions/redis"
- )
-
-@@ -64,10 +65,17 @@ func validateRedisSessionStore(o *options.Options) []string {
+@@ -64,10 +64,17 @@ func validateRedisSessionStore(o *options.Options) []string {
  func sendRedisConnectionTest(client redis.Client, key string, val string) []string {
         msgs := []string{}
         ctx := context.Background()
 -
 +       for i := 0; i < 5; i++ {
-+               logger.Printf("Testing connection to redis...")
++               fmt.Println("Testing connection to redis...")
 +               err := client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
 +               if err == nil {
 +                       break

--- a/modules/150-user-authn/images/dex-authenticator/patches/README.md
+++ b/modules/150-user-authn/images/dex-authenticator/patches/README.md
@@ -18,3 +18,7 @@ Two options to fix this without patch:
 
 Add a new flag: https://github.com/oauth2-proxy/oauth2-proxy/issues/2144
 Migrate to a structured config (alpha config): https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/alpha-config
+
+### Redis retries
+
+Prevents oauth2-proxy from failing with exit 1 if Redis has not started in time. Adds a loop to retry sendRedisConnectionTest.

--- a/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
+++ b/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
@@ -26,9 +26,7 @@ git:
     tag: v7.5.1
     stageDependencies:
       install:
-        - '**/*.go'
-        - '**/go.mod'
-        - '**/go.sum'
+        - '**/*'
 shell:
   install:
     - cd /src

--- a/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
+++ b/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
@@ -21,12 +21,17 @@ final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches/
     to: /patches
+    stageDependencies:
+      install:
+        - '**/*'
   - url: {{ $.SOURCE_REPO }}/oauth2-proxy/oauth2-proxy.git
     to: /src
     tag: v7.5.1
     stageDependencies:
       install:
-        - '**/*'
+        - '**/*.go'
+        - '**/go.mod'
+        - '**/go.sum'
 shell:
   install:
     - cd /src


### PR DESCRIPTION
## Description
Patch to oauth2-proxy that adds a loop to `sendRedisConnectionTest` to retry these connection. 
fixes https://github.com/deckhouse/deckhouse/issues/4644

<details>
<summary>Patched function:</summary>

```go
func sendRedisConnectionTest(client redis.Client, key string, val string) []string {
	msgs := []string{}
	ctx := context.Background()
	var err error
	for i := 0; i < 10; i++ {
		logger.Printf("testing connection to redis...")
		err = client.Set(ctx, key, []byte(val), time.Duration(60)*time.Second)
		if err == nil {
			break
		}
		time.Sleep(2 * time.Second)
	}
	if err != nil {
		msgs = append(msgs, fmt.Sprintf("unable to set a redis initialization key: %v", err))
	} else {
		gval, errGet := client.Get(ctx, key)
		if errGet != nil {
			msgs = append(msgs,
				fmt.Sprintf("unable to retrieve redis initialization key: %v", err))
		}
		if string(gval) != val {
			msgs = append(msgs,
				"the retrieved redis initialization key did not match the value we set")
		}
	}

	err = client.Del(ctx, key)
	if err != nil {
		msgs = append(msgs, fmt.Sprintf("unable to delete the redis initialization key: %v", err))
	}
	return msgs
}
```
</details>


Usually takes a couple of retries to wait for Redis:
```
root@ob-pr12034:~# kubectl -n d8-monitoring logs grafana-dex-authenticator-5b75489655-4bwf7
Defaulted container "dex-authenticator" out of: dex-authenticator, redis, self-signed-generator (init)
[2025/02/14 15:28:37] [sessions.go:70] testing connection to redis...
[2025/02/14 15:28:39] [sessions.go:70] testing connection to redis...
[2025/02/14 15:28:39] [proxy.go:83] mapping path "/dev/null" => file system "/dev/null"
[2025/02/14 15:28:39] [oauthproxy.go:166] OAuthProxy configured for OpenID Connect Client ID: grafana-d8-monitoring-dex-authenticator
[2025/02/14 15:28:39] [oauthproxy.go:172] Cookie settings: name:_oauth2_proxy secure(https):true httponly:true expiry:168h0m0s domains: path:/ samesite: refresh:after 10m0s
```

Case if Redis is specifically broken (wrong port):
```
root@ob-pr12034:~# kubectl -n d8-monitoring logs -p grafana-dex-authenticator-85df5bc765-4vrlr
Defaulted container "dex-authenticator" out of: dex-authenticator, redis, self-signed-generator (init)
[2025/02/14 15:27:45] [sessions.go:70] testing connection to redis...
[2025/02/14 15:27:48] [sessions.go:70] testing connection to redis...
[2025/02/14 15:27:50] [sessions.go:70] testing connection to redis...
[2025/02/14 15:27:52] [sessions.go:70] testing connection to redis...
[2025/02/14 15:27:54] [sessions.go:70] testing connection to redis...
[2025/02/14 15:27:56] [sessions.go:70] testing connection to redis...
[2025/02/14 15:27:58] [sessions.go:70] testing connection to redis...
[2025/02/14 15:28:00] [sessions.go:70] testing connection to redis...
[2025/02/14 15:28:02] [sessions.go:70] testing connection to redis...
[2025/02/14 15:28:04] [sessions.go:70] testing connection to redis...
[2025/02/14 15:28:06] [main.go:54] invalid configuration:
  unable to set a redis initialization key: dial tcp 127.0.0.1:6379: connect: connection refused
  unable to delete the redis initialization key: dial tcp 127.0.0.1:6379: connect: connection refused
```

## Why do we need it, and what problem does it solve?

Prevents container to exit with `code 1` when Redis couldn't start on time (90% of cases)

## Why do we need it in the patch release (if we do)?

No

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Fixed dex-authenticator restarts with exit 1 on pod creation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
