### PR TITLE
Chore/update block e2e tests during dev image build

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -336,6 +336,9 @@ check_e2e_labels:
     - check_e2e_labels
 {!{- end }!}
     - git_info
+{!{- if ne $ctx.workflowName "Daily e2e tests" }!}
+    - block-e2e-until-image-is-not-ready
+{!{- end -}!}
 {!{- if coll.Has $ctx "manualRun" }!}
   if: needs.check_e2e_labels.outputs.run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!} == 'true'
 {!{- end }!}

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -98,6 +98,60 @@ git_info:
 # </template: git_info_job>
 {!{- end -}!}
 
+{!{ define "block-e2e-until-image-is-not-ready" }!}
+# </template: block-e2e-until-image-is-not-ready>
+{!{- $ctx := . }!}
+block-e2e-until-image-is-not-ready:
+  name: Block e2e until the docker image is not ready
+  runs-on: ubuntu-latest
+  steps:
+    - uses: {!{ index (ds "actions") "actions/checkout" }!}
+    - name: Block e2e until the docker image is not ready
+      id: block-e2e
+      uses: {!{ index (ds "actions") "actions/github-script" }!}
+      with:
+        script: |
+          const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
+          const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
+
+          let branchName = context.payload.inputs.ci_commit_ref_name;
+          if (!branchName) {
+            branchName = githubAction.GetBranchNameFromContext(context);
+          }
+ 
+          if (branchName) {
+            let prNum = context.payload.inputs.issue_number;
+            // if the pull request id is not found, search it by the branch name
+            if (!prNum && branchName !== 'main') {
+              const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
+              prNum = prInfo.number;
+            }
+
+            let infoText = `Check build workflow is completed for branch: ${branchName}`;
+            if (prNum) {
+              infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
+            }
+            core.info(infoText);
+
+            const { waitForJobInWorkflowIsCompletedWithSuccess } = require('./.github/scripts/js/validators/validate-job-in-workflow-is-ready')({ github, context, core });
+            try {
+              let workflowName = 'Build and test for dev branches';
+              let jobName = 'Build Deckhouse';
+              if (isReleaseBranch(branchName)) {
+                workflowName = 'Build and test for release branches';
+                jobName = 'Build Deckhouse FE';
+              }
+              if (branchName === 'main') {
+                return true;
+              }
+              await waitForJobInWorkflowIsCompletedWithSuccess(branchName, workflowName, jobName);
+            } catch(error) {
+              core.setFailed(error);
+            }
+          }
+
+# </template: block-e2e-until-image-is-not-ready>
+{!{- end -}!}
 
 # Check pull request state on push or pull_request_target events:
 # - find PR info on push event

--- a/.github/scripts/js/helpers/github-actions.js
+++ b/.github/scripts/js/helpers/github-actions.js
@@ -1,0 +1,142 @@
+// Copyright 2025 Flant JSC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @module GithubActions
+ * This module provides utilities for interacting with GitHub Actions workflows
+ * @example
+ * const githubActions = require('../helpers/github-actions')(github, context);
+ */
+
+const WORKFLOW_STATUS_RUNNING = 'in_progress';
+const WORKFLOW_STATUS_COMPLETED = 'completed';
+
+const CONCLUSION_STATUS_SUCCESS = 'success';
+const CONCLUSION_STATUS_CANCELLED = 'cancelled';
+const CONCLUSION_STATUS_FAILURE = 'failure';
+
+const MAX_ITEMS_PER_PAGE = 100;
+
+module.exports = ({ github, context, core }) => {
+  /**
+   * @param {string} workflowName
+   * @param {string} branch
+   * @param {string=} status
+   * @param {number=} per_page
+   *
+   * @returns {GithubWorkflow[]}
+   */
+  async function GetWorkflowsByNameAndStatus(
+    workflowName,
+    branch,
+    status = WORKFLOW_STATUS_RUNNING,
+    per_page = MAX_ITEMS_PER_PAGE
+  ) {
+    const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      branch: branch,
+      per_page: per_page
+    });
+
+    return data.workflow_runs.filter((run) => run.name === workflowName && run.status === status);
+  }
+
+  /**
+   * @param {string} run_id
+   * @param {string} attempt_number
+   * @param {string} job_name
+   * @param {number=} per_page
+   *
+   * @returns {GithubWorkflowJob}
+   */
+  async function GetJobsForWorkflowRunAttempt(run_id, attempt_number, job_name, per_page = MAX_ITEMS_PER_PAGE) {
+    const { data } = await github.rest.actions.listJobsForWorkflowRunAttempt({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      run_id: run_id,
+      attempt_number: attempt_number,
+      per_page: per_page
+    });
+
+    // search jobs by jobName
+    return data.jobs.filter((job) => job.name === job_name);
+  }
+
+  /**
+   * @param {GithubContextPayload} context
+   * @returns {string}
+   */
+  function GetBranchNameFromContext(context) {
+    /** @type {string[]} */
+    const splitref = context.payload.ref.split('refs/heads/');
+    return splitref[splitref.length - 1];
+  }
+
+  /**
+   * @param {string} branchName
+   * @returns {GithubPullRequest|null}
+   */
+  async function GetPullRequestByBranchName(branchName) {
+    let hasPreviousPage = true;
+    let startCursor = null;
+
+    while (hasPreviousPage) {
+      const { repository } = await github.graphql(
+        `
+        query($owner: String!, $repo: String!, $headRefName: String!, $before: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequests(headRefName: $headRefName, states: OPEN, last: 5, before: $before) {
+              nodes {
+                number
+                title
+                url
+                state
+              }
+              pageInfo {
+                hasPreviousPage
+                startCursor
+              }
+            }
+          }
+        }
+      `,
+        {
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          headRefName: branchName,
+          before: startCursor
+        }
+      );
+
+      if (repository.pullRequests.nodes.length === 1) {
+        return repository.pullRequests.nodes[0];
+      }
+
+      hasPreviousPage = repository.pullRequests.pageInfo.hasPreviousPage;
+      startCursor = repository.pullRequests.pageInfo.startCursor;
+    }
+
+    return null;
+  }
+
+  return {
+    WORKFLOW_STATUS_COMPLETED,
+    WORKFLOW_STATUS_RUNNING,
+    CONCLUSION_STATUS_SUCCESS,
+    CONCLUSION_STATUS_CANCELLED,
+    CONCLUSION_STATUS_FAILURE,
+    GetWorkflowsByNameAndStatus,
+    GetJobsForWorkflowRunAttempt,
+    GetBranchNameFromContext,
+    GetPullRequestByBranchName
+  };
+};

