### PR TITLE
[vertical-pod-autoscaler] recommender memory-save

### DIFF
--- a/modules/302-vertical-pod-autoscaler/templates/recommender/deployment.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/recommender/deployment.yaml
@@ -63,6 +63,7 @@ spec:
         - --memory-aggregation-interval=1h
         - --recommender-interval={{ printf "%vs" $.Values.global.discovery.prometheusScrapeInterval }}
         - --stderrthreshold=0
+        - --memory-saver=true
         - --v=4
         ports:
         - containerPort: 8080


### PR DESCRIPTION
## Description

As described here https://github.com/kubernetes/autoscaler/issues/6368 vpa recommender can consume a lot of RAM. Resource consumption increases with a large number of pods and with frequent deployment rollouts.

This commentary details the mechanisms for storing and cleaning data inside the VPA https://github.com/kubernetes/autoscaler/issues/6368#issuecomment-1963800975.

The simplest solution is to enable the memory-saver option. This should reduce RAM consumption, since not all pods use VPA

```
--memory-saver 	Bool 	false 	If true, only track pods which have an associated VPA
```


## Why do we need it, and what problem does it solve?

In large clusters, VPA recommender can consume a large amount of RAM over time

## Why do we need it in the patch release (if we do)?


Example memory usage:

- 10 Deployment
- every Deployment has 10 Pod replicas
- Rollout every 30 sec

Memory utilization delta ~50 MB per hour - 1.2 GB in 24 hours

![Снимок экрана 2025-02-14 в 10 17 01](https://github.com/user-attachments/assets/ff5d1294-f376-4b66-aa72-a3787c175143)




## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: vertical-pod-autoscaler
type: fix
summary: VPA recommender memory-save option enable
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
