### PR TITLE
[dhctl] fix: sudoPassword is not passed for dhctl-server

### DIFF
--- a/dhctl/pkg/server/pkg/helper/ssh_client.go
+++ b/dhctl/pkg/server/pkg/helper/ssh_client.go
@@ -79,6 +79,7 @@ func CreateSSHClient(config *config.ConnectionConfig) (*ssh.Client, func() error
 	app.SSHBastionPort = util.PortToString(config.SSHConfig.SSHBastionPort)
 	app.SSHBastionUser = config.SSHConfig.SSHBastionUser
 	app.SSHUser = config.SSHConfig.SSHUser
+	app.BecomePass = config.SSHConfig.SudoPassword
 	app.SSHHosts = sshHosts
 	app.SSHPort = util.PortToString(config.SSHConfig.SSHPort)
 	app.SSHExtraArgs = config.SSHConfig.SSHExtraArgs


### PR DESCRIPTION
## Description

Related https://github.com/deckhouse/deckhouse/pull/12099
Fixes dhctl-server use-case.

## Why do we need it, and what problem does it solve?

Allow sudoPassword field in the SSHConfig kind.

## Why do we need it in the patch release (if we do)?

Fixes dhctl-server use-case of sudoPassword field. Previous PR added only ability to pass param using dhctl-cli.