### PR TITLE
[candi] Fix update_node_labels.sh

### DIFF
--- a/candi/bashible/common-steps/all/098_update_node_labels.sh.tpl
+++ b/candi/bashible/common-steps/all/098_update_node_labels.sh.tpl
@@ -32,7 +32,6 @@ def recursive_glob(base_dir, pattern):
     for root, _, filenames in os.walk(base_dir):
         for filename in glob.glob(os.path.join(root, pattern)):
             matches.append(filename)
-    print(matches)
     return matches
 
 

--- a/candi/bashible/common-steps/all/098_update_node_labels.sh.tpl
+++ b/candi/bashible/common-steps/all/098_update_node_labels.sh.tpl
@@ -27,6 +27,23 @@ import json
 
 system_lables = {"beta.kubernetes.io/arch", "beta.kubernetes.io/os", "failure-domain.beta.kubernetes.io/region", "failure-domain.beta.kubernetes.io/zone", "kubernetes.io/arch", "kubernetes.io/hostname", "kubernetes.io/os", "node.deckhouse.io/group", "node.deckhouse.io/type", "topology.kubernetes.io/region", "topology.kubernetes.io/zone"}
 
+def recursive_glob(base_dir, pattern):
+    matches = []
+    for root, _, filenames in os.walk(base_dir):
+        for filename in glob.glob(os.path.join(root, pattern)):
+            matches.append(filename)
+    print(matches)
+    return matches
+
+
+def find_files(base_dir, pattern):
+    if sys.version_info[0] == 2:
+        return recursive_glob(base_dir, pattern)
+    elif sys.version_info[0] == 3:
+        return glob.glob(os.path.join(base_dir, '**'), recursive=True)
+    else:
+        raise RuntimeError("unknown Py Ver")
+
 def validate(string, is_key = True):
     if len(string) > 63:
         return False
@@ -36,12 +53,12 @@ def validate(string, is_key = True):
         pattern = re.compile("^(?:(?:(?:[a-z0-9][a-z0-9-]+)\.)+[a-z0-9]+/)*[A-Za-z0-9][A-Za-z0-9-._]*$")
     else:
         pattern = re.compile("^[A-Za-z0-9][A-Za-z0-9-._]*$")
-    if pattern.fullmatch(string):
+    if pattern.match(string):
         return True
     return False
 
 def fetch_labels(fileglob, valid = True):
-    files = glob.glob(fileglob, recursive=True)
+    files = find_files(fileglob, "**")
     labels = dict()
     for f in files:
         if os.path.isfile(f):
@@ -72,7 +89,7 @@ def get_removed(d1, d2):
     removed = d1_keys - d2_keys
     return removed
 
-labels = fetch_labels("$1" + "/**", True)
+labels = fetch_labels("$1", True)
 
 if "$2" == "add":
     format = "$4"


### PR DESCRIPTION
## Description

Make update_node_labels.sh working with python2 as well as with python3

## Why do we need it, and what problem does it solve?

On old systems, where there's only python2 available, update_node_labels.sh is broken

## Why do we need it in the patch release (if we do)?

Script is broken in 1.68

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix update_node_labels.sh to work on python2.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
