### PR TITLE
[control-plane-manager] Stale service account alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1634,11 +1634,10 @@ alerts:
         - Ensure your application is configured to periodically reload the token from the file system.
         - Verify that you are using an up-to-date client library that supports automatic token rotation.
 
-        **Note:**
-        Currently, these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (Default: true). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
+        Note thar currently these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (`Default: true`). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
 
         **For further investigation:**
-        Log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
+        log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
 
         ```
         jq 'select(.annotations["authentication.k8s.io/stale-token"]) | {auditID, stageTimestamp, requestURI, verb, user: .user.username, stale_token: .annotations["authentication.k8s.io/stale-token"]}' /var/log/kube-audit/audit.log

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1634,7 +1634,7 @@ alerts:
         - Ensure your application is configured to periodically reload the token from the file system.
         - Verify that you are using an up-to-date client library that supports automatic token rotation.
 
-        Note thar currently these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (`Default: true`). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
+        Note that currently these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (`Default: true`). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
 
         **For further investigation:**
         log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1622,6 +1622,31 @@ alerts:
         etcd database size is approaching the limit.
       severity: "3"
       markupFormat: markdown
+    - name: D8KubernetesStaleTokensDetected
+      sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+      moduleUrl: 040-control-plane-manager
+      module: control-plane-manager
+      edition: ce
+      description: |-
+        This issue may occur if the application reads the token only at startup and does not reload it periodically. As a result, an outdated token might be used, leading to security breach and authentication failures.
+
+        **Recommended Actions:**
+        - Ensure your application is configured to periodically reload the token from the file system.
+        - Verify that you are using an up-to-date client library that supports automatic token rotation.
+
+        **Note:**
+        Currently, these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (Default: true). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
+
+        **For further investigation:**
+        Log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
+
+        ```
+        jq 'select(.annotations["authentication.k8s.io/stale-token"]) | {auditID, stageTimestamp, requestURI, verb, user: .user.username, stale_token: .annotations["authentication.k8s.io/stale-token"]}' /var/log/kube-audit/audit.log
+        ```
+      summary: |
+        Stale service account tokens detected
+      severity: "8"
+      markupFormat: markdown
     - name: D8KubernetesVersionIsDeprecated
       sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
       moduleUrl: 040-control-plane-manager

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1628,22 +1628,23 @@ alerts:
       module: control-plane-manager
       edition: ce
       description: |-
-        This issue may occur if the application reads the token only at startup and does not reload it periodically. As a result, an outdated token might be used, leading to security breach and authentication failures.
+        This issue may occur if an application reads the token only at startup and does not reload it periodically. As a result, an outdated token might be used, leading to security breach and authentication failures.
 
-        **Recommended Actions:**
+        **Recommended actions:**
+
         - Ensure your application is configured to periodically reload the token from the file system.
         - Verify that you are using an up-to-date client library that supports automatic token rotation.
 
         Note that currently these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (`Default: true`). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
 
         **For further investigation:**
-        log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
+        Log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
 
-        ```
+        ```bash
         jq 'select(.annotations["authentication.k8s.io/stale-token"]) | {auditID, stageTimestamp, requestURI, verb, user: .user.username, stale_token: .annotations["authentication.k8s.io/stale-token"]}' /var/log/kube-audit/audit.log
         ```
       summary: |
-        Stale service account tokens detected
+        Stale service account tokens detected.
       severity: "8"
       markupFormat: markdown
     - name: D8KubernetesVersionIsDeprecated

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -64,19 +64,20 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      summary: "Stale service account tokens detected"
+      summary: Stale service account tokens detected.
       description: |-
-        This issue may occur if the application reads the token only at startup and does not reload it periodically. As a result, an outdated token might be used, leading to security breach and authentication failures.
+        This issue may occur if an application reads the token only at startup and does not reload it periodically. As a result, an outdated token might be used, leading to security breach and authentication failures.
 
-        **Recommended Actions:**
+        **Recommended actions:**
+
         - Ensure your application is configured to periodically reload the token from the file system.
         - Verify that you are using an up-to-date client library that supports automatic token rotation.
 
         Note that currently these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (`Default: true`). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
 
         **For further investigation:**
-        log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
+        Log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
 
