### PR TITLE
[metallb] Fix race condition between hooks

### DIFF
--- a/ee/se/modules/380-metallb/hooks/migration_adopt_old_fashioned_l2_lbs.go
+++ b/ee/se/modules/380-metallb/hooks/migration_adopt_old_fashioned_l2_lbs.go
@@ -24,7 +24,7 @@ import (
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	// Depends on 'migration-auto-generating-l2-mlbc.go' hook, we need the ipAddressPoolToMLBCMap here
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
-	Queue:        "/modules/metallb/services-migration",
+	Queue:        "/modules/metallb/discovery",
 }, dependency.WithExternalDependencies(discoveryServicesForMigrate))
 
 func discoveryServicesForMigrate(input *go_hook.HookInput, dc dependency.Container) error {

--- a/ee/se/modules/380-metallb/hooks/migration_auto_generating_l2_mlbc.go
+++ b/ee/se/modules/380-metallb/hooks/migration_auto_generating_l2_mlbc.go
@@ -17,9 +17,9 @@ import (
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	// Depends on 'migration-adopt-old-fashioned-l2-lbs.go' hook
+	// 'migration-adopt-old-fashioned-l2-lbs.go' depends on this hook
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 5},
-	Queue:        "/modules/metallb/generate-mlbc",
+	Queue:        "/modules/metallb/discovery",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "module_config",


### PR DESCRIPTION
## Description
Multiple interdependent hooks are executed in parallel, causing a race condition. We have moved them to a single queue with sequential execution.

## Why do we need it, and what problem does it solve?
Sometimes, due to parallel work of hooks, not all the Services are being migrated to the new controller and old External IPs are assigned to the wrong Services.

## Why do we need it in the patch release (if we do)?
Customers face this problem at the production stage.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: fix
summary: Fixed race condition in migration hook.
```
