### PR TITLE
[dhctl] Add pdbs deletion to DeckhouseDestroyer

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -72,6 +72,34 @@ func DeleteDeckhouseDeployment(kubeCl *client.KubernetesClient) error {
 	})
 }
 
+func DeletePDBs(kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Delete pdbs", 45, 5*time.Second).WithShowError(false).Run(func() error {
+		foregroundPolicy := metav1.DeletePropagationForeground
+		namespaces, err := kubeCl.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+
+		for _, ns := range namespaces.Items {
+			pdbs, err := kubeCl.PolicyV1().PodDisruptionBudgets(ns.Name).List(context.TODO(), metav1.ListOptions{})
+			if err != nil {
+				// return err
+				continue
+			}
+
+			for _, pdb := range pdbs.Items {
+				fmt.Printf("Deleting PodDisruptionBudget %s in namespace %s\n", pdb.Name, ns.Name)
+				err := kubeCl.PolicyV1().PodDisruptionBudgets(ns.Name).Delete(context.TODO(), pdb.Name, metav1.DeleteOptions{PropagationPolicy: &foregroundPolicy})
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	})
+}
+
 func ListD8StorageResources(kubeCl *client.KubernetesClient, cr schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -83,12 +83,10 @@ func DeletePDBs(kubeCl *client.KubernetesClient) error {
 		for _, ns := range namespaces.Items {
 			pdbs, err := kubeCl.PolicyV1().PodDisruptionBudgets(ns.Name).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
-				// return err
 				continue
 			}
 
 			for _, pdb := range pdbs.Items {
-				fmt.Printf("Deleting PodDisruptionBudget %s in namespace %s\n", pdb.Name, ns.Name)
 				err := kubeCl.PolicyV1().PodDisruptionBudgets(ns.Name).Delete(context.TODO(), pdb.Name, metav1.DeleteOptions{PropagationPolicy: &foregroundPolicy})
 				if err != nil {
 					return err

--- a/dhctl/pkg/operations/destroy/deckhouse.go
+++ b/dhctl/pkg/operations/destroy/deckhouse.go
@@ -118,6 +118,11 @@ func (g *DeckhouseDestroyer) deleteEntities(kubeCl *client.KubernetesClient) err
 		return err
 	}
 
+	err = deckhouse.DeletePDBs(kubeCl)
+	if err != nil {
+		return err
+	}
+
 	err = deckhouse.DeleteServices(kubeCl)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Add pdbs deletion to DeckhouseDestroyer

## Why do we need it, and what problem does it solve?

Sometimes, if pdbs exists, destroy process stucks. So we need to delete it to avoid such stucks. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Add pdbs deletion to DeckhouseDestroyer.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
