### PR TITLE
[deckhouse-controller] add reinstall annotation

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
@@ -124,6 +124,10 @@ func (in *DeckhouseRelease) GetForce() bool {
 	return ok && v == "true"
 }
 
+func (*DeckhouseRelease) GetReinstall() bool {
+	return false
+}
+
 func (in *DeckhouseRelease) GetApplyNow() bool {
 	v, ok := in.Annotations[DeckhouseReleaseAnnotationApplyNow]
 	return ok && v == "true"

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_release.go
@@ -45,6 +45,7 @@ const (
 	ModuleReleaseFinalizerExistOnFs              = "modules.deckhouse.io/exist-on-fs"
 	ModuleReleaseAnnotationNotificationTimeShift = "modules.deckhouse.io/notification-time-shift"
 	ModuleReleaseAnnotationForce                 = "modules.deckhouse.io/force"
+	ModuleReleaseAnnotationReinstall             = "modules.deckhouse.io/reinstall"
 
 	ModuleReleaseLabelStatus          = "status"
 	ModuleReleaseLabelSource          = "source"
@@ -156,6 +157,10 @@ func (mr *ModuleRelease) GetPhase() string {
 
 func (mr *ModuleRelease) GetForce() bool {
 	return false
+}
+
+func (mr *ModuleRelease) GetReinstall() bool {
+	return mr.Annotations[ModuleReleaseAnnotationReinstall] == "true"
 }
 
 func (mr *ModuleRelease) GetApplyNow() bool {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/release.go
@@ -35,6 +35,7 @@ type Release interface {
 	GetDisruptionApproved() bool
 	GetPhase() string
 	GetForce() bool
+	GetReinstall() bool
 	GetApplyNow() bool
 	GetApprovedStatus() bool
 	SetApprovedStatus(b bool)

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -324,6 +324,24 @@ func (r *reconciler) preHandleCheck(ctx context.Context, release *v1alpha1.Modul
 func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha1.ModuleRelease) (ctrl.Result, error) {
 	var needsUpdate bool
 
+	var modulesChangedReason string
+	defer func() {
+		if modulesChangedReason != "" {
+			r.emitRestart(modulesChangedReason)
+		}
+	}()
+
+	if release.GetReinstall() {
+		err := r.runReleaseDeploy(ctx, release, nil)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("run release deploy: %w", err)
+		}
+
+		modulesChangedReason = "module release reloaded"
+
+		return ctrl.Result{}, nil
+	}
+
 	// check if RegistrySpecChanged annotation is set process it
 	if _, set := release.GetAnnotations()[v1alpha1.ModuleReleaseAnnotationRegistrySpecChanged]; set {
 		// if module is enabled - push runModule task in the main queue
@@ -334,8 +352,10 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 
 		if err := r.moduleManager.RunModuleWithNewOpenAPISchema(release.GetModuleName(), source, modulePath); err != nil {
 			r.log.Error("failed to run module with new openAPI schema", slog.String("module", release.GetModuleName()), log.Err(err))
-			return ctrl.Result{Requeue: true}, nil
+
+			return ctrl.Result{}, fmt.Errorf("run module with new open api schema: %w", err)
 		}
+
 		// delete annotation and requeue
 		delete(release.ObjectMeta.Annotations, v1alpha1.ModuleReleaseAnnotationRegistrySpecChanged)
 		needsUpdate = true
@@ -358,6 +378,8 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 	if needsUpdate {
 		if err := r.client.Update(ctx, release); err != nil {
 			r.log.Error("failed to update module release", slog.String("release", release.GetName()), log.Err(err))
+
+			return ctrl.Result{}, fmt.Errorf("update module release: %w", err)
 		}
 
 		return ctrl.Result{Requeue: true}, nil
@@ -367,14 +389,16 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 	source := new(v1alpha1.ModuleSource)
 	if err := r.client.Get(ctx, client.ObjectKey{Name: release.GetModuleSource()}, source); err != nil {
 		r.log.Error("failed to get module source", slog.String("module_source", release.GetModuleSource()), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+
+		return ctrl.Result{}, fmt.Errorf("get module source: %w", err)
 	}
 
 	if !controllerutil.ContainsFinalizer(source, v1alpha1.ModuleSourceFinalizerReleaseExists) {
 		controllerutil.AddFinalizer(source, v1alpha1.ModuleSourceFinalizerReleaseExists)
 		if err := r.client.Update(ctx, source); err != nil {
 			r.log.Error("failed to add finalizer to module source", slog.String("module_source", release.GetModuleSource()), log.Err(err))
-			return ctrl.Result{Requeue: true}, nil
+
+			return ctrl.Result{}, fmt.Errorf("add finalizer to module source: %w", err)
 		}
 	}
 
@@ -382,10 +406,12 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 	exists, err := utils.ModulePullOverrideExists(ctx, r.client, release.GetModuleName())
 	if err != nil {
 		r.log.Error("failed to get module pull override", slog.String("module", release.GetModuleName()), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+
+		return ctrl.Result{}, fmt.Errorf("module pull override exists: %w", err)
 	}
 	if exists {
 		r.log.Debug("module is overridden, skip it", slog.String("module", release.GetModuleName()))
+
 		return ctrl.Result{}, nil
 	}
 
@@ -408,11 +434,19 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 	// mpo not found - update the docs from the module release version
 	if err = utils.EnsureModuleDocumentation(ctx, r.client, release.GetModuleName(), release.GetModuleSource(), moduleChecksum, moduleVersion, modulePath, ownerRef); err != nil {
 		r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+
+		return ctrl.Result{}, fmt.Errorf("ensure module documentation: %w", err)
 	}
 
 	r.log.Debug("delete outdated releases for module", slog.String("module", release.GetModuleName()))
-	return r.deleteOutdatedModuleReleases(ctx, release.GetModuleSource(), release.GetModuleName())
+	err = r.deleteOutdatedModuleReleases(ctx, release.GetModuleSource(), release.GetModuleName())
+	if err != nil {
+		r.log.Error("failed to delete outdated module releases", slog.String("module", release.GetModuleName()), log.Err(err))
+
+		return ctrl.Result{}, fmt.Errorf("delete outdated module releases: %w", err)
+	}
+
+	return ctrl.Result{}, nil
 }
 
 // handlePendingRelease handles pending releases
@@ -676,88 +710,9 @@ func (r *reconciler) ApplyRelease(ctx context.Context, mr *v1alpha1.ModuleReleas
 func (r *reconciler) runReleaseDeploy(ctx context.Context, release *v1alpha1.ModuleRelease, deployedReleaseInfo *releaseUpdater.ReleaseInfo) error {
 	r.log.Info("applying release", slog.String("release", release.GetName()))
 
-	// download desired module version
-	source := new(v1alpha1.ModuleSource)
-	if err := r.client.Get(ctx, client.ObjectKey{Name: release.GetModuleSource()}, source); err != nil {
-		return fmt.Errorf("get the '%s' module source: %w", release.GetModuleSource(), err)
-	}
-
-	tmpDir, err := os.MkdirTemp("", "module*")
+	downloadStatistic, err := r.loadModule(ctx, release)
 	if err != nil {
-		return fmt.Errorf("create tmp directory: %w", err)
-	}
-
-	// clear tmp dir
-	defer func() {
-		if err = os.RemoveAll(tmpDir); err != nil {
-			r.log.Error("failed to remove old module directory", slog.String("directory", tmpDir), log.Err(err))
-		}
-	}()
-
-	options := utils.GenerateRegistryOptionsFromModuleSource(source, r.clusterUUID, r.log)
-	md := downloader.NewModuleDownloader(r.dependencyContainer, tmpDir, source, options)
-
-	downloadStatistic, err := md.DownloadByModuleVersion(release.GetModuleName(), release.GetVersion().String())
-	if err != nil {
-		return fmt.Errorf("download the '%s/%s' module: %w", release.GetModuleName(), release.GetVersion().String(), err)
-	}
-
-	def := &moduletypes.Definition{
-		Name:   release.GetModuleName(),
-		Weight: release.Spec.Weight,
-		Path:   path.Join(tmpDir, release.GetModuleName(), "v"+release.GetVersion().String()),
-	}
-
-	values := make(addonutils.Values)
-	if module := r.moduleManager.GetModule(release.GetModuleName()); module != nil {
-		values = module.GetConfigValues(false)
-	}
-
-	err = def.Validate(values, r.log)
-	if err != nil {
-		err = r.updateReleaseStatus(ctx, newModuleReleaseWithName(deployedReleaseInfo.Name), &v1alpha1.ModuleReleaseStatus{
-			Phase:   v1alpha1.ModuleReleasePhaseSuspended,
-			Message: "validation failed: " + err.Error(),
-		})
-		if err != nil {
-			r.log.Error("update status", slog.String("release", deployedReleaseInfo.Name), log.Err(err))
-
-			return fmt.Errorf("update status: the '%s:v%s' module validation: %w", release.GetModuleName(), release.GetVersion().String(), err)
-		}
-
-		return fmt.Errorf("the '%s:v%s' module validation: %w", release.GetModuleName(), release.GetVersion().String(), err)
-	}
-
-	moduleVersionPath := path.Join(r.downloadedModulesDir, release.GetModuleName(), "v"+release.GetVersion().String())
-	if err = os.RemoveAll(moduleVersionPath); err != nil {
-		return fmt.Errorf("remove the '%s' old module dir: %w", moduleVersionPath, err)
-	}
-
-	if err = cp.Copy(def.Path, moduleVersionPath); err != nil {
-		return fmt.Errorf("copy module dir: %w", err)
-	}
-
-	// search symlink for module by regexp
-	// module weight for a new version of the module may be different from the old one,
-	// we need to find a symlink that contains the module name without looking at the weight prefix.
-	currentModuleSymlink, err := utils.GetModuleSymlink(r.symlinksDir, release.GetModuleName())
-	if err != nil {
-		r.log.Warn("failed to find the current module symlink", slog.String("module", release.GetModuleName()), log.Err(err))
-
-		currentModuleSymlink = "900-" + release.GetModuleName() // fallback
-	}
-
-	newModuleSymlink := path.Join(r.symlinksDir, fmt.Sprintf("%d-%s", def.Weight, release.GetModuleName()))
-
-	relativeModulePath := path.Join("../", release.GetModuleName(), "v"+release.GetVersion().String())
-
-	if err = utils.EnableModule(r.downloadedModulesDir, currentModuleSymlink, newModuleSymlink, relativeModulePath); err != nil {
-		return fmt.Errorf("enable the '%s' module: %w", release.GetModuleName(), err)
-	}
-
-	// disable target module hooks so as not to invoke them before restart
-	if r.moduleManager.GetModule(release.GetModuleName()) != nil {
-		r.moduleManager.DisableModuleHooks(release.GetModuleName())
+		return fmt.Errorf("load module: %w", err)
 	}
 
 	if deployedReleaseInfo != nil {
@@ -806,6 +761,10 @@ func (r *reconciler) runReleaseDeploy(ctx context.Context, release *v1alpha1.Mod
 			delete(release.Annotations, v1alpha1.ModuleReleaseAnnotationForce)
 		}
 
+		if release.GetReinstall() {
+			delete(release.Annotations, v1alpha1.ModuleReleaseAnnotationReinstall)
+		}
+
 		controllerutil.AddFinalizer(release, v1alpha1.ModuleReleaseFinalizerExistOnFs)
 
 		return nil
@@ -827,6 +786,94 @@ func (r *reconciler) runReleaseDeploy(ctx context.Context, release *v1alpha1.Mod
 	}
 
 	return nil
+}
+
+func (r *reconciler) loadModule(ctx context.Context, release *v1alpha1.ModuleRelease) (*downloader.DownloadStatistic, error) {
+	// download desired module version
+	source := new(v1alpha1.ModuleSource)
+	if err := r.client.Get(ctx, client.ObjectKey{Name: release.GetModuleSource()}, source); err != nil {
+		return nil, fmt.Errorf("get the '%s' module source: %w", release.GetModuleSource(), err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "module*")
+	if err != nil {
+		return nil, fmt.Errorf("create tmp directory: %w", err)
+	}
+
+	// clear tmp dir
+	defer func() {
+		if err = os.RemoveAll(tmpDir); err != nil {
+			r.log.Error("failed to remove old module directory", slog.String("directory", tmpDir), log.Err(err))
+		}
+	}()
+
+	options := utils.GenerateRegistryOptionsFromModuleSource(source, r.clusterUUID, r.log)
+	md := downloader.NewModuleDownloader(r.dependencyContainer, tmpDir, source, options)
+
+	downloadStatistic, err := md.DownloadByModuleVersion(release.GetModuleName(), release.GetVersion().String())
+	if err != nil {
+		return nil, fmt.Errorf("download the '%s/%s' module: %w", release.GetModuleName(), release.GetVersion().String(), err)
+	}
+
+	def := &moduletypes.Definition{
+		Name:   release.GetModuleName(),
+		Weight: release.Spec.Weight,
+		Path:   path.Join(tmpDir, release.GetModuleName(), "v"+release.GetVersion().String()),
+	}
+
+	values := make(addonutils.Values)
+	if module := r.moduleManager.GetModule(release.GetModuleName()); module != nil {
+		values = module.GetConfigValues(false)
+	}
+
+	err = def.Validate(values, r.log)
+	if err != nil {
+		err := r.updateReleaseStatus(ctx, release, &v1alpha1.ModuleReleaseStatus{
+			Phase:   v1alpha1.ModuleReleasePhaseSuspended,
+			Message: "validation failed: " + err.Error(),
+		})
+		if err != nil {
+			r.log.Error("update status", slog.String("release", release.Name), log.Err(err))
+
+			return nil, fmt.Errorf("update status: the '%s:v%s' module validation: %w", release.GetModuleName(), release.GetVersion().String(), err)
+		}
+
+		return nil, fmt.Errorf("the '%s:v%s' module validation: %w", release.GetModuleName(), release.GetVersion().String(), err)
+	}
+
+	moduleVersionPath := path.Join(r.downloadedModulesDir, release.GetModuleName(), "v"+release.GetVersion().String())
+	if err = os.RemoveAll(moduleVersionPath); err != nil {
+		return nil, fmt.Errorf("remove the '%s' old module dir: %w", moduleVersionPath, err)
+	}
+
+	if err = cp.Copy(def.Path, moduleVersionPath); err != nil {
+		return nil, fmt.Errorf("copy module dir: %w", err)
+	}
+
+	// search symlink for module by regexp
+	// module weight for a new version of the module may be different from the old one,
+	// we need to find a symlink that contains the module name without looking at the weight prefix.
+	currentModuleSymlink, err := utils.GetModuleSymlink(r.symlinksDir, release.GetModuleName())
+	if err != nil {
+		r.log.Warn("failed to find the current module symlink", slog.String("module", release.GetModuleName()), log.Err(err))
+
+		currentModuleSymlink = "900-" + release.GetModuleName() // fallback
+	}
+
+	newModuleSymlink := path.Join(r.symlinksDir, fmt.Sprintf("%d-%s", def.Weight, release.GetModuleName()))
+
+	relativeModulePath := path.Join("../", release.GetModuleName(), "v"+release.GetVersion().String())
+
+	if err = utils.EnableModule(r.downloadedModulesDir, currentModuleSymlink, newModuleSymlink, relativeModulePath); err != nil {
+		return nil, fmt.Errorf("enable the '%s' module: %w", release.GetModuleName(), err)
+	}
+
+	// disable target module hooks so as not to invoke them before restart
+	if r.moduleManager.GetModule(release.GetModuleName()) != nil {
+		r.moduleManager.DisableModuleHooks(release.GetModuleName())
+	}
+
+	return downloadStatistic, nil
 }
 
 var ErrPreApplyCheckIsFailed = errors.New("pre apply check is failed")
@@ -1048,12 +1095,13 @@ func (r *reconciler) deleteRelease(ctx context.Context, release *v1alpha1.Module
 
 // deleteOutdatedModuleReleases finds and deletes all outdated releases of the module in
 // Suspend, Skipped or Superseded phases, except for <outdatedReleasesKeepCount> most recent ones
-func (r *reconciler) deleteOutdatedModuleReleases(ctx context.Context, moduleSource, module string) (ctrl.Result, error) {
+func (r *reconciler) deleteOutdatedModuleReleases(ctx context.Context, moduleSource, module string) error {
 	releases := new(v1alpha1.ModuleReleaseList)
 	labelSelector := client.MatchingLabels{v1alpha1.ModuleReleaseLabelSource: moduleSource, v1alpha1.ModuleReleaseLabelModule: module}
 	if err := r.client.List(ctx, releases, labelSelector); err != nil {
 		r.log.Error("failed to list all module releases", log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+
+		return fmt.Errorf("list releases: %w", err)
 	}
 
 	type outdatedRelease struct {
@@ -1090,14 +1138,16 @@ func (r *reconciler) deleteOutdatedModuleReleases(ctx context.Context, moduleSou
 				}
 				if err := r.client.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
 					r.log.Error("failed to delete outdated release", slog.String("outdated_release", outdated[idx].name), log.Err(err))
-					return ctrl.Result{Requeue: true}, nil
+
+					return fmt.Errorf("delete outdated release: %w", err)
 				}
+
 				r.log.Info("cleaned up outdated release", slog.String("outdated_release", outdated[idx].name), slog.String("module_name", moduleName))
 			}
 		}
 	}
 
-	return ctrl.Result{}, nil
+	return nil
 }
 
 func (r *reconciler) updateReleaseStatusMessage(ctx context.Context, release *v1alpha1.ModuleRelease, message string) error {

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
@@ -334,6 +334,24 @@ func (suite *ReleaseControllerTestSuite) TestCreateReconcile() {
 			require.NoError(suite.T(), err)
 		})
 	})
+
+	suite.Run("Reinstall", func() {
+		mup := &v1alpha2.ModuleUpdatePolicySpec{
+			Update: v1alpha2.ModuleUpdatePolicySpecUpdate{
+				Mode:    "AutoPatch",
+				Windows: update.Windows{{From: "10:00", To: "11:00", Days: update.Everyday()}},
+			},
+			ReleaseChannel: "Stable",
+		}
+
+		testData := suite.fetchTestFileData("reinstall-annotation.yaml")
+		suite.setupReleaseController(testData, withModuleUpdatePolicy(mup))
+
+		_, err = suite.ctr.handleRelease(ctx, suite.getModuleRelease("parca-1.26.2"))
+		require.NoError(suite.T(), err)
+		_, err = suite.ctr.handleRelease(ctx, suite.getModuleRelease("parca-1.26.2"))
+		require.NoError(suite.T(), err)
+	})
 }
 
 func (suite *ReleaseControllerTestSuite) loopUntilDeploy(dc *dependency.MockedContainer, releaseName string) {

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/reinstall-annotation.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/reinstall-annotation.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/release-exists
+  name: foxtrot-suitable
+  resourceVersion: "999"
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+  - name: mcplay-suitable
+    policy: foxtrot-alpha-suitable
+  - name: parca-suitable
+    policy: foxtrot-alpha-suitable
+  modulesCount: 2
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/exist-on-fs
+  labels:
+    module: parca
+    status: deployed
+  name: parca-1.26.2
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: foxtrot-suitable
+    uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+  resourceVersion: "1002"
+spec:
+  moduleName: parca
+  version: 1.26.2
+  weight: 900
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  pullDuration: 9m15s
+  size: 0
+  transitionTime: "2021-12-08T08:34:01Z"

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/reinstall-annotation.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/reinstall-annotation.yaml
@@ -1,0 +1,45 @@
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/reinstall: "true"
+  name: parca-1.26.2
+  ownerReferences:
+    - apiVersion: deckhouse.io/v1alpha1
+      controller: true
+      kind: ModuleSource
+      name: foxtrot-suitable
+      uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+spec:
+  moduleName: parca
+  version: 1.26.2
+  weight: 900
+status:
+  approved: true
+  phase: Deployed
+  transitionTime: "2021-12-08T08:34:01Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  finalizers:
+    - modules.deckhouse.io/release-exists
+  name: foxtrot-suitable
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  message: ""
+  moduleErrors: []
+  modules:
+    - name: mcplay-suitable
+      policy: foxtrot-alpha-suitable
+    - name: parca-suitable
+      policy: foxtrot-alpha-suitable
+  modulesCount: 2
+  syncTime: "2024-05-03T21:05:05Z"

--- a/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scaner/cache/cache_test.go
+++ b/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scaner/cache/cache_test.go
@@ -15,10 +15,10 @@
 package cache
 
 import (
-	"registry-modules-watcher/internal/backends"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"registry-modules-watcher/internal/backends"
 )
 
 func TestGetState(t *testing.T) {

--- a/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scaner/registry-scaner.go
+++ b/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scaner/registry-scaner.go
@@ -16,12 +16,13 @@ package registryscaner
 
 import (
 	"context"
-	"registry-modules-watcher/internal/backends"
-	"registry-modules-watcher/internal/backends/pkg/registry-scaner/cache"
 	"time"
 
-	"github.com/deckhouse/deckhouse/pkg/log"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"registry-modules-watcher/internal/backends"
+	"registry-modules-watcher/internal/backends/pkg/registry-scaner/cache"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 type Client interface {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add reinstall annotation
Close issue

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Sometime we have broken (by different reasons) module. We need an annotation to download it again and restart the D8.
After add this annotation to ModuleRelease resource, reconciler redownload module, recreate symlinks, e.t.c (make default deploy process). At last, we remove "modules.deckhouse.io/reinstall" annotation.

## Why do we need it in the patch release (if we do)?
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Add reinstall annotation to reinstall module
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
