### PR TITLE
[cloud-provider-aws] Fix values setting(`cloudProviderAws.internal`) in a golang hooks

### DIFF
--- a/modules/030-cloud-provider-aws/hooks/aws_cluster_configuration.go
+++ b/modules/030-cloud-provider-aws/hooks/aws_cluster_configuration.go
@@ -133,19 +133,15 @@ func clusterConfiguration(input *go_hook.HookInput) error {
 		}
 	}
 
-	values := InternalValues{
-		KeyName:                   discoveryData.KeyName,
-		LoadBalancerSecurityGroup: discoveryData.LoadBalancerSecurityGroup,
-		Zones:                     discoveryData.Zones,
-		ZoneToSubnetIDMap:         discoveryData.ZoneToSubnetIDMap,
-		Instances:                 discoveryData.Instances,
-		Region:                    provider.Region,
-		ProviderAccessKeyID:       provider.ProviderAccessKeyID,
-		ProviderSecretAccessKey:   provider.ProviderSecretAccessKey,
-		Tags:                      tags,
-	}
-
-	input.Values.Set("cloudProviderAws.internal", values)
+	input.Values.Set("cloudProviderAws.internal.keyName", discoveryData.KeyName)
+	input.Values.Set("cloudProviderAws.internal.loadBalancerSecurityGroup", discoveryData.LoadBalancerSecurityGroup)
+	input.Values.Set("cloudProviderAws.internal.zones", discoveryData.Zones)
+	input.Values.Set("cloudProviderAws.internal.zoneToSubnetIdMap", discoveryData.ZoneToSubnetIDMap)
+	input.Values.Set("cloudProviderAws.internal.instances", discoveryData.Instances)
+	input.Values.Set("cloudProviderAws.internal.region", provider.Region)
+	input.Values.Set("cloudProviderAws.internal.providerAccessKeyId", provider.ProviderAccessKeyID)
+	input.Values.Set("cloudProviderAws.internal.providerSecretAccessKey", provider.ProviderSecretAccessKey)
+	input.Values.Set("cloudProviderAws.internal.tags", tags)
 
 	return nil
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Set `cloudProviderAws.internal` values individually in the `provider_cluster_configuration` hook.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We can't set `cloudProviderAws.internal` values in other hooks.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: fix
summary: Set `cloudProviderAws.internal` values individually in the `provider_cluster_configuration` hook.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
