### PR TITLE
[dhctl] Add opportunity to bootstrap terranodes parallel with env DHCTL_PARALLEL_CLOUD_PERMANENT_NODES_BOOTSTRAP revert sequentially by default 

### DIFF
--- a/dhctl/pkg/operations/converge/runner.go
+++ b/dhctl/pkg/operations/converge/runner.go
@@ -193,7 +193,12 @@ func (r *runner) convergeTerraNodes(ctx *context.Context, metaConfig *config.Met
 
 	log.DebugF("NodeGroups for creating %v\n", nodeGroupsWithoutStateInCluster)
 
-	if err := operations.ParallelCreateNodeGroup(ctx.KubeClient(), metaConfig, nodeGroupsWithoutStateInCluster, ctx.Terraform()); err != nil {
+	bootstrapNewNodeGroups := operations.ParallelCreateNodeGroup
+	if operations.IsSequentialNodesBootstrap() {
+		bootstrapNewNodeGroups = operations.BootstrapSequentialTerraNodes
+	}
+
+	if err := bootstrapNewNodeGroups(ctx.KubeClient(), metaConfig, nodeGroupsWithoutStateInCluster, ctx.Terraform()); err != nil {
 		return err
 	}
 

--- a/dhctl/pkg/operations/nodebootstrap.go
+++ b/dhctl/pkg/operations/nodebootstrap.go
@@ -33,7 +33,11 @@ import (
 )
 
 func IsSequentialNodesBootstrap() bool {
-	return os.Getenv("DHCTL_SEQUENTIAL_CLOUD_PERMANENT_NODES_BOOTSTRAP") == "yes"
+	if os.Getenv("DHCTL_PARALLEL_CLOUD_PERMANENT_NODES_BOOTSTRAP") == "yes" {
+		return false
+	}
+
+	return true
 }
 
 func NodeName(cfg *config.MetaConfig, nodeGroupName string, index int) string {

--- a/dhctl/pkg/operations/nodebootstrap.go
+++ b/dhctl/pkg/operations/nodebootstrap.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
@@ -30,6 +31,10 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
+
+func IsSequentialNodesBootstrap() bool {
+	return os.Getenv("DHCTL_SEQUENTIAL_CLOUD_PERMANENT_NODES_BOOTSTRAP") == "yes"
+}
 
 func NodeName(cfg *config.MetaConfig, nodeGroupName string, index int) string {
 	return fmt.Sprintf("%s-%s-%v", cfg.ClusterPrefix, nodeGroupName, index)
@@ -77,6 +82,34 @@ func BootstrapAdditionalNode(kubeCl *client.KubernetesClient, cfg *config.MetaCo
 		return err
 	}
 
+	return nil
+}
+
+func BootstrapSequentialTerraNodes(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, terraNodeGroups []config.TerraNodeGroupSpec, terraformContext *terraform.TerraformContext) error {
+	for _, ng := range terraNodeGroups {
+		err := log.Process("bootstrap", fmt.Sprintf("Create %s NodeGroup", ng.Name), func() error {
+			err := entity.CreateNodeGroup(kubeCl, ng.Name, log.GetDefaultLogger(), metaConfig.NodeGroupManifest(ng))
+			if err != nil {
+				return err
+			}
+
+			cloudConfig, err := entity.GetCloudConfig(kubeCl, ng.Name, global.ShowDeckhouseLogs, log.GetDefaultLogger())
+			if err != nil {
+				return err
+			}
+
+			for i := 0; i < ng.Replicas; i++ {
+				err = BootstrapAdditionalNode(kubeCl, metaConfig, i, "static-node", ng.Name, cloudConfig, false, terraformContext)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Add opportunity to bootstrap terranodes parallel with env DHCTL_PARALLEL_CLOUD_PERMANENT_NODES_BOOTSTRAP revert sequentially by default 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
