### PR TITLE
Fix the hook error is no apiserver endpoints

### DIFF
--- a/modules/150-user-authn/hooks/discover_apiserver_endpoints.go
+++ b/modules/150-user-authn/hooks/discover_apiserver_endpoints.go
@@ -44,7 +44,7 @@ func applyKubernetesServicePortFilter(obj *unstructured.Unstructured) (go_hook.F
 	return ports[0].TargetPort.IntVal, nil
 }
 
-type KubernetesEndpoints []string
+type kubernetesEndpoints []string
 
 func applyKubernetesEndpointsFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	endpoints := &v1.Endpoints{}
@@ -53,7 +53,7 @@ func applyKubernetesEndpointsFilter(obj *unstructured.Unstructured) (go_hook.Fil
 		return nil, fmt.Errorf("cannot convert kubernetes service endpoints to endpoints: %v", err)
 	}
 
-	var parsedEndpoints KubernetesEndpoints
+	parsedEndpoints := make(kubernetesEndpoints, 0, len(endpoints.Subsets))
 	for _, subset := range endpoints.Subsets {
 		for _, address := range subset.Addresses {
 			parsedEndpoints = append(parsedEndpoints, address.IP)

--- a/modules/150-user-authn/hooks/discover_apiserver_endpoints_test.go
+++ b/modules/150-user-authn/hooks/discover_apiserver_endpoints_test.go
@@ -105,4 +105,37 @@ subsets:
 			})
 		})
 	})
+
+	Context("No APIServer endpoints", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes
+  namespace: default
+spec:
+  ports:
+  - targetPort: 6443
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: kubernetes
+  namespace: default
+subsets:
+- addresses: []
+`))
+			f.RunHook()
+		})
+
+		It("Should not generate an error", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+			Expect(f.ValuesGet("userAuthn.internal.kubernetesApiserverTargetPort").String()).To(Equal("6443"))
+			Expect(f.ValuesGet("userAuthn.internal.kubernetesApiserverAddresses").String()).To(Equal(`[]`))
+		})
+	})
+
 })


### PR DESCRIPTION
## Description
Fix hook internal error

## Why do we need it, and what problem does it solve?
Rarely, when no apiservers provided hook can generate an error:
```
 ModuleHookRun:/modules/user-authn:kubernetes:150-user-authn/hooks/discover_apiserver_endpoints.go:endpoints:Kubernetes:failures 8:2 errors occurred:
    * cannot apply values patch for module values
    * userAuthn.internal.kubernetesApiserverAddresses must be of type array: "null"
```
I don't think we have to block the whole queue while apiservers are not ready. When they become ready, hook will execute with the a new values.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Fix publishAPI hook error when apiservers are not ready.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
