### PR TITLE
[cni] Adding the ability to switch to another CNI in cloud installations.

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/get_cni_secret.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2022 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderZvirt")

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/get_cni_secret.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/get_cni_secret.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Flant JSC
+Copyright 2025 Flant JSC
 Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 

--- a/modules/030-cloud-provider-aws/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-aws/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderAws")

--- a/modules/030-cloud-provider-aws/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-aws/hooks/get_cni_secret.go
@@ -1,6 +1,17 @@
 /*
 Copyright 2025 Flant JSC
-Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package hooks

--- a/modules/030-cloud-provider-aws/openapi/values.yaml
+++ b/modules/030-cloud-provider-aws/openapi/values.yaml
@@ -6,6 +6,8 @@ properties:
     type: object
     default: {}
     properties:
+      cniSecretData:
+        type: string
       storageClasses:
         type: array
         items:

--- a/modules/030-cloud-provider-aws/openapi/values.yaml
+++ b/modules/030-cloud-provider-aws/openapi/values.yaml
@@ -6,8 +6,6 @@ properties:
     type: object
     default: {}
     properties:
-      cniSecretData:
-        type: string
       storageClasses:
         type: array
         items:
@@ -52,6 +50,8 @@ properties:
               additionalProperties: false
         x-examples:
         - [{"name": "gp3", "type": "gp3", "iops": "6000", "throughput": "300"}]
+      cniSecretData:
+        type: string
       instances:
         type: object
         properties:

--- a/modules/030-cloud-provider-aws/templates/cni.yaml
+++ b/modules/030-cloud-provider-aws/templates/cni.yaml
@@ -6,4 +6,8 @@ metadata:
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 data:
+{{- if hasKey .Values.cloudProviderAws.internal "cniSecretData" }}
+  {{- .Values.cloudProviderAws.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
   cni: {{ b64enc "simple-bridge" | quote }}
+{{- end }}

--- a/modules/030-cloud-provider-azure/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-azure/hooks/get_cni_secret.go
@@ -1,6 +1,17 @@
 /*
 Copyright 2025 Flant JSC
-Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package hooks

--- a/modules/030-cloud-provider-azure/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-azure/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderAzure")

--- a/modules/030-cloud-provider-azure/openapi/values.yaml
+++ b/modules/030-cloud-provider-azure/openapi/values.yaml
@@ -6,6 +6,8 @@ properties:
     type: object
     default: {}
     properties:
+      cniSecretData:
+        type: string
       storageClasses:
         type: array
         additionalProperties:

--- a/modules/030-cloud-provider-azure/templates/cni.yaml
+++ b/modules/030-cloud-provider-azure/templates/cni.yaml
@@ -6,4 +6,8 @@ metadata:
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 data:
+{{- if hasKey .Values.cloudProviderAzure.internal "cniSecretData" }}
+  {{- .Values.cloudProviderAzure.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
   cni: {{ b64enc "simple-bridge" | quote }}
+{{- end }}

--- a/modules/030-cloud-provider-gcp/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-gcp/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderGcp")

--- a/modules/030-cloud-provider-gcp/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-gcp/hooks/get_cni_secret.go
@@ -1,6 +1,17 @@
 /*
 Copyright 2025 Flant JSC
-Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package hooks

--- a/modules/030-cloud-provider-gcp/openapi/values.yaml
+++ b/modules/030-cloud-provider-gcp/openapi/values.yaml
@@ -6,6 +6,8 @@ properties:
     type: object
     default: {}
     properties:
+      cniSecretData:
+        type: string
       storageClasses:
         type: array
         additionalProperties:

--- a/modules/030-cloud-provider-gcp/templates/cni.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cni.yaml
@@ -6,4 +6,8 @@ metadata:
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 data:
+{{- if hasKey .Values.cloudProviderGcp.internal "cniSecretData" }}
+  {{- .Values.cloudProviderGcp.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
   cni: {{ b64enc "simple-bridge" | quote }}
+{{- end }}

--- a/modules/030-cloud-provider-yandex/hooks/ensure_crds.go
+++ b/modules/030-cloud-provider-yandex/hooks/ensure_crds.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2025 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/030-cloud-provider-yandex/hooks/ensure_crds.go
+++ b/modules/030-cloud-provider-yandex/hooks/ensure_crds.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 Flant JSC
+Copyright 2021 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/030-cloud-provider-yandex/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-yandex/hooks/get_cni_secret.go
@@ -1,6 +1,17 @@
 /*
 Copyright 2025 Flant JSC
-Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package hooks

--- a/modules/030-cloud-provider-yandex/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-yandex/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderYandex")

--- a/modules/030-cloud-provider-yandex/openapi/values.yaml
+++ b/modules/030-cloud-provider-yandex/openapi/values.yaml
@@ -6,6 +6,8 @@ properties:
     type: object
     default: {}
     properties:
+      cniSecretData:
+        type: string
       storageClasses:
         type: array
         additionalProperties:

--- a/modules/030-cloud-provider-yandex/templates/cni.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cni.yaml
@@ -6,4 +6,8 @@ metadata:
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 data:
+{{- if hasKey .Values.cloudProviderYandex.internal "cniSecretData" }}
+  {{- .Values.cloudProviderYandex.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
   cni: {{ b64enc "simple-bridge" | quote }}
+{{- end }}


### PR DESCRIPTION
## Description

We have added a hook to the modules of all our cloud providers that helps to prevent overwriting the settings of selected CNI.

All the cloud-providers were refactored to use `go_lib/hooks/get_cni_secret/hook.go` by analogy with the `cloud-provider-openstack`.

## Why do we need it, and what problem does it solve?

Some customers want to use CNI `Cilium` in their cloud installations (in particular, in AWS and YC). However, in the current implementation, CNI automatically switches to `simple-brigade` after a certain period of time.

The general solution is coming soon.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-aws
type: chore
summary: Added the ability to switch to another CNI.
impact_level: default
---
section: cloud-provider-azure
type: chore
summary: Added the ability to switch to another CNI.
impact_level: default
---
section: cloud-provider-gcp
type: chore
summary: Added the ability to switch to another CNI.
impact_level: default
---
section: cloud-provider-yandex
type: chore
summary: Added the ability to switch to another CNI.
impact_level: default
---
section: cloud-provider-zvirt
type: chore
summary: Added the ability to switch to another CNI.
impact_level: default
```
