### PR TITLE
[dhctl] Add shellescape to sudo preflight

### DIFF
--- a/dhctl/pkg/preflight/sudoers.go
+++ b/dhctl/pkg/preflight/sudoers.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/alessio/shellescape"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
@@ -39,7 +40,7 @@ func (pc *Checker) CheckSudoIsAllowedForUser() error {
 }
 
 func callSudo(nodeInterface node.Interface, password string) error {
-	args := []string{"-Sv", "<<<", password}
+	args := []string{"-Sv", "<<<", shellescape.Quote(password)}
 	if password == "" {
 		args = []string{"-n", "echo", "-n"}
 	}


### PR DESCRIPTION
## Description

Add shellescape to sudo preflight check

## Why do we need it, and what problem does it solve?

If sudo password contains special shell characters like `$`, sudo preflight check will fail. To avoid issues like this, we should escape all special shell characters 

## Why do we need it in the patch release (if we do)?

v1.68 is affected, so we need to fix it

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Escape special shell characters in sudo preflight check.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
