### PR TITLE
[service-with-healthcheck] Fixed the creation of endpointslices and performing PGSQL-probes

### DIFF
--- a/ee/modules/610-service-with-healthchecks/crds/doc-ru-servicewithhealthchecks.yaml
+++ b/ee/modules/610-service-with-healthchecks/crds/doc-ru-servicewithhealthchecks.yaml
@@ -68,6 +68,8 @@ spec:
                               authSecretName:
                                 description: |-
                                   Имя секрета (Secret), расположенного в том же пространстве имен, что и этот ресурс. Секрет может содержать следующие поля аутентификации: `tlsMode`, `clientCert`, `clientKey`, `aCert`, `password`, `user`.
+
+                                  > **Внимание.** Тип секрета должен быть `network.deckhouse.io/postgresql-credentials`.
                               dbName:
                                 description: Имя базы данных, используемое при подключении. Если не указать, то будет использовано имя пользователя.
                               query:

--- a/ee/modules/610-service-with-healthchecks/crds/servicewithhealthchecks.yaml
+++ b/ee/modules/610-service-with-healthchecks/crds/servicewithhealthchecks.yaml
@@ -153,6 +153,8 @@ spec:
 
                                 The secret can contain the following authentication fields:
                                 `tlsMode`, `clientCert`, `clientKey`, `caCert`, `password`, `user`.
+
+                                > **Warining.** The type of the secret must be `network.deckhouse.io/postgresql-credentials`.
                             dbName:
                               type: string
                               description: Optional Database Name.

