### PR TITLE
[istio] Bump Istio version to 1.24.3 and Kiali to 2.1

### DIFF
--- a/modules/110-istio/images/cni-v1x24x3/werf.inc.yaml
+++ b/modules/110-istio/images/cni-v1x24x3/werf.inc.yaml
@@ -1,0 +1,54 @@
+---
+{{- $istioVersion := "1.24.3" }}
+{{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.24.3 -> v1x24x3 */}}
+---
+# Based on https://github.com/istio/istio/blob/1.24.3/cni/deployments/kubernetes/Dockerfile.install-cni
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/distroless
+import:
+- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+  add: /src/istio/out/istio-cni
+  to: /opt/cni/bin/istio-cni
+  owner: 1337
+  group: 1337
+  after: setup
+- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+  add: /src/istio/out/install-cni
+  to: /usr/local/bin/install-cni
+  owner: 1337
+  group: 1337
+  after: setup
+imageSpec:
+  config:
+    env: {"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin"}
+    workingDir: "/opt/cni/bin"
+    user: "1337:1337"
+    entrypoint: ["/usr/local/bin/install-cni"]
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+final: false
+from: {{ .Images.BASE_GOLANG_23_ALPINE }}
+import:
+- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+  add: /src/istio
+  to: /src/istio
+  before: install
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+shell:
+  beforeInstall:
+  {{- include "alpine packages proxy" . | nindent 2 }}
+  - apk add --no-cache bash git binutils
+  install:
+  - cd /src/istio/
+  - echo {{ $istioVersion }} > version
+  - export GOPROXY={{ $.GOPROXY }} GOOS=linux GOARCH=amd64
+  - export LDFLAGS='-extldflags -static -s -w'
+  - go mod download
+  - common/scripts/gobuild.sh /src/istio/out/ -tags=agent,disable_pgv /src/istio/cni/cmd/install-cni/
+  - common/scripts/gobuild.sh /src/istio/out/ -tags=agent,disable_pgv /src/istio/cni/cmd/istio-cni/
+  - strip /src/istio/out/install-cni
+  - strip /src/istio/out/istio-cni
+  - chmod 0700 /src/istio/out/install-cni /src/istio/out/istio-cni
+  - chown 1337:1337 /src/istio/out/istio-cni

--- a/modules/110-istio/images/common-v1x24x3/patches/README.md
+++ b/modules/110-istio/images/common-v1x24x3/patches/README.md
@@ -1,0 +1,1 @@
+# Patches

--- a/modules/110-istio/images/common-v1x24x3/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x24x3/werf.inc.yaml
@@ -1,0 +1,26 @@
+---
+{{- $istioVersion := "1.24.3" }}
+{{- $kialiVersion := "v2.1.1" }}
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+fromImage: common/src-artifact
+final: false
+git:
+- add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+    - '**/*'
+shell:
+  install:
+  - git clone --depth 1 --branch {{ $istioVersion }} {{ $.SOURCE_REPO }}/istio/istio.git /src/istio/
+  # - cd /src/istio/
+  # - git apply --verbose /patches/istio-*.patch
+  - rm -rf /src/istio/.git
+  - git clone --depth 1 --branch {{ $kialiVersion }} {{ $.SOURCE_REPO }}/istio/kiali.git /src/kiali/
+  # - cd /src/kiali/
+  # - git apply --verbose /patches/kiali-*.patch
+  - rm -rf /src/kiali/.git
+
+  # getting rid of unused vulnerable code
+  - rm -rf /src/istio/samples

