### PR TITLE
[multitenancy-manager][docs] update template paths

### DIFF
--- a/modules/160-multitenancy-manager/docs/USAGE.md
+++ b/modules/160-multitenancy-manager/docs/USAGE.md
@@ -14,20 +14,20 @@ The following project templates are included in the Deckhouse Kubernetes Platfor
   * choice of security profile;
   * project administrators setup.
 
-  Template description on [GitHub](https://github.com/deckhouse/deckhouse/blob/main/modules/160-multitenancy-manager/images/multitenancy-manager/src/default/default.yaml).
+  Template description on [GitHub](https://github.com/deckhouse/deckhouse/blob/main/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml).
 
 - `secure` — includes all the capabilities of the `default` template and additional features:
   * setting up permissible UID/GID for the project;
   * audit rules for project users' access to the Linux kernel;
   * scanning of launched container images for CVE presence.
 
-  Template description on [GitHub](https://github.com/deckhouse/deckhouse/blob/main/modules/160-multitenancy-manager/images/multitenancy-manager/src/default/secure.yaml).
+  Template description on [GitHub](https://github.com/deckhouse/deckhouse/blob/main/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml).
 
 - `secure-with-dedicated-nodes` — includes all the capabilities of the `secure` template and additional features:
   * defining the node selector for all the pods in the project: if a pod is created, the node selector pod will be **substituted** with the project's node selector automatically;
   * defining the default toleration for all the pods in the project: if a pod is created, the default toleration will be **added** to the pod automatically.
 
-  Template description on [GitHub](https://github.com/deckhouse/deckhouse/blob/main/modules/160-multitenancy-manager/images/multitenancy-manager/src/default/secure-with-dedicated-nodes.yaml).
+  Template description on [GitHub](https://github.com/deckhouse/deckhouse/blob/main/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml).
 
 To list all available parameters for a project template, execute the command:
 

--- a/modules/160-multitenancy-manager/docs/USAGE_RU.md
+++ b/modules/160-multitenancy-manager/docs/USAGE_RU.md
@@ -13,20 +13,20 @@ title: "Модуль multitenancy-manager: примеры использован
   * выбор профиля безопасности;
   * настройка администраторов проекта.
 
-    Описание шаблона [в GitHub](https://github.com/deckhouse/deckhouse/blob/main/modules/160-multitenancy-manager/images/multitenancy-manager/src/default/default.yaml).
+    Описание шаблона [в GitHub](https://github.com/deckhouse/deckhouse/blob/main/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml).
 
 - `secure` — включает все возможности шаблона `default`, а также дополнительные функции:
   * настройка допустимых для проекта UID/GID;
   * правила аудита обращения Linux-пользователей проекта к ядру;
   * сканирование запускаемых образов контейнеров на наличие известных уязвимостей (CVE).
 
-  Описание шаблона [в GitHub](https://github.com/deckhouse/deckhouse/blob/main/modules/160-multitenancy-manager/images/multitenancy-manager/src/default/secure.yaml).
+  Описание шаблона [в GitHub](https://github.com/deckhouse/deckhouse/blob/main/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml).
 
 - `secure-with-dedicated-nodes` — включает все возможности шаблона `secure`, а также дополнительные функции:
   * определение селектора узла для всех подов в проекте: если под создан, селектор узла пода будет автоматически **заменён** на селектор узла проекта;
   * определение стандартных tolerations для всех подов в проекте: если под создан, стандартные значения tolerations **добавляются** к нему автоматически.
 
-  Описание шаблона [в GitHub](https://github.com/deckhouse/deckhouse/blob/main/modules/160-multitenancy-manager/images/multitenancy-manager/src/default/secure-with-dedicated-nodes.yaml).
+  Описание шаблона [в GitHub](https://github.com/deckhouse/deckhouse/blob/main/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml).
 
 Чтобы перечислить все доступные параметры для шаблона проекта, выполните команду:
 


### PR DESCRIPTION
## Description

Updated the GitHub links for template descriptions in USAGE.md to point to the correct 'templates' directory instead of the 'default' directory.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: multitenancy-manager
type: chore
summary: Update Project template paths in the documentation.
impact_level: low
```