--- a/ee/modules/610-service-with-healthchecks/images/artifact/cmd/agent/main.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/cmd/agent/main.go
@@ -108,12 +108,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	secretController := &agent.PostgreSQLCredentialsReconciler{
+		Client: mgr.GetClient(),
+		Logger: ctrl.Log.WithName("secret-controller"),
+		Scheme: mgr.GetScheme(),
+	}
+	if err = secretController.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "PostgreSQLCredentials")
+		os.Exit(1)
+	}
+
 	serviceWithHealthchecksController := agent.NewServiceWithHealthchecksReconciler(
 		mgr.GetClient(),
 		workersCount,
 		nodeName,
 		mgr.GetScheme(),
-		ctrl.Log.WithName("agent"),
+		ctrl.Log.WithName("service-with-healthchecks-controller"),
+		secretController,
 	)
 	if err = serviceWithHealthchecksController.RunWorkers(context.Background()); err != nil {
 		setupLog.Error(err, "unable to run controller workers", "controller", "ServiceWithHealthchecks")

--- a/ee/modules/610-service-with-healthchecks/images/artifact/cmd/controller/main.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/cmd/controller/main.go
@@ -45,6 +45,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var debugging bool
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":4250", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
@@ -54,8 +56,9 @@ func main() {
 		"If set the metrics endpoint is served securely")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.BoolVar(&debugging, "debugging", false, "If set, enables debugging")
 	opts := zap.Options{
-		Development: true,
+		Development: debugging,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/postgres_credentials_controller.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/postgres_credentials_controller.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+// Currently, the code uses a fasthttp probes implementation, but this implementation,
+// which uses only the standard library, was left as a backup.
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	secretTypePostgresqlCredentials = "network.deckhouse.io/postgresql-credentials"
+)
+
+type PostgreSQLCredentialsReconciler struct {
+	client.Client
+	Logger logr.Logger
+	Scheme *runtime.Scheme
+
+	secretsCache sync.Map
+}
+
+func (r *PostgreSQLCredentialsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Logger.V(1).Info("reconcile secret", "name", req.Name, "namespace", req.Namespace)
+
+	var creds PostgreSQLCredentials
+
+	var secret corev1.Secret
+	if err := r.Get(ctx, client.ObjectKey{
+		Namespace: req.Namespace,
+		Name:      req.Name,
+	}, &secret); err != nil {
+		r.Logger.V(0).Error(err, "unable to fetch Secret", "name", req.Name, "namespace", req.Namespace)
+		return ctrl.Result{}, err
+	}
+
+	if secret.DeletionTimestamp != nil {
+		r.secretsCache.Delete(req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	creds.TlsMode = getNativeTLSMode(string(secret.Data["tlsMode"]))
+	creds.User = string(secret.Data["user"])
+	creds.Password = string(secret.Data["password"])
+	creds.ClientCert = string(secret.Data["clientCert"])
+	creds.ClientKey = string(secret.Data["clientKey"])
+	creds.CaCert = string(secret.Data["caCert"])
+
+	r.secretsCache.Store(req.NamespacedName, creds)
+
+	return ctrl.Result{}, nil
+}
+
+func (r *PostgreSQLCredentialsReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}).
+		WithEventFilter(predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				oldSecret := e.ObjectOld.(*corev1.Secret)
+				newSecret := e.ObjectNew.(*corev1.Secret)
+
+				if newSecret.Type != secretTypePostgresqlCredentials {
+					return false
+				}
+				return oldSecret.ResourceVersion != newSecret.ResourceVersion
+			},
+			CreateFunc: func(e event.CreateEvent) bool {
+				secret := e.Object.(*corev1.Secret)
+				if secret.Type != secretTypePostgresqlCredentials {
+					return false
+				}
+				return true
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				secret := e.Object.(*corev1.Secret)
+				if secret.Type != secretTypePostgresqlCredentials {
+					return false
+				}
+				return true
+			},
+			GenericFunc: func(e event.GenericEvent) bool {
+				return false
+			},
+		}).
+		Complete(r)
+}
+
+func (r *PostgreSQLCredentialsReconciler) findObjectsForSecret(ctx context.Context, obj client.Object) []reconcile.Request {
+	secret := obj.(*corev1.Secret)
+	return []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      secret.Name,
+				Namespace: secret.Namespace,
+			},
+		},
+	}
+}
+
+func (r *PostgreSQLCredentialsReconciler) GetCachedSecret(key types.NamespacedName) (PostgreSQLCredentials, error) {
+	value, exists := r.secretsCache.Load(key)
+	if !exists {
+		return PostgreSQLCredentials{}, fmt.Errorf("secret not found")
+	}
+	return value.(PostgreSQLCredentials), nil
+}

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/postgresql.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/postgresql.go
@@ -133,7 +133,7 @@ func getNativeTLSMode(tlsMode string) string {
 	case "VerifyAll":
 		return "verify-full"
 	case "Disabled":
-		return "disabled"
+		return "disable"
 	default:
 		return "require"
 	}

--- a/ee/modules/610-service-with-healthchecks/templates/controller/deployment.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/controller/deployment.yaml
@@ -68,6 +68,9 @@ spec:
       containers:
         - args:
             - --metrics-bind-address=:8080
+            {{- if .Values.serviceWithHealthchecks.debug }}
+            - --debugging=true
+            {{- end }}
           image: {{ include "helm_lib_module_image" (list . "controller") }}
           imagePullPolicy: IfNotPresent
           name: controller


### PR DESCRIPTION
## Description
Fix several issues:
- fix the creation of endpointslices.
- reduce verbosity of loggers in the controller and agent in the default mode (debug: false).
- create a separate type of Secrets "network.deck house.io/postgresql-credentials "and a separate controller for processing it to improve the experience with PostreSQL probes.

## Why do we need it, and what problem does it solve?
- endpoint slices were created with the wrong port.
- the probes for PostgreSQL did not have the flexibility to change the credentials part.
- the logs of the controller and agents were too verbose. This made it difficult to find problems.

## Why do we need it in the patch release (if we do)?
The corrections affect the correct functioning of the module. It needs to be fixed as soon as possible.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: service-with-healthchecks
type: fix
summary: Fixed several issues.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