--- a/.github/scripts/js/helpers/types.js
+++ b/.github/scripts/js/helpers/types.js
@@ -1,0 +1,167 @@
+// Copyright 2025 Flant JSC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @typedef {object} GithubContext
+ * @property {object} repo
+ * @property {string} repo.owner
+ * @property {string} repo.repo
+ */
+
+/**
+ * @typedef {object} GithubContextPayload
+ * @property {object} payload
+ * @property {string} payload.eventName
+ * @property {string} payload.ref
+ */
+
+/**
+ * @typedef {object} GithubWorkflowJob
+ * @property {string} name
+ * @property {number} id
+ * @property {number} run_id
+ * @property {string} workflow_name
+ * @property {string} head_branch
+ * @property {string} run_url
+ * @property {number} run_attempt
+ * @property {string} status
+ * @property {string} conclusion
+ */
+
+/**
+ * @typedef {object} GithubWorkflow
+ * @property {number} id
+ * @property {string} name
+ * @property {string} node_id
+ * @property {string} head_branch
+ * @property {string} head_sha
+ * @property {string} path
+ * @property {string} display_title
+ * @property {number} run_number
+ * @property {string} event
+ * @property {string} status
+ * @property {string} conclusion
+ * @property {number} workflow_id
+ * @property {number} check_suite_id
+ * @property {string} check_suite_node_id
+ * @property {string} url
+ * @property {string} html_url
+ * @property {Array<object>} pull_requests
+ * @property {string} created_at
+ * @property {string} updated_at
+ * @property {GithubActor} actor
+ * @property {number} run_attempt
+ * @property {Array<object>} referenced_workflows
+ * @property {string} run_started_at
+ * @property {GithubActor} triggering_actor
+ * @property {string} jobs_url
+ * @property {string} logs_url
+ * @property {string} check_suite_url
+ * @property {string} artifacts_url
+ * @property {string} cancel_url
+ * @property {string} rerun_url
+ * @property {string} previous_attempt_url
+ * @property {string} workflow_url
+ * @property {GithubCommit} head_commit
+ * @property {GithubRepository} repository
+ * @property {GithubRepository} head_repository
+ */
+
+/**
+ * @typedef {object} GithubActor
+ * @property {string} login
+ * @property {number} id
+ * @property {string} node_id
+ * @property {string} avatar_url
+ * @property {string} gravatar_id
+ * @property {string} url
+ * @property {string} html_url
+ * @property {string} followers_url
+ * @property {string} following_url
+ * @property {string} gists_url
+ * @property {string} starred_url
+ * @property {string} subscriptions_url
+ * @property {string} organizations_url
+ * @property {string} repos_url
+ * @property {string} events_url
+ * @property {string} received_events_url
+ * @property {string} type
+ * @property {string} user_view_type
+ * @property {boolean} site_admin
+ */
+
+/**
+ * @typedef {object} GithubCommit
+ * @property {string} id
+ * @property {string} tree_id
+ * @property {string} message
+ * @property {string} timestamp
+ * @property {object} author
+ * @property {object} committer
+ */
+
+/**
+ * @typedef {object} GithubRepository
+ * @property {number} id
+ * @property {string} node_id
+ * @property {string} name
+ * @property {string} full_name
+ * @property {boolean} private
+ * @property {object} owner
+ * @property {string} html_url
+ * @property {string} description
+ * @property {boolean} fork
+ * @property {string} url
+ * @property {string} forks_url
+ * @property {string} keys_url
+ * @property {string} collaborators_url
+ * @property {string} teams_url
+ * @property {string} hooks_url
+ * @property {string} issue_events_url
+ * @property {string} events_url
+ * @property {string} assignees_url
+ * @property {string} branches_url
+ * @property {string} tags_url
+ * @property {string} blobs_url
+ * @property {string} git_tags_url
+ * @property {string} git_refs_url
+ * @property {string} trees_url
+ * @property {string} statuses_url
+ * @property {string} languages_url
+ * @property {string} stargazers_url
+ * @property {string} contributors_url
+ * @property {string} subscribers_url
+ * @property {string} subscription_url
+ * @property {string} commits_url
+ * @property {string} git_commits_url
+ * @property {string} comments_url
+ * @property {string} issue_comment_url
+ * @property {string} contents_url
+ * @property {string} compare_url
+ * @property {string} merges_url
+ * @property {string} archive_url
+ * @property {string} downloads_url
+ * @property {string} issues_url
+ * @property {string} pulls_url
+ * @property {string} milestones_url
+ * @property {string} notifications_url
+ * @property {string} labels_url
+ * @property {string} releases_url
+ * @property {string} deployments_url
+ */
+
+/**
+ * @typedef {object} GithubPullRequest
+ * @property {number} number
+ * @property {string} title
+ * @property {string} url
+ * @property {string} state
+ */

