### PR TITLE
[chore] add tests for ci js scripts

### DIFF
--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -77,7 +77,7 @@ const labels = {
   'e2e/use/cis': { type: 'e2e-use', cis: true },
 
   // security validation for images
-  'security/rootless': {type: 'security', security: 'rootless'}
+  'security/rootless': { type: 'security', security: 'rootless' }
 };
 module.exports.knownLabels = labels;
 
@@ -85,22 +85,9 @@ module.exports.knownLabels = labels;
 const releaseIssueLabel = 'issue/release';
 module.exports.releaseIssueLabel = releaseIssueLabel;
 
-
 const slashCommands = {
-  deploy: [
-    'deploy/alpha',
-    'deploy/beta',
-    'deploy/early-access',
-    'deploy/stable',
-    'deploy/rock-solid'
-  ],
-  suspend: [
-    'suspend/alpha',
-    'suspend/beta',
-    'suspend/early-access',
-    'suspend/stable',
-    'suspend/rock-solid'
-  ],
+  deploy: ['deploy/alpha', 'deploy/beta', 'deploy/early-access', 'deploy/stable', 'deploy/rock-solid'],
+  suspend: ['suspend/alpha', 'suspend/beta', 'suspend/early-access', 'suspend/stable', 'suspend/rock-solid']
 };
 module.exports.knownSlashCommands = slashCommands;
 
@@ -167,14 +154,7 @@ module.exports.e2eDefaults = {
   edition: 'FE',
   multimaster: false,
   cis: false
-}
+};
 
-const editions = [
-  'CE',
-  'EE',
-  'FE',
-  'BE',
-  'SE',
-  'SE-plus'
-];
+const editions = ['CE', 'EE', 'FE', 'BE', 'SE', 'SE-plus'];
 module.exports.knownEditions = editions;

--- a/.github/scripts/js/specs/constants.test.js
+++ b/.github/scripts/js/specs/constants.test.js
@@ -9,42 +9,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const {
-  knownProviders,
-  knownKubernetesVersions,
-  knownCRINames,
-  labelsSrv
-} = require('../constants');
+const { knownProviders, knownKubernetesVersions, labelsSrv } = require('../constants');
 
 test('knownProviders', () => {
-  expect(knownProviders).toContain('azure')
-  expect(knownProviders).toContain('aws')
-})
-
-test('knownCRINames', () => {
-  expect(knownCRINames).toContain('Containerd')
-})
+  expect(knownProviders).toContain('azure');
+  expect(knownProviders).toContain('aws');
+});
 
 test('knownKubernetesVersions', () => {
-  expect(knownKubernetesVersions).toContain('1.20')
-  expect(knownKubernetesVersions).toContain('1.23')
-})
+  knownKubernetesVersions.forEach((version) => {
+    expect(version).toMatch(/^(\d+\.\d+)|(Automatic)$/); // Check version format 'X.Y'
+  });
+});
 
 test('e2e/run/azure', () => {
-  const l = labelsSrv.findLabel({labelType: 'e2e-run', labelSubject: 'azure'})
-  expect(l).toBe('e2e/run/azure')
+  const l = labelsSrv.findLabel({ labelType: 'e2e-run', labelSubject: 'azure' });
+  expect(l).toBe('e2e/run/azure');
 });
 
 test('deploy/web/stage', () => {
-  const l = labelsSrv.findLabel({labelType: 'deploy-web', labelSubject: 'stage'})
-  expect(l).toBe('deploy/web/stage')
+  const l = labelsSrv.findLabel({ labelType: 'deploy-web', labelSubject: 'stage' });
+  expect(l).toBe('deploy/web/stage');
 });
 
 test('unknown label', () => {
-  let l = labelsSrv.findLabel({labelType: 'e2e-run-', labelSubject: 'azure'})
-  expect(l).toBe('')
-  l = labelsSrv.findLabel({labelType: 'e2e-run', labelSubject: 'azure-'})
-  expect(l).toBe('')
-  l = labelsSrv.findLabel({labelType: '', labelSubject: ''})
-  expect(l).toBe('')
+  let l = labelsSrv.findLabel({ labelType: 'e2e-run-', labelSubject: 'azure' });
+  expect(l).toBe('');
+  l = labelsSrv.findLabel({ labelType: 'e2e-run', labelSubject: 'azure-' });
+  expect(l).toBe('');
+  l = labelsSrv.findLabel({ labelType: '', labelSubject: '' });
+  expect(l).toBe('');
 });

--- a/.github/workflow_templates/run-ci-tests-on-changes.yml
+++ b/.github/workflow_templates/run-ci-tests-on-changes.yml
@@ -1,0 +1,39 @@
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Run Ci Tests On Changes
+on:
+  push:
+    paths:
+      - '.github/scripts/js/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+
+    - name: Install dependencies
+      run: npm ci
+      working-directory: .github/scripts/js
+
+    - name: Run Jest tests
+      run: npm test
+      working-directory: .github/scripts/js

--- a/.github/workflows/run-ci-tests-on-changes.yml
+++ b/.github/workflows/run-ci-tests-on-changes.yml
@@ -1,0 +1,43 @@
+#
+# THIS FILE IS GENERATED, PLEASE DO NOT EDIT.
+#
+
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Run Ci Tests On Changes
+on:
+  push:
+    paths:
+      - '.github/scripts/js/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+
+    - name: Install dependencies
+      run: npm ci
+      working-directory: .github/scripts/js
+
+    - name: Run Jest tests
+      run: npm test
+      working-directory: .github/scripts/js


### PR DESCRIPTION
## Description
Added a CI job to run tests when scripts are changed in .github/scripts/js
Fixed falling Jest tests for JS code

## Why do we need it, and what problem does it solve?
The addition of a CI job to run tests whenever scripts are changed in the .github/scripts/js directory ensures that any modifications to these scripts are automatically validated

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Added a CI job to run tests when scripts are changed in .github/scripts/js
impact_level: low
---
section: ci
type: chore
summary: Fixed falling Jest tests for JS code
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
