### PR TITLE
[prometheus] Grafana v8 cleanup hook add label filter

### DIFF
--- a/modules/300-prometheus/hooks/grafana_v8_cleanup.go
+++ b/modules/300-prometheus/hooks/grafana_v8_cleanup.go
@@ -20,6 +20,7 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -44,6 +45,17 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 					MatchNames: []string{"d8-monitoring"},
 				},
 			},
+			LabelSelector: &v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "heritage",
+						Operator: v1.LabelSelectorOpIn,
+						Values: []string{
+							"deckhouse",
+						},
+					},
+				},
+			},
 			NameSelector: &types.NameSelector{MatchNames: []string{
 				"grafana",
 				"grafana-v8-dex-authenticator",
@@ -59,6 +71,17 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 					MatchNames: []string{"d8-monitoring"},
 				},
 			},
+			LabelSelector: &v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "heritage",
+						Operator: v1.LabelSelectorOpIn,
+						Values: []string{
+							"deckhouse",
+						},
+					},
+				},
+			},
 			NameSelector: &types.NameSelector{MatchNames: []string{
 				"grafana",
 				"grafana-v8-dex-authenticator",
@@ -72,6 +95,17 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			NamespaceSelector: &types.NamespaceSelector{
 				NameSelector: &types.NameSelector{
 					MatchNames: []string{"d8-monitoring"},
+				},
+			},
+			LabelSelector: &v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "heritage",
+						Operator: v1.LabelSelectorOpIn,
+						Values: []string{
+							"deckhouse",
+						},
+					},
 				},
 			},
 			NameSelector: &types.NameSelector{MatchNames: []string{
@@ -90,6 +124,17 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 					MatchNames: []string{"d8-monitoring"},
 				},
 			},
+			LabelSelector: &v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "heritage",
+						Operator: v1.LabelSelectorOpIn,
+						Values: []string{
+							"deckhouse",
+						},
+					},
+				},
+			},
 			NameSelector: &types.NameSelector{MatchNames: []string{
 				"grafana-v8-dex-authenticator",
 			}},
@@ -102,6 +147,17 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			NamespaceSelector: &types.NamespaceSelector{
 				NameSelector: &types.NameSelector{
 					MatchNames: []string{"d8-monitoring"},
+				},
+			},
+			LabelSelector: &v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "heritage",
+						Operator: v1.LabelSelectorOpIn,
+						Values: []string{
+							"deckhouse",
+						},
+					},
 				},
 			},
 			NameSelector: &types.NameSelector{MatchNames: []string{


### PR DESCRIPTION
## Description

Add additional label `heritage: deckhouse`filter for grafana v8 resources cleanup hook.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: chore
summary: Minor improvements
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
