### PR TITLE
[cloud-provider-azure] Disable caching of API calls in `CCM`

### DIFF
--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.28/002-fix-disable-api-call-cache.patch
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.28/002-fix-disable-api-call-cache.patch
@@ -1,0 +1,76 @@
+Subject: [PATCH] Fix some issues with the disable API call cache feature
+---
+Index: pkg/provider/azure_vmss.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure_vmss.go b/pkg/provider/azure_vmss.go
+--- a/pkg/provider/azure_vmss.go	(revision c887a2328e97a92da61ec57f25601edb6122616a)
++++ b/pkg/provider/azure_vmss.go	(date 1742471359310)
+@@ -428,6 +428,25 @@
+ 	vmManagementType, err := ss.getVMManagementTypeByProviderID(providerID, azcache.CacheReadTypeUnsafe)
+ 	if err != nil {
+ 		klog.Errorf("Failed to check VM management type: %v", err)
++
++		if vmManagementType == ManagedByUnknownVMSet {
++			klog.V(2).Infof("Failed to get VM management type for provider ID %q, trying to get node name from availability set or vmss flex", providerID)
++
++			nodeName, err := ss.availabilitySet.GetNodeNameByProviderID(providerID)
++			if err != nil {
++				klog.Warningf("Failed to get node name for provider ID %q: %v", providerID, err)
++			} else {
++				return nodeName, nil
++			}
++
++			nodeName, err = ss.flexScaleSet.GetNodeNameByProviderID(providerID)
++			if err != nil {
++				klog.Warningf("Failed to get node name for provider ID %q: %v", providerID, err)
++			} else {
++				return nodeName, nil
++			}
++		}
++
+ 		return "", err
+ 	}
+ 
+Index: pkg/provider/azure_instance_metadata.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure_instance_metadata.go b/pkg/provider/azure_instance_metadata.go
+--- a/pkg/provider/azure_instance_metadata.go	(revision c887a2328e97a92da61ec57f25601edb6122616a)
++++ b/pkg/provider/azure_instance_metadata.go	(date 1742471359317)
+@@ -106,12 +106,12 @@
+ }
+ 
+ // NewInstanceMetadataService creates an instance of the InstanceMetadataService accessor object.
+-func NewInstanceMetadataService(imdsServer string) (*InstanceMetadataService, error) {
++func NewInstanceMetadataService(imdsServer string, disableAPICallCache bool) (*InstanceMetadataService, error) {
+ 	ims := &InstanceMetadataService{
+ 		imdsServer: imdsServer,
+ 	}
+ 
+-	imsCache, err := azcache.NewTimedCache(consts.MetadataCacheTTL, ims.getMetadata, false)
++	imsCache, err := azcache.NewTimedCache(consts.MetadataCacheTTL, ims.getMetadata, disableAPICallCache)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+Index: pkg/provider/azure.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure.go b/pkg/provider/azure.go
+--- a/pkg/provider/azure.go	(revision c887a2328e97a92da61ec57f25601edb6122616a)
++++ b/pkg/provider/azure.go	(date 1742471359327)
+@@ -698,7 +698,7 @@
+ 	az.Config = *config
+ 	az.Environment = *env
+ 	az.ResourceRequestBackoff = resourceRequestBackoff
+-	az.Metadata, err = NewInstanceMetadataService(consts.ImdsServer)
++	az.Metadata, err = NewInstanceMetadataService(consts.ImdsServer, config.DisableAPICallCache)
+ 	if err != nil {
+ 		return err
+ 	}

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.28/README.md
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.28/README.md
@@ -5,3 +5,7 @@ This patch add NodeController options to main context object CloudControllerMana
 ### 001-go-mod.patch
 
 Fixes CVEs (bumps go mod)
+
+### 002-fix-disable-api-call-cache.patch
+
+Fix some issues with the disable API call cache feature.

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.29/002-fix-disable-api-call-cache.patch
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.29/002-fix-disable-api-call-cache.patch
@@ -1,0 +1,76 @@
+Subject: [PATCH] Fix some issues with the disable API call cache feature
+---
+Index: pkg/provider/azure_vmss.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure_vmss.go b/pkg/provider/azure_vmss.go
+--- a/pkg/provider/azure_vmss.go	(revision cedcbf22e1e16274960c7c933a3a6407ec1d0d13)
++++ b/pkg/provider/azure_vmss.go	(date 1742471634907)
+@@ -430,6 +430,25 @@
+ 	vmManagementType, err := ss.getVMManagementTypeByProviderID(providerID, azcache.CacheReadTypeUnsafe)
+ 	if err != nil {
+ 		klog.Errorf("Failed to check VM management type: %v", err)
++
++		if vmManagementType == ManagedByUnknownVMSet {
++			klog.V(2).Infof("Failed to get VM management type for provider ID %q, trying to get node name from availability set or vmss flex", providerID)
++
++			nodeName, err := ss.availabilitySet.GetNodeNameByProviderID(providerID)
++			if err != nil {
++				klog.Warningf("Failed to get node name for provider ID %q: %v", providerID, err)
++			} else {
++				return nodeName, nil
++			}
++
++			nodeName, err = ss.flexScaleSet.GetNodeNameByProviderID(providerID)
++			if err != nil {
++				klog.Warningf("Failed to get node name for provider ID %q: %v", providerID, err)
++			} else {
++				return nodeName, nil
++			}
++		}
++
+ 		return "", err
+ 	}
+ 
+Index: pkg/provider/azure_instance_metadata.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure_instance_metadata.go b/pkg/provider/azure_instance_metadata.go
+--- a/pkg/provider/azure_instance_metadata.go	(revision cedcbf22e1e16274960c7c933a3a6407ec1d0d13)
++++ b/pkg/provider/azure_instance_metadata.go	(date 1742471634912)
+@@ -107,12 +107,12 @@
+ }
+ 
+ // NewInstanceMetadataService creates an instance of the InstanceMetadataService accessor object.
+-func NewInstanceMetadataService(imdsServer string) (*InstanceMetadataService, error) {
++func NewInstanceMetadataService(imdsServer string, disableAPICallCache bool) (*InstanceMetadataService, error) {
+ 	ims := &InstanceMetadataService{
+ 		imdsServer: imdsServer,
+ 	}
+ 
+-	imsCache, err := azcache.NewTimedCache(consts.MetadataCacheTTL, ims.getMetadata, false)
++	imsCache, err := azcache.NewTimedCache(consts.MetadataCacheTTL, ims.getMetadata, disableAPICallCache)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+Index: pkg/provider/azure.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure.go b/pkg/provider/azure.go
+--- a/pkg/provider/azure.go	(revision cedcbf22e1e16274960c7c933a3a6407ec1d0d13)
++++ b/pkg/provider/azure.go	(date 1742471634919)
+@@ -629,7 +629,7 @@
+ 	az.Config = *config
+ 	az.Environment = *env
+ 	az.ResourceRequestBackoff = resourceRequestBackoff
+-	az.Metadata, err = NewInstanceMetadataService(consts.ImdsServer)
++	az.Metadata, err = NewInstanceMetadataService(consts.ImdsServer, config.DisableAPICallCache)
+ 	if err != nil {
+ 		return err
+ 	}

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.29/README.md
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.29/README.md
@@ -5,3 +5,7 @@ This patch add NodeController options to main context object CloudControllerMana
 ### 001-go-mod.patch
 
 Fixes CVEs (bumps go mod)
+
+### 002-fix-disable-api-call-cache.patch
+
+Fix some issues with the disable API call cache feature.

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.30/002-fix-disable-api-call-cache.patch
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.30/002-fix-disable-api-call-cache.patch
@@ -1,0 +1,76 @@
+Subject: [PATCH] Fix some issues with the disable API call cache feature
+---
+Index: pkg/provider/azure_vmss.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure_vmss.go b/pkg/provider/azure_vmss.go
+--- a/pkg/provider/azure_vmss.go	(revision ebecf6de86eae1889fd1675cb660528134cb1e1c)
++++ b/pkg/provider/azure_vmss.go	(date 1741624707025)
+@@ -430,6 +430,25 @@
+ 	vmManagementType, err := ss.getVMManagementTypeByProviderID(providerID, azcache.CacheReadTypeUnsafe)
+ 	if err != nil {
+ 		klog.Errorf("Failed to check VM management type: %v", err)
++
++		if vmManagementType == ManagedByUnknownVMSet {
++			klog.V(2).Infof("Failed to get VM management type for provider ID %q, trying to get node name from availability set or vmss flex", providerID)
++
++			nodeName, err := ss.availabilitySet.GetNodeNameByProviderID(providerID)
++			if err != nil {
++				klog.Warningf("Failed to get node name for provider ID %q: %v", providerID, err)
++			} else {
++				return nodeName, nil
++			}
++
++			nodeName, err = ss.flexScaleSet.GetNodeNameByProviderID(providerID)
++			if err != nil {
++				klog.Warningf("Failed to get node name for provider ID %q: %v", providerID, err)
++			} else {
++				return nodeName, nil
++			}
++		}
++
+ 		return "", err
+ 	}
+
+Index: pkg/provider/azure_instance_metadata.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure_instance_metadata.go b/pkg/provider/azure_instance_metadata.go
+--- a/pkg/provider/azure_instance_metadata.go	(revision ebecf6de86eae1889fd1675cb660528134cb1e1c)
++++ b/pkg/provider/azure_instance_metadata.go	(date 1742470925784)
+@@ -107,12 +107,12 @@
+ }
+
+ // NewInstanceMetadataService creates an instance of the InstanceMetadataService accessor object.
+-func NewInstanceMetadataService(imdsServer string) (*InstanceMetadataService, error) {
++func NewInstanceMetadataService(imdsServer string, disableAPICallCache bool) (*InstanceMetadataService, error) {
+ 	ims := &InstanceMetadataService{
+ 		imdsServer: imdsServer,
+ 	}
+
+-	imsCache, err := azcache.NewTimedCache(consts.MetadataCacheTTL, ims.getMetadata, false)
++	imsCache, err := azcache.NewTimedCache(consts.MetadataCacheTTL, ims.getMetadata, disableAPICallCache)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+Index: pkg/provider/azure.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure.go b/pkg/provider/azure.go
+--- a/pkg/provider/azure.go	(revision ebecf6de86eae1889fd1675cb660528134cb1e1c)
++++ b/pkg/provider/azure.go	(date 1742457863247)
+@@ -632,7 +632,7 @@
+ 	az.Config = *config
+ 	az.Environment = *env
+ 	az.ResourceRequestBackoff = resourceRequestBackoff
+-	az.Metadata, err = NewInstanceMetadataService(consts.ImdsServer)
++	az.Metadata, err = NewInstanceMetadataService(consts.ImdsServer, config.DisableAPICallCache)
+ 	if err != nil {
+ 		return err
+ 	}

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.30/README.md
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.30/README.md
@@ -5,3 +5,7 @@ This patch add NodeController options to main context object CloudControllerMana
 ### 001-go-mod.patch
 
 Fixes CVEs (bumps go mod)
+
+### 002-fix-disable-api-call-cache.patch
+
+Fix some issues with the disable API call cache feature.

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.31/002-fix-disable-api-call-cache.patch
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.31/002-fix-disable-api-call-cache.patch
@@ -1,0 +1,76 @@
+Subject: [PATCH] Fix some issues with the disable API call cache feature
+---
+Index: pkg/provider/azure_vmss.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure_vmss.go b/pkg/provider/azure_vmss.go
+--- a/pkg/provider/azure_vmss.go	(revision 301bb5195472aa76bb36e24726c197ccbb19cfca)
++++ b/pkg/provider/azure_vmss.go	(date 1742471711635)
+@@ -429,6 +429,25 @@
+ 	vmManagementType, err := ss.getVMManagementTypeByProviderID(providerID, azcache.CacheReadTypeUnsafe)
+ 	if err != nil {
+ 		klog.Errorf("Failed to check VM management type: %v", err)
++
++		if vmManagementType == ManagedByUnknownVMSet {
++			klog.V(2).Infof("Failed to get VM management type for provider ID %q, trying to get node name from availability set or vmss flex", providerID)
++
++			nodeName, err := ss.availabilitySet.GetNodeNameByProviderID(providerID)
++			if err != nil {
++				klog.Warningf("Failed to get node name for provider ID %q: %v", providerID, err)
++			} else {
++				return nodeName, nil
++			}
++
++			nodeName, err = ss.flexScaleSet.GetNodeNameByProviderID(providerID)
++			if err != nil {
++				klog.Warningf("Failed to get node name for provider ID %q: %v", providerID, err)
++			} else {
++				return nodeName, nil
++			}
++		}
++
+ 		return "", err
+ 	}
+ 
+Index: pkg/provider/azure_instance_metadata.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure_instance_metadata.go b/pkg/provider/azure_instance_metadata.go
+--- a/pkg/provider/azure_instance_metadata.go	(revision 301bb5195472aa76bb36e24726c197ccbb19cfca)
++++ b/pkg/provider/azure_instance_metadata.go	(date 1742471711640)
+@@ -107,12 +107,12 @@
+ }
+ 
+ // NewInstanceMetadataService creates an instance of the InstanceMetadataService accessor object.
+-func NewInstanceMetadataService(imdsServer string) (*InstanceMetadataService, error) {
++func NewInstanceMetadataService(imdsServer string, disableAPICallCache bool) (*InstanceMetadataService, error) {
+ 	ims := &InstanceMetadataService{
+ 		imdsServer: imdsServer,
+ 	}
+ 
+-	imsCache, err := azcache.NewTimedCache(consts.MetadataCacheTTL, ims.getMetadata, false)
++	imsCache, err := azcache.NewTimedCache(consts.MetadataCacheTTL, ims.getMetadata, disableAPICallCache)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+Index: pkg/provider/azure.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure.go b/pkg/provider/azure.go
+--- a/pkg/provider/azure.go	(revision 301bb5195472aa76bb36e24726c197ccbb19cfca)
++++ b/pkg/provider/azure.go	(date 1742471711646)
+@@ -632,7 +632,7 @@
+ 	az.Config = *config
+ 	az.Environment = *env
+ 	az.ResourceRequestBackoff = resourceRequestBackoff
+-	az.Metadata, err = NewInstanceMetadataService(consts.ImdsServer)
++	az.Metadata, err = NewInstanceMetadataService(consts.ImdsServer, config.DisableAPICallCache)
+ 	if err != nil {
+ 		return err
+ 	}

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.31/README.md
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.31/README.md
@@ -5,3 +5,7 @@ This patch add NodeController options to main context object CloudControllerMana
 ### 001-go-mod.patch
 
 Fixes CVEs (bumps go mod)
+
+### 002-fix-disable-api-call-cache.patch
+
+Fix some issues with the disable API call cache feature.

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.32/002-fix-disable-api-call-cache.patch
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.32/002-fix-disable-api-call-cache.patch
@@ -1,0 +1,76 @@
+Subject: [PATCH] Fix some issues with the disable API call cache feature
+---
+Index: pkg/provider/azure_vmss.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure_vmss.go b/pkg/provider/azure_vmss.go
+--- a/pkg/provider/azure_vmss.go	(revision b8981af52775d1fa800338f434e3413d92bacec6)
++++ b/pkg/provider/azure_vmss.go	(date 1742473658056)
+@@ -448,6 +448,25 @@
+ 	vmManagementType, err := ss.getVMManagementTypeByProviderID(ctx, providerID, azcache.CacheReadTypeUnsafe)
+ 	if err != nil {
+ 		klog.Errorf("Failed to check VM management type: %v", err)
++
++		if vmManagementType == ManagedByUnknownVMSet {
++			klog.V(2).Infof("Failed to get VM management type for provider ID %q, trying to get node name from availability set or vmss flex", providerID)
++
++			nodeName, err := ss.availabilitySet.GetNodeNameByProviderID(ctx, providerID)
++			if err != nil {
++				klog.Warningf("Failed to get node name for provider ID %q: %v", providerID, err)
++			} else {
++				return nodeName, nil
++			}
++
++			nodeName, err = ss.flexScaleSet.GetNodeNameByProviderID(ctx, providerID)
++			if err != nil {
++				klog.Warningf("Failed to get node name for provider ID %q: %v", providerID, err)
++			} else {
++				return nodeName, nil
++			}
++		}
++
+ 		return "", err
+ 	}
+ 
+Index: pkg/provider/azure_instance_metadata.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure_instance_metadata.go b/pkg/provider/azure_instance_metadata.go
+--- a/pkg/provider/azure_instance_metadata.go	(revision b8981af52775d1fa800338f434e3413d92bacec6)
++++ b/pkg/provider/azure_instance_metadata.go	(date 1742471800406)
+@@ -108,12 +108,12 @@
+ }
+ 
+ // NewInstanceMetadataService creates an instance of the InstanceMetadataService accessor object.
+-func NewInstanceMetadataService(imdsServer string) (*InstanceMetadataService, error) {
++func NewInstanceMetadataService(imdsServer string, disableAPICallCache bool) (*InstanceMetadataService, error) {
+ 	ims := &InstanceMetadataService{
+ 		imdsServer: imdsServer,
+ 	}
+ 
+-	imsCache, err := azcache.NewTimedCache(consts.MetadataCacheTTL, ims.getMetadata, false)
++	imsCache, err := azcache.NewTimedCache(consts.MetadataCacheTTL, ims.getMetadata, disableAPICallCache)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+Index: pkg/provider/azure.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/provider/azure.go b/pkg/provider/azure.go
+--- a/pkg/provider/azure.go	(revision b8981af52775d1fa800338f434e3413d92bacec6)
++++ b/pkg/provider/azure.go	(date 1742471800412)
+@@ -338,7 +338,7 @@
+ 	az.Config = *config
+ 	az.Environment = env
+ 	az.ResourceRequestBackoff = resourceRequestBackoff
+-	az.Metadata, err = NewInstanceMetadataService(consts.ImdsServer)
++	az.Metadata, err = NewInstanceMetadataService(consts.ImdsServer, config.DisableAPICallCache)
+ 	if err != nil {
+ 		return err
+ 	}

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.32/README.md
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/patches/1.32/README.md
@@ -1,3 +1,7 @@
 ### 001-options.patch
 
 This patch add NodeController options to main context object CloudControllerManager from package "k8s.io/cloud-provider/options" witch return flag "node controller".
+
+### 002-fix-disable-api-call-cache.patch
+
+Fix some issues with the disable API call cache feature.

--- a/modules/030-cloud-provider-azure/templates/cloud-controller-manager/secret.yaml
+++ b/modules/030-cloud-provider-azure/templates/cloud-controller-manager/secret.yaml
@@ -11,8 +11,8 @@
     "routeTableName": {{ .Values.global.clusterConfiguration.cloud.prefix | quote }},
     "vnetName": {{ .Values.cloudProviderAzure.internal.providerDiscoveryData.vnetName | quote }},
     "subnetName": {{ .Values.cloudProviderAzure.internal.providerDiscoveryData.subnetName | quote }},
-    "useInstanceMetadata": true,
-    "loadBalancerSku": "standard"
+    "loadBalancerSku": "standard",
+    "disableAPICallCache": true
 }
 {{- end }}
 ---


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

To disable API call caching, the following changes have been made:  
- Added the `disableAPICallCache: true` option to the `cloud-controller-manager` configuration
- Removed the `useInstanceMetadata: true` option from the `cloud-controller-manager` configuration
- Applied a patch to fix issues in the disable API call cache feature

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Deleting or recreating a virtual machine does not trigger the deletion of the `Node` resource if API call caching is enabled.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-azure
type: fix
summary: Disable API call caching in `cloud-controller-manager`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
