### PR TITLE
[user-authz] add rbacv2 for new providers

### DIFF
--- a/docs/documentation/_data/rbac/rbac.yaml
+++ b/docs/documentation/_data/rbac/rbac.yaml
@@ -324,6 +324,38 @@ modules:
     namespace: d8-cloud-provider-azure
     subsystems:
     - infrastructure
+  cloud-provider-dynamix:
+    capabilities:
+      manage:
+      - name: d8:manage:permission:module:cloud-provider-dynamix:view
+        rules:
+        - apiGroups:
+          - deckhouse.io
+          resourceNames:
+          - cloud-provider-dynamix
+          resources:
+          - moduleconfigs
+          verbs:
+          - get
+          - list
+          - watch
+      - name: d8:manage:permission:module:cloud-provider-dynamix:edit
+        rules:
+        - apiGroups:
+          - deckhouse.io
+          resourceNames:
+          - cloud-provider-dynamix
+          resources:
+          - moduleconfigs
+          verbs:
+          - create
+          - update
+          - patch
+          - delete
+      use: null
+    namespace: d8-cloud-provider-dynamix
+    subsystems:
+    - infrastructure
   cloud-provider-gcp:
     capabilities:
       manage:
@@ -354,6 +386,38 @@ modules:
           - delete
       use: null
     namespace: d8-cloud-provider-gcp
+    subsystems:
+    - infrastructure
+  cloud-provider-huaweicloud:
+    capabilities:
+      manage:
+      - name: d8:manage:permission:module:cloud-provider-huaweicloud:view
+        rules:
+        - apiGroups:
+          - deckhouse.io
+          resourceNames:
+          - cloud-provider-huaweicloud
+          resources:
+          - moduleconfigs
+          verbs:
+          - get
+          - list
+          - watch
+      - name: d8:manage:permission:module:cloud-provider-huaweicloud:edit
+        rules:
+        - apiGroups:
+          - deckhouse.io
+          resourceNames:
+          - cloud-provider-huaweicloud
+          resources:
+          - moduleconfigs
+          verbs:
+          - create
+          - update
+          - patch
+          - delete
+      use: null
+    namespace: d8-cloud-provider-huaweicloud
     subsystems:
     - infrastructure
   cloud-provider-openstack:
@@ -2528,6 +2592,8 @@ subsystems:
     - d8-system
   infrastructure:
     modules:
+    - cloud-provider-dynamix
+    - cloud-provider-huaweicloud
     - cloud-provider-openstack
     - cloud-provider-vcd
     - keepalived
@@ -2554,7 +2620,9 @@ subsystems:
     - d8-cloud-instance-manager
     - d8-cloud-provider-aws
     - d8-cloud-provider-azure
+    - d8-cloud-provider-dynamix
     - d8-cloud-provider-gcp
+    - d8-cloud-provider-huaweicloud
     - d8-cloud-provider-openstack
     - d8-cloud-provider-vcd
     - d8-cloud-provider-vsphere

--- a/ee/modules/030-cloud-provider-dynamix/module.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/module.yaml
@@ -1,0 +1,5 @@
+name: cloud-provider-dynamix
+weight: 30
+subsystems:
+  - infrastructure
+namespace: d8-cloud-provider-dynamix

--- a/ee/modules/030-cloud-provider-dynamix/templates/rbacv2/manage/edit.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/rbacv2/manage/edit.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-dynamix
+    rbac.deckhouse.io/aggregate-to-infrastructure-as: manager
+    rbac.deckhouse.io/kind: manage
+    rbac.deckhouse.io/level: module
+    rbac.deckhouse.io/namespace: d8-cloud-provider-dynamix
+  name: d8:manage:permission:module:cloud-provider-dynamix:edit
+rules:
+- apiGroups:
+  - deckhouse.io
+  resourceNames:
+  - cloud-provider-dynamix
+  resources:
+  - moduleconfigs
+  verbs:
+  - create
+  - update
+  - patch
+  - delete

--- a/ee/modules/030-cloud-provider-dynamix/templates/rbacv2/manage/view.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/rbacv2/manage/view.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-dynamix
+    rbac.deckhouse.io/aggregate-to-infrastructure-as: viewer
+    rbac.deckhouse.io/kind: manage
+    rbac.deckhouse.io/level: module
+    rbac.deckhouse.io/namespace: d8-cloud-provider-dynamix
+  name: d8:manage:permission:module:cloud-provider-dynamix:view
+rules:
+- apiGroups:
+  - deckhouse.io
+  resourceNames:
+  - cloud-provider-dynamix
+  resources:
+  - moduleconfigs
+  verbs:
+  - get
+  - list
+  - watch

--- a/ee/modules/030-cloud-provider-huaweicloud/module.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/module.yaml
@@ -1,0 +1,5 @@
+name: cloud-provider-huaweicloud
+weight: 30
+subsystems:
+  - infrastructure
+namespace: d8-cloud-provider-huaweicloud

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/rbacv2/manage/edit.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/rbacv2/manage/edit.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-huaweicloud
+    rbac.deckhouse.io/aggregate-to-infrastructure-as: manager
+    rbac.deckhouse.io/kind: manage
+    rbac.deckhouse.io/level: module
+    rbac.deckhouse.io/namespace: d8-cloud-provider-huaweicloud
+  name: d8:manage:permission:module:cloud-provider-huaweicloud:edit
+rules:
+- apiGroups:
+  - deckhouse.io
+  resourceNames:
+  - cloud-provider-huaweicloud
+  resources:
+  - moduleconfigs
+  verbs:
+  - create
+  - update
+  - patch
+  - delete

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/rbacv2/manage/view.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/rbacv2/manage/view.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-huaweicloud
+    rbac.deckhouse.io/aggregate-to-infrastructure-as: viewer
+    rbac.deckhouse.io/kind: manage
+    rbac.deckhouse.io/level: module
+    rbac.deckhouse.io/namespace: d8-cloud-provider-huaweicloud
+  name: d8:manage:permission:module:cloud-provider-huaweicloud:view
+rules:
+- apiGroups:
+  - deckhouse.io
+  resourceNames:
+  - cloud-provider-huaweicloud
+  resources:
+  - moduleconfigs
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
## Description
It provides rbacv2 for new cloud providers

## Why do we need it, and what problem does it solve?
New providers should have rbacv2 roles

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: user-authz
type: chore
summary: Add rbacv2 for dynamix and huaweicloud providers.
```
