### PR TITLE
[node-manager] ignore timeout error in handleDraining hook

### DIFF
--- a/go_lib/dependency/k8s/drain/default.go
+++ b/go_lib/dependency/k8s/drain/default.go
@@ -17,10 +17,10 @@ limitations under the License.
 package drain
 
 import (
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // This file contains default implementations of how to
@@ -34,7 +34,7 @@ func RunNodeDrain(drainer *Helper, nodeName string) error {
 	// TODO(justinsb): Ensure we have adequate e2e coverage of this function in library consumers
 	list, errs := drainer.GetPodsForDeletion(nodeName)
 	if errs != nil {
-		return utilerrors.NewAggregate(errs)
+		return errors.Join(errs...)
 	}
 	if warnings := list.Warnings(); warnings != "" {
 		fmt.Fprintf(drainer.ErrOut, "WARNING: %s\n", warnings)

--- a/go_lib/dependency/k8s/drain/drain.go
+++ b/go_lib/dependency/k8s/drain/drain.go
@@ -48,9 +48,7 @@ const (
 )
 
 type DrainTimeoutError struct {
-	PodName   string
-	Namespace string
-	Timeout   time.Duration
+	Timeout time.Duration
 }
 
 func (e *DrainTimeoutError) Error() string {
@@ -300,9 +298,7 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 				}
 				select {
 				case <-ctx.Done():
-					returnCh <- &DrainTimeoutError{
-						PodName:   pod.Name,
-						Namespace: pod.Namespace,
+					returnCh <- &DrainTimeoutError{,
 						Timeout:   globalTimeout,
 					}
 					return
@@ -453,7 +449,9 @@ func waitForDelete(params waitForDeleteParams) ([]corev1.Pod, error) {
 		if len(pendingPods) > 0 {
 			select {
 			case <-params.ctx.Done():
-				return false, fmt.Errorf("global timeout reached: %v", params.globalTimeout)
+				return false, &DrainTimeoutError{
+					Timeout: params.globalTimeout,
+				}
 			default:
 				return false, nil
 			}

--- a/go_lib/dependency/k8s/drain/drain.go
+++ b/go_lib/dependency/k8s/drain/drain.go
@@ -52,7 +52,7 @@ type DrainTimeoutError struct {
 }
 
 func (e *DrainTimeoutError) Error() string {
-	return fmt.Sprintf("error when evicting pod %q -n %q: global timeout reached: %v", e.PodName, e.Namespace, e.Timeout)
+	return fmt.Sprintf("drain timeout reached: %v", e.Timeout)
 }
 
 // Helper contains the parameters to control the behaviour of drainer
@@ -298,8 +298,8 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 				}
 				select {
 				case <-ctx.Done():
-					returnCh <- &DrainTimeoutError{,
-						Timeout:   globalTimeout,
+					returnCh <- &DrainTimeoutError{
+						Timeout: globalTimeout,
 					}
 					return
 				default:

--- a/go_lib/dependency/k8s/drain/drain.go
+++ b/go_lib/dependency/k8s/drain/drain.go
@@ -19,7 +19,6 @@ package drain
 import (
 	"context"
 	"errors"
-	goerr "errors"
 	"fmt"
 	"io"
 	"math"
@@ -361,7 +360,7 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 	}
 
 	doneCount := 0
-	var errors []error
+	var errs []error
 
 	numPods := len(pods)
 	for doneCount < numPods {
@@ -369,12 +368,12 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 		case err := <-returnCh:
 			doneCount++
 			if err != nil {
-				errors = append(errors, err)
+				errs = append(errs, err)
 			}
 		}
 	}
 
-	return goerr.Join(errors...)
+	return errors.Join(errs...)
 }
 
 func (d *Helper) deletePods(pods []corev1.Pod, getPodFn func(namespace, name string) (*corev1.Pod, error)) error {

--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -211,7 +211,7 @@ func handleDraining(input *go_hook.HookInput, dc dependency.Container) error {
 			input.PatchCollector.Create(event, object_patch.UpdateIfExists())
 			input.MetricsCollector.Set("d8_node_draining", 1, map[string]string{"node": drainedNode.NodeName, "message": drainedNode.Err.Error()})
 			if shouldIgnoreErr {
-				input.Logger.Errorf("node %q drain error skiped: %s", drainedNode.NodeName, drainedNode.Err)
+				input.Logger.Errorf("node %q drain error skipped: %s", drainedNode.NodeName, drainedNode.Err)
 			} else {
 				continue
 			}

--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -206,7 +206,7 @@ func handleDraining(input *go_hook.HookInput, dc dependency.Container) error {
 	for drainedNode := range drainingNodesC {
 		if drainedNode.Err != nil {
 			input.Logger.Errorf("node %q drain failed: %s", drainedNode.NodeName, drainedNode.Err)
-			shouldIgnoreErr = handleDrainError(err)
+			shouldIgnoreErr = handleDrainError(drainedNode.Err)
 			event := drainedNode.buildEvent()
 			input.PatchCollector.Create(event, object_patch.UpdateIfExists())
 			input.MetricsCollector.Set("d8_node_draining", 1, map[string]string{"node": drainedNode.NodeName, "message": drainedNode.Err.Error()})

--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -206,7 +206,7 @@ func handleDraining(input *go_hook.HookInput, dc dependency.Container) error {
 	for drainedNode := range drainingNodesC {
 		if drainedNode.Err != nil {
 			input.Logger.Errorf("node %q drain failed: %s", drainedNode.NodeName, drainedNode.Err)
-			shouldIgnoreErr = errors.Is(err, drain.ErrDrainTimeout)
+			shouldIgnoreErr = errors.Is(drainedNode.Err, drain.ErrDrainTimeout)
 			event := drainedNode.buildEvent()
 			input.PatchCollector.Create(event, object_patch.UpdateIfExists())
 			input.MetricsCollector.Set("d8_node_draining", 1, map[string]string{"node": drainedNode.NodeName, "message": drainedNode.Err.Error()})

--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -18,8 +18,8 @@ package hooks
 
 import (
 	"context"
-	"errors"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -202,11 +202,11 @@ func handleDraining(input *go_hook.HookInput, dc dependency.Container) error {
 	}()
 
 	input.MetricsCollector.Expire("d8_node_draining")
-	var drainTimeoutErr *drain.DrainTimeoutError
 	var shouldIgnoreErr bool
 	for drainedNode := range drainingNodesC {
 		if drainedNode.Err != nil {
-			if errors.As(drainedNode.Err, &drainTimeoutErr) {
+			input.Logger.Errorf("Drain error type is %T with text: %v", drainedNode.Err, drainedNode.Err)
+			if strings.Contains(err.Error(), "drain timeout reached:") {
 				shouldIgnoreErr = true
 				input.Logger.Errorf("node %q drain timeout: %s", drainedNode.NodeName, drainedNode.Err)
 			} else {


### PR DESCRIPTION
## Description

handleDraining hook does not consider timeout to be a critical error and continues working

test: https://github.com/deckhouse/deckhouse/pull/12542#issuecomment-2721351697

## Why do we need it, and what problem does it solve?

handleDraining hook does cordon and drain node, this hook has a timeout. In some cases drain cannot be executed at the right time for various reasons, such as an incorrectly configured PDB. This results in the hook never being executed


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: ignore timeout error in handleDraining hook
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
