### PR TITLE
[deckhouse] fix overridden status

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -313,6 +313,18 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 		// clear overridden
 		availableModule.Overridden = false
 
+		if module.Properties.Source != source.Name {
+			availableModules = append(availableModules, availableModule)
+			r.log.Debugf("the '%s' source not active source for the '%s' module, skip it", source.Name, moduleName)
+			continue
+		}
+
+		if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+			availableModules = append(availableModules, availableModule)
+			r.log.Debugf("skip the '%s' disabled module", moduleName)
+			continue
+		}
+
 		var cachedChecksum = availableModule.Checksum
 
 		// check if release exists

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -292,30 +292,11 @@ func (r *reconciler) ensureModule(ctx context.Context, sourceName, moduleName, r
 		if !slices.Contains(module.Properties.AvailableSources, sourceName) {
 			module.Properties.AvailableSources = append(module.Properties.AvailableSources, sourceName)
 		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("update the '%s' module: %w", moduleName, err)
-	}
-
-	if module.Properties.Source != sourceName {
-		r.log.Debugf("the '%s' source not active source for the '%s' module, skip it", sourceName, moduleName)
-		return nil, nil
-	}
-
-	if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
-		r.log.Debugf("skip the '%s' disabled module", moduleName)
-		return nil, nil
-	}
-
-	// update release channel
-	err = ctrlutils.UpdateWithRetry(ctx, r.client, module, func() error {
 		module.Properties.ReleaseChannel = releaseChannel
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("update release channel for the '%s' module: %w", moduleName, err)
+		return nil, fmt.Errorf("update the '%s' module: %w", moduleName, err)
 	}
 
 	return module, nil


### PR DESCRIPTION
## Description
It fixes stuck overridden status in ms.

## Why do we need it, and what problem does it solve?
Overridden status not cleared.

## Why do we need it in the patch release (if we do)?
Stuck overridden status can confuse.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix stuck overridden status in ms.
impact_level: low
```
