### PR TITLE
[deckhouse-controller] fix creating deckhouse release loop

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
@@ -43,6 +43,7 @@ const (
 	DeckhouseReleaseAnnotationDryrun                = "dryrun"
 	DeckhouseReleaseAnnotationTriggeredByDryrun     = "triggered_by_dryrun"
 	DeckhouseReleaseAnnotationCurrentRestored       = "release.deckhouse.io/current-restored"
+	DeckhouseReleaseAnnotationChangeCause           = "release.deckhouse.io/change-cause"
 
 	// TODO: remove in entire code
 	DeckhouseReleaseAnnotationCooldown = "release.deckhouse.io/cooldown"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -187,13 +187,6 @@ func (f *DeckhouseReleaseFetcher) fetchDeckhouseRelease(ctx context.Context) err
 		return fmt.Errorf("get new image: %w", imageErr)
 	}
 
-	var releaseMetadata *ReleaseMetadata
-
-	// only if image changed
-	if imageErr == nil {
-		releaseMetadata = imageInfo.Metadata
-	}
-
 	var (
 		deployedRelease *v1alpha1.DeckhouseRelease
 	)
@@ -240,7 +233,7 @@ func (f *DeckhouseReleaseFetcher) fetchDeckhouseRelease(ctx context.Context) err
 		return nil
 	}
 
-	newSemver, err := semver.NewVersion(releaseMetadata.Version)
+	newSemver, err := semver.NewVersion(imageInfo.Metadata.Version)
 	if err != nil {
 		// TODO: maybe set something like v1.0.0-{meta.Version} for developing purpose
 		return fmt.Errorf("parse semver: %w", err)
@@ -262,7 +255,7 @@ func (f *DeckhouseReleaseFetcher) fetchDeckhouseRelease(ctx context.Context) err
 		releasesInCluster = releasesFromDeployed
 	}
 
-	lastCreatedMeta, err := f.createReleases(ctx, releaseMetadata, releaseForUpdate, releasesInCluster, newSemver)
+	lastCreatedMeta, err := f.createReleases(ctx, imageInfo.Metadata, releaseForUpdate, releasesInCluster, newSemver)
 	if err != nil {
 		return fmt.Errorf("create releases: %w", err)
 	}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -193,7 +193,7 @@ func (f *DeckhouseReleaseFetcher) fetchDeckhouseRelease(ctx context.Context) err
 	}
 
 	var releaseForUpdate *v1alpha1.DeckhouseRelease
-	releasesInCluster := make([]*v1alpha1.DeckhouseRelease, 0)
+	releasesInCluster := make([]*v1alpha1.DeckhouseRelease, 0, len(releases))
 
 	idx, deployedRelease := getLatestDeployedRelease(releases)
 	if idx != -1 {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -167,7 +167,6 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 		return fmt.Errorf("parse semver: %w", err)
 	}
 
-	r.releaseVersionImageHash = imageInfo.Digest.String()
 	r.metricStorage.Grouped().ExpireGroupMetrics(metricUpdatingFailedGroup)
 
 	releaseForUpdate := deployedRelease
@@ -184,6 +183,9 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 	if err != nil {
 		return fmt.Errorf("create releases: %w", err)
 	}
