### PR TITLE
[node-manager] the `get_crds` hook will fail with error if the node groups count in cluster is not equal to the calculated one

### DIFF
--- a/modules/040-node-manager/hooks/get_crds.go
+++ b/modules/040-node-manager/hooks/get_crds.go
@@ -501,6 +501,12 @@ func getCRDsHandler(input *go_hook.HookInput) error {
 	if !input.Values.Exists("nodeManager.internal") {
 		input.Values.Set("nodeManager.internal", map[string]interface{}{})
 	}
+
+	if len(input.Snapshots["ngs"]) != len(finalNodeGroups) {
+		return fmt.Errorf("incorrect final nodegroups count (%d) should be %d in snapshots. See errors above for additional information",
+			len(finalNodeGroups), len(input.Snapshots["ngs"]))
+	}
+
 	input.Values.Set("nodeManager.internal.nodeGroups", finalNodeGroups)
 	return nil
 }

--- a/modules/040-node-manager/hooks/get_crds_test.go
+++ b/modules/040-node-manager/hooks/get_crds_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hooks
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"testing"
@@ -784,82 +785,10 @@ metadata:
 		})
 
 		It("Proper NGs must be stored to nodeManager.internal.nodeGroups, hook must warn user about improper NG", func() {
-			Expect(f).To(ExecuteSuccessfully())
+			Expect(f).NotTo(ExecuteSuccessfully())
 
-			expectedJSON := `
-				[
-				  {
-				    "cloudInstances": {
-				      "classReference": {
-				        "kind": "D8TestInstanceClass",
-				        "name": "proper1"
-				      },
-				      "zones": [
-				        "a",
-						"b",
-						"c"
-				      ]
-				    },
-                    "nodeType": "CloudEphemeral",
-				    "name": "proper1",
-				    "manualRolloutID": "",
-                    "kubernetesVersion": "1.28",
-					"cri": {
-                      "type": "Containerd"
-                    },
-				    "instanceClass": null,
-				    "kubelet": {
-					"containerLogMaxSize": "50Mi",
-					"containerLogMaxFiles": 4,
-					"resourceReservation": {
-						"mode": "Auto"
-					},
-					"topologyManager": {}
-				    },
-                    "updateEpoch": "` + calculateEpoch("proper1", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
-				  },
-				  {
-				    "cloudInstances": {
-				      "classReference": {
-				        "kind": "D8TestInstanceClass",
-				        "name": "proper2"
-				      },
-				      "zones": [
-				        "a",
-				        "b"
-				      ]
-				    },
-                    "nodeType": "CloudEphemeral",
-				    "name": "proper2",
-				    "manualRolloutID": "",
-                    "kubernetesVersion": "1.28",
-					"cri": {
-                      "type": "Containerd"
-                    },
-				    "instanceClass": null,
-				    "kubelet": {
-					"containerLogMaxSize": "50Mi",
-					"containerLogMaxFiles": 4,
-					"resourceReservation": {
-						"mode": "Auto"
-					},
-					"topologyManager": {}
-				    },
-                    "updateEpoch": "` + calculateEpoch("proper2", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
-				  }
-				]
-			`
-			Expect(f.ValuesGet("nodeManager.internal.nodeGroups").String()).To(MatchJSON(expectedJSON))
-
-			Expect(f.LoggerOutput).Should(gbytes.Say("Wrong classReference: Kind ImproperInstanceClass is not allowed, the only allowed kind is D8TestInstanceClass."))
-
-			Expect(f.KubernetesGlobalResource("NodeGroup", "proper1").Field("status.error").Value()).To(Equal(""))
-			Expect(f.KubernetesGlobalResource("NodeGroup", "proper1").Field("status.kubernetesVersion").Value()).To(Equal("1.28"))
-
-			Expect(f.KubernetesGlobalResource("NodeGroup", "proper2").Field("status.error").Value()).To(Equal(""))
-			Expect(f.KubernetesGlobalResource("NodeGroup", "proper2").Field("status.kubernetesVersion").Value()).To(Equal("1.28"))
-
-			Expect(f.KubernetesGlobalResource("NodeGroup", "improper").Field("status.error").String()).To(Equal("Wrong classReference: Kind ImproperInstanceClass is not allowed, the only allowed kind is D8TestInstanceClass."))
+			Expect(bytes.Contains(f.LoggerOutput.Contents(), []byte("Wrong classReference: Kind ImproperInstanceClass is not allowed, the only allowed kind is D8TestInstanceClass.")))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`incorrect final nodegroups count (2) should be 3 in snapshots. See errors above for additional information`))
 		})
 	})
 
@@ -971,82 +900,10 @@ metadata:
 		})
 
 		It("Proper NGs must be stored to nodeManager.internal.nodeGroups, hook must warn user about improper NG", func() {
-			Expect(f).To(ExecuteSuccessfully())
+			Expect(f).NotTo(ExecuteSuccessfully())
 
-			expectedJSON := `
-				[
-				  {
-				    "cloudInstances": {
-				      "classReference": {
-				        "kind": "D8TestInstanceClass",
-				        "name": "proper1"
-				      },
-				      "zones": [
-				        "a",
-						"b",
-						"c"
-				      ]
-				    },
-                    "nodeType": "CloudEphemeral",
-				    "name": "proper1",
-				    "manualRolloutID": "",
-                    "kubernetesVersion": "1.28",
-					"cri": {
-                      "type": "Containerd"
-                    },
-				    "instanceClass": null,
-				    "kubelet": {
-					"containerLogMaxSize": "50Mi",
-					"containerLogMaxFiles": 4,
-					"resourceReservation": {
-						"mode": "Auto"
-					},
-					"topologyManager": {}
-				    },
-                    "updateEpoch": "` + calculateEpoch("proper1", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
-				  },
-				  {
-				    "cloudInstances": {
-				      "classReference": {
-				        "kind": "D8TestInstanceClass",
-				        "name": "proper2"
-				      },
-				      "zones": [
-				        "a",
-				        "b"
-				      ]
-				    },
-                    "nodeType": "CloudEphemeral",
-				    "name": "proper2",
-				    "manualRolloutID": "",
-                    "kubernetesVersion": "1.28",
-					"cri": {
-                      "type": "Containerd"
-                    },
-				    "instanceClass": null,
-				    "kubelet": {
-					"containerLogMaxSize": "50Mi",
-					"containerLogMaxFiles": 4,
-					"resourceReservation": {
-						"mode": "Auto"
-					},
-					"topologyManager": {}
-				    },
-                    "updateEpoch": "` + calculateEpoch("proper2", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
-				  }
-				]
-			`
-			Expect(f.ValuesGet("nodeManager.internal.nodeGroups").String()).To(MatchJSON(expectedJSON))
-
-			Expect(f.LoggerOutput).Should(gbytes.Say(`Wrong classReference: There is no valid instance class improper of type D8TestInstanceClass.`))
-
-			Expect(f.KubernetesGlobalResource("NodeGroup", "proper1").Field("status.error").Value()).To(Equal(""))
-			Expect(f.KubernetesGlobalResource("NodeGroup", "proper1").Field("status.kubernetesVersion").Value()).To(Equal("1.28"))
-
-			Expect(f.KubernetesGlobalResource("NodeGroup", "proper2").Field("status.error").Value()).To(Equal(""))
-			Expect(f.KubernetesGlobalResource("NodeGroup", "proper2").Field("status.kubernetesVersion").Value()).To(Equal("1.28"))
-
-			Expect(f.KubernetesGlobalResource("NodeGroup", "improper").Field("status.error").String()).To(Equal("Wrong classReference: There is no valid instance class improper of type D8TestInstanceClass."))
+			Expect(bytes.Contains(f.LoggerOutput.Contents(), []byte("Wrong classReference: There is no valid instance class improper of type D8TestInstanceClass.")))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`incorrect final nodegroups count (2) should be 3 in snapshots. See errors above for additional information`))
 		})
 	})
 
@@ -1057,82 +914,10 @@ metadata:
 		})
 
 		It("Proper NGs must be stored to nodeManager.internal.nodeGroups, hook must warn user about improper NG", func() {
-			Expect(f).To(ExecuteSuccessfully())
+			Expect(f).NotTo(ExecuteSuccessfully())
 
-			expectedJSON := `
-				[
-				  {
-				    "cloudInstances": {
-				      "classReference": {
-				        "kind": "D8TestInstanceClass",
-				        "name": "proper1"
-				      },
-				      "zones": [
-				        "a",
-						"b",
-						"c"
-				      ]
-				    },
-                    "nodeType": "CloudEphemeral",
-				    "name": "proper1",
-				    "manualRolloutID": "",
-                    "kubernetesVersion": "1.28",
-					"cri": {
-                      "type": "Containerd"
-                    },
-				    "instanceClass": null,
-				    "kubelet": {
-					"containerLogMaxSize": "50Mi",
-					"containerLogMaxFiles": 4,
-					"resourceReservation": {
-						"mode": "Auto"
-					},
-					"topologyManager": {}
-				    },
-                    "updateEpoch": "` + calculateEpoch("proper1", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
-				  },
-				  {
-				    "cloudInstances": {
-				      "classReference": {
-				        "kind": "D8TestInstanceClass",
-				        "name": "proper2"
-				      },
-				      "zones": [
-				        "a",
-				        "b"
-				      ]
-				    },
-                    "nodeType": "CloudEphemeral",
-				    "name": "proper2",
-				    "manualRolloutID": "",
-                    "kubernetesVersion": "1.28",
-					"cri": {
-                      "type": "Containerd"
-                    },
-				    "instanceClass": null,
-				    "kubelet": {
-					"containerLogMaxSize": "50Mi",
-					"containerLogMaxFiles": 4,
-					"resourceReservation": {
-						"mode": "Auto"
-					},
-					"topologyManager": {}
-				    },
-                    "updateEpoch": "` + calculateEpoch("proper2", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
-				  }
-				]
-			`
-			Expect(f.ValuesGet("nodeManager.internal.nodeGroups").String()).To(MatchJSON(expectedJSON))
-
-			Expect(f.LoggerOutput).Should(gbytes.Say(`unknown cloudInstances\.zones: \[xxx\]`))
-
-			Expect(f.KubernetesGlobalResource("NodeGroup", "proper1").Field("status.error").Value()).To(Equal(""))
-			Expect(f.KubernetesGlobalResource("NodeGroup", "proper1").Field("status.kubernetesVersion").Value()).To(Equal("1.28"))
-
-			Expect(f.KubernetesGlobalResource("NodeGroup", "proper2").Field("status.error").Value()).To(Equal(""))
-			Expect(f.KubernetesGlobalResource("NodeGroup", "proper2").Field("status.kubernetesVersion").Value()).To(Equal("1.28"))
-
-			Expect(f.KubernetesGlobalResource("NodeGroup", "improper").Field("status.error").String()).To(ContainSubstring("unknown cloudInstances.zones"))
+			Expect(bytes.Contains(f.LoggerOutput.Contents(), []byte("Wrong classReference: There is no valid instance class improper of type D8TestInstanceClass.")))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`incorrect final nodegroups count (2) should be 3 in snapshots. See errors above for additional information`))
 		})
 	})
 
@@ -1456,11 +1241,10 @@ spec: {}
 		})
 
 		It("NodeGroup values must be valid", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			// nodeGroup should not be rendered at all
-			Expect(f.ValuesGet("nodeManager.internal.nodeGroups").Array()).To(HaveLen(0))
-			// but we have an error in logs
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("Calculate capacity failed for: D8TestInstanceClass"))
+			Expect(f).NotTo(ExecuteSuccessfully())
+
+			Expect(bytes.Contains(f.LoggerOutput.Contents(), []byte("Calculate capacity failed for: D8TestInstanceClass")))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`incorrect final nodegroups count (0) should be 1 in snapshots. See errors above for additional information`))
 		})
 	})
 


### PR DESCRIPTION
## Description
The `get_crds` hook will fail with error if the node groups count in cluster is not equal to the calculated one.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

We had an indecent with dropping all machinedeployments and cloud nodes and we decide to add error if count calculated nodegroups not equals node groups in the cluster 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary:  The `get_crds` hook will fail with error if the node groups count in cluster is not equal to the calculated one.
impact_level: default
```
