### PR TITLE
[dhctl] feat(dhctl-for-commander-cancels): add ctx to kube client calls

### DIFF
--- a/dhctl/cmd/dhctl/commands/deckhouse.go
+++ b/dhctl/cmd/dhctl/commands/deckhouse.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -47,7 +48,7 @@ func DefineDeckhouseRemoveDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 				return fmt.Errorf("open kubernetes connection: %v", err)
 			}
 
-			err = deckhouse.DeleteDeckhouseDeployment(kubeCl)
+			err = deckhouse.DeleteDeckhouseDeployment(context.Background(), kubeCl)
 			if err != nil {
 				return err
 			}
@@ -110,12 +111,12 @@ func DefineDeckhouseCreateDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 				return fmt.Errorf("open kubernetes connection: %v", err)
 			}
 
-			err = deckhouse.CreateDeckhouseDeployment(kubeCl, installConfig)
+			err = deckhouse.CreateDeckhouseDeployment(context.Background(), kubeCl, installConfig)
 			if err != nil {
 				return fmt.Errorf("deckhouse install: %v", err)
 			}
 
-			err = deckhouse.WaitForReadiness(kubeCl)
+			err = deckhouse.WaitForReadiness(context.Background(), kubeCl)
 			if err != nil {
 				return fmt.Errorf("deckhouse install: %v", err)
 			}

--- a/dhctl/cmd/dhctl/commands/kube.go
+++ b/dhctl/cmd/dhctl/commands/kube.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -103,7 +104,7 @@ func DefineWaitDeploymentReadyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 				return fmt.Errorf("open kubernetes connection: %v", err)
 			}
 
-			err = deckhouse.WaitForReadiness(kubeCl)
+			err = deckhouse.WaitForReadiness(context.Background(), kubeCl)
 			if err != nil {
 				return err
 			}

--- a/dhctl/cmd/dhctl/commands/lock.go
+++ b/dhctl/cmd/dhctl/commands/lock.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -78,7 +79,7 @@ func DefineReleaseConvergeLockCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 		}
 
 		cnf := lock.GetLockLeaseConfig("lock-releaser")
-		return lease.RemoveLease(kubeCl, cnf, confirm)
+		return lease.RemoveLease(context.Background(), kubeCl, cnf, confirm)
 	})
 	return cmd
 }

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -61,10 +61,10 @@ var d8storageConfig = []schema.GroupVersionResource{
 	},
 }
 
