### PR TITLE
[kube-dns] Change pattern for stubZones to allow _

### DIFF
--- a/modules/042-kube-dns/openapi/config-values.yaml
+++ b/modules/042-kube-dns/openapi/config-values.yaml
@@ -51,7 +51,7 @@ properties:
           description: |
             The CoreDNS zone.
           type: string
-          pattern: '^[0-9a-zA-Z\.-_]+$
+          pattern: '^[0-9a-zA-Z\.-_]+$'
           x-doc-example: consul.local
         upstreamNameservers:
           mixLength: 1

--- a/modules/042-kube-dns/openapi/config-values.yaml
+++ b/modules/042-kube-dns/openapi/config-values.yaml
@@ -54,7 +54,7 @@ properties:
           pattern: '^[0-9a-zA-Z\.-_]+$'
           x-doc-example: consul.local
         upstreamNameservers:
-          mixLength: 1
+          minLength: 1
           description: |
             A list of IP addresses of recursive DNS servers that CoreDNS will use to resolve domains in this zone.
           type: array

--- a/modules/042-kube-dns/openapi/config-values.yaml
+++ b/modules/042-kube-dns/openapi/config-values.yaml
@@ -51,7 +51,7 @@ properties:
           description: |
             The CoreDNS zone.
           type: string
-          pattern: '^[0-9a-zA-Z\.-]+$'
+          pattern: '^(?:[a-zA-Z0-9-_]+\.)*(?:[a-zA-Z0-9-]+\.)[a-zA-Z]{2,6}$'
           x-doc-example: consul.local
         upstreamNameservers:
           mixLength: 1

--- a/modules/042-kube-dns/openapi/config-values.yaml
+++ b/modules/042-kube-dns/openapi/config-values.yaml
@@ -54,7 +54,7 @@ properties:
           pattern: '^[0-9a-zA-Z\.-_]+$'
           x-doc-example: consul.local
         upstreamNameservers:
-          minLength: 1
+          minItems: 1
           description: |
             A list of IP addresses of recursive DNS servers that CoreDNS will use to resolve domains in this zone.
           type: array

--- a/modules/042-kube-dns/openapi/config-values.yaml
+++ b/modules/042-kube-dns/openapi/config-values.yaml
@@ -51,7 +51,7 @@ properties:
           description: |
             The CoreDNS zone.
           type: string
-          pattern: '^(?:[a-zA-Z0-9-_]+\.)*[a-zA-Z0-9-]+\.+[a-zA-Z]{2,}$'
+          pattern: '^[0-9a-zA-Z\.-_]+$
           x-doc-example: consul.local
         upstreamNameservers:
           mixLength: 1

--- a/modules/042-kube-dns/openapi/config-values.yaml
+++ b/modules/042-kube-dns/openapi/config-values.yaml
@@ -51,7 +51,7 @@ properties:
           description: |
             The CoreDNS zone.
           type: string
-          pattern: '^(?:[a-zA-Z0-9-_]+\.)*(?:[a-zA-Z0-9-]+\.)[a-zA-Z]{2,6}$'
+          pattern: '^(?:[a-zA-Z0-9-_]+\.)*[a-zA-Z0-9-]+\.+[a-zA-Z]{2,}$'
           x-doc-example: consul.local
         upstreamNameservers:
           mixLength: 1

--- a/modules/042-kube-dns/openapi/openapi-case-tests.yaml
+++ b/modules/042-kube-dns/openapi/openapi-case-tests.yaml
@@ -36,27 +36,27 @@ negative:
       - domain: two-another.example.com
         ip: 10.10.0.128
     - stubZones:
-      - zone: consul.local:53
+      - zone: consul.local
         upstreamNameservers:
           - 10.a150.0.1
     - enableLogs: 1
     - clusterDomainAliases:
       - foo?.bar
     - stubZones:
-      - zone: consul.local:53
+      - zone: consul.local
         upstreamNameservers:
         - 10.10.0.1
         cacheTTLSeconds: 3800
     - stubZones:
-      - zone: consul.local:53
+      - zone: consul.local
         upstreamNameservers:
           - 10.10.0.1
         cacheTTLSeconds: "abc"
     - stubZones:
-      - zone: consul.local:53
+      - zone: consul.local
         upstreamNameservers: []
     - stubZones:
-      - zone: consul.local:53
+      - zone: consul.local
   values:
     - internal:
         enablePodAntiAffinity: 1


### PR DESCRIPTION
## Description
Make validation pattern for stubZones more widely.

https://regex101.com/r/XZ2Q0X/1
https://regex101.com/r/khD908/1

## Why do we need it, and what problem does it solve?
Fix https://github.com/deckhouse/deckhouse/issues/390

For example, we can setting kube-dns like this:

```
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: kube-dns
spec:
  enabled: true
  settings:
    stubZones:
    - upstreamNameservers:
      - 8.8.8.8
      zone: _acme-challenge.example.com
    upstreamNameservers:
    - 10.128.0.6
  version: 1
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: kube-dns
type: feature
summary: Change pattern for stubZones to allow _. 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
