### PR TITLE
[prometheus] Fix grafana CVEs

### DIFF
--- a/modules/300-prometheus/templates/grafana/deployment-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment-v10.yaml
@@ -157,10 +157,9 @@ spec:
           value: "true"
         - name: GF_SECURITY_COOKIE_SECURE
           value: "true"
-        {{- else }}
+        {{- end }}
         - name: GF_SECURITY_COOKIE_SAMESITE
           value: "strict"
-        {{- end }}
         - name: PROMETHEUS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/modules/300-prometheus/templates/grafana/deployment-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment-v10.yaml
@@ -157,6 +157,9 @@ spec:
           value: "true"
         - name: GF_SECURITY_COOKIE_SECURE
           value: "true"
+        {{- else }}
+        - name: GF_SECURITY_COOKIE_SAMESITE
+          value: "strict"
         {{- end }}
         - name: PROMETHEUS_TOKEN
           valueFrom:

--- a/modules/300-prometheus/templates/grafana/deployment-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment-v10.yaml
@@ -150,6 +150,14 @@ spec:
           value: "{{- range $i, $v := .Values.prometheus.grafana.customPlugins }}{{- if ne $i 0 -}},{{- end -}}{{- $v -}}{{- end }}"
           {{- end }}
         {{- end }}
+        - name: GF_SECURITY_COOKIE_SAMESITE
+          value: "strict"
+        - name: GF_SECURITY_CONTENT_SECURITY_POLICY
+          value: "true"
+        {{- if ne .Values.global.modules.https.mode "Disabled" }}
+        - name: GF_SERVER_STRICT_TRANSPORT_SECURITY
+          value: "true"
+        {{- end }}
         - name: PROMETHEUS_TOKEN
           valueFrom:
             secretKeyRef:

--- a/modules/300-prometheus/templates/grafana/deployment-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment-v10.yaml
@@ -150,12 +150,12 @@ spec:
           value: "{{- range $i, $v := .Values.prometheus.grafana.customPlugins }}{{- if ne $i 0 -}},{{- end -}}{{- $v -}}{{- end }}"
           {{- end }}
         {{- end }}
-        - name: GF_SECURITY_COOKIE_SAMESITE
-          value: "strict"
         - name: GF_SECURITY_CONTENT_SECURITY_POLICY
           value: "true"
         {{- if ne .Values.global.modules.https.mode "Disabled" }}
         - name: GF_SERVER_STRICT_TRANSPORT_SECURITY
+          value: "true"
+        - name: GF_SECURITY_COOKIE_SECURE
           value: "true"
         {{- end }}
         - name: PROMETHEUS_TOKEN

--- a/modules/300-prometheus/templates/grafana/ingress-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/ingress-v10.yaml
@@ -31,6 +31,7 @@ metadata:
       proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
       proxy_ssl_protocols TLSv1.2;
       proxy_ssl_session_reuse on;
+      more_set_headers "X-Content-Type-Options: nosniff";
     # In Deckhouse, Grafana is an "IAC" configured platform.
     # This rewrite forbids users to log in and get higher privileges.
     nginx.ingress.kubernetes.io/server-snippet: |


### PR DESCRIPTION
## Description
Fix of image vulnerabilities

## Why do we need it, and what problem does it solve?
To improve security of deckhouse

## What is the expected result?
Fixed CVEs

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fix grafana CVEs
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
