### PR TITLE
[docs] Use detailed tooltips for a module stage in the sidebar

### DIFF
--- a/docs/documentation/_plugins/custom_sidebar.rb
+++ b/docs/documentation/_plugins/custom_sidebar.rb
@@ -85,7 +85,7 @@ module Jekyll
          if entry.has_key?('featureStatus')
            result.push(%Q(
                <span class='sidebar__badge_v2'
-                     title="#{ @context.registers[:site].data['i18n']['features'][entry['featureStatus']][lang].gsub(/<\/?[^>]*>/, "").lstrip.sub(/\.$/, '')}">
+                     title="#{ @context.registers[:site].data['i18n']['features']["%s_long" % entry['featureStatus']][lang].gsub(/<\/?[^>]*>/, "").lstrip.sub(/\.$/, '')}">
                    #{case entry['featureStatus']
                        when "experimental"
                            "Exp"

--- a/docs/site/backends/docs-builder-template/layouts/partials/sidebar.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/sidebar.html
@@ -77,8 +77,8 @@
                     {{- end }}
                     {{- if and $sidebarItem.moduleStatus (index $.Site.Data.helpers.moduleStageBageMap ( replace (lower $sidebarItem.moduleStatus) " " "_")) -}}
                       <span class='sidebar__badge_v2'
-                          {{- if (T (printf "module_alert_%s" (lower $sidebarItem.moduleStatus ))) }}
-                            title='{{ (T (printf "module_alert_%s" (lower $sidebarItem.moduleStatus ))) }}'
+                          {{- if (T (printf "module_alert_%s_long" (lower $sidebarItem.moduleStatus ))) }}
+                            title='{{ (T (printf "module_alert_%s_long" (lower $sidebarItem.moduleStatus ))) }}'
                           {{ end -}}
                           >{{ index $.Site.Data.helpers.moduleStageBageMap ( lower $sidebarItem.moduleStatus ) -}}
                       </span>


### PR DESCRIPTION
## Description

Use detailed tooltips for a module stage in the sidebar.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Use detailed tooltips for a module stage in the sidebar.
impact_level: low
```
