### PR TITLE
[huaweicloud] Fix `EIP` creation in `cloud-controller-manager`

### DIFF
--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/001-fix-empty-shared-bandwidth-id-sending.patch
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/001-fix-empty-shared-bandwidth-id-sending.patch
@@ -1,4 +1,4 @@
-Subject: [PATCH] comment some fields
+Subject: [PATCH] Prevent sending empty shared bandwidth identifier in HTTP requests to create EIP.
 ---
 Index: pkg/cloudprovider/huaweicloud/sharedloadbalancer.go
 IDEA additional info:

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/README.md
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/README.md
@@ -1,0 +1,3 @@
+## 001-fix-empty-shared-bandwidth-id-sending.patch
+
+Prevent sending empty shared bandwidth identifier in HTTP requests to create EIP.

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/comment_some_fields.patch
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/comment_some_fields.patch
@@ -1,0 +1,54 @@
+Subject: [PATCH] comment some fields
+---
+Index: pkg/cloudprovider/huaweicloud/sharedloadbalancer.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/cloudprovider/huaweicloud/sharedloadbalancer.go b/pkg/cloudprovider/huaweicloud/sharedloadbalancer.go
+--- a/pkg/cloudprovider/huaweicloud/sharedloadbalancer.go	(revision a2521439748697680ba5ab25e693b1125a456b8f)
++++ b/pkg/cloudprovider/huaweicloud/sharedloadbalancer.go	(date 1739444245700)
+@@ -1087,7 +1087,7 @@
+ 	eip, err := l.eipClient.Create(&eipmodel.CreatePublicipRequestBody{
+ 		Bandwidth: &eipmodel.CreatePublicipBandwidthOption{
+ 			Name:       &name,
+-			Id:         &opts.ShareID,
++			Id:         opts.ShareID,
+ 			Size:       &opts.BandwidthSize,
+ 			ShareType:  shareType,
+ 			ChargeMode: chargeModel,
+@@ -1102,10 +1102,10 @@
+ }
+ 
+ type CreateEIPOptions struct {
+-	BandwidthSize int32  `json:"bandwidth_size"`
+-	ShareType     string `json:"share_type"`
+-	ShareID       string `json:"share_id"`
+-	ChargeMode    string `json:"charge_mode"`
++	BandwidthSize int32   `json:"bandwidth_size"`
++	ShareType     string  `json:"share_type"`
++	ShareID       *string `json:"share_id"`
++	ChargeMode    string  `json:"charge_mode"`
+ 
+ 	IPType string `json:"ip_type"`
+ }
+Index: pkg/cloudprovider/huaweicloud/dedicatedloadbalancer.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/cloudprovider/huaweicloud/dedicatedloadbalancer.go b/pkg/cloudprovider/huaweicloud/dedicatedloadbalancer.go
+--- a/pkg/cloudprovider/huaweicloud/dedicatedloadbalancer.go	(revision a2521439748697680ba5ab25e693b1125a456b8f)
++++ b/pkg/cloudprovider/huaweicloud/dedicatedloadbalancer.go	(date 1739444307297)
+@@ -278,9 +278,9 @@
+ 			ChargeMode: chargeModel,
+ 		}
+ 	}
+-	if eipOpt.ShareID != "" {
++	if eipOpt.ShareID != nil {
+ 		publicIP.Bandwidth = &elbmodel.CreateLoadBalancerBandwidthOption{
+-			Id: &eipOpt.ShareID,
++			Id: eipOpt.ShareID,
+ 		}
+ 	}
+ 	return publicIP, nil

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/werf.inc.yaml
@@ -21,7 +21,6 @@ git:
         - '**/*'
 shell:
   install:
-    - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
     - git clone --depth 1 --branch v0.26.9 {{ $.SOURCE_REPO }}/kubernetes-sigs/cloud-provider-huaweicloud.git /src
     - cd /src
     - git apply /patches/*.patch --verbose
@@ -29,7 +28,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ $.Images.BASE_GOLANG_21_BULLSEYE }}
+from: {{ $.Images.BASE_GOLANG_23_BULLSEYE }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/werf.inc.yaml
@@ -10,9 +10,31 @@ imageSpec:
   config:
     entrypoint: ["/huaweicloud-cloud-controller-manager"]
 ---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+final: false
+fromImage: common/src-artifact
+git:
+  - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+    to: /patches
+    stageDependencies:
+      install:
+        - '**/*'
+shell:
+  install:
+    - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
+    - git clone --depth 1 --branch v0.26.9 {{ $.SOURCE_REPO }}/kubernetes-sigs/cloud-provider-huaweicloud.git /src
+    - cd /src
+    - git apply /patches/*.patch --verbose
+    - rm -rf .git
+---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ $.Images.BASE_GOLANG_21_BULLSEYE }}
+import:
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+    add: /src
+    to: /src
+    before: install
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
@@ -22,8 +44,6 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY={{ $.GOPROXY }}
-    - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
-    - git clone --depth 1 --branch v0.26.9 {{ $.SOURCE_REPO }}/kubernetes-sigs/cloud-provider-huaweicloud.git /src
     - cd /src
     - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w " -o /huaweicloud-cloud-controller-manager cmd/cloud-controller-manager/cloud-controller-manager.go
     - chown 64535:64535 /huaweicloud-cloud-controller-manager

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/rbac-for-us.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/rbac-for-us.yaml
@@ -85,6 +85,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Prevent sending empty shared bandwidth identifier in HTTP requests to create `EIP`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

If we try to create an `EIP` with an empty shared bandwidth ID, the `EIP` will be automatically deleted, for example:
```json
{
    "bandwidth": {
        "id": "",
        "charge_mode": "traffic",
        "name": "d8-ingress-nginx_nginx-load-balancer",
        "share_type": "PER",
        "size": 5
    },
    "publicip": {
        "type": "5_bgp"
    }
}
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-huaweicloud
type: fix
summary: Fix `EIP` creation in `cloud-controller-manager`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
