### PR TITLE
[dhctl] fix: sudoPassword is not passed for dhctl-server and cannot be used non-interactively (1.68)

### DIFF
--- a/dhctl/pkg/preflight/sudoers.go
+++ b/dhctl/pkg/preflight/sudoers.go
@@ -34,7 +34,7 @@ func (pc *Checker) CheckSudoIsAllowedForUser() error {
 		return callSudo(pc.nodeInterface, app.BecomePass)
 	}
 
-	return callSudo(pc.nodeInterface, "")
+	return callSudo(pc.nodeInterface, app.BecomePass)
 
 }
 

--- a/dhctl/pkg/server/pkg/helper/ssh_client.go
+++ b/dhctl/pkg/server/pkg/helper/ssh_client.go
@@ -79,6 +79,7 @@ func CreateSSHClient(config *config.ConnectionConfig) (*ssh.Client, func() error
 	app.SSHBastionPort = util.PortToString(config.SSHConfig.SSHBastionPort)
 	app.SSHBastionUser = config.SSHConfig.SSHBastionUser
 	app.SSHUser = config.SSHConfig.SSHUser
+	app.BecomePass = config.SSHConfig.SudoPassword
 	app.SSHHosts = sshHosts
 	app.SSHPort = util.PortToString(config.SSHConfig.SSHPort)
 	app.SSHExtraArgs = config.SSHConfig.SSHExtraArgs


### PR DESCRIPTION
## Description

Related old PR: https://github.com/deckhouse/deckhouse/pull/12099
Related PR to master: https://github.com/deckhouse/deckhouse/pull/12368

Fixes dhctl-server use-case and dhctl-cli and connection-config use-case when passing sudoPassword in a non-interactive way.

## Why do we need it, and what problem does it solve?

Allow sudoPassword field in the SSHConfig kind.

## Why do we need it in the patch release (if we do)?

Fixes dhctl-server use-case of sudoPassword field.
Fixes dhctl-cli use-case of sudoPassword usage (previously sudoPassword field in the connection-config has no effect and not used actually, this PR fixes non-interactive way of passing password).

## Changelog entries

```changes
section: dhctl
type: fix
summary: sudoPassword from the connection-config not used in dhctl CLI and dhctl server
impact_level: default
```