### PR TITLE
chore: add prealloc linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -87,3 +87,4 @@ linters:
   - copyloopvar
   - nonamedreturns
   - musttag
+  - prealloc

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -913,7 +913,7 @@ func (f *DeckhouseReleaseFetcher) getNewVersions(ctx context.Context, actual, ta
 
 func (f *DeckhouseReleaseFetcher) parseAndFilterVersions(tags []string) []*semver.Version {
 	versionMatcher := regexp.MustCompile(`^v(([0-9]+).([0-9]+).([0-9]+))$`)
-	var versions []*semver.Version
+	versions := make([]*semver.Version, 0)
 
 	for _, tag := range tags {
 		if !versionMatcher.MatchString(tag) {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -260,7 +260,7 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 	md := downloader.NewModuleDownloader(r.dependencyContainer, r.downloadedModulesDir, source, opts)
 	sort.Strings(pulledModules)
 
-	var availableModules []v1alpha1.AvailableModule
+	availableModules := make([]v1alpha1.AvailableModule, 0)
 	var pullErrorsExist bool
 	for _, moduleName := range pulledModules {
 		if moduleName == "modules" {

--- a/go_lib/dependency/helm/hash.go
+++ b/go_lib/dependency/helm/hash.go
@@ -61,7 +61,7 @@ func escapeValue(value interface{}, writer *hash.Hash) {
 }
 
 func sortedKeys(sum map[string]interface{}) []string {
-	var keys []string
+	keys := make([]string, 0, len(sum))
 	for k := range sum {
 		keys = append(keys, k)
 	}

--- a/go_lib/dependency/vsphere/vsphere.go
+++ b/go_lib/dependency/vsphere/vsphere.go
@@ -247,7 +247,7 @@ func getZonesInDC(ctx context.Context, client client, datacenter *object.Datacen
 		}
 	}
 
-	var matchingZones []string
+	matchingZones := make([]string, 0, len(matchingZonesMap))
 	for zone := range matchingZonesMap {
 		matchingZones = append(matchingZones, zone)
 	}
@@ -270,7 +270,7 @@ func getDataStoresInDC(ctx context.Context, client client, datacenter *object.Da
 		return nil, fmt.Errorf("not a single Datastore or DatastoreCluster found in the cluster:\n%s\n%s", dsNotFoundErr, dscNotFoundErr)
 	}
 
-	var datastoreReferences []mo.Reference
+	datastoreReferences := make([]mo.Reference, 0, len(datastores))
 	for _, ds := range datastores {
 		datastoreReferences = append(datastoreReferences, ds)
 	}
@@ -310,7 +310,7 @@ func getDataStoresInDC(ctx context.Context, client client, datacenter *object.Da
 		return nil, err
 	}
 
-	var zds []ZonedDataStore
+	zds := make([]ZonedDataStore, 0)
 	for _, attachedTags := range datastoresWithTags {
 		var dsZones []string
 		for _, tag := range attachedTags.Tags {

--- a/go_lib/hooks/tls_certificate/order_certificate.go
+++ b/go_lib/hooks/tls_certificate/order_certificate.go
@@ -119,8 +119,9 @@ func ApplyCertificateSecretFilter(obj *unstructured.Unstructured) (go_hook.Filte
 }
 
 func RegisterOrderCertificateHook(requests []OrderCertificateRequest) bool {
-	var namespaces []string
-	var secretNames []string
+	namespaces := make([]string, 0, len(requests))
+	secretNames := make([]string, 0, len(requests))
+
 	for _, request := range requests {
 		namespaces = append(namespaces, request.Namespace)
 		secretNames = append(secretNames, request.SecretName)

--- a/modules/030-cloud-provider-aws/hooks/storage_classes.go
+++ b/modules/030-cloud-provider-aws/hooks/storage_classes.go
@@ -98,7 +98,7 @@ func storageClasses(input *go_hook.HookInput) error {
 		provisionExcludeNames = append(provisionExcludeNames, sc.Get("name"))
 	}
 
-	var provisionRegexps []*regexp.Regexp
+	provisionRegexps := make([]*regexp.Regexp, 0, len(provisionExcludeNames))
 
 	// compile regular expressions
 	for _, excludePattern := range provisionExcludeNames {
@@ -109,7 +109,7 @@ func storageClasses(input *go_hook.HookInput) error {
 		provisionRegexps = append(provisionRegexps, r)
 	}
 
-	var storageClassesFilteredProvision []StorageClass
+	storageClassesFilteredProvision := make([]StorageClass, 0)
 	for _, storageClass := range defaultStorageClasses {
 		if !excludeCheck(provisionRegexps, storageClass.Name) {
 			storageClassesFilteredProvision = append(storageClassesFilteredProvision, storageClass)
@@ -128,7 +128,7 @@ func storageClasses(input *go_hook.HookInput) error {
 
 	excludeStorageClasses := input.Values.Get("cloudProviderAws.storageClass.exclude").Array()
 
-	var excludeRegexps []*regexp.Regexp
+	excludeRegexps := make([]*regexp.Regexp, 0, len(excludeStorageClasses))
 
 	// compile regular expressions
 	for _, excludePattern := range excludeStorageClasses {
@@ -139,7 +139,7 @@ func storageClasses(input *go_hook.HookInput) error {
 		excludeRegexps = append(excludeRegexps, r)
 	}
 
-	var storageClassesFiltered []StorageClass
+	storageClassesFiltered := make([]StorageClass, 0)
 	for _, storageClass := range storageClassesFilteredProvision {
 		if !excludeCheck(excludeRegexps, storageClass.Name) {
 			storageClassesFiltered = append(storageClassesFiltered, storageClass)
@@ -156,7 +156,7 @@ func storageClasses(input *go_hook.HookInput) error {
 		input.Values.Set("cloudProviderAws.internal.storageClasses", []StorageClass{})
 	}
 
-	var existedStorageClasses []StorageClass
+	existedStorageClasses := make([]StorageClass, 0, len(input.Snapshots["module_storageclasses"]))
 	for _, v := range input.Snapshots["module_storageclasses"] {
 		sc := v.(*storagev1.StorageClass)
 		existedStorageClasses = append(existedStorageClasses, StorageClass{

--- a/modules/030-cloud-provider-azure/hooks/storage_classes.go
+++ b/modules/030-cloud-provider-azure/hooks/storage_classes.go
@@ -75,7 +75,7 @@ func storageClasses(input *go_hook.HookInput) error {
 		provision = input.Values.Get("cloudProviderAzure.storageClass.provision").Array()
 	}
 
-	var provisionStorageClasses []StorageClass
+	provisionStorageClasses := make([]StorageClass, 0, len(provision))
 
 	for _, sc := range provision {
 		tagsArray := sc.Get("tags").Array()

--- a/modules/031-local-path-provisioner/hooks/storage_classes.go
+++ b/modules/031-local-path-provisioner/hooks/storage_classes.go
@@ -79,11 +79,11 @@ func applyModuleCRDFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 }
 
 func storageClasses(input *go_hook.HookInput) error {
-	var existedStorageClasses []StorageClass
-
 	if len(input.Snapshots["module_storageclasses"]) == 0 || len(input.Snapshots["module_crds"]) == 0 {
 		return nil
 	}
+
+	existedStorageClasses := make([]StorageClass, 0, len(input.Snapshots["module_storageclasses"]))
 
 	for _, snapshot := range input.Snapshots["module_storageclasses"] {
 		sc := snapshot.(StorageClass)

--- a/modules/040-control-plane-manager/hooks/effective_kubernetes_version.go
+++ b/modules/040-control-plane-manager/hooks/effective_kubernetes_version.go
@@ -307,7 +307,7 @@ func handleEffectiveK8sVersion(input *go_hook.HookInput, dc dependency.Container
 func ekvProcessPodsSnapshot(input *go_hook.HookInput, dc dependency.Container) (*semver.Version, *semver.Version, error) {
 	snap := input.Snapshots["control_plane_versions"]
 
-	var controlPlaneVersions []controlPlanePod
+	controlPlaneVersions := make([]controlPlanePod, 0, len(snap))
 	var apiserverExists bool
 
 	for _, res := range snap {
@@ -354,7 +354,7 @@ func ekvProcessPodsSnapshot(input *go_hook.HookInput, dc dependency.Container) (
 func ekvProcessNodeSnapshot(input *go_hook.HookInput) (*semver.Version /*minNodeVersion*/, *semver.Version /*maxNodeVersion*/, error) {
 	snap := input.Snapshots["node_versions"]
 
-	var nodeVersions []*semver.Version
+	nodeVersions := make([]*semver.Version, 0, len(snap))
 	for _, res := range snap {
 		nodeVersions = append(nodeVersions, res.(*semver.Version))
 	}

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances.go
@@ -221,7 +221,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func deleteMachines(input *go_hook.HookInput) error {
 	var (
 		timeNow                        = time.Now().UTC()
-		machines                       []*Machine
+		machines                       = make([]*Machine, 0)
 		preemptibleMachineClassesSet   = set.Set{}
 		nodeNameToNodeMap              = make(map[string]*Node)
 		nodeGroupNameToNodeGroupStatus = make(map[string]*NodeGroupStatus)

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
@@ -146,7 +146,7 @@ func generateNMachines(ngNodes, ngReady int, prefix string, machinesCount ...dur
 func generateNGsAndMCs(ngNodes, ngReady int, prefix string, durationStrings ...string) string {
 	timeNow := time.Now().UTC()
 
-	var offsets []time.Duration
+	offsets := make([]time.Duration, 0, len(durationStrings))
 	for i, d := range durationStrings {
 		duration, err := time.ParseDuration(d)
 		if err != nil {

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -1928,7 +1928,7 @@ internal:
 func verifyClusterAutoscalerDeploymentArgs(deployment object_store.KubeObject, mds ...object_store.KubeObject) error {
 	args := deployment.Field("spec.template.spec.containers.0.args").AsStringSlice()
 
-	var nodesArgs []string
+	nodesArgs := make([]string, 0)
 	for _, arg := range args {
 		if !strings.HasPrefix(arg, "--nodes") {
 			continue
@@ -1937,7 +1937,7 @@ func verifyClusterAutoscalerDeploymentArgs(deployment object_store.KubeObject, m
 		nodesArgs = append(nodesArgs, strings.Split(arg, ".")[1])
 	}
 
-	var mdsNames []string
+	mdsNames := make([]string, 0, len(mds))
 	for _, md := range mds {
 		mdsNames = append(mdsNames, md.Field("metadata.name").String())
 	}

--- a/modules/402-ingress-nginx/hooks/get_ingress_controllers.go
+++ b/modules/402-ingress-nginx/hooks/get_ingress_controllers.go
@@ -129,7 +129,7 @@ func setInternalValues(input *go_hook.HookInput) error {
 	defaultControllerVersion := input.Values.Get("ingressNginx.defaultControllerVersion").String()
 	input.MetricsCollector.Expire("")
 
-	var controllers []Controller
+	controllers := make([]Controller, 0, len(controllersFilterResult))
 
 	for _, c := range controllersFilterResult {
 		controller := c.(Controller)

--- a/modules/460-log-shipper/hooks/generate_config.go
+++ b/modules/460-log-shipper/hooks/generate_config.go
@@ -292,7 +292,7 @@ func generateConfig(input *go_hook.HookInput) error {
 
 	clusterDomain := input.Values.Get("global.discovery.clusterDomain").String()
 
-	var destinations []v1alpha1.ClusterLogDestination
+	destinations := make([]v1alpha1.ClusterLogDestination, 0)
 
 	for _, destination := range destSnap {
 		dest := destination.(v1alpha1.ClusterLogDestination)

--- a/testing/helm/init.go
+++ b/testing/helm/init.go
@@ -223,7 +223,7 @@ func trimBlankLines(content string) string {
 	lines := strings.Split(content, "\n")
 
 	// Filter out blank lines
-	var filteredLines []string
+	filteredLines := make([]string, 0)
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {

--- a/testing/openapi_cases/library.go
+++ b/testing/openapi_cases/library.go
@@ -106,12 +106,12 @@ func getPossiblePathToModules() []string {
 }
 
 func GetAllOpenAPIDirs() ([]string, error) {
-	var (
-		dirs        []string
-		openAPIDirs []string
-	)
+	possiblePathToModules := getPossiblePathToModules()
 
-	for _, possibleDir := range getPossiblePathToModules() {
+	dirs := make([]string, 0, len(possiblePathToModules))
+	openAPIDirs := make([]string, 0)
+
+	for _, possibleDir := range possiblePathToModules {
 		globDirs, err := filepath.Glob(possibleDir)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description
Added prealloc linter
## Why do we need it, and what problem does it solve?
When we can prealloc slice - we'll do it. Sometimes we forget to do it. This linter can help to check accidentally missed prealloc.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: added prealloc linter
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
