### PR TITLE
[dhctl] feat(dhctl-for-commander-cancels): add ctx to terraform runner

### DIFF
--- a/dhctl/cmd/dhctl/commands/edit.go
+++ b/dhctl/cmd/dhctl/commands/edit.go
@@ -15,7 +15,9 @@
 package commands
 
 import (
+	"context"
 	"fmt"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -43,7 +45,7 @@ func baseEditConfigCMD(parent *kingpin.CmdClause, name, secret, dataKey string) 
 			return err
 		}
 
-		kubeCl, err := kubernetes.ConnectToKubernetesAPI(ssh.NewNodeInterfaceWrapper(sshClient))
+		kubeCl, err := kubernetes.ConnectToKubernetesAPI(context.Background(), ssh.NewNodeInterfaceWrapper(sshClient))
 		if err != nil {
 			return err
 		}

--- a/dhctl/cmd/dhctl/commands/ssh.go
+++ b/dhctl/cmd/dhctl/commands/ssh.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -43,7 +44,7 @@ func DefineTestSSHConnectionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		err = sshCl.Check().AwaitAvailability()
+		err = sshCl.Check().AwaitAvailability(context.Background())
 
 		if err != nil {
 			return fmt.Errorf("check connection: %v", err)

--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -62,7 +63,7 @@ func DefineTerraformCheckCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return fmt.Errorf("Not enough flags were passed to perform the operation.\nUse dhctl terraform check --help to get available flags.\nSsh host is not provided. Need to pass --ssh-host, or specify SSHHost manifest in the --connection-config file")
 		}
 
-		kubeCl, err := kubernetes.ConnectToKubernetesAPI(ssh.NewNodeInterfaceWrapper(sshClient))
+		kubeCl, err := kubernetes.ConnectToKubernetesAPI(context.Background(), ssh.NewNodeInterfaceWrapper(sshClient))
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/infrastructure/base.go
+++ b/dhctl/pkg/infrastructure/base.go
@@ -15,6 +15,8 @@
 package infrastructure
 
 import (
+	"context"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
@@ -43,5 +45,6 @@ func (r *BaseInfraTerraformController) Destroy(clusterState []byte, autoApprove 
 		AutoApprove: autoApprove,
 	})
 
-	return terraform.DestroyPipeline(baseRunner, "Kubernetes cluster")
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	return terraform.DestroyPipeline(context.TODO(), baseRunner, "Kubernetes cluster")
 }

--- a/dhctl/pkg/infrastructure/nodes.go
+++ b/dhctl/pkg/infrastructure/nodes.go
@@ -15,6 +15,7 @@
 package infrastructure
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -87,7 +88,8 @@ func (r *NodeGroupTerraformController) DestroyNode(name string, nodeState []byte
 		NodeIndex:     nodeIndex,
 	})
 
-	if err := terraform.DestroyPipeline(nodeRunner, name); err != nil {
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	if err := terraform.DestroyPipeline(context.TODO(), nodeRunner, name); err != nil {
 		return fmt.Errorf("destroing of node %s failed: %v", name, err)
 	}
 

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -508,14 +508,15 @@ func CreateDeckhouseDeploymentManifest(cfg *config.DeckhouseInstaller) *appsv1.D
 	return manifests.DeckhouseDeployment(params)
 }
 
