### PR TITLE
[multitenancy-manager] fix installed status for the project

### DIFF
--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/apis/deckhouse.io/v1alpha2/project.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/apis/deckhouse.io/v1alpha2/project.go
@@ -241,7 +241,7 @@ func (p *ProjectStatus) DeepCopyInto(newObj *ProjectStatus) {
 }
 
 type ResourceKind struct {
-	Installed bool     `json:"installed,omitempty"`
+	Installed bool     `json:"installed"`
 	Names     []string `json:"names,omitempty"`
 }
 


### PR DESCRIPTION
## Description
It fixes empty installed flag when it is false

## Why do we need it, and what problem does it solve?
It is convenient.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: fix
summary: Fix resource installed status for the project.
impact_level: low
```
