### PR TITLE
[cni-cilium] l2 neigh discovery (arp flood) disabled

### DIFF
--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
   operator-api-serve-addr: "127.0.0.1:9234"
   enable-metrics: "true"
 
+  enable-l2-neigh-discovery: "false"
   enable-ipv4: "true"
   enable-ipv6: "false"
 


### PR DESCRIPTION
## Description

When cilium neighbor discovery is enabled (by default) and a neighboring node is not available, cilium sends ARP requests for the IP address of this node to all network interfaces, thereby misleading certain switches (they start thinking that the sender's IP address belongs to two (or more) ports) and cyclically sends traffic to one port, then to another, then to one, then to another..

I don't see a case where this behavior can help us. I suggest disabling this artificial intelligence of cilium by default
[https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#neighbor-discovery](https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#neighbor-discovery)

before:
![image](https://github.com/user-attachments/assets/b970d92f-c27b-4fc4-a614-6240d9fc0223)

after:

![image](https://github.com/user-attachments/assets/4882d967-8e09-406f-b8da-e0405bdbb2f0)

## Why do we need it, and what problem does it solve?
This solves the problem of traffic "freezing" on L3 switches

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: l2 neigh discovery (arp flood) disabled
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
