### PR TITLE
[admission-policy-engine] fix the trivy provider hook to support anonymous cred registry secret

### DIFF
--- a/modules/015-admission-policy-engine/hooks/trivy_provider_registry_secrets_test.go
+++ b/modules/015-admission-policy-engine/hooks/trivy_provider_registry_secrets_test.go
@@ -109,13 +109,13 @@ data:
 ---
 apiVersion: v1
 kind: Secret
-type: Opaque
+type: kubernetes.io/dockerconfigjson
 metadata:
   name: test-3
   namespace: d8-admission-policy-engine
 data:
-  # base64 -w0 <<< '{"auths":{"registry.test-3.com":{}}}' && echo
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS50ZXN0LTMuY29tIjp7fX19Cg==
+  # base64 -w0 <<< '{"auths":{"registry.test-4.com":{}}}' && echo
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS50ZXN0LTQuY29tIjp7fX19Cg==
 `
 
 	testDenyVulnerableImagesSecretsValues = `
@@ -130,8 +130,8 @@ data:
       "username": "test-3",
       "password": "password-3",
       "auth": "dGVzdC0zOnBhc3N3b3JkLTM="
-    }
-    "registry.test-4com": {}
+    },
+    "registry.test-4.com": {}
   }
 }
 `

--- a/modules/015-admission-policy-engine/hooks/trivy_provider_registry_secrets_test.go
+++ b/modules/015-admission-policy-engine/hooks/trivy_provider_registry_secrets_test.go
@@ -106,6 +106,16 @@ metadata:
 data:
   # base64 -w0 <<< '{"auths":{"registry.test-2.com":{"username":"test-2","password":"password-2"}}}' && echo
   .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS50ZXN0LTIuY29tIjp7InVzZXJuYW1lIjoidGVzdC0yIiwicGFzc3dvcmQiOiJwYXNzd29yZC0yIn19fQo=
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: test-3
+  namespace: d8-admission-policy-engine
+data:
+  # base64 -w0 <<< '{"auths":{"registry.test-3.com":{}}}' && echo
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS50ZXN0LTMuY29tIjp7fX19Cg==
 `
 
 	testDenyVulnerableImagesSecretsValues = `
@@ -121,6 +131,7 @@ data:
       "password": "password-3",
       "auth": "dGVzdC0zOnBhc3N3b3JkLTM="
     }
+    "registry.test-4com": {}
   }
 }
 `


### PR DESCRIPTION
## Description
It fixes incorrect trivy-provider secret when using anonymous registry cred secret. 

## Why do we need it, and what problem does it solve?
Fixes #12000

Anonymous cred will be:
```
{"auths":{"registry.rmorozov.ru/dev":{}}}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix
summary: Fix the trivy provider hook to support anonymous registry cred secret.
```
