### PR TITLE
[docs] Update module lifecycle stage values in the documentation

### DIFF
--- a/docs/documentation/pages/module-development/STRUCTURE.md
+++ b/docs/documentation/pages/module-development/STRUCTURE.md
@@ -422,7 +422,7 @@ If confirmation is required to disable a module (the `confirmation` parameter is
 - `deckhouse` — *String.* Pod dependency [on Deckhouse Kubernetes Platform version](../dependencies/#deckhouse-kubernetes-platform-version-dependency) that the pod is compatible with.
 - `kubernetes` — *String.* Pod dependency [on Kubernetes version](../dependencies/#kubernetes-version-dependency) that the pod is compatible with.
 - `modules` — *Object.* Module dependency [on the version of other modules](../dependencies/#dependency-on-the-version-of-other-modules).
-- `stage` — *String.* [Module lifecycle stage](../versioning/#how-do-i-figure-out-how-stable-a-module-is). Possible values: `Experimental`, `Preview`, `General Availability`, `Deprecated`. 
+- `stage` — *String.* [Module lifecycle stage](../versioning/#how-do-i-figure-out-how-stable-a-module-is). Possible values: `Experimental`, `Preview`, `General Availability`, `Deprecated`.
 - `tags` — *Array of strings.* List of additional module tags. Tags are converted to [Module](../../cr.html#module) object labels according to the template `module.deckhouse.io/<TAG>=""` (where `<TAG>` is the tag name).
 
 For example, if you specify `tags: ["test", "myTag"]`, then the corresponding Module object in the cluster will be assigned the labels `module.deckhouse.io/test=""` and `module.deckhouse.io/myTag=""`.

--- a/docs/documentation/pages/module-development/STRUCTURE.md
+++ b/docs/documentation/pages/module-development/STRUCTURE.md
@@ -422,7 +422,7 @@ If confirmation is required to disable a module (the `confirmation` parameter is
 - `deckhouse` — *String.* Pod dependency [on Deckhouse Kubernetes Platform version](../dependencies/#deckhouse-kubernetes-platform-version-dependency) that the pod is compatible with.
 - `kubernetes` — *String.* Pod dependency [on Kubernetes version](../dependencies/#kubernetes-version-dependency) that the pod is compatible with.
 - `modules` — *Object.* Module dependency [on the version of other modules](../dependencies/#dependency-on-the-version-of-other-modules).
-- `stage` — *String.* [Module lifecycle stage](../versioning/#how-do-i-figure-out-how-stable-a-module-is). Possible values: `Sandbox`, `Incubating`, `Graduated`, or `Deprecated`.
+- `stage` — *String.* [Module lifecycle stage](../versioning/#how-do-i-figure-out-how-stable-a-module-is). Possible values: `Experimental`, `Preview`, `General Availability`, `Deprecated`. 
 - `tags` — *Array of strings.* List of additional module tags. Tags are converted to [Module](../../cr.html#module) object labels according to the template `module.deckhouse.io/<TAG>=""` (where `<TAG>` is the tag name).
 
 For example, if you specify `tags: ["test", "myTag"]`, then the corresponding Module object in the cluster will be assigned the labels `module.deckhouse.io/test=""` and `module.deckhouse.io/myTag=""`.

--- a/docs/documentation/pages/module-development/STRUCTURE_RU.md
+++ b/docs/documentation/pages/module-development/STRUCTURE_RU.md
@@ -422,7 +422,7 @@ dependencies:
   - `deckhouse` — *Строка.* Зависимость модуля [от версии Deckhouse Kubernetes Platform](../dependencies/#зависимость-от-версии-deckhouse-kubernetes-platform), с которой совместим модуль.
   - `kubernetes` — *Строка.* Зависимость модуля [от версии Kubernetes](../dependencies/#зависимость-от-версии-kubernetes), с которой совместим модуль.
   - `modules` — *Объект.* Зависимость модуля [от версии других модулей](../dependencies/#зависимость-от-версии-других-модулей).
-- `stage` — *Строка.* [Стадия жизненного цикла модуля](../versioning/#как-понять-насколько-модуль-стабилен). Допустимые значения: `Sandbox`, `Incubating`, `Graduated` или `Deprecated`.
+- `stage` — *Строка.* [Стадия жизненного цикла модуля](../versioning/#как-понять-насколько-модуль-стабилен). Допустимые значения: `Experimental`, `Preview`, `General Availability`, `Deprecated`.
 - `tags` — *Массив строк.* Список дополнительных тегов модуля. Теги преобразуются в лейблы объекта [Module](../../cr.html#module) в соответствии с шаблоном `module.deckhouse.io/<TAG>=""` (где `<TAG>` — название тега).
 
   Например, если указать `tags: ["test", "myTag"]`, то на соответствующий объект Module в кластере будут назначены лейблы `module.deckhouse.io/test=""` и `module.deckhouse.io/myTag=""`.


### PR DESCRIPTION
## Description

Fix module lifecycle stage values in the documentation.

## Why do we need it in the patch release (if we do)?

There is conflicting information in the documentation

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix module lifecycle stage values in the documentation.
impact_level: low
```
