### PR TITLE
[deckhouse-tools] build fix

### DIFF
--- a/.github/ci_includes/werf_envs.yml
+++ b/.github/ci_includes/werf_envs.yml
@@ -22,10 +22,5 @@ CLOUD_PROVIDERS_SOURCE_REPO: "${{secrets.CLOUD_PROVIDERS_SOURCE_REPO}}"
 GOPROXY: "${{vars.GOPROXY}}"
 # observability source repo should contain creds for repo for ex https://user:password@my-repo.com/group
 OBSERVABILITY_SOURCE_REPO: "${{secrets.OBSERVABILITY_SOURCE_REPO}}"
-# Next two are required for accessing the stronghold repo during d8 cli builds.
-# Stronghold pull token should contain CI token with read access to stronghold repos.
-STRONGHOLD_PULL_TOKEN: "${{secrets.STRONGHOLD_PULL_TOKEN}}"
-# deckhouse private repo should contain the host address of proprietary parts of deckhouse ecosystem. Ex repo.my-repo.com
-DECKHOUSE_PRIVATE_REPO: "${{secrets.DECKHOUSE_PRIVATE_REPO}}"
 # </template: git_source_envs>
 {!{- end -}!}

--- a/.github/ci_includes/werf_envs.yml
+++ b/.github/ci_includes/werf_envs.yml
@@ -22,5 +22,6 @@ CLOUD_PROVIDERS_SOURCE_REPO: "${{secrets.CLOUD_PROVIDERS_SOURCE_REPO}}"
 GOPROXY: "${{vars.GOPROXY}}"
 # observability source repo should contain creds for repo for ex https://user:password@my-repo.com/group
 OBSERVABILITY_SOURCE_REPO: "${{secrets.OBSERVABILITY_SOURCE_REPO}}"
