### PR TITLE
[docs] Updated information about service account roles at Yandex Cloud

### DIFF
--- a/candi/cloud-providers/yandex/docs/ENVIRONMENT.md
+++ b/candi/cloud-providers/yandex/docs/ENVIRONMENT.md
@@ -19,7 +19,7 @@ You need to create a service account with the editor role with the cloud provide
 
 1. Assign the required roles to the newly created user for your cloud:
 
-   ```console
+   ```yaml
    yc resource-manager folder add-access-binding --id <folderID> --role compute.editor --subject serviceAccount:<userID>
    yc resource-manager folder add-access-binding --id <folderID> --role api-gateway.editor --subject serviceAccount:<userID>
    yc resource-manager folder add-access-binding --id <folderID> --role connection-manager.editor --subject serviceAccount:<userID>

--- a/candi/cloud-providers/yandex/docs/ENVIRONMENT.md
+++ b/candi/cloud-providers/yandex/docs/ENVIRONMENT.md
@@ -17,13 +17,18 @@ You need to create a service account with the editor role with the cloud provide
    name: deckhouse
    ```
 
-2. Assign the `editor` role to the newly created user:
+1. Assign the required roles to the newly created user for your cloud:
 
-   ```yaml
-   yc resource-manager folder add-access-binding --id <folderID> --role editor --subject serviceAccount:<userID>
+   ```console
+   yc resource-manager folder add-access-binding --id <folderID> --role compute.editor --subject serviceAccount:<userID>
+   yc resource-manager folder add-access-binding --id <folderID> --role api-gateway.editor --subject serviceAccount:<userID>
+   yc resource-manager folder add-access-binding --id <folderID> --role connection-manager.editor --subject serviceAccount:<userID>
+   yc resource-manager folder add-access-binding --id <folderID> --role vpc.admin --subject serviceAccount:<userID>
+   yc resource-manager folder add-access-binding --id <folderID> --role load-balancer.editor --subject serviceAccount:<userID>
+   yc resource-manager folder add-access-binding --id <folderID> --role logging.editor --subject serviceAccount:<userID>
    ```
 
-3. Create a JSON file containing the parameters for user authorization in the cloud. These parameters will be used to log in to the cloud:
+1. Create a JSON file containing the parameters for user authorization in the cloud. These parameters will be used to log in to the cloud:
 
    ```yaml
    yc iam key create --service-account-name deckhouse --output deckhouse-sa-key.json
@@ -38,6 +43,7 @@ You need to create a service account with the editor role with the cloud provide
 > Note that you need to increase the quotas using the Yandex console when provisioning a new cluster.
 
 Recommended quotas for a new cluster:
+
 * The number of virtual processors: 64.
 * The total volume of SSD disks: 2000 GB.
 * The number of virtual machines: 25.

--- a/candi/cloud-providers/yandex/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/yandex/docs/ENVIRONMENT_RU.md
@@ -19,7 +19,7 @@ description: "Настройка Yandex Cloud для работы облачно
 
 1. Назначьте необходимые роли вновь созданному пользователю для своего облака:
 
-   ```console
+   ```yaml
    yc resource-manager folder add-access-binding --id <folderID> --role compute.editor --subject serviceAccount:<userID>
    yc resource-manager folder add-access-binding --id <folderID> --role api-gateway.editor --subject serviceAccount:<userID>
    yc resource-manager folder add-access-binding --id <folderID> --role connection-manager.editor --subject serviceAccount:<userID>

--- a/candi/cloud-providers/yandex/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/yandex/docs/ENVIRONMENT_RU.md
@@ -17,13 +17,18 @@ description: "Настройка Yandex Cloud для работы облачно
    name: deckhouse
    ```
 
-2. Назначьте роль `editor` вновь созданному пользователю для своего облака:
+1. Назначьте необходимые роли вновь созданному пользователю для своего облака:
 
-   ```yaml
-   yc resource-manager folder add-access-binding --id <folderID> --role editor --subject serviceAccount:<userID>
+   ```console
+   yc resource-manager folder add-access-binding --id <folderID> --role compute.editor --subject serviceAccount:<userID>
+   yc resource-manager folder add-access-binding --id <folderID> --role api-gateway.editor --subject serviceAccount:<userID>
+   yc resource-manager folder add-access-binding --id <folderID> --role connection-manager.editor --subject serviceAccount:<userID>
+   yc resource-manager folder add-access-binding --id <folderID> --role vpc.admin --subject serviceAccount:<userID>
+   yc resource-manager folder add-access-binding --id <folderID> --role load-balancer.editor --subject serviceAccount:<userID>
+   yc resource-manager folder add-access-binding --id <folderID> --role logging.editor --subject serviceAccount:<userID>
    ```
 
-3. Создайте JSON-файл с параметрами авторизации пользователя в облаке. В дальнейшем с помощью этих данных будет происходить авторизация в облаке:
+1. Создайте JSON-файл с параметрами авторизации пользователя в облаке. В дальнейшем с помощью этих данных будет происходить авторизация в облаке:
 
    ```yaml
    yc iam key create --service-account-name deckhouse --output deckhouse-sa-key.json
@@ -38,6 +43,7 @@ description: "Настройка Yandex Cloud для работы облачно
 При заказе нового кластера необходимо увеличить квоты в консоли Yandex Cloud.
 
 Рекомендованные значения квот при создании нового кластера:
