### PR TITLE
[deckhouse] set EnabledByModuleConfig condition for modules by default

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
@@ -268,6 +268,15 @@ func (m *Module) DisabledByModuleConfigMoreThan(timeout time.Duration) bool {
 	return false
 }
 
+func (m *Module) HasCondition(condName string) bool {
+	for _, cond := range m.Status.Conditions {
+		if cond.Type == condName {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *Module) GetVersion() string {
 	return m.Properties.Version
 }

--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -344,6 +344,10 @@ func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, 
 				module.Properties.Version = l.version
 			}
 
+			if !module.HasCondition(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+				module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleManager, v1alpha1.ModuleReasonDisabled, v1alpha1.ModuleMessageDisabled)
+			}
+
 			if !reflect.DeepEqual(moduleCopy.Properties, module.Properties) ||
 				!reflect.DeepEqual(moduleCopy.Labels, module.Labels) ||
 				!reflect.DeepEqual(moduleCopy.Annotations, module.Annotations) {

--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -286,7 +286,7 @@ func (l *Loader) LoadModulesFromFS(ctx context.Context) error {
 		}
 
 		if !module.HasCondition(v1alpha1.ModuleConditionEnabledByModuleConfig) {
-			module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleManager, v1alpha1.ModuleReasonDisabled, v1alpha1.ModuleMessageDisabled)
+			module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleConfig, v1alpha1.ModuleReasonDisabled, v1alpha1.ModuleMessageDisabled)
 			if err := l.client.Status().Update(ctx, &module); err != nil {
 				return fmt.Errorf("update status for the '%s' module: %w", module.Name, err)
 			}

--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -346,6 +346,9 @@ func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, 
 
 			if !module.HasCondition(v1alpha1.ModuleConditionEnabledByModuleConfig) {
 				module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleManager, v1alpha1.ModuleReasonDisabled, v1alpha1.ModuleMessageDisabled)
+				if err := l.client.Status().Update(ctx, module); err != nil {
+					return fmt.Errorf("update status for the '%s' module: %w", def.Name, err)
+				}
 			}
 
 			if !reflect.DeepEqual(moduleCopy.Properties, module.Properties) ||


### PR DESCRIPTION
## Description
It sets EnabledByModuleConfig condition by default for all modules.

## Why do we need it, and what problem does it solve?
Before 1.67, module releases were created by default, the process did not depend on a module enabling. After 1.67, module releases are created only if the module is enabled. And if a module is disabled(by config) more than 3 days - it`s deleted. But if a module was not enabled(there is no config) deckhouse does not consider the module as disabled and does not delete releases.  To fix it - module loader sets EnabledByModuleConfig condition if it is unset.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Set EnabledByModuleConfig condition by default for modules without this condition.
```
