### PR TITLE
[dhctl] Fix sudo and add preflight to bootstrap-phase abort

### DIFF
--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -23,6 +23,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/commander"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/destroy"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	terrastate "github.com/deckhouse/deckhouse/dhctl/pkg/state/terraform"
@@ -201,6 +202,27 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(forceAbortFromCache bool) erro
 
 	if err != nil {
 		return err
+	}
+
+	if err := terminal.AskBecomePassword(); err != nil {
+		return err
+	}
+
+	if metaConfig.IsStatic() {
+		deckhouseInstallConfig, err := config.PrepareDeckhouseInstallConfig(metaConfig)
+		if err != nil {
+			return err
+		}
+
+		if b.CommanderMode {
+			deckhouseInstallConfig.CommanderMode = b.CommanderMode
+			deckhouseInstallConfig.CommanderUUID = b.CommanderUUID
+		}
+		bootstrapState := NewBootstrapState(stateCache)
+		preflightChecker := preflight.NewChecker(b.NodeInterface, deckhouseInstallConfig, metaConfig, bootstrapState)
+		if err := preflightChecker.StaticSudo(); err != nil {
+			return err
+		}
 	}
 
 	if destroyer == nil {

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -457,6 +457,9 @@ func RunBashiblePipeline(nodeInterface node.Interface, cfg *config.MetaConfig, n
 
 			return nil
 		})
+		if err != nil {
+			return fmt.Errorf("cannot create %s directories: %w", app.DeckhouseNodeTmpPath, err)
+		}
 
 		// in end of pipeline steps bashible write "OK" to this file
 		// we need creating it before because we do not want handle errors from cat
@@ -470,6 +473,9 @@ func RunBashiblePipeline(nodeInterface node.Interface, cfg *config.MetaConfig, n
 			return nil
 		})
 	})
+	if err != nil {
+		return err
+	}
 
 	if wrapper, ok := nodeInterface.(*ssh.NodeInterfaceWrapper); ok {
 		cleanUpTunnel, err := setupRPPTunnel(wrapper.Client())

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -150,6 +150,37 @@ func (pc *Checker) Static() error {
 	return pc.bootstrapState.SetStaticPreflightchecksWasRan()
 }
 
+func (pc *Checker) StaticSudo() error {
+	_, err := pc.bootstrapState.StaticPreflightchecksWasRan()
+	if err != nil {
+		msg := fmt.Sprintf("Can not get state from cache: %v", err)
+		return errors.New(msg)
+	}
+
+	err = pc.do("Preflight checks for SSH and sudo", []checkStep{
+		{
+			fun:            pc.CheckSSHCredential,
+			successMessage: "ssh credential is correctly",
+			skipFlag:       app.SSHCredentialsCheckArgName,
+		},
+		{
+			fun:            pc.CheckSSHTunnel,
+			successMessage: "ssh tunnel between installer and node is possible",
+			skipFlag:       app.SSHForwardArgName,
+		},
+		{
+			fun:            pc.CheckSudoIsAllowedForUser,
+			successMessage: "sudo is allowed for user",
+			skipFlag:       app.SudoAllowedCheckArgName,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (pc *Checker) Cloud() error {
 	ready, err := pc.bootstrapState.CloudPreflightchecksWasRan()
 	if err != nil {

--- a/dhctl/pkg/system/node/ssh/frontend/command.go
+++ b/dhctl/pkg/system/node/ssh/frontend/command.go
@@ -102,23 +102,24 @@ func (c *Command) Sudo() {
 	passSent := false
 	c.WithMatchHandler(func(pattern string) string {
 		if pattern == "SudoPassword" {
+			var becomePass string
+
+			if c.Session.BecomePass != "" {
+				becomePass = c.Session.BecomePass
+			} else {
+				becomePass = app.BecomePass
+			}
 			if !passSent {
 				// send pass through stdin
 				log.DebugLn("Send become pass to cmd")
-				var becomePass string
-
-				if c.Session.BecomePass != "" {
-					becomePass = c.Session.BecomePass
-				} else {
-					becomePass = app.BecomePass
-				}
-
 				_, _ = c.Executor.Stdin.Write([]byte(becomePass + "\n"))
 				passSent = true
 			} else {
 				// Second prompt is error!
-				log.ErrorLn("Bad sudo password, exiting. TODO handle this correctly.")
-				os.Exit(1)
+				log.ErrorLn("Bad sudo password")
+				// sending wrong password again will raise an error in process.Run()
+				_, _ = c.Executor.Stdin.Write([]byte(becomePass + "\n"))
+				// os.Exit(1)
 			}
 			return "reset"
 		}


### PR DESCRIPTION
## Description

Fix [#12439](https://github.com/deckhouse/deckhouse/issues/12439)

## Why do we need it, and what problem does it solve?

If sudo password is wrong, bootstrap-phase abort just exits with non-readable error. So we'll add preflight checks to ensure what provided password is correct.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Add minimal preflight checks to bootstrap-phase abort.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
