### PR TITLE
[dhctl] Add deckhouse user and group existence preflight check

### DIFF
--- a/candi/bashible/common-steps/all/002_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/002_create_static_node_cleanup_script.sh.tpl
@@ -73,6 +73,7 @@ rm -rf /var/lib/deckhouse
 rm -rf /var/lib/upmeter
 rm -rf /etc/sudoers.d/sudoers_flant_kubectl
 rm -rf /etc/sudoers.d/30-deckhouse-nodeadmins
+chown -R deckhouse:deckhouse /home/deckhouse
 
 shutdown -r -t 5
 EOF

--- a/candi/bashible/common-steps/all/002_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/002_create_static_node_cleanup_script.sh.tpl
@@ -74,7 +74,7 @@ rm -rf /var/lib/upmeter
 rm -rf /etc/sudoers.d/sudoers_flant_kubectl
 rm -rf /etc/sudoers.d/30-deckhouse-nodeadmins
 userdel deckhouse
-groupdel deckhouse
+groupdel nodeadmin
 rm -rf /home/deckhouse
 
 shutdown -r -t 5

--- a/candi/bashible/common-steps/all/002_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/002_create_static_node_cleanup_script.sh.tpl
@@ -73,7 +73,9 @@ rm -rf /var/lib/deckhouse
 rm -rf /var/lib/upmeter
 rm -rf /etc/sudoers.d/sudoers_flant_kubectl
 rm -rf /etc/sudoers.d/30-deckhouse-nodeadmins
-chown -R deckhouse:deckhouse /home/deckhouse
+userdel deckhouse
+groupdel deckhouse
+rm -rf /home/deckhouse
 
 shutdown -r -t 5
 EOF

