### PR TITLE
[docs][website] update memory requests for documentation pods

### DIFF
--- a/docs/documentation/.helm/values.yaml
+++ b/docs/documentation/.helm/values.yaml
@@ -11,5 +11,5 @@ resources:
   requests:
     memory:
       _default: 30M
-      web-production: 50M
+      web-production: 150M
 

--- a/docs/site/.helm/values.yaml
+++ b/docs/site/.helm/values.yaml
@@ -36,7 +36,7 @@ resources:
   requests:
     memory:
       _default: 32M
-      web-production: 64M
+      web-production: 150M
 
 vrouter:
   defaultGroup: "v1"


### PR DESCRIPTION
## Description
Increase memory requests for documentation pods to 150M.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Increase memory requests for documentation pods to 150M.
impact_level: low
```
