### PR TITLE
[dhctl] Preflight check: CIDRs intersection

### DIFF
--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -32,6 +32,7 @@ var (
 	PreflightSkipSystemRequirementsCheck   = false
 	PreflightSkipOneSSHHost                = false
 	PreflightSkipCloudAPIAccessibility     = false
+	PreflightSkipCIDRIntersection          = false
 )
 
 const (
@@ -68,6 +69,7 @@ var (
 		SudoAllowedCheckArgName:          &PreflightSkipSudoIsAllowedForUserCheck,
 		SystemRequirementsArgName:        &PreflightSkipSystemRequirementsCheck,
 		OneSSHHostCheckArgName:           &PreflightSkipOneSSHHost,
+		CIDRIntersection:                 &PreflightSkipCIDRIntersection,
 	}
 )
 
@@ -125,4 +127,7 @@ func DefinePreflight(cmd *kingpin.CmdClause) {
 	cmd.Flag(OneSSHHostCheckArgName, "Skip verifying one ssh-host parametr").
 		Envar(configEnvName("PREFLIGHT_SKIP_ONE_SSH_HOST")).
 		BoolVar(PreflightSkipOptionsMap[OneSSHHostCheckArgName])
+	cmd.Flag(CIDRIntersection, "Skip verifying CIDRs intersection").
+		Envar(configEnvName("PREFLIGHT_SKIP_CIDR_INTERSECTION")).
+		BoolVar(PreflightSkipOptionsMap[CIDRIntersection])
 }

