### PR TITLE
[log-shipper] Add field validation to clusterloggingconfigs CRD

### DIFF
--- a/modules/460-log-shipper/crds/cluster-logging-config.yaml
+++ b/modules/460-log-shipper/crds/cluster-logging-config.yaml
@@ -118,10 +118,18 @@ spec:
                                   - production
                                   - staging
                               items:
+                                oneOf:
+                                  - properties:
+                                      operator:
+                                        enum: [Exists, DoesNotExist]
+                                    required: [key, operator]
+                                    not:
+                                      required: [values]
+                                  - properties:
+                                      operator:
+                                        enum: [In, NotIn]
+                                    required: [key, operator, values]
                                 type: object
-                                required:
-                                  - key
-                                  - operator
                                 properties:
                                   key:
                                     description: A label name.
@@ -139,6 +147,9 @@ spec:
                                     type: array
                                     items:
                                       type: string
+                                      pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+                                      minLength: 1
+                                      maxLength: 63
                     labelSelector:
                       type: object
                       description: |


### PR DESCRIPTION
## Description

Adds validation to `ClusterLoggingConfig` CRD fields `KubernetesPods.namespaceSelector.labelSelector.matchExpressions`.


## Why do we need it, and what problem does it solve?

Helps prevent panic when `values` is specified along with `Exists, DoesNotExist` operators.

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: fix 
summary: Minor improvements in clusterloggingconfigs CRD
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
