### PR TITLE
[docs] Fix sidebar behaviour with links

### DIFF
--- a/docs/documentation/_plugins/custom_sidebar.rb
+++ b/docs/documentation/_plugins/custom_sidebar.rb
@@ -116,7 +116,7 @@ module Jekyll
       elsif !external_url.nil? && external_url.size > 0
         result.push("<li class='#{ parameters['item_entry_class']}'><a href='#{ external_url }' target='_blank'>#{entry.dig('title', lang)} ↗</a></li>")
       elsif page_url == entry['url'] or page_url == entry_with_lang
-        result.push("<li class='#{ parameters['item_entry_class']} active'><a href='#{ getTrueRelativeUrl(entry['url']) }' target='_blank'>#{entry.dig('title', lang)}</a></li>")
+        result.push("<li class='#{ parameters['item_entry_class']} active'><a href='#{ getTrueRelativeUrl(entry['url']) }'>#{entry.dig('title', lang)}</a></li>")
       else
         if @context.registers[:page]['url'] == '404.md'
           result.push(%Q(<li class='#{ parameters['item_entry_class']}'><a data-proofer-ignore href='#{ @context.registers[:site].config['canonical_url_prefix_documentation'] + getTrueRelativeUrl(entry['url']) }'>#{entry.dig('title', lang)}</a></li>))


### PR DESCRIPTION
## Description

This pull request includes a minor update to the `sidebar_entry` method in the `docs/documentation/_plugins/custom_sidebar.rb` file. The change removes the `target='_blank'` attribute from internal links to improve user experience and consistency.

* [`docs/documentation/_plugins/custom_sidebar.rb`](diffhunk://#diff-9a72a7b1ff62aa6f5804ae3e0510e235f771412700830f2c3466898be4b796a2L119-R119): Removed the `target='_blank'` attribute from internal links within the `sidebar_entry` method.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fixed sidebar behaviour with links.
impact_level: low
```
