### PR TITLE
[multitenancy-manager] fix namespace rendering

### DIFF
--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/client_test.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/client_test.go
@@ -76,7 +76,7 @@ func test(templates map[string][]byte, basePath string) error {
 	rendered := releaseutil.SplitManifests(buf.String())
 
 	// uncomment for test and render rendered resources
-	//os.WriteFile(filepath.Join(basePath, "rendered.yaml"), buf.Bytes(), 0644)
+	//os.WriteFile(filepath.Join(basePath, "resources.yaml"), buf.Bytes(), 0644)
 
 	rawExpected, err := os.ReadFile(filepath.Join(basePath, "resources.yaml"))
 	if err != nil {

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/renderer.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/renderer.go
@@ -51,7 +51,7 @@ func (r *postRenderer) Run(renderedManifests *bytes.Buffer) (modifiedManifests *
 	// clear resources
 	r.project.Status.Resources = make(map[string]map[string]v1alpha2.ResourceKind)
 
-	var coreFound bool
+	var core *unstructured.Unstructured
 	builder := strings.Builder{}
 	for _, manifest := range releaseutil.SplitManifests(renderedManifests.String()) {
 		object := new(unstructured.Unstructured)
@@ -104,16 +104,16 @@ func (r *postRenderer) Run(renderedManifests *bytes.Buffer) (modifiedManifests *
 
 		object.SetLabels(labels)
 
-		if object.GetKind() != "Namespace" {
-			object.SetNamespace(r.project.Name)
-		} else {
+		if object.GetKind() == "Namespace" {
 			// skip other namespaces
-			if object.GetName() != r.project.Name {
-				r.logger.Info("namespace skipped during render project", "project", r.project.Name, "namespace", object.GetName())
-				continue
+			if object.GetName() == r.project.Name {
+				r.project.AddResource(object, true)
+				core = object
 			}
-			coreFound = true
+			continue
 		}
+
+		object.SetNamespace(r.project.Name)
 
 		r.project.AddResource(object, true)
 
@@ -122,11 +122,15 @@ func (r *postRenderer) Run(renderedManifests *bytes.Buffer) (modifiedManifests *
 	}
 
 	buf := bytes.NewBuffer(nil)
+
 	// ensure core namespace
-	if !coreFound {
-		core := r.newNamespace(r.project.Name)
-		buf.WriteString("\n---\n" + string(core))
+	if core == nil {
+		buf.WriteString("\n---\n" + string(r.newNamespace(r.project.Name)))
+	} else {
+		data, _ := yaml.Marshal(core.Object)
+		buf.WriteString("\n---\n" + string(data))
 	}
+
 	buf.WriteString(builder.String())
 
 	return buf, nil

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
@@ -1,5 +1,20 @@
 
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    key: val
+  labels:
+    extended-monitoring.deckhouse.io/enabled: ""
+    heritage: multitenancy-manager
+    key: val
+    projects.deckhouse.io/project: test
+    projects.deckhouse.io/project-template: default
+    security.deckhouse.io/pod-policy: baseline
+  name: test
+
+---
 apiVersion: deckhouse.io/v1alpha1
 kind: AuthorizationRule
 metadata:
@@ -109,18 +124,3 @@ spec:
       requests:
       - cpu
       - memory
-
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    key: val
-  labels:
-    extended-monitoring.deckhouse.io/enabled: ""
-    heritage: multitenancy-manager
-    key: val
-    projects.deckhouse.io/project: test
-    projects.deckhouse.io/project-template: default
-    security.deckhouse.io/pod-policy: baseline
-  name: test

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
@@ -1,5 +1,18 @@
 
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    extended-monitoring.deckhouse.io/enabled: ""
+    heritage: multitenancy-manager
+    projects.deckhouse.io/project: test
+    projects.deckhouse.io/project-template: secure
+    security-scanning.deckhouse.io/enabled: ""
+    security.deckhouse.io/pod-policy: baseline
+  name: test
+
+---
 apiVersion: deckhouse.io/v1alpha1
 kind: AuthorizationRule
 metadata:
@@ -121,16 +134,3 @@ spec:
       - max: 2
         min: 1
       rule: MustRunAs
-
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    extended-monitoring.deckhouse.io/enabled: ""
-    heritage: multitenancy-manager
-    projects.deckhouse.io/project: test
-    projects.deckhouse.io/project-template: secure
-    security-scanning.deckhouse.io/enabled: ""
-    security.deckhouse.io/pod-policy: baseline
-  name: test

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
@@ -1,19 +1,16 @@
 
 ---
 apiVersion: v1
-kind: ResourceQuota
+kind: Namespace
 metadata:
+  annotations: null
   labels:
+    extended-monitoring.deckhouse.io/enabled: ""
     heritage: multitenancy-manager
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: secure-with-dedicated-nodes
-  name: all-pods
-  namespace: test
-spec:
-  hard:
-    limits.memory: 20Gi
-    requests.cpu: 2
-    requests.memory: 10Gi
+    security.deckhouse.io/pod-policy: baseline
+  name: test
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -140,19 +137,6 @@ spec:
       rule: MustRunAs
 
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations: null
-  labels:
-    extended-monitoring.deckhouse.io/enabled: ""
-    heritage: multitenancy-manager
-    projects.deckhouse.io/project: test
-    projects.deckhouse.io/project-template: secure-with-dedicated-nodes
-    security.deckhouse.io/pod-policy: baseline
-  name: test
-
----
 apiVersion: deckhouse.io/v1alpha1
 kind: AuthorizationRule
 metadata:
@@ -167,3 +151,19 @@ spec:
   subjects:
   - kind: User
     name: user@gmail.com
+
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  labels:
+    heritage: multitenancy-manager
+    projects.deckhouse.io/project: test
+    projects.deckhouse.io/project-template: secure-with-dedicated-nodes
+  name: all-pods
+  namespace: test
+spec:
+  hard:
+    limits.memory: 20Gi
+    requests.cpu: 2
+    requests.memory: 10Gi

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/manager/project/manager.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/manager/project/manager.go
@@ -106,7 +106,7 @@ func (m *Manager) Handle(ctx context.Context, project *v1alpha2.Project) (ctrl.R
 			m.logger.Error(updateErr, "failed to update project status", "project", project.Name, "template", project.Spec.ProjectTemplateName)
 			return ctrl.Result{}, updateErr
 		}
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
 	// check if the project template exists

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/manager/project/manager.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/manager/project/manager.go
@@ -142,17 +142,14 @@ func (m *Manager) Handle(ctx context.Context, project *v1alpha2.Project) (ctrl.R
 	// upgrade project`s resources
 	m.logger.Info("upgrade resources for the project", "project", project.Name, "template", projectTemplate.Name)
 	if err = m.helmClient.Upgrade(ctx, project, projectTemplate); err != nil {
-		// to avoid helm flaky errors
-		m.logger.Info("failed to upgrade the project resources, try again", "project", project.Name, "template", projectTemplate.Name)
-		if err = m.helmClient.Upgrade(ctx, project, projectTemplate); err != nil {
-			project.SetState(v1alpha2.ProjectStateError)
-			project.SetConditionFalse(v1alpha2.ProjectConditionProjectResourcesUpgraded, err.Error())
-			if updateErr := m.updateProjectStatus(ctx, project); updateErr != nil {
-				m.logger.Error(updateErr, "failed to update the project status", "project", project.Name, "template", projectTemplate.Name)
-				return ctrl.Result{}, updateErr
-			}
-			return ctrl.Result{}, nil
+		m.logger.Error(err, "failed to upgrade the project resources", "project", project.Name, "template", projectTemplate.Name)
+		project.SetState(v1alpha2.ProjectStateError)
+		project.SetConditionFalse(v1alpha2.ProjectConditionProjectResourcesUpgraded, err.Error())
+		if updateErr := m.updateProjectStatus(ctx, project); updateErr != nil {
+			m.logger.Error(updateErr, "failed to update the project status", "project", project.Name, "template", projectTemplate.Name)
+			return ctrl.Result{}, updateErr
 		}
+		return ctrl.Result{}, err
 	}
 
 	project.SetState(v1alpha2.ProjectStateDeployed)


### PR DESCRIPTION
## Description
It fixes namespace rendering.

## Why do we need it, and what problem does it solve?
Helm can try to render the resources before the namespace, we put the namespace before all resources via postrenderer.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: multitenancy-manager
type: fix
summary: Fix namespace rendering.
impact_level: low
```