### PR TITLE
[ci] Switch CI runners

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -47,7 +47,7 @@ steps:
 {!{- $ctx := index . 0 -}!}
 {!{- $buildType := index . 1 -}!}
 # <template: build_template>
-runs-on: [self-hosted, regular, selectel]
+runs-on: [self-hosted, selectel]
 outputs:
   tests_image_name: ${{ steps.build.outputs.tests_image_name }}
 steps:

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -142,7 +142,7 @@ jobs:
   security_scan_images:
     name: Security scan images
     if: ${{ needs.pull_request_info.outputs.security_rootless_scan == 'true' }}
-    runs-on: [ self-hosted, regular, selectel ]
+    runs-on: [self-hosted, selectel]
     needs:
       - git_info
       - pull_request_info

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -229,7 +229,7 @@ jobs:
   security_scan_images:
     name: {!{ $jobNames.security_scan_images }!}
     if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' }}
-    runs-on: [ self-hosted, regular, selectel ]
+    runs-on: [self-hosted, selectel]
     needs:
       - git_info
       - build_fe

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -34,7 +34,7 @@ jobs:
     if: |
       github.event.label.name == 'security/cve' ||
       (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
-    runs-on: [ self-hosted, regular, selectel ]
+    runs-on: [self-hosted, selectel]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"
       TAG: pr${{ github.event.number }}

--- a/.github/workflow_templates/cve-weekly.yml
+++ b/.github/workflow_templates/cve-weekly.yml
@@ -61,7 +61,7 @@ jobs:
     name: Main
     needs:
       - skip_tests_repos
-    runs-on: [ self-hosted, regular, selectel ]
+    runs-on: [self-hosted, selectel]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"
       TAG: ${{ github.event.inputs.release_branch || 'main' }}
@@ -84,7 +84,7 @@ jobs:
       fail-fast: false
       matrix:
         tag: ${{ fromJson(needs.fetch_tags_for_test.outputs.tag_matrix) }}
-    runs-on: [ self-hosted, regular ]
+    runs-on: [self-hosted, regular]
     steps:
   {!{ tmpl.Exec "checkout_full_step"           $ctx | strings.Indent 6 }!}
   {!{ tmpl.Exec "login_dev_registry_step"      $ctx | strings.Indent 6 }!}
@@ -108,7 +108,7 @@ jobs:
 #       - test_cve_report_channels
 # {!{- end }!}
 #     if: success() || failure()
-#     runs-on: [ self-hosted, regular ]
+#     runs-on: [self-hosted, regular]
 #     steps:
 #       - name: Clear output directory
 #         run: |

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -571,7 +571,7 @@ jobs:
     env:
       WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, selectel]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
@@ -954,7 +954,7 @@ jobs:
   security_scan_images:
     name: Security scan images
     if: ${{ needs.pull_request_info.outputs.security_rootless_scan == 'true' }}
-    runs-on: [ self-hosted, regular, selectel ]
+    runs-on: [self-hosted, selectel]
     needs:
       - git_info
       - pull_request_info

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -269,7 +269,7 @@ jobs:
     env:
       WERF_ENV: "FE"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, selectel]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -418,7 +418,7 @@ jobs:
     env:
       WERF_ENV: "FE"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, selectel]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
@@ -779,7 +779,7 @@ jobs:
     env:
       WERF_ENV: "EE"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, selectel]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
@@ -1140,7 +1140,7 @@ jobs:
     env:
       WERF_ENV: "SE"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, selectel]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
@@ -1501,7 +1501,7 @@ jobs:
     env:
       WERF_ENV: "SE-plus"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, selectel]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
@@ -1862,7 +1862,7 @@ jobs:
     env:
       WERF_ENV: "BE"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, selectel]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
@@ -2223,7 +2223,7 @@ jobs:
     env:
       WERF_ENV: "CE"
     # <template: build_template>
-    runs-on: [self-hosted, regular, selectel]
+    runs-on: [self-hosted, selectel]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
@@ -2931,7 +2931,7 @@ jobs:
   security_scan_images:
     name: Security scan images
     if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' }}
-    runs-on: [ self-hosted, regular, selectel ]
+    runs-on: [self-hosted, selectel]
     needs:
       - git_info
       - build_fe

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -32,7 +32,7 @@ jobs:
     if: |
       github.event.label.name == 'security/cve' ||
       (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
-    runs-on: [ self-hosted, regular, selectel ]
+    runs-on: [self-hosted, selectel]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"
       TAG: pr${{ github.event.number }}

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -63,7 +63,7 @@ jobs:
     name: Main
     needs:
       - skip_tests_repos
-    runs-on: [ self-hosted, regular, selectel ]
+    runs-on: [self-hosted, selectel]
     env:
       IMAGE: "dev-registry.deckhouse.io/sys/deckhouse-oss"
       TAG: ${{ github.event.inputs.release_branch || 'main' }}
@@ -198,7 +198,7 @@ jobs:
 #       - test_cve_report_main
 #
 #     if: success() || failure()
-#     runs-on: [ self-hosted, regular ]
+#     runs-on: [self-hosted, regular]
 #     steps:
 #       - name: Clear output directory
 #         run: |

--- a/.github/workflows/rootless-images-scan.yml
+++ b/.github/workflows/rootless-images-scan.yml
@@ -42,10 +42,10 @@ on:
         required: false
       pull_request_head_label:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
-        required: false 
+        required: false
   pull_request:
     types:
-      - synchronize 
+      - synchronize
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
@@ -85,7 +85,7 @@ jobs:
           echo "Triggered by: ${{ github.event_name }}"
           echo "Image tag: $image_tag"
   scan_images:
-    runs-on: [ self-hosted, regular, selectel ]
+    runs-on: [self-hosted, selectel]
     needs: check_trigger
     if: ${{ needs.check_trigger.outputs.image_tag != 'unknown' }}
     steps:


### PR DESCRIPTION
## Description
Switch CI runners.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Switch CI runners.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
