### PR TITLE
[dhctl] converge should drain node before removal

### DIFF
--- a/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group.go
@@ -25,13 +25,20 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/context"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infra/hook/controlplane"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
 
 type CloudPermanentNodeGroupController struct {
 	*NodeGroupController
+}
+
+func NewCloudPermanentNodeGroupController(controller *NodeGroupController) *CloudPermanentNodeGroupController {
+	cloudPermanentNodeGroupController := &CloudPermanentNodeGroupController{NodeGroupController: controller}
+	cloudPermanentNodeGroupController.layoutStep = "static-node"
+	cloudPermanentNodeGroupController.nodeGroup = cloudPermanentNodeGroupController
+
+	return cloudPermanentNodeGroupController
 }
 
 func (c *CloudPermanentNodeGroupController) Run(ctx *context.Context) error {
@@ -142,7 +149,7 @@ func (c *CloudPermanentNodeGroupController) deleteNodes(ctx *context.Context, no
 	title := fmt.Sprintf("Delete Nodes from NodeGroup %s (replicas: %v)", c.name, c.desiredReplicas)
 	return log.Process("converge", title, func() error {
 		return c.deleteRedundantNodes(ctx, c.state.Settings, nodesToDeleteInfo, func(nodeName string) terraform.InfraActionHook {
-			return controlplane.NewHookForDestroyPipeline(ctx, nodeName, ctx.CommanderMode())
+			return NewHookForDestroyPipeline(ctx, nodeName, ctx.CommanderMode())
 		})
 	})
 }

--- a/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group.go
@@ -33,14 +33,6 @@ type CloudPermanentNodeGroupController struct {
 	*NodeGroupController
 }
 
-func NewCloudPermanentNodeGroupController(controller *NodeGroupController) *CloudPermanentNodeGroupController {
-	cloudPermanentNodeGroupController := &CloudPermanentNodeGroupController{NodeGroupController: controller}
-	cloudPermanentNodeGroupController.layoutStep = "static-node"
-	cloudPermanentNodeGroupController.nodeGroup = cloudPermanentNodeGroupController
-
-	return cloudPermanentNodeGroupController
-}
-
 func (c *CloudPermanentNodeGroupController) Run(ctx *context.Context) error {
 	metaConfig, err := ctx.MetaConfig()
 	if err != nil {
@@ -149,7 +141,7 @@ func (c *CloudPermanentNodeGroupController) deleteNodes(ctx *context.Context, no
 	title := fmt.Sprintf("Delete Nodes from NodeGroup %s (replicas: %v)", c.name, c.desiredReplicas)
 	return log.Process("converge", title, func() error {
 		return c.deleteRedundantNodes(ctx, c.state.Settings, nodesToDeleteInfo, func(nodeName string) terraform.InfraActionHook {
-			return &terraform.DummyHook{}
+			return NewHookForDestroyPipeline(ctx, nodeName)
 		})
 	})
 }

--- a/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group.go
@@ -25,6 +25,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/context"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infra/hook/controlplane"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
@@ -141,7 +142,7 @@ func (c *CloudPermanentNodeGroupController) deleteNodes(ctx *context.Context, no
 	title := fmt.Sprintf("Delete Nodes from NodeGroup %s (replicas: %v)", c.name, c.desiredReplicas)
 	return log.Process("converge", title, func() error {
 		return c.deleteRedundantNodes(ctx, c.state.Settings, nodesToDeleteInfo, func(nodeName string) terraform.InfraActionHook {
-			return NewHookForDestroyPipeline(ctx, nodeName)
+			return controlplane.NewHookForDestroyPipeline(ctx, nodeName, ctx.CommanderMode())
 		})
 	})
 }

--- a/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group_hook.go
+++ b/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group_hook.go
@@ -29,14 +29,17 @@ type CloudPermanentNodeGroupHook struct {
 }
 
 type HookForDestroyPipeline struct {
-	getter        kubernetes.KubeClientProvider
-	nodeToDestroy string
+	getter            kubernetes.KubeClientProvider
+	nodeToDestroy     string
+	oldMasterIPForSSH string
+	commanderMode     bool
 }
 
-func NewHookForDestroyPipeline(getter kubernetes.KubeClientProvider, nodeToDestroy string) *HookForDestroyPipeline {
+func NewHookForDestroyPipeline(getter kubernetes.KubeClientProvider, nodeToDestroy string, commanderMode bool) *HookForDestroyPipeline {
 	return &HookForDestroyPipeline{
 		getter:        getter,
 		nodeToDestroy: nodeToDestroy,
+		commanderMode: commanderMode,
 	}
 }
 
@@ -52,14 +55,6 @@ func (h *HookForDestroyPipeline) IsReady() error {
 	return nil
 }
 
-func (h *HookForDestroyPipeline) AfterAction(terraform.RunnerInterface) error {
+func (h *HookForDestroyPipeline) AfterAction(ctx context.Context, runner terraform.RunnerInterface) error {
 	return nil
-}
-
-func NewCloudPermanentNodeGroupController(controller *NodeGroupController) *CloudPermanentNodeGroupController {
-	cloudPermanentNodeGroupController := &CloudPermanentNodeGroupController{NodeGroupController: controller}
-	cloudPermanentNodeGroupController.layoutStep = "static-node"
-	cloudPermanentNodeGroupController.nodeGroup = cloudPermanentNodeGroupController
-
-	return cloudPermanentNodeGroupController
 }

--- a/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group_hook.go
+++ b/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group_hook.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
+
+	infra_utils "github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infra/utils"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
+)
+
+type CloudPermanentNodeGroupHook struct {
+	getter        kubernetes.KubeClientProvider
+	nodeToDestroy string
+}
+
+type HookForDestroyPipeline struct {
+	getter        kubernetes.KubeClientProvider
+	nodeToDestroy string
+}
+
+func NewHookForDestroyPipeline(getter kubernetes.KubeClientProvider, nodeToDestroy string) *HookForDestroyPipeline {
+	return &HookForDestroyPipeline{
+		getter:        getter,
+		nodeToDestroy: nodeToDestroy,
+	}
+}
+
+func (h *HookForDestroyPipeline) BeforeAction(runner terraform.RunnerInterface) (runPostAction bool, err error) {
+	err = infra_utils.TryToDrainNode(h.getter.KubeClient(), h.nodeToDestroy)
+	if err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func (h *HookForDestroyPipeline) IsReady() error {
+	return nil
+}
+
+func (h *HookForDestroyPipeline) AfterAction(terraform.RunnerInterface) error {
+	return nil
+}
+
+func NewCloudPermanentNodeGroupController(controller *NodeGroupController) *CloudPermanentNodeGroupController {
+	cloudPermanentNodeGroupController := &CloudPermanentNodeGroupController{NodeGroupController: controller}
+	cloudPermanentNodeGroupController.layoutStep = "static-node"
+	cloudPermanentNodeGroupController.nodeGroup = cloudPermanentNodeGroupController
+
+	return cloudPermanentNodeGroupController
+}

--- a/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group_hook.go
+++ b/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group_hook.go
@@ -15,6 +15,8 @@
 package controller
 
 import (
+	"context"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 
 	infra_utils "github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infra/utils"
@@ -38,8 +40,8 @@ func NewHookForDestroyPipeline(getter kubernetes.KubeClientProvider, nodeToDestr
 	}
 }
 
-func (h *HookForDestroyPipeline) BeforeAction(runner terraform.RunnerInterface) (runPostAction bool, err error) {
-	err = infra_utils.TryToDrainNode(h.getter.KubeClient(), h.nodeToDestroy)
+func (h *HookForDestroyPipeline) BeforeAction(ctx context.Context, runner terraform.RunnerInterface) (runPostAction bool, err error) {
+	err = infra_utils.TryToDrainNode(ctx, h.getter.KubeClient(), h.nodeToDestroy)
 	if err != nil {
 		return false, err
 	}

--- a/dhctl/pkg/operations/converge/controller/node_group_controller.go
+++ b/dhctl/pkg/operations/converge/controller/node_group_controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"slices"
 
-	infra_utils "github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infra/utils"
 	gcmp "github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -174,8 +173,6 @@ func (c *NodeGroupController) deleteRedundantNodes(
 		if !ctx.CommanderMode() {
 			nodeState = nodeToDeleteInfo.state
 		}
-
-		infra_utils.TryToDrainNode(ctx.KubeClient(), nodeToDeleteInfo.name)
 
 		nodeRunner := ctx.Terraform().GetConvergeNodeDeleteRunner(cfg, terraform.NodeDeleteRunnerOptions{
 			AutoDismissDestructive: ctx.ChangesSettings().AutoDismissDestructive,

--- a/dhctl/pkg/operations/converge/controller/node_group_controller.go
+++ b/dhctl/pkg/operations/converge/controller/node_group_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"slices"
 
+	infra_utils "github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infra/utils"
 	gcmp "github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -173,6 +174,8 @@ func (c *NodeGroupController) deleteRedundantNodes(
 		if !ctx.CommanderMode() {
 			nodeState = nodeToDeleteInfo.state
 		}
+
+		infra_utils.TryToDrainNode(ctx.KubeClient(), nodeToDeleteInfo.name)
 
 		nodeRunner := ctx.Terraform().GetConvergeNodeDeleteRunner(cfg, terraform.NodeDeleteRunnerOptions{
 			AutoDismissDestructive: ctx.ChangesSettings().AutoDismissDestructive,
@@ -334,7 +337,6 @@ func (c *NodeGroupController) updateNodes(ctx *context.Context) error {
 
 			return nil
 		})
-
 		if err != nil {
 			// We do not return an error immediately for the following reasons:
 			// - some nodes cannot be converged for some reason, but other nodes must be converged

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
@@ -100,7 +100,7 @@ func removeControlPlaneRoleFromNode(ctx context.Context, kubeCl *client.Kubernet
 		return fmt.Errorf("failed to check etcd has no member '%s': %v", nodeName, err)
 	}
 
-	err = infra_utils.TryToDrainNode(kubeCl, nodeName)
+	err = infra_utils.TryToDrainNode(ctx, kubeCl, nodeName)
 	if err != nil {
 		return fmt.Errorf("failed to drain node '%s': %v", nodeName, err)
 	}

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
@@ -29,6 +29,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	infra_utils "github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infra/utils"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh/session"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
@@ -99,7 +100,7 @@ func removeControlPlaneRoleFromNode(ctx context.Context, kubeCl *client.Kubernet
 		return fmt.Errorf("failed to check etcd has no member '%s': %v", nodeName, err)
 	}
 
-	err = tryToDrainNode(ctx, kubeCl, nodeName)
+	err = infra_utils.TryToDrainNode(kubeCl, nodeName)
 	if err != nil {
 		return fmt.Errorf("failed to drain node '%s': %v", nodeName, err)
 	}

--- a/dhctl/pkg/operations/converge/infra/utils/drain.go
+++ b/dhctl/pkg/operations/converge/infra/utils/drain.go
@@ -31,10 +31,11 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
-func TryToDrainNode(kubeCl *client.KubernetesClient, nodeName string) error {
-	return retry.NewLoop(fmt.Sprintf("Drain node '%s'", nodeName), 45, 10*time.Second).Run(func() error {
-		return drainNode(kubeCl, nodeName)
-	})
+func TryToDrainNode(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string) error {
+	return retry.NewLoop(fmt.Sprintf("Drain node '%s'", nodeName), 45, 10*time.Second).
+		RunContext(ctx, func() error {
+			return drainNode(ctx, kubeCl, nodeName)
+		})
 }
 
 func drainNode(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string) error {

--- a/dhctl/pkg/operations/converge/infra/utils/drain.go
+++ b/dhctl/pkg/operations/converge/infra/utils/drain.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controlplane
+package utils
 
 import (
 	"context"
@@ -31,11 +31,10 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
-func tryToDrainNode(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string) error {
-	return retry.NewLoop(fmt.Sprintf("Drain node '%s'", nodeName), 45, 10*time.Second).
-		RunContext(ctx, func() error {
-			return drainNode(ctx, kubeCl, nodeName)
-		})
+func TryToDrainNode(kubeCl *client.KubernetesClient, nodeName string) error {
+	return retry.NewLoop(fmt.Sprintf("Drain node '%s'", nodeName), 45, 10*time.Second).Run(func() error {
+		return drainNode(kubeCl, nodeName)
+	})
 }
 
 func drainNode(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string) error {

--- a/dhctl/pkg/operations/converge/infra/utils/drain.go
+++ b/dhctl/pkg/operations/converge/infra/utils/drain.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TryToDrainNode(kubeCl *client.KubernetesClient, nodeName string) error {
-	return retry.NewLoop(fmt.Sprintf("Drain node '%s'", nodeName), 45, 10*time.Second).Run(func() error {
+	return retry.NewLoop(fmt.Sprintf("Drain node '%s'", nodeName), 3, 10*time.Second).Run(func() error {
 		return drainNode(kubeCl, nodeName)
 	})
 }

--- a/dhctl/pkg/operations/converge/infra/utils/drain.go
+++ b/dhctl/pkg/operations/converge/infra/utils/drain.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TryToDrainNode(kubeCl *client.KubernetesClient, nodeName string) error {
-	return retry.NewLoop(fmt.Sprintf("Drain node '%s'", nodeName), 3, 10*time.Second).Run(func() error {
+	return retry.NewLoop(fmt.Sprintf("Drain node '%s'", nodeName), 45, 10*time.Second).Run(func() error {
 		return drainNode(kubeCl, nodeName)
 	})
 }


### PR DESCRIPTION
## Description

Added before hook for Cloud Permanent Node removal pipeline. Hook executes Node drain before deletion (just like we do for control plane nodes)

## Why do we need it, and what problem does it solve?

Deleting a node without drain can cause CSI problems or service interruptions

## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Cloud Permanent Node converge should drain node before removal
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
