### PR TITLE
[cloud-provider-vcd](ccm) Fix a patch that ignored static nodes

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/patches/001_ignore_static_nodes.patch
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/patches/001_ignore_static_nodes.patch
@@ -1,12 +1,18 @@
+Subject: [PATCH] Ignore static nodes
+---
+Index: pkg/ccm/instances.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
 diff --git a/pkg/ccm/instances.go b/pkg/ccm/instances.go
-index 541e5fc..5704ac1 100644
---- a/pkg/ccm/instances.go
-+++ b/pkg/ccm/instances.go
-@@ -146,6 +146,10 @@ func (i *instances) CurrentNodeName(ctx context.Context, hostName string) (types
+--- a/pkg/ccm/instances.go	(revision f3f44d21165e798e1a8e1a14324b09e01fe35fd4)
++++ b/pkg/ccm/instances.go	(date 1741840814883)
+@@ -146,6 +146,10 @@
  func (i *instances) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
  	klog.Infof("instances.InstanceExistsByProviderID() called with provider ID [%s]", providerID)
  
-+	if providerID == "static://" {
++	if strings.HasPrefix(providerID, "static://") {
 +		return true, nil
 +	}
 +

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager/patches/001_ignore_static_nodes.patch
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager/patches/001_ignore_static_nodes.patch
@@ -1,12 +1,18 @@
+Subject: [PATCH] Ignore static nodes
+---
+Index: pkg/ccm/instances.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
 diff --git a/pkg/ccm/instances.go b/pkg/ccm/instances.go
-index 541e5fc..5704ac1 100644
---- a/pkg/ccm/instances.go
-+++ b/pkg/ccm/instances.go
-@@ -146,6 +146,10 @@ func (i *instances) CurrentNodeName(ctx context.Context, hostName string) (types
+--- a/pkg/ccm/instances.go	(revision a0a0e916a5eda50705f9f3e3b7da8471bd6ff763)
++++ b/pkg/ccm/instances.go	(date 1741840814883)
+@@ -146,6 +146,10 @@
  func (i *instances) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
  	klog.Infof("instances.InstanceExistsByProviderID() called with provider ID [%s]", providerID)
  
-+	if providerID == "static://" {
++	if strings.HasPrefix(providerID, "static://") {
 +		return true, nil
 +	}
 +


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Ignore a node if `providerID` has `static://` prefix.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need to ignore static nodes created by `CAPS`.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: Add a patch to `cloud-controller-manager` that ignores a node if `providerID` has `static://` prefix.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
