### PR TITLE
[docs] Deleted information about CLI in zVirt provider at GS

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
@@ -62,7 +62,7 @@ Scheme of Deckhouse installation in a private environment:<br />
 {%- else %}
    - HTTPS access to the `registry.deckhouse.io` container image registry;
 {%- endif %}
-{%- if page.platform_type == 'cloud' %}
+{%- if page.platform_type == 'cloud' and page.platform_code != 'zvirt' %}
    - access to the API of the cloud provider, an account with rights to create resources, and a configured
      {%- if page.platform_code == 'aws' %} [awscli](https://aws.amazon.com/cli/) utility
      {%- elsif page.platform_code == "gcp" %} [gcloud](https://cloud.google.com/sdk/docs/install) utility

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
@@ -73,7 +73,8 @@ Scheme of Deckhouse installation in a private environment:<br />
      {%- elsif page.platform_code == "openstack" %} management [utility](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) via CLI
      {%- elsif page.platform_code == "vsphere" %} [govc](https://github.com/vmware/govmomi/tree/master/govc#installation) utility
      {%- else %} management utility via CLI
-     {%- endif %};
+     {%- endif %}
+     {%- endunless %};
 {%- endif %}
 {%- if page.platform_type == "existing" %}
    - the `kubectl` command-line tool must be configured to communicate with your cluster.

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
@@ -74,7 +74,7 @@ Scheme of Deckhouse installation in a private environment:<br />
      {%- elsif page.platform_code == "vsphere" %} [govc](https://github.com/vmware/govmomi/tree/master/govc#installation) utility
      {%- else %} management utility via CLI
      {%- endif %}
-     {%- endunless %};
+     {%- endunless %}.
 {%- endif %}
 {%- if page.platform_type == "existing" %}
    - the `kubectl` command-line tool must be configured to communicate with your cluster.

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
@@ -62,8 +62,10 @@ Scheme of Deckhouse installation in a private environment:<br />
 {%- else %}
    - HTTPS access to the `registry.deckhouse.io` container image registry;
 {%- endif %}
-{%- if page.platform_type == 'cloud' and page.platform_code != 'zvirt' %}
-   - access to the API of the cloud provider, an account with rights to create resources, and a configured
+{%- if page.platform_type == 'cloud' %}
+   - access to the API of the cloud provider, an account with rights to create resources
+     {%- unless page.platform_code == 'zvirt' %}
+     , and a configured
      {%- if page.platform_code == 'aws' %} [awscli](https://aws.amazon.com/cli/) utility
      {%- elsif page.platform_code == "gcp" %} [gcloud](https://cloud.google.com/sdk/docs/install) utility
      {%- elsif page.platform_code == "azure" %} [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) utility

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
@@ -69,8 +69,10 @@
 {%- else %}
    - HTTPS-доступ до хранилища образов контейнеров `registry.deckhouse.ru`;
 {%- endif %}
-{%- if page.platform_type == 'cloud' and page.platform_code != 'zvirt' %}
-   - доступ до API облачного провайдера, учетная запись с правами на создание ресурсов и настроенная
+{%- if page.platform_type == 'cloud' %}
+   - доступ до API облачного провайдера, учетная запись с правами на создание ресурсов
+     {%- unless page.platform_code == 'zvirt' %}
+     и настроенная
      {%- if page.platform_code == 'aws' %} утилита [awscli](https://aws.amazon.com/cli/)
      {%- elsif page.platform_code == "gcp" %} утилита [gcloud](https://cloud.google.com/sdk/docs/install)
      {%- elsif page.platform_code == "azure" %} утилита [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
@@ -81,7 +81,7 @@
      {%- elsif page.platform_code == "vsphere" %} утилита [govc](https://github.com/vmware/govmomi/tree/master/govc#installation)
      {%- else %} CLI-утилита управления облачными ресурсами
      {%- endif %}
-     {%- endunless %};
+     {%- endunless %}.
 {%- endif %}
 {%- if page.platform_type == "existing" %}
    - `kubectl`, настроенный для доступа к существующему кластеру.

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
@@ -80,7 +80,8 @@
      {%- elsif page.platform_code == "openstack" %} [утилита](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) управления через CLI
      {%- elsif page.platform_code == "vsphere" %} утилита [govc](https://github.com/vmware/govmomi/tree/master/govc#installation)
      {%- else %} CLI-утилита управления облачными ресурсами
-     {%- endif %};
+     {%- endif %}
+     {%- endunless %};
 {%- endif %}
 {%- if page.platform_type == "existing" %}
    - `kubectl`, настроенный для доступа к существующему кластеру.

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
@@ -69,7 +69,7 @@
 {%- else %}
    - HTTPS-доступ до хранилища образов контейнеров `registry.deckhouse.ru`;
 {%- endif %}
-{%- if page.platform_type == 'cloud' %}
+{%- if page.platform_type == 'cloud' and page.platform_code != 'zvirt' %}
    - доступ до API облачного провайдера, учетная запись с правами на создание ресурсов и настроенная
      {%- if page.platform_code == 'aws' %} утилита [awscli](https://aws.amazon.com/cli/)
      {%- elsif page.platform_code == "gcp" %} утилита [gcloud](https://cloud.google.com/sdk/docs/install)


### PR DESCRIPTION
## Description
Deleted information about CLI in zVirt provider at GS.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Deleted information about CLI in zVirt provider at GS.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
