### PR TITLE
[deckhouse-controller] module loader add list option to get releases with label status deployed

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_release.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -53,6 +54,8 @@ const (
 )
 
 var (
+	ModuleReleaseLabelDeployed = strings.ToLower(ModuleReleasePhaseDeployed)
+
 	ModuleReleaseGVR = schema.GroupVersionResource{
 		Group:    SchemeGroupVersion.Group,
 		Version:  SchemeGroupVersion.Version,

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -347,11 +347,11 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		needsUpdate = true
 	}
 
-	if len(release.Labels) == 0 || (release.Labels[v1alpha1.ModuleReleaseLabelStatus] != strings.ToLower(v1alpha1.ModuleReleasePhaseDeployed)) {
+	if len(release.Labels) == 0 || (release.Labels[v1alpha1.ModuleReleaseLabelStatus] != v1alpha1.ModuleReleaseLabelDeployed) {
 		if len(release.ObjectMeta.Labels) == 0 {
 			release.ObjectMeta.Labels = make(map[string]string)
 		}
-		release.ObjectMeta.Labels[v1alpha1.ModuleReleaseLabelStatus] = strings.ToLower(v1alpha1.ModuleReleasePhaseDeployed)
+		release.ObjectMeta.Labels[v1alpha1.ModuleReleaseLabelStatus] = v1alpha1.ModuleReleaseLabelDeployed
 		needsUpdate = true
 	}
 
@@ -796,7 +796,7 @@ func (r *reconciler) runReleaseDeploy(ctx context.Context, release *v1alpha1.Mod
 			release.ObjectMeta.Labels = make(map[string]string, 1)
 		}
 
-		release.ObjectMeta.Labels[v1alpha1.ModuleReleaseLabelStatus] = strings.ToLower(v1alpha1.ModuleReleasePhaseDeployed)
+		release.ObjectMeta.Labels[v1alpha1.ModuleReleaseLabelStatus] = v1alpha1.ModuleReleaseLabelDeployed
 
 		if release.GetApplyNow() {
 			delete(release.Annotations, v1alpha1.ModuleReleaseAnnotationApplyNow)

--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -166,7 +166,13 @@ func (l *Loader) restoreAbsentModulesFromOverrides(ctx context.Context) error {
 // restoreAbsentModulesFromReleases checks ModuleReleases with Deployed status and restore them on the FS
 func (l *Loader) restoreAbsentModulesFromReleases(ctx context.Context) error {
 	releaseList := new(v1alpha1.ModuleReleaseList)
-	if err := l.client.List(ctx, releaseList); err != nil {
+	if err := l.client.List(
+		ctx,
+		releaseList,
+		client.MatchingLabels{
+			v1alpha1.ModuleReleaseLabelStatus: v1alpha1.ModuleReleaseLabelDeployed,
+		},
+	); err != nil {
 		return fmt.Errorf("list releases: %w", err)
 	}
 

--- a/deckhouse-controller/pkg/controller/moduleloader/testdata/releases/release.yaml
+++ b/deckhouse-controller/pkg/controller/moduleloader/testdata/releases/release.yaml
@@ -78,6 +78,7 @@ metadata:
     modules.deckhouse.io/update-policy: example
     release-checksum: 98d00f741c99e06e6c6c4d18b763c550
     source: example
+    status: deployed
   name: echo-v1.0.0
   ownerReferences:
     - apiVersion: deckhouse.io/v1alpha1


### PR DESCRIPTION
## Description

Add list option to function [restoreAbsentModulesFromReleases](https://github.com/deckhouse/deckhouse/blob/e88df4aea92534c31db006eacc6edfee8c4eb9fc/deckhouse-controller/pkg/controller/moduleloader/sync.go#L167) to find only releases with label `status: deployed`
## Why do we need it, and what problem does it solve?

We already have labels on every deployed release.
This optimization can make our function faster and clearer.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: added list option to restoreAbsentModulesFromReleases to find releases with label status deployed
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
