### PR TITLE
[deckhouse] trigger the module config when a module created

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -99,7 +99,7 @@ func RegisterController(
 		For(&v1alpha1.ModuleConfig{}).
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
 		Watches(&v1alpha1.Module{}, ctrlhandler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
-			return []reconcile.Request{{NamespacedName: client.ObjectKey{Name: obj.(*v1alpha1.Module).Properties.Source}}}
+			return []reconcile.Request{{NamespacedName: client.ObjectKey{Name: obj.(*v1alpha1.Module).Name}}}
 		}), builder.WithPredicates(predicate.Funcs{
 			CreateFunc: func(_ event.CreateEvent) bool {
 				return true

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -104,7 +104,7 @@ func RegisterController(
 			CreateFunc: func(_ event.CreateEvent) bool {
 				return true
 			},
-			UpdateFunc: func(updateEvent event.UpdateEvent) bool { return false },
+			UpdateFunc: func(_ event.UpdateEvent) bool { return false },
 			DeleteFunc: func(_ event.DeleteEvent) bool {
 				return false
 			},

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -28,11 +28,15 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	ctrlhandler "sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/confighandler"
@@ -94,6 +98,20 @@ func RegisterController(
 	return ctrl.NewControllerManagedBy(runtimeManager).
 		For(&v1alpha1.ModuleConfig{}).
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
+		Watches(&v1alpha1.Module{}, ctrlhandler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
+			return []reconcile.Request{{NamespacedName: client.ObjectKey{Name: obj.(*v1alpha1.Module).Properties.Source}}}
+		}), builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(_ event.CreateEvent) bool {
+				return true
+			},
+			UpdateFunc: func(updateEvent event.UpdateEvent) bool { return false },
+			DeleteFunc: func(_ event.DeleteEvent) bool {
+				return false
+			},
+			GenericFunc: func(_ event.GenericEvent) bool {
+				return false
+			},
+		})).
 		Complete(configController)
 }
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -308,7 +308,7 @@ func (r *reconciler) ensureModule(ctx context.Context, sourceName, moduleName, r
 	}
 
 	// update release channel
-	err = ctrlutils.UpdateWithRetry[*v1alpha1.Module](ctx, r.client, module, func() error {
+	err = ctrlutils.UpdateWithRetry(ctx, r.client, module, func() error {
 		module.Properties.ReleaseChannel = releaseChannel
 		return nil
 	})

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -19,7 +19,6 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/ctrlutils"
 	"path/filepath"
 	"slices"
 	"time"
@@ -33,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/ctrlutils"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/downloader"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers/reginjector"

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -275,10 +275,12 @@ func (r *reconciler) ensureModule(ctx context.Context, sourceName, moduleName, r
 
 	err := ctrlutils.UpdateStatusWithRetry(ctx, r.client, module, func() error {
 		// init just created downloaded modules
-		module.Status.Phase = v1alpha1.ModulePhaseAvailable
-		module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleConfig, v1alpha1.ModuleReasonDisabled, v1alpha1.ModuleMessageDisabled)
-		module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleManager, "", "")
-		module.SetConditionFalse(v1alpha1.ModuleConditionIsReady, v1alpha1.ModuleReasonNotInstalled, v1alpha1.ModuleMessageNotInstalled)
+		if module.Status.Phase == "" {
+			module.Status.Phase = v1alpha1.ModulePhaseAvailable
+			module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleConfig, v1alpha1.ModuleReasonDisabled, v1alpha1.ModuleMessageDisabled)
+			module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleManager, "", "")
+			module.SetConditionFalse(v1alpha1.ModuleConditionIsReady, v1alpha1.ModuleReasonNotInstalled, v1alpha1.ModuleMessageNotInstalled)
+		}
 
 		return nil
 	})

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -19,6 +19,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/ctrlutils"
 	"path/filepath"
 	"slices"
 	"time"
@@ -272,27 +273,25 @@ func (r *reconciler) ensureModule(ctx context.Context, sourceName, moduleName, r
 		}
 	}
 
