### PR TITLE
[deckhouse-controller] remove release cooldown

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
@@ -45,9 +45,6 @@ const (
 
 	DeckhouseReleaseAnnotationDryrun            = "dryrun"
 	DeckhouseReleaseAnnotationTriggeredByDryrun = "triggered_by_dryrun"
-
-	// TODO: remove in entire code
-	DeckhouseReleaseAnnotationCooldown = "release.deckhouse.io/cooldown"
 )
 
 var DeckhouseReleaseGVK = schema.GroupVersionKind{
@@ -93,19 +90,6 @@ func (in *DeckhouseRelease) GetRequirements() map[string]string {
 
 func (in *DeckhouseRelease) GetChangelogLink() string {
 	return in.Spec.ChangelogLink
-}
-
-// TODO: remove cooldown from entire code
-func (in *DeckhouseRelease) GetCooldownUntil() *time.Time {
-	cooldown := new(time.Time)
-	if v, ok := in.Annotations[DeckhouseReleaseAnnotationCooldown]; ok {
-		cd, err := time.Parse(time.RFC3339, v)
-		if err == nil {
-			cooldown = &cd
-		}
-	}
-
-	return cooldown
 }
 
 func (in *DeckhouseRelease) GetDisruptions() []string {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/release.go
@@ -30,7 +30,6 @@ type Release interface {
 	GetVersion() *semver.Version
 	GetRequirements() map[string]string
 	GetChangelogLink() string
-	GetCooldownUntil() *time.Time
 	GetDisruptions() []string
 	GetDisruptionApproved() bool
 	GetPhase() string

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
@@ -26,7 +26,6 @@ kind: DeckhouseRelease
 metadata:
   annotations:
     release.deckhouse.io/change-cause: check release (from deployed)
-    release.deckhouse.io/cooldown: "2026-06-06T16:16:16Z"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
@@ -26,7 +26,6 @@ kind: DeckhouseRelease
 metadata:
   annotations:
     release.deckhouse.io/change-cause: check release (from deployed)
-    release.deckhouse.io/cooldown: "2030-05-05T15:15:15Z"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
@@ -26,7 +26,6 @@ kind: DeckhouseRelease
 metadata:
   annotations:
     release.deckhouse.io/change-cause: check release (from deployed)
-    release.deckhouse.io/cooldown: "2026-06-06T16:16:16Z"
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null

--- a/deckhouse-controller/pkg/releaseupdater/deploy_time_checker.go
+++ b/deckhouse-controller/pkg/releaseupdater/deploy_time_checker.go
@@ -159,19 +159,6 @@ func (c *DeployTimeService) processWindow(dtr *DeployTimeResult) {
 	dtr.Reason = dtr.Reason.add(outOfWindowReason)
 }
 
-func (c *DeployTimeService) checkCooldown(dtr *DeployTimeResult, release v1alpha1.Release) {
-	// check: release cooldown
-	if release.GetCooldownUntil() != nil {
-		cooldownUntil := *release.GetCooldownUntil()
-		if c.now.Before(cooldownUntil) {
-			c.logger.Warn("release in cooldown", slog.String("name", release.GetName()))
-
-			dtr.ReleaseApplyTime = *release.GetCooldownUntil()
-			dtr.Reason = dtr.Reason.add(cooldownDelayReason)
-		}
-	}
-}
-
 // CalculatePatchDeployTime calculates deploy time, returns deploy time or postpone time and reason.
 // To calculate deploy time, we need to check:
 //
@@ -230,8 +217,6 @@ func (c *DeployTimeService) CalculateMinorDeployTime(release v1alpha1.Release, m
 	if release.GetApplyNow() {
 		return result
 	}
-
-	c.checkCooldown(result, release)
 
 	if !c.settings.InManualMode() {
 		c.checkCanary(result, release)

--- a/modules/002-deckhouse/docs/internal/RELEASE.md
+++ b/modules/002-deckhouse/docs/internal/RELEASE.md
@@ -7,7 +7,6 @@
 | `release.deckhouse.io/force`               | Apply specified release without any checks. Force deploy.                                    |
 | `release.deckhouse.io/disruption-approved` | Approve release with disruptive changes. Works if `update.disruptionApprovalMode` is Manual. |
 | `release.deckhouse.io/approved`            | Approve release for deployment. Works if `update.mode` is Manual.                            |
-| `release.deckhouse.io/cooldown`            | Timestamp for release cooldown. Works on minor versions. Internal system info.               |
 
 ## Difference between disruption check and requirement check
 


### PR DESCRIPTION
## Description
Remove deckhouserelease cooldown annotation

## Why do we need it, and what problem does it solve?

We don't use it. But we have to respect this option in the code, which make it more complex.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: deckhouserelease cooldown removed
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
