### PR TITLE
[doc] update port number

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -147,17 +147,17 @@ groups:
     description:
       en: "*kube-router* metrics"
       ru: "Метрики *kube-router*"
-  - ports: "9695"
+  - ports: "4202"
     protocol: TCP
     description:
-      en: "*sds-node-configurator* node agent metrics"
+      en: "*sds-node-configurator* node agent metrix"
       ru: "Метрики агента *sds-node-configurator*"
-  - ports: "3367"
+  - ports: "4214"
     protocol: TCP
     description:
       en: API of the *sds-replicated-volume* module node agent
       ru: API агента модуля *sds-replicated-volume*
-  - ports: "9942"
+  - ports: "4215"
     protocol: TCP
     description:
       en: "*sds-replicated-volume* node agent metrics"


### PR DESCRIPTION
## Description
deckhouse-ports.yml updated with new port number values

## Why do we need it, and what problem does it solve?
Keeping documentation up to date

## Why do we need it in the patch release (if we do)?
-

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
`impact_level: low`
At deckhouse-ports.yml: '*sds-node-configurator* node agent metrix', 'API of the *sds-replicated-volume* module node agent', '*sds-replicated-volume* node agent metrics' have new values

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
