### PR TITLE
[runtime-audit-engine] built-in rules fix

### DIFF
--- a/ee/modules/650-runtime-audit-engine/rules/k8s_audit_rules.yaml
+++ b/ee/modules/650-runtime-audit-engine/rules/k8s_audit_rules.yaml
@@ -9,122 +9,23 @@
     - name: json
       version: 0.3.0
 
-# Like always_true/always_false, but works with k8s audit events
-- macro: k8s_audit_always_true
-  condition: (jevt.rawtime exists)
-
-- macro: k8s_audit_never_true
-  condition: (jevt.rawtime=0)
-
-# Generally only consider audit events once the response has completed
 - list: k8s_audit_stages
   items: ["ResponseComplete"]
 
-# Generally exclude users starting with "system:"
-- macro: non_system_user
-  condition: (not ka.user.name startswith "system:")
-
-- macro: non_deckhouse_service_account_user
-  condition: (not ka.user.name startswith "system:serviceaccount:d8-")
-
-# This macro selects the set of Audit Events used by the below rules.
 - macro: kevt
   condition: (jevt.value[/stage] in (k8s_audit_stages))
-
-- macro: kevt_started
-  condition: (jevt.value[/stage]=ResponseStarted)
 
 - macro: response_successful
   condition: (ka.response.code startswith 2)
 
-# Verbs
-- macro: kget
-  condition: ka.verb=get
-
 - macro: kcreate
   condition: ka.verb=create
-
-- macro: kmodify
-  condition: (ka.verb in (create,update,patch))
 
 - macro: kdelete
   condition: ka.verb=delete
 
-# Resources
-- macro: pod
-  condition: ka.target.resource=pods and not ka.target.subresource exists
-
-- macro: pod_subresource
-  condition: ka.target.resource=pods and ka.target.subresource exists
-
-- macro: deployment
-  condition: ka.target.resource=deployments
-
-- macro: service
-  condition: ka.target.resource=services
-
-- macro: configmap
-  condition: ka.target.resource=configmaps
-
-- macro: namespace
-  condition: ka.target.resource=namespaces
-
-- macro: serviceaccount
-  condition: ka.target.resource=serviceaccounts
-
-- macro: clusterrole
-  condition: ka.target.resource=clusterroles
-
-- macro: clusterrolebinding
-  condition: ka.target.resource=clusterrolebindings
-
-- macro: role
-  condition: ka.target.resource=roles
-
-- macro: secret
-  condition: ka.target.resource=secrets
-
 - macro: falcoauditrules
   condition: ka.target.resource=falcoauditrules
-
-# Endpoints
-- macro: health_endpoint
-  condition: ka.uri=/healthz
-
-- macro: live_endpoint
-  condition: ka.uri=/livez
-
-- macro: ready_endpoint
-  condition: ka.uri=/readyz
-
-# Rules
-
-# Corresponds to K8s CIS Benchmark, 1.1.1.
-- rule: Anonymous Request Allowed
-  desc: >
-    Detect any request made by the anonymous user that was allowed
-  condition: kevt and ka.user.name=system:anonymous and ka.auth.decision="allow" and not health_endpoint and not live_endpoint and not ready_endpoint
-  output: Request by anonymous user allowed (user=%ka.user.name verb=%ka.verb uri=%ka.uri reason=%ka.auth.reason))
-  priority: WARNING
-  source: k8s_audit
-  tags: [k8s]
-
-- rule: Attach/Exec Pod
-  desc: >
-    Detect any attempt to attach/exec to a pod
-  condition: kevt_started and pod_subresource and kcreate and ka.target.subresource in (exec,attach)
-  output: Attach/Exec to pod (user=%ka.user.name pod=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace action=%ka.target.subresource command=%ka.uri.param[command])
-  priority: NOTICE
-  source: k8s_audit
-  tags: [k8s]
-
-# The rules below this point are less discriminatory and generally
-# represent a stream of activity for a cluster.
-# - macro: consider_activity_events
-#   condition: (k8s_audit_always_true)
-
-# - macro: kactivity
-#   condition: (kevt and consider_activity_events)
 
 - rule: FalcoAuditRules Created
   desc: Detect any attempt to create a FalcoAuditRules.

