### PR TITLE
[control-plane-manager] additionalAPIIssuers/additionalAPIAudiences fix and tests

### DIFF
--- a/candi/control-plane-kubeadm/patches/kube-apiserver.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/kube-apiserver.yaml.tpl
@@ -156,9 +156,10 @@ spec:
 
 {{- if .apiserver.serviceAccount }}
   {{- if .apiserver.serviceAccount.additionalAPIIssuers }}
-    {{- $uniqueIssuers := uniq .apiserver.serviceAccount.additionalAPIIssuers }}
     {{- $defaultIssuer := printf "https://kubernetes.default.svc.%s" .clusterConfiguration.clusterDomain }}
-    {{- if not (and (eq (len $uniqueIssuers) 1) (eq (index $uniqueIssuers 0) $defaultIssuer)) }}
+    {{- $issuerToRemove := default $defaultIssuer .apiserver.serviceAccount.issuer }}
+    {{- $uniqueIssuers := uniq .apiserver.serviceAccount.additionalAPIIssuers }}
+    {{- if not (and (eq (len $uniqueIssuers) 1) (eq (index $uniqueIssuers 0) $issuerToRemove)) }}
 ---
 apiVersion: v1
 kind: Pod
@@ -170,12 +171,12 @@ spec:
   - name: kube-apiserver
     args:
     {{- range $uniqueIssuers }}
-      {{- if ne . $defaultIssuer }}
+      {{- if ne . $issuerToRemove }}
     - --service-account-issuer={{ . }}
       {{- end }}
     {{- end }}
+    {{- end }}
   {{- end }}
-{{- end }}
 {{- end }}
 ---
 apiVersion: v1

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -18,14 +18,14 @@ package template_tests
 
 import (
 	"encoding/base64"
-	"fmt"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"gopkg.in/yaml.v2"
+	"strings"
 
 	. "github.com/deckhouse/deckhouse/testing/helm"
 	"github.com/deckhouse/deckhouse/testing/library/object_store"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type Arg struct {
@@ -34,11 +34,11 @@ type Arg struct {
 }
 
 type ControlPlaneComponent struct {
-	ExtraArgs []Arg
+	ExtraArgs map[string]string `yaml:"extraArgs,omitempty"`
 }
 
 type APIServer struct {
-	ControlPlaneComponent
+	ControlPlaneComponent `yaml:",inline"`
 }
 
 type ClusterConfiguration struct {
@@ -84,6 +84,84 @@ var _ = Describe("Module :: control-plane-manager :: helm template :: arguments 
       - https://192.168.199.186:2379
     pkiChecksum: checksum
     rolloutEpoch: 1857
+`
+
+	const moduleValuesOnlyIssuer = `
+internal:
+  effectiveKubernetesVersion: "1.29"
+  etcdServers:
+    - https://192.168.199.186:2379
+  pkiChecksum: checksum
+  rolloutEpoch: 1857
+apiserver:
+  serviceAccount:
+    issuer: https://api.example.com
+`
+	const moduleValuesIssuerAdditionalAudiences = `
+internal:
+  effectiveKubernetesVersion: "1.29"
+  etcdServers:
+    - https://192.168.199.186:2379
+  pkiChecksum: checksum
+  rolloutEpoch: 1857
+apiserver:
+  serviceAccount:
+    issuer: https://api.example.com
+    additionalAPIAudiences:
+      - https://api.example.com
+      - https://bob.com
+`
+
+	const moduleValuesSuperCombo = `
+internal:
+  effectiveKubernetesVersion: "1.29"
+  etcdServers:
+    - https://192.168.199.186:2379
+  pkiChecksum: checksum
+  rolloutEpoch: 1857
+apiserver:
+  serviceAccount:
+    issuer: https://api.example.com
+    additionalAPIIssuers:
+      - https://kubernetes.default.svc.cluster.local
+      - https://flant.ru
+    additionalAPIAudiences:
+      - https://kubernetes.default.svc.cluster.local
+      - https://flant.ru
+`
+
+	const additionalAPIIssuersSuperComboWithDublicates = `
+internal:
+  effectiveKubernetesVersion: "1.29"
+  etcdServers:
+    - https://192.168.199.186:2379
+  pkiChecksum: checksum
+  rolloutEpoch: 1857
+apiserver:
+  serviceAccount:
+    issuer: https://kubernetes.default.svc.cluster.local
+    additionalAPIIssuers:
+      - https://kubernetes.default.svc.cluster.local
+      - https://flant.ru
+    additionalAPIAudiences:
+      - https://kubernetes.default.svc.cluster.local
+      - https://flant.ru
+`
+	const additionalAPIIssuersSuperComboWithDublicates2 = `
+internal:
+  effectiveKubernetesVersion: "1.29"
+  etcdServers:
+    - https://192.168.199.186:2379
+  pkiChecksum: checksum
+  rolloutEpoch: 1857
+apiserver:
+  serviceAccount:
+    additionalAPIIssuers:
+      - https://kubernetes.default.svc.cluster.local
+      - https://flant.com
+    additionalAPIAudiences:
+      - https://kubernetes.default.svc.cluster.local
+      - https://flant.com
 `
 
 	f := SetupHelmConfig(`controlPlaneManager: {}`)
@@ -165,22 +243,163 @@ resources:
 `))
 		})
 	})