-func DeleteDeckhouseDeployment(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Deckhouse", 45, 5*time.Second).WithShowError(false).Run(func() error {
+func DeleteDeckhouseDeployment(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Delete Deckhouse", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		foregroundPolicy := metav1.DeletePropagationForeground
-		err := kubeCl.AppsV1().Deployments(deckhouseDeploymentNamespace).Delete(context.TODO(), deckhouseDeploymentName, metav1.DeleteOptions{PropagationPolicy: &foregroundPolicy})
+		err := kubeCl.AppsV1().Deployments(deckhouseDeploymentNamespace).Delete(ctx, deckhouseDeploymentName, metav1.DeleteOptions{PropagationPolicy: &foregroundPolicy})
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
@@ -72,22 +72,22 @@ func DeleteDeckhouseDeployment(kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func DeletePDBs(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete pdbs", 45, 5*time.Second).WithShowError(false).Run(func() error {
+func DeletePDBs(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Delete pdbs", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		foregroundPolicy := metav1.DeletePropagationForeground
-		namespaces, err := kubeCl.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+		namespaces, err := kubeCl.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
 
 		for _, ns := range namespaces.Items {
-			pdbs, err := kubeCl.PolicyV1().PodDisruptionBudgets(ns.Name).List(context.TODO(), metav1.ListOptions{})
+			pdbs, err := kubeCl.PolicyV1().PodDisruptionBudgets(ns.Name).List(ctx, metav1.ListOptions{})
 			if err != nil {
 				continue
 			}
 
 			for _, pdb := range pdbs.Items {
-				err := kubeCl.PolicyV1().PodDisruptionBudgets(ns.Name).Delete(context.TODO(), pdb.Name, metav1.DeleteOptions{PropagationPolicy: &foregroundPolicy})
+				err := kubeCl.PolicyV1().PodDisruptionBudgets(ns.Name).Delete(ctx, pdb.Name, metav1.DeleteOptions{PropagationPolicy: &foregroundPolicy})
 				if err != nil {
 					return err
 				}
@@ -98,8 +98,8 @@ func DeletePDBs(kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func ListD8StorageResources(kubeCl *client.KubernetesClient, cr schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+func ListD8StorageResources(ctx context.Context, kubeCl *client.KubernetesClient, cr schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	storageCR, err := kubeCl.Dynamic().Resource(cr).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -108,8 +108,8 @@ func ListD8StorageResources(kubeCl *client.KubernetesClient, cr schema.GroupVers
 	return storageCR, err
 }
 
-func DeleteD8StorageResources(kubeCl *client.KubernetesClient, obj unstructured.Unstructured, cr schema.GroupVersionResource) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+func DeleteD8StorageResources(ctx context.Context, kubeCl *client.KubernetesClient, obj unstructured.Unstructured, cr schema.GroupVersionResource) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	err := kubeCl.Dynamic().Resource(cr).Namespace(obj.GetNamespace()).Delete(ctx, obj.GetName(), metav1.DeleteOptions{})
@@ -120,10 +120,10 @@ func DeleteD8StorageResources(kubeCl *client.KubernetesClient, obj unstructured.
 	return nil
 }
 
-func DeleteAllD8StorageResources(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Deckhouse Storage CRs", 45, 5*time.Second).WithShowError(false).Run(func() error {
+func DeleteAllD8StorageResources(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Delete Deckhouse Storage CRs", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		for _, cr := range d8storageConfig {
-			storageCRs, err := ListD8StorageResources(kubeCl, cr)
+			storageCRs, err := ListD8StorageResources(ctx, kubeCl, cr)
 			if err != nil {
 				if errors.IsNotFound(err) {
 					log.InfoF("Resources kind of %s not found, skipping...\n", cr)
@@ -132,7 +132,7 @@ func DeleteAllD8StorageResources(kubeCl *client.KubernetesClient) error {
 				return fmt.Errorf("get %s: %v", cr, err)
 			}
 			for _, obj := range storageCRs.Items {
-				err = DeleteD8StorageResources(kubeCl, obj, cr)
+				err = DeleteD8StorageResources(ctx, kubeCl, obj, cr)
 				if err != nil {
 					return err
 				}
@@ -142,15 +142,15 @@ func DeleteAllD8StorageResources(kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func DeleteStorageClasses(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete StorageClasses", 45, 5*time.Second).WithShowError(false).Run(func() error {
-		return kubeCl.StorageV1().StorageClasses().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
+func DeleteStorageClasses(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Delete StorageClasses", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+		return kubeCl.StorageV1().StorageClasses().DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
 	})
 }
 
-func DeletePods(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Pods", 45, 5*time.Second).WithShowError(false).Run(func() error {
-		pods, err := kubeCl.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+func DeletePods(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Delete Pods", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+		pods, err := kubeCl.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -173,7 +173,7 @@ func DeletePods(kubeCl *client.KubernetesClient) error {
 				continue
 			}
 
-			err := kubeCl.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			err := kubeCl.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 			if err != nil {
 				log.ErrorLn(err.Error())
 			} else {
@@ -185,9 +185,9 @@ func DeletePods(kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func DeleteServices(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Services", 45, 5*time.Second).WithShowError(false).Run(func() error {
-		allServices, err := kubeCl.CoreV1().Services(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+func DeleteServices(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Delete Services", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+		allServices, err := kubeCl.CoreV1().Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -197,7 +197,7 @@ func DeleteServices(kubeCl *client.KubernetesClient) error {
 				continue
 			}
 
-			err := kubeCl.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+			err := kubeCl.CoreV1().Services(service.Namespace).Delete(ctx, service.Name, metav1.DeleteOptions{})
 			if err != nil {
 				return err
 			}
@@ -207,15 +207,15 @@ func DeleteServices(kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func DeletePVC(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete PersistentVolumeClaims", 45, 5*time.Second).WithShowError(false).Run(func() error {
-		volumeClaims, err := kubeCl.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+func DeletePVC(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Delete PersistentVolumeClaims", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+		volumeClaims, err := kubeCl.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
 
 		for _, claim := range volumeClaims.Items {
-			err := kubeCl.CoreV1().PersistentVolumeClaims(claim.Namespace).Delete(context.TODO(), claim.Name, metav1.DeleteOptions{})
+			err := kubeCl.CoreV1().PersistentVolumeClaims(claim.Namespace).Delete(ctx, claim.Name, metav1.DeleteOptions{})
 			if err != nil {
 				return err
 			}
@@ -225,9 +225,9 @@ func DeletePVC(kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func DeletePV(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete PersistentVolumes provided manually or contain reclaimPolicy other than Delete.", 45, 5*time.Second).WithShowError(false).Run(func() error {
-		persistentVolumes, err := kubeCl.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
+func DeletePV(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Delete PersistentVolumes provided manually or contain reclaimPolicy other than Delete.", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+		persistentVolumes, err := kubeCl.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -235,7 +235,7 @@ func DeletePV(kubeCl *client.KubernetesClient) error {
 		annotationKey := "pv.kubernetes.io/provisioned-by"
 		for _, volume := range persistentVolumes.Items {
 			if _, exists := volume.Annotations[annotationKey]; !exists || volume.Spec.PersistentVolumeReclaimPolicy != v1.PersistentVolumeReclaimDelete {
-				err := kubeCl.CoreV1().PersistentVolumes().Delete(context.TODO(), volume.Name, metav1.DeleteOptions{})
+				err := kubeCl.CoreV1().PersistentVolumes().Delete(ctx, volume.Name, metav1.DeleteOptions{})
 				if err != nil {
 					return err
 				}
@@ -246,9 +246,9 @@ func DeletePV(kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func WaitForDeckhouseDeploymentDeletion(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for Deckhouse Deployment deletion", 30, 5*time.Second).WithShowError(false).Run(func() error {
-		_, err := kubeCl.AppsV1().Deployments(deckhouseDeploymentNamespace).Get(context.TODO(), deckhouseDeploymentName, metav1.GetOptions{})
+func WaitForDeckhouseDeploymentDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Wait for Deckhouse Deployment deletion", 30, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+		_, err := kubeCl.AppsV1().Deployments(deckhouseDeploymentNamespace).Get(ctx, deckhouseDeploymentName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			log.InfoLn("Deckhouse Deployment and its dependents are removed")
 			return nil
@@ -263,9 +263,9 @@ func WaitForDeckhouseDeploymentDeletion(kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func WaitForServicesDeletion(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for Services deletion", 45, 15*time.Second).WithShowError(false).Run(func() error {
-		resources, err := kubeCl.CoreV1().Services(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+func WaitForServicesDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Wait for Services deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
+		resources, err := kubeCl.CoreV1().Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -290,9 +290,9 @@ func WaitForServicesDeletion(kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func WaitForPVDeletion(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for PersistentVolumes deletion", 45, 15*time.Second).WithShowError(false).Run(func() error {
-		resources, err := kubeCl.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
+func WaitForPVDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Wait for PersistentVolumes deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
+		resources, err := kubeCl.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -324,9 +324,9 @@ func WaitForPVDeletion(kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func WaitForPVCDeletion(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for PersistentVolumeClaims deletion", 45, 15*time.Second).WithShowError(false).Run(func() error {
-		resources, err := kubeCl.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+func WaitForPVCDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Wait for PersistentVolumeClaims deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
+		resources, err := kubeCl.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -379,12 +379,12 @@ const (
 	MCMGroupVersion = "v1alpha1"
 )
 
-func DeleteMCMMachineDeployments(kubeCl *client.KubernetesClient) error {
+func DeleteMCMMachineDeployments(ctx context.Context, kubeCl *client.KubernetesClient) error {
 	machineDeploymentsSchema := schema.GroupVersionResource{Group: MCMGroup, Version: MCMGroupVersion, Resource: "machinedeployments"}
 	machinesSchema := schema.GroupVersionResource{Group: MCMGroup, Version: MCMGroupVersion, Resource: "machines"}
 
-	return retry.NewLoop("Delete MCM MachineDeployments", 45, 5*time.Second).Run(func() error {
-		allMachines, err := kubeCl.Dynamic().Resource(machinesSchema).Namespace(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	return retry.NewLoop("Delete MCM MachineDeployments", 45, 5*time.Second).RunContext(ctx, func() error {
+		allMachines, err := kubeCl.Dynamic().Resource(machinesSchema).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("get machines: %v", err)
 		}
@@ -400,13 +400,13 @@ func DeleteMCMMachineDeployments(kubeCl *client.KubernetesClient) error {
 				return err
 			}
 
-			_, err = kubeCl.Dynamic().Resource(machinesSchema).Namespace(machine.GetNamespace()).Patch(context.TODO(), machine.GetName(), types.MergePatchType, content, metav1.PatchOptions{})
+			_, err = kubeCl.Dynamic().Resource(machinesSchema).Namespace(machine.GetNamespace()).Patch(ctx, machine.GetName(), types.MergePatchType, content, metav1.PatchOptions{})
 			if err != nil {
 				return fmt.Errorf("patch machine %s: %v", machine.GetName(), err)
 			}
 		}
 
-		allMachineDeployments, err := kubeCl.Dynamic().Resource(machineDeploymentsSchema).Namespace(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		allMachineDeployments, err := kubeCl.Dynamic().Resource(machineDeploymentsSchema).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("get machinedeployments: %v", err)
 		}
@@ -414,7 +414,7 @@ func DeleteMCMMachineDeployments(kubeCl *client.KubernetesClient) error {
 		for _, machineDeployment := range allMachineDeployments.Items {
 			namespace := machineDeployment.GetNamespace()
 			name := machineDeployment.GetName()
-			err := kubeCl.Dynamic().Resource(machineDeploymentsSchema).Namespace(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+			err := kubeCl.Dynamic().Resource(machineDeploymentsSchema).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 			if err != nil {
 				return fmt.Errorf("delete machinedeployments %s: %v", name, err)
 			}
@@ -424,10 +424,10 @@ func DeleteMCMMachineDeployments(kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func WaitForMCMMachinesDeletion(kubeCl *client.KubernetesClient) error {
+func WaitForMCMMachinesDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
 	resourceSchema := schema.GroupVersionResource{Group: MCMGroup, Version: MCMGroupVersion, Resource: "machines"}
-	return retry.NewLoop("Wait for MCM Machines deletion", 45, 15*time.Second).WithShowError(false).Run(func() error {
-		resources, err := kubeCl.Dynamic().Resource(resourceSchema).List(context.TODO(), metav1.ListOptions{})
+	return retry.NewLoop("Wait for MCM Machines deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
+		resources, err := kubeCl.Dynamic().Resource(resourceSchema).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -454,9 +454,9 @@ func checkMCMMachinesAPI(kubeCl *client.KubernetesClient) error {
 	return checkMachinesAPI(kubeCl, gv)
 }
 
-func DeleteMachinesIfResourcesExist(kubeCl *client.KubernetesClient) error {
+func DeleteMachinesIfResourcesExist(ctx context.Context, kubeCl *client.KubernetesClient) error {
 	err := retry.NewLoop("Get Kubernetes cluster resources for MCM group/version", 5, 5*time.Second).WithShowError(false).
-		Run(func() error {
+		RunContext(ctx, func() error {
 			return checkMCMMachinesAPI(kubeCl)
 		})
 	if err != nil {
@@ -470,18 +470,18 @@ func DeleteMachinesIfResourcesExist(kubeCl *client.KubernetesClient) error {
 		return fmt.Errorf("Machines deletion aborted.\n")
 	}
 
-	err = DeleteMCMMachineDeployments(kubeCl)
+	err = DeleteMCMMachineDeployments(ctx, kubeCl)
 	if err != nil {
 		return err
 	}
 
-	if err := WaitForMCMMachinesDeletion(kubeCl); err != nil {
+	if err := WaitForMCMMachinesDeletion(ctx, kubeCl); err != nil {
 		return err
 	}
 
 	// try to remove CAPI machines it needs for static clusters and cluster with cluster api support
 	err = retry.NewLoop("Get Kubernetes cluster resources for CAPI group/version", 5, 5*time.Second).WithShowError(false).
-		Run(func() error {
+		RunContext(ctx, func() error {
 			return checkCAPIMachinesAPI(kubeCl)
 		})
 	if err != nil {
@@ -495,12 +495,12 @@ func DeleteMachinesIfResourcesExist(kubeCl *client.KubernetesClient) error {
 		return fmt.Errorf("Machines deletion aborted.\n")
 	}
 
-	err = DeleteCAPIMachineDeployments(kubeCl)
+	err = DeleteCAPIMachineDeployments(ctx, kubeCl)
 	if err != nil {
 		return err
 	}
 
-	return WaitForCAPIMachinesDeletion(kubeCl)
+	return WaitForCAPIMachinesDeletion(ctx, kubeCl)
 }
 
 // CAPI
@@ -520,11 +520,11 @@ func checkCAPIMachinesAPI(kubeCl *client.KubernetesClient) error {
 	return checkMachinesAPI(kubeCl, gv)
 }
 
-func DeleteCAPIMachineDeployments(kubeCl *client.KubernetesClient) error {
+func DeleteCAPIMachineDeployments(ctx context.Context, kubeCl *client.KubernetesClient) error {
 	machineDeploymentsSchema := schema.GroupVersionResource{Group: CAPIGroup, Version: CAPIGroupVersion, Resource: "machinedeployments"}
 
-	return retry.NewLoop("Delete CAPI MachineDeployments", 45, 5*time.Second).Run(func() error {
-		allMachines, err := kubeCl.Dynamic().Resource(capiMachinesSchema).Namespace(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	return retry.NewLoop("Delete CAPI MachineDeployments", 45, 5*time.Second).RunContext(ctx, func() error {
+		allMachines, err := kubeCl.Dynamic().Resource(capiMachinesSchema).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("get machines: %v", err)
 		}
@@ -535,7 +535,7 @@ func DeleteCAPIMachineDeployments(kubeCl *client.KubernetesClient) error {
 			// we delete cluster anyway and we can force delete machine (without drain)
 			unstructured.SetNestedField(m.Object, "10s", "spec", "nodeDrainTimeout")
 
-			_, err = kubeCl.Dynamic().Resource(capiMachinesSchema).Namespace(machine.GetNamespace()).Update(context.TODO(), &m, metav1.UpdateOptions{})
+			_, err = kubeCl.Dynamic().Resource(capiMachinesSchema).Namespace(machine.GetNamespace()).Update(ctx, &m, metav1.UpdateOptions{})
 			if err != nil {
 				return fmt.Errorf("patch machine %s: %v", machine.GetName(), err)
 			}
@@ -543,7 +543,7 @@ func DeleteCAPIMachineDeployments(kubeCl *client.KubernetesClient) error {
 			log.DebugF("Machine %s patched\n", machine.GetName())
 		}
 
-		allMachineDeployments, err := kubeCl.Dynamic().Resource(machineDeploymentsSchema).Namespace(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		allMachineDeployments, err := kubeCl.Dynamic().Resource(machineDeploymentsSchema).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("get machinedeployments: %v", err)
 		}
@@ -555,7 +555,7 @@ func DeleteCAPIMachineDeployments(kubeCl *client.KubernetesClient) error {
 				log.InfoLn("Machine deployment 'master' was skipped. It will be deleted later.")
 				continue
 			}
-			err := kubeCl.Dynamic().Resource(machineDeploymentsSchema).Namespace(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+			err := kubeCl.Dynamic().Resource(machineDeploymentsSchema).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 			if err != nil {
 				return fmt.Errorf("delete machinedeployments %s: %v", name, err)
 			}
@@ -565,9 +565,9 @@ func DeleteCAPIMachineDeployments(kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func WaitForCAPIMachinesDeletion(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for CAPI Machines deletion", 45, 15*time.Second).WithShowError(false).Run(func() error {
-		resources, err := kubeCl.Dynamic().Resource(capiMachinesSchema).List(context.TODO(), metav1.ListOptions{})
+func WaitForCAPIMachinesDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Wait for CAPI Machines deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
+		resources, err := kubeCl.Dynamic().Resource(capiMachinesSchema).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete_test.go
@@ -104,12 +104,13 @@ func TestDeleteMachinesIfResourcesExist(t *testing.T) {
 }
 
 func TestDeletePods(t *testing.T) {
+	ctx := context.Background()
 	log.InitLogger("json")
 
 	t.Run("Without pods", func(t *testing.T) {
 		fakeClient := client.NewFakeKubernetesClient()
 
-		err := DeletePods(fakeClient)
+		err := DeletePods(ctx, fakeClient)
 		require.NoError(t, err)
 	})
 
@@ -189,7 +190,7 @@ func TestDeletePods(t *testing.T) {
 		_, err = fakeClient.CoreV1().Pods("test-ns").Create(context.TODO(), pod4, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		err = DeletePods(fakeClient)
+		err = DeletePods(ctx, fakeClient)
 		require.NoError(t, err)
 
 		pods, err := fakeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -42,10 +42,17 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
-func prepareDeckhouseDeploymentForUpdate(kubeCl *client.KubernetesClient, cfg *config.DeckhouseInstaller, manifestForUpdate *appsv1.Deployment) (*appsv1.Deployment, error) {
+func prepareDeckhouseDeploymentForUpdate(
+	ctx context.Context,
+	kubeCl *client.KubernetesClient,
+	cfg *config.DeckhouseInstaller,
+	manifestForUpdate *appsv1.Deployment,
+) (*appsv1.Deployment, error) {
 	resDeployment := manifestForUpdate
 	err := retry.NewSilentLoop("get deployment", 10, 3*time.Second).Run(func() error {
-		currentManifestInCluster, err := kubeCl.AppsV1().Deployments(manifestForUpdate.GetNamespace()).Get(context.TODO(), manifestForUpdate.GetName(), metav1.GetOptions{})
+		currentManifestInCluster, err := kubeCl.AppsV1().
+			Deployments(manifestForUpdate.GetNamespace()).
+			Get(ctx, manifestForUpdate.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -68,34 +75,41 @@ func prepareDeckhouseDeploymentForUpdate(kubeCl *client.KubernetesClient, cfg *c
 	return resDeployment, err
 }
 
-func controllerDeploymentTask(kubeCl *client.KubernetesClient, cfg *config.DeckhouseInstaller) actions.ManifestTask {
+func controllerDeploymentTask(
+	ctx context.Context,
+	kubeCl *client.KubernetesClient,
+	cfg *config.DeckhouseInstaller,
+) actions.ManifestTask {
 	return actions.ManifestTask{
 		Name: `Deployment "deckhouse"`,
 		Manifest: func() interface{} {
 			return CreateDeckhouseDeploymentManifest(cfg)
 		},
 		CreateFunc: func(manifest interface{}) error {
-			_, err := kubeCl.AppsV1().Deployments("d8-system").Create(context.TODO(), manifest.(*appsv1.Deployment), metav1.CreateOptions{})
+			_, err := kubeCl.AppsV1().Deployments("d8-system").Create(ctx, manifest.(*appsv1.Deployment), metav1.CreateOptions{})
 			return err
 		},
 		UpdateFunc: func(manifest interface{}) error {
-			preparedManifest, err := prepareDeckhouseDeploymentForUpdate(kubeCl, cfg, manifest.(*appsv1.Deployment))
+			preparedManifest, err := prepareDeckhouseDeploymentForUpdate(ctx, kubeCl, cfg, manifest.(*appsv1.Deployment))
 			if err != nil {
 				return err
 			}
 
-			_, err = kubeCl.AppsV1().Deployments("d8-system").Update(context.TODO(), preparedManifest, metav1.UpdateOptions{})
+			_, err = kubeCl.AppsV1().Deployments("d8-system").Update(ctx, preparedManifest, metav1.UpdateOptions{})
 
 			return err
 		},
 	}
 }
 
-func LockDeckhouseQueueBeforeCreatingModuleConfigs(kubeCl *client.KubernetesClient) (*actions.ManifestTask, error) {
+func LockDeckhouseQueueBeforeCreatingModuleConfigs(
+	ctx context.Context,
+	kubeCl *client.KubernetesClient,
+) (*actions.ManifestTask, error) {
 	deckhouseDeploymentPresent := false
 
-	err := retry.NewLoop("Get deckhouse manifest", 10, 5*time.Second).Run(func() error {
-		_, err := kubeCl.AppsV1().Deployments("d8-system").Get(context.TODO(), "deckhouse", metav1.GetOptions{})
+	err := retry.NewLoop("Get deckhouse manifest", 10, 5*time.Second).RunContext(ctx, func() error {
+		_, err := kubeCl.AppsV1().Deployments("d8-system").Get(ctx, "deckhouse", metav1.GetOptions{})
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				return err
@@ -135,7 +149,7 @@ func LockDeckhouseQueueBeforeCreatingModuleConfigs(kubeCl *client.KubernetesClie
 		CreateFunc: func(manifest interface{}) error {
 			cm := manifest.(*apiv1.ConfigMap)
 			_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
-				Create(context.TODO(), cm, metav1.CreateOptions{})
+				Create(ctx, cm, metav1.CreateOptions{})
 			return err
 		},
 		UpdateFunc: func(manifest interface{}) error {
@@ -144,10 +158,10 @@ func LockDeckhouseQueueBeforeCreatingModuleConfigs(kubeCl *client.KubernetesClie
 	}, nil
 }
 
-func UnlockDeckhouseQueueAfterCreatingModuleConfigs(kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Unlock Deckhouse controller queue", 15, 5*time.Second).Run(func() error {
+func UnlockDeckhouseQueueAfterCreatingModuleConfigs(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Unlock Deckhouse controller queue", 15, 5*time.Second).RunContext(ctx, func() error {
 		err := kubeCl.CoreV1().ConfigMaps("d8-system").
-			Delete(context.TODO(), "deckhouse-bootstrap-lock", metav1.DeleteOptions{})
+			Delete(ctx, "deckhouse-bootstrap-lock", metav1.DeleteOptions{})
 
 		if apierrors.IsNotFound(err) {
 			return nil
@@ -162,16 +176,20 @@ type ManifestsResult struct {
 	PostBootstrapMCTasks []actions.ModuleConfigTask
 }
 
-func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.DeckhouseInstaller) (*ManifestsResult, error) {
+func CreateDeckhouseManifests(
+	ctx context.Context,
+	kubeCl *client.KubernetesClient,
+	cfg *config.DeckhouseInstaller,
+) (*ManifestsResult, error) {
 	tasks := []actions.ManifestTask{
 		{
 			Name:     `Namespace "d8-system"`,
 			Manifest: func() interface{} { return manifests.DeckhouseNamespace("d8-system") },
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Namespaces().Get(context.TODO(), manifest.(*apiv1.Namespace).GetName(), metav1.GetOptions{})
+				_, err := kubeCl.CoreV1().Namespaces().Get(ctx, manifest.(*apiv1.Namespace).GetName(), metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
-						_, err = kubeCl.CoreV1().Namespaces().Create(context.TODO(), manifest.(*apiv1.Namespace), metav1.CreateOptions{})
+						_, err = kubeCl.CoreV1().Namespaces().Create(ctx, manifest.(*apiv1.Namespace), metav1.CreateOptions{})
 					}
 				} else {
 					log.InfoLn("Already exists. Skip!")
@@ -186,11 +204,11 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 			Name:     `Admin ClusterRole "cluster-admin"`,
 			Manifest: func() interface{} { return manifests.DeckhouseAdminClusterRole() },
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.RbacV1().ClusterRoles().Create(context.TODO(), manifest.(*rbacv1.ClusterRole), metav1.CreateOptions{})
+				_, err := kubeCl.RbacV1().ClusterRoles().Create(ctx, manifest.(*rbacv1.ClusterRole), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.RbacV1().ClusterRoles().Update(context.TODO(), manifest.(*rbacv1.ClusterRole), metav1.UpdateOptions{})
+				_, err := kubeCl.RbacV1().ClusterRoles().Update(ctx, manifest.(*rbacv1.ClusterRole), metav1.UpdateOptions{})
 				return err
 			},
 		},
@@ -198,11 +216,11 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 			Name:     `ClusterRoleBinding "deckhouse"`,
 			Manifest: func() interface{} { return manifests.DeckhouseAdminClusterRoleBinding() },
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.RbacV1().ClusterRoleBindings().Create(context.TODO(), manifest.(*rbacv1.ClusterRoleBinding), metav1.CreateOptions{})
+				_, err := kubeCl.RbacV1().ClusterRoleBindings().Create(ctx, manifest.(*rbacv1.ClusterRoleBinding), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.RbacV1().ClusterRoleBindings().Update(context.TODO(), manifest.(*rbacv1.ClusterRoleBinding), metav1.UpdateOptions{})
+				_, err := kubeCl.RbacV1().ClusterRoleBindings().Update(ctx, manifest.(*rbacv1.ClusterRoleBinding), metav1.UpdateOptions{})
 				return err
 			},
 		},
@@ -210,11 +228,11 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 			Name:     `ServiceAccount "deckhouse"`,
 			Manifest: func() interface{} { return manifests.DeckhouseServiceAccount() },
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ServiceAccounts("d8-system").Create(context.TODO(), manifest.(*apiv1.ServiceAccount), metav1.CreateOptions{})
+				_, err := kubeCl.CoreV1().ServiceAccounts("d8-system").Create(ctx, manifest.(*apiv1.ServiceAccount), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ServiceAccounts("d8-system").Update(context.TODO(), manifest.(*apiv1.ServiceAccount), metav1.UpdateOptions{})
+				_, err := kubeCl.CoreV1().ServiceAccounts("d8-system").Update(ctx, manifest.(*apiv1.ServiceAccount), metav1.UpdateOptions{})
 				return err
 			},
 		},
@@ -238,13 +256,13 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 			CreateFunc: func(manifest interface{}) error {
 				cm := manifest.(*apiv1.ConfigMap)
 				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
-					Create(context.TODO(), cm, metav1.CreateOptions{})
+					Create(ctx, cm, metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
 				cm := manifest.(*apiv1.ConfigMap)
 				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
-					Update(context.TODO(), cm, metav1.UpdateOptions{})
+					Update(ctx, cm, metav1.UpdateOptions{})
 				return err
 			},
 		},
@@ -255,11 +273,11 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 			Name:     `Secret "deckhouse-registry"`,
 			Manifest: func() interface{} { return manifests.DeckhouseRegistrySecret(cfg.Registry) },
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Update(context.TODO(), manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("d8-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
 				return err
 			},
 		})
@@ -270,11 +288,11 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 			Name:     `Secret "d8-cluster-terraform-state"`,
 			Manifest: func() interface{} { return manifests.SecretWithTerraformState(cfg.TerraformState) },
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Update(context.TODO(), manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("d8-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
 				return err
 			},
 		})
@@ -286,11 +304,11 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 			Name:     fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, nodeName),
 			Manifest: getManifest,
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Update(context.TODO(), manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("d8-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
 				return err
 			},
 		})
@@ -301,11 +319,11 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 			Name:     `Secret "d8-cluster-configuration"`,
 			Manifest: func() interface{} { return manifests.SecretWithClusterConfig(cfg.ClusterConfig) },
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("kube-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("kube-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("kube-system").Update(context.TODO(), manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("kube-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
 				return err
 			},
 		})
@@ -320,7 +338,7 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 				)
 			},
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("kube-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("kube-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
@@ -328,7 +346,7 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 				if err != nil {
 					return err
 				}
-				_, err = kubeCl.CoreV1().Secrets("kube-system").Patch(context.TODO(),
+				_, err = kubeCl.CoreV1().Secrets("kube-system").Patch(ctx,
 					"d8-provider-cluster-configuration",
 					types.MergePatchType,
 					data,
@@ -346,7 +364,7 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 				return manifests.SecretWithStaticClusterConfig(cfg.StaticClusterConfig)
 			},
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("kube-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("kube-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
@@ -355,7 +373,7 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 					return err
 				}
 				_, err = kubeCl.CoreV1().Secrets("kube-system").Patch(
-					context.TODO(),
+					ctx,
 					"d8-static-cluster-configuration",
 					types.MergePatchType,
 					data,
@@ -373,11 +391,11 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 				return manifests.ClusterUUIDConfigMap(cfg.UUID)
 			},
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Create(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
+				_, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Create(ctx, manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Update(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.UpdateOptions{})
+				_, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Update(ctx, manifest.(*apiv1.ConfigMap), metav1.UpdateOptions{})
 				return err
 			},
 		})
@@ -394,7 +412,7 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 				return manifests.KubeDNSService(cfg.KubeDNSAddress)
 			},
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Services("kube-system").Create(context.TODO(), manifest.(*apiv1.Service), metav1.CreateOptions{})
+				_, err := kubeCl.CoreV1().Services("kube-system").Create(ctx, manifest.(*apiv1.Service), metav1.CreateOptions{})
 				if err != nil && strings.Contains(err.Error(), "provided IP is already allocated") {
 					log.InfoLn("Service for DNS already exists. Skip!")
 					return nil
@@ -402,13 +420,13 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Services("kube-system").Update(context.TODO(), manifest.(*apiv1.Service), metav1.UpdateOptions{})
+				_, err := kubeCl.CoreV1().Services("kube-system").Update(ctx, manifest.(*apiv1.Service), metav1.UpdateOptions{})
 				return err
 			},
 		})
 	}
 
-	lockCmTask, err := LockDeckhouseQueueBeforeCreatingModuleConfigs(kubeCl)
+	lockCmTask, err := LockDeckhouseQueueBeforeCreatingModuleConfigs(ctx, kubeCl)
 	if err != nil {
 		return nil, err
 	}
@@ -417,17 +435,17 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 		tasks = append(tasks, *lockCmTask)
 	}
 
-	tasks = append(tasks, controllerDeploymentTask(kubeCl, cfg))
+	tasks = append(tasks, controllerDeploymentTask(ctx, kubeCl, cfg))
 
 	result := &ManifestsResult{}
 
 	if len(cfg.ModuleConfigs) > 0 {
-		prepareModuleConfig(cfg.ModuleConfigs[0], result)
-		tasks = append(tasks, createModuleConfigManifestTask(kubeCl, cfg.ModuleConfigs[0], "Waiting for creating ModuleConfig CRD..."))
+		prepareModuleConfig(ctx, cfg.ModuleConfigs[0], result)
+		tasks = append(tasks, createModuleConfigManifestTask(ctx, kubeCl, cfg.ModuleConfigs[0], "Waiting for creating ModuleConfig CRD..."))
 
 		for i := 1; i < len(cfg.ModuleConfigs); i++ {
-			prepareModuleConfig(cfg.ModuleConfigs[i], result)
-			tasks = append(tasks, createModuleConfigManifestTask(kubeCl, cfg.ModuleConfigs[i], ""))
+			prepareModuleConfig(ctx, cfg.ModuleConfigs[i], result)
+			tasks = append(tasks, createModuleConfigManifestTask(ctx, kubeCl, cfg.ModuleConfigs[i], ""))
 		}
 	}
 
@@ -444,16 +462,16 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *config.Deckh
 		return nil, err
 	}
 
-	return result, UnlockDeckhouseQueueAfterCreatingModuleConfigs(kubeCl)
+	return result, UnlockDeckhouseQueueAfterCreatingModuleConfigs(ctx, kubeCl)
 }
 
-func WaitForReadiness(kubeCl *client.KubernetesClient) error {
-	return WaitForReadinessNotOnNode(kubeCl, "")
+func WaitForReadiness(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return WaitForReadinessNotOnNode(ctx, kubeCl, "")
 }
 
-func WaitForReadinessNotOnNode(kubeCl *client.KubernetesClient, excludeNode string) error {
+func WaitForReadinessNotOnNode(ctx context.Context, kubeCl *client.KubernetesClient, excludeNode string) error {
 	return log.Process("default", "Waiting for Deckhouse to become Ready", func() error {
-		ctx, cancel := context.WithTimeout(context.Background(), app.DeckhouseTimeout)
+		ctx, cancel := context.WithTimeout(ctx, app.DeckhouseTimeout)
 		defer cancel()
 
 		for {
@@ -485,8 +503,8 @@ func WaitForReadinessNotOnNode(kubeCl *client.KubernetesClient, excludeNode stri
 	})
 }
 
-func CreateDeckhouseDeployment(kubeCl *client.KubernetesClient, cfg *config.DeckhouseInstaller) error {
-	task := controllerDeploymentTask(kubeCl, cfg)
+func CreateDeckhouseDeployment(ctx context.Context, kubeCl *client.KubernetesClient, cfg *config.DeckhouseInstaller) error {
+	task := controllerDeploymentTask(ctx, kubeCl, cfg)
 
 	return log.Process("default", "Create Deployment", task.CreateOrUpdate)
 }
@@ -519,7 +537,7 @@ func WaitForKubernetesAPI(ctx context.Context, kubeCl *client.KubernetesClient) 
 		})
 }
 
-func ConfigureDeckhouseRelease(kubeCl *client.KubernetesClient) error {
+func ConfigureDeckhouseRelease(ctx context.Context, kubeCl *client.KubernetesClient) error {
 	// if we have correct semver version we should create Deckhouse Release for prevent rollback on previous version
 	// if installer version > version in release channel
 	if tag, found := config.ReadVersionTagFromInstallerContainer(); found {
@@ -537,8 +555,8 @@ func ConfigureDeckhouseRelease(kubeCl *client.KubernetesClient) error {
 
 		err := retry.NewLoop(fmt.Sprintf("Create deckhouse release for version %s", tag), 15, 5*time.Second).
 			BreakIf(apierrors.IsAlreadyExists).
-			Run(func() error {
-				_, err := kubeCl.Dynamic().Resource(v1alpha1.DeckhouseReleaseGVR).Create(context.TODO(), &deckhouseRelease, metav1.CreateOptions{})
+			RunContext(ctx, func() error {
+				_, err := kubeCl.Dynamic().Resource(v1alpha1.DeckhouseReleaseGVR).Create(ctx, &deckhouseRelease, metav1.CreateOptions{})
 				if err != nil {
 					return err
 				}

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestDeckhouseInstall(t *testing.T) {
+	ctx := context.Background()
 	err := os.Setenv("DHCTL_TEST", "yes")
 	require.NoError(t, err)
 	err = os.Setenv("DHCTL_TEST_VERSION_TAG", "1.54.1")
@@ -52,7 +53,7 @@ func TestDeckhouseInstall(t *testing.T) {
 		{
 			"Empty config",
 			func() error {
-				_, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{})
+				_, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{})
 				return err
 			},
 			false,
@@ -60,11 +61,11 @@ func TestDeckhouseInstall(t *testing.T) {
 		{
 			"Double install",
 			func() error {
-				_, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{})
+				_, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{})
 				if err != nil {
 					return err
 				}
-				_, err = CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{})
+				_, err = CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{})
 				return err
 			},
 			false,
@@ -72,7 +73,7 @@ func TestDeckhouseInstall(t *testing.T) {
 		{
 			"With docker cfg",
 			func() error {
-				_, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+				_, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 					Registry: config.RegistryData{DockerCfg: "YW55dGhpbmc="},
 				})
 				if err != nil {
@@ -99,7 +100,7 @@ func TestDeckhouseInstall(t *testing.T) {
 					ProviderClusterConfig: []byte(`test`),
 					TerraformState:        []byte(`test`),
 				}
-				_, err := CreateDeckhouseManifests(fakeClient, &conf)
+				_, err := CreateDeckhouseManifests(ctx, fakeClient, &conf)
 				if err != nil {
 					return err
 				}
@@ -124,6 +125,7 @@ func TestDeckhouseInstall(t *testing.T) {
 }
 
 func TestDeckhouseInstallWithDevBranch(t *testing.T) {
+	ctx := context.Background()
 	err := os.Setenv("DHCTL_TEST", "yes")
 	require.NoError(t, err)
 	err = os.Setenv("DHCTL_TEST_VERSION_TAG", "dev")
@@ -135,7 +137,7 @@ func TestDeckhouseInstallWithDevBranch(t *testing.T) {
 
 	fakeClient := client.NewFakeKubernetesClient()
 
-	_, err = CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+	_, err = CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 		DevBranch: "pr1111",
 	})
 
@@ -143,6 +145,7 @@ func TestDeckhouseInstallWithDevBranch(t *testing.T) {
 }
 
 func TestDeckhouseInstallWithModuleConfig(t *testing.T) {
+	ctx := context.Background()
 	err := os.Setenv("DHCTL_TEST", "yes")
 	require.NoError(t, err)
 	err = os.Setenv("DHCTL_TEST_VERSION_TAG", "dev")
@@ -169,7 +172,7 @@ func TestDeckhouseInstallWithModuleConfig(t *testing.T) {
 		"ha": true,
 	})
 
-	_, err = CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+	_, err = CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 		DevBranch:     "pr1111",
 		ModuleConfigs: []*config.ModuleConfig{mc1},
 	})
@@ -187,6 +190,7 @@ func TestDeckhouseInstallWithModuleConfig(t *testing.T) {
 }
 
 func TestDeckhouseInstallWithModuleConfigs(t *testing.T) {
+	ctx := context.Background()
 	err := os.Setenv("DHCTL_TEST", "yes")
 	require.NoError(t, err)
 	err = os.Setenv("DHCTL_TEST_VERSION_TAG", "dev")
@@ -226,7 +230,7 @@ func TestDeckhouseInstallWithModuleConfigs(t *testing.T) {
 		"bundle": "Minimal",
 	})
 
-	_, err = CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+	_, err = CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 		DevBranch:     "pr1111",
 		ModuleConfigs: []*config.ModuleConfig{mc1, mc2},
 	})
@@ -244,6 +248,7 @@ func TestDeckhouseInstallWithModuleConfigs(t *testing.T) {
 }
 
 func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
+	ctx := context.Background()
 	err := os.Setenv("DHCTL_TEST", "yes")
 	require.NoError(t, err)
 	err = os.Setenv("DHCTL_TEST_VERSION_TAG", "dev")
@@ -265,7 +270,7 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 				"releaseChannel": "Alpha",
 			})
 
-			res, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+			res, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 				DevBranch:     "pr1111",
 				ModuleConfigs: []*config.ModuleConfig{mc},
 			})
@@ -302,7 +307,7 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 				},
 			})
 
-			res, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+			res, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 				DevBranch:     "pr1111",
 				ModuleConfigs: []*config.ModuleConfig{mc},
 			})
@@ -331,7 +336,7 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 				"highAvailability": true,
 			})
 
-			res, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+			res, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 				DevBranch:     "pr1111",
 				ModuleConfigs: []*config.ModuleConfig{mc},
 			})
@@ -370,7 +375,7 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 				},
 			})
 
-			res, err := CreateDeckhouseManifests(fakeClient, &config.DeckhouseInstaller{
+			res, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 				DevBranch:     "pr1111",
 				ModuleConfigs: []*config.ModuleConfig{mcDeckhouse, mcGlobal},
 			})

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -179,7 +179,7 @@ func (d *LogPrinter) WithLeaderElectionAwarenessMode(leaderElectionLease types.N
 	return d
 }
 
-func (d *LogPrinter) printErrorsForTask(taskID string, errorTaskTime time.Time) {
+func (d *LogPrinter) printErrorsForTask(ctx context.Context, taskID string, errorTaskTime time.Time) {
 	if taskID == "" {
 		return
 	}
@@ -198,7 +198,7 @@ func (d *LogPrinter) printErrorsForTask(taskID string, errorTaskTime time.Time) 
 	var lastErr error
 	err := retry.NewSilentLoop("getting logs for error", 2, 1*time.Second).Run(func() error {
 		request := d.kubeCl.CoreV1().Pods("d8-system").GetLogs(d.deckhousePod.Name, &logOptions)
-		result, lastErr = request.DoRaw(context.TODO())
+		result, lastErr = request.DoRaw(ctx)
 		if lastErr != nil {
 			log.DebugF("printErrorsForTask: %s\n %s", lastErr.Error(), string(result))
 			return ErrRequestFailed
@@ -242,10 +242,10 @@ func (d *LogPrinter) printErrorsForTask(taskID string, errorTaskTime time.Time) 
 	d.lastErrorTime = errorTaskTime
 }
 
-func (d *LogPrinter) printLogsByLine(content []byte) {
+func (d *LogPrinter) printLogsByLine(ctx context.Context, content []byte) {
 	parseLogByLine(content, func(line *logLine) bool {
 		if isErrorLine(line) {
-			d.printErrorsForTask(line.TaskID, line.Time)
+			d.printErrorsForTask(ctx, line.TaskID, line.Time)
 			return true
 		}
 
@@ -266,8 +266,8 @@ func (d *LogPrinter) printLogsByLine(content []byte) {
 	})
 }
 
-func (d *LogPrinter) GetPod() error {
-	pod, err := GetPod(d.kubeCl, d.leaderElectionLeaseName)
+func (d *LogPrinter) GetPod(ctx context.Context) error {
+	pod, err := GetPod(ctx, d.kubeCl, d.leaderElectionLeaseName)
 	if err != nil {
 		return err
 	}
@@ -284,12 +284,12 @@ func (d *LogPrinter) GetPod() error {
 	return nil
 }
 
-func (d *LogPrinter) checkDeckhousePodReady() (bool, error) {
+func (d *LogPrinter) checkDeckhousePodReady(ctx context.Context) (bool, error) {
 	if !d.waitPodBecomeReady || d.deckhousePod == nil {
 		return false, nil
 	}
 
-	runningPod, err := d.kubeCl.CoreV1().Pods("d8-system").Get(context.TODO(), d.deckhousePod.Name, metav1.GetOptions{})
+	runningPod, err := d.kubeCl.CoreV1().Pods("d8-system").Get(ctx, d.deckhousePod.Name, metav1.GetOptions{})
 	if err != nil {
 		log.DebugF("checkDeckhousePodReady: %s\n", err.Error())
 		return false, ErrRequestFailed
@@ -312,7 +312,7 @@ func (d *LogPrinter) checkDeckhousePodReady() (bool, error) {
 }
 
 func (d *LogPrinter) Print(ctx context.Context) (bool, error) {
-	if err := d.GetPod(); err != nil {
+	if err := d.GetPod(ctx); err != nil {
 		return false, err
 	}
 
@@ -333,7 +333,7 @@ func (d *LogPrinter) Print(ctx context.Context) (bool, error) {
 			log.ErrorLn(strings.Join(d.deckhouseErrors, "\n"))
 			return false, ErrTimedOut
 		default:
-			ready, err := d.checkDeckhousePodReady()
+			ready, err := d.checkDeckhousePodReady(ctx)
 			if err != nil {
 				return false, err
 			}
@@ -342,13 +342,13 @@ func (d *LogPrinter) Print(ctx context.Context) (bool, error) {
 			}
 
 			request := d.kubeCl.CoreV1().Pods("d8-system").GetLogs(d.deckhousePod.Name, &logOptions)
-			result, err := request.DoRaw(context.TODO())
+			result, err := request.DoRaw(ctx)
 			if err != nil {
 				log.DebugF("Print: %s\n %s", err.Error(), string(result))
 				return false, ErrRequestFailed
 			}
 
-			d.printLogsByLine(result)
+			d.printLogsByLine(ctx, result)
 
 			time.Sleep(time.Second)
 			currentTime := metav1.NewTime(time.Now())

--- a/dhctl/pkg/kubernetes/actions/deckhouse/module_config_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/module_config_test.go
@@ -46,6 +46,7 @@ func createMC(name string, settings map[string]interface{}) *config.ModuleConfig
 }
 
 func TestPrepareDeckhouseModuleConfig(t *testing.T) {
+	ctx := context.Background()
 	log.InitLogger("json")
 
 	t.Run("ModuleConfig deckhouse with releaseChannel should remove releaseChannel from mc and adds to result task with returning releaseChannel to post bootstrap tasks", func(t *testing.T) {
@@ -60,7 +61,7 @@ func TestPrepareDeckhouseModuleConfig(t *testing.T) {
 		})
 
 		res := &ManifestsResult{}
-		prepareModuleConfig(mc, res)
+		prepareModuleConfig(ctx, mc, res)
 
 		require.NotContains(t, mc.Spec.Settings, "releaseChannel")
 		require.Contains(t, mc.Spec.Settings, "bundle")
@@ -111,7 +112,7 @@ func TestPrepareDeckhouseModuleConfig(t *testing.T) {
 		})
 
 		res := &ManifestsResult{}
-		prepareModuleConfig(mc, res)
+		prepareModuleConfig(ctx, mc, res)
 
 		require.NotContains(t, mc.Spec.Settings, "releaseChannel")
 		require.Contains(t, mc.Spec.Settings, "bundle")
@@ -128,6 +129,7 @@ func TestPrepareDeckhouseModuleConfig(t *testing.T) {
 }
 
 func TestPrepareGlobalModuleConfig(t *testing.T) {
+	ctx := context.Background()
 	log.InitLogger("json")
 
 	assertSaveAnotherFields := func(t *testing.T, mc *unstructured.Unstructured, publicDomainTemplateFound bool) {
@@ -186,7 +188,7 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 			})
 
 			res := &ManifestsResult{}
-			prepareModuleConfig(mc, res)
+			prepareModuleConfig(ctx, mc, res)
 
 			assertMCAfterPrepare(t, mc)
 
@@ -230,7 +232,7 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 			})
 
 			res := &ManifestsResult{}
-			prepareModuleConfig(mc, res)
+			prepareModuleConfig(ctx, mc, res)
 
 			require.NotContains(t, mc.Spec.Settings, "modules")
 			require.True(t, mc.Spec.Settings["highAvailability"].(bool))
@@ -270,7 +272,7 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 		})
 
 		res := &ManifestsResult{}
-		prepareModuleConfig(mc, res)
+		prepareModuleConfig(ctx, mc, res)
 
 		assertMCAfterPrepare(t, mc)
 

--- a/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
@@ -27,8 +27,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
-func GetPod(kubeCl *client.KubernetesClient, leaderElectionLeaseName types.NamespacedName) (*v1.Pod, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+func GetPod(ctx context.Context, kubeCl *client.KubernetesClient, leaderElectionLeaseName types.NamespacedName) (*v1.Pod, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	pods, err := kubeCl.CoreV1().Pods("d8-system").List(ctx, metav1.ListOptions{LabelSelector: "app=deckhouse"})

--- a/dhctl/pkg/kubernetes/actions/entity/node.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node.go
@@ -44,13 +44,13 @@ var (
 	nodeGroupResource = schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1", Resource: "nodegroups"}
 )
 
-func GetCloudConfig(kubeCl *client.KubernetesClient, nodeGroupName string, showDeckhouseLogs bool, logger log.Logger, apiserverHosts ...string) (string, error) {
+func GetCloudConfig(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupName string, showDeckhouseLogs bool, logger log.Logger, apiserverHosts ...string) (string, error) {
 	var cloudData string
 
 	name := fmt.Sprintf("Waiting for %s cloud config️", nodeGroupName)
 	err := logger.LogProcess("default", name, func() error {
 		if showDeckhouseLogs {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
 			go func() {
@@ -67,10 +67,10 @@ func GetCloudConfig(kubeCl *client.KubernetesClient, nodeGroupName string, showD
 			}()
 		}
 
-		err := retry.NewSilentLoop(name, 45, 5*time.Second).Run(func() error {
+		err := retry.NewSilentLoop(name, 45, 5*time.Second).RunContext(ctx, func() error {
 			secret, err := kubeCl.CoreV1().
 				Secrets("d8-cloud-instance-manager").
-				Get(context.TODO(), "manual-bootstrap-for-"+nodeGroupName, metav1.GetOptions{})
+				Get(ctx, "manual-bootstrap-for-"+nodeGroupName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -116,56 +116,59 @@ func GetCloudConfig(kubeCl *client.KubernetesClient, nodeGroupName string, showD
 	return cloudData, err
 }
 
-func CreateNodeGroup(kubeCl *client.KubernetesClient, nodeGroupName string, logger log.Logger, data map[string]interface{}) error {
+func CreateNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupName string, logger log.Logger, data map[string]interface{}) error {
 	doc := unstructured.Unstructured{}
 	doc.SetUnstructuredContent(data)
 
-	return retry.NewLoop(fmt.Sprintf("Create NodeGroup %q", nodeGroupName), 45, 15*time.Second).WithLogger(logger).Run(func() error {
-		res, err := kubeCl.Dynamic().
-			Resource(nodeGroupResource).
-			Create(context.TODO(), &doc, metav1.CreateOptions{})
-		if err == nil {
-			logger.LogInfoF("NodeGroup %q created\n", res.GetName())
-			return nil
-		}
-
-		if errors.IsAlreadyExists(err) {
-			logger.LogInfoF("Object %v, updating ... ", err)
-			content, err := doc.MarshalJSON()
-			if err != nil {
-				return err
-			}
-			_, err = kubeCl.Dynamic().
+	return retry.NewLoop(fmt.Sprintf("Create NodeGroup %q", nodeGroupName), 45, 15*time.Second).
+		WithLogger(logger).
+		RunContext(ctx, func() error {
+			res, err := kubeCl.Dynamic().
 				Resource(nodeGroupResource).
-				Patch(context.TODO(), doc.GetName(), types.MergePatchType, content, metav1.PatchOptions{})
-			if err != nil {
-				return err
+				Create(ctx, &doc, metav1.CreateOptions{})
+			if err == nil {
+				logger.LogInfoF("NodeGroup %q created\n", res.GetName())
+				return nil
 			}
-			logger.LogInfoF("OK!")
-			return nil
-		}
 
-		return err
-	})
+			if errors.IsAlreadyExists(err) {
+				logger.LogInfoF("Object %v, updating ... ", err)
+				content, err := doc.MarshalJSON()
+				if err != nil {
+					return err
+				}
+				_, err = kubeCl.Dynamic().
+					Resource(nodeGroupResource).
+					Patch(ctx, doc.GetName(), types.MergePatchType, content, metav1.PatchOptions{})
+				if err != nil {
+					return err
+				}
+				logger.LogInfoF("OK!")
+				return nil
+			}
+
+			return err
+		})
 }
 
-func GetNodeGroupDirect(kubeCl *client.KubernetesClient, nodeGroupName string) (*unstructured.Unstructured, error) {
+func GetNodeGroupDirect(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupName string) (*unstructured.Unstructured, error) {
 	var err error
 	ng, err := kubeCl.Dynamic().
 		Resource(nodeGroupResource).
-		Get(context.TODO(), nodeGroupName, metav1.GetOptions{})
+		Get(ctx, nodeGroupName, metav1.GetOptions{})
 
 	return ng, err
 }
 
-func GetNodeGroup(kubeCl *client.KubernetesClient, nodeGroupName string) (*unstructured.Unstructured, error) {
+func GetNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupName string) (*unstructured.Unstructured, error) {
 	var ng *unstructured.Unstructured
-	err := retry.NewSilentLoop(fmt.Sprintf("Get NodeGroup %q", nodeGroupName), 45, 15*time.Second).Run(func() error {
-		var err error
-		ng, err = GetNodeGroupDirect(kubeCl, nodeGroupName)
+	err := retry.NewSilentLoop(fmt.Sprintf("Get NodeGroup %q", nodeGroupName), 45, 15*time.Second).
+		RunContext(ctx, func() error {
+			var err error
+			ng, err = GetNodeGroupDirect(ctx, kubeCl, nodeGroupName)
 
-		return err
-	})
+			return err
+		})
 	if err != nil {
 		return nil, err
 	}
@@ -173,10 +176,10 @@ func GetNodeGroup(kubeCl *client.KubernetesClient, nodeGroupName string) (*unstr
 	return ng, nil
 }
 
-func GetNodeGroups(kubeCl *client.KubernetesClient) ([]unstructured.Unstructured, error) {
+func GetNodeGroups(ctx context.Context, kubeCl *client.KubernetesClient) ([]unstructured.Unstructured, error) {
 	ngs, err := kubeCl.Dynamic().
 		Resource(nodeGroupResource).
-		List(context.TODO(), metav1.ListOptions{})
+		List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -184,13 +187,13 @@ func GetNodeGroups(kubeCl *client.KubernetesClient) ([]unstructured.Unstructured
 	return ngs.Items, err
 }
 
-func UpdateNodeGroup(kubeCl *client.KubernetesClient, nodeGroupName string, ng *unstructured.Unstructured) error {
+func UpdateNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupName string, ng *unstructured.Unstructured) error {
 	err := retry.NewLoop(fmt.Sprintf("Update node template in NodeGroup %q", nodeGroupName), 45, 15*time.Second).
 		BreakIf(errors.IsConflict).
-		Run(func() error {
+		RunContext(ctx, func() error {
 			_, err := kubeCl.Dynamic().
 				Resource(nodeGroupResource).
-				Update(context.TODO(), ng, metav1.UpdateOptions{})
+				Update(ctx, ng, metav1.UpdateOptions{})
 
 			return err
 		})
@@ -202,183 +205,189 @@ func UpdateNodeGroup(kubeCl *client.KubernetesClient, nodeGroupName string, ng *
 	return err
 }
 
-func WaitForSingleNodeBecomeReady(kubeCl *client.KubernetesClient, nodeName string) error {
-	return retry.NewLoop(fmt.Sprintf("Waiting for  Node %s to become Ready", nodeName), 100, 20*time.Second).Run(func() error {
-		node, err := kubeCl.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-
-		for _, c := range node.Status.Conditions {
-			if c.Type == apiv1.NodeReady {
-				if c.Status == apiv1.ConditionTrue {
-					return nil
-				}
-			}
-		}
-
-		return fmt.Errorf("node %q is not Ready yet", nodeName)
-	})
-}
-
-func WaitForNodesBecomeReady(kubeCl *client.KubernetesClient, nodeGroupsMap map[string]int) error {
-	ngsName := slices.Collect(maps.Keys(nodeGroupsMap))
-	return retry.NewLoop(fmt.Sprintf("Waiting for NodeGroups %v to become Ready", ngsName), 100, 20*time.Second).Run(func() error {
-		desiredReadyNodes := 0
-		for _, countNodes := range nodeGroupsMap {
-			desiredReadyNodes += countNodes
-		}
-		labelSel := fmt.Sprintf("node.deckhouse.io/group in (%s)", strings.Join(ngsName, ", "))
-
-		nodes, err := kubeCl.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: labelSel})
-		if err != nil {
-			return err
-		}
-
-		readyNodes := make(map[string]struct{})
-
-		for _, node := range nodes.Items {
-			for _, c := range node.Status.Conditions {
-				if c.Type == apiv1.NodeReady {
-					if c.Status == apiv1.ConditionTrue {
-						readyNodes[node.Name] = struct{}{}
-					}
-				}
-			}
-		}
-
-		message := fmt.Sprintf("Nodes Ready %v of %v\n", len(readyNodes), desiredReadyNodes)
-		for _, node := range nodes.Items {
-			condition := "NotReady"
-			if _, ok := readyNodes[node.Name]; ok {
-				condition = "Ready"
-			}
-			message += fmt.Sprintf("* %s | %s\n", node.Name, condition)
-		}
-
-		if len(readyNodes) >= desiredReadyNodes {
-			log.InfoLn(message)
-			return nil
-		}
-
-		return fmt.Errorf(strings.TrimSuffix(message, "\n"))
-	})
-}
-
-func WaitForNodesListBecomeReady(kubeCl *client.KubernetesClient, nodes []string, checker hook.NodeChecker) error {
-	return retry.NewLoop("Waiting for nodes to become Ready", 100, 20*time.Second).Run(func() error {
-		desiredReadyNodes := len(nodes)
-		var nodesList apiv1.NodeList
-
-		for _, nodeName := range nodes {
-			node, err := kubeCl.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+func WaitForSingleNodeBecomeReady(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string) error {
+	return retry.NewLoop(fmt.Sprintf("Waiting for  Node %s to become Ready", nodeName), 100, 20*time.Second).
+		RunContext(ctx, func() error {
+			node, err := kubeCl.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
-			nodesList.Items = append(nodesList.Items, *node)
-		}
 
-		readyNodes := make(map[string]struct{})
-
-		for _, node := range nodesList.Items {
 			for _, c := range node.Status.Conditions {
 				if c.Type == apiv1.NodeReady {
 					if c.Status == apiv1.ConditionTrue {
-						ready := true
-						if checker != nil {
-							var err error
-							ready, err = checker.IsReady(node.Name)
-							if err != nil {
-								log.InfoF("While doing check '%s' node %s has error: %v\n", checker.Name(), node.Name, err)
-							} else if !ready {
-								log.InfoF("Node %s is ready but %s is not ready\n", node.Name, checker.Name())
-							}
-						}
+						return nil
+					}
+				}
+			}
 
-						if ready {
+			return fmt.Errorf("node %q is not Ready yet", nodeName)
+		})
+}
+
+func WaitForNodesBecomeReady(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupsMap map[string]int) error {
+	ngsName := slices.Collect(maps.Keys(nodeGroupsMap))
+	return retry.NewLoop(fmt.Sprintf("Waiting for NodeGroups %v to become Ready", ngsName), 100, 20*time.Second).
+		RunContext(ctx, func() error {
+			desiredReadyNodes := 0
+			for _, countNodes := range nodeGroupsMap {
+				desiredReadyNodes += countNodes
+			}
+			labelSel := fmt.Sprintf("node.deckhouse.io/group in (%s)", strings.Join(ngsName, ", "))
+
+			nodes, err := kubeCl.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: labelSel})
+			if err != nil {
+				return err
+			}
+
+			readyNodes := make(map[string]struct{})
+
+			for _, node := range nodes.Items {
+				for _, c := range node.Status.Conditions {
+					if c.Type == apiv1.NodeReady {
+						if c.Status == apiv1.ConditionTrue {
 							readyNodes[node.Name] = struct{}{}
 						}
 					}
 				}
 			}
-		}
 
-		message := fmt.Sprintf("Nodes Ready %v of %v\n", len(readyNodes), desiredReadyNodes)
-		for _, node := range nodesList.Items {
-			condition := "NotReady"
-			if _, ok := readyNodes[node.Name]; ok {
-				condition = "Ready"
+			message := fmt.Sprintf("Nodes Ready %v of %v\n", len(readyNodes), desiredReadyNodes)
+			for _, node := range nodes.Items {
+				condition := "NotReady"
+				if _, ok := readyNodes[node.Name]; ok {
+					condition = "Ready"
+				}
+				message += fmt.Sprintf("* %s | %s\n", node.Name, condition)
 			}
-			message += fmt.Sprintf("* %s | %s\n", node.Name, condition)
-		}
 
-		if len(readyNodes) >= desiredReadyNodes {
-			log.InfoLn(message)
-			return nil
-		}
+			if len(readyNodes) >= desiredReadyNodes {
+				log.InfoLn(message)
+				return nil
+			}
 
-		return fmt.Errorf(strings.TrimSuffix(message, "\n"))
-	})
+			return fmt.Errorf(strings.TrimSuffix(message, "\n"))
+		})
 }
 
-func GetNodeGroupTemplates(kubeCl *client.KubernetesClient) (map[string]map[string]interface{}, error) {
-	nodeTemplates := make(map[string]map[string]interface{})
+func WaitForNodesListBecomeReady(ctx context.Context, kubeCl *client.KubernetesClient, nodes []string, checker hook.NodeChecker) error {
+	return retry.NewLoop("Waiting for nodes to become Ready", 100, 20*time.Second).
+		RunContext(ctx, func() error {
+			desiredReadyNodes := len(nodes)
+			var nodesList apiv1.NodeList
 
-	err := retry.NewLoop("Get NodeGroups node template settings", 10, 5*time.Second).Run(func() error {
-		nodeGroups, err := kubeCl.Dynamic().Resource(nodeGroupResource).List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			return err
-		}
+			for _, nodeName := range nodes {
+				node, err := kubeCl.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				nodesList.Items = append(nodesList.Items, *node)
+			}
 
-		for _, group := range nodeGroups.Items {
-			var nodeTemplate map[string]interface{}
-			if spec, ok := group.Object["spec"].(map[string]interface{}); ok {
-				nodeTemplate, _ = spec["nodeTemplate"].(map[string]interface{})
-				// if we do not set node template in cluster provider configuration
-				// we get nil node template from config,
-				// but k8s always returns empty map (not nil)
-				// and we have D8TerraformStateExporterNodeTemplateChanged alert
-				// therefore, we convert empty map to nil
-				if len(nodeTemplate) == 0 {
-					nodeTemplate = nil
+			readyNodes := make(map[string]struct{})
+
+			for _, node := range nodesList.Items {
+				for _, c := range node.Status.Conditions {
+					if c.Type == apiv1.NodeReady {
+						if c.Status == apiv1.ConditionTrue {
+							ready := true
+							if checker != nil {
+								var err error
+								ready, err = checker.IsReady(node.Name)
+								if err != nil {
+									log.InfoF("While doing check '%s' node %s has error: %v\n", checker.Name(), node.Name, err)
+								} else if !ready {
+									log.InfoF("Node %s is ready but %s is not ready\n", node.Name, checker.Name())
+								}
+							}
+
+							if ready {
+								readyNodes[node.Name] = struct{}{}
+							}
+						}
+					}
 				}
 			}
 
-			nodeTemplates[group.GetName()] = nodeTemplate
-		}
-		return nil
-	})
+			message := fmt.Sprintf("Nodes Ready %v of %v\n", len(readyNodes), desiredReadyNodes)
+			for _, node := range nodesList.Items {
+				condition := "NotReady"
+				if _, ok := readyNodes[node.Name]; ok {
+					condition = "Ready"
+				}
+				message += fmt.Sprintf("* %s | %s\n", node.Name, condition)
+			}
+
+			if len(readyNodes) >= desiredReadyNodes {
+				log.InfoLn(message)
+				return nil
+			}
+
+			return fmt.Errorf(strings.TrimSuffix(message, "\n"))
+		})
+}
+
+func GetNodeGroupTemplates(ctx context.Context, kubeCl *client.KubernetesClient) (map[string]map[string]interface{}, error) {
+	nodeTemplates := make(map[string]map[string]interface{})
+
+	err := retry.NewLoop("Get NodeGroups node template settings", 10, 5*time.Second).
+		RunContext(ctx, func() error {
+			nodeGroups, err := kubeCl.Dynamic().Resource(nodeGroupResource).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return err
+			}
+
+			for _, group := range nodeGroups.Items {
+				var nodeTemplate map[string]interface{}
+				if spec, ok := group.Object["spec"].(map[string]interface{}); ok {
+					nodeTemplate, _ = spec["nodeTemplate"].(map[string]interface{})
+					// if we do not set node template in cluster provider configuration
+					// we get nil node template from config,
+					// but k8s always returns empty map (not nil)
+					// and we have D8TerraformStateExporterNodeTemplateChanged alert
+					// therefore, we convert empty map to nil
+					if len(nodeTemplate) == 0 {
+						nodeTemplate = nil
+					}
+				}
+
+				nodeTemplates[group.GetName()] = nodeTemplate
+			}
+			return nil
+		})
 
 	return nodeTemplates, err
 }
 
-func DeleteNode(kubeCl *client.KubernetesClient, nodeName string) error {
-	return retry.NewLoop(fmt.Sprintf("Delete Node %s", nodeName), 45, 10*time.Second).Run(func() error {
-		err := kubeCl.CoreV1().Nodes().Delete(context.TODO(), nodeName, metav1.DeleteOptions{})
-		if errors.IsNotFound(err) {
-			// Node has already been deleted
-			return nil
-		}
-		return err
-	})
+func DeleteNode(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string) error {
+	return retry.NewLoop(fmt.Sprintf("Delete Node %s", nodeName), 45, 10*time.Second).
+		RunContext(ctx, func() error {
+			err := kubeCl.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+			if errors.IsNotFound(err) {
+				// Node has already been deleted
+				return nil
+			}
+			return err
+		})
 }
 
-func DeleteNodeGroup(kubeCl *client.KubernetesClient, nodeGroupName string) error {
-	return retry.NewLoop(fmt.Sprintf("Delete NodeGroup %s", nodeGroupName), 45, 10*time.Second).Run(func() error {
-		err := kubeCl.Dynamic().Resource(nodeGroupResource).Delete(context.TODO(), nodeGroupName, metav1.DeleteOptions{})
-		if errors.IsNotFound(err) {
-			// NodeGroup has already been deleted
-			return nil
-		}
-		return err
-	})
+func DeleteNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupName string) error {
+	return retry.NewLoop(fmt.Sprintf("Delete NodeGroup %s", nodeGroupName), 45, 10*time.Second).
+		RunContext(ctx, func() error {
+			err := kubeCl.Dynamic().Resource(nodeGroupResource).Delete(ctx, nodeGroupName, metav1.DeleteOptions{})
+			if errors.IsNotFound(err) {
+				// NodeGroup has already been deleted
+				return nil
+			}
+			return err
+		})
 }
 
-func requestNodeExists(kubeCl *client.KubernetesClient, nodeName string) (bool, error) {
+func requestNodeExists(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string) (bool, error) {
 	_, err := kubeCl.
 		CoreV1().
 		Nodes().
-		Get(context.TODO(), nodeName, metav1.GetOptions{})
+		Get(ctx, nodeName, metav1.GetOptions{})
 
 	if err == nil {
 		return true, nil
@@ -391,13 +400,15 @@ func requestNodeExists(kubeCl *client.KubernetesClient, nodeName string) (bool, 
 	return true, err
 }
 
-func IsNodeExistsInCluster(kubeCl *client.KubernetesClient, nodeName string, logger log.Logger) (bool, error) {
+func IsNodeExistsInCluster(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string, logger log.Logger) (bool, error) {
 	exists := false
-	err := retry.NewLoop(fmt.Sprintf("Checking node exists %s", nodeName), 5, 2*time.Second).WithLogger(logger).Run(func() error {
-		var err error
-		exists, err = requestNodeExists(kubeCl, nodeName)
-		return err
-	})
+	err := retry.NewLoop(fmt.Sprintf("Checking node exists %s", nodeName), 5, 2*time.Second).
+		WithLogger(logger).
+		RunContext(ctx, func() error {
+			var err error
+			exists, err = requestNodeExists(ctx, kubeCl, nodeName)
+			return err
+		})
 
 	return exists, err
 }

--- a/dhctl/pkg/kubernetes/actions/entity/state.go
+++ b/dhctl/pkg/kubernetes/actions/entity/state.go
@@ -39,25 +39,26 @@ import (
 var ErrNoTerraformState = errors.New("Terraform state is not found in outputs.")
 
 // Create secret for node with group settings only.
-func CreateNodeTerraformState(kubeCl *client.KubernetesClient, nodeName, nodeGroup string, settings []byte) error {
+func CreateNodeTerraformState(ctx context.Context, kubeCl *client.KubernetesClient, nodeName, nodeGroup string, settings []byte) error {
 	task := actions.ManifestTask{
 		Name: fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, nodeName),
 		Manifest: func() interface{} {
 			return manifests.SecretWithNodeTerraformState(nodeName, nodeGroup, nil, settings)
 		},
 		CreateFunc: func(manifest interface{}) error {
-			_, err := kubeCl.CoreV1().Secrets("d8-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
+			_, err := kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 			return err
 		},
 		UpdateFunc: func(manifest interface{}) error {
-			_, err := kubeCl.CoreV1().Secrets("d8-system").Update(context.TODO(), manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+			_, err := kubeCl.CoreV1().Secrets("d8-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
 			return err
 		},
 	}
-	return retry.NewLoop(fmt.Sprintf("Create Terraform state for Node %q", nodeName), 45, 10*time.Second).Run(task.CreateOrUpdate)
+	return retry.NewLoop(fmt.Sprintf("Create Terraform state for Node %q", nodeName), 45, 10*time.Second).
+		RunContext(ctx, task.CreateOrUpdate)
 }
 
-func SaveNodeTerraformState(kubeCl *client.KubernetesClient, nodeName, nodeGroup string, tfState, settings []byte, logger log.Logger) error {
+func SaveNodeTerraformState(ctx context.Context, kubeCl *client.KubernetesClient, nodeName, nodeGroup string, tfState, settings []byte, logger log.Logger) error {
 	if len(tfState) == 0 {
 		return ErrNoTerraformState
 	}
@@ -68,18 +69,19 @@ func SaveNodeTerraformState(kubeCl *client.KubernetesClient, nodeName, nodeGroup
 			return manifests.SecretWithNodeTerraformState(nodeName, nodeGroup, tfState, settings)
 		},
 		CreateFunc: func(manifest interface{}) error {
-			_, err := kubeCl.CoreV1().Secrets("d8-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
+			_, err := kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 			return err
 		},
 		UpdateFunc: func(manifest interface{}) error {
-			_, err := kubeCl.CoreV1().Secrets("d8-system").Update(context.TODO(), manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+			_, err := kubeCl.CoreV1().Secrets("d8-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
 			return err
 		},
 	}
-	return retry.NewLoop(fmt.Sprintf("Save Terraform state for Node %q", nodeName), 45, 10*time.Second).WithLogger(logger).Run(task.CreateOrUpdate)
+	return retry.NewLoop(fmt.Sprintf("Save Terraform state for Node %q", nodeName), 45, 10*time.Second).
+		WithLogger(logger).RunContext(ctx, task.CreateOrUpdate)
 }
 
-func SaveMasterNodeTerraformState(kubeCl *client.KubernetesClient, nodeName string, tfState, devicePath []byte) error {
+func SaveMasterNodeTerraformState(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string, tfState, devicePath []byte) error {
 	if len(tfState) == 0 {
 		return ErrNoTerraformState
 	}
@@ -96,11 +98,11 @@ func SaveMasterNodeTerraformState(kubeCl *client.KubernetesClient, nodeName stri
 			Name:     fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, nodeName),
 			Manifest: getTerraformStateManifest,
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Update(context.TODO(), manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("d8-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
 				return err
 			},
 		},
@@ -108,7 +110,7 @@ func SaveMasterNodeTerraformState(kubeCl *client.KubernetesClient, nodeName stri
 			Name:     `Secret "d8-masters-kubernetes-data-device-path"`,
 			Manifest: getDevicePathManifest,
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
+				_, err := kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
@@ -117,7 +119,7 @@ func SaveMasterNodeTerraformState(kubeCl *client.KubernetesClient, nodeName stri
 					return err
 				}
 				_, err = kubeCl.CoreV1().Secrets("d8-system").Patch(
-					context.TODO(),
+					ctx,
 					"d8-masters-kubernetes-data-device-path",
 					types.MergePatchType,
 					data,
@@ -128,7 +130,7 @@ func SaveMasterNodeTerraformState(kubeCl *client.KubernetesClient, nodeName stri
 		},
 	}
 
-	return retry.NewLoop(fmt.Sprintf("Save Terraform state for master Node %s", nodeName), 45, 10*time.Second).Run(func() error {
+	return retry.NewLoop(fmt.Sprintf("Save Terraform state for master Node %s", nodeName), 45, 10*time.Second).RunContext(ctx, func() error {
 		var allErrs *multierror.Error
 		for _, task := range tasks {
 			if err := task.CreateOrUpdate(); err != nil {
@@ -139,7 +141,7 @@ func SaveMasterNodeTerraformState(kubeCl *client.KubernetesClient, nodeName stri
 	})
 }
 
-func SaveClusterTerraformState(kubeCl *client.KubernetesClient, outputs *terraform.PipelineOutputs) error {
+func SaveClusterTerraformState(ctx context.Context, kubeCl *client.KubernetesClient, outputs *terraform.PipelineOutputs) error {
 	if outputs == nil || len(outputs.TerraformState) == 0 {
 		return ErrNoTerraformState
 	}
@@ -148,16 +150,16 @@ func SaveClusterTerraformState(kubeCl *client.KubernetesClient, outputs *terrafo
 		Name:     `Secret "d8-cluster-terraform-state"`,
 		Manifest: func() interface{} { return manifests.SecretWithTerraformState(outputs.TerraformState) },
 		CreateFunc: func(manifest interface{}) error {
-			_, err := kubeCl.CoreV1().Secrets("d8-system").Create(context.TODO(), manifest.(*apiv1.Secret), metav1.CreateOptions{})
+			_, err := kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 			return err
 		},
 		UpdateFunc: func(manifest interface{}) error {
-			_, err := kubeCl.CoreV1().Secrets("d8-system").Update(context.TODO(), manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+			_, err := kubeCl.CoreV1().Secrets("d8-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
 			return err
 		},
 	}
 
-	err := retry.NewLoop("Save Cluster Terraform state", 45, 10*time.Second).Run(task.CreateOrUpdate)
+	err := retry.NewLoop("Save Cluster Terraform state", 45, 10*time.Second).RunContext(ctx, task.CreateOrUpdate)
 	if err != nil {
 		return err
 	}
@@ -171,9 +173,9 @@ func SaveClusterTerraformState(kubeCl *client.KubernetesClient, outputs *terrafo
 		return err
 	}
 
-	return retry.NewLoop("Update cloud discovery data", 45, 10*time.Second).Run(func() error {
+	return retry.NewLoop("Update cloud discovery data", 45, 10*time.Second).RunContext(ctx, func() error {
 		_, err = kubeCl.CoreV1().Secrets("kube-system").Patch(
-			context.TODO(),
+			ctx,
 			"d8-provider-cluster-configuration",
 			types.MergePatchType,
 			patch,
@@ -183,10 +185,11 @@ func SaveClusterTerraformState(kubeCl *client.KubernetesClient, outputs *terrafo
 	})
 }
 
-func DeleteTerraformState(kubeCl *client.KubernetesClient, secretName string) error {
-	return retry.NewLoop(fmt.Sprintf("Delete Terraform state %s", secretName), 45, 10*time.Second).Run(func() error {
-		return kubeCl.CoreV1().Secrets("d8-system").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
-	})
+func DeleteTerraformState(ctx context.Context, kubeCl *client.KubernetesClient, secretName string) error {
+	return retry.NewLoop(fmt.Sprintf("Delete Terraform state %s", secretName), 45, 10*time.Second).
+		RunContext(ctx, func() error {
+			return kubeCl.CoreV1().Secrets("d8-system").Delete(ctx, secretName, metav1.DeleteOptions{})
+		})
 }
 
 // NewClusterStateSaver returns StateSaver that saves intermediate terraform state to Secret.
@@ -204,6 +207,8 @@ func DeleteTerraformState(kubeCl *client.KubernetesClient, secretName string) er
 // '/tmp/dhctl/static-node-dhctl.043483477.tfstate' stat: 0 bytes, mode: -rw-------
 // got FS event "/tmp/dhctl/static-node-dhctl.043483477.tfstate": WRITE
 // '/tmp/dhctl/static-node-dhctl.043483477.tfstate' stat: 8840 bytes, mode: -rw-------
+
+// TODO(dhctl-for-commander-cancels): pass ctx to all kube client functions
 
 var (
 	_ terraform.SaverDestination = &ClusterStateSaver{}

--- a/dhctl/pkg/kubernetes/actions/resources/resouce_ready.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resouce_ready.go
@@ -55,7 +55,7 @@ func resourceName(r *template.Resource) string {
 	return result + r.Object.GetName() + "'"
 }
 
-func (c *resourceReadinessChecker) IsReady() (bool, error) {
+func (c *resourceReadinessChecker) IsReady(ctx context.Context) (bool, error) {
 	defer func() {
 		c.attempt++
 		c.logger.LogInfoF("\n")
@@ -91,7 +91,7 @@ func (c *resourceReadinessChecker) IsReady() (bool, error) {
 		return false, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	objectInCluster, err := c.kubeCl.Dynamic().

--- a/dhctl/pkg/kubernetes/actions/resources/waiter.go
+++ b/dhctl/pkg/kubernetes/actions/resources/waiter.go
@@ -15,6 +15,7 @@
 package resources
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/hashicorp/go-multierror"
@@ -25,7 +26,7 @@ import (
 )
 
 type Checker interface {
-	IsReady() (bool, error)
+	IsReady(ctx context.Context) (bool, error)
 	Name() string
 	Single() bool
 }
@@ -87,11 +88,11 @@ func NewWaiter(checkers []Checker) *Waiter {
 	}
 }
 
-func (w *Waiter) ReadyAll() (bool, error) {
+func (w *Waiter) ReadyAll(ctx context.Context) (bool, error) {
 	checkersToStay := make([]Checker, 0)
 
 	for _, c := range w.checkers {
-		ready, err := c.IsReady()
+		ready, err := c.IsReady(ctx)
 		if err != nil {
 			return false, err
 		}

--- a/dhctl/pkg/kubernetes/actions/resources/waiter_test.go
+++ b/dhctl/pkg/kubernetes/actions/resources/waiter_test.go
@@ -15,6 +15,7 @@
 package resources
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -302,7 +303,7 @@ func newTestChecker(returns bool, err error, single bool, name string) *testChec
 	}
 }
 
-func (n *testChecker) IsReady() (bool, error) {
+func (n *testChecker) IsReady(_ context.Context) (bool, error) {
 	return n.returns, n.err
 }
 
@@ -315,9 +316,11 @@ func (n *testChecker) Single() bool {
 }
 
 func TestWaiterStep(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("without checks", func(t *testing.T) {
 		w := NewWaiter(make([]Checker, 0))
-		ready, err := w.ReadyAll()
+		ready, err := w.ReadyAll(ctx)
 
 		require.NoError(t, err)
 		require.True(t, ready, "should ready")
@@ -325,7 +328,7 @@ func TestWaiterStep(t *testing.T) {
 
 	t.Run("with one ready check", func(t *testing.T) {
 		w := NewWaiter([]Checker{newTestChecker(true, nil, false, "Test 1")})
-		ready, err := w.ReadyAll()
+		ready, err := w.ReadyAll(ctx)
 
 		require.NoError(t, err)
 		require.True(t, ready, "should ready")
@@ -337,7 +340,7 @@ func TestWaiterStep(t *testing.T) {
 			newTestChecker(true, nil, false, "Test 2"),
 			newTestChecker(true, nil, false, "Test 3"),
 		})
-		ready, err := w.ReadyAll()
+		ready, err := w.ReadyAll(ctx)
 
 		require.NoError(t, err)
 		require.True(t, ready, "should ready")
@@ -349,7 +352,7 @@ func TestWaiterStep(t *testing.T) {
 			newTestChecker(false, fmt.Errorf("error"), false, "Test 2"),
 			newTestChecker(true, nil, false, "Test 3"),
 		})
-		ready, err := w.ReadyAll()
+		ready, err := w.ReadyAll(ctx)
 
 		require.Error(t, err, "should error")
 		require.False(t, ready)
@@ -361,7 +364,7 @@ func TestWaiterStep(t *testing.T) {
 			newTestChecker(false, nil, false, "Test 2"),
 			newTestChecker(true, nil, false, "Test 3"),
 		})
-		ready, err := w.ReadyAll()
+		ready, err := w.ReadyAll(ctx)
 
 		require.NoError(t, err)
 		require.False(t, ready, "should not ready")
@@ -374,7 +377,7 @@ func TestWaiterStep(t *testing.T) {
 			newTestChecker(true, nil, false, "Test 3"),
 		})
 
-		_, err := w.ReadyAll()
+		_, err := w.ReadyAll(ctx)
 
 		require.NoError(t, err)
 		require.Len(t, w.checkers, 1, "should remove ready checks")

--- a/dhctl/pkg/kubernetes/lease/lock.go
+++ b/dhctl/pkg/kubernetes/lease/lock.go
@@ -100,23 +100,23 @@ func NewLeaseLock(getter kubernetes.KubeClientProvider, config LeaseLockConfig) 
 	}
 }
 
-func (l *LeaseLock) Lock(force bool) error {
+func (l *LeaseLock) Lock(ctx context.Context, force bool) error {
 	l.lockLease.Lock()
 	defer l.lockLease.Unlock()
 
-	lease, err := l.tryAcquire(force)
+	lease, err := l.tryAcquire(ctx, force)
 	if err != nil {
 		return err
 	}
 
 	l.lease = lease
 
-	go l.startAutoRenew()
+	go l.startAutoRenew(ctx)
 
 	return nil
 }
 
-func (l *LeaseLock) Unlock() {
+func (l *LeaseLock) Unlock(ctx context.Context) {
 	l.lockLease.Lock()
 	defer l.lockLease.Unlock()
 
@@ -128,7 +128,7 @@ func (l *LeaseLock) Unlock() {
 
 	deleteRetries := l.config.RenewRetries()
 	err := retry.NewSilentLoop("unlock lease", deleteRetries, l.config.RetryWaitDuration).Run(func() error {
-		err := l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Delete(context.TODO(), l.lease.Name, metav1.DeleteOptions{})
+		err := l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Delete(ctx, l.lease.Name, metav1.DeleteOptions{})
 		if errors.IsNotFound(err) {
 			return nil
 		}
@@ -145,7 +145,7 @@ func (l *LeaseLock) StopAutoRenew() {
 	close(l.exitRenewCh)
 }
 
-func (l *LeaseLock) startAutoRenew() {
+func (l *LeaseLock) startAutoRenew(ctx context.Context) {
 	defer log.Debug("lease autorenew stopped")
 	log.Debug("lease autorenew started")
 
@@ -157,7 +157,7 @@ func (l *LeaseLock) startAutoRenew() {
 		case <-l.exitRenewCh:
 			return
 		case <-t.C:
-			lease, err := l.tryRenew(l.lease, true)
+			lease, err := l.tryRenew(ctx, l.lease, true)
 			if err == nil {
 				l.lease = lease
 				continue
@@ -171,7 +171,7 @@ func (l *LeaseLock) startAutoRenew() {
 	}
 }
 
-func (l *LeaseLock) tryAcquire(force bool) (*coordinationv1.Lease, error) {
+func (l *LeaseLock) tryAcquire(ctx context.Context, force bool) (*coordinationv1.Lease, error) {
 	var lease *coordinationv1.Lease
 
 	prefix := "Can't acquire lease lock."
@@ -182,18 +182,18 @@ func (l *LeaseLock) tryAcquire(force bool) (*coordinationv1.Lease, error) {
 	acquireRetries := l.config.RenewRetries()
 	err := retry.NewSilentLoop("acquire lease", acquireRetries, l.config.RetryWaitDuration).BreakIf(cannotRenew).Run(func() error {
 		var err error
-		lease, err = l.createLease()
+		lease, err = l.createLease(ctx)
 		if err == nil {
 			return nil
 		}
 
 		if errors.IsAlreadyExists(err) {
-			lease, err = l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Get(context.TODO(), l.config.Name, metav1.GetOptions{})
+			lease, err = l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Get(ctx, l.config.Name, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("%s Can't get current lease %v", prefix, err)
 			}
 
-			lease, err = l.tryRenew(lease, force)
+			lease, err = l.tryRenew(ctx, lease, force)
 			if err != nil {
 				return fmt.Errorf("%s \n%v", prefix, err)
 			}
@@ -205,7 +205,7 @@ func (l *LeaseLock) tryAcquire(force bool) (*coordinationv1.Lease, error) {
 	return lease, err
 }
 
-func (l *LeaseLock) createLease() (lease *coordinationv1.Lease, err error) {
+func (l *LeaseLock) createLease(ctx context.Context) (lease *coordinationv1.Lease, err error) {
 	userInfo := NewLockUserInfo(l.config.AdditionalUserInfo)
 	userInfoStr, err := json.Marshal(userInfo)
 	if err != nil {
@@ -227,10 +227,10 @@ func (l *LeaseLock) createLease() (lease *coordinationv1.Lease, err error) {
 		},
 	}
 
-	return l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Create(context.TODO(), lease, metav1.CreateOptions{})
+	return l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Create(ctx, lease, metav1.CreateOptions{})
 }
 
-func (l *LeaseLock) tryRenew(lease *coordinationv1.Lease, force bool) (*coordinationv1.Lease, error) {
+func (l *LeaseLock) tryRenew(ctx context.Context, lease *coordinationv1.Lease, force bool) (*coordinationv1.Lease, error) {
 	if *lease.Spec.HolderIdentity != l.config.Identity {
 		return nil, getCurrentLockerError(lease)
 	}
@@ -249,14 +249,14 @@ func (l *LeaseLock) tryRenew(lease *coordinationv1.Lease, force bool) (*coordina
 	err := retry.NewSilentLoop("try to renew", renewRetries, l.config.RetryWaitDuration).Run(func() error {
 		var err error
 		lease.Spec.RenewTime = now()
-		newLease, err = l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Update(context.TODO(), lease, metav1.UpdateOptions{})
+		newLease, err = l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Update(ctx, lease, metav1.UpdateOptions{})
 		if err != nil && strings.Contains(err.Error(), "the object has been modified; please apply your changes to the latest version and try again") {
-			leaseTemp, err := l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Get(context.TODO(), l.config.Name, metav1.GetOptions{})
+			leaseTemp, err := l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Get(ctx, l.config.Name, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 			leaseTemp.Spec.RenewTime = now()
-			newLease, err = l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Update(context.TODO(), leaseTemp, metav1.UpdateOptions{})
+			newLease, err = l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Update(ctx, leaseTemp, metav1.UpdateOptions{})
 			return err
 		}
 		return err
@@ -336,9 +336,9 @@ func LockInfo(lease *coordinationv1.Lease) (string, *LockUserInfo) {
 	), &userInfo
 }
 
-func RemoveLease(kubeCl *client.KubernetesClient, config *LeaseLockConfig, confirm func(lease *coordinationv1.Lease) error) error {
+func RemoveLease(ctx context.Context, kubeCl *client.KubernetesClient, config *LeaseLockConfig, confirm func(lease *coordinationv1.Lease) error) error {
 	leasesCl := kubeCl.CoordinationV1().Leases(config.Namespace)
-	lease, err := leasesCl.Get(context.TODO(), config.Name, metav1.GetOptions{})
+	lease, err := leasesCl.Get(ctx, config.Name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -350,7 +350,7 @@ func RemoveLease(kubeCl *client.KubernetesClient, config *LeaseLockConfig, confi
 	log.Infof("Starting remove lease lock")
 
 	err = retry.NewSilentLoop("release lease", 5, config.RetryWaitDuration).Run(func() error {
-		err := leasesCl.Delete(context.TODO(), lease.Name, metav1.DeleteOptions{})
+		err := leasesCl.Delete(ctx, lease.Name, metav1.DeleteOptions{})
 		if errors.IsNotFound(err) {
 			return nil
 		}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
@@ -71,6 +71,7 @@ func (b *ClusterBootstrapper) InstallDeckhouse() error {
 		return err
 	}
 
-	_, err = InstallDeckhouse(kubeCl, installConfig)
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	_, err = InstallDeckhouse(context.TODO(), kubeCl, installConfig)
 	return err
 }

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
@@ -88,6 +88,7 @@ func (b *ClusterBootstrapper) CreateResources() error {
 			return err
 		}
 
-		return resources.CreateResourcesLoop(kubeCl, resourcesToCreate, checkers, nil)
+		// TODO(dhctl-for-commander-cancels): pass ctx
+		return resources.CreateResourcesLoop(context.TODO(), kubeCl, resourcesToCreate, checkers, nil)
 	})
 }

--- a/dhctl/pkg/operations/bootstrap/steps_test.go
+++ b/dhctl/pkg/operations/bootstrap/steps_test.go
@@ -114,6 +114,7 @@ func TestBootstrapGetNodesFromCache(t *testing.T) {
 }
 
 func TestInstallDeckhouse(t *testing.T) {
+	ctx := context.Background()
 	err := os.Setenv("DHCTL_TEST", "yes")
 	require.NoError(t, err)
 	defer func() {
@@ -210,7 +211,7 @@ func TestInstallDeckhouse(t *testing.T) {
 			fakeClient := client.NewFakeKubernetesClient()
 			createReadyDeckhousePod(fakeClient)
 
-			_, err := InstallDeckhouse(fakeClient, conf)
+			_, err := InstallDeckhouse(ctx, fakeClient, conf)
 
 			require.NoError(t, err, "Should install Deckhouse")
 
@@ -227,7 +228,7 @@ func TestInstallDeckhouse(t *testing.T) {
 				createReadyDeckhousePod(fakeClient)
 				createUUIDConfigMap(fakeClient, curUUID)
 
-				_, err := InstallDeckhouse(fakeClient, conf)
+				_, err := InstallDeckhouse(ctx, fakeClient, conf)
 
 				require.Error(t, err, "Should not install Deckhouse")
 
@@ -244,7 +245,7 @@ func TestInstallDeckhouse(t *testing.T) {
 				createReadyDeckhousePod(fakeClient)
 				createUUIDConfigMap(fakeClient, curUUID)
 
-				_, err := InstallDeckhouse(fakeClient, conf)
+				_, err := InstallDeckhouse(ctx, fakeClient, conf)
 
 				require.Error(t, err, "Should not install Deckhouse")
 
@@ -258,7 +259,7 @@ func TestInstallDeckhouse(t *testing.T) {
 				createReadyDeckhousePod(fakeClient)
 				createUUIDConfigMap(fakeClient, clusterUUID)
 
-				_, err := InstallDeckhouse(fakeClient, conf)
+				_, err := InstallDeckhouse(ctx, fakeClient, conf)
 
 				require.NoError(t, err, "Should install Deckhouse")
 

--- a/dhctl/pkg/operations/check/check.go
+++ b/dhctl/pkg/operations/check/check.go
@@ -288,7 +288,8 @@ func CheckState(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, 
 		}
 	}
 
-	nodeTemplates, err := entity.GetNodeGroupTemplates(kubeCl)
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	nodeTemplates, err := entity.GetNodeGroupTemplates(context.TODO(), kubeCl)
 	if err != nil {
 		allErrs = multierror.Append(allErrs, fmt.Errorf("node goups in Kubernetes cluster not found: %w", err))
 	}
@@ -465,7 +466,8 @@ func sortNodesByIndex(nodesState map[string][]byte) ([]string, error) {
 func getStatusForMissedNode(kubeCl *client.KubernetesClient, nodeName, nodeGroupName string, allErrs **multierror.Error) NodeCheckResult {
 	status := AbsentStatus
 
-	exists, err := entity.IsNodeExistsInCluster(kubeCl, nodeName, log.GetDefaultLogger())
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	exists, err := entity.IsNodeExistsInCluster(context.TODO(), kubeCl, nodeName, log.GetDefaultLogger())
 	if err != nil {
 		*allErrs = multierror.Append(*allErrs, err)
 		status = ErrorStatus

--- a/dhctl/pkg/operations/commander/attach/attacher.go
+++ b/dhctl/pkg/operations/commander/attach/attacher.go
@@ -282,7 +282,7 @@ func (i *Attacher) scan(
 }
 
 func (i *Attacher) capture(
-	_ context.Context,
+	ctx context.Context,
 	kubeClient *client.KubernetesClient,
 ) error {
 	return log.Process("commander/attach", "Capture cluster", func() error {
@@ -299,7 +299,7 @@ func (i *Attacher) capture(
 			return fmt.Errorf("unable to get resource checkers: %w", err)
 		}
 
-		err = resources.CreateResourcesLoop(kubeClient, attachResources, checkers, nil)
+		err = resources.CreateResourcesLoop(ctx, kubeClient, attachResources, checkers, nil)
 		if err != nil {
 			return fmt.Errorf("unable to create resources: %w", err)
 		}

--- a/dhctl/pkg/operations/commander/detach/detacher.go
+++ b/dhctl/pkg/operations/commander/detach/detacher.go
@@ -91,7 +91,7 @@ func (op *Detacher) Detach(ctx context.Context) error {
 			return fmt.Errorf("unable to get resource checkers: %w", err)
 		}
 
-		err = resources.CreateResourcesLoop(kubeClient, detachResources, checkers, nil)
+		err = resources.CreateResourcesLoop(ctx, kubeClient, detachResources, checkers, nil)
 		if err != nil {
 			return fmt.Errorf("unable to create resources: %w", err)
 		}

--- a/dhctl/pkg/operations/converge/context/client_switcher.go
+++ b/dhctl/pkg/operations/converge/context/client_switcher.go
@@ -185,7 +185,7 @@ func (s *KubeClientSwitcher) replaceKubeClient(convergeState *State, state map[s
 
 	if s.lockRunner != nil {
 		log.DebugLn("starting reset lock after replacing kube client")
-		err := s.lockRunner.ResetLock()
+		err := s.lockRunner.ResetLock(s.ctx.Ctx())
 		if err != nil {
 			return fmt.Errorf("failed to reset lock: %w", err)
 		}

--- a/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group.go
@@ -77,13 +77,13 @@ func (c *CloudPermanentNodeGroupController) addNodes(ctx *context.Context) error
 
 	err = log.Process("terraform", fmt.Sprintf("Pipelines %s for %s-%s-%v", c.layoutStep, metaConfig.ClusterPrefix, c.name, nodesIndexToCreate), func() error {
 		var err error
-		nodesToWait, err = operations.ParallelBootstrapAdditionalNodes(ctx.KubeClient(), metaConfig, nodesIndexToCreate, c.layoutStep, c.name, c.cloudConfig, true, ctx.Terraform(), log.GetDefaultLogger(), false)
+		nodesToWait, err = operations.ParallelBootstrapAdditionalNodes(ctx.Ctx(), ctx.KubeClient(), metaConfig, nodesIndexToCreate, c.layoutStep, c.name, c.cloudConfig, true, ctx.Terraform(), log.GetDefaultLogger(), false)
 		return err
 	})
 	if err != nil {
 		return err
 	}
-	return entity.WaitForNodesListBecomeReady(ctx.KubeClient(), nodesToWait, nil)
+	return entity.WaitForNodesListBecomeReady(ctx.Ctx(), ctx.KubeClient(), nodesToWait, nil)
 }
 
 func (c *CloudPermanentNodeGroupController) updateNode(ctx *context.Context, nodeName string) error {
@@ -137,12 +137,12 @@ func (c *CloudPermanentNodeGroupController) updateNode(ctx *context.Context, nod
 		return global.ErrConvergeInterrupted
 	}
 
-	err = entity.SaveNodeTerraformState(ctx.KubeClient(), nodeName, c.name, outputs.TerraformState, nodeGroupSettingsFromConfig, log.GetDefaultLogger())
+	err = entity.SaveNodeTerraformState(ctx.Ctx(), ctx.KubeClient(), nodeName, c.name, outputs.TerraformState, nodeGroupSettingsFromConfig, log.GetDefaultLogger())
 	if err != nil {
 		return err
 	}
 
-	return entity.WaitForSingleNodeBecomeReady(ctx.KubeClient(), nodeName)
+	return entity.WaitForSingleNodeBecomeReady(ctx.Ctx(), ctx.KubeClient(), nodeName)
 }
 
 func (c *CloudPermanentNodeGroupController) deleteNodes(ctx *context.Context, nodesToDeleteInfo []nodeToDeleteInfo) error {

--- a/dhctl/pkg/operations/converge/controller/master_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/master_node_group.go
@@ -187,7 +187,7 @@ func (c *MasterNodeGroupController) addNodes(ctx *context.Context) error {
 		candidateName := fmt.Sprintf("%s-%s-%v", metaConfig.ClusterPrefix, c.name, index)
 
 		if _, ok := c.state.State[candidateName]; !ok {
-			output, err := operations.BootstrapAdditionalMasterNode(ctx.KubeClient(), metaConfig, index, c.cloudConfig, true, ctx.Terraform())
+			output, err := operations.BootstrapAdditionalMasterNode(ctx.Ctx(), ctx.KubeClient(), metaConfig, index, c.cloudConfig, true, ctx.Terraform())
 			if err != nil {
 				return err
 			}
@@ -202,7 +202,7 @@ func (c *MasterNodeGroupController) addNodes(ctx *context.Context) error {
 		index++
 	}
 
-	err = entity.WaitForNodesListBecomeReady(ctx.KubeClient(), nodesToWait, controlplane.NewManagerReadinessChecker(ctx))
+	err = entity.WaitForNodesListBecomeReady(ctx.Ctx(), ctx.KubeClient(), nodesToWait, controlplane.NewManagerReadinessChecker(ctx))
 	if err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func (c *MasterNodeGroupController) addNodes(ctx *context.Context) error {
 		}
 
 		// we hide deckhouse logs because we always have config
-		nodeCloudConfig, err := entity.GetCloudConfig(ctx.KubeClient(), c.name, global.HideDeckhouseLogs, log.GetDefaultLogger(), nodeInternalIPList...)
+		nodeCloudConfig, err := entity.GetCloudConfig(ctx.Ctx(), ctx.KubeClient(), c.name, global.HideDeckhouseLogs, log.GetDefaultLogger(), nodeInternalIPList...)
 		if err != nil {
 			return err
 		}
@@ -303,14 +303,14 @@ func (c *MasterNodeGroupController) updateNode(ctx *context.Context, nodeName st
 		return global.ErrConvergeInterrupted
 	}
 
-	err = entity.SaveMasterNodeTerraformState(ctx.KubeClient(), nodeName, outputs.TerraformState, []byte(outputs.KubeDataDevicePath))
+	err = entity.SaveMasterNodeTerraformState(ctx.Ctx(), ctx.KubeClient(), nodeName, outputs.TerraformState, []byte(outputs.KubeDataDevicePath))
 	if err != nil {
 		return err
 	}
 
 	c.state.State[nodeName] = outputs.TerraformState
 
-	return entity.WaitForSingleNodeBecomeReady(ctx.KubeClient(), nodeName)
+	return entity.WaitForSingleNodeBecomeReady(ctx.Ctx(), ctx.KubeClient(), nodeName)
 }
 
 func (c *MasterNodeGroupController) newHookForUpdatePipeline(ctx *context.Context, convergedNode string, metaConfig *config.MetaConfig) terraform.InfraActionHook {

--- a/dhctl/pkg/operations/converge/controller/node_group_controller.go
+++ b/dhctl/pkg/operations/converge/controller/node_group_controller.go
@@ -62,7 +62,7 @@ func NewNodeGroupController(name string, state state.NodeGroupTerraformState, ex
 
 func (c *NodeGroupController) Run(ctx *context.Context) error {
 	// we hide deckhouse logs because we always have config
-	nodeCloudConfig, err := entity.GetCloudConfig(ctx.KubeClient(), c.name, global.HideDeckhouseLogs, log.GetDefaultLogger())
+	nodeCloudConfig, err := entity.GetCloudConfig(ctx.Ctx(), ctx.KubeClient(), c.name, global.HideDeckhouseLogs, log.GetDefaultLogger())
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func (c *NodeGroupController) deleteRedundantNodes(
 			return allErrs.ErrorOrNil()
 		}
 
-		if err := entity.DeleteNode(ctx.KubeClient(), nodeToDeleteInfo.name); err != nil {
+		if err := entity.DeleteNode(ctx.Ctx(), ctx.KubeClient(), nodeToDeleteInfo.name); err != nil {
 			allErrs = multierror.Append(allErrs, fmt.Errorf("%s: %w", nodeToDeleteInfo.name, err))
 			continue
 		}
@@ -211,7 +211,7 @@ func (c *NodeGroupController) deleteRedundantNodes(
 			continue
 		}
 
-		if err := entity.DeleteTerraformState(ctx.KubeClient(), fmt.Sprintf("d8-node-terraform-state-%s", nodeToDeleteInfo.name)); err != nil {
+		if err := entity.DeleteTerraformState(ctx.Ctx(), ctx.KubeClient(), fmt.Sprintf("d8-node-terraform-state-%s", nodeToDeleteInfo.name)); err != nil {
 			allErrs = multierror.Append(allErrs, fmt.Errorf("%s: %w", nodeToDeleteInfo.name, err))
 			continue
 		}
@@ -223,7 +223,7 @@ func (c *NodeGroupController) deleteRedundantNodes(
 func (c *NodeGroupController) tryUpdateNodeTemplate(ctx *context.Context, nodeTemplate map[string]interface{}) error {
 	nodeTemplatePath := []string{"spec", "nodeTemplate"}
 	for {
-		ng, err := entity.GetNodeGroup(ctx.KubeClient(), c.name)
+		ng, err := entity.GetNodeGroup(ctx.Ctx(), ctx.KubeClient(), c.name)
 		if err != nil {
 			return err
 		}
@@ -251,7 +251,7 @@ func (c *NodeGroupController) tryUpdateNodeTemplate(ctx *context.Context, nodeTe
 			return err
 		}
 
-		err = entity.UpdateNodeGroup(ctx.KubeClient(), c.name, ng)
+		err = entity.UpdateNodeGroup(ctx.Ctx(), ctx.KubeClient(), c.name, ng)
 
 		if err == nil {
 			return nil
@@ -278,7 +278,7 @@ func (c *NodeGroupController) tryDeleteNodeGroup(ctx *context.Context) error {
 	}
 
 	return log.Process("converge", fmt.Sprintf("Delete NodeGroup %s", c.name), func() error {
-		return entity.DeleteNodeGroup(ctx.KubeClient(), c.name)
+		return entity.DeleteNodeGroup(ctx.Ctx(), ctx.KubeClient(), c.name)
 	})
 }
 
@@ -325,7 +325,7 @@ func (c *NodeGroupController) updateNodes(ctx *context.Context) error {
 			}
 
 			// we hide deckhouse logs because we always have config
-			nodeCloudConfig, err := entity.GetCloudConfig(ctx.KubeClient(), c.name, global.HideDeckhouseLogs, log.GetDefaultLogger())
+			nodeCloudConfig, err := entity.GetCloudConfig(ctx.Ctx(), ctx.KubeClient(), c.name, global.HideDeckhouseLogs, log.GetDefaultLogger())
 			if err != nil {
 				return err
 			}

--- a/dhctl/pkg/operations/converge/runner.go
+++ b/dhctl/pkg/operations/converge/runner.go
@@ -100,7 +100,7 @@ func (r *runner) isSkip(phase phases.OperationPhase) bool {
 
 func (r *runner) RunConverge(ctx *context.Context) error {
 	if r.lockRunner != nil {
-		err := r.lockRunner.Run(func() error {
+		err := r.lockRunner.Run(ctx.Ctx(), func() error {
 			return r.converge(ctx)
 		})
 
@@ -198,7 +198,7 @@ func (r *runner) convergeTerraNodes(ctx *context.Context, metaConfig *config.Met
 		bootstrapNewNodeGroups = operations.BootstrapSequentialTerraNodes
 	}
 
-	if err := bootstrapNewNodeGroups(ctx.KubeClient(), metaConfig, nodeGroupsWithoutStateInCluster, ctx.Terraform()); err != nil {
+	if err := bootstrapNewNodeGroups(ctx.Ctx(), ctx.KubeClient(), metaConfig, nodeGroupsWithoutStateInCluster, ctx.Terraform()); err != nil {
 		return err
 	}
 
@@ -343,7 +343,7 @@ func (r *runner) updateClusterState(ctx *context.Context, metaConfig *config.Met
 			return global.ErrConvergeInterrupted
 		}
 
-		return entity.SaveClusterTerraformState(ctx.KubeClient(), outputs)
+		return entity.SaveClusterTerraformState(ctx.Ctx(), ctx.KubeClient(), outputs)
 	})
 
 	if err != nil {

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -24,6 +24,9 @@ import (
 
 	"github.com/google/uuid"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	infra "github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -38,8 +41,6 @@ import (
 	tf "github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Destroyer interface {
@@ -183,7 +184,8 @@ func (d *ClusterDestroyer) DestroyCluster(autoApprove bool) error {
 		} else if shouldStop {
 			return nil
 		}
-		if err := d.d8Destroyer.DeleteResources(clusterType); err != nil {
+		// TODO(dhctl-for-commander-cancels): pass ctx
+		if err := d.d8Destroyer.DeleteResources(context.TODO(), clusterType); err != nil {
 			return err
 		}
 		if err := d.PhasedExecutionContext.CompletePhase(d.stateCache, nil); err != nil {

--- a/dhctl/pkg/operations/nodebootstrap.go
+++ b/dhctl/pkg/operations/nodebootstrap.go
@@ -45,11 +45,19 @@ func NodeName(cfg *config.MetaConfig, nodeGroupName string, index int) string {
 	return fmt.Sprintf("%s-%s-%v", cfg.ClusterPrefix, nodeGroupName, index)
 }
 
-func BootstrapAdditionalNode(kubeCl *client.KubernetesClient, cfg *config.MetaConfig, index int, step, nodeGroupName, cloudConfig string, isConverge bool, terraformContext *terraform.TerraformContext) error {
+func BootstrapAdditionalNode(
+	ctx context.Context,
+	kubeCl *client.KubernetesClient,
+	cfg *config.MetaConfig,
+	index int,
+	step, nodeGroupName, cloudConfig string,
+	isConverge bool,
+	terraformContext *terraform.TerraformContext,
+) error {
 	nodeName := NodeName(cfg, nodeGroupName, index)
 
 	if isConverge {
-		nodeExists, err := entity.IsNodeExistsInCluster(kubeCl, nodeName, log.GetDefaultLogger())
+		nodeExists, err := entity.IsNodeExistsInCluster(ctx, kubeCl, nodeName, log.GetDefaultLogger())
 		if err != nil {
 			return err
 		} else if nodeExists {
@@ -83,7 +91,8 @@ func BootstrapAdditionalNode(kubeCl *client.KubernetesClient, cfg *config.MetaCo
 		return global.ErrConvergeInterrupted
 	}
 
-	err = entity.SaveNodeTerraformState(kubeCl, nodeName, nodeGroupName, outputs.TerraformState, nodeGroupSettings, log.GetDefaultLogger())
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	err = entity.SaveNodeTerraformState(context.TODO(), kubeCl, nodeName, nodeGroupName, outputs.TerraformState, nodeGroupSettings, log.GetDefaultLogger())
 	if err != nil {
 		return err
 	}
@@ -91,21 +100,21 @@ func BootstrapAdditionalNode(kubeCl *client.KubernetesClient, cfg *config.MetaCo
 	return nil
 }
 
-func BootstrapSequentialTerraNodes(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, terraNodeGroups []config.TerraNodeGroupSpec, terraformContext *terraform.TerraformContext) error {
+func BootstrapSequentialTerraNodes(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, terraNodeGroups []config.TerraNodeGroupSpec, terraformContext *terraform.TerraformContext) error {
 	for _, ng := range terraNodeGroups {
 		err := log.Process("bootstrap", fmt.Sprintf("Create %s NodeGroup", ng.Name), func() error {
-			err := entity.CreateNodeGroup(kubeCl, ng.Name, log.GetDefaultLogger(), metaConfig.NodeGroupManifest(ng))
+			err := entity.CreateNodeGroup(ctx, kubeCl, ng.Name, log.GetDefaultLogger(), metaConfig.NodeGroupManifest(ng))
 			if err != nil {
 				return err
 			}
 
-			cloudConfig, err := entity.GetCloudConfig(kubeCl, ng.Name, global.ShowDeckhouseLogs, log.GetDefaultLogger())
+			cloudConfig, err := entity.GetCloudConfig(ctx, kubeCl, ng.Name, global.ShowDeckhouseLogs, log.GetDefaultLogger())
 			if err != nil {
 				return err
 			}
 
 			for i := 0; i < ng.Replicas; i++ {
-				err = BootstrapAdditionalNode(kubeCl, metaConfig, i, "static-node", ng.Name, cloudConfig, false, terraformContext)
+				err = BootstrapAdditionalNode(ctx, kubeCl, metaConfig, i, "static-node", ng.Name, cloudConfig, false, terraformContext)
 				if err != nil {
 					return err
 				}
@@ -119,7 +128,15 @@ func BootstrapSequentialTerraNodes(kubeCl *client.KubernetesClient, metaConfig *
 	return nil
 }
 
-func BootstrapAdditionalNodeForParallelRun(kubeCl *client.KubernetesClient, cfg *config.MetaConfig, index int, step, nodeGroupName, cloudConfig string, isConverge bool, terraformContext *terraform.TerraformContext, runnerLogger log.Logger) error {
+func BootstrapAdditionalNodeForParallelRun(
+	kubeCl *client.KubernetesClient,
+	cfg *config.MetaConfig,
+	index int,
+	step, nodeGroupName, cloudConfig string,
+	isConverge bool,
+	terraformContext *terraform.TerraformContext,
+	runnerLogger log.Logger,
+) error {
 	nodeName := NodeName(cfg, nodeGroupName, index)
 	nodeGroupSettings := cfg.FindTerraNodeGroup(nodeGroupName)
 	// TODO pass cache as argument or better refact func
@@ -146,7 +163,8 @@ func BootstrapAdditionalNodeForParallelRun(kubeCl *client.KubernetesClient, cfg 
 		return global.ErrConvergeInterrupted
 	}
 
-	err = entity.SaveNodeTerraformState(kubeCl, nodeName, nodeGroupName, outputs.TerraformState, nodeGroupSettings, runnerLogger)
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	err = entity.SaveNodeTerraformState(context.TODO(), kubeCl, nodeName, nodeGroupName, outputs.TerraformState, nodeGroupSettings, runnerLogger)
 	if err != nil {
 		return err
 	}
@@ -155,6 +173,7 @@ func BootstrapAdditionalNodeForParallelRun(kubeCl *client.KubernetesClient, cfg 
 }
 
 func ParallelBootstrapAdditionalNodes(
+	ctx context.Context,
 	kubeCl *client.KubernetesClient,
 	cfg *config.MetaConfig,
 	nodesIndexToCreate []int,
@@ -179,7 +198,7 @@ func ParallelBootstrapAdditionalNodes(
 
 	for _, indexCandidate := range nodesIndexToCreate {
 		candidateName := fmt.Sprintf("%s-%s-%v", cfg.ClusterPrefix, nodeGroupName, indexCandidate)
-		nodeExists, err := entity.IsNodeExistsInCluster(kubeCl, candidateName, ngLogger)
+		nodeExists, err := entity.IsNodeExistsInCluster(ctx, kubeCl, candidateName, ngLogger)
 		if err != nil {
 			return nil, err
 		} else if nodeExists {
@@ -246,7 +265,13 @@ func ParallelBootstrapAdditionalNodes(
 	return nodesToWait, nil
 }
 
-func ParallelCreateNodeGroup(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, terraNodeGroups []config.TerraNodeGroupSpec, terraformContext *terraform.TerraformContext) error {
+func ParallelCreateNodeGroup(
+	ctx context.Context,
+	kubeCl *client.KubernetesClient,
+	metaConfig *config.MetaConfig,
+	terraNodeGroups []config.TerraNodeGroupSpec,
+	terraformContext *terraform.TerraformContext,
+) error {
 	msg := "Create NodeGroups "
 	for _, group := range terraNodeGroups {
 		msg += fmt.Sprintf("%s (replicas: %v)️; ", group.Name, group.Replicas)
@@ -285,7 +310,7 @@ func ParallelCreateNodeGroup(kubeCl *client.KubernetesClient, metaConfig *config
 					ngLogger = currentLogger.CreateBufferLogger(&buffNGLog)
 				}
 
-				err := entity.CreateNodeGroup(kubeCl, group.Name, ngLogger, metaConfig.NodeGroupManifest(group))
+				err := entity.CreateNodeGroup(ctx, kubeCl, group.Name, ngLogger, metaConfig.NodeGroupManifest(group))
 				if err != nil {
 					resultsChan <- checkResult{
 						name:    group.Name,
@@ -295,7 +320,7 @@ func ParallelCreateNodeGroup(kubeCl *client.KubernetesClient, metaConfig *config
 					return
 				}
 
-				nodeCloudConfig, err := entity.GetCloudConfig(kubeCl, group.Name, global.ShowDeckhouseLogs, ngLogger)
+				nodeCloudConfig, err := entity.GetCloudConfig(ctx, kubeCl, group.Name, global.ShowDeckhouseLogs, ngLogger)
 				if err != nil {
 					resultsChan <- checkResult{
 						name:    group.Name,
@@ -310,7 +335,7 @@ func ParallelCreateNodeGroup(kubeCl *client.KubernetesClient, metaConfig *config
 					nodesIndexToCreate = append(nodesIndexToCreate, i)
 				}
 
-				_, err = ParallelBootstrapAdditionalNodes(kubeCl, metaConfig, nodesIndexToCreate, "static-node", group.Name, nodeCloudConfig, true, terraformContext, ngLogger, saveLogToBuffer)
+				_, err = ParallelBootstrapAdditionalNodes(ctx, kubeCl, metaConfig, nodesIndexToCreate, "static-node", group.Name, nodeCloudConfig, true, terraformContext, ngLogger, saveLogToBuffer)
 
 				resultsChan <- checkResult{
 					name:    group.Name,
@@ -342,15 +367,23 @@ func ParallelCreateNodeGroup(kubeCl *client.KubernetesClient, metaConfig *config
 			currentPLogger.LogProcessEnd()
 		}
 
-		return entity.WaitForNodesBecomeReady(kubeCl, ngWaitMap)
+		return entity.WaitForNodesBecomeReady(ctx, kubeCl, ngWaitMap)
 	})
 }
 
-func BootstrapAdditionalMasterNode(kubeCl *client.KubernetesClient, cfg *config.MetaConfig, index int, cloudConfig string, isConverge bool, terraformContext *terraform.TerraformContext) (*terraform.PipelineOutputs, error) {
+func BootstrapAdditionalMasterNode(
+	ctx context.Context,
+	kubeCl *client.KubernetesClient,
+	cfg *config.MetaConfig,
+	index int,
+	cloudConfig string,
+	isConverge bool,
+	terraformContext *terraform.TerraformContext,
+) (*terraform.PipelineOutputs, error) {
 	nodeName := NodeName(cfg, global.MasterNodeGroupName, index)
 
 	if isConverge {
-		nodeExists, existsErr := entity.IsNodeExistsInCluster(kubeCl, nodeName, log.GetDefaultLogger())
+		nodeExists, existsErr := entity.IsNodeExistsInCluster(ctx, kubeCl, nodeName, log.GetDefaultLogger())
 		if existsErr != nil {
 			return nil, existsErr
 		} else if nodeExists {
@@ -382,7 +415,8 @@ func BootstrapAdditionalMasterNode(kubeCl *client.KubernetesClient, cfg *config.
 		return nil, global.ErrConvergeInterrupted
 	}
 
-	err = entity.SaveMasterNodeTerraformState(kubeCl, nodeName, outputs.TerraformState, []byte(outputs.KubeDataDevicePath))
+	// TODO(dhctl-for-commander-cancels): pass ctx
+	err = entity.SaveMasterNodeTerraformState(context.TODO(), kubeCl, nodeName, outputs.TerraformState, []byte(outputs.KubeDataDevicePath))
 	if err != nil {
 		return outputs, err
 	}


### PR DESCRIPTION
## Description
Make kube client methods accept context.Context. Now, calls to the Kube client are canceled when the context is canceled. In the future, the context from bootstrapping and destroying operations will be used. Relevant TODOs comments have been added (dhctl-for-commander-cancels).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: make kube client calls cancellable
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
