### PR TITLE
[metallb] Add logging for hooks

### DIFF
--- a/ee/se/modules/380-metallb/hooks/discovery_l2_load_balancers.go
+++ b/ee/se/modules/380-metallb/hooks/discovery_l2_load_balancers.go
@@ -240,6 +240,11 @@ func handleL2LoadBalancers(input *go_hook.HookInput) error {
 				service.Namespace,
 				service.Name,
 				object_patch.WithSubresource("/status"))
+			input.Logger.Info("MetalLoadBalancerClass was selected and added to the service status",
+				"Service", service.Name,
+				"Namespace", service.Namespace,
+				"MetalLoadBalancerClass", mlbcForUse.Name,
+			)
 		}
 
 		desiredIPsCount := len(service.DesiredIPs)

--- a/ee/se/modules/380-metallb/hooks/migration_adopt_old_fashioned_l2_lbs.go
+++ b/ee/se/modules/380-metallb/hooks/migration_adopt_old_fashioned_l2_lbs.go
@@ -50,6 +50,7 @@ func discoveryServicesForMigrate(input *go_hook.HookInput, dc dependency.Contain
 	}
 	if moduleConfig.Spec.Version >= 2 {
 		input.Values.Set("metallb.internal.migrationOfOldFashionedLBsAdoptionComplete", true)
+		input.Logger.Info("processing skipped", "ModuleConfig version", moduleConfig.Spec.Version)
 		return nil
 	}
 	for _, pool := range moduleConfig.Spec.Settings.AddressPools {
@@ -143,6 +144,7 @@ func discoveryServicesForMigrate(input *go_hook.HookInput, dc dependency.Contain
 		if err != nil {
 			return fmt.Errorf("error to apply patch to Service %s: %w", service.Name, err)
 		}
+		input.Logger.Info("annotations added", "Service", service.Name)
 	}
 	input.Values.Set("metallb.internal.migrationOfOldFashionedLBsAdoptionComplete", true)
 	return nil

--- a/ee/se/modules/380-metallb/hooks/migration_auto_generating_l2_mlbc.go
+++ b/ee/se/modules/380-metallb/hooks/migration_auto_generating_l2_mlbc.go
@@ -153,6 +153,7 @@ func createMetalLoadBalancerClass(input *go_hook.HookInput, mlbcInfo *MetalLoadB
 		return
 	}
 	input.PatchCollector.Create(mlbcUnstructured, object_patch.UpdateIfExists())
+	input.Logger.Info("MetalLoadBalancerClass created", "name", mlbcInfo.Name)
 }
 
 func deleteMetalLoadBalancerClass(input *go_hook.HookInput, mlbcName string) {
@@ -163,6 +164,7 @@ func deleteMetalLoadBalancerClass(input *go_hook.HookInput, mlbcName string) {
 		mlbcName,
 		object_patch.InBackground(),
 	)
+	input.Logger.Info("MetalLoadBalancerClass deleted", "name", mlbcName)
 }
 
 func migrateMCtoMLBC(input *go_hook.HookInput) error {
@@ -172,6 +174,7 @@ func migrateMCtoMLBC(input *go_hook.HookInput) error {
 	}
 	mc, ok := snapsMC[0].(*ModuleConfig)
 	if !ok || mc.Spec.Version >= 2 {
+		input.Logger.Info("processing skipped", "ModuleConfig version", mc.Spec.Version)
 		return nil
 	}
 

--- a/ee/se/modules/380-metallb/hooks/update_service_status.go
+++ b/ee/se/modules/380-metallb/hooks/update_service_status.go
@@ -90,6 +90,10 @@ func handleL2LBServices(input *go_hook.HookInput) error {
 			namespacedName.Namespace,
 			namespacedName.Name,
 			object_patch.WithSubresource("/status"))
+		input.Logger.Info("Service status updated",
+			"name", namespacedName.Name,
+			"Namespace", namespacedName.Name,
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
Add hook logging when migrating to a new version of the module with `MetalLoadBalancerClass`.

## Why do we need it, and what problem does it solve?
We need to know what actions the hook performs in the process.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: chore
summary: Added logging for hooks.
impact_level: low
```