-	Context("kubeadm-config.yaml sa issuer check", func() {
-		BeforeEach(func() {
-			f.HelmRender()
+	Context("ServiceAccount Issuer update tests", func() {
+		Context("only issuer", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("controlPlaneManager", moduleValuesOnlyIssuer)
+				f.HelmRender()
+			})
+
+			It("should render kubeadm-config.yaml with only issuer", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				s := f.KubernetesResource("Secret", "kube-system", "d8-control-plane-manager-config")
+				Expect(s.Exists()).To(BeTrue())
+				data, err := base64.StdEncoding.DecodeString(s.Field("data.kubeadm-config\\.yaml").String())
+				Expect(err).ShouldNot(HaveOccurred())
+				var config ClusterConfiguration
+				err = yaml.Unmarshal(data, &config)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(config.APIServer.ExtraArgs).To(HaveKeyWithValue("service-account-issuer", "https://api.example.com"))
+				Expect(config.APIServer.ExtraArgs).To(HaveKeyWithValue("api-audiences", "https://kubernetes.default.svc.cluster.local"))
+			})
 		})
 
-		It("should render correctly", func() {
-			Expect(f.RenderError).ShouldNot(HaveOccurred())
+		Context("issuer + additionalAPIAudiences", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("controlPlaneManager", moduleValuesIssuerAdditionalAudiences)
+				f.HelmRender()
+			})
 
-			s := f.KubernetesResource("Secret", "kube-system", "d8-control-plane-manager-config")
-			Expect(s.Exists()).To(BeTrue())
-			data, err := base64.StdEncoding.DecodeString(s.Field("data.kubeadm-config\\.yaml").String())
-			Expect(err).To(BeNil())
-			Expect(data).ToNot(BeNil())
-			var config ClusterConfiguration
-			err = yaml.Unmarshal(data, &config)
-			fmt.Printf("Parsed ClusterConfiguration: %+v\n", config)
+			It("should render kubeadm-config.yaml with issuer and additionalAPIAudiences", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				s := f.KubernetesResource("Secret", "kube-system", "d8-control-plane-manager-config")
+				Expect(s.Exists()).To(BeTrue())
+				data, err := base64.StdEncoding.DecodeString(s.Field("data.kubeadm-config\\.yaml").String())
+				Expect(err).ShouldNot(HaveOccurred())
+				var config ClusterConfiguration
+				err = yaml.Unmarshal(data, &config)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(config.APIServer.ExtraArgs).To(HaveKeyWithValue("service-account-issuer", "https://api.example.com"))
+				Expect(config.APIServer.ExtraArgs).To(HaveKeyWithValue("api-audiences", "https://kubernetes.default.svc.cluster.local,https://api.example.com,https://bob.com"))
+
+				// kube-apiserver.yaml.tpl - contains patches for kube-api pod, including patches for adding additional service-account-issuer
+				kubeApiserver, err := base64.StdEncoding.DecodeString(s.Field("data.kube-apiserver\\.yaml\\.tpl").String())
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(kubeApiserver).ToNot(ContainSubstring("--service-account-issuer"))
+			})
+		})
+
+		Context("additionalAPIIssuersSuperCombo", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("controlPlaneManager", moduleValuesSuperCombo)
+				f.HelmRender()
+			})
+
+			It("additionalAPIIssuersSuperCombo", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				s := f.KubernetesResource("Secret", "kube-system", "d8-control-plane-manager-config")
+				Expect(s.Exists()).To(BeTrue())
+
+				// kubeadm-config.yaml
+				kubeadmConfig, err := base64.StdEncoding.DecodeString(s.Field("data.kubeadm-config\\.yaml").String())
+				Expect(err).ShouldNot(HaveOccurred())
+				var config ClusterConfiguration
+				err = yaml.Unmarshal(kubeadmConfig, &config)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(config.APIServer.ExtraArgs).To(HaveKeyWithValue("service-account-issuer", "https://api.example.com"))
+				Expect(config.APIServer.ExtraArgs).To(HaveKeyWithValue("api-audiences", "https://kubernetes.default.svc.cluster.local,https://flant.ru"))
+
+				// kube-apiserver.yaml.tpl - contains patches for kube-api pod, including patches for adding additional service-account-issuer
+				kubeApiserver, err := base64.StdEncoding.DecodeString(s.Field("data.kube-apiserver\\.yaml\\.tpl").String())
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(kubeApiserver).To(ContainSubstring("--service-account-issuer"))
+				documents := strings.Split(string(kubeApiserver), "---")
+				Expect(documents).To(HaveLen(8))
+				podWithExtraArgs := []byte(documents[6])
+				var pod corev1.Pod
+				expectedServiceAccountIssuers := []string{
+					"--service-account-issuer=https://kubernetes.default.svc.cluster.local",
+					"--service-account-issuer=https://flant.ru",
+				}
+				err = yaml.Unmarshal(podWithExtraArgs, &pod)
+				Expect(pod.Spec.Containers[0].Args).To(Equal(expectedServiceAccountIssuers))
+			})
+		})
+
+		Context("additionalAPIIssuersSuperComboWithDublicates", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("controlPlaneManager", additionalAPIIssuersSuperComboWithDublicates)
+				f.HelmRender()
+			})
+
+			It("additionalAPIIssuersSuperComboWithDublicates", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				s := f.KubernetesResource("Secret", "kube-system", "d8-control-plane-manager-config")
+				Expect(s.Exists()).To(BeTrue())
+
+				// kubeadm-config.yaml
+				kubeadmConfig, err := base64.StdEncoding.DecodeString(s.Field("data.kubeadm-config\\.yaml").String())
+				Expect(err).ShouldNot(HaveOccurred())
+				var config ClusterConfiguration
+				err = yaml.Unmarshal(kubeadmConfig, &config)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(config.APIServer.ExtraArgs).To(HaveKeyWithValue("service-account-issuer", "https://kubernetes.default.svc.cluster.local"))
+				Expect(config.APIServer.ExtraArgs).To(HaveKeyWithValue("api-audiences", "https://kubernetes.default.svc.cluster.local,https://flant.ru"))
+
+				// kube-apiserver.yaml.tpl - contains patches for kube-api pod, including patches for adding additional service-account-issuer
+				kubeApiserver, err := base64.StdEncoding.DecodeString(s.Field("data.kube-apiserver\\.yaml\\.tpl").String())
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(kubeApiserver).To(ContainSubstring("--service-account-issuer"))
+				documents := strings.Split(string(kubeApiserver), "---")
+				Expect(documents).To(HaveLen(8))
+				podWithExtraArgs := []byte(documents[6])
+				var pod corev1.Pod
+				expectedServiceAccountIssuers := []string{
+					"--service-account-issuer=https://flant.ru",
+				}
+				err = yaml.Unmarshal(podWithExtraArgs, &pod)
+				Expect(pod.Spec.Containers[0].Args).To(Equal(expectedServiceAccountIssuers))
+			})
+		})
+		Context("additionalAPIIssuersSuperComboWithDublicates: 2", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("controlPlaneManager", additionalAPIIssuersSuperComboWithDublicates2)
+				f.HelmRender()
+			})
+
+			It("additionalAPIIssuersSuperComboWithDublicates: 2", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				s := f.KubernetesResource("Secret", "kube-system", "d8-control-plane-manager-config")
+				Expect(s.Exists()).To(BeTrue())
+
+				// kubeadm-config.yaml
+				kubeadmConfig, err := base64.StdEncoding.DecodeString(s.Field("data.kubeadm-config\\.yaml").String())
+				Expect(err).ShouldNot(HaveOccurred())
+				var config ClusterConfiguration
+				err = yaml.Unmarshal(kubeadmConfig, &config)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(config.APIServer.ExtraArgs).To(HaveKeyWithValue("service-account-issuer", "https://kubernetes.default.svc.cluster.local"))
+				Expect(config.APIServer.ExtraArgs).To(HaveKeyWithValue("api-audiences", "https://kubernetes.default.svc.cluster.local,https://flant.com"))
+
+				// kube-apiserver.yaml.tpl - contains patches for kube-api pod, including patches for adding additional service-account-issuer
+				kubeApiserver, err := base64.StdEncoding.DecodeString(s.Field("data.kube-apiserver\\.yaml\\.tpl").String())
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(kubeApiserver).To(ContainSubstring("--service-account-issuer"))
+				documents := strings.Split(string(kubeApiserver), "---")
+				Expect(documents).To(HaveLen(8))
+				podWithExtraArgs := []byte(documents[6])
+				var pod corev1.Pod
+				expectedServiceAccountIssuers := []string{
+					"--service-account-issuer=https://flant.com",
+				}
+				err = yaml.Unmarshal(podWithExtraArgs, &pod)
+				Expect(pod.Spec.Containers[0].Args).To(Equal(expectedServiceAccountIssuers))
+			})
 		})
 	})
 })

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -18,16 +18,36 @@ package template_tests
 
 import (
 	"encoding/base64"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
 
 	. "github.com/deckhouse/deckhouse/testing/helm"
 	"github.com/deckhouse/deckhouse/testing/library/object_store"
 )
 
