### PR TITLE
[deckhouse-tools] Fix tools links pointing to wrong path

### DIFF
--- a/modules/800-deckhouse-tools/images/web/static/tools.json
+++ b/modules/800-deckhouse-tools/images/web/static/tools.json
@@ -4,19 +4,19 @@
     "name": "Deckhouse CLI",
     "links": [
       {
-        "link": "/files/d8-cli/linux-amd64/d8",
+        "link": "/files/d8-cli/linux-amd64/bin/d8",
         "platform": "Linux (Intel)"
       },
       {
-        "link": "/files/d8-cli/darwin-amd64/d8",
+        "link": "/files/d8-cli/darwin-amd64/bin/d8",
         "platform": "MacOS (Intel)"
       },
       {
-        "link": "/files/d8-cli/darwin-arm64/d8",
+        "link": "/files/d8-cli/darwin-arm64/bin/d8",
         "platform": "MacOS (ARM)"
       },
       {
-        "link": "/files/d8-cli/windows-amd64/d8.exe",
+        "link": "/files/d8-cli/windows-amd64/bin/d8.exe",
         "platform": "Windows (Intel)"
       }
     ]


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Binaries are build into the `/bin` subfolder nowdays, but tools were still linking to the old location, fixed paths in tools.json to point to the right place.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This fixes 404 errors during downloads of d8 binaries from deckhouse tools

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

This is a fix for broken functionality that users generally require if they are in the air-gapped environment

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-tools
type: fix
summary: Fix tools links pointing to wrong path
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