--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -49,6 +49,7 @@ const (
 	SystemRequirementsArgName        = "preflight-skip-system-requirements-check"
 	CloudAPIAccessibilityArgName     = "preflight-cloud-api-accesibility-check"
 	OneSSHHostCheckArgName           = "preflight-skip-one-ssh-host"
+	CIDRIntersection                 = "preflight-skip-cidr-intersection"
 )
 
 var (

--- a/dhctl/pkg/preflight/cidr_intersection.go
+++ b/dhctl/pkg/preflight/cidr_intersection.go
@@ -57,7 +57,7 @@ func (pc *Checker) CheckCidrIntersectionStatic() error {
 	var internalNetworkCIDRs []string
 	err = json.Unmarshal(pc.metaConfig.StaticClusterConfig["internalNetworkCIDRs"], &internalNetworkCIDRs)
 	if err != nil {
-		return err
+		return fmt.Errorf("missing internalNetworkCIDRs field in ClusterConfiguration")
 	}
 
 	err = cidrIntersects(podSubnetCIDR, serviceSubnetCIDR)
@@ -101,12 +101,12 @@ func getCidrFromMetaConfig(metaConfig *config.MetaConfig) (string, string, error
 	var serviceSubnetCIDR string
 	err := json.Unmarshal(metaConfig.ClusterConfig["podSubnetCIDR"], &podSubnetCIDR)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("missing podSubnetCIDR field in ClusterConfiguration")
 	}
 
 	err = json.Unmarshal(metaConfig.ClusterConfig["serviceSubnetCIDR"], &serviceSubnetCIDR)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("missing serviceSubnetCIDR field in ClusterConfiguration")
 	}
 
 	return podSubnetCIDR, serviceSubnetCIDR, nil

--- a/dhctl/pkg/preflight/cidr_intersection.go
+++ b/dhctl/pkg/preflight/cidr_intersection.go
@@ -49,6 +49,10 @@ func (pc *Checker) CheckCidrIntersectionStatic() error {
 		return nil
 	}
 
+	if pc.metaConfig.StaticClusterConfig["internalNetworkCIDRs"] == nil {
+		return nil
+	}
+
 	podSubnetCIDR, serviceSubnetCIDR, err := getCidrFromMetaConfig(pc.metaConfig)
 	if err != nil {
 		return err
@@ -58,11 +62,6 @@ func (pc *Checker) CheckCidrIntersectionStatic() error {
 	err = json.Unmarshal(pc.metaConfig.StaticClusterConfig["internalNetworkCIDRs"], &internalNetworkCIDRs)
 	if err != nil {
 		return fmt.Errorf("missing internalNetworkCIDRs field in ClusterConfiguration")
-	}
-
-	err = cidrIntersects(podSubnetCIDR, serviceSubnetCIDR)
-	if err != nil {
-		return err
 	}
 
 	for _, ininternalNetworkCIDR := range internalNetworkCIDRs {

--- a/dhctl/pkg/preflight/cidr_intersection.go
+++ b/dhctl/pkg/preflight/cidr_intersection.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
 type internalNetworkCIDRs struct {
@@ -27,6 +29,11 @@ type internalNetworkCIDRs struct {
 }
 
 func (pc *Checker) CheckCidrIntersection() error {
+	if app.PreflightSkipCIDRIntersection {
+		log.DebugLn("Verification of CIDRs intersection is skipped")
+		return nil
+	}
+
 	podSubnetCIDR, serviceSubnetCIDR, err := getCidrFromMetaConfig(pc.metaConfig)
 	if err != nil {
 		return err
@@ -41,6 +48,11 @@ func (pc *Checker) CheckCidrIntersection() error {
 }
 
 func (pc *Checker) CheckCidrIntersectionStatic() error {
+	if app.PreflightSkipCIDRIntersection {
+		log.DebugLn("Verification of CIDRs intersection is skipped")
+		return nil
+	}
+
 	podSubnetCIDR, serviceSubnetCIDR, err := getCidrFromMetaConfig(pc.metaConfig)
 	if err != nil {
 		return err

--- a/dhctl/pkg/preflight/cidr_intersection.go
+++ b/dhctl/pkg/preflight/cidr_intersection.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+)
+
+type internalNetworkCIDRs struct {
+	internalNetworkCIDR []string
+}
+
+func (pc *Checker) CheckCidrIntersection() error {
+	podSubnetCIDR, serviceSubnetCIDR, err := getCidrFromMetaConfig(pc.metaConfig)
+	if err != nil {
+		return err
+	}
+
+	err = cidrIntersects(podSubnetCIDR, serviceSubnetCIDR)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (pc *Checker) CheckCidrIntersectionStatic() error {
+	podSubnetCIDR, serviceSubnetCIDR, err := getCidrFromMetaConfig(pc.metaConfig)
+	if err != nil {
+		return err
+	}
+
+	var internalNetworkCIDRs internalNetworkCIDRs
+	err = json.Unmarshal(pc.metaConfig.StaticClusterConfig["internalNetworkCIDRs"], &internalNetworkCIDRs)
+	if err != nil {
+		return err
+	}
+
+	err = cidrIntersects(podSubnetCIDR, serviceSubnetCIDR)
+	if err != nil {
+		return err
+	}
+
+	for _, ininternalNetworkCIDR := range internalNetworkCIDRs.internalNetworkCIDR {
+		err := cidrIntersects(podSubnetCIDR, ininternalNetworkCIDR)
+		if err != nil {
+			return err
+		}
+		err = cidrIntersects(serviceSubnetCIDR, ininternalNetworkCIDR)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func cidrIntersects(cidr1, cidr2 string) error {
+	_, ipNet1, err := net.ParseCIDR(cidr1)
+	if err != nil {
+		return fmt.Errorf("invalid CIDR address: %s", cidr1)
+	}
+
+	_, ipNet2, err := net.ParseCIDR(cidr2)
+	if err != nil {
+		return fmt.Errorf("invalid CIDR address: %s", cidr2)
+	}
+
+	if ipNet1.Contains(ipNet2.IP) || ipNet2.Contains(ipNet1.IP) {
+		return fmt.Errorf("CIDRs %s and %s are intersects", cidr1, cidr2)
+	}
+	return nil
+}
+
+func getCidrFromMetaConfig(metaConfig *config.MetaConfig) (string, string, error) {
+	podSubnetCIDR := fmt.Sprint(metaConfig.ClusterConfig["podSubnetCIDR"])
+	serviceSubnetCIDR := fmt.Sprint(metaConfig.ClusterConfig["serviceSubnetCIDR"])
+
+	return podSubnetCIDR, serviceSubnetCIDR, nil
+}

--- a/dhctl/pkg/preflight/cidr_intersection_test.go
+++ b/dhctl/pkg/preflight/cidr_intersection_test.go
@@ -1,0 +1,366 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCidrFromMetaConfig(t *testing.T) {
+	tests := []struct {
+		metaConfig          *config.MetaConfig
+		expectedPodCIDR     string
+		expectedServiceCIDR string
+		expectError         bool
+		errorMsg            string
+	}{
+		{
+			metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     json.RawMessage(`"10.0.0.0/8"`),
+					"serviceSubnetCIDR": json.RawMessage(`"192.168.0.0/16"`),
+				},
+			},
+			expectedPodCIDR:     "10.0.0.0/8",
+			expectedServiceCIDR: "192.168.0.0/16",
+			expectError:         false,
+		},
+		{
+			metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"serviceSubnetCIDR": json.RawMessage(`"192.168.0.0/16"`),
+				},
+			},
+			expectError: true,
+			errorMsg:    "unexpected end of JSON input",
+		},
+		{
+			metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{},
+			},
+			expectError: true,
+			errorMsg:    "unexpected end of JSON input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("PodCIDR:%s_ServiceCIDR:%s", tt.expectedPodCIDR, tt.expectedServiceCIDR), func(t *testing.T) {
+			podCIDR, serviceCIDR, err := getCidrFromMetaConfig(tt.metaConfig)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedPodCIDR, podCIDR)
+				assert.Equal(t, tt.expectedServiceCIDR, serviceCIDR)
+			}
+		})
+	}
+}
+
+func TestCidrIntersects(t *testing.T) {
+	tests := []struct {
+		cidr1       string
+		cidr2       string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			cidr1:       "10.0.0.0/8",
+			cidr2:       "10.0.1.0/24",
+			expectError: true,
+			errorMsg:    "CIDRs 10.0.0.0/8 and 10.0.1.0/24 are intersects",
+		},
+		{
+			cidr1:       "10.0.0.0/8",
+			cidr2:       "192.168.0.0/16",
+			expectError: false,
+		},
+		{
+			cidr1:       "invalidCIDR",
+			cidr2:       "10.0.0.0/8",
+			expectError: true,
+			errorMsg:    "invalid CIDR address: invalidCIDR",
+		},
+		{
+			cidr1:       "10.0.0.0/8",
+			cidr2:       "invalidCIDR",
+			expectError: true,
+			errorMsg:    "invalid CIDR address: invalidCIDR",
+		},
+		{
+			cidr1:       "invalidCIDR1",
+			cidr2:       "invalidCIDR2",
+			expectError: true,
+			errorMsg:    "invalid CIDR address: invalidCIDR1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s_%s", tt.cidr1, tt.cidr2), func(t *testing.T) {
+			err := cidrIntersects(tt.cidr1, tt.cidr2)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCheckCidrIntersection(t *testing.T) {
+	type fields struct {
+		metaConfig *config.MetaConfig
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "happy path",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     []byte(`"10.111.0.0/16"`),
+					"serviceSubnetCIDR": []byte(`"10.222.0.0/16"`),
+				},
+			}},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "intersects subnets",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     []byte(`"10.111.0.0/17"`),
+					"serviceSubnetCIDR": []byte(`"10.111.110.0/18"`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "are intersects")
+			},
+		},
+		{
+			name: "missing podSubnetCIDR",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"serviceSubnetCIDR": []byte(`"10.0.0.0/8"`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "unexpected end of JSON input")
+			},
+		},
+		{
+			name: "missing serviceSubnetCIDR",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR": []byte(`"10.0.0.0/8"`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "unexpected end of JSON input")
+			},
+		},
+		{
+			name: "invalid podSubnetCIDR",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     []byte(`"invalidCIDR"`),
+					"serviceSubnetCIDR": []byte(`"10.222.0.0/16"`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "invalid CIDR address: invalidCIDR")
+			},
+		},
+		{
+			name: "invalid serviceSubnetCIDR",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     []byte(`"10.111.0.0/16"`),
+					"serviceSubnetCIDR": []byte(`"invalidCIDR"`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "invalid CIDR address: invalidCIDR")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pc := &Checker{
+				metaConfig: tt.fields.metaConfig,
+			}
+			tt.wantErr(t, pc.CheckCidrIntersection(), fmt.Sprintf("CheckCidrIntersection()"))
+		})
+	}
+}
+
+func TestCheckCidrIntersectionStatic(t *testing.T) {
+	type fields struct {
+		metaConfig *config.MetaConfig
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "happy path",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     []byte(`"10.111.0.0/16"`),
+					"serviceSubnetCIDR": []byte(`"10.222.0.0/16"`),
+				},
+				StaticClusterConfig: map[string]json.RawMessage{
+					"internalNetworkCIDRs": []byte(`["10.128.0.0/24"]`),
+				},
+			}},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "intersects subnets",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     []byte(`"10.111.0.0/17"`),
+					"serviceSubnetCIDR": []byte(`"10.111.110.0/18"`),
+				},
+				StaticClusterConfig: map[string]json.RawMessage{
+					"internalNetworkCIDRs": []byte(`["10.128.0.0/24"]`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "are intersects")
+			},
+		},
+		{
+			name: "intersects subnets with internal",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     []byte(`"10.111.0.0/16"`),
+					"serviceSubnetCIDR": []byte(`"10.222.0.0/16"`),
+				},
+				StaticClusterConfig: map[string]json.RawMessage{
+					"internalNetworkCIDRs": []byte(`["10.0.0.0/8"]`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "are intersects")
+			},
+		},
+		{
+			name: "missing podSubnetCIDR",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"serviceSubnetCIDR": []byte(`"10.0.0.0/8"`),
+				},
+				StaticClusterConfig: map[string]json.RawMessage{
+					"internalNetworkCIDRs": []byte(`["10.128.0.0/24"]`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "unexpected end of JSON input")
+			},
+		},
+		{
+			name: "missing serviceSubnetCIDR",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR": []byte(`"10.0.0.0/8"`),
+				},
+				StaticClusterConfig: map[string]json.RawMessage{
+					"internalNetworkCIDRs": []byte(`["10.128.0.0/24"]`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "unexpected end of JSON input")
+			},
+		},
+		{
+			name: "missing internalNetworkCIDRs",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     []byte(`"10.111.0.0/16"`),
+					"serviceSubnetCIDR": []byte(`"10.222.0.0/16"`),
+				},
+				StaticClusterConfig: map[string]json.RawMessage{},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "unexpected end of JSON input")
+			},
+		},
+		{
+			name: "invalid podSubnetCIDR",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     []byte(`"invalidCIDR"`),
+					"serviceSubnetCIDR": []byte(`"10.222.0.0/16"`),
+				},
+				StaticClusterConfig: map[string]json.RawMessage{
+					"internalNetworkCIDRs": []byte(`["10.128.0.0/24"]`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "invalid CIDR address: invalidCIDR")
+			},
+		},
+		{
+			name: "invalid serviceSubnetCIDR",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     []byte(`"10.111.0.0/16"`),
+					"serviceSubnetCIDR": []byte(`"invalidCIDR"`),
+				},
+				StaticClusterConfig: map[string]json.RawMessage{
+					"internalNetworkCIDRs": []byte(`["10.128.0.0/24"]`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "invalid CIDR address: invalidCIDR")
+			},
+		},
+		{
+			name: "invalid internalNetworkCIDRs",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     []byte(`"10.111.0.0/16"`),
+					"serviceSubnetCIDR": []byte(`"10.222.0.0/16"`),
+				},
+				StaticClusterConfig: map[string]json.RawMessage{
+					"internalNetworkCIDRs": []byte(`["invalidCIDR"]`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "invalid CIDR address: invalidCIDR")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pc := &Checker{
+				metaConfig: tt.fields.metaConfig,
+			}
+			tt.wantErr(t, pc.CheckCidrIntersectionStatic(), fmt.Sprintf("CheckCidrIntersectionStatic()"))
+		})
+	}
+}

