### PR TITLE
[docs][operator-trivy] Update info about databases with vulnerabilities

### DIFF
--- a/ee/modules/500-operator-trivy/docs/README.md
+++ b/ee/modules/500-operator-trivy/docs/README.md
@@ -3,7 +3,7 @@ title: "The operator-trivy module"
 description: operator-trivy is a Deckhouse module for periodic scanning for vulnerabilities in a Kubernetes cluster.
 ---
 
-The module allows you to run periodic vulnerability scans. The module uses the [Trivy](https://github.com/aquasecurity/trivy) project.
+The module allows you to run a regular vulnerability scans of user images in runtime on known CVEs. The module uses the [Trivy](https://github.com/aquasecurity/trivy) project. [Public databases](https://github.com/aquasecurity/travy-db/tree/main/pkg/vulnsrc) are used for scanning vulnerabilities.
 
 Scanning is performed every 24 hours in namespaces that contain the label `security-scanning.deckhouse.io/enabled=""`.
 If there are no namespaces with this label in the cluster, the `default` namespace is scanned.

--- a/ee/modules/500-operator-trivy/docs/README_RU.md
+++ b/ee/modules/500-operator-trivy/docs/README_RU.md
@@ -3,7 +3,7 @@ title: "Модуль operator-trivy"
 description: operator-trivy — модуль Deckhouse для периодического сканирования на уязвимости в кластере Kubernetes. 
 ---
 
-Модуль позволяет запускать периодическое сканирование на уязвимости. Базируется на проекте [Trivy](https://github.com/aquasecurity/trivy).
+Модуль позволяет запускать регулярную проверку пользовательских образов в runtime на известные CVE, включая уязвимости Astra Linux, Redos и Altlinux. Базируется на проекте [Trivy](https://github.com/aquasecurity/trivy). Для сканирования используются [публичные базы](https://github.com/aquasecurity/trivy-db/tree/main/pkg/vulnsrc) уязвимостей, обогощаемые базами Astra Linux, ALT Linux и Redos.
 
 Модуль каждые 24 часа выполняет сканирование в пространствах имён, которые содержат метку `security-scanning.deckhouse.io/enabled=""`.
 Если в кластере отсутствуют пространства имён с указанной меткой, сканируется пространство имён `default`.

--- a/ee/modules/500-operator-trivy/docs/README_RU.md
+++ b/ee/modules/500-operator-trivy/docs/README_RU.md
@@ -3,7 +3,7 @@ title: "Модуль operator-trivy"
 description: operator-trivy — модуль Deckhouse для периодического сканирования на уязвимости в кластере Kubernetes. 
 ---
 
-Модуль позволяет запускать регулярную проверку пользовательских образов в runtime на известные CVE, включая уязвимости Astra Linux, Redos и Altlinux. Базируется на проекте [Trivy](https://github.com/aquasecurity/trivy). Для сканирования используются [публичные базы](https://github.com/aquasecurity/trivy-db/tree/main/pkg/vulnsrc) уязвимостей, обогощаемые базами Astra Linux, ALT Linux и Redos.
+Модуль позволяет запускать регулярную проверку пользовательских образов в runtime на известные CVE, включая уязвимости Astra Linux, Redos и ALT Linux. Базируется на проекте [Trivy](https://github.com/aquasecurity/trivy). Для сканирования используются [публичные базы](https://github.com/aquasecurity/trivy-db/tree/main/pkg/vulnsrc) уязвимостей, обогащаемые базами Astra Linux, ALT Linux и РЕД ОС.
 
 Модуль каждые 24 часа выполняет сканирование в пространствах имён, которые содержат метку `security-scanning.deckhouse.io/enabled=""`.
 Если в кластере отсутствуют пространства имён с указанной меткой, сканируется пространство имён `default`.


### PR DESCRIPTION
## Description

This pull request includes updates to the documentation of the `operator-trivy` module to provide more detailed information about its functionality and the sources used for vulnerability scanning.

Documentation updates:

* [`ee/modules/500-operator-trivy/docs/README.md`](diffhunk://#diff-861c441a1cade7abc857133b0319a59e2eae93ad3fe1b33e845ce4f919f3d684L6-R6): Updated the description to specify that the module scans user images in runtime for known CVEs using public databases.
* [`ee/modules/500-operator-trivy/docs/README_RU.md`](diffhunk://#diff-2d38f2dffe10d09819c85884602d59abb2711bb54ea217a35c59fa336d522cddL6-R6): Enhanced the description to include details about scanning user images in runtime for known CVEs, including vulnerabilities specific to Astra Linux, Redos, and Altlinux, and the use of public databases enriched with additional data.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: fix
summary: Updated info about databases with vulnerabilities.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