-	err := utils.UpdateStatus[*v1alpha1.Module](ctx, r.client, module, func(module *v1alpha1.Module) bool {
+	err := ctrlutils.UpdateStatusWithRetry(ctx, r.client, module, func() error {
 		// init just created downloaded modules
-		if len(module.Status.Conditions) == 0 {
-			module.Status.Phase = v1alpha1.ModulePhaseAvailable
-			module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleConfig, v1alpha1.ModuleReasonDisabled, v1alpha1.ModuleMessageDisabled)
-			module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleManager, "", "")
-			module.SetConditionFalse(v1alpha1.ModuleConditionIsReady, v1alpha1.ModuleReasonNotInstalled, v1alpha1.ModuleMessageNotInstalled)
-			return true
-		}
-		return false
+		module.Status.Phase = v1alpha1.ModulePhaseAvailable
+		module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleConfig, v1alpha1.ModuleReasonDisabled, v1alpha1.ModuleMessageDisabled)
+		module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleManager, "", "")
+		module.SetConditionFalse(v1alpha1.ModuleConditionIsReady, v1alpha1.ModuleReasonNotInstalled, v1alpha1.ModuleMessageNotInstalled)
+
+		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("update the '%s' module status: %w", moduleName, err)
 	}
 
-	err = utils.Update[*v1alpha1.Module](ctx, r.client, module, func(module *v1alpha1.Module) bool {
+	err = ctrlutils.UpdateWithRetry(ctx, r.client, module, func() error {
 		if !slices.Contains(module.Properties.AvailableSources, sourceName) {
 			module.Properties.AvailableSources = append(module.Properties.AvailableSources, sourceName)
-			return true
 		}
-		return false
+
+		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("update the '%s' module: %w", moduleName, err)
@@ -309,12 +308,9 @@ func (r *reconciler) ensureModule(ctx context.Context, sourceName, moduleName, r
 	}
 
 	// update release channel
-	err = utils.Update[*v1alpha1.Module](ctx, r.client, module, func(module *v1alpha1.Module) bool {
-		if module.Properties.ReleaseChannel != releaseChannel {
-			module.Properties.ReleaseChannel = releaseChannel
-			return true
-		}
-		return false
+	err = ctrlutils.UpdateWithRetry[*v1alpha1.Module](ctx, r.client, module, func() error {
+		module.Properties.ReleaseChannel = releaseChannel
+		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("update release channel for the '%s' module: %w", moduleName, err)


### PR DESCRIPTION
## Description
It triggers the module config when a module created.

## Why do we need it, and what problem does it solve?
A module config can be created before the module is discovered.

## Why do we need it in the patch release (if we do)?
It can help people with CI/CD.

Delete the module to test and then check that the module does not exist:
```
root@dev-master-0:~# k get module commander
Error from server (NotFound): modules.deckhouse.io "commander" not found
```

Create the module config(its normal that it is ignored now):
```
root@dev-master-0:~# kubectl get mc
NAME                         ENABLED   VERSION   AGE     MESSAGE
commander                    true      1         3m23s   Ignored: unknown module name
```

Wait for 3 minutes to source resync:
```
root@dev-master-0:~# k get module commander -oyaml
apiVersion: deckhouse.io/v1alpha1
kind: Module
metadata:
  creationTimestamp: "2025-02-12T18:05:01Z"
  generation: 3
  name: commander
  resourceVersion: "305624798"
  uid: 65c97bf5-0b93-4463-b1f9-9d31cc61343f
properties:
  availableSources:
  - deckhouse
  releaseChannel: Stable
  source: deckhouse
status:
  conditions:
  - lastProbeTime: "2025-02-12T18:05:01Z"
    lastTransitionTime: "2025-02-12T18:05:01Z"
    status: "True"
    type: EnabledByModuleConfig
  - lastProbeTime: "2025-02-12T18:05:01Z"
    lastTransitionTime: "2025-02-12T18:05:01Z"
    status: "False"
    type: EnabledByModuleManager
  - lastProbeTime: "2025-02-12T18:05:02Z"
    lastTransitionTime: "2025-02-12T18:05:01Z"
    status: "True"
    type: IsReady
  phase: Ready
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix 
summary: Trigger the module config when a module created.
```