--- a/candi/bashible/preflight/check_deckhouse_user.sh.tpl
+++ b/candi/bashible/preflight/check_deckhouse_user.sh.tpl
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+{{- /*
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+    
+uid="$(id -u deckhouse 2>/dev/null || true)"
+gid="$(getent group deckhouse | cut -d: -f3 || true)"
+
+if [ -n "$uid" ] || [ -n "$gid" ]; then
+    echo "deckhouse user or group already exists with id: uid=${uid}, gid=${gid}"
+    exit 1
+fi

--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -33,6 +33,7 @@ var (
 	PreflightSkipOneSSHHost                = false
 	PreflightSkipCloudAPIAccessibility     = false
 	PreflightSkipCIDRIntersection          = false
+	PreflightSkipDeckhouseUserCheck        = false
 )
 
 const (
@@ -51,6 +52,7 @@ const (
 	CloudAPIAccessibilityArgName     = "preflight-cloud-api-accesibility-check"
 	OneSSHHostCheckArgName           = "preflight-skip-one-ssh-host"
 	CIDRIntersection                 = "preflight-skip-cidr-intersection"
+	DeckhouseUserCheckName           = "preflight-skip-deckhouse-user-check"
 )
 
 var (
@@ -70,6 +72,7 @@ var (
 		SystemRequirementsArgName:        &PreflightSkipSystemRequirementsCheck,
 		OneSSHHostCheckArgName:           &PreflightSkipOneSSHHost,
 		CIDRIntersection:                 &PreflightSkipCIDRIntersection,
+		DeckhouseUserCheckName:           &PreflightSkipDeckhouseUserCheck,
 	}
 )
 
@@ -130,4 +133,7 @@ func DefinePreflight(cmd *kingpin.CmdClause) {
 	cmd.Flag(CIDRIntersection, "Skip verifying CIDRs intersection").
 		Envar(configEnvName("PREFLIGHT_SKIP_CIDR_INTERSECTION")).
 		BoolVar(PreflightSkipOptionsMap[CIDRIntersection])
+	cmd.Flag(DeckhouseUserCheckName, "Skip verifying deckhouse user existence").
+		Envar(configEnvName("PREFLIGHT_SKIP_DECKHOUSE_USER")).
+		BoolVar(PreflightSkipOptionsMap[DeckhouseUserCheckName])
 }

--- a/dhctl/pkg/preflight/deckhouse_user.go
+++ b/dhctl/pkg/preflight/deckhouse_user.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
+)
+
+func (pc *Checker) CheckDeckhouseUser() error {
+	if app.PreflightSkipDeckhouseUserCheck {
+		log.InfoLn("Deckhouse user existence preflight check was skipped")
+		return nil
+	}
+
+	log.DebugLn("Checking deckhouse user and group aren't present on destination host")
+
+	file, err := template.RenderAndSavePreflightCheckDeckhouseUserScript()
+	if err != nil {
+		return err
+	}
+
+	scriptCmd := pc.nodeInterface.UploadScript(file)
+	out, err := scriptCmd.Execute()
+	if err != nil {
+		log.ErrorLn(strings.Trim(string(out), "\n"))
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return fmt.Errorf("Deckhouse user existence check failed: %w, %s", err, string(ee.Stderr))
+		}
+		return fmt.Errorf("Could not execute a script to check deckhouse user and group aren't present on the node: %w", err)
+	}
+
+	log.DebugLn(string(out))
+	return nil
+}

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -100,6 +100,11 @@ func (pc *Checker) Static() error {
 			skipFlag:       app.SSHForwardArgName,
 		},
 		{
+			fun:            pc.CheckDeckhouseUser,
+			successMessage: "deckhouse user and group aren't present on node",
+			skipFlag:       app.DeckhouseUserCheckName,
+		},
+		{
 			fun:            pc.CheckStaticNodeSystemRequirements,
 			successMessage: "that node meets system requirements",
 			skipFlag:       app.SystemRequirementsArgName,

--- a/dhctl/pkg/template/bundle.go
+++ b/dhctl/pkg/template/bundle.go
@@ -169,6 +169,7 @@ func InitGlobalVars(pwd string) {
 	candiBashibleDir = candiDir + "/bashible"
 	checkPortsScriptPath = candiBashibleDir + "/preflight/check_ports.sh.tpl"
 	checkLocalhostScriptPath = candiBashibleDir + "/preflight/check_localhost.sh.tpl"
+	checkDeckhouseUserScriptPath = candiBashibleDir + "/preflight/check_deckhouse_user.sh.tpl"
 	preflightScriptDirPath = candiBashibleDir + "/preflight/"
 	killReverseTunnelPath = candiBashibleDir + "/preflight/kill_reverse_tunnel.sh.tpl"
 	checkProxyRevTunnelOpenScriptPath = candiBashibleDir + "/preflight/check_reverse_tunnel_open.sh.tpl"

--- a/dhctl/pkg/template/preflight.go
+++ b/dhctl/pkg/template/preflight.go
@@ -21,6 +21,7 @@ var (
 	checkLocalhostScriptPath          = candiBashibleDir + "/preflight/check_localhost.sh.tpl"
 	checkProxyRevTunnelOpenScriptPath = candiBashibleDir + "/preflight/check_reverse_tunnel_open.sh.tpl"
 	killReverseTunnelPath             = candiBashibleDir + "/preflight/kill_reverse_tunnel.sh.tpl"
+	checkDeckhouseUserScriptPath      = candiBashibleDir + "/preflight/check_deckhouse_user.sh.tpl"
 	preflightScriptDirPath            = candiBashibleDir + "/preflight/"
 )
 
@@ -28,6 +29,12 @@ func RenderAndSavePreflightCheckPortsScript() (string, error) {
 	log.DebugLn("Start render check ports script")
 
 	return RenderAndSaveTemplate("check_ports.sh", checkPortsScriptPath, map[string]interface{}{})
+}
+
+func RenderAndSavePreflightCheckDeckhouseUserScript() (string, error) {
+	log.DebugLn("Start render check user script")
+
+	return RenderAndSaveTemplate("check_deckhouse_user.sh", checkDeckhouseUserScriptPath, map[string]interface{}{})
 }
 
 func RenderAndSavePreflightCheckLocalhostScript() (string, error) {


### PR DESCRIPTION
## Description

Fixes https://github.com/deckhouse/deckhouse/issues/11928

## Why do we need it, and what problem does it solve?

By bootstrap, we should not use `deckhouse` user and group. By destroy, we should cleanup that user and group as well as it's home directory

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Delete /home/deckhouse and deckhouse user and group by cleanup.
impact_level: low
```

```changes
section: dhctl
type: feature
summary: Add preflight check for existence of deckhouse user and group.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
