### PR TITLE
[docs]  Fixed the block with availability in editions

### DIFF
--- a/docs/documentation/_plugins/custom_hooks.rb
+++ b/docs/documentation/_plugins/custom_hooks.rb
@@ -133,7 +133,7 @@ Jekyll::Hooks.register :site, :pre_render do |site|
       insert_module_webiface_block(page)
     end
 
-    if page.data['module-kebab-name'] && !page.name.match?(/CR(\.ru|_RU)?\.md$/)
+    if page.data['module-kebab-name'] and !page.name.match?(/CR(\.ru|_RU)?\.md$/)
       insert_module_stage_block(site.data['sidebars'][page.data['sidebar']]['entries'], page)
     
       if page.name.match?(/^README(\.ru|_RU)?\.md$/i) ||

--- a/docs/documentation/_plugins/custom_hooks.rb
+++ b/docs/documentation/_plugins/custom_hooks.rb
@@ -133,9 +133,13 @@ Jekyll::Hooks.register :site, :pre_render do |site|
       insert_module_webiface_block(page)
     end
 
-    if page.data['module-kebab-name'] and !page.name.match?(/CR(\.ru|_RU)?\.md$/)
+    if page.data['module-kebab-name'] && !page.name.match?(/CR(\.ru|_RU)?\.md$/)
       insert_module_stage_block(site.data['sidebars'][page.data['sidebar']]['entries'], page)
-      insert_module_edition_block(page)
+    
+      if page.name.match?(/^README(\.ru|_RU)?\.md$/i) ||
+         page.name.match?(/^CONFIGURATION(\.ru|_RU)?\.md$/i)
+        insert_module_edition_block(page)
+      end
     end
 
     next if ! ( page.name.end_with?('CR.md') or page.name.end_with?('CR_RU.md') or page.name.end_with?('CONFIGURATION.md') or page.name.end_with?('CONFIGURATION_RU.md') )

--- a/docs/site/backends/docs-builder-template/layouts/_default/single.html
+++ b/docs/site/backends/docs-builder-template/layouts/_default/single.html
@@ -22,8 +22,8 @@
 
     <div class="post-content">
 
-        {{- if $currentModuleName }}
-          {{- partial "module-editions" (dict "moduleName" $currentModuleName "lang" .Language.Lang ) }}
+        {{- if and $currentModuleName (or (eq .File.ContentBaseName "README") (eq .File.ContentBaseName "CONFIGURATION")) }}
+         {{- partial "module-editions" (dict "moduleName" $currentModuleName "lang" .Language.Lang ) }}
         {{- end }}
 
         {{- if $moduleStatus }}


### PR DESCRIPTION
## Description
Fixed the block with availability in editions.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix 
summary: Fixed the block with availability in editions.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
