### PR TITLE
[candi] Fix disable_unattended_upgrades bashible step

### DIFF
--- a/candi/bashible/common-steps/all/002_disable_unattended_upgrades.sh.tpl
+++ b/candi/bashible/common-steps/all/002_disable_unattended_upgrades.sh.tpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if ! systemctl list-unit-files unattended-upgrades.service > /dev/null 2>&1; then
+if ! systemctl list-unit-files unattended-upgrades.service >/dev/null 2>&1; then
   exit 0
 fi
 

--- a/candi/bashible/common-steps/all/002_disable_unattended_upgrades.sh.tpl
+++ b/candi/bashible/common-steps/all/002_disable_unattended_upgrades.sh.tpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if ! systemctl list-unit-files unattended-upgrades  > /dev/null 2>&1; then
+if ! systemctl list-unit-files unattended-upgrades.service > /dev/null 2>&1; then
   exit 0
 fi
 


### PR DESCRIPTION
## Description
Fix `disable_unattended_upgrades` bashible step

## Why do we need it, and what problem does it solve?
Step not working

```
root@kovalkov-master-0:~# systemctl list-unit-files unattended-upgrades
UNIT FILE STATE PRESET

0 unit files listed.
root@kovalkov-master-0:~# systemctl list-unit-files unattended-upgrades.service
UNIT FILE                   STATE   PRESET
unattended-upgrades.service enabled enabled

1 unit files listed.
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix `disable_unattended_upgrades` bashible step
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
