### PR TITLE
[deckhouse] Fix webhook-handler's RBAC

### DIFF
--- a/modules/002-deckhouse/templates/webhook-handler/rbac-for-us.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/rbac-for-us.yaml
@@ -28,7 +28,7 @@ rules:
   resources: ["clusterroles"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["network.deckhouse.io"]
-  resources: ["*"]
+  resources: ["metalloadbalancerclasses"]
   verbs: ["get","list","watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Description
Fix wildcard resources mask in webhook-handler's RBAC for `network.deckhouse.io` apiGroup.

## Why do we need it, and what problem does it solve?
Eliminates excessive permissions, increasing security.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Fix webhook-handler's RBAC for network.deckhouse.io apiGroup.
impact_level: low
```
