### PR TITLE
[extended-monitoring] Fix certificate alert expressions/description

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -16,7 +16,7 @@ alerts:
       module: extended-monitoring
       edition: ce
       description: |
-        A certificate in Secret `{{$labels.namespace}}/{{$labels.name}}` has expired.
+        A certificate in Secret `{{$labels.secret_namespace}}/{{$labels.secret_name}}` has expired.
 
         Ways to resolve:
 
@@ -25,13 +25,13 @@ alerts:
           1. Retrieve the certificate name from the Secret:
 
              ```bash
-             cert=$(kubectl get secret -n {{$labels.namespace}} {{$labels.name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
+             cert=$(kubectl get secret -n {{$labels.secret_namespace}} {{$labels.secret_name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
              ```
 
           2. Check the certificate status and investigate why it hasn't been updated:
 
              ```bash
-             kubectl describe cert -m {{$labels.namespace}} "$cert"
+             kubectl describe cert -m {{$labels.secret_namespace}} "$cert"
              ```
       summary: |
         Certificate has expired.
@@ -43,7 +43,7 @@ alerts:
       module: extended-monitoring
       edition: ce
       description: |
-        A certificate in Secret `{{$labels.namespace}}/{{$labels.name}}` will expire in less than two weeks.
+        A certificate in Secret `{{$labels.secret_namespace}}/{{$labels.secret_name}}` will expire in less than two weeks.
 
         Ways to resolve:
 
@@ -52,13 +52,13 @@ alerts:
           1. Retrieve the certificate name from the Secret:
 
              ```bash
-             cert=$(kubectl get secret -n {{$labels.namespace}} {{$labels.name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
+             cert=$(kubectl get secret -n {{$labels.secret_namespace}} {{$labels.secret_name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
              ```
 
           2. Check the certificate status and investigate why it hasn't been updated:
 
              ```bash
-             kubectl describe cert -n {{$labels.namespace}} "$cert"
+             kubectl describe cert -n {{$labels.secret_namespace}} "$cert"
              ```
       summary: |
         Certificate is expiring soon.

--- a/docs/documentation/_plugins/custom_filters.rb
+++ b/docs/documentation/_plugins/custom_filters.rb
@@ -108,6 +108,7 @@ module Jekyll
               gsub(/{{\s*\$labels\.revision\s*\}\}/m,'REVISION_NUMBER').
               gsub(/{{\s*\$labels\.scheme\s*\}\}/m,'SCHEME').
               gsub(/{{\s*\$labels\.secret_name\s*\}\}/m,'SECRET_NAME').
+              gsub(/{{\s*\$labels\.secret_namespace\s*\}\}/m,'SECRET_NAMESPACE').
               gsub(/{{\s*\$labels\.service\s*\}\}/m,'SERVICE_NAME').
               gsub(/{{\s*\$labels\.service_port\s*\}\}/m,'SERVICE_PORT').
               gsub(/{{\s*\$labels\.stage\s*\}\}/m,'STAGE_NAME').

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
@@ -4,7 +4,7 @@
     expr: |
       max by (secret_name, secret_namespace) (
         x509_cert_not_after{job="x509-certificate-exporter", secret_key!="ca.crt"} - time() < 1209600
-      ) * on (namespace) group_left() max by (secret_namespace) (extended_monitoring_enabled)
+      ) * on (secret_namespace) group_left() max by (secret_namespace) (label_replace(extended_monitoring_enabled, "secret_namespace", "$1", "namespace", "(.+)"))
     for: 1h
     labels:
       severity_level: "8"
@@ -37,7 +37,7 @@
     expr: |
       max by (secret_name, secret_namespace) (
         x509_cert_not_after{job="x509-certificate-exporter", secret_key!="ca.crt"} - time() < 0
-      ) * on (namespace) group_left() max by (secret_namespace) (extended_monitoring_enabled)
+      ) * on (secret_namespace) group_left() max by (secret_namespace) (label_replace(extended_monitoring_enabled, "secret_namespace", "$1", "namespace", "(.+)"))
     for: 1h
     labels:
       severity_level: "8"

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
@@ -2,9 +2,9 @@
   rules:
   - alert: CertificateSecretExpiredSoon
     expr: |
-      max by (name, namespace) (
+      max by (secret_name, secret_namespace) (
         x509_cert_not_after{job="x509-certificate-exporter", secret_key!="ca.crt"} - time() < 1209600
-      ) * on (namespace) group_left() max by (namespace) (extended_monitoring_enabled)
+      ) * on (namespace) group_left() max by (secret_namespace) (extended_monitoring_enabled)
     for: 1h
     labels:
       severity_level: "8"
@@ -15,7 +15,7 @@
       plk_grouped_by__certificate_secret_expiration: "CertificateSecretExpiration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
       summary: Certificate is expiring soon.
       description: |
-        A certificate in Secret `{{$labels.namespace}}/{{$labels.name}}` will expire in less than two weeks.
+        A certificate in Secret `{{$labels.secret_namespace}}/{{$labels.secret_name}}` will expire in less than two weeks.
 
         Ways to resolve:
 
@@ -24,20 +24,20 @@
           1. Retrieve the certificate name from the Secret:
 
              ```bash
-             cert=$(kubectl get secret -n {{$labels.namespace}} {{$labels.name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
+             cert=$(kubectl get secret -n {{$labels.secret_namespace}} {{$labels.secret_name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
              ```
 
           2. Check the certificate status and investigate why it hasn't been updated:
 
              ```bash
-             kubectl describe cert -n {{$labels.namespace}} "$cert"
+             kubectl describe cert -n {{$labels.secret_namespace}} "$cert"
              ```
 
   - alert: CertificateSecretExpired
     expr: |
-      max by (name, namespace) (
+      max by (secret_name, secret_namespace) (
         x509_cert_not_after{job="x509-certificate-exporter", secret_key!="ca.crt"} - time() < 0
-      ) * on (namespace) group_left() max by (namespace) (extended_monitoring_enabled)
+      ) * on (namespace) group_left() max by (secret_namespace) (extended_monitoring_enabled)
     for: 1h
     labels:
       severity_level: "8"
@@ -48,7 +48,7 @@
       plk_grouped_by__certificate_secret_expiration: "CertificateSecretExpiration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes"
       summary: Certificate has expired.
       description: |
-        A certificate in Secret `{{$labels.namespace}}/{{$labels.name}}` has expired.
+        A certificate in Secret `{{$labels.secret_namespace}}/{{$labels.secret_name}}` has expired.
 
         Ways to resolve:
 
@@ -57,11 +57,11 @@
           1. Retrieve the certificate name from the Secret:
 
              ```bash
-             cert=$(kubectl get secret -n {{$labels.namespace}} {{$labels.name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
+             cert=$(kubectl get secret -n {{$labels.secret_namespace}} {{$labels.secret_name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
              ```
 
           2. Check the certificate status and investigate why it hasn't been updated:
 
              ```bash
-             kubectl describe cert -m {{$labels.namespace}} "$cert"
+             kubectl describe cert -m {{$labels.secret_namespace}} "$cert"
              ```


### PR DESCRIPTION
## Description

Fixes the grouping of alerts based on secret `namespace`/`name` metadata.

Before: uses 'namespace' label that is taken from exporter namespace.
After: uses 'secret_namespace'/'secret_name' that is taken from secret resources metadata.


## Why do we need it, and what problem does it solve?

Improves/fixes the grouping of series based on proper labels.

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: extended-monitoring
type: fix 
summary:  Minor certificate alerts improvements
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
