### PR TITLE
feat: add security context with RuntimeDefault seccomp profile to dex container

### DIFF
--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.43.1
-digest: sha256:7719d1be5ba5d644edac2ca16265565f47e63df1d685f727f68cdebc78a64ea7
-generated: "2025-02-17T17:16:00.646524188+03:00"
+  version: 1.44.2
+digest: sha256:2119d89782d355e92a473ac9bae054998a07e60ec10f06865b2dc2b93249e538
+generated: "2025-03-06T14:45:38.907999+03:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: "Helm helpers"
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.43.1"
+    version: "1.44.2"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.43.1
+version: 1.44.2

--- a/helm_lib/charts/deckhouse_lib_helm/README.md
+++ b/helm_lib/charts/deckhouse_lib_helm/README.md
@@ -64,6 +64,7 @@
 | [helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add](#helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add) |
 | [helm_lib_module_container_security_context_capabilities_drop_all_and_add](#helm_lib_module_container_security_context_capabilities_drop_all_and_add) |
 | [helm_lib_module_container_security_context_capabilities_drop_all_and_run_as_user_custom](#helm_lib_module_container_security_context_capabilities_drop_all_and_run_as_user_custom) |
+| [helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted](#helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted) |
 | **Module Storage Class** |
 | [helm_lib_module_storage_class_annotations](#helm_lib_module_storage_class_annotations) |
 | **Monitoring Grafana Dashboards** |
@@ -361,7 +362,7 @@ list:
 
 #### Usage
 
-`{{ include "helm_lib_module_image" (list . "<container-name>") }} `
+`{{ include "helm_lib_module_image" (list . "<container-name>" "<module-name>(optional)") }} `
 
 #### Arguments
 
@@ -732,6 +733,19 @@ list:
 -  Template context with .Values, .Chart, etc 
 -  User id 
 -  Group id 
+
+
+### helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted
+
+ returns SecurityContext parameters for Container with minimal required settings to comply with the Restricted mode of the Pod Security Standards 
+
+#### Usage
+
+`{{ include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted" . }} `
+
+#### Arguments
+
+-  Template context with .Values, .Chart, etc 
 
 ## Module Storage Class
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
@@ -65,6 +65,7 @@ memory: 50Mi
   {{- $livenessProbePort := $config.livenessProbePort | default 9808 }}
   {{- $initContainers := $config.initContainers }}
   {{- $customNodeSelector := $config.customNodeSelector }}
+  {{- $additionalPullSecrets := $config.additionalPullSecrets }}
 
   {{- $kubernetesSemVer := semver $context.Values.global.discovery.kubernetesVersion }}
 
@@ -198,6 +199,9 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:
       - name: deckhouse-registry
+      {{- if $additionalPullSecrets }}
+      {{- $additionalPullSecrets | toYaml | nindent 6 }}
+      {{- end }}
       {{- include "helm_lib_priority_class" (tuple $context "system-cluster-critical") | nindent 6 }}
       {{- if $customNodeSelector }}
       nodeSelector:

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
@@ -26,6 +26,7 @@ memory: 25Mi
   {{- $customNodeSelector := $config.customNodeSelector }}
   {{- $additionalContainers := $config.additionalContainers }}
   {{- $initContainers := $config.initContainers }}
+  {{- $additionalPullSecrets := $config.additionalPullSecrets }}
 
   {{- $kubernetesSemVer := semver $context.Values.global.discovery.kubernetesVersion }}
   {{- $driverRegistrarImageName := join "" (list "csiNodeDriverRegistrar" $kubernetesSemVer.Major $kubernetesSemVer.Minor) }}
@@ -109,6 +110,9 @@ spec:
       {{- end }}
       imagePullSecrets:
       - name: deckhouse-registry
+      {{- if $additionalPullSecrets }}
+      {{- $additionalPullSecrets | toYaml | nindent 6 }}
+      {{- end }}
       {{- include "helm_lib_priority_class" (tuple $context "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple $context "any-node" "with-no-csi") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_image.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_image.tpl
@@ -1,12 +1,13 @@
-{{- /* Usage: {{ include "helm_lib_module_image" (list . "<container-name>") }} */ -}}
+{{- /* Usage: {{ include "helm_lib_module_image" (list . "<container-name>" "<module-name>(optional)") }} */ -}}
 {{- /* returns image name */ -}}
 {{- define "helm_lib_module_image" }}
   {{- $context := index . 0 }} {{- /* Template context with .Values, .Chart, etc */ -}}
   {{- $containerName := index . 1 | trimAll "\"" }} {{- /* Container name */ -}}
-  {{- $moduleName := (include "helm_lib_module_camelcase_name" $context) }}
+  {{- $rawModuleName := $context.Chart.Name }}
   {{- if ge (len .) 3 }}
-  {{- $moduleName = (include "helm_lib_module_camelcase_name" (index . 2)) }} {{- /* Optional module name */ -}}
+  {{- $rawModuleName = (index . 2) }} {{- /* Optional module name */ -}}
   {{- end }}
+  {{- $moduleName := (include "helm_lib_module_camelcase_name" $rawModuleName) }}
   {{- $imageDigest := index $context.Values.global.modulesImages.digests $moduleName $containerName }}
   {{- if not $imageDigest }}
   {{- $error := (printf "Image %s.%s has no digest" $moduleName $containerName ) }}
@@ -18,11 +19,12 @@
     {{- if index $context.Values $moduleName "registry" }}
       {{- if index $context.Values $moduleName "registry" "base" }}
         {{- $host := trimAll "/" (index $context.Values $moduleName "registry" "base") }}
-        {{- $path := trimAll "/" $context.Chart.Name }}
+        {{- $path := trimAll "/" (include "helm_lib_module_kebabcase_name" $rawModuleName) }}
         {{- $registryBase = join "/" (list $host $path) }}
       {{- end }}
     {{- end }}
   {{- end }}
+  {{- /* end of external module handling block */}}
   {{- printf "%s@%s" $registryBase $imageDigest }}
 {{- end }}
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_name.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_name.tpl
@@ -9,3 +9,15 @@
 
 {{ $moduleName | replace "-" "_" | camelcase | untitle }}
 {{- end -}}
+
+
+{{- define "helm_lib_module_kebabcase_name" -}}
+{{- $moduleName := "" -}}
+{{- if (kindIs "string" .) -}}
+{{- $moduleName = . | trimAll "\"" -}}
+{{- else -}}
+{{- $moduleName = .Chart.Name -}}
+{{- end -}}
+
+{{ $moduleName | kebabcase }}
+{{- end -}}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
@@ -59,8 +59,8 @@ securityContext:
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
-  drop:
-  - all
+    drop:
+    - all
   runAsGroup: 64535
   runAsNonRoot: true
   runAsUser: 64535

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
@@ -149,6 +149,8 @@ securityContext:
 securityContext:
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
   capabilities:
     drop:
     - ALL

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
@@ -149,8 +149,6 @@ securityContext:
 securityContext:
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
-  seccompProfile:
-    type: RuntimeDefault
   capabilities:
     drop:
     - ALL
@@ -198,4 +196,18 @@ securityContext:
   capabilities:
     drop:
     - ALL
+{{- end }}
+
+{{- /* Usage: {{ include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted" . }} */ -}}
+{{- /* returns SecurityContext parameters for Container with minimal required settings to comply with the Restricted mode of the Pod Security Standards */ -}}
+{{- define "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted" -}}
+{{- /* Template context with .Values, .Chart, etc */ -}}
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 {{- end }}

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -119,10 +119,10 @@ spec:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
           limits:
             memory: 10Mi
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted" . | nindent 8 }}
       containers:
       - name: dex-authenticator
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list $context "dexAuthenticator") }}
         args:
         - --provider=oidc
@@ -211,7 +211,7 @@ spec:
           containerPort: 8443
           protocol: TCP
       - name: redis
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list $context "redisStatic") }}
         args:
           - "--save"

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -210,6 +210,9 @@ spec:
         - name: dex-https
           containerPort: 8443
           protocol: TCP
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
       - name: redis
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list $context "redisStatic") }}

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -210,9 +210,6 @@ spec:
         - name: dex-https
           containerPort: 8443
           protocol: TCP
-        securityContext:
-          seccompProfile:
-            type: RuntimeDefault
       - name: redis
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list $context "redisStatic") }}


### PR DESCRIPTION
## Description

fixed: #12070

## Why do we need it, and what problem does it solve?

Change seccomp profile to RuntimeDefault instead of Unlimited

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: add security context with RuntimeDefault seccomp profile to dex container
impact_level: default
```
