### PR TITLE
[okmeter] Explicitly remove service account fields from DaemonSet

### DIFF
--- a/ee/fe/modules/500-okmeter/templates/daemonset.yaml
+++ b/ee/fe/modules/500-okmeter/templates/daemonset.yaml
@@ -108,6 +108,8 @@ spec:
   {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
             {{- include "okagent_resources" . | nindent 12 }}
   {{- end }}
+      serviceAccount: null
+      serviceAccountName: null
       volumes:
       - name: containerdsocket
         hostPath:

--- a/modules/500-okmeter/templates/daemonset.yaml
+++ b/modules/500-okmeter/templates/daemonset.yaml
@@ -96,6 +96,8 @@ spec:
   {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
             {{- include "okagent_resources" . | nindent 12 }}
   {{- end }}
+      serviceAccount: null
+      serviceAccountName: null
       volumes:
       - name: containerdsocket
         hostPath:


### PR DESCRIPTION
## Description
Admission controller interference voids changes made in the [commit](https://github.com/deckhouse/deckhouse/commit/401c6555bdc79caf4f582072ef3ff14be6c1bb98#diff-bfa24c7a2cdffe17fc43b99474f1b86f68352192e768acf9415b074eb0d3e1b7L48) which removes `serviceAccountName` field from the DaemonSet. As a result, okmeter pods still require the service account and thus don't start.

## Why do we need it, and what problem does it solve?
This PR explicitly sets both serviceAccount and serviceAccountName to null effectively solving the issue described above.

## Why do we need it in the patch release (if we do)?
We do. Okmeter DaemonSet still has the serviceAccountName field set, but the service account is missing. This prevents pods from being updated.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: okmeter
type: fix
summary: drop service account fields from the okmeter daemonset manifest
impact: okmeter daemonset pods will be rollout restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
