### PR TITLE
fix changelog generation

### DIFF
--- a/.github/scripts/js/changelog-command-validate.js
+++ b/.github/scripts/js/changelog-command-validate.js
@@ -30,7 +30,7 @@ module.exports = async ({ github, core, context }) => {
     return;
   }
 
-  return issue.milestone && issue.milestone.status == 'open';
+  return issue.milestone;
 };
 
 function validate(issue) {
@@ -41,10 +41,5 @@ function validate(issue) {
   if (!issue.milestone) {
     return 'No milestone, skip.';
   }
-
-  if (issue.milestone.state != 'open') {
-    return `Milestone ${issue.milestone.title} is not open.`;
-  }
-
   return '';
 }

--- a/.github/workflow_templates/dispatch-slash-command.yml
+++ b/.github/workflow_templates/dispatch-slash-command.yml
@@ -60,7 +60,7 @@ jobs:
               return core.setOutput('trigger_for_release_issue', 'true');
             }
 
-            if (isPR && milestoneState === 'open' && hasChangelogLabel && hasAutoLabel) {
+            if (isPR && hasChangelogLabel && hasAutoLabel) {
               core.notice(`Comment on changelog pull request.`);
               return core.setOutput('trigger_for_changelog', 'true');
             }

--- a/.github/workflows/dispatch-slash-command.yml
+++ b/.github/workflows/dispatch-slash-command.yml
@@ -64,7 +64,7 @@ jobs:
               return core.setOutput('trigger_for_release_issue', 'true');
             }
 
-            if (isPR && milestoneState === 'open' && hasChangelogLabel && hasAutoLabel) {
+            if (isPR && hasChangelogLabel && hasAutoLabel) {
               core.notice(`Comment on changelog pull request.`);
               return core.setOutput('trigger_for_changelog', 'true');
             }


### PR DESCRIPTION
## Description  
This update enhances the changelog generation action, allowing it to run for closed milestones as well. Previously, the action was restricted to open milestones, which limited the ability to retrospectively update changelogs for completed releases.  

## Why do we need it, and what problem does it solve?  
By enabling changelog generation for closed milestones, this change improves visibility into past releases, ensuring that all changes are properly documented. This is particularly useful for auditing purposes and release management, where maintaining an accurate changelog is critical.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: This update enhances the changelog generation action
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