--- a/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
@@ -274,10 +274,11 @@ spec:
           - fstec
           - rbac_drift
         source: K8sAudit
+
     - rule:
-        name: Attach/Exec Pod
+        name: Attach/Exec Pod fstec
         condition: |
-          kevt_started and pod_subresource and kcreate and ka.target.subresource in (exec,attach) and not user_known_exec_pod_activities
+          kevt_started and pod_subresource and (kcreate or kget) and ka.target.subresource in (exec,attach)
         desc: |
           Detect any attempt to attach/exec to a pod
         output: Attach/Exec to pod (user=%ka.user.name pod=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace action=%ka.target.subresource command=%ka.uri.param[command])

--- a/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
@@ -3,6 +3,7 @@ apiVersion: deckhouse.io/v1alpha1
 kind: FalcoAuditRules
 metadata:
   name: fstec
+  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
 spec:
   rules:
     - macro:

--- a/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
@@ -293,7 +293,7 @@ spec:
           kevt and pod_subresource and kmodify and ka.target.subresource in (ephemeralcontainers) and not user_known_pod_debug_activities
         desc: |
           Detect any ephemeral container created
-        output: Ephemeral container is created in pod (user=%ka.user.name pod=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace ephemeral_container_name=%jevt.value[/requestObject/ephemeralContainers/0/name] ephemeral_container_image=%jevt.value[/requestObject/ephemeralContainers/0/image])
+        output: Ephemeral container is created in pod (user=%ka.user.name pod=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace ephemeral_container_name=%jevt.value[/requestObject/spec/ephemeralContainers/0/name] ephemeral_container_image=%jevt.value[/requestObject/spec/ephemeralContainers/0/image])
         priority: Notice
         tags:
           - fstec
@@ -326,7 +326,7 @@ spec:
         condition: |
           kevt and (role or clusterrole) and (kmodify or kdelete) and (ka.target.name startswith "system:") and not ka.target.name in (system:coredns, system:managed-certificate-controller)
         desc: Detect any attempt to modify/delete a ClusterRole/Role starting with system
-        output: System ClusterRole/Role modified or deleted (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace action=%ka.verb)
+        output: System ClusterRole/Role modified or deleted (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource action=%ka.verb)
         priority: Warning
         tags:
           - fstec
@@ -440,7 +440,7 @@ spec:
             or (evt.type in (recvfrom,recvmsg))
           ) and fd.sport=22
         desc: Detect Inbound SSH Connection
-        output: Inbound SSH Connection (command=%proc.cmdline pid=%proc.pid connection=%fd.name user=%user.name user_loginuid=%user.loginuid container_id=%container.id image=%container.image.repository type=%evt.type)
+        output: Inbound SSH Connection (command=%proc.cmdline pid=%proc.pid connection=%fd.name user=%user.name user_loginuid=%user.loginuid type=%evt.type)
         priority: Notice
         tags:
           - fstec

--- a/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   rules:
     - macro:
-        name: never_true
-        condition: (evt.num=0)
-    - macro:
         name: always_true
         condition: (evt.num>=0)
     - macro:
@@ -19,20 +16,11 @@ spec:
         name: open_read
         condition: (evt.type in (open,openat,openat2) and evt.is_open_read=true and fd.typechar='f' and fd.num>=0)
     - macro:
-        name: open_directory
-        condition: (evt.type in (open,openat,openat2) and evt.is_open_read=true and fd.typechar='d' and fd.num>=0)
-    - macro:
-        name: open_file_failed
-        condition: (evt.type in (open,openat,openat2) and fd.typechar='f' and fd.num=-1 and evt.res startswith E)
-    - macro:
         name: chmod
         condition: (evt.type in (chmod, fchmod, fchmodat) and evt.dir=<)
     - macro:
         name: rename
         condition: (evt.type in (rename, renameat, renameat2))
