### PR TITLE
[cni-cilium] Improving the stability of the cilium-operator.

### DIFF
--- a/modules/021-cni-cilium/templates/operator/deployment.yaml
+++ b/modules/021-cni-cilium/templates/operator/deployment.yaml
@@ -58,6 +58,8 @@ spec:
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
+        - --leader-election-lease-duration=25s
+        - --leader-election-renew-deadline=20s
         command:
         - cilium-operator
         env:


### PR DESCRIPTION
## Description

Increasing the `leader-election` timeouts for the cilium-operator.

## Why do we need it, and what problem does it solve?

In clusters with heavily loaded master-nodes, the cilium-operator may experience difficulty updating the `leader-election-lease` within the allocated time, which can result in frequent restarts of the cilium-operator pods.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: chore
summary: Improved the stability of the cilium-operator.
impact_level: default
```
