### PR TITLE
[deckhouse-controller] Remove heritage label from deckhouse release

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -542,9 +542,6 @@ func (f *DeckhouseReleaseFetcher) createRelease(
 				v1alpha1.DeckhouseReleaseAnnotationNotified:    "false",
 				v1alpha1.DeckhouseReleaseAnnotationChangeCause: changeCause,
 			},
-			Labels: map[string]string{
-				"heritage": "deckhouse",
-			},
 		},
 		Spec: v1alpha1.DeckhouseReleaseSpec{
 			Version:       releaseMetadata.Version,

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
@@ -29,8 +29,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.16.0
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
@@ -29,8 +29,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.16.5
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
@@ -29,8 +29,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.16.3
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
@@ -29,8 +29,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.16.1
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
@@ -30,8 +30,6 @@ metadata:
     release.deckhouse.io/notified: "false"
     release.deckhouse.io/suspended: "true"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.16.0
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
@@ -29,8 +29,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.16.2
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
@@ -29,8 +29,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.16.1
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
@@ -29,8 +29,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.16.0
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
@@ -29,8 +29,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.16.0
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
@@ -29,8 +29,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.16.0
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
@@ -29,8 +29,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.16.0
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/restore-absent-releases-from-registry.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/restore-absent-releases-from-registry.yaml
@@ -23,8 +23,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.58.1
   resourceVersion: "1"
 spec:
@@ -44,8 +42,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.59.3
   resourceVersion: "1"
 spec:
@@ -65,8 +61,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.60.2
   resourceVersion: "1"
 spec:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-update-successfully.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-update-successfully.yaml
@@ -23,8 +23,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.32.3
   resourceVersion: "1"
 spec:
@@ -44,8 +42,6 @@ metadata:
     release.deckhouse.io/isUpdating: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
-  labels:
-    heritage: deckhouse
   name: v1.33.1
   resourceVersion: "1"
 spec:

--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -50,7 +50,7 @@ spec:
     - name: 'exclude-users'
       expression: '!(["system:apiserver", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler", "dhctl", "observability"].exists(e, (e == request.userInfo.username)))'
     - name: 'exclude-kinds'
-      expression: '!(has(request.kind) && ["StorageClass"].exists(e, (e == request.kind.kind)))'
+      expression: '!(has(request.kind) && ["StorageClass", "DeckhouseRelease", "ModuleRelease"].exists(e, (e == request.kind.kind)))'
     - name: 'exclude-restartedAt'
       expression: '!((has(object.spec) && has(object.spec.template) && has(object.spec.template.metadata)
           && has(oldObject.spec) && has(oldObject.spec.template) && has(oldObject.spec.template.metadata))


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Remove heritage label from deckhouse release

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

Impossible to update DeckhouseRelease in Manual update mode.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix DeckhouseRelease approval in the Manual update mode.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
