### PR TITLE
[deckhouse-controller] chore: add mustttag linter to golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -86,3 +86,4 @@ linters:
   - whitespace
   - copyloopvar
   - nonamedreturns
+  - musttag

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -679,7 +679,7 @@ type ReleaseMetadata struct {
 	Disruptions  map[string][]string       `json:"disruptions"`
 	Suspend      bool                      `json:"suspend"`
 
-	Changelog map[string]interface{}
+	Changelog map[string]interface{} `json:"-"`
 
 	Cooldown *metav1.Time `json:"-"`
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
@@ -464,5 +464,5 @@ func isRel(candidate, target string) bool {
 type ModuleReleaseMetadata struct {
 	Version *semver.Version `json:"version"`
 
-	Changelog map[string]any
+	Changelog map[string]any `json:"-"`
 }

--- a/ee/modules/110-istio/hooks/ee/common_test.go
+++ b/ee/modules/110-istio/hooks/ee/common_test.go
@@ -23,10 +23,10 @@ type HTTPMockResponse struct {
 }
 
 type jwtPayload struct {
-	Iss   string
-	Sub   string
-	Aud   string
-	Scope string
-	Nbf   int64
-	Exp   int64
+	Iss   string `json:"iss"`
+	Sub   string `json:"sub"`
+	Aud   string `json:"aud"`
+	Scope string `json:"scope"`
+	Nbf   int64  `json:"nbf"`
+	Exp   int64  `json:"exp"`
 }

--- a/modules/040-node-manager/hooks/handle_node_templates.go
+++ b/modules/040-node-manager/hooks/handle_node_templates.go
@@ -46,14 +46,14 @@ const (
 )
 
 type NodeSettings struct {
-	Name        string
-	NodeType    ngv1.NodeType
-	NodeGroup   string
-	Annotations map[string]string
-	Labels      map[string]string
-	Taints      []v1.Taint
+	Name        string            `json:"name"`
+	NodeType    ngv1.NodeType     `json:"nodeType"`
+	NodeGroup   string            `json:"-"`
+	Annotations map[string]string `json:"annotations"`
+	Labels      map[string]string `json:"labels"`
+	Taints      []v1.Taint        `json:"taints"`
 
-	IsClusterAPINode bool
+	IsClusterAPINode bool `json:"-"`
 }
 
 // Hook will be executed when NodeType or NodeTemplate are changed.

--- a/modules/040-node-manager/hooks/machineclass_checksum_collect.go
+++ b/modules/040-node-manager/hooks/machineclass_checksum_collect.go
@@ -143,7 +143,7 @@ func saveMachineClassChecksum(input *go_hook.HookInput) error {
 type nodeGroupValue struct {
 	Name string        `json:"name"`
 	Type ngv1.NodeType `json:"nodeType"`
-	Raw  interface{}
+	Raw  interface{}   `json:"-"`
 }
 
 func parseNodeGroupValues(values go_hook.PatchableValuesCollector) ([]*nodeGroupValue, error) {


### PR DESCRIPTION
## Description
Added musttag linter to golangci-lint

## Why do we need it, and what problem does it solve?

If we marshall/unmarshall structs - we need to check all struct fields for correct struct tags applied.
If not - we get unpredictable result.

It's easy linter to apply (not so much errors in a code), but have a powerful impact in the future.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: added musttag linter to golangci-lint
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
