### PR TITLE
[upmeter] add alert D8UpmeterDiskUsage

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2607,11 +2607,11 @@ alerts:
       module: upmeter
       edition: ce
       description: |
-        The only way to resolve is to the PVC using the following steps:
+        The only way to resolve is to recreate the PVC using the following steps:
 
         1. Save the PVC data if you need it.
 
-        1. Delete the PVC and restart upmeter:
+        1. Delete the PVC and restart `upmeter`:
 
            ```shell
            kubectl -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2601,6 +2601,21 @@ alerts:
         One or more Upmeter agent pods is NOT Running
       severity: "6"
       markupFormat: markdown
+    - name: D8UpmeterDiskUsage
+      sourceFile: modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+      moduleUrl: 500-upmeter
+      module: upmeter
+      edition: ce
+      description: |
+        If the data is critical for you, then save it. You need to recreate the pvc using the command:
+        ```
+        kubectl -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0
+        ```
+        check pvc `kubectl -n d8-upmeter get pvc`
+      summary: |
+        Upmeter disk is over 80% used.
+      severity: "5"
+      markupFormat: markdown
     - name: D8UpmeterProbeGarbageConfigmap
       sourceFile: modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
       moduleUrl: 500-upmeter

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2607,13 +2607,23 @@ alerts:
       module: upmeter
       edition: ce
       description: |
-        If the data is critical for you, then save it. You need to recreate the pvc using the command:
-        ```
-        kubectl -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0
-        ```
-        check pvc `kubectl -n d8-upmeter get pvc`
+        The only way to resolve is to the PVC using the following steps:
+
+        1. Save the PVC data if you need it.
+
+        1. Delete the PVC and restart upmeter:
+
+           ```shell
+           kubectl -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0
+           ```
+
+        1. Check the status of the created PVC:
+
+           ```shell
+           kubectl -n d8-upmeter get pvc
+           ```
       summary: |
-        Upmeter disk is over 80% used.
+        Upmeter disk usage is over 80%.
       severity: "5"
       markupFormat: markdown
     - name: D8UpmeterProbeGarbageConfigmap

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -490,10 +490,20 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        summary: Upmeter disk is over 80% used.
+        summary: Upmeter disk usage is over 80%.
         description: |
-          If the data is critical for you, then save it. You need to recreate the pvc using the command:
-          ```
-          kubectl -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0
-          ```
-          check pvc `kubectl -n d8-upmeter get pvc`
+          The only way to resolve is to the PVC using the following steps:
+
+          1. Save the PVC data if you need it.
+
+          1. Delete the PVC and restart upmeter:
+
+             ```shell
+             kubectl -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0
+             ```
+
+          1. Check the status of the created PVC:
+
+             ```shell
+             kubectl -n d8-upmeter get pvc
+             ```

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -492,11 +492,11 @@
         plk_markup_format: "markdown"
         summary: Upmeter disk usage is over 80%.
         description: |
-          The only way to resolve is to the PVC using the following steps:
+          The only way to resolve is to recreate the PVC using the following steps:
 
           1. Save the PVC data if you need it.
 
-          1. Delete the PVC and restart upmeter:
+          1. Delete the PVC and restart `upmeter`:
 
              ```shell
              kubectl -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -476,14 +476,12 @@
           kubectl -n d8-upmeter get secret -ojson | jq -r '.items[] | .metadata.name' | grep upmeter-cm-probe | xargs -n 1 -- kubectl -n d8-upmeter delete secret
           ```
 
-- name: d8.upmeter.storage
-  rules:
     - alert: D8UpmeterDiskUsage
-      for: 10m
       expr: |
         100 * (
         kubelet_volume_stats_used_bytes{persistentvolumeclaim="data-upmeter-0",namespace="d8-upmeter"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="data-upmeter-0",namespace="d8-upmeter"}
         ) > 80
+      for: 10m
       labels:
         severity_level: "5"
         tier: cluster

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -480,7 +480,10 @@
   rules:
     - alert: D8UpmeterDiskUsage
       for: 10m
-      expr: 100 * (kubelet_volume_stats_used_bytes{persistentvolumeclaim="data-upmeter-0",namespace="d8-upmeter"}/kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="data-upmeter-0",namespace="d8-upmeter"}) > 80
+      expr: |
+        100 * (
+        kubelet_volume_stats_used_bytes{persistentvolumeclaim="data-upmeter-0",namespace="d8-upmeter"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="data-upmeter-0",namespace="d8-upmeter"}
+        ) > 80
       labels:
         severity_level: "5"
         tier: cluster
@@ -492,9 +495,7 @@
         summary: Upmeter disk is over 80% used.
         description: |
           If the data is critical for you, then save it. You need to recreate the pvc using the command:
-            
           ```
           kubectl -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0
           ```
-
           check pvc `kubectl -n d8-upmeter get pvc`

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -475,3 +475,26 @@
           kubectl -n d8-upmeter delete certificate -l upmeter-probe=cert-manager
           kubectl -n d8-upmeter get secret -ojson | jq -r '.items[] | .metadata.name' | grep upmeter-cm-probe | xargs -n 1 -- kubectl -n d8-upmeter delete secret
           ```
+
+- name: d8.upmeter.storage
+  rules:
+    - alert: D8UpmeterDiskUsage
+      for: 10m
+      expr: 100 * (kubelet_volume_stats_used_bytes{persistentvolumeclaim="data-upmeter-0",namespace="d8-upmeter"}/kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="data-upmeter-0",namespace="d8-upmeter"}) > 80
+      labels:
+        severity_level: "5"
+        tier: cluster
+        d8_module: upmeter
+        d8_component: server
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        summary: Upmeter disk is over 80% used.
+        description: |
+          If the data is critical for you, then save it. You need to recreate the pvc using the command:
+            
+          ```
+          kubectl -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0
+          ```
+
+          check pvc `kubectl -n d8-upmeter get pvc`


### PR DESCRIPTION
## Description

  add upmeter server storage usage alerts

## Why do we need it, and what problem does it solve?
  If it fixes an issue https://github.com/deckhouse/deckhouse/issues/11682

## Why do we need it in the patch release (if we do)?

will help to avoid problems in the operation of the upmeter
## Checklist
- [*] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: upmeter
type: fix
summary: Add D8UpmeterDiskUsage alert.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
