### PR TITLE
[candi] Add Oracle Linux as centos

### DIFF
--- a/candi/bashible/bashbooster/56_detect_bundle.sh
+++ b/candi/bashible/bashbooster/56_detect_bundle.sh
@@ -23,7 +23,7 @@ bb-is-bundle(){
 
   . /etc/os-release
   case "$ID" in
-    centos|rocky|almalinux|rhel)
+    centos|rocky|almalinux|rhel|ol)
       case "$VERSION_ID" in 7*|8*|9*)
         os="centos" ;;
       esac

--- a/candi/bashible/detect_bundle.sh
+++ b/candi/bashible/detect_bundle.sh
@@ -32,7 +32,7 @@ fi
 
 . /etc/os-release
 case "$ID" in
-  centos|rocky|almalinux|rhel)
+  centos|rocky|almalinux|rhel|ol)
     case "$VERSION_ID" in 7|7.*|8|8.*|9|9.*)
       echo "centos" && exit 0 ;;
     esac

--- a/ee/be/candi/bashible/detect_bundle.sh
+++ b/ee/be/candi/bashible/detect_bundle.sh
@@ -21,7 +21,7 @@ fi
 
 . /etc/os-release
 case "$ID" in
-  centos|rocky|almalinux|rhel)
+  centos|rocky|almalinux|rhel|ol)
     case "$VERSION_ID" in 7|7.*|8|8.*|9|9.*)
       echo "centos" && exit 0 ;;
     esac


### PR DESCRIPTION
## Description
Add Oracle Linux as centos

## Why do we need it, and what problem does it solve?
Oracle Linux is the same distro like as RockyLinux, AlmaLinux, CentOS, RHEL
```
[root@kovalkov-oracle ~]# cat /etc/os-release
NAME="Oracle Linux Server"
VERSION="9.5"
ID="ol"
ID_LIKE="fedora"
VARIANT="Server"
VARIANT_ID="server"
VERSION_ID="9.5"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Oracle Linux Server 9.5"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:oracle:linux:9:5:server"
HOME_URL="https://linux.oracle.com/"
BUG_REPORT_URL="https://github.com/oracle/oracle-linux"

ORACLE_BUGZILLA_PRODUCT="Oracle Linux 9"
ORACLE_BUGZILLA_PRODUCT_VERSION=9.5
ORACLE_SUPPORT_PRODUCT="Oracle Linux"
ORACLE_SUPPORT_PRODUCT_VERSION=9.5
```

But we not detect it and detect bundle works too slow
```
┌ ⛵ ~ Bootstrap: Detect Bashible Bundle
│ Detected bundle: centos
└ ⛵ ~ Bootstrap: Detect Bashible Bundle (51.21 seconds)
```

After this patch we have:
```
┌ ⛵ ~ Bootstrap: Detect Bashible Bundle
│ Detected bundle: centos
└ ⛵ ~ Bootstrap: Detect Bashible Bundle (1.30 seconds)
```

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Add Oracle Linux as `centos`.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