+DECKHOUSE_PRIVATE_REPO: "${{secrets.DECKHOUSE_PRIVATE_REPO}}"
 # </template: git_source_envs>
 {!{- end -}!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -45,6 +45,7 @@ env:
   GOPROXY: "${{vars.GOPROXY}}"
   # observability source repo should contain creds for repo for ex https://user:password@my-repo.com/group
   OBSERVABILITY_SOURCE_REPO: "${{secrets.OBSERVABILITY_SOURCE_REPO}}"
+  DECKHOUSE_PRIVATE_REPO: "${{secrets.DECKHOUSE_PRIVATE_REPO}}"
   # </template: git_source_envs>
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -45,11 +45,6 @@ env:
   GOPROXY: "${{vars.GOPROXY}}"
   # observability source repo should contain creds for repo for ex https://user:password@my-repo.com/group
   OBSERVABILITY_SOURCE_REPO: "${{secrets.OBSERVABILITY_SOURCE_REPO}}"
-  # Next two are required for accessing the stronghold repo during d8 cli builds.
-  # Stronghold pull token should contain CI token with read access to stronghold repos.
-  STRONGHOLD_PULL_TOKEN: "${{secrets.STRONGHOLD_PULL_TOKEN}}"
-  # deckhouse private repo should contain the host address of proprietary parts of deckhouse ecosystem. Ex repo.my-repo.com
-  DECKHOUSE_PRIVATE_REPO: "${{secrets.DECKHOUSE_PRIVATE_REPO}}"
   # </template: git_source_envs>
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -47,11 +47,6 @@ env:
   GOPROXY: "${{vars.GOPROXY}}"
   # observability source repo should contain creds for repo for ex https://user:password@my-repo.com/group
   OBSERVABILITY_SOURCE_REPO: "${{secrets.OBSERVABILITY_SOURCE_REPO}}"
-  # Next two are required for accessing the stronghold repo during d8 cli builds.
-  # Stronghold pull token should contain CI token with read access to stronghold repos.
-  STRONGHOLD_PULL_TOKEN: "${{secrets.STRONGHOLD_PULL_TOKEN}}"
-  # deckhouse private repo should contain the host address of proprietary parts of deckhouse ecosystem. Ex repo.my-repo.com
-  DECKHOUSE_PRIVATE_REPO: "${{secrets.DECKHOUSE_PRIVATE_REPO}}"
   # </template: git_source_envs>
 
 # Cancel in-progress jobs for the same branch.

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -47,6 +47,7 @@ env:
   GOPROXY: "${{vars.GOPROXY}}"
   # observability source repo should contain creds for repo for ex https://user:password@my-repo.com/group
   OBSERVABILITY_SOURCE_REPO: "${{secrets.OBSERVABILITY_SOURCE_REPO}}"
+  DECKHOUSE_PRIVATE_REPO: "${{secrets.DECKHOUSE_PRIVATE_REPO}}"
   # </template: git_source_envs>
 
 # Cancel in-progress jobs for the same branch.

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -60,6 +60,7 @@ env:
   GOPROXY: "${{vars.GOPROXY}}"
   # observability source repo should contain creds for repo for ex https://user:password@my-repo.com/group
   OBSERVABILITY_SOURCE_REPO: "${{secrets.OBSERVABILITY_SOURCE_REPO}}"
+  DECKHOUSE_PRIVATE_REPO: "${{secrets.DECKHOUSE_PRIVATE_REPO}}"
   # </template: git_source_envs>
 
 # Cancel in-progress jobs for the same tag/branch.

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -60,11 +60,6 @@ env:
   GOPROXY: "${{vars.GOPROXY}}"
   # observability source repo should contain creds for repo for ex https://user:password@my-repo.com/group
   OBSERVABILITY_SOURCE_REPO: "${{secrets.OBSERVABILITY_SOURCE_REPO}}"
-  # Next two are required for accessing the stronghold repo during d8 cli builds.
-  # Stronghold pull token should contain CI token with read access to stronghold repos.
-  STRONGHOLD_PULL_TOKEN: "${{secrets.STRONGHOLD_PULL_TOKEN}}"
-  # deckhouse private repo should contain the host address of proprietary parts of deckhouse ecosystem. Ex repo.my-repo.com
-  DECKHOUSE_PRIVATE_REPO: "${{secrets.DECKHOUSE_PRIVATE_REPO}}"
   # </template: git_source_envs>
 
 # Cancel in-progress jobs for the same tag/branch.

--- a/.werf/defines/modules.tmpl
+++ b/.werf/defines/modules.tmpl
@@ -25,6 +25,7 @@ args:
   SOURCE_REPO: {{ .SOURCE_REPO }}
   CLOUD_PROVIDERS_SOURCE_REPO: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}
   OBSERVABILITY_SOURCE_REPO: {{ .OBSERVABILITY_SOURCE_REPO }}
+  DECKHOUSE_PRIVATE_REPO: {{ .DECKHOUSE_PRIVATE_REPO }}
   # proxies for various packages
   GOPROXY: {{ .GOPROXY }}
     {{- if not (has (list .ModuleName .ImageName | join "/") (list "common/distroless")) }}

--- a/.werf/defines/modules.tmpl
+++ b/.werf/defines/modules.tmpl
@@ -25,8 +25,6 @@ args:
   SOURCE_REPO: {{ .SOURCE_REPO }}
   CLOUD_PROVIDERS_SOURCE_REPO: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}
   OBSERVABILITY_SOURCE_REPO: {{ .OBSERVABILITY_SOURCE_REPO }}
-  STRONGHOLD_PULL_TOKEN: {{ .STRONGHOLD_PULL_TOKEN }}
-  DECKHOUSE_PRIVATE_REPO: {{ .DECKHOUSE_PRIVATE_REPO }}
   # proxies for various packages
   GOPROXY: {{ .GOPROXY }}
     {{- if not (has (list .ModuleName .ImageName | join "/") (list "common/distroless")) }}

--- a/.werf/werf-modules.yaml
+++ b/.werf/werf-modules.yaml
@@ -55,8 +55,6 @@
       {{- $_ := set $ctx "CLOUD_PROVIDERS_SOURCE_REPO" $Root.CLOUD_PROVIDERS_SOURCE_REPO }}
       {{- $_ := set $ctx "OBSERVABILITY_SOURCE_REPO" $Root.OBSERVABILITY_SOURCE_REPO }}
       {{- $_ := set $ctx "GOPROXY" $Root.GOPROXY }}
