### PR TITLE
[operator-trivy] refactor node-collector image building

### DIFF
--- a/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
@@ -10,6 +10,12 @@ import:
     add: /usr/bin/ps
     to: /usr/bin/ps
     before: setup
+  - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+    add: /usr/lib64
+    to: /usr/lib64
+    before: setup
+    includePaths:
+    - 'libproc2.so.0*'
 imageSpec:
   config:
     entrypoint: [ "/usr/local/bin/node-collector" ]

--- a/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
@@ -7,9 +7,12 @@ import:
     to: /usr/local/bin/node-collector
     before: setup
   - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
-    add: /usr/bin/ps
-    to: /usr/bin/ps
+    add: /usr/bin
+    to: /usr/bin
     before: setup
+    includePaths:
+    - 'ps'
+    - 'pgrep'
   - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
     add: /usr/lib64
     to: /usr/lib64

--- a/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
@@ -1,19 +1,26 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/alt-p11-artifact
+fromImage: common/alt-p11
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /node-collector
     to: /usr/local/bin/node-collector
     before: setup
+  - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+    add: /usr/bin/ps
+    to: /usr/bin/ps
+    before: setup
 imageSpec:
   config:
     entrypoint: [ "/usr/local/bin/node-collector" ]
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+fromImage: common/alt-p11-artifact
+final: false
 shell:
   setup:
   - apt-get update
   - apt-get install procps -y
-  - rm /var/lib/apt/lists/ftp* -f
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 fromImage: common/src-artifact


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Updates the node-collector image building so that it's built from alt_p11 image (not artifact).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need it to have the node-collector image's default user set.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: chore
summary: Refactor node-collector image building.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