--- a/.github/scripts/js/helpers/utils.js
+++ b/.github/scripts/js/helpers/utils.js
@@ -1,0 +1,33 @@
+// Copyright 2025 Flant JSC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @example await sleep(1000 * 30); // 30 seconds
+ * @param {number} ms
+ */
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * @example isReleaseBranch('release-1.67')
+ * @param {string} branchName
+ * @returns {boolean}
+ */
+function isReleaseBranch(branchName) {
+  const regex = /^release-(\d+)\.(\d+)$/;
+  return regex.test(branchName);
+}
+
+module.exports = {
+  sleep,
+  isReleaseBranch
+};

--- a/.github/scripts/js/package-lock.json
+++ b/.github/scripts/js/package-lock.json
@@ -14,6 +14,7 @@
         "@octokit/graphql": "^4.8.0",
         "@types/node": "^16.11.11",
         "jest": "28.1.2",
+        "jest-mock-extended": "^4.0.0-beta1",
         "marked": "^15.0.6",
         "prettier": "^2.5.0",
         "yaml": "^2.7.0"
@@ -2417,6 +2418,21 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/jest-mock-extended": {
+      "version": "4.0.0-beta1",
+      "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-4.0.0-beta1.tgz",
+      "integrity": "sha512-MYcI0wQu3ceNhqKoqAJOdEfsVMamAFqDTjoLN5Y45PAG3iIm4WGnhOu0wpMjlWCexVPO71PMoNir9QrGXrnIlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-essentials": "^10.0.2"
+      },
+      "peerDependencies": {
+        "@jest/globals": "^28.0.0 || ^29.0.0",
+        "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
+        "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -3492,6 +3508,21 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true
     },
+    "node_modules/ts-essentials": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.0.4.tgz",
+      "integrity": "sha512-lwYdz28+S4nicm+jFi6V58LaAIpxzhg9rLdgNC1VsdP/xiFBseGhF1M/shwCk6zMmwahBZdXcl34LVHrEang3A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -3520,6 +3551,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/universal-user-agent": {

--- a/.github/scripts/js/package.json
+++ b/.github/scripts/js/package.json
@@ -16,6 +16,7 @@
     "@octokit/graphql": "^4.8.0",
     "@types/node": "^16.11.11",
     "jest": "28.1.2",
+    "jest-mock-extended": "^4.0.0-beta1",
     "marked": "^15.0.6",
     "prettier": "^2.5.0",
     "yaml": "^2.7.0"

--- a/.github/scripts/js/validators/validate-job-in-workflow-is-ready.js
+++ b/.github/scripts/js/validators/validate-job-in-workflow-is-ready.js
@@ -1,0 +1,99 @@
+// Copyright 2025 Flant JSC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const WORKFLOW_STATUS_RUNNING = 'in_progress';
+const WORKFLOW_STATUS_COMPLETED = 'completed';
+const CONCLUSION_STATUS_SUCCESS = 'success';
+const MAX_ATTEMPTS = 60;
+const TIMEOUT_BETWEEN_ATTEMPT = 1000 * 30;
+const MAX_ITEMS_PER_PAGE = 100;
+
+module.exports = ({ github, context, core }) => {
+  /**
+   *
+   * @param {string} branch
+   * @param {string} workflowName
+   * @param {string} jobName
+   * @returns
+   */
+  async function isJobInWorkflowOrWorkflowCompleted(branch, workflowName, jobName) {
+    try {
+      const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        branch: branch,
+        per_page: MAX_ITEMS_PER_PAGE
+      });
+
+      const activeRuns = data.workflow_runs.filter((run) => run.name === workflowName && run.status === WORKFLOW_STATUS_RUNNING);
+
+      if (activeRuns.length > 0) {
+        core.info(`🔄 Active '${workflowName}' workflows found...`);
+        const activeRun = activeRuns[activeRuns.length - 1];
+        core.info(`🔄 Last active '${workflowName}' workflow found, check job '${jobName}' status ...`);
+        const { data } = await github.rest.actions.listJobsForWorkflowRunAttempt({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          run_id: activeRun.id,
+          attempt_number: activeRun.run_attempt,
+          per_page: MAX_ITEMS_PER_PAGE
+        });
+
+        // search job by jobName
+        const jobs = data.jobs.filter((job) => job.name === jobName);
+        const foundJob = jobs[0];
+
+        core.info(foundJob.status, foundJob.conclusion);
+        return foundJob.status === WORKFLOW_STATUS_COMPLETED && foundJob.conclusion === CONCLUSION_STATUS_SUCCESS;
+      }
+      return true;
+    } catch (error) {
+      core.setFailed(`🔥 Error: ${error.message}`);
+      return false;
+    }
+  }
+
+  function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   *
+   * @param {string} branchName
+   * @param {string} workflowName
+   * @param {string} jobName
+   * @param {int=} [maxAttempts=MAX_ATTEMPTS]
+   * @param {int=} [timeoutBetweenAttempt=TIMEOUT_BETWEEN_ATTEMPT]
+   * @returns
+   */
+  return async function waitForJobInWorkflowIsCompletedWithSuccess(
+    branchName,
+    workflowName,
+    jobName,
+    maxAttempts = MAX_ATTEMPTS,
+    timeoutBetweenAttempt = TIMEOUT_BETWEEN_ATTEMPT
+  ) {
+    for (let i = 0; i < maxAttempts; i++) {
+      core.info(`🚀 Attempt ${i + 1}/${maxAttempts}`);
+      const isReady = await isJobInWorkflowOrWorkflowCompleted(branchName, workflowName, jobName);
+
+      if (isReady) {
+        core.info('✅ Job In Workflow completed successfully!');
+        return true;
+      }
+
+      await sleep(timeoutBetweenAttempt);
+    }
+
+    core.setFailed('⌛ Timeout waiting for workflow completion');
+    throw new Error('Max attempts reached');
+  };
+};