-      {{- $_ := set $ctx "DECKHOUSE_PRIVATE_REPO" $Root.DECKHOUSE_PRIVATE_REPO }}
-      {{- $_ := set $ctx "STRONGHOLD_PULL_TOKEN" $Root.STRONGHOLD_PULL_TOKEN }}
       {{- $_ := set $ctx "DistroPackagesProxy" $Root.DistroPackagesProxy }}
       {{- $_ := set $ctx "CargoProxy" $Root.CargoProxy }}
 ---

--- a/.werf/werf-modules.yaml
+++ b/.werf/werf-modules.yaml
@@ -55,6 +55,7 @@
       {{- $_ := set $ctx "CLOUD_PROVIDERS_SOURCE_REPO" $Root.CLOUD_PROVIDERS_SOURCE_REPO }}
       {{- $_ := set $ctx "OBSERVABILITY_SOURCE_REPO" $Root.OBSERVABILITY_SOURCE_REPO }}
       {{- $_ := set $ctx "GOPROXY" $Root.GOPROXY }}
+      {{- $_ := set $ctx "DECKHOUSE_PRIVATE_REPO" $Root.DECKHOUSE_PRIVATE_REPO }}
       {{- $_ := set $ctx "DistroPackagesProxy" $Root.DistroPackagesProxy }}
       {{- $_ := set $ctx "CargoProxy" $Root.CargoProxy }}
 ---

--- a/Makefile
+++ b/Makefile
@@ -375,7 +375,10 @@ set-build-envs:
   ifeq ($(OBSERVABILITY_SOURCE_REPO),)
   	export OBSERVABILITY_SOURCE_REPO=https://example.com
   endif
-
+  ifeq ($(DECKHOUSE_PRIVATE_REPO),)
+  	export DECKHOUSE_PRIVATE_REPO=https://github.com
+  endif
+  
 	export WERF_REPO=$(DEV_REGISTRY_PATH)
 	export REGISTRY_SUFFIX=$(shell echo $(WERF_ENV) | tr '[:upper:]' '[:lower:]')
 	export SECONDARY_REPO=--secondary-repo $(DECKHOUSE_REGISTRY_HOST)/deckhouse/$(REGISTRY_SUFFIX)

--- a/Makefile
+++ b/Makefile
@@ -375,12 +375,6 @@ set-build-envs:
   ifeq ($(OBSERVABILITY_SOURCE_REPO),)
   	export OBSERVABILITY_SOURCE_REPO=https://example.com
   endif
-  ifeq ($(DECKHOUSE_PRIVATE_REPO),)
-  	export DECKHOUSE_PRIVATE_REPO=https://github.com
-  endif
-  ifeq ($(STRONGHOLD_PULL_TOKEN=),)
-  	export STRONGHOLD_PULL_TOKEN="token"
-  endif
 
 	export WERF_REPO=$(DEV_REGISTRY_PATH)
 	export REGISTRY_SUFFIX=$(shell echo $(WERF_ENV) | tr '[:upper:]' '[:lower:]')

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -1,23 +1,23 @@
 bashible: &bashible
   ubuntu:
-    '18.04':
-    '20.04':
-    '22.04':
-    '24.04':
+    "18.04":
+    "20.04":
+    "22.04":
+    "24.04":
   debian:
-    '10':
-    '11':
-    '12':
+    "10":
+    "11":
+    "12":
   centos:
-    '7':
-    '8':
-    '9':
+    "7":
+    "8":
+    "9":
   opensuse:
-    '15.4':
-    '15.5':
-    '15.6':
+    "15.4":
+    "15.5":
+    "15.6":
 k8s:
-  '1.28':
+  "1.28":
     status: end-of-life
     patch: 15
     bashible: *bashible
@@ -41,7 +41,7 @@ k8s:
       registrar: v2.13.0
       snapshotter: v8.1.1
       livenessprobe: v2.15.0
-  '1.29':
+  "1.29":
     status: available
     patch: 14
     bashible: *bashible
@@ -65,7 +65,7 @@ k8s:
       registrar: v2.13.0
       snapshotter: v8.1.1
       livenessprobe: v2.15.0
