### PR TITLE
[dhctl] Fix broken connection-config in CLI and support sudoPassword in SSHConfig (1.68)

### DIFF
--- a/candi/openapi/dhctl/ssh_configuration.yaml
+++ b/candi/openapi/dhctl/ssh_configuration.yaml
@@ -48,3 +48,7 @@ apiVersions:
         type: integer
       sshBastionUser:
         type: string
+      sudoPassword:
+        description: |
+          A sudo password for the user.
+        type: string

--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -59,6 +59,10 @@ func DefineTerraformCheckCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
+		if sshClient == nil {
+			return fmt.Errorf("Not enough flags were passed to perform the operation.\nUse dhctl terraform check --help to get available flags.\nSsh host is not provided. Need to pass --ssh-host, or specify SSHHost manifest in the --connection-config file")
+		}
+
 		kubeCl, err := kubernetes.ConnectToKubernetesAPI(ssh.NewNodeInterfaceWrapper(sshClient))
 		if err != nil {
 			return err

--- a/dhctl/pkg/config/connection_test.go
+++ b/dhctl/pkg/config/connection_test.go
@@ -80,6 +80,7 @@ func TestParseConnectionConfig(t *testing.T) {
 					SSHBastionHost: "158.160.111.65",
 					SSHBastionPort: ptr.To(int32(22)),
 					SSHBastionUser: "ubuntu",
+					SudoPassword:   "gfhjkm",
 				},
 				SSHHosts: []SSHHost{
 					{
@@ -212,6 +213,7 @@ sshAgentPrivateKeys:
 sshBastionHost: 158.160.111.65
 sshBastionPort: 22
 sshBastionUser: ubuntu
+sudoPassword: gfhjkm
 ---
 apiVersion: dhctl.deckhouse.io/v1
 kind: SSHHost

--- a/dhctl/pkg/config/load.go
+++ b/dhctl/pkg/config/load.go
@@ -130,7 +130,7 @@ func newSchemaStore(schemasDir []string) *SchemaStore {
 	entries, err := os.ReadDir(modulesDir)
 	if err != nil {
 		// autoconverger and state exporter do not contains module dir
-		log.WarnF("Modules dir not found\n")
+		log.WarnF("Modules dir %s not found\n", modulesDir)
 		return st
 	}
 

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
-    "github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"	
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/converge"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/check"
@@ -110,9 +110,9 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 	if c.KubeClient != nil {
 		kubeCl = c.KubeClient
 	} else {
-                if c.SSHClient == nil {
-                      return nil, fmt.Errorf("Not enough flags were passed to perform the operation.\nUse dhctl converge --help to get available flags.\nSsh host flag is not provided. Need to pass --ssh-host")
-                }
+		if c.SSHClient == nil {
+			return nil, fmt.Errorf("Not enough flags were passed to perform the operation.\nUse dhctl converge --help to get available flags.\nSsh host is not provided. Need to pass --ssh-host, or specify SSHHost manifest in the --connection-config file")
+		}
 
 		kubeCl, err = kubernetes.ConnectToKubernetesAPI(ssh.NewNodeInterfaceWrapper(c.SSHClient))
 		if err != nil {


### PR DESCRIPTION
## Description

This PR fixes `--connection-config` option in dhctl CLI, it is broken in current version.
Ability to pass sudoPassword using SSHConfig kind in `--connection-config` yaml configuration file (non-interactively).

## Why do we need it, and what problem does it solve?

Non-interactive declarative way to specify connection settings with the option `--connection-config` is now fully available in  dhctl CLI. In previous versions of deckhouse it only worked in the dhctl-server, but it was broken in dhctl-cli: private ssh-keys was not added into the agent properly.

SudoPassword needed for full support of different connection options.

## Changelog entries

```changes
section: dhctl
type: fix
summary: fix broken connection-config in CLI and support sudoPassword in SSHConfig
```
