### PR TITLE
[candi] Clarify error message about kubelet certificates

### DIFF
--- a/candi/bashible/common-steps/all/069_start_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/069_start_kubelet.sh.tpl
@@ -19,7 +19,7 @@ function wait-kubelet-client-certificate() {
   until [ -f /var/lib/kubelet/pki/kubelet-client-current.pem ]; do
     attempt=$(( attempt + 1 ))
     if [ "$attempt" -gt "30" ]; then
-      bb-log-error "The file /var/lib/kubelet/pki/kubelet-client-current.pem was not generated in 5 minutes."
+      bb-log-error "The file /var/lib/kubelet/pki/kubelet-client-current.pem was not generated in 5 minutes.\nPlease check logs of kubelet: journalctl -u kubelet.service"
       break
     fi
     bb-log-info "Waiting till the file /var/lib/kubelet/pki/kubelet-client-current.pem generated (10sec)..."


### PR DESCRIPTION
## Description

Clarify error message what steps needed if we see, that `The file /var/lib/kubelet/pki/kubelet-client-current.pem was not generated in 5 minutes.`

## Why do we need it, and what problem does it solve?

Give the user a hint on what exactly to do next. Because the message that the certificate has not been generated is not obvious to the user and confuses the user.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Clarify error message about kubelet certificates.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
