### PR TITLE
[istio] fix api version for validations serviceentry ports

### DIFF
--- a/ee/modules/110-istio/templates/validations.yaml
+++ b/ee/modules/110-istio/templates/validations.yaml
@@ -1,6 +1,6 @@
 ---
 kind: ValidatingAdmissionPolicy
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: {{ if semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version }} admissionregistration.k8s.io/v1 {{ else }} admissionregistration.k8s.io/v1beta1 {{ end }}
 metadata:
   name: d8-istio-serviceentry-ports
   {{- include "helm_lib_module_labels" (list $) | nindent 2 }}
@@ -16,7 +16,7 @@ spec:
         operations: ["CREATE", "UPDATE"]
   failurePolicy: Ignore
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: {{ if semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version }} admissionregistration.k8s.io/v1 {{ else }} admissionregistration.k8s.io/v1beta1 {{ end }}
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: d8-istio-serviceentry-ports-binding

--- a/ee/modules/110-istio/templates/validations.yaml
+++ b/ee/modules/110-istio/templates/validations.yaml
@@ -1,6 +1,7 @@
+{{- if and (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicy")) (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicyBinding")) }}
 ---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
 kind: ValidatingAdmissionPolicy
-apiVersion: {{ if semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version }} admissionregistration.k8s.io/v1 {{ else }} admissionregistration.k8s.io/v1beta1 {{ end }}
 metadata:
   name: d8-istio-serviceentry-ports
   {{- include "helm_lib_module_labels" (list $) | nindent 2 }}
@@ -16,8 +17,8 @@ spec:
         operations: ["CREATE", "UPDATE"]
   failurePolicy: Ignore
 ---
-apiVersion: {{ if semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version }} admissionregistration.k8s.io/v1 {{ else }} admissionregistration.k8s.io/v1beta1 {{ end }}
 kind: ValidatingAdmissionPolicyBinding
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
 metadata:
   name: d8-istio-serviceentry-ports-binding
   {{- include "helm_lib_module_labels" (list $) | nindent 2 }}
@@ -31,3 +32,4 @@ spec:
         operations: ["CREATE", "UPDATE"]
   validationActions: ["Warn"]
 ---
+{{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Included `helm_lib_get_api_version_by_kind` library to dynamically render apiVersion  `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding` depending on `Capabilities.APIVersions`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

During e2e tests it was found out that api admissionregistration.k8s.io/v1beta1 is deprecated and since Kubernetes 1.30 version admissionregistration.k8s.io/v1 is used, helm chart validation condition is required.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Added kubernetes version check in helm chart.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