-        ```
+        ```bash
         jq 'select(.annotations["authentication.k8s.io/stale-token"]) | {auditID, stageTimestamp, requestURI, verb, user: .user.username, stale_token: .annotations["authentication.k8s.io/stale-token"]}' /var/log/kube-audit/audit.log
         ```

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -1,56 +1,83 @@
 - name: d8.control-plane-manager.malfunctioning
   rules:
-  - alert: D8ControlPlaneManagerPodNotRunning
-    for: 10m
-    expr: |
-      max by (node) (
-        kube_node_role{role="master"}
-        unless
-        kube_node_role{role="master"}
-        * on(node) group_left() (
-          (kube_pod_status_ready{condition="true"} == 1)
-          * on (pod, namespace) group_right()
-          kube_controller_pod{
-            controller_type="DaemonSet",
-            namespace="kube-system",
-            controller_name="d8-control-plane-manager"
-          }
+    - alert: D8ControlPlaneManagerPodNotRunning
+      for: 10m
+      expr: |
+        max by (node) (
+          kube_node_role{role="master"}
+          unless
+          kube_node_role{role="master"}
+          * on(node) group_left() (
+            (kube_pod_status_ready{condition="true"} == 1)
+            * on (pod, namespace) group_right()
+            kube_controller_pod{
+              controller_type="DaemonSet",
+              namespace="kube-system",
+              controller_name="d8-control-plane-manager"
+            }
+          )
         )
-      )
-    labels:
-      d8_component: control-plane-manager
-      d8_module: control-plane-manager
-      severity_level: "6"
-      tier: cluster
-    annotations:
-      plk_protocol_version: "1"
-      plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_control_plane_manager_unavailable: "D8ControlPlaneManagerUnavailable,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_grouped_by__d8_control_plane_manager_unavailable: "D8ControlPlaneManagerUnavailable,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      summary: Controller pod isn't running on node `{{ $labels.node }}`.
-      description: |-
-        The `d8-control-plane-manager` pod is either failing or hasn't been scheduled on node `{{ $labels.node }}`.
+      labels:
+        d8_component: control-plane-manager
+        d8_module: control-plane-manager
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_create_group_if_not_exists__d8_control_plane_manager_unavailable: "D8ControlPlaneManagerUnavailable,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_control_plane_manager_unavailable: "D8ControlPlaneManagerUnavailable,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        summary: Controller pod isn't running on node `{{ $labels.node }}`.
+        description: |-
+          The `d8-control-plane-manager` pod is either failing or hasn't been scheduled on node `{{ $labels.node }}`.
 
-        To resolve this issue, check the status of the `kube-system/d8-control-plane-manager` DaemonSet and its pods by running the following command:
+          To resolve this issue, check the status of the `kube-system/d8-control-plane-manager` DaemonSet and its pods by running the following command:
 
-        ```bash
-        kubectl -n kube-system get daemonset,pod --selector=app=d8-control-plane-manager
-        ```
-  - alert: D8KubernetesVersionIsDeprecated
-    for: 10m
-    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.28"}) == 1
-    labels:
-      severity_level: "7"
-      tier: cluster
-    annotations:
-      plk_protocol_version: "1"
-      plk_markup_format: "markdown"
-      summary: Kubernetes version `{{ $labels.k8s_version }}` is deprecated.
-      description: |-
-        The current Kubernetes version `{{ $labels.k8s_version }}` has been deprecated, and support for it will be removed in upcoming releases.
+          ```bash
+          kubectl -n kube-system get daemonset,pod --selector=app=d8-control-plane-manager
+          ```
+    - alert: D8KubernetesVersionIsDeprecated
+      for: 10m
+      expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.28"}) == 1
+      labels:
+        severity_level: "7"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        summary: Kubernetes version `{{ $labels.k8s_version }}` is deprecated.
+        description: |-
+          The current Kubernetes version `{{ $labels.k8s_version }}` has been deprecated, and support for it will be removed in upcoming releases.
 
-        Please migrate to the next kubernetes version (at least 1.29)
+          Please migrate to the next kubernetes version (at least 1.29)
 
-        Check how to update the Kubernetes version in the cluster here - https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster
+          Check how to update the Kubernetes version in the cluster here - https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster
 
-        Refer to the [Kubernetes upgrade guide](https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster) for instructions.
+          Refer to the [Kubernetes upgrade guide](https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster) for instructions.
+
+    - alert: D8KubernetesStaleTokensDetected
+      for: 10m
+      expr: sum(rate(serviceaccount_stale_tokens_total[$__rate_interval])) by (instance) > 0
+      labels:
+        severity_level: "8"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        summary: "Stale service account tokens detected"
+        description: |-
+          This issue may occur if the application reads the token only at startup and does not reload it periodically. As a result, an outdated token might be used, leading to security breach and authentication failures.
+
+          **Recommended Actions:**
+          - Ensure your application is configured to periodically reload the token from the file system.
+          - Verify that you are using an up-to-date client library that supports automatic token rotation.
+
+          **Note:**
+          Currently, these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (Default: true). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
+
+          **For further investigation:**
+          Log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
+
+          ```
+          jq 'select(.annotations["authentication.k8s.io/stale-token"]) | {auditID, stageTimestamp, requestURI, verb, user: .user.username, stale_token: .annotations["authentication.k8s.io/stale-token"]}' /var/log/kube-audit/audit.log
+          ```

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -1,83 +1,83 @@
 - name: d8.control-plane-manager.malfunctioning
   rules:
-    - alert: D8ControlPlaneManagerPodNotRunning
-      for: 10m
-      expr: |
-        max by (node) (
-          kube_node_role{role="master"}
-          unless
-          kube_node_role{role="master"}
-          * on(node) group_left() (
-            (kube_pod_status_ready{condition="true"} == 1)
-            * on (pod, namespace) group_right()
-            kube_controller_pod{
-              controller_type="DaemonSet",
-              namespace="kube-system",
-              controller_name="d8-control-plane-manager"
-            }
-          )
+  - alert: D8ControlPlaneManagerPodNotRunning
+    for: 10m
+    expr: |
+      max by (node) (
+        kube_node_role{role="master"}
+        unless
+        kube_node_role{role="master"}
+        * on(node) group_left() (
+          (kube_pod_status_ready{condition="true"} == 1)
+          * on (pod, namespace) group_right()
+          kube_controller_pod{
+            controller_type="DaemonSet",
+            namespace="kube-system",
+            controller_name="d8-control-plane-manager"
+          }
         )
-      labels:
-        d8_component: control-plane-manager
-        d8_module: control-plane-manager
-        severity_level: "6"
-        tier: cluster
-      annotations:
-        plk_protocol_version: "1"
-        plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_control_plane_manager_unavailable: "D8ControlPlaneManagerUnavailable,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_control_plane_manager_unavailable: "D8ControlPlaneManagerUnavailable,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        summary: Controller pod isn't running on node `{{ $labels.node }}`.
-        description: |-
-          The `d8-control-plane-manager` pod is either failing or hasn't been scheduled on node `{{ $labels.node }}`.
+      )
+    labels:
+      d8_component: control-plane-manager
+      d8_module: control-plane-manager
+      severity_level: "6"
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__d8_control_plane_manager_unavailable: "D8ControlPlaneManagerUnavailable,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_control_plane_manager_unavailable: "D8ControlPlaneManagerUnavailable,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      summary: Controller pod isn't running on node `{{ $labels.node }}`.
+      description: |-
+        The `d8-control-plane-manager` pod is either failing or hasn't been scheduled on node `{{ $labels.node }}`.
 
-          To resolve this issue, check the status of the `kube-system/d8-control-plane-manager` DaemonSet and its pods by running the following command:
+        To resolve this issue, check the status of the `kube-system/d8-control-plane-manager` DaemonSet and its pods by running the following command:
 
-          ```bash
-          kubectl -n kube-system get daemonset,pod --selector=app=d8-control-plane-manager
-          ```
-    - alert: D8KubernetesVersionIsDeprecated
-      for: 10m
-      expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.28"}) == 1
-      labels:
-        severity_level: "7"
-        tier: cluster
-      annotations:
-        plk_protocol_version: "1"
-        plk_markup_format: "markdown"
-        summary: Kubernetes version `{{ $labels.k8s_version }}` is deprecated.
-        description: |-
-          The current Kubernetes version `{{ $labels.k8s_version }}` has been deprecated, and support for it will be removed in upcoming releases.
+        ```bash
+        kubectl -n kube-system get daemonset,pod --selector=app=d8-control-plane-manager
+        ```
+  - alert: D8KubernetesVersionIsDeprecated
+    for: 10m
+    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.28"}) == 1
+    labels:
+      severity_level: "7"
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      summary: Kubernetes version `{{ $labels.k8s_version }}` is deprecated.
+      description: |-
+        The current Kubernetes version `{{ $labels.k8s_version }}` has been deprecated, and support for it will be removed in upcoming releases.
 
-          Please migrate to the next kubernetes version (at least 1.29)
+        Please migrate to the next kubernetes version (at least 1.29)
 
-          Check how to update the Kubernetes version in the cluster here - https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster
+        Check how to update the Kubernetes version in the cluster here - https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster
 
-          Refer to the [Kubernetes upgrade guide](https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster) for instructions.
+        Refer to the [Kubernetes upgrade guide](https://deckhouse.io/documentation/deckhouse-faq.html#how-do-i-upgrade-the-kubernetes-version-in-a-cluster) for instructions.
 
-    - alert: D8KubernetesStaleTokensDetected
-      for: 10m
-      expr: sum(rate(serviceaccount_stale_tokens_total[$__rate_interval])) by (instance) > 0
-      labels:
-        severity_level: "8"
-        tier: cluster
-      annotations:
-        plk_protocol_version: "1"
-        plk_markup_format: "markdown"
-        summary: "Stale service account tokens detected"
-        description: |-
-          This issue may occur if the application reads the token only at startup and does not reload it periodically. As a result, an outdated token might be used, leading to security breach and authentication failures.
+  - alert: D8KubernetesStaleTokensDetected
+    for: 10m
+    expr: sum(rate(serviceaccount_stale_tokens_total[$__rate_interval])) by (instance) > 0
+    labels:
+      severity_level: "8"
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      summary: "Stale service account tokens detected"
+      description: |-
+        This issue may occur if the application reads the token only at startup and does not reload it periodically. As a result, an outdated token might be used, leading to security breach and authentication failures.
 
-          **Recommended Actions:**
-          - Ensure your application is configured to periodically reload the token from the file system.
-          - Verify that you are using an up-to-date client library that supports automatic token rotation.
+        **Recommended Actions:**
+        - Ensure your application is configured to periodically reload the token from the file system.
+        - Verify that you are using an up-to-date client library that supports automatic token rotation.
 
-          **Note:**
-          Currently, these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (Default: true). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
+        **Note:**
+        Currently, these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (Default: true). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
 
-          **For further investigation:**
-          Log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
+        **For further investigation:**
+        Log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
 
-          ```
-          jq 'select(.annotations["authentication.k8s.io/stale-token"]) | {auditID, stageTimestamp, requestURI, verb, user: .user.username, stale_token: .annotations["authentication.k8s.io/stale-token"]}' /var/log/kube-audit/audit.log
-          ```
+        ```
+        jq 'select(.annotations["authentication.k8s.io/stale-token"]) | {auditID, stageTimestamp, requestURI, verb, user: .user.username, stale_token: .annotations["authentication.k8s.io/stale-token"]}' /var/log/kube-audit/audit.log
+        ```

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -72,11 +72,10 @@
         - Ensure your application is configured to periodically reload the token from the file system.
         - Verify that you are using an up-to-date client library that supports automatic token rotation.
 
-        **Note:**
-        Currently, these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (Default: true). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
+        Note that currently these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (`Default: true`). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
 
         **For further investigation:**
-        Log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
+        log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
 
         ```
         jq 'select(.annotations["authentication.k8s.io/stale-token"]) | {auditID, stageTimestamp, requestURI, verb, user: .user.username, stale_token: .annotations["authentication.k8s.io/stale-token"]}' /var/log/kube-audit/audit.log


### PR DESCRIPTION
## Description
This PR adds a new alert rule: **D8KubernetesStaleTokensDetected**.  
The alert fires when stale service account tokens are detected in the cluster.

Currently these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (Default: true). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.

For security reasons, this should be fixed.

## Why do we need it, and what problem does it solve?

Stale tokens can cause security risks and authentication failures because some applications read the token only at startup and do not refresh it later.  

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: control-plane-manager
type: feature
summary: add alert for detecting stale service account tokens
impact: 
impact_level: default