-var _ = Describe("Module :: control-plane-manager :: helm template :: arguments secret", func() {
+type Arg struct {
+	Name  string
+	Value string
+}
 
+type ControlPlaneComponent struct {
+	ExtraArgs []Arg
+}
+
+type APIServer struct {
+	ControlPlaneComponent
+}
+
+type ClusterConfiguration struct {
+	APIVersion string    `yaml:"apiVersion"`
+	Kind       string    `yaml:"kind"`
+	APIServer  APIServer `yaml:"apiServer"`
+}
+
+var _ = Describe("Module :: control-plane-manager :: helm template :: arguments secret", func() {
 	const globalValues = `
   clusterConfiguration:
     apiVersion: deckhouse.io/v1
@@ -82,7 +102,6 @@ var _ = Describe("Module :: control-plane-manager :: helm template :: arguments 
 
 			Expect(groups.IsArray()).To(BeTrue())
 			Expect(groups.Array()).To(HaveLen(length))
-
 		}
 
 		Context("For etcd main", func() {
@@ -146,5 +165,22 @@ resources:
 `))
 		})
 	})
+	Context("kubeadm-config.yaml sa issuer check", func() {
+		BeforeEach(func() {
+			f.HelmRender()
+		})
 
+		It("should render correctly", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			s := f.KubernetesResource("Secret", "kube-system", "d8-control-plane-manager-config")
+			Expect(s.Exists()).To(BeTrue())
+			data, err := base64.StdEncoding.DecodeString(s.Field("data.kubeadm-config\\.yaml").String())
+			Expect(err).To(BeNil())
+			Expect(data).ToNot(BeNil())
+			var config ClusterConfiguration
+			err = yaml.Unmarshal(data, &config)
+			fmt.Printf("Parsed ClusterConfiguration: %+v\n", config)
+		})
+	})
 })


### PR DESCRIPTION
## Description

Added tests for parameters `additionalAPIIssuers` and `additionalAPIAudiences` of `control-plane-manager` module, fixed golang template

## Why do we need it, and what problem does it solve?

In some cases templates did not work correctly, now all cases are covered by tests

## Why do we need it in the patch release (if we do)?

At the moment there is a bug that prevents successful migration to another service-account issuer.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: additionalAPIIssuers/additionalAPIAudiences fix and tests
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