--- a/dhctl/pkg/preflight/cidr_intersection_test.go
+++ b/dhctl/pkg/preflight/cidr_intersection_test.go
@@ -49,14 +49,23 @@ func TestGetCidrFromMetaConfig(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorMsg:    "unexpected end of JSON input",
+			errorMsg:    "missing podSubnetCIDR field in ClusterConfiguration",
+		},
+		{
+			metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR": json.RawMessage(`"192.168.0.0/16"`),
+				},
+			},
+			expectError: true,
+			errorMsg:    "missing serviceSubnetCIDR field in ClusterConfiguration",
 		},
 		{
 			metaConfig: &config.MetaConfig{
 				ClusterConfig: map[string]json.RawMessage{},
 			},
 			expectError: true,
-			errorMsg:    "unexpected end of JSON input",
+			errorMsg:    "missing podSubnetCIDR field in ClusterConfiguration",
 		},
 	}
 
@@ -167,7 +176,7 @@ func TestCheckCidrIntersection(t *testing.T) {
 				},
 			}},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "unexpected end of JSON input")
+				return assert.ErrorContains(t, err, "missing podSubnetCIDR field in ClusterConfiguration")
 			},
 		},
 		{
@@ -178,7 +187,7 @@ func TestCheckCidrIntersection(t *testing.T) {
 				},
 			}},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "unexpected end of JSON input")
