### PR TITLE
[deckhouse] terminating for ms and mr

### DIFF
--- a/deckhouse-controller/crds/doc-ru-module-source.yaml
+++ b/deckhouse-controller/crds/doc-ru-module-source.yaml
@@ -29,6 +29,8 @@ spec:
               properties:
                 syncTime:
                   description: Время последней синхронизации с container registry.
+                status:
+                  description: Текущий статус.
                 modulesCount:
                   type: integer
                   description: Количество доступных модулей.
@@ -58,14 +60,14 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-        - name: "release channel"
-          type: string
-          jsonPath: .spec.releaseChannel
-          description: Канал обновлений по умолчанию для модулей в данном репозитории.
         - name: count
           type: integer
           jsonPath: .status.modulesCount
           description: Количество доступных модулей в данном репозитории.
+        - name: status
+          type: string
+          jsonPath: .status.status
+          description: Текущий статусю
         - name: sync
           jsonPath: .status.syncTime
           type: date

--- a/deckhouse-controller/crds/doc-ru-module-source.yaml
+++ b/deckhouse-controller/crds/doc-ru-module-source.yaml
@@ -29,8 +29,8 @@ spec:
               properties:
                 syncTime:
                   description: Время последней синхронизации с container registry.
-                status:
-                  description: Текущий статус.
+                phase:
+                  description: Текущая фаза.
                 modulesCount:
                   type: integer
                   description: Количество доступных модулей.
@@ -66,7 +66,7 @@ spec:
           description: Количество доступных модулей в данном репозитории.
         - name: status
           type: string
-          jsonPath: .status.status
+          jsonPath: .status.phase
           description: Текущий статусю
         - name: sync
           jsonPath: .status.syncTime

--- a/deckhouse-controller/crds/doc-ru-module-source.yaml
+++ b/deckhouse-controller/crds/doc-ru-module-source.yaml
@@ -67,7 +67,7 @@ spec:
         - name: status
           type: string
           jsonPath: .status.phase
-          description: Текущий статусю
+          description: Текущая фаза.
         - name: sync
           jsonPath: .status.syncTime
           type: date

--- a/deckhouse-controller/crds/module-release.yaml
+++ b/deckhouse-controller/crds/module-release.yaml
@@ -79,6 +79,7 @@ spec:
                     - Superseded
                     - Suspended
                     - Skipped
+                    - Terminating
                   description: Current status of the release.
                 message:
                   type: string

--- a/deckhouse-controller/crds/module-source.yaml
+++ b/deckhouse-controller/crds/module-source.yaml
@@ -77,6 +77,13 @@ spec:
                 syncTime:
                   type: string
                   description: When the repository was synchronized.
+                status:
+                  type: string
+                  description: The current status.
+                  enum:
+                    - Active
+                    - Terminating
+                    - Error
                 modulesCount:
                   type: integer
                   description: The number of modules available.
@@ -110,6 +117,10 @@ spec:
           type: integer
           jsonPath: .status.modulesCount
           description: The number of modules available.
+        - name: status
+          type: string
+          jsonPath: .status.status
+          description: The current status.
         - name: sync
           type: date
           jsonPath: .status.syncTime

--- a/deckhouse-controller/crds/module-source.yaml
+++ b/deckhouse-controller/crds/module-source.yaml
@@ -83,7 +83,6 @@ spec:
                   enum:
                     - Active
                     - Terminating
-                    - Error
                 modulesCount:
                   type: integer
                   description: The number of modules available.

--- a/deckhouse-controller/crds/module-source.yaml
+++ b/deckhouse-controller/crds/module-source.yaml
@@ -77,9 +77,9 @@ spec:
                 syncTime:
                   type: string
                   description: When the repository was synchronized.
-                status:
+                phase:
                   type: string
-                  description: The current status.
+                  description: The current phase.
                   enum:
                     - Active
                     - Terminating
@@ -119,8 +119,8 @@ spec:
           description: The number of modules available.
         - name: status
           type: string
