### PR TITLE
[deckhouse] change the method of connecting deckhouse-controller to API-server

### DIFF
--- a/modules/002-deckhouse/template_tests/module_test.go
+++ b/modules/002-deckhouse/template_tests/module_test.go
@@ -53,6 +53,32 @@ modules:
   placement: {}
 `
 
+	globalValues2 = `
+deckhouseVersion: test
+enabledModules: ["vertical-pod-autoscaler", "prometheus", "operator-prometheus", "control-plane-manager"]
+clusterConfiguration:
+  apiVersion: deckhouse.io/v1
+  kind: ClusterConfiguration
+  clusterDomain: cluster.local
+  clusterType: Static
+  kubernetesVersion: "Automatic"
+  podSubnetCIDR: 10.111.0.0/16
+  podSubnetNodeCIDRPrefix: "24"
+  serviceSubnetCIDR: 10.222.0.0/16
+discovery:
+  clusterMasterCount: 3
+  prometheusScrapeInterval: 30
+  kubernetesVersion: "1.28.10"
+  d8SpecificNodeCountByRole:
+    system: 1
+modules:
+  placement: {}
+`
+
+	clusterIsBootstrapped = `
+clusterIsBootstrapped: true
+`
+
 	moduleValuesForMasterNode = `
 bundle: Default
 logLevel: Info
@@ -142,6 +168,85 @@ var _ = Describe("Module :: deckhouse :: helm template ::", func() {
 - key: testkey
   operator: Exists
 `))
+		})
+	})
+
+	Context("Control-plane is managed by third-party team: use service by default", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("deckhouse", moduleValuesForDeckhouseNode)
+			f.HelmRender()
+		})
+
+		nsName := "d8-system"
+		chartName := "deckhouse"
+
+		It("Everything must render properly", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			dp := f.KubernetesResource("Deployment", nsName, chartName)
+			Expect(dp.Exists()).To(BeTrue())
+			serviceHostValue := dp.Field("spec.template.spec.containers.0.env." +
+				"#(name==\"KUBERNETES_SERVICE_HOST\").value",
+			)
+			Expect(serviceHostValue.Exists()).To(BeFalse())
+			servicePort := dp.Field("spec.template.spec.containers.0.env." +
+				"#(name==\"KUBERNETES_SERVICE_PORT\").value",
+			)
+			Expect(servicePort.Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Managed by Deckhouse: use API-proxy", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues2+clusterIsBootstrapped)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("deckhouse", moduleValuesForDeckhouseNode)
+			f.HelmRender()
+		})
+
+		nsName := "d8-system"
+		chartName := "deckhouse"
+
+		It("Everything must render properly", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			dp := f.KubernetesResource("Deployment", nsName, chartName)
+			Expect(dp.Exists()).To(BeTrue())
+			serviceHostValue := dp.Field("spec.template.spec.containers.0.env." +
+				"#(name==\"KUBERNETES_SERVICE_HOST\").value",
+			).String()
+			Expect(serviceHostValue).To(Equal("127.0.0.1"))
+			servicePort := dp.Field("spec.template.spec.containers.0.env." +
+				"#(name==\"KUBERNETES_SERVICE_PORT\").value",
+			).String()
+			Expect(servicePort).To(Equal("6445"))
+		})
+	})
+
+	Context("Bootstrap phase: use direct connection", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues2)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("deckhouse", moduleValuesForDeckhouseNode)
+			f.HelmRender()
+		})
+
+		nsName := "d8-system"
+		chartName := "deckhouse"
+
+		It("Everything must render properly", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			dp := f.KubernetesResource("Deployment", nsName, chartName)
+			Expect(dp.Exists()).To(BeTrue())
+			serviceHostValue := dp.Field("spec.template.spec.containers.0.env." +
+				"#(name==\"KUBERNETES_SERVICE_HOST\")." +
+				"valueFrom.fieldRef.fieldPath",
+			).String()
+			Expect(serviceHostValue).To(Equal("status.hostIP"))
+			servicePort := dp.Field("spec.template.spec.containers.0.env." +
+				"#(name==\"KUBERNETES_SERVICE_PORT\").value",
+			).String()
+			Expect(servicePort).To(Equal("6443"))
 		})
 	})
 

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -147,10 +147,15 @@ spec:
           image: "{{ .Values.deckhouse.internal.currentReleaseImageName }}"
           imagePullPolicy: Always
           env:
-{{- if (not (.Values.global.enabledModules | has "control-plane-manager")) }}
-# control-plane is managed by third-party team (EKS/GKP/...): use Service by default
-{{- else }}
-  {{- if not .Values.global.clusterIsBootstrapped }}
+{{- if (.Values.global.enabledModules | has "control-plane-manager") }}
+# control-plane is NOT managed by third-party team (EKS/GKP/...)
+  {{- if .Values.global.clusterIsBootstrapped }}
+  # managed by Deckhouse: use API-proxy
+            - name: KUBERNETES_SERVICE_HOST
+              value: 127.0.0.1
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6445"
+  {{- else }}
   # bootstrap phase: use direct connection
             - name: KUBERNETES_SERVICE_HOST
               valueFrom:
@@ -159,12 +164,6 @@ spec:
                   fieldPath: status.hostIP
             - name: KUBERNETES_SERVICE_PORT
               value: "6443"
-  {{- else }}
-  # managed by Deckhouse: use API-proxy
-            - name: KUBERNETES_SERVICE_HOST
-              value: 127.0.0.1
-            - name: KUBERNETES_SERVICE_PORT
-              value: "6445"
   {{- end }}
 {{- end }}
             - name: LOG_LEVEL

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -147,8 +147,11 @@ spec:
           image: "{{ .Values.deckhouse.internal.currentReleaseImageName }}"
           imagePullPolicy: Always
           env:
-# KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are needed on the bootstrap phase to make Deckhouse work without kube-proxy
-{{- if not .Values.global.clusterIsBootstrapped }}
+{{- if (not (.Values.global.enabledModules | has "control-plane-manager")) }}
+# control-plane is managed by third-party team (EKS/GKP/...): use service by default
+{{- else }}
+  {{- if not .Values.global.clusterIsBootstrapped }}
+  # bootstrap phase: use direct connection
             - name: KUBERNETES_SERVICE_HOST
               valueFrom:
                 fieldRef:
@@ -156,6 +159,13 @@ spec:
                   fieldPath: status.hostIP
             - name: KUBERNETES_SERVICE_PORT
               value: "6443"
+  {{- else }}
+  # managed by Deckhouse: use API-proxy
+            - name: KUBERNETES_SERVICE_HOST
+              value: 127.0.0.1
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6445"
+  {{- end }}
 {{- end }}
             - name: LOG_LEVEL
               value: {{ .Values.deckhouse.logLevel }}

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -148,7 +148,7 @@ spec:
           imagePullPolicy: Always
           env:
 {{- if (not (.Values.global.enabledModules | has "control-plane-manager")) }}
-# control-plane is managed by third-party team (EKS/GKP/...): use service by default
+# control-plane is managed by third-party team (EKS/GKP/...): use Service by default
 {{- else }}
   {{- if not .Values.global.clusterIsBootstrapped }}
   # bootstrap phase: use direct connection


### PR DESCRIPTION
## Description
Add conditions for using direct connection, API-proxy and Service.

## Why do we need it, and what problem does it solve?
Deckhouse stucks when cni is malfunctioned.
Also, if you switch CNIs in a cluster, the network becomes unavailable, including all services. Deckhouse works with API through the service, so it loses access to it.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Changed the method of connecting deckhouse-controller to API-server.
```