### PR TITLE
[dex] init delay probe

### DIFF
--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -186,7 +186,7 @@ spec:
             command:
             - /usr/local/bin/url-exec-prober
             - https://dex.d8-user-authn/.well-known/openid-configuration
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
           failureThreshold: 5
         livenessProbe:


### PR DESCRIPTION
## Description
Hey, everybody!
a small edit with a readinessProbe

## Why do we need it, and what problem does it solve?

The dex-authenticator feed has a sidecar container with redis and it often lacks a fraction of a second to start. Because of this the dex-authenticator container restarts on a trial basis. It seems to me that it would be enough to increase the delay a bit.