-  '1.30':
+  "1.30":
     status: available
     patch: 10
     bashible: *bashible
@@ -89,7 +89,7 @@ k8s:
       registrar: v2.13.0
       snapshotter: v8.1.1
       livenessprobe: v2.15.0
-  '1.31':
+  "1.31":
     status: available
     patch: 6
     bashible: *bashible
@@ -113,7 +113,7 @@ k8s:
       registrar: v2.13.0
       snapshotter: v8.1.1
       livenessprobe: v2.15.0
-  '1.32':
+  "1.32":
     status: preview
     patch: 2
     bashible: *bashible
@@ -138,6 +138,6 @@ k8s:
       snapshotter: v8.1.1
       livenessprobe: v2.15.0
 d8:
-  d8CliVersion: v0.10.4
+  d8CliVersion: go-mod-pull-fix
 jq:
   version: 1.7.1

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -138,6 +138,6 @@ k8s:
       snapshotter: v8.1.1
       livenessprobe: v2.15.0
 d8:
-  d8CliVersion: go-mod-pull-fix
+  d8CliVersion: v0.11.0
 jq:
   version: 1.7.1

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -52,10 +52,12 @@ shell:
   - apt-get update && apt-get install libbtrfs-dev -y
   install:
   - export GOPROXY={{ $.GOPROXY }}
-  - export PRIVATE_REPO={{ $.DECKHOUSE_PRIVATE_REPO }}
-  - export PRIVATE_REPO_TOKEN={{ $.STRONGHOLD_PULL_TOKEN }}
-  - export GOPRIVATE={{ $.DECKHOUSE_PRIVATE_REPO }}
-  - git config --global url."https://gitlab-ci-token:${PRIVATE_REPO_TOKEN}@${PRIVATE_REPO}/".insteadOf https://${PRIVATE_REPO}/
+
+  - SOURCE_REPO_GIT=$(grep -oP '(?<=@)[^/:]+' <<< $SOURCE_REPO_GIT)
+  - GOPRIVATE="flant.internal"
+  - git config --global url."ssh://git@${SOURCE_REPO_GIT}/".insteadOf "https://flant.internal/"
+  - git config --global --add safe.directory '*'
+
   - cd /src/deckhouse-cli
   - task build:dist:linux:amd64
   - mv ./dist/{{ .CandiVersionMap.d8.d8CliVersion }}/linux-amd64/bin/d8 /d8

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -62,11 +62,6 @@ shell:
   - ssh-keyscan -H ${PRIVATE_REPO} >> ~/.ssh/known_hosts
 
   - cd /src/deckhouse-cli