+				return assert.ErrorContains(t, err, "missing serviceSubnetCIDR field in ClusterConfiguration")
 			},
 		},
 		{
@@ -294,7 +303,7 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 				},
 			}},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "unexpected end of JSON input")
+				return assert.ErrorContains(t, err, "missing podSubnetCIDR field in ClusterConfiguration")
 			},
 		},
 		{
@@ -308,7 +317,7 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 				},
 			}},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "unexpected end of JSON input")
+				return assert.ErrorContains(t, err, "missing serviceSubnetCIDR field in ClusterConfiguration")
 			},
 		},
 		{
@@ -321,7 +330,7 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 				StaticClusterConfig: map[string]json.RawMessage{},
 			}},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "unexpected end of JSON input")
+				return assert.ErrorContains(t, err, "missing internalNetworkCIDRs field in ClusterConfiguration")
 			},
 		},
 		{

--- a/dhctl/pkg/preflight/cidr_intersection_test.go
+++ b/dhctl/pkg/preflight/cidr_intersection_test.go
@@ -248,19 +248,14 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name: "intersects subnets",
+			name: "happy path",
 			fields: fields{metaConfig: &config.MetaConfig{
 				ClusterConfig: map[string]json.RawMessage{
-					"podSubnetCIDR":     []byte(`"10.111.0.0/17"`),
-					"serviceSubnetCIDR": []byte(`"10.111.110.0/18"`),
-				},
-				StaticClusterConfig: map[string]json.RawMessage{
-					"internalNetworkCIDRs": []byte(`["10.128.0.0/24"]`),
+					"podSubnetCIDR":     []byte(`"10.111.0.0/16"`),
+					"serviceSubnetCIDR": []byte(`"10.222.0.0/16"`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "are intersects")
-			},
+			wantErr: assert.NoError,
 		},
 		{
 			name: "intersects subnets with internal",
@@ -318,19 +313,6 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 			}},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.ErrorContains(t, err, "missing serviceSubnetCIDR field in ClusterConfiguration")
-			},
-		},
-		{
-			name: "missing internalNetworkCIDRs",
-			fields: fields{metaConfig: &config.MetaConfig{
-				ClusterConfig: map[string]json.RawMessage{
-					"podSubnetCIDR":     []byte(`"10.111.0.0/16"`),
-					"serviceSubnetCIDR": []byte(`"10.222.0.0/16"`),
-				},
-				StaticClusterConfig: map[string]json.RawMessage{},
-			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "missing internalNetworkCIDRs field in ClusterConfiguration")
 			},
 		},
 		{

--- a/dhctl/pkg/preflight/cidr_intersection_test.go
+++ b/dhctl/pkg/preflight/cidr_intersection_test.go
@@ -269,6 +269,21 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 			},
 		},
 		{
+			name: "intersects serviceSubnetCIDR with internalNetworkCIDRs",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ClusterConfig: map[string]json.RawMessage{
+					"podSubnetCIDR":     []byte(`"10.111.0.0/16"`),
+					"serviceSubnetCIDR": []byte(`"10.222.0.0/16"`),
+				},
+				StaticClusterConfig: map[string]json.RawMessage{
+					"internalNetworkCIDRs": []byte(`["10.222.128.0/24"]`),
+				},
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "are intersects")
+			},
+		},
+		{
 			name: "missing podSubnetCIDR",
 			fields: fields{metaConfig: &config.MetaConfig{
 				ClusterConfig: map[string]json.RawMessage{

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -129,6 +129,11 @@ func (pc *Checker) Static() error {
 			successMessage: "sudo is allowed for user",
 			skipFlag:       app.SudoAllowedCheckArgName,
 		},
+		{
+			fun:            pc.CheckCidrIntersectionStatic,
+			successMessage: "CIDRs are not intersects",
+			skipFlag:       app.CIDRIntersection,
+		},
 	})
 
 	if err != nil {
@@ -218,6 +223,11 @@ func (pc *Checker) Global() error {
 			fun:            pc.CheckRegistryCredentials,
 			successMessage: "registry credentials are correct",
 			skipFlag:       app.RegistryCredentialsCheckArgName,
+		},
+		{
+			fun:            pc.CheckCidrIntersection,
+			successMessage: "CIDRs are not intersects",
+			skipFlag:       app.CIDRIntersection,
 		},
 	})
 


### PR DESCRIPTION
## Description

Add new preflight check for dhctl: CIDRs intersection. Fail if podSubnetCIDR intersects with serviceSubnetCIRD

## Why do we need it, and what problem does it solve?

This check allows to fail faster, without try to bootstrap cluster. CIDRs should not intersects

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Add CIDR intersection preflight check to dhctl
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
