### PR TITLE
[candi] Delete unnecessary warnings at sysctl tuner

### DIFF
--- a/candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl
+++ b/candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl
@@ -85,7 +85,7 @@ sysctl -w kernel.panic_on_oops=1
 sysctl -w kernel.panic={{ $fencingTime }}
 
 # we use tee for work with globs
-echo 256 | tee /sys/block/*/queue/nr_requests >/dev/null # put more in the request queue, increase throughput
+echo 256 | tee /sys/block/*/queue/nr_requests >/dev/null 2>&1 # put more in the request queue, increase throughput
 echo 256 | tee /sys/block/*/queue/read_ahead_kb >/dev/null # the most controversial thing, Netflix recommends increasing a little, but you need to test on different setups, this number looks safe
 transparent_hugepage_current=$(grep -o '\[.*\]' /sys/kernel/mm/transparent_hugepage/enabled | tr -d '[]')
 if [ "$transparent_hugepage_current" != "never" ]; then


### PR DESCRIPTION
## Description

Delete unnecessary warnings at sysctl tuner.

```
Feb 25 14:17:49 master-usmanov sysctl-tuner[697725]: tee: /sys/block/loop0/queue/nr_requests: Invalid argument
Feb 25 14:17:49 master-usmanov sysctl-tuner[697725]: tee: /sys/block/loop1/queue/nr_requests: Invalid argument
Feb 25 14:17:49 master-usmanov sysctl-tuner[697725]: tee: /sys/block/loop2/queue/nr_requests: Invalid argument
Feb 25 14:17:49 master-usmanov sysctl-tuner[697725]: tee: /sys/block/loop3/queue/nr_requests: Invalid argument
Feb 25 14:17:49 master-usmanov sysctl-tuner[697725]: tee: /sys/block/loop4/queue/nr_requests: Invalid argument
Feb 25 14:17:49 master-usmanov sysctl-tuner[697725]: tee: /sys/block/loop5/queue/nr_requests: Invalid argument
Feb 25 14:17:49 master-usmanov sysctl-tuner[697725]: tee: /sys/block/loop6/queue/nr_requests: Invalid argument
Feb 25 14:17:49 master-usmanov sysctl-tuner[697725]: tee: /sys/block/loop7/queue/nr_requests: Invalid argument
```
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

We have this warning because we can't change default value on some devices, but script changes values for all devices with necessary devices too, so we don't need to output errors.

More details https://www.spinics.net/lists/lvm/msg24341.html

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Delete unnecessary warnings at sysctl tuner
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