--- a/modules/110-istio/images/kiali-v1x24x3/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x24x3/werf.inc.yaml
@@ -1,0 +1,67 @@
+---
+{{- $istioVersion := "1.24.3" }}
+{{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.24.3 -> v1x24x3 */}}
+{{- $kialiVersion := "v2.1.1" }}
+---
+# Based on https://github.com/kiali/kiali/blob/v2.1.1/deploy/docker/Dockerfile-distroless
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/alt-p11
+import:
+- image: {{ .ModuleName }}/{{ .ImageName }}-backend-build-artifact
+  add: /src/kiali/out/kiali
+  to: /opt/kiali/kiali
+  before: install
+- image: {{ .ModuleName }}/{{ .ImageName }}-frontend-build-artifact
+  add: /src/kiali/frontend/build
+  to: /opt/kiali/console
+  before: install
+shell:
+  install:
+  - adduser --no-create-home --uid 1000 kiali
+  - chown -R kiali:kiali /opt/kiali/console
+  - chmod -R g=u /opt/kiali/console
+imageSpec:
+  config:
+    user: "1000"
+    workingDir: "/opt/kiali"
+    entrypoint: ["/opt/kiali/kiali"]
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-backend-build-artifact
+final: false
+from: {{ .Images.BASE_GOLANG_23_ALPINE }}
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+import:
+- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+  add: /src/kiali
+  to: /src/kiali
+  before: setup
+shell:
+  beforeInstall:
+  {{- include "alpine packages proxy" . | nindent 2 }}
+  - apk add --no-cache bash git binutils
+  setup:
+  - cd /src/kiali/
+  - echo {{ $kialiVersion }} > version
+  - export GOPROXY={{ $.GOPROXY }} GOOS=linux GOARCH=amd64
+  - export LDFLAGS='-X main.version=${kialiVersion}'
+  - go mod download
+  - go build -o /src/kiali/out/kiali /src/kiali/
+  - strip /src/kiali/out/kiali
+  - chmod 0755 /src/kiali/out/kiali
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-frontend-build-artifact
+final: false
+from: {{ .Images.BASE_NODE_20_ALPINE }}
+import:
+- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+  add: /src/kiali
+  to: /src/kiali
+  before: setup
+shell:
+  setup:
+  {{- include "node packages proxy" . | nindent 2 }}
+  - cd /src/kiali/frontend
+  - yarn install --frozen-lockfile
+  - yarn run build

--- a/modules/110-istio/images/pilot-v1x24x3/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x24x3/werf.inc.yaml
@@ -1,0 +1,56 @@
+---
+{{- $istioVersion := "1.24.3" }}
+{{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.24.3 -> v1x24x3 */}}
+---
+# Based on https://github.com/istio/istio/blob/1.24.3/pilot/docker/Dockerfile.pilot
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/distroless
+import:
+- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+  add: /src/istio/out/pilot-discovery
+  to: /usr/local/bin/pilot-discovery
+  owner: 1337
+  group: 1337
+  after: setup
+- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+  add: /src/istio/tools/packaging/common/envoy_bootstrap.json
+  to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+  owner: 1337
+  group: 1337
+  after: setup
+# - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+#   add: /src/istio/tools/packaging/common/gcp_envoy_bootstrap.json
+#   to: /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
+#   owner: 1337
+#   group: 1337
+#   after: setup
+imageSpec:
+  config:
+    user: "1337:1337"
+    entrypoint: ["/usr/local/bin/pilot-discovery"]
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+final: false
+from: {{ .Images.BASE_GOLANG_23_ALPINE }}
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+import:
+- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+  add: /src/istio
+  to: /src/istio
+  before: setup
+shell:
+  beforeInstall:
+  {{- include "alpine packages proxy" . | nindent 2 }}
+  - apk add --no-cache bash git binutils
+  setup:
+  - cd /src/istio/
+  - echo {{ $istioVersion }} > version
+  - export GOPROXY={{ $.GOPROXY }} GOOS=linux GOARCH=amd64
+  - export LDFLAGS='-extldflags -static -s -w'
+  - go mod download
+  - common/scripts/gobuild.sh /src/istio/out/ -tags=agent,disable_pgv /src/istio/pilot/cmd/pilot-discovery/
+  - strip /src/istio/out/pilot-discovery
+  - chmod 0700 /src/istio/out/pilot-discovery
+  - chown 1337:1337 /src/istio/out/pilot-discovery


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: feature
summary: Bump Istio version to 1.24.3 and Kiali to 2.1
impact_level: default
```