+
 * Количество виртуальных процессоров: 64.
 * Общий объем SSD-дисков: 2000 ГБ.
 * Количество виртуальных машин: 25.

--- a/docs/site/_includes/getting_started/yandex/STEP_ENV.md
+++ b/docs/site/_includes/getting_started/yandex/STEP_ENV.md
@@ -11,10 +11,15 @@ created_at: "YYYY-MM-DDTHH:MM:SSZ"
 name: deckhouse
 ```
 
-Assign the `editor` role to the newly created user:
+Assign the required roles to the newly created user for your cloud:
 
-```yaml
-yc resource-manager folder add-access-binding <folderID> --role editor --subject serviceAccount:<userID>
+```console
+yc resource-manager folder add-access-binding --id <folderID> --role compute.editor --subject serviceAccount:<userID>
+yc resource-manager folder add-access-binding --id <folderID> --role api-gateway.editor --subject serviceAccount:<userID>
+yc resource-manager folder add-access-binding --id <folderID> --role connection-manager.editor --subject serviceAccount:<userID>
+yc resource-manager folder add-access-binding --id <folderID> --role vpc.admin --subject serviceAccount:<userID>
+yc resource-manager folder add-access-binding --id <folderID> --role load-balancer.editor --subject serviceAccount:<userID>
+yc resource-manager folder add-access-binding --id <folderID> --role logging.editor --subject serviceAccount:<userID>
 ```
 
 Create a JSON file containing the parameters for user authorization in the cloud. These parameters will be used to log in to the cloud:

--- a/docs/site/_includes/getting_started/yandex/STEP_ENV.md
+++ b/docs/site/_includes/getting_started/yandex/STEP_ENV.md
@@ -14,7 +14,7 @@ name: deckhouse
 
 Assign the required roles to the newly created user for your cloud:
 
-```console
+```yaml
 yc resource-manager folder add-access-binding --id <folderID> --role compute.editor --subject serviceAccount:<userID>
 yc resource-manager folder add-access-binding --id <folderID> --role api-gateway.editor --subject serviceAccount:<userID>
 yc resource-manager folder add-access-binding --id <folderID> --role connection-manager.editor --subject serviceAccount:<userID>

--- a/docs/site/_includes/getting_started/yandex/STEP_ENV.md
+++ b/docs/site/_includes/getting_started/yandex/STEP_ENV.md
@@ -3,6 +3,7 @@
 You need to create a Yandex Cloud service account with the editor role to manage cloud resources. The detailed instructions for creating a service account with Yandex Cloud are available in the [documentation](/products/kubernetes-platform/documentation/v1/modules/cloud-provider-yandex/environment.html). Below, we will provide a brief overview of the necessary actions:
 
 Create a user named `deckhouse`. The command response will contain its parameters:
+
 ```yaml
 yc iam service-account create --name deckhouse
 id: <userID>

--- a/docs/site/_includes/getting_started/yandex/STEP_ENV_RU.md
+++ b/docs/site/_includes/getting_started/yandex/STEP_ENV_RU.md
@@ -14,7 +14,7 @@ name: deckhouse
 
 Назначьте необходимые роли вновь созданному пользователю для своего облака:
 
-```console
+```yaml
 yc resource-manager folder add-access-binding --id <folderID> --role compute.editor --subject serviceAccount:<userID>
 yc resource-manager folder add-access-binding --id <folderID> --role api-gateway.editor --subject serviceAccount:<userID>
 yc resource-manager folder add-access-binding --id <folderID> --role connection-manager.editor --subject serviceAccount:<userID>

--- a/docs/site/_includes/getting_started/yandex/STEP_ENV_RU.md
+++ b/docs/site/_includes/getting_started/yandex/STEP_ENV_RU.md
@@ -12,10 +12,15 @@ created_at: "YYYY-MM-DDTHH:MM:SSZ"
 name: deckhouse
 ```
 
-Назначьте роль `editor` вновь созданному пользователю для своего облака:
+Назначьте необходимые роли вновь созданному пользователю для своего облака:
 
-```yaml
-yc resource-manager folder add-access-binding <folderID> --role editor --subject serviceAccount:<userID>
+```console
+yc resource-manager folder add-access-binding --id <folderID> --role compute.editor --subject serviceAccount:<userID>
+yc resource-manager folder add-access-binding --id <folderID> --role api-gateway.editor --subject serviceAccount:<userID>
+yc resource-manager folder add-access-binding --id <folderID> --role connection-manager.editor --subject serviceAccount:<userID>
+yc resource-manager folder add-access-binding --id <folderID> --role vpc.admin --subject serviceAccount:<userID>
+yc resource-manager folder add-access-binding --id <folderID> --role load-balancer.editor --subject serviceAccount:<userID>
+yc resource-manager folder add-access-binding --id <folderID> --role logging.editor --subject serviceAccount:<userID>
 ```
 
 Создайте JSON-файл с параметрами авторизации пользователя в облаке. В дальнейшем с помощью этих данных будем авторизовываться в облаке:


### PR DESCRIPTION
## Description
Updated information about service account roles at Yandex Cloud. Based on [11012 issue](https://github.com/deckhouse/deckhouse/issues/11012).

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Updated information about service account roles at Yandex Cloud.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
