### PR TITLE
[metallb] Add hook for deleting a deprecated CRD

### DIFF
--- a/global-hooks/migrate/delete-metallb-deprecated-crd.go
+++ b/global-hooks/migrate/delete-metallb-deprecated-crd.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 10},
+}, removeValidatingWebhook)
+
+func removeValidatingWebhook(input *go_hook.HookInput) error {
+	input.PatchCollector.Delete(
+		"apiextensions.k8s.io/v1",
+		"CustomResourceDefinition",
+		"",
+		"addresspools.metallb.io",
+		object_patch.InForeground(),
+	)
+	return nil
+}

--- a/global-hooks/migrate/delete-metallb-deprecated-crd_test.go
+++ b/global-hooks/migrate/delete-metallb-deprecated-crd_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const deprecatedCRD = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: addresspools.metallb.io
+spec: {}
+`
+
+var _ = Describe("MetalLB hooks :: delete deprecated AddressPool CRD", func() {
+	f := HookExecutionConfigInit(`{}`, `{}`)
+	Context("Empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Must be executed successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+	Context("Deprecated CRD exists", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(deprecatedCRD))
+			f.RunHook()
+		})
+		It("Must be executed successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource(
+				"CustomResourceDefinition",
+				"addresspools.metallb.io",
+			).Exists()).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
## Description
Add a global hook that removes the deprecated CRD `addresspools.metallb.io` from the MetalLB module from the cluster.

Before:

```shell
# kubectl get addresspools -A
Warning: metallb.io v1beta1 AddressPool is deprecated, consider using IPAddressPool
No resources found
# kubectl get crd | grep addresspools.metallb.io
addresspools.metallb.io                                           2024-09-17T16:46:54Z
ipaddresspools.metallb.io                                         2024-05-16T10:31:23Z
```

After:

```shell
# kubectl get addresspools -A
Error from server (NotFound): Unable to list "metallb.io/v1beta1, Resource=addresspools": the server could not find the requested resource (get addresspools.metallb.io)
# kubectl get crd | grep addresspools.metallb.io
ipaddresspools.metallb.io                                         2024-05-16T10:31:23Z
```

## Why do we need it, and what problem does it solve?
In the cluster logs `/var/log/kube-audit/audit.log` there are messages that the CRD `addresspools.metallb.io` are deprecated.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: chore
summary: Added hook for deleting a deprecated CRD.
impact_level: default
```

