### PR TITLE
[docs] Add edition restrictions and comments for observability-platform module

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -203,7 +203,16 @@
   "observability-platform": {
     "external": "true",
     "path": "/products/kubernetes-platform/modules/observability-platform/stable/",
-    "editionMinimumAvailable": "ee"
+    "editionMinimumAvailable": "ee",
+    "editionsWithRestrictions": [
+      "ee"
+    ],
+    "editionsWithRestrictionsComments": {
+      "all": {
+        "ru": "Требуется дополнительная лицензия",
+        "en": "Additional license required"
+      }
+    }
   },
   "operator-argo": {
     "external": "true",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -116,7 +116,16 @@
     "path": "/products/kubernetes-platform/modules/observability-platform/stable/",
     "editions": [
       "ee"
-    ]
+    ],
+    "editionsWithRestrictions": [
+      "ee"
+    ],
+    "editionsWithRestrictionsComments": {
+      "all": {
+        "ru": "Требуется дополнительная лицензия",
+        "en": "Additional license required"
+      }
+    }
   },
   "operator-argo": {
     "editionMinimumAvailable": "ee",


### PR DESCRIPTION
## Description

Add edition restrictions and comments for observability-platform module on the site

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add edition restrictions and comments for observability-platform module on the site.
impact_level: low
```