-    - macro:
-        name: mkdir
-        condition: (evt.type in (mkdir, mkdirat))
     - macro:
         name: remove
         condition: (evt.type in (rmdir, unlink, unlinkat))
@@ -45,9 +33,6 @@ spec:
     - macro:
         name: spawned_process
         condition: (evt.type in (execve, execveat) and evt.dir=<)
-    - macro:
-        name: proc_name_exists
-        condition: (proc.name!="<NA>")
     - macro:
         name: package_mgmt_ancestor_procs
         condition: proc.pname in (package_mgmt_binaries) or proc.aname[2] in (package_mgmt_binaries) or proc.aname[3] in (package_mgmt_binaries) or proc.aname[4] in (package_mgmt_binaries)
@@ -108,9 +93,6 @@ spec:
         name: writable_verbs
         condition: kcreate or kmodify or kdelete
     - macro:
-        name: namespace
-        condition: ka.target.resource=namespaces
-    - macro:
         name: serviceaccount
         condition: ka.target.resource=serviceaccounts
     - macro:
@@ -122,9 +104,6 @@ spec:
     - macro:
         name: role
         condition: ka.target.resource=roles
-    - macro:
-        name: secret
-        condition: ka.target.resource=secrets
     - macro:
         name: pod
         condition: ka.target.resource=pods and not ka.target.subresource exists
@@ -142,12 +121,6 @@ spec:
         condition: (always_true)
     - macro:
         name: user_known_package_manager_in_container
-        condition: (always_true)
-    - macro:
-        name: user_known_exec_pod_activities
-        condition: (always_true)
-    - macro:
-        name: user_known_pod_debug_activities
         condition: (always_true)
     - macro:
         name: system_namespace
@@ -276,7 +249,7 @@ spec:
         source: K8sAudit
 
     - rule:
-        name: Attach/Exec Pod fstec
+        name: Attach/Exec Pod
         condition: |
           kevt_started and pod_subresource and (kcreate or kget) and ka.target.subresource in (exec,attach)
         desc: |
@@ -290,7 +263,7 @@ spec:
     - rule:
         name: EphemeralContainers created
         condition: |
-          kevt and pod_subresource and kmodify and ka.target.subresource in (ephemeralcontainers) and not user_known_pod_debug_activities
+          kevt and pod_subresource and kmodify and ka.target.subresource in (ephemeralcontainers)
         desc: |
           Detect any ephemeral container created
         output: Ephemeral container is created in pod (user=%ka.user.name pod=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace ephemeral_container_name=%jevt.value[/requestObject/spec/ephemeralContainers/0/name] ephemeral_container_image=%jevt.value[/requestObject/spec/ephemeralContainers/0/image])

--- a/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
@@ -3,7 +3,6 @@ apiVersion: deckhouse.io/v1alpha1
 kind: FalcoAuditRules
 metadata:
   name: fstec
-  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
 spec:
   rules:
     - macro:

