### PR TITLE
[deckhouse-controller] additional fix for kubectl in deckhouse image

### DIFF
--- a/deckhouse-controller/files/bashrc
+++ b/deckhouse-controller/files/bashrc
@@ -11,7 +11,7 @@ fi
 
 case "$kubernetes_version" in
   1.27.* | 1.28.* | 1.29.* )
-    kubectl_version="1.28"
+    kubectl_version="1.29"
     ;;
   1.30.* | 1.31.* | 1.32.* )
     kubectl_version="1.31"

--- a/werf.yaml
+++ b/werf.yaml
@@ -61,7 +61,7 @@ cleanup:
 
 {{- $_ := set . "CandiVersionMap" $versionMap }}
 
-# do not forget change /deckhouse-controller/files/kubectl_wrapper.sh
+# do not forget change /deckhouse-controller/files/kubectl_wrapper.sh and /deckhouse-controller/files/bashrc
 {{- $_ := set . "kubectlForBaseComponents" (list "1.29" "1.31") }}
 ---
 # Terraform Versions


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Additional fix for https://github.com/deckhouse/deckhouse/pull/11501.
Forget change kubectl version in bashrc.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

```
[root@dev-master-0 ~]# kubectl  exec -it -n d8-system svc/deckhouse-leader -- /bin/bash
bash: kubectl-1.28: command not found
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Change kubectl version in bashrc.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
