### PR TITLE
[upmeter] Fix metallb probe

### DIFF
--- a/ee/modules/380-metallb/templates/controller/deployment.yaml
+++ b/ee/modules/380-metallb/templates/controller/deployment.yaml
@@ -45,6 +45,7 @@ spec:
     metadata:
       labels:
         app: controller
+        metallb-role: controller
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}

--- a/ee/modules/380-metallb/templates/speaker/daemonset.yaml
+++ b/ee/modules/380-metallb/templates/speaker/daemonset.yaml
@@ -46,6 +46,7 @@ spec:
         {{ include "helm_lib_prevent_ds_eviction_annotation" . | nindent 8 }}
       labels:
         app: speaker
+        metallb-role: speaker
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}

--- a/ee/se/modules/380-metallb/templates/l2lb/controller/deployment.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/controller/deployment.yaml
@@ -45,6 +45,7 @@ spec:
     metadata:
       labels:
         app: l2lb-controller
+        metallb-role: controller
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}

--- a/ee/se/modules/380-metallb/templates/l2lb/speaker/daemonset.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/speaker/daemonset.yaml
@@ -44,6 +44,7 @@ spec:
     metadata:
       labels:
         app: l2lb-speaker
+        metallb-role: speaker
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}

--- a/modules/500-upmeter/images/upmeter/src/pkg/probe/group_loadbalancing.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/probe/group_loadbalancing.go
@@ -53,7 +53,7 @@ func initLoadBalancing(access kubernetes.Access, preflight checker.Doer) []runne
 				Access:           access,
 				Timeout:          5 * time.Second,
 				Namespace:        "d8-metallb",
-				LabelSelector:    "app=controller",
+				LabelSelector:    "metallb-role=controller",
 				PreflightChecker: controlPlanePinger,
 			},
 		}, {
@@ -65,7 +65,7 @@ func initLoadBalancing(access kubernetes.Access, preflight checker.Doer) []runne
 				Access:           access,
 				Timeout:          5 * time.Second,
 				Namespace:        "d8-metallb",
-				LabelSelector:    "app=speaker",
+				LabelSelector:    "metallb-role=speaker",
 				PreflightChecker: controlPlanePinger,
 			},
 		},


### PR DESCRIPTION
## Description
- Add an additional labels to **metallb** module pods (`metallb-role: <value>`).
- Add these labels in the **upmeter** module settings.

## Why do we need it, and what problem does it solve?
After extending the capabilities of the **metallb** module, **upmeter** monitoring broke.
![image](https://github.com/user-attachments/assets/4c9ce3c2-f393-45a2-a3b6-26d194a29758)

This PR solves that problem.
<img width="1161" alt="image" src="https://github.com/user-attachments/assets/a13f56e3-82d6-4231-b710-d752bcc893a6" />

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: upmeter
type: fix
summary: Fixed metallb module probe.
```
