### PR TITLE
[user-authz] use dvp dict

### DIFF
--- a/modules/140-user-authz/templates/rbacv2/global/use/roles/dict.yaml
+++ b/modules/140-user-authz/templates/rbacv2/global/use/roles/dict.yaml
@@ -57,3 +57,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - virtualization.deckhouse.io
+    resources:
+      - virtualmachineclasses
+      - clustervirtualimages
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
## Description
Add DVP dicts for next resources:
      - virtualmachineclasses
      - clustervirtualimages

## Why do we need it, and what problem does it solve?
We need to get and list DVP resources too.
It extends this [PR](https://github.com/deckhouse/deckhouse/pull/11943)

```
root@dev-master-0:~# cat testrole.yaml 
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: developer
subjects:
- kind: User
  name: developer
  apiGroup: rbac.authorization.k8s.io
- kind: User
  name: developer2
  apiGroup: rbac.authorization.k8s.io
roleRef:
  kind: ClusterRole
  name: d8:use:role:viewer
  apiGroup: rbac.authorization.k8s.io
```

```
root@dev-master-0:~# kubectl get clusterrolebindings.rbac.authorization.k8s.io d8:dict:
2h6xn  kk58q  
root@dev-master-0:~# kubectl get clusterrolebindings.rbac.authorization.k8s.io d8:dict:2h6xn -oyaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  annotations:
    rbac.deckhouse.io/subject: user:developer
  creationTimestamp: "2025-03-11T12:21:24Z"
  generateName: 'd8:dict:'
  labels:
    heritage: deckhouse
    rbac.deckhouse.io/automated: "true"
    rbac.deckhouse.io/dict: "true"
  name: d8:dict:2h6xn
  resourceVersion: "337389954"
  uid: 7dbf1553-9afb-41a4-97ed-eb8ec82b9468
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: d8:use:dict
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: developer
```

```
root@dev-master-0:~# kubectl get clusterrole d8:use:dict -oyaml | grep virt
  - virtualization.deckhouse.io
  - virtualmachineclasses
  - clustervirtualimages
 ```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authz
type: feature
summary: Add DVP use dict.
```
