### PR TITLE
[docs] Fix the transfer of badges

### DIFF
--- a/docs/documentation/_plugins/custom_sidebar.rb
+++ b/docs/documentation/_plugins/custom_sidebar.rb
@@ -66,8 +66,9 @@ module Jekyll
       if entry.dig('folders') && entry['folders'].size > 0
          result.push(%Q(<li class='#{ parameters['folder_entry_class']}'>
             <a href='#'>
-                <span class='sidebar__submenu-title'>#{entry.dig('title',lang)}</span>))
+              <span class='sidebar__submenu-title'>#{entry.dig('title',lang)}</span>
 
+              <span class='sidebar__badge--container'>))
          if (site_mode != 'module' && avail_in_commercial_editions_only) ||
             (doc_edition == 'ce' && avail_in_commercial_editions_only) ||
             (site_mode == 'module' && not_avail_in_this_edition)
@@ -99,6 +100,7 @@ module Jekyll
          end
 
          result.push(%q(
+           </span>
            </a>
            <ul class='sidebar__submenu'>))
          entry['folders'].each do |sub_entry|

--- a/docs/site/_assets/css/docs.scss
+++ b/docs/site/_assets/css/docs.scss
@@ -497,6 +497,11 @@ a.comparison-table__module::after {
 }
 
 // The version used after DKP ~1.68
+
+.sidebar__badge--container {
+  display: inline-block;
+}
+
 .sidebar__badge_v2 {
   display: inline-flex;
   margin-right: 4px;

--- a/docs/site/backends/docs-builder-template/layouts/partials/sidebar.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/sidebar.html
@@ -72,16 +72,17 @@
                     {{- $sidebarItem.title -}}
                   </span>
 
-
-                  {{- if ne $sidebarItem.d8Edition "ce" }}<span class="sidebar__badge_v2 sidebar__badge_commercial" title='{{ T "commercial" }}'>{{ T "currency_sign"  }}</span>{{ end }}
-                  {{- if and $sidebarItem.moduleStatus (index $.Site.Data.helpers.moduleStageBageMap ( replace (lower $sidebarItem.moduleStatus) " " "_")) -}}
-                    <span class='sidebar__badge_v2'
-                        {{- if (T (printf "module_alert_%s" (lower $sidebarItem.moduleStatus ))) }}
-                          title='{{ (T (printf "module_alert_%s" (lower $sidebarItem.moduleStatus ))) }}'
-                        {{ end -}}
-                        >{{ index $.Site.Data.helpers.moduleStageBageMap ( lower $sidebarItem.moduleStatus ) -}}
-                    </span>
-                  {{- end }}
+                  <span class="sidebar__badge--container">
+                    {{- if ne $sidebarItem.d8Edition "ce" }}<span class="sidebar__badge_v2 sidebar__badge_commercial" title='{{ T "commercial" }}'>{{ T "currency_sign"  }}</span>{{ end }}
+                    {{- if and $sidebarItem.moduleStatus (index $.Site.Data.helpers.moduleStageBageMap ( replace (lower $sidebarItem.moduleStatus) " " "_")) -}}
+                      <span class='sidebar__badge_v2'
+                          {{- if (T (printf "module_alert_%s" (lower $sidebarItem.moduleStatus ))) }}
+                            title='{{ (T (printf "module_alert_%s" (lower $sidebarItem.moduleStatus ))) }}'
+                          {{ end -}}
+                          >{{ index $.Site.Data.helpers.moduleStageBageMap ( lower $sidebarItem.moduleStatus ) -}}
+                      </span>
+                    {{- end }}
+                  </span>
                 </a>
                   {{- template "subpages" (dict "parent" $sidebarItem "pages" $pages "ctx" $ctx) }}
             </li>


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix the transfer of badges.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix the tooltip.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
