### PR TITLE
[monitoring] Fix promql query for the queue variable in the dashboard for rabbitmq

### DIFF
--- a/ee/fe/modules/340-monitoring-applications/applications/rabbitmq/grafana-dashboards/rabbitmq.json
+++ b/ee/fe/modules/340-monitoring-applications/applications/rabbitmq/grafana-dashboards/rabbitmq.json
@@ -4474,15 +4474,15 @@
           "type": "prometheus",
           "uid": "$ds_prometheus"
         },
-        "definition": "label_values(rabbitmq_queue_messages_published_total{namespace=~\"$namespace\",pod=~\"$pod\",queue_vhost=~\"$vhost\"}, queue)",
+        "definition": "label_values(rabbitmq_queue_messages_published_total{namespace=~\"$namespace\",pod=~\"$pod\",queue_vhost=~\"$vhost\"}, queue=~\".*\")",
         "hide": 0,
         "includeAll": true,
         "label": "Queue",
-        "multi": false,
+        "multi": true,
         "name": "queue",
         "options": [],
         "query": {
-          "query": "label_values(rabbitmq_queue_messages_published_total{namespace=~\"$namespace\",pod=~\"$pod\",queue_vhost=~\"$vhost\"}, queue)",
+          "query": "label_values(rabbitmq_queue_messages_published_total{namespace=~\"$namespace\",pod=~\"$pod\",queue_vhost=~\"$vhost\"}, queue=~\".*\")",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
## Description
Added regular expression for queue label in grafana dashboard for rabbitmq.

## Why do we need it, and what problem does it solve?
If you do not specify a regular expression in a promql query for the queue label, then grafana substitutes all queue names into this label. When there are too many queues, the query becomes invalid.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```
section: prometheus
type: fix
summary: Fix promql query for the queue variable in the dashboard for rabbitmq
impact_level: default
```