### PR TITLE
[istio] Fix missing libraries for envoy 

### DIFF
--- a/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
@@ -52,7 +52,7 @@ shell:
   beforeInstall:
   - |
     apt-get update && \
-    apt-get install -y ca-certificates curl
+    apt-get install -y ca-certificates curl glibc
   - update-ca-trust
   - apt-get clean
   - rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old

--- a/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
@@ -139,5 +139,3 @@ shell:
     apt-get install -y glibc
   - apt-get clean
   - rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
-  - update-alternatives --set iptables /usr/sbin/iptables-legacy
-  - update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy

--- a/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
@@ -48,14 +48,18 @@ import:
   add: /iptables-wrapper
   to: /sbin/iptables-wrapper
   before: setup
-# - image: {{ .ModuleName }}/{{ .ImageName }}-library-artifact
-#   add: /usr/lib64/librt.so.1
-#   to: /usr/lib64/librt.so.1
-#   after: setup
+- image: {{ .ModuleName }}/{{ .ImageName }}-library-artifact
+  add: /usr/lib64/librt.so.1
+  to: /usr/lib64/librt.so.1
+  after: setup
+- image: {{ .ModuleName }}/{{ .ImageName }}-library-artifact
+  add: /usr/lib64/libpthread.so.0
+  to: /usr/lib64/libpthread.so.0
+  after: setup
 shell:
   beforeInstall:
-  # - chmod 0644 /usr/lib64/librt.so.1
-  # - ldconfig
+  - chmod 0644 /usr/lib64/librt.so.1
+  - chmod 0644 /usr/lib64/libpthread.so.0
   - |
     apt-get update && \
     apt-get install -y ca-certificates curl
@@ -69,7 +73,7 @@ shell:
   - echo istio-proxy ALL=NOPASSWD:ALL | tee -a /etc/sudoers
 imageSpec:
   config:
-    # user: "1337:1337"
+    user: "1337:1337"
     env: { "ISTIO_META_ISTIO_PROXY_SHA": "istio-proxy:af5e0ef2c1473f0f4e61f78adf81c85ff6389f87",  "ISTIO_META_ISTIO_VERSION": "1.19.7" }
     workingDir: "/"
     entrypoint: ["/usr/local/bin/pilot-agent"]
@@ -124,16 +128,16 @@ shell:
         done
       done
     done
-# ---
-# image: {{ .ModuleName }}/{{ .ImageName }}-library-artifact
-# fromImage: common/alt-p11
-# final: false
-# shell:
-#   beforeInstall:
-#   - |
-#     apt-get update && \
-#     apt-get install -y glibc
-#   - apt-get clean
-#   - rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
-#   - update-alternatives --set iptables /usr/sbin/iptables-legacy
-#   - update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-library-artifact
+fromImage: common/alt-p11
+final: false
+shell:
+  beforeInstall:
+  - |
+    apt-get update && \
+    apt-get install -y glibc
+  - apt-get clean
+  - rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
+  - update-alternatives --set iptables /usr/sbin/iptables-legacy
+  - update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy

--- a/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
@@ -58,8 +58,6 @@ import:
   before: install
 shell:
   beforeInstall:
-  - chmod 0644 /usr/lib64/librt.so.1
-  - chmod 0644 /usr/lib64/libpthread.so.0
   - |
     apt-get update && \
     apt-get install -y ca-certificates curl
@@ -69,6 +67,8 @@ shell:
   - update-alternatives --set iptables /usr/sbin/iptables-legacy
   - update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
   install:
+  - chmod 0644 /usr/lib64/librt.so.1
+  - chmod 0644 /usr/lib64/libpthread.so.0
   - useradd -m --uid 1337 istio-proxy
   - echo istio-proxy ALL=NOPASSWD:ALL | tee -a /etc/sudoers
 imageSpec:

--- a/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
@@ -48,11 +48,17 @@ import:
   add: /iptables-wrapper
   to: /sbin/iptables-wrapper
   before: setup
+# - image: {{ .ModuleName }}/{{ .ImageName }}-library-artifact
+#   add: /usr/lib64/librt.so.1
+#   to: /usr/lib64/librt.so.1
+#   after: setup
 shell:
   beforeInstall:
+  # - chmod 0644 /usr/lib64/librt.so.1
+  # - ldconfig
   - |
     apt-get update && \
-    apt-get install -y ca-certificates curl glibc
+    apt-get install -y ca-certificates curl
   - update-ca-trust
   - apt-get clean
   - rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
@@ -63,7 +69,7 @@ shell:
   - echo istio-proxy ALL=NOPASSWD:ALL | tee -a /etc/sudoers
 imageSpec:
   config:
-    user: "1337:1337"
+    # user: "1337:1337"
     env: { "ISTIO_META_ISTIO_PROXY_SHA": "istio-proxy:af5e0ef2c1473f0f4e61f78adf81c85ff6389f87",  "ISTIO_META_ISTIO_VERSION": "1.19.7" }
     workingDir: "/"
     entrypoint: ["/usr/local/bin/pilot-agent"]
@@ -118,3 +124,16 @@ shell:
         done
       done
     done
+# ---
+# image: {{ .ModuleName }}/{{ .ImageName }}-library-artifact
+# fromImage: common/alt-p11
+# final: false
+# shell:
+#   beforeInstall:
+#   - |
+#     apt-get update && \
+#     apt-get install -y glibc
+#   - apt-get clean
+#   - rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
+#   - update-alternatives --set iptables /usr/sbin/iptables-legacy
+#   - update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy

--- a/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
@@ -51,11 +51,11 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-library-artifact
   add: /usr/lib64/librt.so.1
   to: /usr/lib64/librt.so.1
-  after: setup
+  before: beforeInstall
 - image: {{ .ModuleName }}/{{ .ImageName }}-library-artifact
   add: /usr/lib64/libpthread.so.0
   to: /usr/lib64/libpthread.so.0
-  after: setup
+  before: beforeInstall
 shell:
   beforeInstall:
   - chmod 0644 /usr/lib64/librt.so.1

--- a/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x19x7/werf.inc.yaml
@@ -51,11 +51,11 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-library-artifact
   add: /usr/lib64/librt.so.1
   to: /usr/lib64/librt.so.1
-  before: beforeInstall
+  before: install
 - image: {{ .ModuleName }}/{{ .ImageName }}-library-artifact
   add: /usr/lib64/libpthread.so.0
   to: /usr/lib64/libpthread.so.0
-  before: beforeInstall
+  before: install
 shell:
   beforeInstall:
   - chmod 0644 /usr/lib64/librt.so.1


### PR DESCRIPTION
## Description
Return missed `librt.so.1` and `libpthread.so.0` libraries.

## Why do we need it, and what problem does it solve?
If we run Istio 1.19.7 and try to add sidecars for applications, a pod startup error will occur due to the lack of a libraries for envoy proxy operation.

## Why do we need it in the patch release (if we do)?
Sidecars and ingressgateway do not work in Istio version 1.19.7. We have a failure in the operation of applications deployed in the cluster.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: fix
summary: Return missed `librt.so.1` and `libpthread.so.0` libraries
impact: ingressgateway pods in d8-istio namespace will be restarted, it is advisable to restart application pods with istio sidecars.
impact_level: default
```
