### PR TITLE
Empty limit handler

### DIFF
--- a/modules/015-admission-policy-engine/crds/operation-policy.yaml
+++ b/modules/015-admission-policy-engine/crds/operation-policy.yaml
@@ -58,9 +58,9 @@ spec:
                       description: |
                         Requires containers to have defined resources set.
                       anyOf:
+                        - required: [ limits, requests ]
                         - required: [ limits ]
                         - required: [ requests ]
-                        - required: [ limits, requests ]
                       properties:
                         limits:
                           type: array

--- a/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
+++ b/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
@@ -122,8 +122,8 @@ type OperationPolicySpec struct {
 	Policies          struct {
 		AllowedRepos      []string `json:"allowedRepos,omitempty"`
 		RequiredResources struct {
-			Limits   []string `json:"limits"`
-			Requests []string `json:"requests"`
+			Limits   []string `json:"limits,omitempty"`
+			Requests []string `json:"requests,omitempty"`
 		} `json:"requiredResources,omitempty"`
 		DisallowedImageTags []string `json:"disallowedImageTags,omitempty"`
 		RequiredProbes      []string `json:"requiredProbes,omitempty"`

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -88,11 +88,11 @@ spec:
         kinds: ["Pod"]
     {{- include "constraint_selector" (list $cr) }}
   parameters:
-    {{- if gt (len $cr.spec.policies.requiredResources.limits) 0 }}
+    {{- if $cr.spec.policies.requiredResources.limits }}
     limits:
       {{- $cr.spec.policies.requiredResources.limits | toYaml | nindent 6 }}
     {{- end }}
-    {{- if gt (len $cr.spec.policies.requiredResources.requests) 0 }}
+    {{- if $cr.spec.policies.requiredResources.requests }}
     requests:
       {{- $cr.spec.policies.requiredResources.requests | toYaml | nindent 6 }}
     {{- end }}


### PR DESCRIPTION
## Description
Fix empty field handling

## Why do we need it, and what problem does it solve?
Deckhouse fails if limits/requests are empty, because of `null` json value

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: fix 
summary: Fix resourceRequests limits handling in the OperationPolicy CR.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