--- a/.github/scripts/js/validators/validate-job-in-workflow-is-ready.js
+++ b/.github/scripts/js/validators/validate-job-in-workflow-is-ready.js
@@ -71,7 +71,7 @@ module.exports = ({ github, context, core }) => {
       branchName,
       githubActions.WORKFLOW_STATUS_RUNNING
     );
-    if (activeRuns.length > 0) {
+    if (activeRuns && activeRuns.length > 0) {
       const result = await isJobInWorkflowCompletedSuccess(activeRuns, jobName);
       if (result.hasFailed) return { isReady: false, hasFailed: true };
       return { isReady: result.success, hasFailed: false };
@@ -82,7 +82,8 @@ module.exports = ({ github, context, core }) => {
       branchName,
       githubActions.WORKFLOW_STATUS_COMPLETED
     );
-    if (completedRuns.length > 0) {
+
+    if (completedRuns && completedRuns.length > 0) {
       const result = await isJobInWorkflowCompletedSuccess(completedRuns, jobName);
       if (result.hasFailed) return { isReady: false, hasFailed: true };
       return { isReady: result.success, hasFailed: false };

--- a/.github/scripts/js/validators/validate-job-in-workflow-is-ready.test-node.js
+++ b/.github/scripts/js/validators/validate-job-in-workflow-is-ready.test-node.js
@@ -1,0 +1,73 @@
+// Copyright 2025 Flant JSC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+export GITHUB_TOKEN=<token>
+export CONTEXT_REPO_OWNER=deckhouse
+export CONTEXT_REPO_NAME=deckhouse-test-1
+export BRANCH="chore/save-logs-from-e2e-clusters-on-error"
+export WORKFLOW_NAME="Build and test for dev branches"
+export JOB_NAME="Build Deckhouse"
+*/
+const envConfig = {
+  repo_owner: process.env.CONTEXT_REPO_OWNER,
+  repo_name: process.env.CONTEXT_REPO_NAME,
+  github_token: process.env.GITHUB_TOKEN,
+  branch: process.env.BRANCH,
+  workflow_name: process.env.WORKFLOW_NAME,
+  job_name: process.env.JOB_NAME
+};
+
+require('../helpers/types');
+const Octokit = require('@actions/github');
+const core = require('@actions/core');
+const github = Octokit.getOctokit(envConfig.github_token);
+
+/** @type {GithubContext} */
+const context = {
+  repo: {
+    owner: envConfig.repo_owner,
+    repo: envConfig.repo_name
+  }
+};
+
+const { waitForJobInWorkflowIsCompletedWithSuccess, isJobInWorkflowCompleted } = require('./validate-job-in-workflow-is-ready')({
+  github,
+  context,
+  core
+});
+
+const githubAction = require('../helpers/github-actions')({
+  github,
+  context,
+  core
+});
+async function main() {
+  console.log(
+    githubAction.GetBranchNameFromContext({
+      payload: {
+        ref: 'refs/heads/release-1.67'
+      }
+    })
+  );
+
+  // const result = await waitForJobInWorkflowIsCompletedWithSuccess(
+  //   envConfig.branch,
+  //   envConfig.workflow_name,
+  //   envConfig.job_name,
+  //   100
+  // );
+
+  let result = await githubAction.GetPullRequestByBranchName(envConfig.branch);
+  console.log(result);
+}
+
+main();

--- a/.github/scripts/js/validators/validate-job-in-workflow-is-ready.test.js
+++ b/.github/scripts/js/validators/validate-job-in-workflow-is-ready.test.js
@@ -1,0 +1,209 @@
+// Copyright 2025 Flant JSC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const { mockDeep } = require('jest-mock-extended');
+const waitForJobUnderTest = require('./validate-job-in-workflow-is-ready');
+
+describe('GitHub Actions Workflow Checker', () => {
+  let github;
+  let context;
+  let core;
+
+  beforeEach(() => {
+    github = mockDeep();
+    context = {
+      repo: {
+        owner: 'test-owner',
+        repo: 'test-repo'
+      }
+    };
+    core = {
+      info: jest.fn((str) => console.log(str)),
+      setFailed: jest.fn((str) => console.error(str))
+    };
+
+    waitForJobInWorkflowIsCompletedWithSuccess = waitForJobUnderTest({ github, context, core });
+
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  ({ github, context, core });
+
+  describe('isJobInWorkflowOrWorkflowCompleted', () => {
+    it('should return true when job is successfully completed', async () => {
+      // Mock workflow runs response
+      github.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({
+        data: {
+          workflow_runs: [
+            {
+              id: 1,
+              name: 'test-workflow',
+              status: 'completed',
+              conclusion: 'success',
+              run_attempt: 1
+            }
+          ]
+        }
+      });
+
+      const result = await waitForJobInWorkflowIsCompletedWithSuccess('main', 'test-workflow', 'test-job');
+
+      console.log(result);
+      expect(result).toBe(true);
+      expect(core.setFailed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('waitForJobInWorkflowIsCompletedWithSuccess', () => {
+    it('should retry until job completes', async () => {
+      let attempt = 0;
+
+      github.rest.actions.listWorkflowRunsForRepo.mockImplementation(() => {
+        attempt++;
+        return {
+          data: {
+            workflow_runs: [
+              {
+                id: 1,
+                name: 'test-workflow',
+                status: attempt > 2 ? 'completed' : 'in_progress',
+                run_attempt: 1,
+                conclusion: 'success'
+              }
+            ]
+          }
+        };
+      });
+
+      github.rest.actions.listJobsForWorkflowRunAttempt.mockResolvedValue({
+        data: {
+          jobs: [
+            {
+              name: 'test-job',
+              status: 'completed',
+              conclusion: 'success'
+            }
+          ]
+        }
+      });
+
+      const resultPromise = waitForJobInWorkflowIsCompletedWithSuccess('main', 'test-workflow', 'test-job', 5, 1000);
+
+      await jest.advanceTimersByTimeAsync(5000);
+      const result = await resultPromise;
+
+      expect(result).toBe(true);
+      expect(github.rest.actions.listWorkflowRunsForRepo).toHaveBeenCalledTimes(3);
+    });
+
+    it('should timeout when max attempts reached', async () => {
+      github.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({
+        data: {
+          workflow_runs: [
+            {
+              id: 1,
+              name: 'test-workflow',
+              status: 'in_progress',
+              run_attempt: 1
+            }
+          ]
+        }
+      });
+
+      github.rest.actions.listJobsForWorkflowRunAttempt.mockResolvedValue({
+        data: {
+          jobs: [
+            {
+              name: 'test-job',
+              status: 'in_progress',
+              conclusion: null
+            }
+          ]
+        }
+      });
+
+      await expect(waitForJobInWorkflowIsCompletedWithSuccess('main', 'test-workflow', 'test-job', 3, 1000)).rejects.toThrow(
+        'Max attempts reached'
+      );
+
+      expect(core.setFailed).toHaveBeenCalledWith('⌛ Timeout waiting for workflow completion');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle missing completed workflow', async () => {
+      github.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({
+        data: {
+          workflow_runs: [
+            {
+              id: 1,
+              name: 'wrong-workflow',
+              status: 'completed',
+              run_attempt: 1
+            }
+          ]
+        }
+      });
+
+      await waitForJobInWorkflowIsCompletedWithSuccess('main', 'test-workflow', 'test-job', 1, 1000);
+
+      expect(core.setFailed).toHaveBeenCalledWith('❌ No completed workflow found');
+    });
+
+    it('should handle multiple active workflow runs', async () => {
+      github.rest.actions.listWorkflowRunsForRepo.mockResolvedValue({
+        data: {
+          workflow_runs: [
+            {
+              id: 2,
+              name: 'test-workflow',
+              status: 'in_progress',
+              run_attempt: 2
+            },
+            {
+              id: 1,
+              name: 'test-workflow',
+              status: 'in_progress',
+              run_attempt: 1
+            }
+          ]
+        }
+      });
+
+      github.rest.actions.listJobsForWorkflowRunAttempt.mockResolvedValue({
+        data: {
+          jobs: [
+            {
+              name: 'test-job',
+              status: 'completed',
+              conclusion: 'success'
+            }
+          ]
+        }
+      });
+
+      const result = await waitForJobInWorkflowIsCompletedWithSuccess('main', 'test-workflow', 'test-job', 1, 1000);
+
+      expect(result).toBe(true);
+      expect(github.rest.actions.listJobsForWorkflowRunAttempt).toHaveBeenCalledWith({
+        owner: 'test-owner',
+        repo: 'test-repo',
+        run_id: 2,
+        attempt_number: 2,
+        per_page: 100
+      });
+    });
+  });
+});

--- a/.github/workflow_templates/e2e-daily.yml
+++ b/.github/workflow_templates/e2e-daily.yml
@@ -42,6 +42,7 @@ jobs:
 
 # Note: git_info is needed for werf.yaml
 {!{- $gitInfoJobCtx := coll.Merge . (dict "dependJobs" (slice "skip_tests_repos")) -}!}
+
 {!{ tmpl.Exec "git_info_job" $gitInfoJobCtx | strings.Indent 2 }!}
 
 {!{- $dependsJobsForAlert := slice "skip_tests_repos" "git_info" -}!}

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -119,6 +119,8 @@ jobs:
 
 {!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
 
+{!{ tmpl.Exec "block-e2e-until-image-is-not-ready" . | strings.Indent 2 }!}
+
 {!{ tmpl.Exec "check_e2e_labels_job" $ctx | strings.Indent 2 }!}
 
 {!{/* Jobs for each CRI and Kubernetes version */}!}

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -167,6 +167,59 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - name: Block e2e until the docker image is not ready
+        id: block-e2e
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
+            const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
+
+            let branchName = context.payload.inputs.ci_commit_ref_name;
+            if (!branchName) {
+              branchName = githubAction.GetBranchNameFromContext(context);
+            }
+
+            if (branchName) {
+              let prNum = context.payload.inputs.issue_number;
+              // if the pull request id is not found, search it by the branch name
+              if (!prNum && branchName !== 'main') {
+                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
+                prNum = prInfo.number;
+              }
+
+              let infoText = `Check build workflow is completed for branch: ${branchName}`;
+              if (prNum) {
+                infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
+              }
+              core.info(infoText);
+
+              const { waitForJobInWorkflowIsCompletedWithSuccess } = require('./.github/scripts/js/validators/validate-job-in-workflow-is-ready')({ github, context, core });
+              try {
+                let workflowName = 'Build and test for dev branches';
+                let jobName = 'Build Deckhouse';
+                if (isReleaseBranch(branchName)) {
+                  workflowName = 'Build and test for release branches';
+                  jobName = 'Build Deckhouse FE';
+                }
+                if (branchName === 'main') {
+                  return true;
+                }
+                await waitForJobInWorkflowIsCompletedWithSuccess(branchName, workflowName, jobName);
+              } catch(error) {
+                core.setFailed(error);
+              }
+            }
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -208,6 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -712,6 +766,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1216,6 +1271,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1720,6 +1776,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2224,6 +2281,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2728,6 +2786,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -167,6 +167,59 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - name: Block e2e until the docker image is not ready
+        id: block-e2e
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
+            const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
+
+            let branchName = context.payload.inputs.ci_commit_ref_name;
+            if (!branchName) {
+              branchName = githubAction.GetBranchNameFromContext(context);
+            }
+
+            if (branchName) {
+              let prNum = context.payload.inputs.issue_number;
+              // if the pull request id is not found, search it by the branch name
+              if (!prNum && branchName !== 'main') {
+                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
+                prNum = prInfo.number;
+              }
+
+              let infoText = `Check build workflow is completed for branch: ${branchName}`;
+              if (prNum) {
+                infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
+              }
+              core.info(infoText);
+
+              const { waitForJobInWorkflowIsCompletedWithSuccess } = require('./.github/scripts/js/validators/validate-job-in-workflow-is-ready')({ github, context, core });
+              try {
+                let workflowName = 'Build and test for dev branches';
+                let jobName = 'Build Deckhouse';
+                if (isReleaseBranch(branchName)) {
+                  workflowName = 'Build and test for release branches';
+                  jobName = 'Build Deckhouse FE';
+                }
+                if (branchName === 'main') {
+                  return true;
+                }
+                await waitForJobInWorkflowIsCompletedWithSuccess(branchName, workflowName, jobName);
+              } catch(error) {
+                core.setFailed(error);
+              }
+            }
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -208,6 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -720,6 +774,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1232,6 +1287,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1744,6 +1800,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2256,6 +2313,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2768,6 +2826,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -167,6 +167,59 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - name: Block e2e until the docker image is not ready
+        id: block-e2e
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
+            const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
+
+            let branchName = context.payload.inputs.ci_commit_ref_name;
+            if (!branchName) {
+              branchName = githubAction.GetBranchNameFromContext(context);
+            }
+
+            if (branchName) {
+              let prNum = context.payload.inputs.issue_number;
+              // if the pull request id is not found, search it by the branch name
+              if (!prNum && branchName !== 'main') {
+                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
+                prNum = prInfo.number;
+              }
+
+              let infoText = `Check build workflow is completed for branch: ${branchName}`;
+              if (prNum) {
+                infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
+              }
+              core.info(infoText);
+
+              const { waitForJobInWorkflowIsCompletedWithSuccess } = require('./.github/scripts/js/validators/validate-job-in-workflow-is-ready')({ github, context, core });
+              try {
+                let workflowName = 'Build and test for dev branches';
+                let jobName = 'Build Deckhouse';
+                if (isReleaseBranch(branchName)) {
+                  workflowName = 'Build and test for release branches';
+                  jobName = 'Build Deckhouse FE';
+                }
+                if (branchName === 'main') {
+                  return true;
+                }
+                await waitForJobInWorkflowIsCompletedWithSuccess(branchName, workflowName, jobName);
+              } catch(error) {
+                core.setFailed(error);
+              }
+            }
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -208,6 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -757,6 +811,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1306,6 +1361,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1855,6 +1911,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2404,6 +2461,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2953,6 +3011,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -167,6 +167,59 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - name: Block e2e until the docker image is not ready
+        id: block-e2e
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
+            const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
+
+            let branchName = context.payload.inputs.ci_commit_ref_name;
+            if (!branchName) {
+              branchName = githubAction.GetBranchNameFromContext(context);
+            }
+
+            if (branchName) {
+              let prNum = context.payload.inputs.issue_number;
+              // if the pull request id is not found, search it by the branch name
+              if (!prNum && branchName !== 'main') {
+                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
+                prNum = prInfo.number;
+              }
+
+              let infoText = `Check build workflow is completed for branch: ${branchName}`;
+              if (prNum) {
+                infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
+              }
+              core.info(infoText);
+
+              const { waitForJobInWorkflowIsCompletedWithSuccess } = require('./.github/scripts/js/validators/validate-job-in-workflow-is-ready')({ github, context, core });
+              try {
+                let workflowName = 'Build and test for dev branches';
+                let jobName = 'Build Deckhouse';
+                if (isReleaseBranch(branchName)) {
+                  workflowName = 'Build and test for release branches';
+                  jobName = 'Build Deckhouse FE';
+                }
+                if (branchName === 'main') {
+                  return true;
+                }
+                await waitForJobInWorkflowIsCompletedWithSuccess(branchName, workflowName, jobName);
+              } catch(error) {
+                core.setFailed(error);
+              }
+            }
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -208,6 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -708,6 +762,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1208,6 +1263,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1708,6 +1764,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2208,6 +2265,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2708,6 +2766,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -167,6 +167,59 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - name: Block e2e until the docker image is not ready
+        id: block-e2e
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
+            const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
+
+            let branchName = context.payload.inputs.ci_commit_ref_name;
+            if (!branchName) {
+              branchName = githubAction.GetBranchNameFromContext(context);
+            }
+
+            if (branchName) {
+              let prNum = context.payload.inputs.issue_number;
+              // if the pull request id is not found, search it by the branch name
+              if (!prNum && branchName !== 'main') {
+                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
+                prNum = prInfo.number;
+              }
+
+              let infoText = `Check build workflow is completed for branch: ${branchName}`;
+              if (prNum) {
+                infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
+              }
+              core.info(infoText);
+
+              const { waitForJobInWorkflowIsCompletedWithSuccess } = require('./.github/scripts/js/validators/validate-job-in-workflow-is-ready')({ github, context, core });
+              try {
+                let workflowName = 'Build and test for dev branches';
+                let jobName = 'Build Deckhouse';
+                if (isReleaseBranch(branchName)) {
+                  workflowName = 'Build and test for release branches';
+                  jobName = 'Build Deckhouse FE';
+                }
+                if (branchName === 'main') {
+                  return true;
+                }
+                await waitForJobInWorkflowIsCompletedWithSuccess(branchName, workflowName, jobName);
+              } catch(error) {
+                core.setFailed(error);
+              }
+            }
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -208,6 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -708,6 +762,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1208,6 +1263,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1708,6 +1764,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2208,6 +2265,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2708,6 +2766,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -167,6 +167,59 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - name: Block e2e until the docker image is not ready
+        id: block-e2e
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
+            const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
+
+            let branchName = context.payload.inputs.ci_commit_ref_name;
+            if (!branchName) {
+              branchName = githubAction.GetBranchNameFromContext(context);
+            }
+
+            if (branchName) {
+              let prNum = context.payload.inputs.issue_number;
+              // if the pull request id is not found, search it by the branch name
+              if (!prNum && branchName !== 'main') {
+                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
+                prNum = prInfo.number;
+              }
+
+              let infoText = `Check build workflow is completed for branch: ${branchName}`;
+              if (prNum) {
+                infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
+              }
+              core.info(infoText);
+
+              const { waitForJobInWorkflowIsCompletedWithSuccess } = require('./.github/scripts/js/validators/validate-job-in-workflow-is-ready')({ github, context, core });
+              try {
+                let workflowName = 'Build and test for dev branches';
+                let jobName = 'Build Deckhouse';
+                if (isReleaseBranch(branchName)) {
+                  workflowName = 'Build and test for release branches';
+                  jobName = 'Build Deckhouse FE';
+                }
+                if (branchName === 'main') {
+                  return true;
+                }
+                await waitForJobInWorkflowIsCompletedWithSuccess(branchName, workflowName, jobName);
+              } catch(error) {
+                core.setFailed(error);
+              }
+            }
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -208,6 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -708,6 +762,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1208,6 +1263,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1708,6 +1764,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2208,6 +2265,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2708,6 +2766,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -167,6 +167,59 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - name: Block e2e until the docker image is not ready
+        id: block-e2e
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
+            const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
+
+            let branchName = context.payload.inputs.ci_commit_ref_name;
+            if (!branchName) {
+              branchName = githubAction.GetBranchNameFromContext(context);
+            }
+
+            if (branchName) {
+              let prNum = context.payload.inputs.issue_number;
+              // if the pull request id is not found, search it by the branch name
+              if (!prNum && branchName !== 'main') {
+                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
+                prNum = prInfo.number;
+              }
+
+              let infoText = `Check build workflow is completed for branch: ${branchName}`;
+              if (prNum) {
+                infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
+              }
+              core.info(infoText);
+
+              const { waitForJobInWorkflowIsCompletedWithSuccess } = require('./.github/scripts/js/validators/validate-job-in-workflow-is-ready')({ github, context, core });
+              try {
+                let workflowName = 'Build and test for dev branches';
+                let jobName = 'Build Deckhouse';
+                if (isReleaseBranch(branchName)) {
+                  workflowName = 'Build and test for release branches';
+                  jobName = 'Build Deckhouse FE';
+                }
+                if (branchName === 'main') {
+                  return true;
+                }
+                await waitForJobInWorkflowIsCompletedWithSuccess(branchName, workflowName, jobName);
+              } catch(error) {
+                core.setFailed(error);
+              }
+            }
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -208,6 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -724,6 +778,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1240,6 +1295,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1756,6 +1812,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2272,6 +2329,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2788,6 +2846,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -167,6 +167,59 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - name: Block e2e until the docker image is not ready
+        id: block-e2e
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
+            const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
+
+            let branchName = context.payload.inputs.ci_commit_ref_name;
+            if (!branchName) {
+              branchName = githubAction.GetBranchNameFromContext(context);
+            }
+
+            if (branchName) {
+              let prNum = context.payload.inputs.issue_number;
+              // if the pull request id is not found, search it by the branch name
+              if (!prNum && branchName !== 'main') {
+                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
+                prNum = prInfo.number;
+              }
+
+              let infoText = `Check build workflow is completed for branch: ${branchName}`;
+              if (prNum) {
+                infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
+              }
+              core.info(infoText);
+
+              const { waitForJobInWorkflowIsCompletedWithSuccess } = require('./.github/scripts/js/validators/validate-job-in-workflow-is-ready')({ github, context, core });
+              try {
+                let workflowName = 'Build and test for dev branches';
+                let jobName = 'Build Deckhouse';
+                if (isReleaseBranch(branchName)) {
+                  workflowName = 'Build and test for release branches';
+                  jobName = 'Build Deckhouse FE';
+                }
+                if (branchName === 'main') {
+                  return true;
+                }
+                await waitForJobInWorkflowIsCompletedWithSuccess(branchName, workflowName, jobName);
+              } catch(error) {
+                core.setFailed(error);
+              }
+            }
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -208,6 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -712,6 +766,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1216,6 +1271,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1720,6 +1776,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2224,6 +2281,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2728,6 +2786,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -167,6 +167,59 @@ jobs:
 
   # </template: git_info_job>
 
+
+  # </template: block-e2e-until-image-is-not-ready>
+  block-e2e-until-image-is-not-ready:
+    name: Block e2e until the docker image is not ready
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - name: Block e2e until the docker image is not ready
+        id: block-e2e
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
+            const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
+
+            let branchName = context.payload.inputs.ci_commit_ref_name;
+            if (!branchName) {
+              branchName = githubAction.GetBranchNameFromContext(context);
+            }
+
+            if (branchName) {
+              let prNum = context.payload.inputs.issue_number;
+              // if the pull request id is not found, search it by the branch name
+              if (!prNum && branchName !== 'main') {
+                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
+                prNum = prInfo.number;
+              }
+
+              let infoText = `Check build workflow is completed for branch: ${branchName}`;
+              if (prNum) {
+                infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
+              }
+              core.info(infoText);
+
+              const { waitForJobInWorkflowIsCompletedWithSuccess } = require('./.github/scripts/js/validators/validate-job-in-workflow-is-ready')({ github, context, core });
+              try {
+                let workflowName = 'Build and test for dev branches';
+                let jobName = 'Build Deckhouse';
+                if (isReleaseBranch(branchName)) {
+                  workflowName = 'Build and test for release branches';
+                  jobName = 'Build Deckhouse FE';
+                }
+                if (branchName === 'main') {
+                  return true;
+                }
+                await waitForJobInWorkflowIsCompletedWithSuccess(branchName, workflowName, jobName);
+              } catch(error) {
+                core.setFailed(error);
+              }
+            }
+
+  # </template: block-e2e-until-image-is-not-ready>
+
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
@@ -208,6 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -716,6 +770,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1224,6 +1279,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1732,6 +1788,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2240,6 +2297,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2748,6 +2806,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
+      - block-e2e-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}


### PR DESCRIPTION
## Description
update job for block run e2e tests until the docker image is not ready

## Why do we need it, and what problem does it solve?
e2e tests may run before the corresponding image is built. it's stopping the test.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: the test will not run until the image build workflow is complete
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