-
-  # TODO test only
-  - echo go-mod-pull-fix > VERSION
-  - sed -i "s|sh:\ git describe --tags|sh:\ cat VERSION|" Taskfile.yml
-
   - task build:dist:linux:amd64
   - mv ./dist/{{ .CandiVersionMap.d8.d8CliVersion }}/linux-amd64/bin/d8 /d8
   - mv /src/scripts/* /

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -57,6 +57,7 @@ shell:
   - GOPRIVATE="flant.internal"
   - git config --global url."ssh://git@${PRIVATE_REPO}/".insteadOf "https://flant.internal/"
   - git config --global --add safe.directory '*'
+  - ssh-keyscan -H ${PRIVATE_REPO} >> ~/.ssh/known_hosts
 
   - cd /src/deckhouse-cli
 

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -53,9 +53,9 @@ shell:
   install:
   - export GOPROXY={{ $.GOPROXY }}
 
-  - SOURCE_REPO_GIT=$(grep -oP '(?<=@)[^/:]+' <<< $SOURCE_REPO_GIT)
+  - export PRIVATE_REPO={{ $.DECKHOUSE_PRIVATE_REPO }}
   - GOPRIVATE="flant.internal"
-  - git config --global url."ssh://git@${SOURCE_REPO_GIT}/".insteadOf "https://flant.internal/"
+  - git config --global url."ssh://git@${PRIVATE_REPO}/".insteadOf "https://flant.internal/"
   - git config --global --add safe.directory '*'
 
   - cd /src/deckhouse-cli

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -64,7 +64,7 @@ shell:
   - cd /src/deckhouse-cli
 
   # TODO test only
-  - echo 0.0.2 > VERSION
+  - echo go-mod-pull-fix > VERSION
   - sed -i "s|sh:\ git describe --tags|sh:\ cat VERSION|" Taskfile.yml
 
   - task build:dist:linux:amd64

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -61,7 +61,7 @@ shell:
   - cd /src/deckhouse-cli
 
   # TODO test only
-  - echo 0.0.1 > VERSION
+  - echo 0.0.2 > VERSION
   - sed -i "s|sh:\ git describe --tags|sh:\ cat VERSION|" Taskfile.yml
 
   - task build:dist:linux:amd64

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -58,11 +58,12 @@ shell:
   - git config --global url."ssh://git@${PRIVATE_REPO}/".insteadOf "https://flant.internal/"
   - git config --global --add safe.directory '*'
 
+  - cd /src/deckhouse-cli
+
   # TODO test only
   - echo 0.0.1 > VERSION
   - sed -i "s|sh:\ git describe --tags|sh:\ cat VERSION|" Taskfile.yml
 
-  - cd /src/deckhouse-cli
   - task build:dist:linux:amd64
   - mv ./dist/{{ .CandiVersionMap.d8.d8CliVersion }}/linux-amd64/bin/d8 /d8
   - mv /src/scripts/* /

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -58,6 +58,10 @@ shell:
   - git config --global url."ssh://git@${PRIVATE_REPO}/".insteadOf "https://flant.internal/"
   - git config --global --add safe.directory '*'
 
+  # TODO test only
+  - echo 0.0.1 > VERSION
+  - sed -i "s|sh:\ git describe --tags|sh:\ cat VERSION|" Taskfile.yml
+
   - cd /src/deckhouse-cli
   - task build:dist:linux:amd64
   - mv ./dist/{{ .CandiVersionMap.d8.d8CliVersion }}/linux-amd64/bin/d8 /d8

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -57,6 +57,8 @@ shell:
   - GOPRIVATE="flant.internal"
   - git config --global url."ssh://git@${PRIVATE_REPO}/".insteadOf "https://flant.internal/"
   - git config --global --add safe.directory '*'
+  - mkdir -p ~/.ssh
+  - touch ~/.ssh/known_hosts
   - ssh-keyscan -H ${PRIVATE_REPO} >> ~/.ssh/known_hosts
 
   - cd /src/deckhouse-cli

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -76,6 +76,7 @@ shell:
     - GOPRIVATE="flant.internal"
     - git config --global url."ssh://git@${PRIVATE_REPO}/".insteadOf "https://flant.internal/"
     - git config --global --add safe.directory '*'
+    - ssh-keyscan -H ${PRIVATE_REPO} >> ~/.ssh/known_hosts
 
     - cd /src
     - task build:dist:all

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -71,9 +71,9 @@ shell:
   install:
     - export GOPROXY={{ $.GOPROXY }}
 
-    - SOURCE_REPO_GIT=$(grep -oP '(?<=@)[^/:]+' <<< $SOURCE_REPO_GIT)
+    - export PRIVATE_REPO={{ $.DECKHOUSE_PRIVATE_REPO }}
     - GOPRIVATE="flant.internal"
-    - git config --global url."ssh://git@${SOURCE_REPO_GIT}/".insteadOf "https://flant.internal/"
+    - git config --global url."ssh://git@${PRIVATE_REPO}/".insteadOf "https://flant.internal/"
     - git config --global --add safe.directory '*'
 
     - cd /src

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -69,10 +69,12 @@ shell:
     - find /var/lib/apt/ /var/cache/apt/ -type f -delete
   install:
     - export GOPROXY={{ $.GOPROXY }}
-    - export PRIVATE_REPO={{ $.DECKHOUSE_PRIVATE_REPO }}
-    - export PRIVATE_REPO_TOKEN={{ $.STRONGHOLD_PULL_TOKEN }}
-    - export GOPRIVATE={{ $.DECKHOUSE_PRIVATE_REPO }}
-    - git config --global url."https://gitlab-ci-token:${PRIVATE_REPO_TOKEN}@${PRIVATE_REPO}/".insteadOf https://${PRIVATE_REPO}/
+
+    - SOURCE_REPO_GIT=$(grep -oP '(?<=@)[^/:]+' <<< $SOURCE_REPO_GIT)
+    - GOPRIVATE="flant.internal"
+    - git config --global url."ssh://git@${SOURCE_REPO_GIT}/".insteadOf "https://flant.internal/"
+    - git config --global --add safe.directory '*'
+
     - cd /src
     - task build:dist:all
     - mkdir -p /app/files/d8-cli

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -33,7 +33,8 @@ shell:
   install:
   - git clone --depth 1 --branch {{ .CandiVersionMap.d8.d8CliVersion }} {{ $.SOURCE_REPO }}/deckhouse/deckhouse-cli.git /src/deckhouse-cli
   - cd /src/deckhouse-cli
-  - git describe --tags > VERSION
+  # - git describe --tags > VERSION
+  - echo 0.0.1 > VERSION
   - sed -i "s|sh:\ git describe --tags|sh:\ cat VERSION|" Taskfile.yml
   - rm -rf /src/deckhouse-cli/.git
 ---

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -35,7 +35,7 @@ shell:
   - cd /src/deckhouse-cli
   # - git describe --tags > VERSION
   # TODO test only
-  - echo 0.0.1 > VERSION
+  - echo 0.0.2 > VERSION
   - sed -i "s|sh:\ git describe --tags|sh:\ cat VERSION|" Taskfile.yml
   - rm -rf /src/deckhouse-cli/.git
 ---

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -33,9 +33,7 @@ shell:
   install:
   - git clone --depth 1 --branch {{ .CandiVersionMap.d8.d8CliVersion }} {{ $.SOURCE_REPO }}/deckhouse/deckhouse-cli.git /src/deckhouse-cli
   - cd /src/deckhouse-cli
-  # - git describe --tags > VERSION
-  # TODO test only
-  - echo go-mod-pull-fix > VERSION
+  - git describe --tags > VERSION
   - sed -i "s|sh:\ git describe --tags|sh:\ cat VERSION|" Taskfile.yml
   - rm -rf /src/deckhouse-cli/.git
 ---

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -76,6 +76,8 @@ shell:
     - GOPRIVATE="flant.internal"
     - git config --global url."ssh://git@${PRIVATE_REPO}/".insteadOf "https://flant.internal/"
     - git config --global --add safe.directory '*'
+    - mkdir -p ~/.ssh
+    - touch ~/.ssh/known_hosts
     - ssh-keyscan -H ${PRIVATE_REPO} >> ~/.ssh/known_hosts
 
     - cd /src

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -35,7 +35,7 @@ shell:
   - cd /src/deckhouse-cli
   # - git describe --tags > VERSION
   # TODO test only
-  - echo 0.0.2 > VERSION
+  - echo go-mod-pull-fix > VERSION
   - sed -i "s|sh:\ git describe --tags|sh:\ cat VERSION|" Taskfile.yml
   - rm -rf /src/deckhouse-cli/.git
 ---

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -34,6 +34,7 @@ shell:
   - git clone --depth 1 --branch {{ .CandiVersionMap.d8.d8CliVersion }} {{ $.SOURCE_REPO }}/deckhouse/deckhouse-cli.git /src/deckhouse-cli
   - cd /src/deckhouse-cli
   # - git describe --tags > VERSION
+  # TODO test only
   - echo 0.0.1 > VERSION
   - sed -i "s|sh:\ git describe --tags|sh:\ cat VERSION|" Taskfile.yml
   - rm -rf /src/deckhouse-cli/.git

--- a/tools/images_tags/main.go
+++ b/tools/images_tags/main.go
@@ -83,6 +83,7 @@ func main() {
 		"GOPROXY=",
 		"CLOUD_PROVIDERS_SOURCE_REPO=",
 		"OBSERVABILITY_SOURCE_REPO=",
+		"DECKHOUSE_PRIVATE_REPO=",
 	)
 	cmd.Dir = path.Join("..")
 	out, err := cmd.CombinedOutput()

--- a/tools/images_tags/main.go
+++ b/tools/images_tags/main.go
@@ -83,8 +83,6 @@ func main() {
 		"GOPROXY=",
 		"CLOUD_PROVIDERS_SOURCE_REPO=",
 		"OBSERVABILITY_SOURCE_REPO=",
-		"STRONGHOLD_PULL_TOKEN=",
-		"DECKHOUSE_PRIVATE_REPO=",
 	)
 	cmd.Dir = path.Join("..")
 	out, err := cmd.CombinedOutput()

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -1,21 +1,19 @@
 giterminismConfigVersion: 1
 config:
-  goTemplateRendering:	# The rules for the Go-template functions
-    allowEnvVariables: 
-    - /CI_.+/
-    - /REPO_MCM_.+/
-    - SOURCE_REPO
-    - GOPROXY
-    - WERF_DISABLE_META_TAGS
-    - CLOUD_PROVIDERS_SOURCE_REPO
-    - OBSERVABILITY_SOURCE_REPO
-    - DISTRO_PACKAGES_PROXY
-    - CARGO_PROXY
-    - STRONGHOLD_PULL_TOKEN
-    - DECKHOUSE_PRIVATE_REPO
-    allowUncommittedFiles: [ "tools/build_includes/*" ]
+  goTemplateRendering: # The rules for the Go-template functions
+    allowEnvVariables:
+      - /CI_.+/
+      - /REPO_MCM_.+/
+      - SOURCE_REPO
+      - GOPROXY
+      - WERF_DISABLE_META_TAGS
+      - CLOUD_PROVIDERS_SOURCE_REPO
+      - OBSERVABILITY_SOURCE_REPO
+      - DISTRO_PACKAGES_PROXY
+      - CARGO_PROXY
+    allowUncommittedFiles: ["tools/build_includes/*"]
   stapel:
     mount:
-     allowBuildDir: true
-     allowFromPaths:
-     - ~/go-pkg-cache
+      allowBuildDir: true
+      allowFromPaths:
+        - ~/go-pkg-cache

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -11,6 +11,7 @@ config:
       - OBSERVABILITY_SOURCE_REPO
       - DISTRO_PACKAGES_PROXY
       - CARGO_PROXY
+      - DECKHOUSE_PRIVATE_REPO
     allowUncommittedFiles: ["tools/build_includes/*"]
   stapel:
     mount:

--- a/werf.yaml
+++ b/werf.yaml
@@ -77,10 +77,6 @@ cleanup:
 # Source repo with observability private code
 {{- $_ := set . "OBSERVABILITY_SOURCE_REPO" (env "OBSERVABILITY_SOURCE_REPO" | default "https://example.com") }}
 
-# Stronghold repo access for building d8 cli
-{{- $_ := set . "STRONGHOLD_PULL_TOKEN" (env "STRONGHOLD_PULL_TOKEN") }}
-{{- $_ := set . "DECKHOUSE_PRIVATE_REPO" (env "DECKHOUSE_PRIVATE_REPO") }}
-
 {{- $_ := set . "CI_COMMIT_TAG" (env "CI_COMMIT_TAG" "dev") }}
 
 # goproxy  settings

--- a/werf.yaml
+++ b/werf.yaml
@@ -77,6 +77,8 @@ cleanup:
 # Source repo with observability private code
 {{- $_ := set . "OBSERVABILITY_SOURCE_REPO" (env "OBSERVABILITY_SOURCE_REPO" | default "https://example.com") }}
 
+{{- $_ := set . "DECKHOUSE_PRIVATE_REPO" (env "DECKHOUSE_PRIVATE_REPO") }}
+
 {{- $_ := set . "CI_COMMIT_TAG" (env "CI_COMMIT_TAG" "dev") }}
 
 # goproxy  settings


### PR DESCRIPTION
## Description

Fixing d8-cli build, removing unnecessary secrets
! Can be merged only after https://github.com/deckhouse/deckhouse-cli/pull/94 and version bumping
Also don't forget to remove `# TODO test only` - needed for dev branch testing

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-tools
type: fix
summary: [chore] d8-cli build fix
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