--- a/modules/040-control-plane-manager/hooks/audit_policy.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy.go
@@ -134,7 +134,7 @@ func handleAuditPolicy(input *go_hook.HookInput) error {
 }
 
 func appendBasicPolicyRules(policy *audit.Policy, extraData []go_hook.FilterResult) {
-	var appendDropResourcesRule = func(resource audit.GroupResources) {
+	appendDropResourcesRule := func(resource audit.GroupResources) {
 		rule := audit.PolicyRule{
 			Level: audit.LevelNone,
 			Resources: []audit.GroupResources{
@@ -273,6 +273,37 @@ func appendBasicPolicyRules(policy *audit.Policy, extraData []go_hook.FilterResu
 		}
 		policy.Rules = append(policy.Rules, rule)
 	}
+
+	policy.Rules = append(policy.Rules, audit.PolicyRule{
+		Level:      audit.LevelRequestResponse,
+		Verbs:      []string{"create", "delete", "patch", "update"},
+		Resources:  []audit.GroupResources{{Resources: []string{"pods"}}},
+		OmitStages: []audit.Stage{audit.StageRequestReceived},
+	})
+	policy.Rules = append(policy.Rules, audit.PolicyRule{
+		Level:      audit.LevelRequestResponse,
+		Verbs:      []string{"create", "delete"},
+		Resources:  []audit.GroupResources{{Group: "", Resources: []string{"serviceaccounts"}}},
+		OmitStages: []audit.Stage{audit.StageRequestReceived},
+	})
+	policy.Rules = append(policy.Rules, audit.PolicyRule{
+		Level:      audit.LevelRequestResponse,
+		Verbs:      []string{"create", "update", "delete", "patch"},
+		Resources:  []audit.GroupResources{{Group: "rbac.authorization.k8s.io", Resources: []string{"roles", "clusterroles"}}},
+		OmitStages: []audit.Stage{audit.StageRequestReceived},
+	})
+	policy.Rules = append(policy.Rules, audit.PolicyRule{
+		Level:      audit.LevelRequestResponse,
+		Verbs:      []string{"create", "update", "delete"},
+		Resources:  []audit.GroupResources{{Group: "rbac.authorization.k8s.io", Resources: []string{"clusterrolebindings"}}},
+		OmitStages: []audit.Stage{audit.StageRequestReceived},
+	})
+	policy.Rules = append(policy.Rules, audit.PolicyRule{
+		Level:      audit.LevelRequestResponse,
+		Verbs:      []string{"create"},
+		Resources:  []audit.GroupResources{{Resources: []string{"pods/exec", "pods/attach", "pods/ephemeralcontainers"}}},
+		OmitStages: []audit.Stage{audit.StageRequestReceived},
+	})
 }
 
 func appendAdditionalPolicyRules(policy *audit.Policy, data *[]byte) error {

--- a/modules/040-control-plane-manager/hooks/audit_policy.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy.go
@@ -273,10 +273,14 @@ func appendBasicPolicyRules(policy *audit.Policy, extraData []go_hook.FilterResu
 		}
 		policy.Rules = append(policy.Rules, rule)
 	}
+
 	// fstec
+	// - K8s Pod created
+	// - K8s Pod deleted
+	// - Container tag is not @sha256
 	{
 		rule := audit.PolicyRule{
-			Level: audit.LevelRequestResponse,
+			Level: audit.LevelRequest,
 			Resources: []audit.GroupResources{
 				{
 					Resources: []string{"pods"},
@@ -289,9 +293,14 @@ func appendBasicPolicyRules(policy *audit.Policy, extraData []go_hook.FilterResu
 		}
 		policy.Rules = append(policy.Rules, rule)
 	}
+
+	// fstec
+	// - K8s ServiceAccount created
+	// - K8s ServiceAccount deleted
+	// - ServiceAccount created in a system namespace
 	{
 		rule := audit.PolicyRule{
-			Level: audit.LevelRequestResponse,
+			Level: audit.LevelMetadata,
 			Resources: []audit.GroupResources{
 				{
 					Group:     "",
@@ -305,9 +314,16 @@ func appendBasicPolicyRules(policy *audit.Policy, extraData []go_hook.FilterResu
 		}
 		policy.Rules = append(policy.Rules, rule)
 	}
+
+	// fstec
+	// - ClusterRole with wildcard created
+	// - ClusterRole with write privileges created
+	// - System ClusterRole modified/deleted
+	// - K8s Role/ClusterRole created
+	// - K8s Role/ClusterRole deleted
 	{
 		rule := audit.PolicyRule{
-			Level: audit.LevelRequestResponse,
+			Level: audit.LevelRequest,
 			Resources: []audit.GroupResources{
 				{
 					Group:     "rbac.authorization.k8s.io",
@@ -321,9 +337,14 @@ func appendBasicPolicyRules(policy *audit.Policy, extraData []go_hook.FilterResu
 		}
 		policy.Rules = append(policy.Rules, rule)
 	}
+
+	// fstec
+	// - Attach to cluster-admin Role
+	// - K8s Role/ClusterRole binding created
+	// - K8s Role/ClusterRole binding deleted
 	{
 		rule := audit.PolicyRule{
-			Level: audit.LevelRequestResponse,
+			Level: audit.LevelRequest,
 			Resources: []audit.GroupResources{
 				{
 					Group:     "rbac.authorization.k8s.io",
@@ -337,9 +358,13 @@ func appendBasicPolicyRules(policy *audit.Policy, extraData []go_hook.FilterResu
 		}
 		policy.Rules = append(policy.Rules, rule)
 	}
+
+	// fstec
+	// - Attach/Exec Pod fstec
+	// - EphemeralContainers created
 	{
 		rule := audit.PolicyRule{
-			Level: audit.LevelRequestResponse,
+			Level: audit.LevelMetadata,
 			Resources: []audit.GroupResources{
 				{
 					Resources: []string{"pods/exec", "pods/attach", "pods/ephemeralcontainers"},

--- a/modules/040-control-plane-manager/hooks/audit_policy.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy.go
@@ -345,7 +345,7 @@ func appendBasicPolicyRules(policy *audit.Policy, extraData []go_hook.FilterResu
 					Resources: []string{"pods/exec", "pods/attach", "pods/ephemeralcontainers"},
 				},
 			},
-			Verbs: []string{"create"},
+			Verbs: []string{"get", "patch"},
 			OmitStages: []audit.Stage{
 				audit.StageRequestReceived,
 			},

--- a/modules/040-control-plane-manager/hooks/audit_policy.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy.go
@@ -273,37 +273,85 @@ func appendBasicPolicyRules(policy *audit.Policy, extraData []go_hook.FilterResu
 		}
 		policy.Rules = append(policy.Rules, rule)
 	}
-
-	policy.Rules = append(policy.Rules, audit.PolicyRule{
-		Level:      audit.LevelRequestResponse,
-		Verbs:      []string{"create", "delete", "patch", "update"},
-		Resources:  []audit.GroupResources{{Resources: []string{"pods"}}},
-		OmitStages: []audit.Stage{audit.StageRequestReceived},
-	})
-	policy.Rules = append(policy.Rules, audit.PolicyRule{
-		Level:      audit.LevelRequestResponse,
-		Verbs:      []string{"create", "delete"},
-		Resources:  []audit.GroupResources{{Group: "", Resources: []string{"serviceaccounts"}}},
-		OmitStages: []audit.Stage{audit.StageRequestReceived},
-	})
-	policy.Rules = append(policy.Rules, audit.PolicyRule{
-		Level:      audit.LevelRequestResponse,
-		Verbs:      []string{"create", "update", "delete", "patch"},
-		Resources:  []audit.GroupResources{{Group: "rbac.authorization.k8s.io", Resources: []string{"roles", "clusterroles"}}},
-		OmitStages: []audit.Stage{audit.StageRequestReceived},
-	})
-	policy.Rules = append(policy.Rules, audit.PolicyRule{
-		Level:      audit.LevelRequestResponse,
-		Verbs:      []string{"create", "update", "delete"},
-		Resources:  []audit.GroupResources{{Group: "rbac.authorization.k8s.io", Resources: []string{"clusterrolebindings"}}},
-		OmitStages: []audit.Stage{audit.StageRequestReceived},
-	})
-	policy.Rules = append(policy.Rules, audit.PolicyRule{
-		Level:      audit.LevelRequestResponse,
-		Verbs:      []string{"create"},
-		Resources:  []audit.GroupResources{{Resources: []string{"pods/exec", "pods/attach", "pods/ephemeralcontainers"}}},
-		OmitStages: []audit.Stage{audit.StageRequestReceived},
-	})
+	// fstec
+	{
+		rule := audit.PolicyRule{
+			Level: audit.LevelRequestResponse,
+			Resources: []audit.GroupResources{
+				{
+					Resources: []string{"pods"},
+				},
+			},
+			Verbs: []string{"create", "delete", "patch", "update"},
+			OmitStages: []audit.Stage{
+				audit.StageRequestReceived,
+			},
+		}
+		policy.Rules = append(policy.Rules, rule)
+	}
+	{
+		rule := audit.PolicyRule{
+			Level: audit.LevelRequestResponse,
+			Resources: []audit.GroupResources{
+				{
+					Group:     "",
+					Resources: []string{"serviceaccounts"},
+				},
+			},
+			Verbs: []string{"create", "delete"},
+			OmitStages: []audit.Stage{
+				audit.StageRequestReceived,
+			},
+		}
+		policy.Rules = append(policy.Rules, rule)
+	}
+	{
+		rule := audit.PolicyRule{
+			Level: audit.LevelRequestResponse,
+			Resources: []audit.GroupResources{
+				{
+					Group:     "rbac.authorization.k8s.io",
+					Resources: []string{"roles", "clusterroles"},
+				},
+			},
+			Verbs: []string{"create", "update", "delete", "patch"},
+			OmitStages: []audit.Stage{
+				audit.StageRequestReceived,
+			},
+		}
+		policy.Rules = append(policy.Rules, rule)
+	}
+	{
+		rule := audit.PolicyRule{
+			Level: audit.LevelRequestResponse,
+			Resources: []audit.GroupResources{
+				{
+					Group:     "rbac.authorization.k8s.io",
+					Resources: []string{"clusterrolebindings"},
+				},
+			},
+			Verbs: []string{"create", "update", "delete"},
+			OmitStages: []audit.Stage{
+				audit.StageRequestReceived,
+			},
+		}
+		policy.Rules = append(policy.Rules, rule)
+	}
+	{
+		rule := audit.PolicyRule{
+			Level: audit.LevelRequestResponse,
+			Resources: []audit.GroupResources{
+				{
+					Resources: []string{"pods/exec", "pods/attach", "pods/ephemeralcontainers"},
+				},
+			},
+			Verbs: []string{"create"},
+			OmitStages: []audit.Stage{
+				audit.StageRequestReceived,
+			},
+		}
+		policy.Rules = append(policy.Rules, rule)
+	}
 }
 
 func appendAdditionalPolicyRules(policy *audit.Policy, data *[]byte) error {

--- a/modules/040-control-plane-manager/hooks/audit_policy.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy.go
@@ -250,6 +250,25 @@ func appendBasicPolicyRules(policy *audit.Policy, extraData []go_hook.FilterResu
 
 		policy.Rules = append(policy.Rules, rule)
 	}
+	// fstec
+	// - K8s Pod created
+	// - K8s Pod deleted
+	// - Container tag is not @sha256
+	{
+		rule := audit.PolicyRule{
+			Level: audit.LevelRequest,
+			Resources: []audit.GroupResources{
+				{
+					Resources: []string{"pods"},
+				},
+			},
+			Verbs: []string{"create", "delete", "patch", "update"},
+			OmitStages: []audit.Stage{
+				audit.StageRequestReceived,
+			},
+		}
+		policy.Rules = append(policy.Rules, rule)
+	}
 	// A rule collecting logs about actions taken on the resources in system namespaces.
 	{
 		rule := audit.PolicyRule{
@@ -270,26 +289,6 @@ func appendBasicPolicyRules(policy *audit.Policy, extraData []go_hook.FilterResu
 			Verbs:      []string{"list"},
 			Namespaces: []string{}, // every namespace
 			// no stage omitted, since apiserver might crash with OOM before it responds, and we want to catch it
-		}
-		policy.Rules = append(policy.Rules, rule)
-	}
-
-	// fstec
-	// - K8s Pod created
-	// - K8s Pod deleted
-	// - Container tag is not @sha256
-	{
-		rule := audit.PolicyRule{
-			Level: audit.LevelRequest,
-			Resources: []audit.GroupResources{
-				{
-					Resources: []string{"pods"},
-				},
-			},
-			Verbs: []string{"create", "delete", "patch", "update"},
-			OmitStages: []audit.Stage{
-				audit.StageRequestReceived,
-			},
 		}
 		policy.Rules = append(policy.Rules, rule)
 	}
@@ -364,7 +363,7 @@ func appendBasicPolicyRules(policy *audit.Policy, extraData []go_hook.FilterResu
 	// - EphemeralContainers created
 	{
 		rule := audit.PolicyRule{
-			Level: audit.LevelMetadata,
+			Level: audit.LevelRequest,
 			Resources: []audit.GroupResources{
 				{
 					Resources: []string{"pods/exec", "pods/attach", "pods/ephemeralcontainers"},

--- a/modules/040-control-plane-manager/hooks/audit_policy_test.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_test.go
@@ -199,11 +199,11 @@ rules:
 			Expect(saRule.Level).To(Equal(audit.LevelMetadata))
 			Expect(saRule.Users).To(Equal(allServiceAccounts))
 
-			namespaceRule := policy.Rules[len(policy.Rules)-7]
+			namespaceRule := policy.Rules[len(policy.Rules)-6]
 			Expect(namespaceRule.Level).To(Equal(audit.LevelMetadata))
 			Expect(namespaceRule.Namespaces).To(Equal(auditPolicyBasicNamespaces))
 
-			listRule := policy.Rules[len(policy.Rules)-6]
+			listRule := policy.Rules[len(policy.Rules)-5]
 			Expect(listRule.Level).To(Equal(audit.LevelMetadata))
 			Expect(listRule.Namespaces).To(BeEmpty())
 		})

--- a/modules/040-control-plane-manager/hooks/audit_policy_test.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_test.go
@@ -189,21 +189,21 @@ rules:
 			}
 
 			// All rules, except last three are dropping rules.
-			for i := 0; i < len(policy.Rules)-3; i++ {
+			for i := 0; i < len(policy.Rules)-8; i++ {
 				Expect(policy.Rules[i].Level).To(Equal(audit.LevelNone))
 			}
 
 			allServiceAccounts := append(auditPolicyBasicServiceAccounts, istiodServiceAccounts...)
 
-			saRule := policy.Rules[len(policy.Rules)-3]
+			saRule := policy.Rules[len(policy.Rules)-8]
 			Expect(saRule.Level).To(Equal(audit.LevelMetadata))
 			Expect(saRule.Users).To(Equal(allServiceAccounts))
 
-			namespaceRule := policy.Rules[len(policy.Rules)-2]
+			namespaceRule := policy.Rules[len(policy.Rules)-7]
 			Expect(namespaceRule.Level).To(Equal(audit.LevelMetadata))
 			Expect(namespaceRule.Namespaces).To(Equal(auditPolicyBasicNamespaces))
 
-			listRule := policy.Rules[len(policy.Rules)-1]
+			listRule := policy.Rules[len(policy.Rules)-6]
 			Expect(listRule.Level).To(Equal(audit.LevelMetadata))
 			Expect(listRule.Namespaces).To(BeEmpty())
 		})


### PR DESCRIPTION
## Description

Checked built-in `runtime-audit-engine` rules, made necessary corrections. Checked that all rules work and all fields have correct values (without `<NA>` in output)
Deleted unused macros. Changed order of rules for correct `runtime-audit-engine` operation

```
falco-rules.yaml | yq e '.spec.rules[] | select(.rule.source == "K8sAudit") | .rule.name' | sort -h
Attach to cluster-admin Role
Attach/Exec Pod
ClusterRole with Pod Exec created
ClusterRole with wildcard created
ClusterRole with write privileges created
Container tag is not @sha256
EphemeralContainers created
K8s Pod created
K8s Pod deleted
K8s Role/ClusterRole binding created
K8s Role/ClusterRole binding deleted
K8s Role/ClusterRole created
K8s Role/ClusterRole deleted
K8s ServiceAccount created
K8s ServiceAccount deleted
ServiceAccount created in a system namespace
System ClusterRole modified/deleted
```


## Why do we need it, and what problem does it solve?

Changes to make the built-in runtime-audit-engine rules work correctly

## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: fix
summary: fix runtime-audit-engine built-in rules
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