-func WaitForKubernetesAPI(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Waiting for Kubernetes API to become Ready", 45, 5*time.Second).Run(func() error {
-		_, err := kubeCl.Discovery().ServerVersion()
-		if err == nil {
-			return nil
-		}
-		return fmt.Errorf("kubernetes API is not Ready: %w", err)
-	})
+func WaitForKubernetesAPI(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Waiting for Kubernetes API to become Ready", 45, 5*time.Second).
+		RunContext(ctx, func() error {
+			_, err := kubeCl.Discovery().ServerVersion()
+			if err == nil {
+				return nil
+			}
+			return fmt.Errorf("kubernetes API is not Ready: %w", err)
+		})
 }
 
 func ConfigureDeckhouseRelease(kubeCl *client.KubernetesClient) error {

--- a/dhctl/pkg/kubernetes/kube.go
+++ b/dhctl/pkg/kubernetes/kube.go
@@ -15,6 +15,7 @@
 package kubernetes
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -26,28 +27,29 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
-func ConnectToKubernetesAPI(nodeInterface node.Interface) (*client.KubernetesClient, error) {
+func ConnectToKubernetesAPI(ctx context.Context, nodeInterface node.Interface) (*client.KubernetesClient, error) {
 	var kubeCl *client.KubernetesClient
 	err := log.Process("common", "Connect to Kubernetes API", func() error {
 		if wrapper, ok := nodeInterface.(*ssh.NodeInterfaceWrapper); ok && wrapper != nil {
-			if err := wrapper.Client().Check().WithDelaySeconds(1).AwaitAvailability(); err != nil {
+			if err := wrapper.Client().Check().WithDelaySeconds(1).AwaitAvailability(ctx); err != nil {
 				return fmt.Errorf("await master available: %v", err)
 			}
 		}
 
-		err := retry.NewLoop("Get Kubernetes API client", 45, 5*time.Second).Run(func() error {
-			kubeCl = client.NewKubernetesClient().WithNodeInterface(nodeInterface)
-			if err := kubeCl.Init(client.AppKubernetesInitParams()); err != nil {
-				return fmt.Errorf("open kubernetes connection: %v", err)
-			}
-			return nil
-		})
+		err := retry.NewLoop("Get Kubernetes API client", 45, 5*time.Second).
+			RunContext(ctx, func() error {
+				kubeCl = client.NewKubernetesClient().WithNodeInterface(nodeInterface)
+				if err := kubeCl.Init(client.AppKubernetesInitParams()); err != nil {
+					return fmt.Errorf("open kubernetes connection: %v", err)
+				}
+				return nil
+			})
 		if err != nil {
 			return err
 		}
 
 		time.Sleep(50 * time.Millisecond) // tick to prevent first probable fail
-		err = deckhouse.WaitForKubernetesAPI(kubeCl)
+		err = deckhouse.WaitForKubernetesAPI(ctx, kubeCl)
 		if err != nil {
 			return fmt.Errorf("wait kubernetes api: %v", err)
 		}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
@@ -15,6 +15,7 @@
 package bootstrap
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
@@ -63,7 +64,8 @@ func (b *ClusterBootstrapper) BaseInfrastructure() error {
 	return log.Process("bootstrap", "Cloud infrastructure", func() error {
 		baseRunner := b.Params.TerraformContext.GetBootstrapBaseInfraRunner(metaConfig, stateCache)
 
-		_, err := terraform.ApplyPipeline(baseRunner, "Kubernetes cluster", terraform.GetBaseInfraResult)
+		// TODO(dhctl-for-commander-cancels): pass ctx
+		_, err := terraform.ApplyPipeline(context.TODO(), baseRunner, "Kubernetes cluster", terraform.GetBaseInfraResult)
 		return err
 	})
 }

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
@@ -15,6 +15,7 @@
 package bootstrap
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
@@ -64,7 +65,8 @@ func (b *ClusterBootstrapper) InstallDeckhouse() error {
 		return err
 	}
 
-	kubeCl, err := kubernetes.ConnectToKubernetesAPI(b.NodeInterface)
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	kubeCl, err := kubernetes.ConnectToKubernetesAPI(context.TODO(), b.NodeInterface)
 	if err != nil {
 		return err
 	}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
@@ -15,6 +15,7 @@
 package bootstrap
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
@@ -76,7 +77,8 @@ func (b *ClusterBootstrapper) CreateResources() error {
 	}
 
 	return log.Process("bootstrap", "Create resources", func() error {
-		kubeCl, err := kubernetes.ConnectToKubernetesAPI(b.NodeInterface)
+		// TODO(dhctl-for-commander-cancels): pass ctx
+		kubeCl, err := kubernetes.ConnectToKubernetesAPI(context.TODO(), b.NodeInterface)
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -15,6 +15,7 @@
 package bootstrap
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -416,7 +417,8 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		return nil
 	}
 
-	kubeCl, err := kubernetes.ConnectToKubernetesAPI(b.NodeInterface)
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	kubeCl, err := kubernetes.ConnectToKubernetesAPI(context.TODO(), b.NodeInterface)
 	if err != nil {
 		return err
 	}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -286,7 +286,8 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 		err = log.Process("bootstrap", "Cloud infrastructure", func() error {
 			baseRunner := b.TerraformContext.GetBootstrapBaseInfraRunner(metaConfig, stateCache)
 
-			baseOutputs, err := terraform.ApplyPipeline(baseRunner, "Kubernetes cluster", terraform.GetBaseInfraResult)
+			// TODO(dhctl-for-commander-cancels): pass ctx
+			baseOutputs, err := terraform.ApplyPipeline(context.TODO(), baseRunner, "Kubernetes cluster", terraform.GetBaseInfraResult)
 			if err != nil {
 				return err
 			}
@@ -314,7 +315,8 @@ func (b *ClusterBootstrapper) Bootstrap() error {
 				RunnerLogger:    log.GetDefaultLogger(),
 			})
 
-			masterOutputs, err := terraform.ApplyPipeline(masterRunner, masterNodeName, terraform.GetMasterNodeResult)
+			// TODO(dhctl-for-commander-cancels): pass ctx
+			masterOutputs, err := terraform.ApplyPipeline(context.TODO(), masterRunner, masterNodeName, terraform.GetMasterNodeResult)
 			if err != nil {
 				return err
 			}

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -18,6 +18,7 @@
 package bootstrap
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -641,7 +642,8 @@ func WaitForSSHConnectionOnMaster(sshClient *ssh.Client) error {
 			log.InfoLn(availabilityCheck.String())
 			return nil
 		})
-		if err := availabilityCheck.WithDelaySeconds(1).AwaitAvailability(); err != nil {
+		// TODO(dhctl-for-commander-cancels): pass ctx
+		if err := availabilityCheck.WithDelaySeconds(1).AwaitAvailability(context.TODO()); err != nil {
 			return fmt.Errorf("await master to become available: %v", err)
 		}
 		return nil

--- a/dhctl/pkg/operations/check/check.go
+++ b/dhctl/pkg/operations/check/check.go
@@ -15,6 +15,7 @@
 package check
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -149,7 +150,8 @@ func checkClusterState(kubeCl *client.KubernetesClient, metaConfig *config.MetaC
 		AdditionalStateSaverDestinations: stateSavers,
 	})
 
-	return terraform.CheckBaseInfrastructurePipeline(baseRunner, "Kubernetes cluster")
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	return terraform.CheckBaseInfrastructurePipeline(context.TODO(), baseRunner, "Kubernetes cluster")
 }
 
 func checkAbandonedNodeState(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, nodeGroup *NodeGroupOptions, nodeGroupState *state.NodeGroupTerraformState, nodeName string, terraformContext *terraform.TerraformContext, opts CheckStateOptions) (int, terraform.TerraformPlan, *terraform.PlanDestructiveChanges, error) {
@@ -196,7 +198,8 @@ func checkAbandonedNodeState(kubeCl *client.KubernetesClient, metaConfig *config
 		AdditionalStateSaverDestinations: stateSavers,
 	})
 
-	return terraform.CheckPipeline(nodeRunner, nodeName, terraform.PlanOptions{Destroy: true})
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	return terraform.CheckPipeline(context.TODO(), nodeRunner, nodeName, terraform.PlanOptions{Destroy: true})
 }
 
 func checkNodeState(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, nodeGroup *NodeGroupOptions, nodeName string, terraformContext *terraform.TerraformContext, opts CheckStateOptions) (int, terraform.TerraformPlan, *terraform.PlanDestructiveChanges, error) {
@@ -237,7 +240,8 @@ func checkNodeState(kubeCl *client.KubernetesClient, metaConfig *config.MetaConf
 		AdditionalStateSaverDestinations: stateSavers,
 	})
 
-	return terraform.CheckPipeline(nodeRunner, nodeName, terraform.PlanOptions{})
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	return terraform.CheckPipeline(context.TODO(), nodeRunner, nodeName, terraform.PlanOptions{})
 }
 
 type CheckStateOptions struct {

--- a/dhctl/pkg/operations/check/checker.go
+++ b/dhctl/pkg/operations/check/checker.go
@@ -198,7 +198,8 @@ func (c *Checker) GetKubeClient() (*client.KubernetesClient, error) {
 		return c.KubeClient, nil
 	}
 
-	kubeCl, err := kubernetes.ConnectToKubernetesAPI(ssh.NewNodeInterfaceWrapper(c.SSHClient))
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	kubeCl, err := kubernetes.ConnectToKubernetesAPI(context.TODO(), ssh.NewNodeInterfaceWrapper(c.SSHClient))
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to kubernetes api over ssh: %w", err)
 	}

--- a/dhctl/pkg/operations/commander/attach/attacher.go
+++ b/dhctl/pkg/operations/commander/attach/attacher.go
@@ -154,7 +154,7 @@ func (i *Attacher) Attach(ctx context.Context) (*AttachResult, error) {
 	}, nil
 }
 
-func (i *Attacher) prepare(_ context.Context) (*client.KubernetesClient, *config.MetaConfig, error) {
+func (i *Attacher) prepare(ctx context.Context) (*client.KubernetesClient, *config.MetaConfig, error) {
 	var (
 		kubeClient *client.KubernetesClient
 		metaConfig *config.MetaConfig
@@ -163,7 +163,7 @@ func (i *Attacher) prepare(_ context.Context) (*client.KubernetesClient, *config
 	err := log.Process("attach", "Prepare cluster attach", func() error {
 		var err error
 
-		kubeClient, err = kubernetes.ConnectToKubernetesAPI(ssh.NewNodeInterfaceWrapper(i.Params.SSHClient))
+		kubeClient, err = kubernetes.ConnectToKubernetesAPI(ctx, ssh.NewNodeInterfaceWrapper(i.Params.SSHClient))
 		if err != nil {
 			return fmt.Errorf("unable to connect to kubernetes api over ssh: %w", err)
 		}

--- a/dhctl/pkg/operations/converge/context/client_switcher.go
+++ b/dhctl/pkg/operations/converge/context/client_switcher.go
@@ -126,7 +126,7 @@ func (s *KubeClientSwitcher) replaceKubeClient(convergeState *State, state map[s
 			return fmt.Errorf("failed to write terraform state: %w", err)
 		}
 
-		ipAddress, err := terraform.GetMasterIPAddressForSSH(statePath)
+		ipAddress, err := terraform.GetMasterIPAddressForSSH(s.ctx.Ctx(), statePath)
 		if err != nil {
 			log.WarnF("failed to get master IP address: %s", err)
 			continue

--- a/dhctl/pkg/operations/converge/context/client_switcher.go
+++ b/dhctl/pkg/operations/converge/context/client_switcher.go
@@ -174,7 +174,7 @@ func (s *KubeClientSwitcher) replaceKubeClient(convergeState *State, state map[s
 
 	log.DebugLn("private keys added for replacing kube client")
 
-	newKubeClient, err := kubernetes.ConnectToKubernetesAPI(ssh.NewNodeInterfaceWrapper(newSSHClient))
+	newKubeClient, err := kubernetes.ConnectToKubernetesAPI(s.ctx.Ctx(), ssh.NewNodeInterfaceWrapper(newSSHClient))
 	if err != nil {
 		return fmt.Errorf("failed to connect to Kubernetes API: %w", err)
 	}

--- a/dhctl/pkg/operations/converge/context/context.go
+++ b/dhctl/pkg/operations/converge/context/context.go
@@ -88,6 +88,10 @@ func (c *Context) Terraform() *terraform.TerraformContext {
 	return c.terraformContext
 }
 
+func (c *Context) Ctx() context.Context {
+	return c.ctx
+}
+
 func (c *Context) WithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(c.ctx, timeout)
 }

--- a/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group.go
@@ -127,7 +127,7 @@ func (c *CloudPermanentNodeGroupController) updateNode(ctx *context.Context, nod
 		Hook: &terraform.DummyHook{},
 	})
 
-	outputs, err := terraform.ApplyPipeline(nodeRunner, nodeName, terraform.OnlyState)
+	outputs, err := terraform.ApplyPipeline(ctx.Ctx(), nodeRunner, nodeName, terraform.OnlyState)
 	if err != nil {
 		log.ErrorF("Terraform exited with an error:\n%s\n", err.Error())
 		return err

--- a/dhctl/pkg/operations/converge/controller/master_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/master_node_group.go
@@ -268,7 +268,7 @@ func (c *MasterNodeGroupController) updateNode(ctx *context.Context, nodeName st
 		Hook: hook,
 	})
 
-	outputs, err := terraform.ApplyPipeline(nodeRunner, nodeName, terraform.GetMasterNodeResult)
+	outputs, err := terraform.ApplyPipeline(ctx.Ctx(), nodeRunner, nodeName, terraform.GetMasterNodeResult)
 	if err != nil {
 		if errors.Is(err, controlplane.ErrSingleMasterClusterTerraformPlanHasDestructiveChanges) {
 			confirmation := input.NewConfirmation().WithMessage("A single-master cluster has disruptive changes in the Terraform plan. Trying to migrate to a multi-master cluster and back to a single-master cluster. Do you want to continue?")

--- a/dhctl/pkg/operations/converge/controller/node_group_controller.go
+++ b/dhctl/pkg/operations/converge/controller/node_group_controller.go
@@ -191,7 +191,7 @@ func (c *NodeGroupController) deleteRedundantNodes(
 			Hook: getHookByNodeName(nodeToDeleteInfo.name),
 		})
 
-		if err := terraform.DestroyPipeline(nodeRunner, nodeToDeleteInfo.name); err != nil {
+		if err := terraform.DestroyPipeline(ctx.Ctx(), nodeRunner, nodeToDeleteInfo.name); err != nil {
 			allErrs = multierror.Append(allErrs, fmt.Errorf("%s: %w", nodeToDeleteInfo.name, err))
 			continue
 		}

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -115,7 +115,7 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 			return nil, fmt.Errorf("Not enough flags were passed to perform the operation.\nUse dhctl converge --help to get available flags.\nSsh host is not provided. Need to pass --ssh-host, or specify SSHHost manifest in the --connection-config file")
 		}
 
-		kubeCl, err = kubernetes.ConnectToKubernetesAPI(ssh.NewNodeInterfaceWrapper(c.SSHClient))
+		kubeCl, err = kubernetes.ConnectToKubernetesAPI(ctx, ssh.NewNodeInterfaceWrapper(c.SSHClient))
 		if err != nil {
 			return nil, fmt.Errorf("unable to connect to Kubernetes over ssh tunnel: %w", err)
 		}

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_destroy_pipeline.go
@@ -50,7 +50,8 @@ func NewHookForDestroyPipeline(getter kubernetes.KubeClientProvider, nodeToDestr
 }
 
 func (h *HookForDestroyPipeline) BeforeAction(runner terraform.RunnerInterface) (bool, error) {
-	outputs, err := terraform.GetMasterNodeResult(runner)
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	outputs, err := terraform.GetMasterNodeResult(context.TODO(), runner)
 	if err != nil {
 		log.ErrorF("Get master node pipeline outputs: %v", err)
 	}

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_update_pipeline.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook_for_update_pipeline.go
@@ -119,7 +119,8 @@ func (h *HookForUpdatePipeline) BeforeAction(runner terraform.RunnerInterface) (
 		return false, fmt.Errorf("failed to remove control plane role from node '%s': %v", h.nodeToConverge, err)
 	}
 
-	outputs, err := terraform.GetMasterNodeResult(runner)
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	outputs, err := terraform.GetMasterNodeResult(context.TODO(), runner)
 	if err != nil {
 		log.ErrorF("Get master node pipeline outputs: %v", err)
 	}
@@ -134,7 +135,8 @@ func (h *HookForUpdatePipeline) AfterAction(runner terraform.RunnerInterface) er
 		return nil
 	}
 
-	outputs, err := terraform.GetMasterNodeResult(runner)
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	outputs, err := terraform.GetMasterNodeResult(context.TODO(), runner)
 	if err != nil {
 		return fmt.Errorf("failed to get master node pipeline outputs: %v", err)
 	}

--- a/dhctl/pkg/operations/converge/runner.go
+++ b/dhctl/pkg/operations/converge/runner.go
@@ -334,7 +334,7 @@ func (r *runner) updateClusterState(ctx *context.Context, metaConfig *config.Met
 			AdditionalStateSaverDestinations: []terraform.SaverDestination{entity.NewClusterStateSaver(ctx)},
 		})
 
-		outputs, err := terraform.ApplyPipeline(baseRunner, "Kubernetes cluster", terraform.GetBaseInfraResult)
+		outputs, err := terraform.ApplyPipeline(ctx.Ctx(), baseRunner, "Kubernetes cluster", terraform.GetBaseInfraResult)
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/operations/destroy/deckhouse.go
+++ b/dhctl/pkg/operations/destroy/deckhouse.go
@@ -15,6 +15,8 @@
 package destroy
 
 import (
+	"context"
+
 	"github.com/google/uuid"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/lock"
@@ -69,7 +71,8 @@ func (g *DeckhouseDestroyer) GetKubeClient() (*client.KubernetesClient, error) {
 		return g.kubeCl, nil
 	}
 
-	kubeCl, err := kubernetes.ConnectToKubernetesAPI(ssh.NewNodeInterfaceWrapper(g.sshClient))
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	kubeCl, err := kubernetes.ConnectToKubernetesAPI(context.TODO(), ssh.NewNodeInterfaceWrapper(g.sshClient))
 	if err != nil {
 		return nil, err
 	}

--- a/dhctl/pkg/operations/nodebootstrap.go
+++ b/dhctl/pkg/operations/nodebootstrap.go
@@ -17,6 +17,7 @@ package operations
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -72,7 +73,8 @@ func BootstrapAdditionalNode(kubeCl *client.KubernetesClient, cfg *config.MetaCo
 		RunnerLogger: log.GetDefaultLogger(),
 	})
 
-	outputs, err := terraform.ApplyPipeline(runner, nodeName, terraform.OnlyState)
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	outputs, err := terraform.ApplyPipeline(context.TODO(), runner, nodeName, terraform.OnlyState)
 	if err != nil {
 		return err
 	}
@@ -134,7 +136,8 @@ func BootstrapAdditionalNodeForParallelRun(kubeCl *client.KubernetesClient, cfg 
 		RunnerLogger: runnerLogger,
 	})
 
-	outputs, err := terraform.ApplyPipeline(runner, nodeName, terraform.OnlyState)
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	outputs, err := terraform.ApplyPipeline(context.TODO(), runner, nodeName, terraform.OnlyState)
 	if err != nil {
 		return err
 	}
@@ -369,7 +372,8 @@ func BootstrapAdditionalMasterNode(kubeCl *client.KubernetesClient, cfg *config.
 		RunnerLogger: log.GetDefaultLogger(),
 	})
 
-	outputs, err := terraform.ApplyPipeline(runner, nodeName, terraform.GetMasterNodeResult)
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	outputs, err := terraform.ApplyPipeline(context.TODO(), runner, nodeName, terraform.GetMasterNodeResult)
 	if err != nil {
 		return nil, err
 	}

--- a/dhctl/pkg/system/node/ssh/frontend/waiting.go
+++ b/dhctl/pkg/system/node/ssh/frontend/waiting.go
@@ -15,6 +15,7 @@
 package frontend
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -38,12 +39,18 @@ func (c *Check) WithDelaySeconds(seconds int) *Check {
 	return c
 }
 
-func (c *Check) AwaitAvailability() error {
+func (c *Check) AwaitAvailability(ctx context.Context) error {
 	if c.Session.Host() == "" {
 		return fmt.Errorf("Empty host for connection received")
 	}
-	time.Sleep(c.delay)
-	return retry.NewLoop("Waiting for SSH connection", 50, 5*time.Second).Run(func() error {
+
+	select {
+	case <-time.After(c.delay):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	return retry.NewLoop("Waiting for SSH connection", 50, 5*time.Second).RunContext(ctx, func() error {
 		log.InfoF("Try to connect to %v host\n", c.Session.Host())
 		output, err := c.ExpectAvailable()
 		if err == nil {

--- a/dhctl/pkg/terraform/outputs.go
+++ b/dhctl/pkg/terraform/outputs.go
@@ -15,13 +15,14 @@
 package terraform
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os/exec"
 )
 
-func GetMasterIPAddressForSSH(statePath string) (string, error) {
+func GetMasterIPAddressForSSH(ctx context.Context, statePath string) (string, error) {
 	args := []string{
 		"output",
 		"-no-color",
@@ -32,7 +33,7 @@ func GetMasterIPAddressForSSH(statePath string) (string, error) {
 
 	executor := &CMDExecutor{}
 
-	result, err := executor.Output(args...)
+	result, err := executor.Output(ctx, args...)
 	if err != nil {
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {

--- a/dhctl/pkg/terraform/pipeline_test.go
+++ b/dhctl/pkg/terraform/pipeline_test.go
@@ -15,6 +15,7 @@
 package terraform
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -77,7 +78,7 @@ func TestGetMasterNodeResult(t *testing.T) {
 				WithStatePath("./mocks/pipeline/empty_state.json").
 				withTerraformExecutor(executor)
 
-			res, err := GetMasterNodeResult(runner)
+			res, err := GetMasterNodeResult(context.Background(), runner)
 			if tc.expectedErr != nil {
 				require.EqualError(t, err, tc.expectedErr.Error())
 			} else {
@@ -146,7 +147,7 @@ func TestCheckBaseInfrastructurePipeline(t *testing.T) {
 				WithStatePath("./mocks/pipeline/empty_state.json").
 				withTerraformExecutor(executor)
 
-			res, plan, _, err := CheckBaseInfrastructurePipeline(runner, "test")
+			res, plan, _, err := CheckBaseInfrastructurePipeline(context.Background(), runner, "test")
 			if tc.expectedErr != nil {
 				require.EqualError(t, err, tc.expectedErr.Error())
 			} else {
@@ -209,7 +210,7 @@ func TestDestroyPipeline(t *testing.T) {
 				WithStatePath(tc.stateFile).
 				withTerraformExecutor(executor)
 
-			err := DestroyPipeline(runner, "test")
+			err := DestroyPipeline(context.Background(), runner, "test")
 			if tc.expectedErr != nil {
 				require.Contains(t, err.Error(), tc.expectedErr.Error())
 			} else {

--- a/dhctl/pkg/terraform/runner.go
+++ b/dhctl/pkg/terraform/runner.go
@@ -15,6 +15,7 @@
 package terraform
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -251,7 +252,7 @@ func (r *Runner) checkTerraformIsRunning() bool {
 	return (atomic.LoadInt32(&r.terraformRunningCounter) % 2) > 0
 }
 
-func (r *Runner) Init() error {
+func (r *Runner) Init(ctx context.Context) error {
 	if r.stopped {
 		return ErrRunnerStopped
 	}
@@ -318,7 +319,7 @@ func (r *Runner) Init() error {
 			r.workingDir,
 		}
 
-		_, err := r.execTerraform(args...)
+		_, err := r.execTerraform(ctx, args...)
 		return err
 	})
 }
@@ -386,7 +387,7 @@ func (r *Runner) isSkipChanges() (skip bool, err error) {
 	return false, err
 }
 
-func (r *Runner) Apply() error {
+func (r *Runner) Apply(ctx context.Context) error {
 	if r.stopped {
 		return ErrRunnerStopped
 	}
@@ -425,7 +426,7 @@ func (r *Runner) Apply() error {
 			)
 		}
 
-		_, err = r.execTerraform(args...)
+		_, err = r.execTerraform(ctx, args...)
 
 		var errRes *multierror.Error
 		errRes = multierror.Append(errRes, err)
@@ -439,7 +440,7 @@ func (r *Runner) Apply() error {
 	})
 }
 
-func (r *Runner) Plan(opts PlanOptions) error {
+func (r *Runner) Plan(ctx context.Context, opts PlanOptions) error {
 	if r.stopped {
 		return ErrRunnerStopped
 	}
@@ -465,10 +466,10 @@ func (r *Runner) Plan(opts PlanOptions) error {
 		}
 		args = append(args, r.workingDir)
 
-		exitCode, err := r.execTerraform(args...)
+		exitCode, err := r.execTerraform(ctx, args...)
 		if exitCode == terraformHasChangesExitCode {
 			r.changesInPlan = PlanHasChanges
-			destructiveChanges, err := r.getPlanDestructiveChanges(tmpFile.Name())
+			destructiveChanges, err := r.getPlanDestructiveChanges(ctx, tmpFile.Name())
 			if err != nil {
 				return err
 			}
@@ -486,7 +487,7 @@ func (r *Runner) Plan(opts PlanOptions) error {
 	})
 }
 
-func (r *Runner) GetTerraformOutput(output string) ([]byte, error) {
+func (r *Runner) GetTerraformOutput(ctx context.Context, output string) ([]byte, error) {
 	if r.stopped {
 		return nil, ErrRunnerStopped
 	}
@@ -502,7 +503,7 @@ func (r *Runner) GetTerraformOutput(output string) ([]byte, error) {
 	}
 	args = append(args, output)
 
-	result, err := r.terraformExecutor.Output(args...)
+	result, err := r.terraformExecutor.Output(ctx, args...)
 	if err != nil {
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {
@@ -514,7 +515,7 @@ func (r *Runner) GetTerraformOutput(output string) ([]byte, error) {
 	return result, nil
 }
 
-func (r *Runner) Destroy() error {
+func (r *Runner) Destroy(ctx context.Context) error {
 	if r.stopped {
 		return ErrRunnerStopped
 	}
@@ -537,7 +538,7 @@ func (r *Runner) Destroy() error {
 	}
 	planDestroyArgs = append(planDestroyArgs, r.workingDir)
 
-	_, err := r.execTerraform(planDestroyArgs...)
+	_, err := r.execTerraform(ctx, planDestroyArgs...)
 	if err != nil {
 		return fmt.Errorf("Cannot prepare terrafrom destroy plan: %w", err)
 	}
@@ -569,7 +570,7 @@ func (r *Runner) Destroy() error {
 		}
 		args = append(args, r.workingDir)
 
-		_, err = r.execTerraform(args...)
+		_, err = r.execTerraform(ctx, args...)
 
 		var errRes *multierror.Error
 		errRes = multierror.Append(errRes, err)
@@ -648,7 +649,7 @@ func (r *Runner) Stop() {
 	}
 }
 
-func (r *Runner) execTerraform(args ...string) (int, error) {
+func (r *Runner) execTerraform(ctx context.Context, args ...string) (int, error) {
 	if r.checkTerraformIsRunning() {
 		return 0, fmt.Errorf("Terraform have been already executed.")
 	}
@@ -656,7 +657,7 @@ func (r *Runner) execTerraform(args ...string) (int, error) {
 	r.switchTerraformIsRunning()
 	defer r.switchTerraformIsRunning()
 	r.terraformExecutor.SetExecutorLogger(r.logger)
-	exitCode, err := r.terraformExecutor.Exec(args...)
+	exitCode, err := r.terraformExecutor.Exec(ctx, args...)
 	r.logger.LogInfoF("Terraform runner %q process exited.\n", r.step)
 
 	return exitCode, err
@@ -675,14 +676,14 @@ type ValueChange struct {
 	Type         string      `json:"type,omitempty"`
 }
 
-func (r *Runner) getPlanDestructiveChanges(planFile string) (*PlanDestructiveChanges, error) {
+func (r *Runner) getPlanDestructiveChanges(ctx context.Context, planFile string) (*PlanDestructiveChanges, error) {
 	args := []string{
 		"show",
 		"-json",
 		planFile,
 	}
 
-	result, err := r.terraformExecutor.Output(args...)
+	result, err := r.terraformExecutor.Output(ctx, args...)
 	if err != nil {
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {

--- a/dhctl/pkg/terraform/runner_interface.go
+++ b/dhctl/pkg/terraform/runner_interface.go
@@ -14,21 +14,25 @@
 
 package terraform
 
-import "github.com/deckhouse/deckhouse/dhctl/pkg/log"
+import (
+	"context"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
 
 type PlanOptions struct {
 	Destroy bool
 }
 
 type RunnerInterface interface {
-	Init() error
-	Apply() error
-	Plan(opts PlanOptions) error
-	Destroy() error
+	Init(ctx context.Context) error
+	Apply(ctx context.Context) error
+	Plan(ctx context.Context, opts PlanOptions) error
+	Destroy(ctx context.Context) error
 	Stop()
 
 	ResourcesQuantityInState() int
-	GetTerraformOutput(output string) ([]byte, error)
+	GetTerraformOutput(ctx context.Context, output string) ([]byte, error)
 	GetState() ([]byte, error)
 	GetStep() string
 	GetChangesInPlan() int

--- a/dhctl/pkg/terraform/runner_test.go
+++ b/dhctl/pkg/terraform/runner_test.go
@@ -15,17 +15,19 @@
 package terraform
 
 import (
+	"context"
 	"os"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
-	"github.com/stretchr/testify/require"
 )
 
 func newTestRunner() *Runner {
@@ -63,7 +65,7 @@ func TestCheckPlanDestructiveChanges(t *testing.T) {
 
 			runner := newTestRunner().withTerraformExecutor(executor)
 
-			changes, err := runner.getPlanDestructiveChanges("")
+			changes, err := runner.getPlanDestructiveChanges(context.Background(), "")
 			if tc.err != nil {
 				require.EqualError(t, err, tc.err.Error())
 			} else {
@@ -176,7 +178,7 @@ type sleepExecutor struct {
 	logger   log.Logger
 }
 
-func (s *sleepExecutor) Output(_ ...string) ([]byte, error) {
+func (s *sleepExecutor) Output(_ context.Context, _ ...string) ([]byte, error) {
 	return nil, nil
 }
 
@@ -184,7 +186,7 @@ func (s *sleepExecutor) SetExecutorLogger(logger log.Logger) {
 	s.logger = logger
 }
 
-func (s *sleepExecutor) Exec(_ ...string) (int, error) {
+func (s *sleepExecutor) Exec(_ context.Context, _ ...string) (int, error) {
 	ticker := time.NewTicker(time.Second)
 loop:
 	for {
@@ -201,17 +203,19 @@ loop:
 func (s *sleepExecutor) Stop() { close(s.cancelCh) }
 
 func TestConcurrentExec(t *testing.T) {
+	ctx := context.Background()
+
 	exec := sleepExecutor{cancelCh: make(chan struct{})}
 	defer exec.Stop()
 
 	runner := newTestRunner().withTerraformExecutor(&exec)
 
 	go func() {
-		_, _ = runner.execTerraform()
+		_, _ = runner.execTerraform(ctx)
 	}()
 
 	runtime.Gosched()
-	_, err := runner.execTerraform()
+	_, err := runner.execTerraform(ctx)
 
 	require.Equal(t, "Terraform have been already executed.", err.Error())
 }

--- a/dhctl/pkg/terraform/single_shot_runner.go
+++ b/dhctl/pkg/terraform/single_shot_runner.go
@@ -15,8 +15,10 @@
 package terraform
 
 import (
-	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"context"
 	"sync"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
 func NewSingleShotRunner(runner *Runner) *SingleShotRunner {
@@ -31,34 +33,34 @@ type SingleShotRunner struct {
 	init, apply, plan, destroy, stop sync.Once
 }
 
-func (r *SingleShotRunner) Init() (err error) {
+func (r *SingleShotRunner) Init(ctx context.Context) (err error) {
 	r.init.Do(func() {
-		err = r.Runner.Init()
+		err = r.Runner.Init(ctx)
 	})
 	return
 }
 
-func (r *SingleShotRunner) Apply() (err error) {
+func (r *SingleShotRunner) Apply(ctx context.Context) (err error) {
 	r.apply.Do(func() {
-		err = r.Runner.Apply()
+		err = r.Runner.Apply(ctx)
 	})
 	return
 }
 
-func (r *SingleShotRunner) Plan(opts PlanOptions) (err error) {
+func (r *SingleShotRunner) Plan(ctx context.Context, opts PlanOptions) (err error) {
 	r.plan.Do(func() {
-		err = r.Runner.Plan(opts)
+		err = r.Runner.Plan(ctx, opts)
 	})
 	return
 }
 
-func (r *SingleShotRunner) GetTerraformOutput(output string) ([]byte, error) {
-	return r.Runner.GetTerraformOutput(output)
+func (r *SingleShotRunner) GetTerraformOutput(ctx context.Context, output string) ([]byte, error) {
+	return r.Runner.GetTerraformOutput(ctx, output)
 }
 
-func (r *SingleShotRunner) Destroy() (err error) {
+func (r *SingleShotRunner) Destroy(ctx context.Context) (err error) {
 	r.destroy.Do(func() {
-		err = r.Runner.Destroy()
+		err = r.Runner.Destroy(ctx)
 	})
 	return
 }

--- a/dhctl/pkg/terraform/state_saver.go
+++ b/dhctl/pkg/terraform/state_saver.go
@@ -15,6 +15,7 @@
 package terraform
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -129,7 +130,7 @@ func (s *StateSaver) FsEventHandler(event fsnotify.Event) {
 		return
 	}
 
-	outputs, err := OnlyState(s.runner)
+	outputs, err := OnlyState(context.Background(), s.runner)
 	if err != nil {
 		log.ErrorF("Parse intermediate state: %v\n", err)
 		return


### PR DESCRIPTION
## Description

Make terraform runner methods accept context.Context. Now, calls to the Terraform utility are canceled when the context is canceled. In the future, the context from bootstrapping and destroying operations will be used. Relevant TODOs comments have been added (dhctl-for-commander-cancels). 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: make terraform runner cancellable
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
