### PR TITLE
[cilium-cni] fix bug on deleting cep in several ces after migration c…

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-managment.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-managment.patch
@@ -635,7 +635,7 @@ index 4a2b401797..64b4012b74 100644
  	"github.com/cilium/cilium/pkg/metrics"
  	"github.com/cilium/cilium/pkg/monitor/notifications"
 diff --git a/pkg/ipcache/ipcache.go b/pkg/ipcache/ipcache.go
-index 59f89704c1..08bb066aac 100644
+index 59f89704c1..cefa7bdf91 100644
 --- a/pkg/ipcache/ipcache.go
 +++ b/pkg/ipcache/ipcache.go
 @@ -12,6 +12,10 @@ import (
@@ -1016,6 +1016,104 @@ index 59f89704c1..08bb066aac 100644
  	// Update both maps.
  	ipc.ipToIdentityCache[ip] = newIdentity
  	// Delete the old identity, if any.
+@@ -686,6 +1023,13 @@ func (ipc *IPCache) DeleteOnMetadataMatch(IP string, source source.Source, names
+ 	return false
+ }
+ 
++func (ipc *IPCache) IsIPcacheOwner(IP string, source source.Source, namespace, name string) (isOwner bool) {
++	ipc.mutex.Lock()
++	defer ipc.mutex.Unlock()
++	k8sMeta := ipc.getK8sMetadata(IP)
++	return k8sMeta != nil && k8sMeta.Namespace == namespace && k8sMeta.PodName == name
++}
++
+ // Delete removes the provided IP-to-security-identity mapping from the IPCache.
+ func (ipc *IPCache) Delete(IP string, source source.Source) (namedPortsChanged bool) {
+ 	ipc.mutex.Lock()
+diff --git a/pkg/k8s/watchers/cilium_endpoint.go b/pkg/k8s/watchers/cilium_endpoint.go
+index aad3684254..75ef4c1093 100644
+--- a/pkg/k8s/watchers/cilium_endpoint.go
++++ b/pkg/k8s/watchers/cilium_endpoint.go
+@@ -254,6 +254,21 @@ func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
+ 	}
+ }
+ 
++func (k *K8sWatcher) endpointIsIPcacheOwner(c *types.CiliumEndpoint) bool {
++	isOwner := true
++	if c.Networking != nil {
++		for _, pair := range c.Networking.Addressing {
++			if pair.IPV4 != "" {
++				isOwner = k.ipcache.IsIPcacheOwner(pair.IPV4, source.CustomResource, c.Namespace, c.Name)
++				if !isOwner {
++					break
++				}
++			}
++		}
++	}
++	return isOwner
++}
++
+ // CreateCiliumEndpointLocalPodIndexFunc returns an IndexFunc that indexes only local
+ // CiliumEndpoints, by their local Node IP.
+ func CreateCiliumEndpointLocalPodIndexFunc() cache.IndexFunc {
+diff --git a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+index 418b23cbc2..5fa9753dee 100644
+--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
++++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+@@ -21,6 +21,7 @@ import (
+ type endpointWatcher interface {
+ 	endpointUpdated(oldC, newC *types.CiliumEndpoint)
+ 	endpointDeleted(c *types.CiliumEndpoint)
++	endpointIsIPcacheOwner(c *types.CiliumEndpoint) bool
+ }
+ 
+ type localEndpointCache interface {
+@@ -166,12 +167,17 @@ func (cs *cesSubscriber) deleteCEPfromCES(CEPName, CESName string, c *types.Cili
+ 			"CEPName": CEPName,
+ 		}).Info("CEP deleted, calling endpointDeleted")
+ 		cs.epWatcher.endpointDeleted(c)
+-	} else {
++	} else if cs.epWatcher.endpointIsIPcacheOwner(c) {
+ 		log.WithFields(logrus.Fields{
+ 			"CESName": CESName,
+ 			"CEPName": CEPName,
+ 		}).Info("CEP deleted, other CEP exists, calling endpointUpdated")
+ 		cs.epWatcher.endpointUpdated(c, cep)
++	} else {
++		log.WithFields(logrus.Fields{
++			"CESName": CESName,
++			"CEPName": CEPName,
++		}).Debug("not last CEP deleted and CEP don't own ipcache, skip ipcache changes")
+ 	}
+ }
+ 
+diff --git a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber_test.go b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber_test.go
+index 7ef00e36ff..b0fba3c0f8 100644
+--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber_test.go
++++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber_test.go
+@@ -48,6 +48,10 @@ func createFakeEPWatcher() *fakeEPWatcher {
+ 	return &fakeEPWatcher{}
+ }
+ 
++func (fw *fakeEPWatcher) endpointIsIPcacheOwner(c *types.CiliumEndpoint) bool {
++	return true
++}
++
+ func (fw *fakeEPWatcher) endpointUpdated(oldC, newC *types.CiliumEndpoint) {
+ 	fw.lastUpdate = endpointUpdate{oldC, newC}
+ }
+diff --git a/pkg/k8s/watchers/watcher.go b/pkg/k8s/watchers/watcher.go
+index 0a0b3935e8..cd83cbb521 100644
+--- a/pkg/k8s/watchers/watcher.go
++++ b/pkg/k8s/watchers/watcher.go
+@@ -218,6 +218,7 @@ type ipcacheManager interface {
+ 	UpsertLabels(prefix netip.Prefix, lbls labels.Labels, src source.Source, resource ipcacheTypes.ResourceID)
+ 	RemoveLabelsExcluded(lbls labels.Labels, toExclude map[netip.Prefix]struct{}, resource ipcacheTypes.ResourceID)
+ 	DeleteOnMetadataMatch(IP string, source source.Source, namespace, name string) (namedPortsChanged bool)
++	IsIPcacheOwner(IP string, source source.Source, namespace, name string) (isOwner bool)
+ }
+ 
+ type K8sWatcher struct {
 diff --git a/pkg/labels/labels.go b/pkg/labels/labels.go
 index 1c026356fa..ad0af6e774 100644
 --- a/pkg/labels/labels.go
@@ -1304,6 +1402,21 @@ index 51261df078..0000000000
 -
 -	return m, nil
 -}
+diff --git a/pkg/testutils/ipcache/ipcache.go b/pkg/testutils/ipcache/ipcache.go
+index 995602f115..1bd3f40a82 100644
+--- a/pkg/testutils/ipcache/ipcache.go
++++ b/pkg/testutils/ipcache/ipcache.go
+@@ -21,6 +21,10 @@ func (m *MockIPCache) GetNamedPorts() types.NamedPortMultiMap {
+ 	return nil
+ }
+ 
++func (m *MockIPCache) IsIPcacheOwner(IP string, source source.Source, namespace, name string) (isOwner bool) {
++	return true
++}
++
+ func (m *MockIPCache) AddListener(listener ipcache.IPIdentityMappingListener) {}
+ 
+ func (m *MockIPCache) AllocateCIDRs(prefixes []netip.Prefix, oldNIDs []identity.NumericIdentity, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error) {
 -- 
 2.34.1
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
 Fixed bug when low priority cep displace other cep with high priority in ipcache.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
 This bug is being reproduced on deleting CEP which exist in several CESs. In the context of a VM migration the low-priority CEP will replace the high-priority CEP in ipcache map then last event delete of low-priority CEP will clear ipcache map and break network access to VM.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: fixed a bug with broken network access to a VM after migration
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
