### PR TITLE
[deckhouse] fix module.yaml ignored when weight == 0

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
@@ -98,9 +98,7 @@ func (md *ModuleDownloader) DownloadDevImageTag(moduleName, imageTag, checksum s
 		return "", nil, err
 	}
 
-	def := md.fetchModuleDefinitionFromFS(moduleName, moduleStorePath)
-
-	return digest.String(), def, nil
+	return digest.String(), md.fetchModuleDefinitionFromFS(moduleName, moduleStorePath), nil
 }
 
 func (md *ModuleDownloader) DownloadByModuleVersion(moduleName, moduleVersion string) (*DownloadStatistic, error) {
@@ -327,26 +325,26 @@ func (md *ModuleDownloader) fetchModuleReleaseMetadataFromReleaseChannel(moduleN
 	return "v" + moduleMetadata.Version.String(), digest.String(), moduleMetadata.Changelog, nil
 }
 
-func (md *ModuleDownloader) fetchModuleDefinitionFromFS(moduleName, moduleVersionPath string) *moduletypes.Definition {
+func (md *ModuleDownloader) fetchModuleDefinitionFromFS(name, path string) *moduletypes.Definition {
 	def := &moduletypes.Definition{
-		Name:   moduleName,
+		Name:   name,
 		Weight: defaultModuleWeight,
-		Path:   moduleVersionPath,
+		Path:   path,
 	}
 
-	moduleDefFile := path.Join(moduleVersionPath, moduletypes.DefinitionFile)
+	defPath := filepath.Join(path, moduletypes.DefinitionFile)
 
-	if _, err := os.Stat(moduleDefFile); err != nil {
+	if _, err := os.Stat(defPath); err != nil {
 		return def
 	}
 
-	f, err := os.Open(moduleDefFile)
+	f, err := os.Open(defPath)
 	if err != nil {
 		return def
 	}
 	defer f.Close()
 
-	if err = yaml.NewDecoder(f).Decode(&def); err != nil {
+	if err = yaml.NewDecoder(f).Decode(def); err != nil {
 		return def
 	}
 
@@ -375,7 +373,7 @@ func (md *ModuleDownloader) fetchModuleDefinitionFromImage(moduleName string, im
 		return def, nil
 	}
 
-	if err = yaml.NewDecoder(buf).Decode(&def); err != nil {
+	if err = yaml.NewDecoder(buf).Decode(def); err != nil {
 		return def, err
 	}
 

--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -341,8 +341,8 @@ func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, 
 			}
 
 			if !reflect.DeepEqual(moduleCopy.Properties, module.Properties) ||
-				!reflect.DeepEqual(module.Labels, module.Labels) ||
-				!reflect.DeepEqual(module.Annotations, module.Annotations) {
+				!reflect.DeepEqual(moduleCopy.Labels, module.Labels) ||
+				!reflect.DeepEqual(moduleCopy.Annotations, module.Annotations) {
 				return l.client.Update(ctx, module)
 			}
 


### PR DESCRIPTION
## Description
It provides fix for module.yaml ignored when weight == 0

## Why do we need it, and what problem does it solve?
Fixes #12235

## Why do we need it in the patch release (if we do)?
It avoids ignoring and also provides some fixes(close open files and deepEqual with wrong structure)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix module.yaml ignored when weight == 0.
```