+
+	// update image hash only if create all releases
+	r.releaseVersionImageHash = imageInfo.Digest.String()
 
 	sort.Sort(sort.Reverse(releaseUpdater.ByVersion[*v1alpha1.DeckhouseRelease](releases)))
 

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -868,7 +868,7 @@ func (f *DeckhouseReleaseFetcher) getNewVersions(ctx context.Context, actual, ta
 	const minVersionsCapacity = 10
 
 	// Get only highest patch version for each minor version between actual and target
-	result := make([]*semver.Version, minVersionsCapacity)
+	result := make([]*semver.Version, 0, minVersionsCapacity)
 	var lastVer *semver.Version
 
 	for _, ver := range collection {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -80,41 +80,6 @@ type DeckhouseReleaseFetcherConfig struct {
 	logger *log.Logger
 }
 
-func NewDeckhouseReleaseFetcher(cfg *DeckhouseReleaseFetcherConfig) *DeckhouseReleaseFetcher {
-	return &DeckhouseReleaseFetcher{
-		k8sClient:               cfg.k8sClient,
-		registryClient:          cfg.registryClient,
-		clock:                   cfg.clock,
-		moduleManager:           cfg.moduleManager,
-		releaseChannel:          cfg.releaseChannel,
-		releaseVersionImageHash: cfg.releaseVersionImageHash,
-		clusterUUID:             cfg.clusterUUID,
-		deckhouseVersion:        cfg.deckhouseVersion,
-		metricStorage:           cfg.metricStorage,
-		logger:                  cfg.logger,
-	}
-}
-
-type DeckhouseReleaseFetcher struct {
-	k8sClient      client.Client
-	registryClient cr.Client
-	clock          clockwork.Clock
-	moduleManager  moduleManager
-
-	clusterUUID             string
-	deckhouseVersion        string
-	releaseChannel          string
-	releaseVersionImageHash string
-
-	metricStorage *metricstorage.MetricStorage
-
-	logger *log.Logger
-}
-
-func (f *DeckhouseReleaseFetcher) GetReleaseChannel() string {
-	return f.releaseChannel
-}
-
 // checkDeckhouseRelease create fetcher and start
 func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) error {
 	if r.updateSettings.Get().ReleaseChannel == "" {
@@ -177,6 +142,41 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 	releaseFetcher := NewDeckhouseReleaseFetcher(cfg)
 
 	return releaseFetcher.fetchDeckhouseRelease(ctx)
+}
+
+func NewDeckhouseReleaseFetcher(cfg *DeckhouseReleaseFetcherConfig) *DeckhouseReleaseFetcher {
+	return &DeckhouseReleaseFetcher{
+		k8sClient:               cfg.k8sClient,
+		registryClient:          cfg.registryClient,
+		clock:                   cfg.clock,
+		moduleManager:           cfg.moduleManager,
+		releaseChannel:          cfg.releaseChannel,
+		releaseVersionImageHash: cfg.releaseVersionImageHash,
+		clusterUUID:             cfg.clusterUUID,
+		deckhouseVersion:        cfg.deckhouseVersion,
+		metricStorage:           cfg.metricStorage,
+		logger:                  cfg.logger,
+	}
+}
+
+type DeckhouseReleaseFetcher struct {
+	k8sClient      client.Client
+	registryClient cr.Client
+	clock          clockwork.Clock
+	moduleManager  moduleManager
+
+	clusterUUID             string
+	deckhouseVersion        string
+	releaseChannel          string
+	releaseVersionImageHash string
+
+	metricStorage *metricstorage.MetricStorage
+
+	logger *log.Logger
+}
+
+func (f *DeckhouseReleaseFetcher) GetReleaseChannel() string {
+	return f.releaseChannel
 }
 
 // fetchDeckhouseRelease is a complete flow for loop

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -274,6 +274,12 @@ func (f *DeckhouseReleaseFetcher) fetchDeckhouseRelease(ctx context.Context) err
 
 	// filter by skipped and suspended
 	for _, release := range releasesInCluster {
+		if release.Status.Phase != v1alpha1.DeckhouseReleasePhasePending &&
+			release.Status.Phase != v1alpha1.DeckhouseReleasePhaseSuspended &&
+			release.Status.Phase != "" {
+			continue
+		}
+
 		switch release.GetVersion().Compare(newSemver) {
 		// Lesser than
 		case -1:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -30,9 +31,8 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	registryv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/iancoleman/strcase"
-	"github.com/pkg/errors"
 	"github.com/spaolacci/murmur3"
 	"gopkg.in/yaml.v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -44,7 +44,6 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
 	releaseUpdater "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/releaseupdater"
-	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/cr"
 	"github.com/deckhouse/deckhouse/go_lib/libapi"
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -58,7 +57,7 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseReleaseLoop(ctx context.Conte
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		err := r.checkDeckhouseRelease(ctx)
 		if err != nil {
-			r.logger.Errorf("check Deckhouse release: %s", err)
+			r.logger.Error("check Deckhouse release", log.Err(err))
 		}
 	}, 3*time.Minute)
 }
@@ -87,6 +86,7 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 		opts           []cr.Option
 		imagesRegistry string
 	)
+
 	if registrySecret != nil {
 		rconf := &utils.RegistryConfig{
 			DockerConfig: registrySecret.DockerConfig,
@@ -100,56 +100,65 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 		imagesRegistry = registrySecret.ImageRegistry
 	}
 
-	releaseChecker, err := NewDeckhouseReleaseChecker(opts, r.logger, r.dc, r.moduleManager, imagesRegistry, releaseChannelName)
+	// client watch only one channel
+	// registry.deckhouse.io/deckhouse/ce/release-channel:$release-channel
+	regCli, err := r.dc.GetRegistryClient(path.Join(imagesRegistry, "release-channel"), opts...)
 	if err != nil {
-		return errors.Wrap(err, "create DeckhouseReleaseChecker failed")
+		return fmt.Errorf("get registry client: %w", err)
 	}
 
-	newImageHash, err := releaseChecker.FetchReleaseMetadata(r.releaseVersionImageHash)
-	if err != nil {
-		return err
+	releaseChecker := NewDeckhouseReleaseChecker(regCli, r.moduleManager, releaseChannelName, r.logger)
+
+	// get image info from release channel
+	imageInfo, imageErr := releaseChecker.GetNewImageInfo(ctx, r.releaseVersionImageHash)
+	if imageErr != nil && !errors.Is(imageErr, ErrImageNotChanged) {
+		return fmt.Errorf("get new image: %w", err)
+	}
+
+	// only if image changed
+	if imageErr == nil {
+		releaseChecker.releaseMetadata = imageInfo.Metadata
 	}
 
 	var (
-		releases               v1alpha1.DeckhouseReleaseList
-		currentDeployedRelease *v1alpha1.DeckhouseRelease
+		deployedRelease *v1alpha1.DeckhouseRelease
 	)
-	err = r.client.List(ctx, &releases)
+
+	releases, err := r.listDeckhouseReleases(ctx)
 	if err != nil {
-		return fmt.Errorf("get deckhouse releases: %w", err)
+		return fmt.Errorf("list deckhouse releases: %w", err)
 	}
 
-	pointerReleases := make([]*v1alpha1.DeckhouseRelease, 0, len(releases.Items))
-	for _, r := range releases.Items {
-		if r.GetPhase() == v1alpha1.DeckhouseReleasePhaseDeployed {
+	sort.Sort(releaseUpdater.ByVersion[*v1alpha1.DeckhouseRelease](releases))
+
+	releasesFromDeployed := make([]*v1alpha1.DeckhouseRelease, 0, len(releases))
+	for _, release := range releases {
+		if release.GetPhase() == v1alpha1.DeckhouseReleasePhaseDeployed {
 			// no deployed release was found or there is more than one deployed release (get the latest)
-			if currentDeployedRelease == nil || r.GetVersion().GreaterThan(currentDeployedRelease.GetVersion()) {
-				currentDeployedRelease = &r
+			if deployedRelease == nil || release.GetVersion().GreaterThan(deployedRelease.GetVersion()) {
+				deployedRelease = release
 			}
 		}
-		pointerReleases = append(pointerReleases, &r)
+
+		if deployedRelease != nil {
+			releasesFromDeployed = append(releasesFromDeployed, release)
+		}
 	}
 
-	sort.Sort(sort.Reverse(releaseUpdater.ByVersion[*v1alpha1.DeckhouseRelease](pointerReleases)))
-
 	// restore current deployed release if no deployed releases found
-	if currentDeployedRelease == nil {
+	if deployedRelease == nil {
+		r.logger.Warn("deployed deckhouse-release is not found, restoring...")
+
 		if err := r.restoreCurrentDeployedRelease(ctx, releaseChecker, r.deckhouseVersion); err != nil {
 			return fmt.Errorf("restore current deployed release: %w", err)
 		}
+
+		r.logger.Warn("deployed deckhouse-release restored")
 	}
 
 	// no new image found
-	if newImageHash == "" {
+	if errors.Is(imageErr, ErrImageNotChanged) {
 		return nil
-	}
-
-	// run only if it's a canary release
-	var (
-		cooldownUntil, notificationShiftTime *metav1.Time
-	)
-	if releaseChecker.releaseMetadata.Cooldown != nil {
-		cooldownUntil = releaseChecker.releaseMetadata.Cooldown
 	}
 
 	newSemver, err := semver.NewVersion(releaseChecker.releaseMetadata.Version)
@@ -157,13 +166,35 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 		// TODO: maybe set something like v1.0.0-{meta.Version} for developing purpose
 		return fmt.Errorf("parse semver: %w", err)
 	}
-	r.releaseVersionImageHash = newImageHash
+
+	r.releaseVersionImageHash = imageInfo.Digest.String()
 	r.metricStorage.Grouped().ExpireGroupMetrics(metricUpdatingFailedGroup)
 
-	for _, release := range pointerReleases {
-		switch {
-		// GT
-		case release.GetVersion().GreaterThan(newSemver):
+	releaseForUpdate := deployedRelease
+	// shortened slice for only releases after deployed
+	releasesInCluster := releasesFromDeployed
+
+	if deployedRelease == nil {
+		// check sequence from the start if no deckhouse release deployed
+		releaseForUpdate = releases[0]
+		releasesInCluster = releases
+	}
+
+	err = r.createReleases(ctx, releaseChecker, releaseForUpdate, releasesInCluster, newSemver)
+	if err != nil {
+		return fmt.Errorf("create releases: %w", err)
+	}
+
+	sort.Sort(sort.Reverse(releaseUpdater.ByVersion[*v1alpha1.DeckhouseRelease](releases)))
+
+	// filter by skipped and suspended
+	for _, release := range releasesInCluster {
+		switch release.GetVersion().Compare(newSemver) {
+		// Lesser than
+		case -1:
+			// pass
+		// Greater than
+		case 1:
 			// cleanup versions which are older than current version in a specified channel and are in a Pending state
 			if release.Status.Phase == v1alpha1.DeckhouseReleasePhasePending {
 				err = r.client.Delete(ctx, release, client.PropagationPolicy(metav1.DeletePropagationBackground))
@@ -171,96 +202,81 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 					return fmt.Errorf("delete old release: %w", err)
 				}
 			}
+		// Equal
+		case 0:
+			r.logger.Debug("Release already exists", slog.String("version", release.GetVersion().Original()))
 
-			// EQ
-		case release.GetVersion().Equal(newSemver):
-			r.logger.Debugf("Release with version %s already exists", release.GetVersion())
 			switch release.Status.Phase {
 			case v1alpha1.DeckhouseReleasePhasePending, "":
 				if releaseChecker.releaseMetadata.Suspend {
-					patch := client.RawPatch(types.MergePatchType, buildSuspendAnnotation(releaseChecker.releaseMetadata.Suspend))
-					err := r.client.Patch(ctx, release, patch)
+					err := r.patchSetSuspendAnnotation(ctx, release, true)
 					if err != nil {
-						return fmt.Errorf("patch release %v: %w", release.Name, err)
-					}
-
-					err = r.client.Status().Patch(ctx, release, patch)
-					if err != nil {
-						return fmt.Errorf("patch release %v status: %w", release.Name, err)
+						return fmt.Errorf("patch suspend annotation: %w", err)
 					}
 				}
 
 			case v1alpha1.DeckhouseReleasePhaseSuspended:
 				if !releaseChecker.releaseMetadata.Suspend {
-					patch := client.RawPatch(types.MergePatchType, buildSuspendAnnotation(releaseChecker.releaseMetadata.Suspend))
-					err := r.client.Patch(ctx, release, patch)
+					err := r.patchSetSuspendAnnotation(ctx, release, false)
 					if err != nil {
-						return fmt.Errorf("patch release %v: %w", release.Name, err)
-					}
-
-					err = r.client.Status().Patch(ctx, release, patch)
-					if err != nil {
-						return fmt.Errorf("patch release %v status: %w", release.Name, err)
+						return fmt.Errorf("patch suspend annotation: %w", err)
 					}
 				}
 			}
 
 			return nil
-
-		// LT
 		default:
-			// inherit cooldown from previous patch release
-			// we need this to automatically set cooldown for next patch releases
-			if cooldownUntil == nil &&
-				release.GetCooldownUntil() != nil &&
-				release.GetVersion().Major() == newSemver.Major() &&
-				release.GetVersion().Minor() == newSemver.Minor() {
-				cooldownUntil = &metav1.Time{Time: *release.GetCooldownUntil()}
-			}
-
-			if release.GetNotificationShift() &&
-				release.GetApplyAfter() != nil &&
-				release.GetVersion().Major() == newSemver.Major() &&
-				release.GetVersion().Minor() == newSemver.Minor() {
-				notificationShiftTime = &metav1.Time{Time: *release.GetApplyAfter()}
-			}
-
-			actual := release.GetVersion()
-			for !actual.Equal(newSemver) {
-				if actual, err = releaseChecker.StepByStepUpdate(ctx, actual, newSemver); err != nil {
-					releaseChecker.logger.Errorf("step by step update failed. err: %v", err)
-					labels := map[string]string{
-						"version": release.GetVersion().Original(),
-					}
-
-					r.metricStorage.Grouped().GaugeSet(metricUpdatingFailedGroup, "d8_updating_is_failed", 1, labels)
-					return err
-				}
-
-				err = r.createRelease(ctx, releaseChecker, cooldownUntil, notificationShiftTime)
-				if err != nil {
-					return fmt.Errorf("create release %s: %w", releaseChecker.releaseMetadata.Version, err)
-				}
-
-				if releaseChecker.releaseMetadata.Cooldown != nil {
-					cooldownUntil = releaseChecker.releaseMetadata.Cooldown
-				}
-			}
+			r.logger.Error("bad compare output, possibly bug")
 		}
 	}
 
 	return nil
 }
 
+// isUpdatingSequence checks that version 'a' and 'b' allowed to updating from 'a' to 'b'
+// this helper function is to calculate necessary of registry listing
+// 'a' version must be lower than 'b' version
+// if 'a' major version +1 is lower than 'b' major version - it's no updating sequence
+// if 'a' minor version +1 is lower than 'b' minor version - it's no updating sequence
+func isUpdatingSequence(a, b *semver.Version) bool {
+	if a.Major()+1 < b.Major() {
+		return false
+	}
+
+	if a.Minor()+1 < b.Minor() {
+		return false
+	}
+
+	return true
+}
+
+func (r *deckhouseReleaseReconciler) listDeckhouseReleases(ctx context.Context) ([]*v1alpha1.DeckhouseRelease, error) {
+	releases := new(v1alpha1.DeckhouseReleaseList)
+
+	if err := r.client.List(ctx, releases); err != nil {
+		return nil, fmt.Errorf("get deckhouse releases: %w", err)
+	}
+
+	result := make([]*v1alpha1.DeckhouseRelease, 0, len(releases.Items))
+
+	for _, release := range releases.Items {
+		result = append(result, &release)
+	}
+
+	return result, nil
+}
+
 func (r *deckhouseReleaseReconciler) restoreCurrentDeployedRelease(ctx context.Context, releaseChecker *DeckhouseReleaseChecker, tag string) error {
 	var releaseMetadata *ReleaseMetadata
 
-	if image, err := releaseChecker.registryClient.Image(ctx, tag); err != nil {
+	image, err := releaseChecker.registryClient.Image(ctx, tag)
+	if err != nil {
 		r.logger.Warn("couldn't get current deployed release's image from registry", slog.String("image", tag), log.Err(err))
-	} else {
-		if releaseMetadata, err = releaseChecker.fetchReleaseMetadata(image); err != nil {
-			r.logger.Warn("couldn't fetch current deployed release's image metadata", slog.String("image", tag), log.Err(err))
-		}
+	}
+
+	releaseMetadata, err = releaseChecker.fetchReleaseMetadata(image)
+	if err != nil {
+		r.logger.Warn("couldn't fetch current deployed release's image metadata", slog.String("image", tag), log.Err(err))
 	}
 
 	release := &v1alpha1.DeckhouseRelease{
@@ -291,6 +307,107 @@ func (r *deckhouseReleaseReconciler) restoreCurrentDeployedRelease(ctx context.C
 	}
 
 	return client.IgnoreAlreadyExists(r.client.Create(ctx, release))
+}
+
+// createReleases flow:
+// 1) if deployed release patch version is lower than channel (with same minor and major) - create from channel
+// 2) if deployed release minor version is lower than channel (with same major) - create from channel
+// 3) if deployed release minor version is lower by 2 or more than channel (with same major) - look at releases in cluster
+// 3.1) if update sequence between deployed release and last release in cluster is broken - get releases from registry between deployed and version from channel, and create releases
+// 3.2) if update sequence between deployed release and last release in cluster not broken - check update sequence between last release in cluster and version in channel
+// 3.2.1) if update sequence between last release in cluster and version in channel is broken - get releases from registry between last release in cluster and version from channel, and create releases
+// 3.2.2) if update sequence between last release in cluster and version in channel not broken - create from channel
+// 3.3) if update sequences not broken - create from channel
+func (r *deckhouseReleaseReconciler) createReleases(ctx context.Context, releaseChecker *DeckhouseReleaseChecker,
+	releaseForUpdate *v1alpha1.DeckhouseRelease, releasesInCluster []*v1alpha1.DeckhouseRelease,
+	newSemver *semver.Version) error {
+	// run only if it's a canary release
+	var (
+		cooldownUntil, notificationShiftTime *metav1.Time
+	)
+
+	if releaseChecker.releaseMetadata.Cooldown != nil {
+		cooldownUntil = releaseChecker.releaseMetadata.Cooldown
+	}
+
+	// create release if deployed release and new release are in updating sequence
+	actual := releaseForUpdate
+	if isUpdatingSequence(actual.GetVersion(), newSemver) {
+		err := r.createRelease(ctx, releaseChecker, cooldownUntil, notificationShiftTime)
+		if err != nil {
+			return fmt.Errorf("create release %s: %w", releaseChecker.releaseMetadata.Version, err)
+		}
+
+		return nil
+	}
+
+	isSequence := false
+	for i := 1; i < len(releasesInCluster); i++ {
+		isSequence = isUpdatingSequence(releasesInCluster[i-1].GetVersion(), releasesInCluster[i].GetVersion())
+		if !isSequence {
+			break
+		}
+	}
+
+	if isSequence {
+		// check
+		actual = releasesInCluster[len(releasesInCluster)-1]
+
+		// create release if last release and new release are in updating sequence
+		if isUpdatingSequence(actual.GetVersion(), newSemver) {
+			// TODO: remove cooldown and notificationShiftTime?
+			err := r.createRelease(ctx, releaseChecker, cooldownUntil, notificationShiftTime)
+			if err != nil {
+				return fmt.Errorf("create release %s: %w", releaseChecker.releaseMetadata.Version, err)
+			}
+
+			return nil
+		}
+	}
+
+	// inherit cooldown from previous patch release
+	// we need this to automatically set cooldown for next patch releases
+	if cooldownUntil == nil &&
+		actual.GetCooldownUntil() != nil &&
+		actual.GetVersion().Major() == newSemver.Major() &&
+		actual.GetVersion().Minor() == newSemver.Minor() {
+		cooldownUntil = &metav1.Time{Time: *actual.GetCooldownUntil()}
+	}
+
+	if actual.GetNotificationShift() &&
+		actual.GetApplyAfter() != nil &&
+		actual.GetVersion().Major() == newSemver.Major() &&
+		actual.GetVersion().Minor() == newSemver.Minor() {
+		notificationShiftTime = &metav1.Time{Time: *actual.GetApplyAfter()}
+	}
+
+	metas, err := releaseChecker.GetNewReleasesMetadata(ctx, actual.GetVersion(), newSemver)
+	if err != nil {
+		releaseChecker.logger.Error("step by step update failed", log.Err(err))
+
+		labels := map[string]string{
+			"version": releaseForUpdate.GetVersion().Original(),
+		}
+
+		r.metricStorage.Grouped().GaugeSet(metricUpdatingFailedGroup, "d8_updating_is_failed", 1, labels)
+
+		return err
+	}
+
+	for _, meta := range metas {
+		releaseChecker.releaseMetadata = &meta
+
+		err = r.createRelease(ctx, releaseChecker, cooldownUntil, notificationShiftTime)
+		if err != nil {
+			return fmt.Errorf("create release %s: %w", releaseChecker.releaseMetadata.Version, err)
+		}
+
+		if releaseChecker.releaseMetadata.Cooldown != nil {
+			cooldownUntil = releaseChecker.releaseMetadata.Cooldown
+		}
+	}
+
+	return nil
 }
 
 func (r *deckhouseReleaseReconciler) createRelease(ctx context.Context, releaseChecker *DeckhouseReleaseChecker,
@@ -363,31 +480,40 @@ func (r *deckhouseReleaseReconciler) createRelease(ctx context.Context, releaseC
 	return client.IgnoreAlreadyExists(r.client.Create(ctx, release))
 }
 
-func NewDeckhouseReleaseChecker(opts []cr.Option, logger *log.Logger, dc dependency.Container, moduleManager moduleManager, imagesRegistry, releaseChannel string) (*DeckhouseReleaseChecker, error) {
-	// registry.deckhouse.io/deckhouse/ce/release-channel:$release-channel
-	regCli, err := dc.GetRegistryClient(path.Join(imagesRegistry, "release-channel"), opts...)
+func (r *deckhouseReleaseReconciler) patchSetSuspendAnnotation(ctx context.Context, release *v1alpha1.DeckhouseRelease, suspend bool) error {
+	patch := client.RawPatch(types.MergePatchType, buildSuspendAnnotation(suspend))
+
+	err := r.client.Patch(ctx, release, patch)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("patch release %v: %w", release.Name, err)
 	}
 
-	dcr := &DeckhouseReleaseChecker{
+	err = r.client.Status().Patch(ctx, release, patch)
+	if err != nil {
+		return fmt.Errorf("patch release %v status: %w", release.Name, err)
+	}
+
+	return nil
+}
+
+func NewDeckhouseReleaseChecker(regCli cr.Client, moduleManager moduleManager, releaseChannel string, logger *log.Logger) *DeckhouseReleaseChecker {
+	return &DeckhouseReleaseChecker{
 		registryClient: regCli,
-		logger:         logger,
 		moduleManager:  moduleManager,
 		releaseChannel: releaseChannel,
+		logger:         logger,
 	}
-
-	return dcr, nil
 }
 
 type DeckhouseReleaseChecker struct {
 	registryClient cr.Client
-	logger         *log.Logger
 	moduleManager  moduleManager
 
 	releaseChannel  string
-	releaseMetadata ReleaseMetadata
+	releaseMetadata *ReleaseMetadata
 	tags            []string
+
+	logger *log.Logger
 }
 
 func (dcr *DeckhouseReleaseChecker) IsCanaryRelease() bool {
@@ -399,33 +525,46 @@ func (dcr *DeckhouseReleaseChecker) releaseCanarySettings() canarySettings {
 	return dcr.releaseMetadata.Canary[dcr.releaseChannel]
 }
 
-func (dcr *DeckhouseReleaseChecker) FetchReleaseMetadata(previousImageHash string) (string, error) {
-	image, err := dcr.registryClient.Image(context.TODO(), dcr.releaseChannel)
+var ErrImageNotChanged = errors.New("image not changed")
+
+type ImageInfo struct {
+	Metadata *ReleaseMetadata
+	Image    registryv1.Image
+	Digest   registryv1.Hash
+}
+
+func (dcr *DeckhouseReleaseChecker) GetNewImageInfo(ctx context.Context, previousImageHash string) (*ImageInfo, error) {
+	image, err := dcr.registryClient.Image(ctx, dcr.releaseChannel)
 	if err != nil {
-		return "", err
+		return nil, fmt.Errorf("get image from channel '%s': %w", dcr.releaseChannel, err)
 	}
 
 	imageDigest, err := image.Digest()
 	if err != nil {
-		return "", err
+		return nil, fmt.Errorf("get image digest: %w", err)
 	}
+
 	if previousImageHash == imageDigest.String() {
-		// image has not been changed
-		return "", nil
+		return &ImageInfo{
+			Image:  image,
+			Digest: imageDigest,
+		}, ErrImageNotChanged
 	}
 
 	releaseMeta, err := dcr.fetchReleaseMetadata(image)
 	if err != nil {
-		return "", err
+		return nil, fmt.Errorf("fetch image metadata: %w", err)
 	}
 
 	if releaseMeta.Version == "" {
-		return "", fmt.Errorf("version not found. Probably image is broken or layer does not exist")
+		return nil, fmt.Errorf("version not found, probably image is broken or layer does not exist")
 	}
 
-	dcr.releaseMetadata = *releaseMeta
-
-	return imageDigest.String(), nil
+	return &ImageInfo{
+		Image:    image,
+		Digest:   imageDigest,
+		Metadata: releaseMeta,
+	}, nil
 }
 
 type releaseReader struct {
@@ -463,12 +602,18 @@ func (rr *releaseReader) untarMetadata(rc io.Reader) error {
 	}
 }
 
-func (dcr *DeckhouseReleaseChecker) fetchReleaseMetadata(img v1.Image) (*ReleaseMetadata, error) {
+var ErrImageIsNil = errors.New("image is nil")
+
+func (dcr *DeckhouseReleaseChecker) fetchReleaseMetadata(img registryv1.Image) (*ReleaseMetadata, error) {
+	if img == nil {
+		return nil, ErrImageIsNil
+	}
+
 	meta := new(ReleaseMetadata)
 
 	rc, err := cr.Extract(img)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("extract image: %w", err)
 	}
 	defer rc.Close()
 
@@ -479,13 +624,13 @@ func (dcr *DeckhouseReleaseChecker) fetchReleaseMetadata(img v1.Image) (*Release
 
 	err = rr.untarMetadata(rc)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("untar metadata: %w", err)
 	}
 
 	if rr.versionReader.Len() > 0 {
 		err = json.NewDecoder(rr.versionReader).Decode(&meta)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("metadata decode: %w", err)
 		}
 	}
 
@@ -495,7 +640,8 @@ func (dcr *DeckhouseReleaseChecker) fetchReleaseMetadata(img v1.Image) (*Release
 		err = yaml.NewDecoder(rr.changelogReader).Decode(&changelog)
 		if err != nil {
 			// if changelog build failed - warn about it but don't fail the release
-			dcr.logger.Warnf("Unmarshal CHANGELOG yaml failed: %s", err)
+			dcr.logger.Warn("Unmarshal CHANGELOG yaml failed", log.Err(err))
+
 			meta.Changelog = make(map[string]any)
 
 			return meta, nil
@@ -512,7 +658,7 @@ func (dcr *DeckhouseReleaseChecker) fetchReleaseMetadata(img v1.Image) (*Release
 	return meta, nil
 }
 
-func (dcr *DeckhouseReleaseChecker) fetchCooldown(image v1.Image) *metav1.Time {
+func (dcr *DeckhouseReleaseChecker) fetchCooldown(image registryv1.Image) *metav1.Time {
 	cfg, err := image.ConfigFile()
 	if err != nil {
 		dcr.logger.Warnf("image config error: %s", err)
@@ -568,76 +714,150 @@ func (dcr *DeckhouseReleaseChecker) CalculateReleaseDelay(ts metav1.Time, cluste
 	return nil
 }
 
-func (dcr *DeckhouseReleaseChecker) StepByStepUpdate(ctx context.Context, actual, target *semver.Version) (*semver.Version, error) {
-	nextVersion, err := dcr.nextVersion(ctx, actual, target)
+// FetchReleasesMetadata realize step by step update
+func (dcr *DeckhouseReleaseChecker) GetNewReleasesMetadata(ctx context.Context, actual, target *semver.Version) ([]ReleaseMetadata, error) {
+	vers, err := dcr.getNewVersions(ctx, actual, target)
 	if err != nil {
 		return nil, fmt.Errorf("get next version: %w", err)
 	}
 
-	image, err := dcr.registryClient.Image(ctx, nextVersion.Original())
-	if err != nil {
-		return nil, fmt.Errorf("get image: %w", err)
+	result := make([]ReleaseMetadata, 0, len(vers))
+
+	current := actual
+	for idx, ver := range vers {
+		// if next version is not in sequence with actual
+		if !isUpdatingSequence(current, ver) {
+			if idx == 0 {
+				return nil, fmt.Errorf("versions is not in sequence: '%s' and '%s'", actual.Original(), ver.Original())
+			}
+
+			dcr.logger.Warn("not sequential version", slog.String("previous", actual.Original()), slog.String("next", ver.Original()))
+
+			break
+		}
+
+		image, err := dcr.registryClient.Image(ctx, ver.Original())
+		if err != nil {
+			return nil, fmt.Errorf("get image: %w", err)
+		}
+
+		releaseMeta, err := dcr.fetchReleaseMetadata(image)
+		if err != nil {
+			return nil, fmt.Errorf("fetch release metadata: %w", err)
+		}
+
+		if releaseMeta.Version == "" {
+			return nil, fmt.Errorf("version not found. Probably image is broken or layer does not exist")
+		}
+
+		result = append(result, *releaseMeta)
+
+		current = ver
 	}
 
-	releaseMeta, err := dcr.fetchReleaseMetadata(image)
-	if err != nil {
-		return nil, fmt.Errorf("fetch release metadata: %w", err)
-	}
-
-	if releaseMeta.Version == "" {
-		return nil, fmt.Errorf("version not found. Probably image is broken or layer does not exist")
-	}
-
-	dcr.releaseMetadata = *releaseMeta
-
-	return nextVersion, nil
+	return result, nil
 }
 
-func (dcr *DeckhouseReleaseChecker) nextVersion(ctx context.Context, actual, target *semver.Version) (*semver.Version, error) {
-	if actual.Major() != target.Major() {
-		return nil, fmt.Errorf("major version updated") // TODO step by step update for major version
-	}
-
-	if actual.Minor() == target.Minor() {
-		return dcr.getMaxPatch(ctx, 1, actual.Minor())
-	}
-
-	// Here we get the following minor with the maximum patch version.
-	// <major.minor+1.max>
-	return dcr.getMaxPatch(ctx, 1, actual.IncMinor().Minor())
-}
-
-func (dcr *DeckhouseReleaseChecker) getMaxPatch(ctx context.Context, major, minor uint64) (*semver.Version, error) {
+// getNewVersions - getting all last patches from registry
+// it's ignore last patch of actual minor version, if it has new minor version
+//
+// f.e.
+// in registry:
+// 1.66.3 (deployed)
+// 1.66.5
+// result will be 1.66.5
+//
+// but if we have a new minor version like:
+// 1.66.3 (deployed)
+// 1.66.5
+// 1.67.11
+// result will be 1.67.11
+//
+// several patches:
+// 1.66.3 (deployed)
+// 1.66.5
+// 1.67.5
+// 1.67.11
+// 1.68.1
+// 1.68.3
+// 1.68.5
+// result will be [1.67.11, 1.68.5]
+func (dcr *DeckhouseReleaseChecker) getNewVersions(ctx context.Context, actual, target *semver.Version) ([]*semver.Version, error) {
 	tags, err := dcr.listTags(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list tags: %w", err)
 	}
 
-	expr := fmt.Sprintf("^v%d.%d.([0-9]+)$", major, minor)
-	r, err := regexp.Compile(expr)
-	if err != nil {
-		return nil, err
-	}
+	versionMatcher := regexp.MustCompile(`^v(([0-9]+).([0-9]+).([0-9]+))$`)
 
 	collection := make([]*semver.Version, 0)
+
+	// to be sure, they are sorted correctly we parse them before working
 	for _, ver := range tags {
-		if r.MatchString(ver) {
-			newSemver, err := semver.NewVersion(ver)
-			if err != nil {
-				dcr.logger.Errorf("unable to parse semver from the registry Version: %v. This version will be skipped.", ver)
-				continue
-			}
-			collection = append(collection, newSemver)
+		if !versionMatcher.MatchString(ver) {
+			dcr.logger.Debug("not suitable. This version will be skipped.", slog.String("version", ver))
+
+			continue
 		}
+
+		newSemver, err := semver.NewVersion(ver)
+		if err != nil {
+			dcr.logger.Warn("unable to parse semver from the registry. This version will be skipped.", slog.String("version", ver))
+
+			continue
+		}
+
+		collection = append(collection, newSemver)
 	}
 
 	if len(collection) == 0 {
-		return nil, fmt.Errorf("next minor version is missed")
+		return nil, fmt.Errorf("no matched tags in registry")
 	}
 
-	sort.Sort(sort.Reverse(semver.Collection(collection)))
+	sort.Sort(semver.Collection(collection))
 
-	return collection[0], nil
+	result := make([]*semver.Version, 0)
+	prevVersion := new(semver.Version)
+
+	for _, ver := range collection {
+		// skip all versions out of actual and target range
+		if actual.Major() > ver.Major() ||
+			(actual.Major() == ver.Major() && actual.Minor() > ver.Minor()) ||
+			target.Major() < ver.Major() ||
+			(target.Major() == ver.Major() && target.Minor() < ver.Minor()) {
+			continue
+		}
+
+		// add only last minor or last major releases
+		if !prevVersion.Equal(new(semver.Version)) &&
+			(prevVersion.Major() < ver.Major() || prevVersion.Minor() < ver.Minor()) {
+			result = append(result, prevVersion)
+		}
+
+		prevVersion = ver
+	}
+
+	// if last patch is more than target release - skip target
+	if prevVersion.Major() > target.Major() ||
+		(prevVersion.Major() == target.Major() && prevVersion.Minor() > target.Minor()) ||
+		(prevVersion.Major() == target.Major() && prevVersion.Minor() == target.Minor() && prevVersion.Patch() > target.Patch()) {
+		dcr.logger.Warn("last release is not equals to target, skipped", slog.String("last", prevVersion.Original()), slog.String("target", target.Original()))
+	} else {
+		result = append(result, prevVersion)
+	}
+
+	// trim max patch from current minor version
+	if len(result) > 1 {
+		if result[0].Minor() == actual.Minor() {
+			result = result[1:]
+		}
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no acceptable for step by step update tags in registry")
+	}
+
+	return result, nil
 }
 
 var globalModules = []string{"candi", "deckhouse-controller", "global"}
@@ -672,7 +892,6 @@ func (dcr *DeckhouseReleaseChecker) listTags(ctx context.Context) ([]string, err
 }
 
 type ReleaseMetadata struct {
-	// TODO: semVer as module?
 	Version      string                    `json:"version"`
 	Canary       map[string]canarySettings `json:"canary"`
 	Requirements map[string]string         `json:"requirements"`

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -409,15 +409,15 @@ func (f *DeckhouseReleaseFetcher) restoreCurrentDeployedRelease(ctx context.Cont
 
 // createReleases create releases and return metadata of last created release.
 // flow:
-// 1) if no releases in cluster - create from channel
-// 2) if deployed release patch version is lower than channel (with same minor and major) - create from channel
-// 3) if deployed release minor version is lower than channel (with same major) - create from channel
-// 4) if deployed release minor version is lower by 2 or more than channel (with same major) - look at releases in cluster
-// 4.1) if update sequence between deployed release and last release in cluster is broken - get releases from registry between deployed and version from channel, and create releases
-// 4.2) if update sequence between deployed release and last release in cluster not broken - check update sequence between last release in cluster and version in channel
-// 4.2.1) if update sequence between last release in cluster and version in channel is broken - get releases from registry between last release in cluster and version from channel, and create releases
-// 4.2.2) if update sequence between last release in cluster and version in channel not broken - create from channel
-// 4.3) if update sequences not broken - create from channel
+//  1. if no releases in cluster - create from channel
+//  2. if deployed release patch version is lower than channel (with same minor and major) - create from channel
+//  3. if deployed release minor version is lower than channel (with same major) - create from channel
+//  4. if deployed release minor version is lower by 2 or more than channel (with same major) - look at releases in cluster
+//     4.1 if update sequence between deployed release and last release in cluster is broken - get releases from registry between deployed and version from channel, and create releases
+//     4.2 if update sequence between deployed release and last release in cluster not broken - check update sequence between last release in cluster and version in channel
+//     4.2.1 if update sequence between last release in cluster and version in channel is broken - get releases from registry between last release in cluster and version from channel, and create releases
+//     4.2.2 if update sequence between last release in cluster and version in channel not broken - create from channel
+//     4.3 if update sequences not broken - create from channel
 func (f *DeckhouseReleaseFetcher) createReleases(
 	ctx context.Context,
 	releaseMetadata *ReleaseMetadata,

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -131,14 +131,6 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 
 	sort.Sort(releaseUpdater.ByVersion[*v1alpha1.DeckhouseRelease](releases))
 
-	var releaseForUpdate *v1alpha1.DeckhouseRelease
-
-	if len(releases) > 0 {
-		releaseForUpdate = releases[0]
-	}
-	releasesInCluster := releases
-
-	// check sequence from the start if no deckhouse release deployed
 	releasesFromDeployed := make([]*v1alpha1.DeckhouseRelease, 0, len(releases))
 	for _, release := range releases {
 		if release.GetPhase() == v1alpha1.DeckhouseReleasePhaseDeployed {
@@ -164,10 +156,6 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 
 		r.logger.Warn("deployed deckhouse-release restored")
 
-		if releaseForUpdate == nil {
-			releaseForUpdate = restored
-		}
-
 		releases = append(releases, restored)
 
 		sort.Sort(releaseUpdater.ByVersion[*v1alpha1.DeckhouseRelease](releases))
@@ -185,6 +173,14 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 	}
 
 	r.metricStorage.Grouped().ExpireGroupMetrics(metricUpdatingFailedGroup)
+
+	var releaseForUpdate *v1alpha1.DeckhouseRelease
+
+	// check sequence from the start if no deckhouse release deployed
+	if len(releases) > 0 {
+		releaseForUpdate = releases[0]
+	}
+	releasesInCluster := releases
 
 	// shortened slice for only releases after deployed
 	if deployedRelease != nil {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -74,7 +74,6 @@ type DeckhouseReleaseFetcherConfig struct {
 	deckhouseVersion        string
 	releaseChannel          string
 	releaseVersionImageHash string
-	tags                    []string
 
 	metricStorage *metricstorage.MetricStorage
 
@@ -106,7 +105,6 @@ type DeckhouseReleaseFetcher struct {
 	deckhouseVersion        string
 	releaseChannel          string
 	releaseVersionImageHash string
-	tags                    []string
 
 	metricStorage *metricstorage.MetricStorage
 
@@ -853,7 +851,7 @@ func (dcr *DeckhouseReleaseFetcher) GetNewReleasesMetadata(ctx context.Context, 
 // 1.68.5
 // result will be [1.67.11, 1.68.5]
 func (dcr *DeckhouseReleaseFetcher) getNewVersions(ctx context.Context, actual, target *semver.Version) ([]*semver.Version, error) {
-	tags, err := dcr.listTags(ctx)
+	tags, err := dcr.registryClient.ListTags(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list tags: %w", err)
 	}
@@ -950,15 +948,6 @@ func (r *DeckhouseReleaseFetcher) generateChangelogForEnabledModules(releaseMeta
 	}
 
 	return enabledModulesChangelog
-}
-
-func (dcr *DeckhouseReleaseFetcher) listTags(ctx context.Context) ([]string, error) {
-	var err error
-	if dcr.tags == nil {
-		dcr.tags, err = dcr.registryClient.ListTags(ctx)
-	}
-
-	return dcr.tags, err
 }
 
 type ReleaseMetadata struct {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -751,7 +751,7 @@ func (f *DeckhouseReleaseFetcher) fetchReleaseMetadata(img registryv1.Image) (*R
 func (f *DeckhouseReleaseFetcher) fetchCooldown(image registryv1.Image) *metav1.Time {
 	cfg, err := image.ConfigFile()
 	if err != nil {
-		f.logger.Warnf("image config error: %s", err)
+		f.logger.Warn("image config error", log.Err(err))
 		return nil
 	}
 

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -202,7 +202,7 @@ func (f *DeckhouseReleaseFetcher) fetchDeckhouseRelease(ctx context.Context) err
 	}
 
 	// check sequence from the start if no deckhouse release deployed
-	// lst element because it's reversed
+	// last element because it's reversed
 	if len(releasesInCluster) == 0 && len(releases) > 0 {
 		releaseForUpdate = releases[len(releases)-1]
 		releasesInCluster = releases
@@ -909,6 +909,7 @@ func (f *DeckhouseReleaseFetcher) getNewVersions(ctx context.Context, actual, ta
 		(prevVersion.Major() == target.Major() && prevVersion.Minor() > target.Minor()) ||
 		(prevVersion.Major() == target.Major() && prevVersion.Minor() == target.Minor() && prevVersion.Patch() > target.Patch()) {
 		f.logger.Warn("last release is not equals to target, skipped", slog.String("last", prevVersion.Original()), slog.String("target", target.Original()))
+		result = append(result, target)
 	} else {
 		result = append(result, prevVersion)
 	}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -164,11 +164,11 @@ func (r *deckhouseReleaseReconciler) checkDeckhouseRelease(ctx context.Context) 
 
 		r.logger.Warn("deployed deckhouse-release restored")
 
-		releases = append(releases, restored)
-
 		if releaseForUpdate == nil {
 			releaseForUpdate = restored
 		}
+
+		releases = append(releases, restored)
 
 		sort.Sort(releaseUpdater.ByVersion[*v1alpha1.DeckhouseRelease](releases))
 	}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -865,8 +865,10 @@ func (f *DeckhouseReleaseFetcher) getNewVersions(ctx context.Context, actual, ta
 
 	sort.Sort(semver.Collection(collection))
 
+	const minVersionsCapacity = 10
+
 	// Get only highest patch version for each minor version between actual and target
-	result := make([]*semver.Version, 0)
+	result := make([]*semver.Version, minVersionsCapacity)
 	var lastVer *semver.Version
 
 	for _, ver := range collection {
@@ -876,10 +878,9 @@ func (f *DeckhouseReleaseFetcher) getNewVersions(ctx context.Context, actual, ta
 		}
 
 		// Add version if it's first or has different minor/major from previous
-		if lastVer == nil || lastVer.Minor() < ver.Minor() || lastVer.Major() < ver.Major() {
-			if lastVer != nil {
-				result = append(result, lastVer)
-			}
+		if lastVer != nil &&
+			(lastVer.Minor() < ver.Minor() || lastVer.Major() < ver.Major()) {
+			result = append(result, lastVer)
 		}
 
 		lastVer = ver

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -223,6 +223,7 @@ func (f *DeckhouseReleaseFetcher) fetchDeckhouseRelease(ctx context.Context) err
 
 		f.logger.Warn("deployed deckhouse-release restored")
 
+		deployedRelease = restored
 		releases = append(releases, restored)
 
 		sort.Sort(releaseUpdater.ByVersion[*v1alpha1.DeckhouseRelease](releases))
@@ -252,7 +253,10 @@ func (f *DeckhouseReleaseFetcher) fetchDeckhouseRelease(ctx context.Context) err
 	// shortened slice for only releases after deployed
 	if deployedRelease != nil {
 		releaseForUpdate = deployedRelease
-		releasesInCluster = releasesFromDeployed
+
+		if len(releasesFromDeployed) > 0 {
+			releasesInCluster = releasesFromDeployed
+		}
 	}
 
 	lastCreatedMeta, err := f.createReleases(ctx, imageInfo.Metadata, releaseForUpdate, releasesInCluster, newSemver)

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -725,6 +725,7 @@ func parseTime(s string) (time.Time, error) {
 	return time.Parse(time.RFC3339, s)
 }
 
+// https://github.com/deckhouse/deckhouse/issues/332
 func (dcr *DeckhouseReleaseChecker) CalculateReleaseDelay(ts metav1.Time, clusterUUID string) *metav1.Time {
 	hash := murmur3.Sum64([]byte(clusterUUID + dcr.releaseMetadata.Version))
 	wave := hash % uint64(dcr.releaseCanarySettings().Waves)

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -275,8 +275,7 @@ func (f *DeckhouseReleaseFetcher) fetchDeckhouseRelease(ctx context.Context) err
 	// filter by skipped and suspended
 	for _, release := range releasesInCluster {
 		if release.Status.Phase != v1alpha1.DeckhouseReleasePhasePending &&
-			release.Status.Phase != v1alpha1.DeckhouseReleasePhaseSuspended &&
-			release.Status.Phase != "" {
+			release.Status.Phase != v1alpha1.DeckhouseReleasePhaseSuspended {
 			continue
 		}
 

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
@@ -438,11 +438,6 @@ global:
 				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
 			},
 		}, nil)
-		dependency.TestDC.CRClient.ImageMock.When("v1.32.3").Then(&fake.FakeImage{
-			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.32.3"}`}}}, nil
-			},
-		}, nil)
 
 		suite.setupController("step-by-step-update-failed.yaml", initValues, embeddedMUP)
 		err := suite.ctr.checkDeckhouseRelease(ctx)
@@ -469,6 +464,7 @@ global:
 				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
 			},
 		}, nil)
+
 		dependency.TestDC.CRClient.ImageMock.When("v1.32.3").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
@@ -254,7 +254,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
 					FilesContent: map[string]string{
-						"version.json": `{"version":"v1.16.0","canary":{"stable":{"enabled":true,"interval":"30m","waves":6},"alpha":{"enabled":true,"interval":"5m","waves":2}, "beta":{"enabled":false,"interval":"1m","waves":1},"early-access":{"enabled":true,"interval":"30m","waves":6},"rock-solid":{"enabled":false,"interval":"5m","waves":5}}}`}}}, nil
+						"version.json": `{"version":"v1.16.1","canary":{"stable":{"enabled":true,"interval":"30m","waves":6},"alpha":{"enabled":true,"interval":"5m","waves":2}, "beta":{"enabled":false,"interval":"1m","waves":1},"early-access":{"enabled":true,"interval":"30m","waves":6},"rock-solid":{"enabled":false,"interval":"5m","waves":5}}}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76859")

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
@@ -85,7 +85,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
-					FilesContent: map[string]string{`version.json`: `{"version": "v1.25.3"}`}},
+					FilesContent: map[string]string{`version.json`: `{"version": "v1.16.3"}`}},
 				}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
@@ -106,7 +106,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
 					FilesContent: map[string]string{
-						`version.json`: `{"version": "v1.25.0", "canary": {"stable": {"enabled": true, "waves": 5, "interval": "6m"}}}`,
+						`version.json`: `{"version": "v1.16.0", "canary": {"stable": {"enabled": true, "waves": 5, "interval": "6m"}}}`,
 					}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
@@ -126,7 +126,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
 					FilesContent: map[string]string{
-						`version.json`: `{"version": "v1.25.5", "canary": {"stable": {"enabled": true, "waves": 5, "interval": "15m"}}}`,
+						`version.json`: `{"version": "v1.16.5", "canary": {"stable": {"enabled": true, "waves": 5, "interval": "15m"}}}`,
 					}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
@@ -144,7 +144,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
-					FilesContent: map[string]string{`version.json`: `{"version": "v1.25.0", "suspend": true}`}}}, nil
+					FilesContent: map[string]string{`version.json`: `{"version": "v1.16.0", "suspend": true}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
@@ -160,7 +160,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
-					FilesContent: map[string]string{`version.json`: `{"version": "v1.25.0", "suspend": true}`}}}, nil
+					FilesContent: map[string]string{`version.json`: `{"version": "v1.16.0", "suspend": true}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
@@ -178,7 +178,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
-					FilesContent: map[string]string{`version.json`: `{"version": "v1.25.0", "suspend": true}`}}}, nil
+					FilesContent: map[string]string{`version.json`: `{"version": "v1.16.0", "suspend": true}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
@@ -196,7 +196,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
-					FilesContent: map[string]string{`version.json`: `{"version": "v1.25.0"}`}}}, nil
+					FilesContent: map[string]string{`version.json`: `{"version": "v1.16.0"}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
@@ -214,7 +214,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
-					FilesContent: map[string]string{`version.json`: `{"version": "v1.25.0"}`}}}, nil
+					FilesContent: map[string]string{`version.json`: `{"version": "v1.16.0"}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f66857")
@@ -234,7 +234,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
 					FilesContent: map[string]string{
-						`version.json`: `{"version": "v1.30.0", "requirements": {"k8s": "1.19", "req1": "dep1"}}`,
+						`version.json`: `{"version": "v1.16.0", "requirements": {"k8s": "1.19", "req1": "dep1"}}`,
 					}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
@@ -254,7 +254,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{
 					FilesContent: map[string]string{
-						"version.json": `{"canary":{"alpha":{"enabled":true,"interval":"5m","waves":2}, "beta":{"enabled":false,"interval":"1m","waves":1},"early-access":{"enabled":true,"interval":"30m","waves":6},"rock-solid":{"enabled":false,"interval":"5m","waves":5},"stable":{"enabled":true,"interval":"30m","waves":6}},"version":"v1.31.0"}`}}}, nil
+						"version.json": `{"version":"v1.16.0","canary":{"stable":{"enabled":true,"interval":"30m","waves":6},"alpha":{"enabled":true,"interval":"5m","waves":2}, "beta":{"enabled":false,"interval":"1m","waves":1},"early-access":{"enabled":true,"interval":"30m","waves":6},"rock-solid":{"enabled":false,"interval":"5m","waves":5}}}`}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
 				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76859")
@@ -268,21 +268,19 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 
 	suite.Run("Release has cooldown", func() {
 		dependency.TestDC.CRClient.ListTagsMock.Return([]string{
-			"v1.31.0",
-			"v1.31.1",
-			"v1.32.0",
-			"v1.32.1",
-			"v1.32.2",
-			"v1.32.3",
-			"v1.33.0",
-			"v1.33.1",
+			"v1.16.0",
+			"v1.16.1",
+			"v1.16.2",
+			"v1.17.0",
+			"v1.17.1",
+			"v1.17.2",
 		}, nil)
 		dependency.TestDC.CRClient.ImageMock.When(testDeckhouseVersion).Then(testDeckhouseVersionImage, nil)
 		dependency.TestDC.CRClient.ImageMock.When("stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{
-					"version.json": `{"version":"v1.31.0"}`,
+					"version.json": `{"version":"v1.16.0"}`,
 				}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
@@ -308,7 +306,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{
-					"version.json": `{"version":"v1.31.1"}`,
+					"version.json": `{"version":"v1.16.1"}`,
 				}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
@@ -334,7 +332,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{
-					"version.json": `{"version":"v1.31.2"}`,
+					"version.json": `{"version":"v1.16.2"}`,
 				}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
@@ -360,7 +358,7 @@ func (suite *ControllerTestSuite) TestCheckDeckhouseRelease() {
 			ManifestStub: ManifestStub,
 			LayersStub: func() ([]v1.Layer, error) {
 				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{
-					"version.json": `{"version": "v1.32.0", "disruptions":{"1.32":["ingressNginx"]}}`,
+					"version.json": `{"version": "v1.16.0", "disruptions":{"1.16":["ingressNginx"]}}`,
 				}}}, nil
 			},
 			DigestStub: func() (v1.Hash, error) {
@@ -406,7 +404,7 @@ global:
 				return []v1.Layer{
 					&fakeLayer{},
 					&fakeLayer{FilesContent: map[string]string{
-						"version.json":   `{"version": "v1.31.0"}`,
+						"version.json":   `{"version": "v1.16.0"}`,
 						"changelog.yaml": changelog,
 					}},
 				}, nil

--- a/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
@@ -40,7 +40,7 @@ type ReleaseTestSuite struct {
 
 	kubeClient client.Client
 	ctr        *deckhouseReleaseReconciler
-	rc         *DeckhouseReleaseChecker
+	rc         *DeckhouseReleaseFetcher
 }
 
 func (suite *ReleaseTestSuite) SetupSuite() {
@@ -72,8 +72,13 @@ func (suite *ReleaseTestSuite) SetupSubTest() {
 	}, nil)
 
 	suite.ctr, suite.kubeClient = setupFakeController(suite.T(), "", initValues, embeddedMUP)
-	suite.rc = NewDeckhouseReleaseChecker(dependency.TestDC.CRClient,
-		suite.ctr.moduleManager, "", suite.ctr.logger)
+	cfg := &DeckhouseReleaseFetcherConfig{
+		registryClient: dependency.TestDC.CRClient,
+		moduleManager:  suite.ctr.moduleManager,
+		logger:         suite.ctr.logger,
+	}
+
+	suite.rc = NewDeckhouseReleaseFetcher(cfg)
 }
 
 func (suite *ReleaseTestSuite) TestCheckRelease() {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
@@ -64,35 +64,54 @@ func (suite *ReleaseTestSuite) SetupSubTest() {
 		"v1.32.3",
 		"v1.33.0",
 		"v1.33.1",
+		"v2.0.0",
+		"v2.0.1",
+		"v2.0.5",
+		"v2.1.2",
+		"v2.1.12",
 	}, nil)
 
 	suite.ctr, suite.kubeClient = setupFakeController(suite.T(), "", initValues, embeddedMUP)
-	var err error
-	suite.rc, err = NewDeckhouseReleaseChecker([]cr.Option{}, suite.ctr.logger, suite.ctr.dc,
-		suite.ctr.moduleManager, "", "")
-	require.NoError(suite.T(), err)
+	suite.rc = NewDeckhouseReleaseChecker(dependency.TestDC.CRClient,
+		suite.ctr.moduleManager, "", suite.ctr.logger)
 }
 
 func (suite *ReleaseTestSuite) TestCheckRelease() {
-	check := func(name string, actual, target string, fail bool) {
+	check := func(name string, actual, target string, vers []*semver.Version) {
 		suite.Run(name, func() {
 			actual, _ := semver.NewVersion(actual)
 			target, _ := semver.NewVersion(target)
-			v, err := suite.rc.nextVersion(
+			v, err := suite.rc.getNewVersions(
 				context.Background(),
 				actual,
 				target,
 			)
 			require.NoError(suite.T(), err)
 
-			if !cmp.Equal(v, target) && !fail {
+			if !cmp.Equal(v, vers) {
 				suite.T().Fatalf("version is not equal: %v", cmp.Diff(v, target))
 			}
 		})
 	}
 
-	check("Patch", "1.31.0", "1.31.1", false)
-	check("Minor", "1.31.0", "1.32.3", false)
-	check("Last Minor", "1.31.0", "1.32.3", false)
-	check("Fail Update", "1.31.0", "1.33.0", true)
+	check("Patch", "1.31.0", "1.31.1", []*semver.Version{semver.MustParse("1.31.1")})
+	check("Minor", "1.31.0", "1.32.3", []*semver.Version{
+		semver.MustParse("1.32.3")})
+	check("Last Minor", "1.31.0", "1.33.1", []*semver.Version{
+		semver.MustParse("1.32.3"),
+		semver.MustParse("1.33.1")})
+	check("Major", "1.31.0", "2.0.5", []*semver.Version{
+		semver.MustParse("1.32.3"),
+		semver.MustParse("1.33.1"),
+		semver.MustParse("2.0.5"),
+	})
+	check("Last Major Minor", "1.31.0", "2.1.12", []*semver.Version{
+		semver.MustParse("1.32.3"),
+		semver.MustParse("1.33.1"),
+		semver.MustParse("2.0.5"),
+		semver.MustParse("2.1.12"),
+	})
+	check("Last Minor is not equal to target", "1.31.0", "1.33.0", []*semver.Version{
+		semver.MustParse("1.32.3"),
+	})
 }

--- a/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
@@ -95,22 +95,27 @@ func (suite *ReleaseTestSuite) TestCheckRelease() {
 	}
 
 	check("Patch", "1.31.0", "1.31.1", []*semver.Version{semver.MustParse("1.31.1")})
+
 	check("Minor", "1.31.0", "1.32.3", []*semver.Version{
 		semver.MustParse("1.32.3")})
+
 	check("Last Minor", "1.31.0", "1.33.1", []*semver.Version{
 		semver.MustParse("1.32.3"),
 		semver.MustParse("1.33.1")})
+
 	check("Major", "1.31.0", "2.0.5", []*semver.Version{
 		semver.MustParse("1.32.3"),
 		semver.MustParse("1.33.1"),
 		semver.MustParse("2.0.5"),
 	})
+
 	check("Last Major Minor", "1.31.0", "2.1.12", []*semver.Version{
 		semver.MustParse("1.32.3"),
 		semver.MustParse("1.33.1"),
 		semver.MustParse("2.0.5"),
 		semver.MustParse("2.1.12"),
 	})
+
 	check("Last Minor is not equal to target", "1.31.0", "1.33.0", []*semver.Version{
 		semver.MustParse("1.32.3"),
 	})

--- a/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/next_version_test.go
@@ -123,5 +123,6 @@ func (suite *ReleaseTestSuite) TestCheckRelease() {
 
 	check("Last Minor is not equal to target", "1.31.0", "1.33.0", []*semver.Version{
 		semver.MustParse("1.32.3"),
+		semver.MustParse("1.33.0"),
 	})
 }

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/deployed-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/deployed-release-suspended.yaml
@@ -1,8 +1,8 @@
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1.25.0
+  name: v1.16.0
 spec:
-  version: "v1.25.0"
+  version: "v1.16.0"
 status:
   phase: Deployed

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/existed-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/existed-release-suspended.yaml
@@ -2,8 +2,8 @@
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1.25.0
+  name: v1.16.0
 spec:
-  version: "v1.25.0"
+  version: "v1.16.0"
 status:
   phase: Pending

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/deployed-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/deployed-release-suspended.yaml
@@ -4,10 +4,10 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   creationTimestamp: null
-  name: v1.25.0
+  name: v1.16.0
   resourceVersion: "999"
 spec:
-  version: v1.25.0
+  version: v1.16.0
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/existed-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/existed-release-suspended.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/existed-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/existed-release-suspended.yaml
@@ -26,10 +26,10 @@ metadata:
   annotations:
     release.deckhouse.io/suspended: "true"
   creationTimestamp: null
-  name: v1.25.0
+  name: v1.16.0
   resourceVersion: "1001"
 spec:
-  version: v1.25.0
+  version: v1.16.0
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
@@ -29,11 +29,12 @@ metadata:
   creationTimestamp: null
   labels:
     heritage: deckhouse
-  name: v1.25.0
+  name: v1.16.0
   resourceVersion: "1"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.25.0
-  version: v1.25.0
+  applyAfter: "2019-10-17T15:51:00Z"
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.0
+  version: v1.16.0
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
@@ -18,3 +18,23 @@ status:
   approved: false
   message: ""
   transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.25.0
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.25.0
+  version: v1.25.0
+status:
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
@@ -24,6 +25,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (from deployed)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
@@ -18,3 +18,24 @@ status:
   approved: false
   message: ""
   transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.25.5
+  resourceVersion: "1"
+spec:
+  applyAfter: "2019-10-17T16:33:00Z"
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.25.5
+  version: v1.25.5
+status:
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
@@ -24,6 +25,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (from deployed)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
@@ -29,12 +29,12 @@ metadata:
   creationTimestamp: null
   labels:
     heritage: deckhouse
-  name: v1.25.5
+  name: v1.16.5
   resourceVersion: "1"
 spec:
-  applyAfter: "2019-10-17T16:33:00Z"
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.25.5
-  version: v1.25.5
+  applyAfter: "2019-10-17T16:03:00Z"
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.5
+  version: v1.16.5
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
@@ -29,11 +29,11 @@ metadata:
   creationTimestamp: null
   labels:
     heritage: deckhouse
-  name: v1.25.3
+  name: v1.16.3
   resourceVersion: "1"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.25.3
-  version: v1.25.3
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.3
+  version: v1.16.3
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
@@ -24,6 +25,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (from deployed)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
@@ -18,3 +18,23 @@ status:
   approved: false
   message: ""
   transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.25.3
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.25.3
+  version: v1.25.3
+status:
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/image-hash-not-changed.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/image-hash-not-changed.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
@@ -30,11 +30,11 @@ metadata:
   creationTimestamp: null
   labels:
     heritage: deckhouse
-  name: v1.31.1
+  name: v1.16.1
   resourceVersion: "1"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.1
-  version: v1.31.1
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.1
+  version: v1.16.1
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
@@ -24,6 +25,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (from deployed)
     release.deckhouse.io/cooldown: "2026-06-06T16:16:16Z"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
@@ -18,3 +18,24 @@ status:
   approved: false
   message: ""
   transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/cooldown: "2026-06-06T16:16:16Z"
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.31.1
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.1
+  version: v1.31.1
+status:
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
@@ -24,6 +25,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (from deployed)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
     release.deckhouse.io/suspended: "true"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
@@ -18,3 +18,24 @@ status:
   approved: false
   message: ""
   transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+    release.deckhouse.io/suspended: "true"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.25.0
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.25.0
+  version: v1.25.0
+status:
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
@@ -30,11 +30,11 @@ metadata:
   creationTimestamp: null
   labels:
     heritage: deckhouse
-  name: v1.25.0
+  name: v1.16.0
   resourceVersion: "1"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.25.0
-  version: v1.25.0
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.0
+  version: v1.16.0
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
@@ -24,6 +25,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (from deployed)
     release.deckhouse.io/cooldown: "2030-05-05T15:15:15Z"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
@@ -18,3 +18,24 @@ status:
   approved: false
   message: ""
   transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/cooldown: "2030-05-05T15:15:15Z"
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.31.2
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.2
+  version: v1.31.2
+status:
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
@@ -30,11 +30,11 @@ metadata:
   creationTimestamp: null
   labels:
     heritage: deckhouse
-  name: v1.31.2
+  name: v1.16.2
   resourceVersion: "1"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.2
-  version: v1.31.2
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.2
+  version: v1.16.2
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
@@ -29,12 +29,12 @@ metadata:
   creationTimestamp: null
   labels:
     heritage: deckhouse
-  name: v1.16.0
+  name: v1.16.1
   resourceVersion: "1"
 spec:
-  applyAfter: "2019-10-17T17:03:00Z"
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.0
-  version: v1.16.0
+  applyAfter: "2019-10-17T16:33:00Z"
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.1
+  version: v1.16.1
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
@@ -29,12 +29,12 @@ metadata:
   creationTimestamp: null
   labels:
     heritage: deckhouse
-  name: v1.31.0
+  name: v1.16.0
   resourceVersion: "1"
 spec:
   applyAfter: "2019-10-17T17:03:00Z"
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.0
-  version: v1.31.0
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.0
+  version: v1.16.0
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
@@ -24,6 +25,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (from deployed)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
@@ -18,3 +18,24 @@ status:
   approved: false
   message: ""
   transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.31.0
+  resourceVersion: "1"
+spec:
+  applyAfter: "2019-10-17T17:03:00Z"
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.0
+  version: v1.31.0
+status:
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
@@ -18,3 +18,24 @@ status:
   approved: false
   message: ""
   transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/cooldown: "2026-06-06T16:16:16Z"
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.31.0
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.0
+  version: v1.31.0
+status:
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
@@ -24,6 +25,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (from deployed)
     release.deckhouse.io/cooldown: "2026-06-06T16:16:16Z"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
@@ -30,11 +30,11 @@ metadata:
   creationTimestamp: null
   labels:
     heritage: deckhouse
-  name: v1.31.0
+  name: v1.16.0
   resourceVersion: "1"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.0
-  version: v1.31.0
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.0
+  version: v1.16.0
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
@@ -29,13 +29,13 @@ metadata:
   creationTimestamp: null
   labels:
     heritage: deckhouse
-  name: v1.32.0
+  name: v1.16.0
   resourceVersion: "1"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.32.0
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.0
   disruptions:
   - ingressNginx
-  version: v1.32.0
+  version: v1.16.0
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
@@ -18,3 +18,25 @@ status:
   approved: false
   message: ""
   transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.32.0
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.32.0
+  disruptions:
+  - ingressNginx
+  version: v1.32.0
+status:
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
@@ -24,6 +25,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (from deployed)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
@@ -18,3 +18,26 @@ status:
   approved: false
   message: ""
   transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.30.0
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.30.0
+  requirements:
+    k8s: "1.19"
+    req1: dep1
+  version: v1.30.0
+status:
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
@@ -29,14 +29,14 @@ metadata:
   creationTimestamp: null
   labels:
     heritage: deckhouse
-  name: v1.30.0
+  name: v1.16.0
   resourceVersion: "1"
 spec:
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.30.0
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.0
   requirements:
     k8s: "1.19"
     req1: dep1
-  version: v1.30.0
+  version: v1.16.0
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
@@ -24,6 +25,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (from deployed)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
@@ -18,3 +18,43 @@ status:
   approved: false
   message: ""
   transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+  name: v1.31.0
+  resourceVersion: "1"
+spec:
+  changelog:
+    cert-manager:
+      fixes:
+      - pull_request: https://github.com/deckhouse/deckhouse/pull/999
+        summary: Remove D8CertmanagerOrphanSecretsWithoutCorrespondingCertificateResources
+    global:
+      features:
+      - description: All master nodes will have `control-plane` role in new exist
+          clusters.
+        note: Add migration for adding role. Bashible steps will be rerunned on master
+          nodes.
+        pull_request: https://github.com/deckhouse/deckhouse/pull/562
+      - description: Update Kubernetes patch versions.
+        pull_request: https://github.com/deckhouse/deckhouse/pull/558
+      fixes:
+      - description: Fix parsing deckhouse images repo if there is the sha256 sum
+          in the image name
+        pull_request: https://github.com/deckhouse/deckhouse/pull/527
+      - description: Fix serialization of empty strings in secrets
+        pull_request: https://github.com/deckhouse/deckhouse/pull/523
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.0
+  version: v1.31.0
+status:
+  approved: false
+  message: ""
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
@@ -29,7 +29,7 @@ metadata:
   creationTimestamp: null
   labels:
     heritage: deckhouse
-  name: v1.31.0
+  name: v1.16.0
   resourceVersion: "1"
 spec:
   changelog:
@@ -52,8 +52,8 @@ spec:
         pull_request: https://github.com/deckhouse/deckhouse/pull/527
       - description: Fix serialization of empty strings in secrets
         pull_request: https://github.com/deckhouse/deckhouse/pull/523
-  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.0
-  version: v1.31.0
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.16.0
+  version: v1.16.0
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
@@ -24,6 +25,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (from deployed)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/restore-absent-releases-from-registry.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/restore-absent-releases-from-registry.yaml
@@ -19,6 +19,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (step-by-step)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
@@ -39,6 +40,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (step-by-step)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
@@ -59,6 +61,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (step-by-step)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/resume-suspended-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/resume-suspended-release.yaml
@@ -4,6 +4,7 @@ approved: true
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (restore release)
     release.deckhouse.io/current-restored: "true"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/resume-suspended-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/resume-suspended-release.yaml
@@ -24,10 +24,10 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   creationTimestamp: null
-  name: v1.25.0
+  name: v1.16.0
   resourceVersion: "1001"
 spec:
-  version: v1.25.0
+  version: v1.16.0
 status:
   approved: false
   message: ""

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-update-successfully.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-update-successfully.yaml
@@ -19,6 +19,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (step-by-step)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
@@ -39,6 +40,7 @@ approved: false
 kind: DeckhouseRelease
 metadata:
   annotations:
+    release.deckhouse.io/change-cause: check release (step-by-step)
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/resume-suspended-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/resume-suspended-release.yaml
@@ -1,10 +1,10 @@
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1.25.0
+  name: v1.16.0
   annotations:
     release.deckhouse.io/suspended: "true"
 spec:
-  version: "v1.25.0"
+  version: "v1.16.0"
 status:
   phase: Suspended

--- a/deckhouse-controller/pkg/registry/deckhouse.go
+++ b/deckhouse-controller/pkg/registry/deckhouse.go
@@ -68,6 +68,7 @@ func (svc *deckhouseReleaseService) GetDeckhouseRelease(ctx context.Context, rel
 		return nil, fmt.Errorf("fetch image: %w", err)
 	}
 
+	// TODO: see check_release with same method
 	releaseMetadata, err := svc.fetchReleaseMetadata(img)
 	if err != nil {
 		return nil, fmt.Errorf("fetch release metadata: %w", err)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix step by step logic
Add restored release in releases sequence
Add annotations for process noting [kubernetes-like](https://kubernetes.io/docs/reference/labels-annotations-taints/#change-cause)
Fix tests and golden files

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: fix deckhouse-release check loop
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
