### PR TITLE
[docs][getting-started] Fix blured blocks on the step4 page

### DIFF
--- a/docs/site/_data/getting_started/dkp_data.yaml
+++ b/docs/site/_data/getting_started/dkp_data.yaml
@@ -3,7 +3,6 @@ global:
     - ce
     - be
     - se
-    - se-plus
     - ee
   step1:
     name:

--- a/docs/site/_data/getting_started/dkp_data.yaml
+++ b/docs/site/_data/getting_started/dkp_data.yaml
@@ -3,6 +3,7 @@ global:
     - ce
     - be
     - se
+    - se-plus
     - ee
   step1:
     name:

--- a/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
+++ b/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
@@ -100,7 +100,7 @@
 {% include getting_started/global/partials/INSTALL_OTHER.liquid revision=revision %}
 {% endif %}
 </div>
-{% if revision == 'ee' or revision == 'be' or revision == 'se' or revision == 'se-plus' %}
+{% if revision == 'ee' or revision == 'be' or revision == 'se'%}
 </div>
 {% endif %}
 

--- a/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
+++ b/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
@@ -100,7 +100,7 @@
 {% include getting_started/global/partials/INSTALL_OTHER.liquid revision=revision %}
 {% endif %}
 </div>
-{% if revision == 'ee' or revision == 'be' or revision == 'se'%}
+{% if revision == 'ee' or revision == 'be' or revision == 'se' %}
 </div>
 {% endif %}
 

--- a/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
+++ b/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
@@ -30,7 +30,7 @@
 {%- if page.ee_only == true and page.se_support == true %}
   <div class="tabs">
     {%- for revision in site.data.getting_started.dkp_data.global.revisions %}
-      {%  if revision == "se" or revision == "ee" %}
+      {%  if revision == "se" or revision == "se-plus" or revision == "ee" %}
       <a id='tab_layout_{{ revision }}' href="javascript:void(0)" class="tabs__btn tabs__btn_revision{% if revision == 'se' %} active{% endif %}"
          onclick="openTabAndSaveStatus(event, 'tabs__btn_revision', 'tabs__content_revision', 'block_layout_{{ revision }}', 'dhctl-revision', '{{ revision }}');
            openTabAndSaveStatus(event, 'tabs__btn_revision', 'tabs__content_other', 'block_other_{{ revision }}');
@@ -46,12 +46,14 @@
 {%- if page.ee_only == true and revision == 'ce' %}{% continue %}{% endif %}
 {%- if page.ee_only == true and revision == 'be' %}{% continue %}{% endif %}
 {%- if page.ee_only == true and revision == 'se' %}{% if page.se_support != true %}{% continue %}{% endif %}{% endif %}
-{%- if page.ce_only == true and revision == 'ee' %}{% continue %}{% endif %}
+{%- if page.ee_only == true and revision == 'se-plus' %}{% if page.se_support != true %}{% continue %}{% endif %}{% endif %}
+  {%- if page.ce_only == true and revision == 'ee' %}{% continue %}{% endif %}
 {% assign layoutCode = '' | append: layout.code %}
 <div id='block_layout_{{ revision }}' class="tabs__content tabs__content_revision
 {% if revision == 'ce' %} active{% endif %}
 {% if page.ee_only == true and page.se_support != true %} active{% endif %}
 {% if revision == 'se' and page.se_support == true %} active{% endif %}
+{% if revision == 'se-plus' and page.se_support == true %} active{% endif %}
 " markdown="1">
     {% if page.lang == 'ru' %}
     {% include getting_started/global/partials/INSTALL_CONFIG_RU.liquid revision=revision layout=layoutCode %}
@@ -90,6 +92,7 @@
 {% if revision == 'ce' %} active{% endif %}
 {% if page.ee_only == true and page.se_support != true %} active{% endif %}
 {% if revision == 'se' and page.se_support == true %} active{% endif %}
+{% if revision == 'se-plus' and page.se_support == true %} active{% endif %}
 " markdown="1">
 {% if page.lang == 'ru' %}
 {% include getting_started/global/partials/INSTALL_OTHER_RU.liquid revision=revision %}
@@ -97,7 +100,7 @@
 {% include getting_started/global/partials/INSTALL_OTHER.liquid revision=revision %}
 {% endif %}
 </div>
-{% if revision == 'ee' or revision == 'be' or revision == 'se' %}
+{% if revision == 'ee' or revision == 'be' or revision == 'se' or revision == 'se-plus' %}
 </div>
 {% endif %}
 


### PR DESCRIPTION
## Description

Fixed generation of blured blocks on the step4 page of GS.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fixed generation of blured blocks on the step4 page of GS.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
