### PR TITLE
[docs] Fixed typos at VMware configuration parameters

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/openapi/config-values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/config-values.yaml
@@ -4,7 +4,7 @@ properties:
     type: object
     default: {}
     description: |
-      The module automatically creates StorageClasses that are available in OpenStack.
+      The module automatically creates StorageClasses that are available in VCD (VMware Cloud Director).
     properties:
       exclude:
         type: array

--- a/ee/modules/030-cloud-provider-vcd/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/doc-ru-config-values.yaml
@@ -2,7 +2,7 @@ type: object
 properties:
   storageClass:
     description: |
-      Автоматическое создание StorageClass'ов, которые есть в OpenStack.
+      Автоматическое создание StorageClass'ов, которые есть в VCD (VMware Cloud Director).
     properties:
       exclude:
         description: |


### PR DESCRIPTION
## Description
Fixed typos at VMware configuration parameters.


## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix 
summary: Fixed typos at VMware configuration parameters.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
