### PR TITLE
[deckhouse] delete useless module phases

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
@@ -68,8 +68,6 @@ const (
 	ModuleReasonModuleError                 = "ModuleError"
 	ModuleReasonReconciling                 = "Reconciling"
 	ModuleReasonInstalling                  = "Installing"
-	ModuleReasonHooksDisabled               = "HooksDisabled"
-	ModuleReasonWaitSyncTasks               = "WaitSyncTasks"
 	ModuleReasonError                       = "Error"
 
 	ModuleMessageBundle                      = "turned off by bundle"
@@ -86,9 +84,7 @@ const (
 	ModuleMessageDownloading                 = "downloading"
 	ModuleMessageReconciling                 = "reconciling"
 	ModuleMessageInstalling                  = "installing"
-	ModuleMessageWaitSyncTasks               = "run sync tasks"
 	ModuleMessageOnStartupHook               = "onStartup hooks done"
-	ModuleMessageHooksDisabled               = "hooks disabled"
 
 	DeckhouseRequirementFieldName        string = "deckhouse"
 	KubernetesRequirementFieldName       string = "kubernetes"

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -273,7 +273,7 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 			// set conflict if there are several available sources
 			err := utils.UpdateStatus[*v1alpha1.Module](ctx, r.client, module, func(module *v1alpha1.Module) bool {
 				module.Status.Phase = v1alpha1.ModulePhaseConflict
-				module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleManager, v1alpha1.ModuleReasonConflict, v1alpha1.ModuleMessageConflict)
+				module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleManager, "", "")
 				module.SetConditionFalse(v1alpha1.ModuleConditionIsReady, v1alpha1.ModuleReasonConflict, v1alpha1.ModuleMessageConflict)
 				return true
 			})

--- a/deckhouse-controller/pkg/controller/module-controllers/config/status.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/status.go
@@ -161,14 +161,6 @@ func (r *reconciler) refreshModuleStatus(module *v1alpha1.Module) {
 			} else {
 				module.SetConditionFalse(v1alpha1.ModuleConditionIsReady, v1alpha1.ModuleReasonInstalling, v1alpha1.ModuleMessageOnStartupHook)
 			}
-
-		case modules.WaitForSynchronization:
-			module.Status.Phase = v1alpha1.ModulePhaseWaitSyncTasks
-			module.SetConditionFalse(v1alpha1.ModuleConditionIsReady, v1alpha1.ModuleReasonWaitSyncTasks, v1alpha1.ModuleMessageWaitSyncTasks)
-
-		case modules.HooksDisabled:
-			module.Status.Phase = v1alpha1.ModulePhaseHooksDisabled
-			module.SetConditionFalse(v1alpha1.ModuleConditionIsReady, v1alpha1.ModuleReasonHooksDisabled, v1alpha1.ModuleMessageHooksDisabled)
 		}
 
 		return


### PR DESCRIPTION
## Description
It removes useless module` phases

## Why do we need it, and what problem does it solve?
These phases can confused and they are not needed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Delete useless module`s phases.
impact_level: low
```