-          jsonPath: .status.status
-          description: The current status.
+          jsonPath: .status.phase
+          description: The current phase.
         - name: sync
           type: date
           jsonPath: .status.syncTime

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_release.go
@@ -28,13 +28,15 @@ import (
 )
 
 const (
-	ModuleReleaseResource        = "modulereleases"
-	ModuleReleaseKind            = "ModuleRelease"
-	ModuleReleasePhasePending    = "Pending"
-	ModuleReleasePhaseDeployed   = "Deployed"
-	ModuleReleasePhaseSuperseded = "Superseded"
-	ModuleReleasePhaseSuspended  = "Suspended"
-	ModuleReleasePhaseSkipped    = "Skipped"
+	ModuleReleaseResource = "modulereleases"
+	ModuleReleaseKind     = "ModuleRelease"
+
+	ModuleReleasePhasePending     = "Pending"
+	ModuleReleasePhaseDeployed    = "Deployed"
+	ModuleReleasePhaseSuperseded  = "Superseded"
+	ModuleReleasePhaseSuspended   = "Suspended"
+	ModuleReleasePhaseSkipped     = "Skipped"
+	ModuleReleasePhaseTerminating = "Terminating"
 
 	ModuleReleaseApprovalAnnotation              = "modules.deckhouse.io/approved"
 	ModuleReleaseAnnotationIsUpdating            = "modules.deckhouse.io/isUpdating"

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_source.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_source.go
@@ -26,9 +26,8 @@ const (
 	ModuleSourceResource = "modulesources"
 	ModuleSourceKind     = "ModuleSource"
 
-	ModuleSourceStatusActive      = "Active"
-	ModuleSourceStatusTerminating = "Terminating"
-	ModuleSourceStatusError       = "Error"
+	ModuleSourcePhaseActive      = "Active"
+	ModuleSourcePhaseTerminating = "Terminating"
 
 	ModuleSourceMessagePullErrors = "Some errors occurred. Inspect status for details"
 
@@ -100,7 +99,7 @@ type ModuleSourceStatus struct {
 	SyncTime         metav1.Time       `json:"syncTime"`
 	ModulesCount     int               `json:"modulesCount"`
 	AvailableModules []AvailableModule `json:"modules"`
-	Status           string            `json:"status"`
+	Phase            string            `json:"phase"`
 	Message          string            `json:"message"`
 }
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_source.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_source.go
@@ -26,8 +26,9 @@ const (
 	ModuleSourceResource = "modulesources"
 	ModuleSourceKind     = "ModuleSource"
 
-	ModuleSourceMessageReady      = "Ready"
-	ModuleSourceMessagePullErrors = "Some errors occurred. Inspect status for details"
+	ModuleSourceMessageTerminating = "Terminating"
+	ModuleSourceMessageReady       = "Ready"
+	ModuleSourceMessagePullErrors  = "Some errors occurred. Inspect status for details"
 
 	ModuleSourceFinalizerReleaseExists = "modules.deckhouse.io/release-exists"
 	ModuleSourceFinalizerModuleExists  = "modules.deckhouse.io/module-exists"

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_source.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_source.go
@@ -26,9 +26,11 @@ const (
 	ModuleSourceResource = "modulesources"
 	ModuleSourceKind     = "ModuleSource"
 
-	ModuleSourceMessageTerminating = "Terminating"
-	ModuleSourceMessageReady       = "Ready"
-	ModuleSourceMessagePullErrors  = "Some errors occurred. Inspect status for details"
+	ModuleSourceStatusActive      = "Active"
+	ModuleSourceStatusTerminating = "Terminating"
+	ModuleSourceStatusError       = "Error"
+
+	ModuleSourceMessagePullErrors = "Some errors occurred. Inspect status for details"
 
 	ModuleSourceFinalizerReleaseExists = "modules.deckhouse.io/release-exists"
 	ModuleSourceFinalizerModuleExists  = "modules.deckhouse.io/module-exists"
@@ -98,6 +100,7 @@ type ModuleSourceStatus struct {
 	SyncTime         metav1.Time       `json:"syncTime"`
 	ModulesCount     int               `json:"modulesCount"`
 	AvailableModules []AvailableModule `json:"modules"`
+	Status           string            `json:"status"`
 	Message          string            `json:"message"`
 }
 

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-mode.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-mode.yaml
@@ -16,6 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules:
   - name: mcplay-suitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-mode.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-mode.yaml
@@ -16,7 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules:
   - name: mcplay-suitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-minor-update.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-minor-update.yaml
@@ -16,6 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules:
   - name: mcplay-suitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-minor-update.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-minor-update.yaml
@@ -16,7 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules:
   - name: mcplay-suitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode-minor-release-approved.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode-minor-release-approved.yaml
@@ -16,6 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules:
   - name: mcplay-suitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode-minor-release-approved.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode-minor-release-approved.yaml
@@ -16,7 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules:
   - name: mcplay-suitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode.yaml
@@ -16,6 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules:
   - name: mcplay-suitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode.yaml
@@ -16,7 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules:
   - name: mcplay-suitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-for-deployed.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-for-deployed.yaml
@@ -18,6 +18,7 @@ spec:
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules: null
   modulesCount: 0

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-for-deployed.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-for-deployed.yaml
@@ -18,7 +18,7 @@ spec:
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules: null
   modulesCount: 0

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-when-deploy.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-when-deploy.yaml
@@ -16,6 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules: null
   modulesCount: 0

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-when-deploy.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-when-deploy.yaml
@@ -16,7 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules: null
   modulesCount: 0

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-suitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-suitable.yaml
@@ -16,6 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules:
   - name: mcplay-suitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-suitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-suitable.yaml
@@ -16,7 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules:
   - name: mcplay-suitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-unsuitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-unsuitable.yaml
@@ -16,7 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules:
     - name: mcplay-unsuitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-unsuitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-unsuitable.yaml
@@ -16,6 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules:
     - name: mcplay-unsuitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-suitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-suitable.yaml
@@ -16,6 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules:
   - name: mcplay-kube-suitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-suitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-suitable.yaml
@@ -16,7 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules:
   - name: mcplay-kube-suitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-unsuitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-unsuitable.yaml
@@ -16,7 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules:
     - name: mcplay-kube-unsuitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-unsuitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-unsuitable.yaml
@@ -16,6 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules:
     - name: mcplay-kube-unsuitable

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/new-module-manual-mode.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/new-module-manual-mode.yaml
@@ -15,7 +15,7 @@ spec:
     dockerCfg: ""
     repo: ""
 status:
-  status: ""
+  phase: ""
   message: ""
   modules: null
   modulesCount: 0

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/new-module-manual-mode.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/new-module-manual-mode.yaml
@@ -15,6 +15,7 @@ spec:
     dockerCfg: ""
     repo: ""
 status:
+  status: ""
   message: ""
   modules: null
   modulesCount: 0

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/simple.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/simple.yaml
@@ -16,6 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules:
   - name: mcplay

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/simple.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/simple.yaml
@@ -16,7 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules:
   - name: mcplay

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/with-annotation.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/with-annotation.yaml
@@ -16,6 +16,7 @@ spec:
     repo: prod.deckhouse.io/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules: null
   modulesCount: 0

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/with-annotation.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/with-annotation.yaml
@@ -16,7 +16,7 @@ spec:
     repo: prod.deckhouse.io/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules: null
   modulesCount: 0

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -416,7 +416,7 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 
 func (r *reconciler) deleteModuleSource(ctx context.Context, source *v1alpha1.ModuleSource) (ctrl.Result, error) {
 	if source.Status.Status != v1alpha1.ModuleSourceStatusTerminating {
-		source.Status.Message = v1alpha1.ModuleSourceStatusTerminating
+		source.Status.Status = v1alpha1.ModuleSourceStatusTerminating
 		if err := r.client.Status().Update(ctx, source); err != nil {
 			r.logger.Warn("failed to set terminating to the source", slog.String("moduleSource", source.GetName()), log.Err(err))
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -385,13 +385,12 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 
 	// update source status
 	err := utils.UpdateStatus[*v1alpha1.ModuleSource](ctx, r.client, source, func(source *v1alpha1.ModuleSource) bool {
-		source.Status.Status = v1alpha1.ModuleSourceStatusActive
+		source.Status.Phase = v1alpha1.ModuleSourcePhaseActive
 		source.Status.SyncTime = metav1.NewTime(r.dependencyContainer.GetClock().Now().UTC())
 		source.Status.AvailableModules = availableModules
 		source.Status.ModulesCount = len(availableModules)
 		if pullErrorsExist {
 			source.Status.Message = v1alpha1.ModuleSourceMessagePullErrors
-			source.Status.Status = v1alpha1.ModuleSourceStatusError
 		}
 		return true
 	})
@@ -415,8 +414,8 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 }
 
 func (r *reconciler) deleteModuleSource(ctx context.Context, source *v1alpha1.ModuleSource) (ctrl.Result, error) {
-	if source.Status.Status != v1alpha1.ModuleSourceStatusTerminating {
-		source.Status.Status = v1alpha1.ModuleSourceStatusTerminating
+	if source.Status.Phase != v1alpha1.ModuleSourcePhaseTerminating {
+		source.Status.Phase = v1alpha1.ModuleSourcePhaseTerminating
 		if err := r.client.Status().Update(ctx, source); err != nil {
 			r.logger.Warn("failed to set terminating to the source", slog.String("moduleSource", source.GetName()), log.Err(err))
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -385,12 +385,13 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 
 	// update source status
 	err := utils.UpdateStatus[*v1alpha1.ModuleSource](ctx, r.client, source, func(source *v1alpha1.ModuleSource) bool {
-		source.Status.Message = v1alpha1.ModuleSourceMessageReady
+		source.Status.Status = v1alpha1.ModuleSourceStatusActive
 		source.Status.SyncTime = metav1.NewTime(r.dependencyContainer.GetClock().Now().UTC())
 		source.Status.AvailableModules = availableModules
 		source.Status.ModulesCount = len(availableModules)
 		if pullErrorsExist {
 			source.Status.Message = v1alpha1.ModuleSourceMessagePullErrors
+			source.Status.Status = v1alpha1.ModuleSourceStatusError
 		}
 		return true
 	})
@@ -414,8 +415,8 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 }
 
 func (r *reconciler) deleteModuleSource(ctx context.Context, source *v1alpha1.ModuleSource) (ctrl.Result, error) {
-	if source.Status.Message != v1alpha1.ModuleSourceMessageTerminating {
-		source.Status.Message = v1alpha1.ModuleSourceMessageTerminating
+	if source.Status.Status != v1alpha1.ModuleSourceStatusTerminating {
+		source.Status.Message = v1alpha1.ModuleSourceStatusTerminating
 		if err := r.client.Status().Update(ctx, source); err != nil {
 			r.log.Warn("failed to set terminating to the source", slog.String("source", source.GetName()), log.Err(err))
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -418,7 +418,7 @@ func (r *reconciler) deleteModuleSource(ctx context.Context, source *v1alpha1.Mo
 	if source.Status.Status != v1alpha1.ModuleSourceStatusTerminating {
 		source.Status.Message = v1alpha1.ModuleSourceStatusTerminating
 		if err := r.client.Status().Update(ctx, source); err != nil {
-			r.logger.Warn("failed to set terminating to the source", slog.String("source", source.GetName()), log.Err(err))
+			r.logger.Warn("failed to set terminating to the source", slog.String("moduleSource", source.GetName()), log.Err(err))
 
 			return ctrl.Result{}, err
 		}
@@ -429,7 +429,7 @@ func (r *reconciler) deleteModuleSource(ctx context.Context, source *v1alpha1.Mo
 			// list deployed ModuleReleases associated with the ModuleSource
 			releases := new(v1alpha1.ModuleReleaseList)
 			if err := r.client.List(ctx, releases, client.MatchingLabels{"source": source.Name, "status": "deployed"}); err != nil {
-				r.logger.Warn("failed to list releases", slog.String("source", source.GetName()), log.Err(err))
+				r.logger.Warn("failed to list releases", slog.String("moduleSource", source.GetName()), log.Err(err))
 
 				return ctrl.Result{}, err
 			}

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -316,13 +316,13 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 
 		if module.Properties.Source != source.Name {
 			availableModules = append(availableModules, availableModule)
-			r.log.Debugf("the '%s' source not active source for the '%s' module, skip it", source.Name, moduleName)
+			r.logger.Debugf("the '%s' source not active source for the '%s' module, skip it", source.Name, moduleName)
 			continue
 		}
 
 		if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
 			availableModules = append(availableModules, availableModule)
-			r.log.Debugf("skip the '%s' disabled module", moduleName)
+			r.logger.Debugf("skip the '%s' disabled module", moduleName)
 			continue
 		}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -101,7 +101,7 @@ func (suite *ControllerTestSuite) setupTestController(raw string) {
 		client:               suite.client,
 		downloadedModulesDir: d8env.GetDownloadedModulesDir(),
 		dependencyContainer:  dependency.NewDependencyContainer(),
-		log:                  log.NewNop(),
+		logger:               log.NewNop(),
 
 		embeddedPolicy: helpers.NewModuleUpdatePolicySpecContainer(&v1alpha2.ModuleUpdatePolicySpec{
 			Update: v1alpha2.ModuleUpdatePolicySpecUpdate{

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -149,11 +149,11 @@ func (r *reconciler) releaseExists(ctx context.Context, sourceName, moduleName, 
 		return false, fmt.Errorf("list module releases: %w", err)
 	}
 	if len(moduleReleases.Items) == 0 {
-		r.log.Debugf("no module release with '%s' checksum for the '%s' module of the '%s' source", checksum, moduleName, sourceName)
+		r.logger.Debugf("no module release with '%s' checksum for the '%s' module of the '%s' source", checksum, moduleName, sourceName)
 		return false, nil
 	}
 
-	r.log.Debugf("the module release with '%s' checksum exists for the '%s' module of the '%s' source", checksum, moduleName, sourceName)
+	r.logger.Debugf("the module release with '%s' checksum exists for the '%s' module of the '%s' source", checksum, moduleName, sourceName)
 	return true, nil
 }
 
@@ -254,7 +254,7 @@ func (r *reconciler) ensureModule(ctx context.Context, sourceName, moduleName, r
 		if !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("get the '%s' module: %w", moduleName, err)
 		}
-		r.log.Debugf("the '%s' module not installed", moduleName)
+		r.logger.Debugf("the '%s' module not installed", moduleName)
 		module = &v1alpha1.Module{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       v1alpha1.ModuleGVK.Kind,
@@ -267,7 +267,7 @@ func (r *reconciler) ensureModule(ctx context.Context, sourceName, moduleName, r
 				AvailableSources: []string{sourceName},
 			},
 		}
-		r.log.Debugf("the '%s' module not found, create it", moduleName)
+		r.logger.Debugf("the '%s' module not found, create it", moduleName)
 		if err = r.client.Create(ctx, module); err != nil {
 			return nil, fmt.Errorf("create the '%s' module: %w", moduleName, err)
 		}

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/empty.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/empty.yaml
@@ -14,7 +14,7 @@ spec:
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
 status:
-  status: ""
+  phase: ""
   message: ""
   modules: null
   modulesCount: 0

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/empty.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/empty.yaml
@@ -14,6 +14,7 @@ spec:
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
 status:
+  status: ""
   message: ""
   modules: null
   modulesCount: 0

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodulepullerror.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodulepullerror.yaml
@@ -16,7 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
 status:
-  status: Error
+  phase: Active
   message: Some errors occurred. Inspect status for details
   modules:
   - checksum: 'sha256:'

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodulepullerror.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodulepullerror.yaml
@@ -16,6 +16,7 @@ spec:
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
 status:
+  status: Error
   message: Some errors occurred. Inspect status for details
   modules:
   - checksum: 'sha256:'

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodules.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodules.yaml
@@ -16,7 +16,8 @@ spec:
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
 status:
-  message: Ready
+  message: ""
+  status: Active
   modules:
   - name: disabledmodule
   - checksum: 'sha256:'

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodules.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodules.yaml
@@ -17,7 +17,7 @@ spec:
     scheme: HTTPS
 status:
   message: ""
-  status: Active
+  phase: Active
   modules:
   - name: disabledmodule
   - checksum: 'sha256:'


### PR DESCRIPTION
## Description
It provides terminating status for ms and mr.

## Why do we need it, and what problem does it solve?
Fixes #12212

To explicitly show that module source/release is deleted.

```
root@dev-master-0:~# k get ms
NAME         COUNT   STATUS        SYNC   MSG
deckhouse    20      Active        5s     Some errors occurred. Inspect status for details
foxtrot      3       Active        5s     Ready
losev-test   1       Active        5s     Ready
test         1       Terminating   37m    The source contains at least 1 deployed release and cannot be deleted. Please delete target ModuleReleases manually to continue
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Terminating status for module source and release.
```
