### PR TITLE
Use all Trivy severity levels

### DIFF
--- a/tools/cve/base-images.sh
+++ b/tools/cve/base-images.sh
@@ -28,7 +28,7 @@ source tools/cve/trivy-wrapper.sh
 # $SEVERITY - output only entries with specified severity levels (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)
 
 if [[ "x$SEVERITY" == "x" ]]; then
-  SEVERITY="CRITICAL,HIGH"
+  SEVERITY="UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
 fi
 
 # Hack to get the base images list.

--- a/tools/cve/d8-images.sh
+++ b/tools/cve/d8-images.sh
@@ -36,7 +36,7 @@ if [ -z "$TAG" ]; then
 fi
 
 if [ -z "$SEVERITY" ]; then
-  SEVERITY="CRITICAL,HIGH"
+  SEVERITY="UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
 fi
 
 function __main__() {

--- a/tools/cve/trivy-wrapper.sh
+++ b/tools/cve/trivy-wrapper.sh
@@ -97,7 +97,7 @@ function prepareImageArgs() {
   fi
 
   if [ -z "$SEVERITY" ]; then
-    SEVERITY="CRITICAL,HIGH"
+    SEVERITY="UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   fi
 
   if [ -z "$OUTPUT" ]; then

--- a/tools/cve/trivy-wrapper.sh
+++ b/tools/cve/trivy-wrapper.sh
@@ -107,7 +107,7 @@ function prepareImageArgs() {
 
 function trivyGetCVEListForImage() (
   prepareImageArgs "$@"
-  bin/trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "$IGNORE" --format json --scanners vuln --quiet "$IMAGE_ARGS" | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
+  bin/trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity $SEVERITY --ignorefile "$IGNORE" --format json --scanners vuln --quiet "$IMAGE_ARGS" | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
   # bin/trivy i --severity=$SEVERITY --ignorefile "$IGNORE" --format json --quiet "$IMAGE_ARGS" | jq -r ".Results[]?.Vulnerabilities[]?.VulnerabilityID" | uniq | sort
 )
 
@@ -118,6 +118,6 @@ function htmlReportHeader() (
 function trivyGetJSONReportPartForImage() (
   prepareImageArgs "$@"
   echo -n "    <h1>$LABEL</h1>"
-  bin/trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "$IGNORE" --format json --scanners vuln --output $OUTPUT --quiet "$IMAGE_ARGS"
+  bin/trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity $SEVERITY --ignorefile "$IGNORE" --format json --scanners vuln --output $OUTPUT --quiet "$IMAGE_ARGS"
   echo -n "    <br/>"
 )


### PR DESCRIPTION
## Description
Trivy will use all severity levels for CVE scan

## Why do we need it, and what problem does it solve?
currently only HIGH and CRITICAL levels are used

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Trivy will use all severity levels for CVE scan
```

