### PR TITLE
[candi] reduce kubernetes api request-timeout to 60s

### DIFF
--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -139,7 +139,7 @@ apiServer:
     encryption-provider-config: /etc/kubernetes/deckhouse/extra-files/secret-encryption-config.yaml
   {{- end }}
     profiling: "false"
-    request-timeout: "300s"
+    request-timeout: "60s"
     tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
   {{- if hasKey .apiserver "certSANs" }}
   certSANs:


### PR DESCRIPTION
## Description

Reduce `request-timeout` in kubernetes-api to 60s.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

If kubelet is restarted at a time when etcd is unavailable (e.g. when etcd is recreated by d8-control-plane-manager), the kubelet will make several attempts to communicate with the kubernetes-api. If the kubernetes-api is running but not working properly (e.g. it's single master), then the etcd container will be launched after more than 10 minutes due to `request-timeout`. This is often the case when bootstrapping a new cluster.

Current value (300s) may have been set as a recommendation from the CIS (1.9) 1.2.20, but the check itself only recommends explicitly setting the `request-timeout`  in kubernetes-api manifest. 
```
  - id: 1.2.20
    text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
    type: manual
    remediation: |
      Edit the API server pod specification file $apiserverconf
      and set the below parameter as appropriate and if needed.
      For example, --request-timeout=300s
```

The default value set by upstream kubernetes is [60 seconds](https://github.com/kubernetes/kubernetes/blob/v1.32.2/staging/src/k8s.io/apiserver/pkg/server/config.go#L434).


-----
Manual reproduce steps:
1. Create cluster with single master.
2. `mv /etc/kubernetes/manifests/etcd.yaml ./; sleep 1; mv ./etcd.yaml /etc/kubernetes/manifests/; systemctl restart kubelet`
3. etcd will start only after 10 minutes.


-----
Extra information:

<details>
  <summary>containerd logs</summary>

  ```
  root@dev-master-0:~# journalctl -u containerd -n 1000 | grep 'etcd'
  Feb 19 07:43:58 dev-master-0 containerd[944]: time="2025-02-19T07:43:58.820616226Z" level=info msg="StopContainer for \"1b09b4e78520b60d0aa858f8ed3e96fe1a116d30d516b6947fbf13fac156035e\" with timeout 30 (s)"
  Feb 19 07:43:58 dev-master-0 containerd[944]: time="2025-02-19T07:43:58.821589186Z" level=info msg="Stop container \"1b09b4e78520b60d0aa858f8ed3e96fe1a116d30d516b6947fbf13fac156035e\" with signal terminated"
  Feb 19 07:43:58 dev-master-0 containerd[944]: time="2025-02-19T07:43:58.858726578Z" level=info msg="received exit event container_id:\"1b09b4e78520b60d0aa858f8ed3e96fe1a116d30d516b6947fbf13fac156035e\" id:\"1b09b4e78520b60d0aa858f8ed3e96fe1a116d30d516b6947fbf13fac156035e\" pid:47147 exited_at:{seconds:1739951038 nanos:858439899}"
  Feb 19 07:43:58 dev-master-0 containerd[944]: time="2025-02-19T07:43:58.884105497Z" level=info msg="shim disconnected" id=1b09b4e78520b60d0aa858f8ed3e96fe1a116d30d516b6947fbf13fac156035e namespace=k8s.io
  Feb 19 07:43:58 dev-master-0 containerd[944]: time="2025-02-19T07:43:58.884172229Z" level=warning msg="cleaning up after shim disconnected" id=1b09b4e78520b60d0aa858f8ed3e96fe1a116d30d516b6947fbf13fac156035e namespace=k8s.io
  Feb 19 07:43:58 dev-master-0 containerd[944]: time="2025-02-19T07:43:58.903911275Z" level=info msg="StopContainer for \"1b09b4e78520b60d0aa858f8ed3e96fe1a116d30d516b6947fbf13fac156035e\" returns successfully"
  Feb 19 07:43:58 dev-master-0 containerd[944]: time="2025-02-19T07:43:58.904566161Z" level=info msg="Container to stop \"1b09b4e78520b60d0aa858f8ed3e96fe1a116d30d516b6947fbf13fac156035e\" must be in running or unknown state, current state \"CONTAINER_EXITED\""
  Feb 19 07:53:59 dev-master-0 containerd[944]: time="2025-02-19T07:53:59.528094073Z" level=info msg="Container to stop \"1b09b4e78520b60d0aa858f8ed3e96fe1a116d30d516b6947fbf13fac156035e\" must be in running or unknown state, current state \"CONTAINER_EXITED\""
  Feb 19 07:53:59 dev-master-0 containerd[944]: time="2025-02-19T07:53:59.529072444Z" level=info msg="RunPodSandbox for &PodSandboxMetadata{Name:etcd-dev-master-0,Uid:8c6910ab93222d3160e061a40a697e7f,Namespace:kube-system,Attempt:19,}"
  Feb 19 07:53:59 dev-master-0 containerd[944]: time="2025-02-19T07:53:59.689346478Z" level=info msg="RunPodSandbox for &PodSandboxMetadata{Name:etcd-dev-master-0,Uid:8c6910ab93222d3160e061a40a697e7f,Namespace:kube-system,Attempt:19,} returns sandbox id \"20a3ee71b8843396e35766390271ca3312ee766c0d517f213969234614266ffb\""
  Feb 19 07:53:59 dev-master-0 containerd[944]: time="2025-02-19T07:53:59.692415067Z" level=info msg="CreateContainer within sandbox \"20a3ee71b8843396e35766390271ca3312ee766c0d517f213969234614266ffb\" for container &ContainerMetadata{Name:etcd,Attempt:5,}"
  Feb 19 07:53:59 dev-master-0 containerd[944]: time="2025-02-19T07:53:59.738720142Z" level=info msg="CreateContainer within sandbox \"20a3ee71b8843396e35766390271ca3312ee766c0d517f213969234614266ffb\" for &ContainerMetadata{Name:etcd,Attempt:5,} returns container id \"9715b0590b934df62c9429762d18e7afa66ab38bcf1a0e78fc19b0447fd54e1e\""
  ```
</details>

<details>

  <summary>kubelet logs</summary>

  ```
  root@dev-master-0:~# journalctl -u kubelet -n 1000 | grep 'Started\|etcd'
  Feb 19 07:43:59 dev-master-0 kubelet[296958]: I0219 07:43:59.131221  296958 server.go:1287] "Started kubelet"
  Feb 19 07:43:59 dev-master-0 kubelet[296958]: I0219 07:43:59.265803  296958 kubelet.go:3200] "Creating a mirror pod for static pod" pod="kube-system/etcd-dev-master-0"
  Feb 19 07:44:33 dev-master-0 kubelet[296958]: E0219 07:44:33.268731  296958 kubelet.go:3202] "Failed creating a mirror pod" err="Timeout: request did not complete within requested timeout - context deadline exceeded" pod="kube-system/etcd-dev-master-0"
  Feb 19 07:46:36 dev-master-0 kubelet[296958]: E0219 07:46:36.269946  296958 pod_workers.go:1301] "Error syncing pod, skipping" err="unmounted volumes=[etcd-certs etcd-data], unattached volumes=[], failed to process volumes=[]: context deadline exceeded" pod="kube-system/etcd-dev-master-0" podUID="8c6910ab93222d3160e061a40a697e7f"
  Feb 19 07:48:39 dev-master-0 kubelet[296958]: E0219 07:48:39.533159  296958 pod_workers.go:1301] "Error syncing pod, skipping" err="unmounted volumes=[etcd-certs etcd-data], unattached volumes=[], failed to process volumes=[]: context deadline exceeded" pod="kube-system/etcd-dev-master-0" podUID="8c6910ab93222d3160e061a40a697e7f"
  Feb 19 07:48:59 dev-master-0 kubelet[296958]: I0219 07:48:59.254106  296958 reconciler_common.go:251] "operationExecutor.VerifyControllerAttachedVolume started for volume \"etcd-data\" (UniqueName: \"kubernetes.io/host-path/8c6910ab93222d3160e061a40a697e7f-etcd-data\") pod \"etcd-dev-master-0\" (UID: \"8c6910ab93222d3160e061a40a697e7f\") " pod="kube-system/etcd-dev-master-0"
  Feb 19 07:48:59 dev-master-0 kubelet[296958]: I0219 07:48:59.254505  296958 reconciler_common.go:251] "operationExecutor.VerifyControllerAttachedVolume started for volume \"etcd-certs\" (UniqueName: \"kubernetes.io/host-path/8c6910ab93222d3160e061a40a697e7f-etcd-certs\") pod \"etcd-dev-master-0\" (UID: \"8c6910ab93222d3160e061a40a697e7f\") " pod="kube-system/etcd-dev-master-0"
  Feb 19 07:50:42 dev-master-0 kubelet[296958]: E0219 07:50:42.805917  296958 pod_workers.go:1301] "Error syncing pod, skipping" err="unmounted volumes=[etcd-certs etcd-data], unattached volumes=[], failed to process volumes=[]: context deadline exceeded" pod="kube-system/etcd-dev-master-0" podUID="8c6910ab93222d3160e061a40a697e7f"
  Feb 19 07:52:46 dev-master-0 kubelet[296958]: E0219 07:52:46.068122  296958 pod_workers.go:1301] "Error syncing pod, skipping" err="unmounted volumes=[etcd-certs etcd-data], unattached volumes=[], failed to process volumes=[]: context deadline exceeded" pod="kube-system/etcd-dev-master-0" podUID="8c6910ab93222d3160e061a40a697e7f"
  Feb 19 07:54:00 dev-master-0 kubelet[296958]: I0219 07:54:00.137393  296958 status_manager.go:890] "Failed to get status for pod" podUID="8c6910ab93222d3160e061a40a697e7f" pod="kube-system/etcd-dev-master-0" err="the server was unable to return a response in the time allotted, but may still be processing the request (get pods etcd-dev-master-0)"
  ```
</details>


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Bad user experience when installing a cluster. Etcd takes a long time to restart.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Reduce `request-timeout` in kubernetes-api to 60s.
impact: kubernetes-api will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
