### PR TITLE
[ovpn] renew ca

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -5275,6 +5275,97 @@ alerts:
         NTP daemon on the node {{$labels.node}} haven't synchronized time for too long.
       severity: "5"
       markupFormat: markdown
+    - name: OpenVPNClientCertificateExpired
+      sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+      moduleUrl: 500-openvpn
+      module: openvpn
+      edition: ce
+      description: |-
+        There are {{ $value }} expired OpenVPN client certificates.
+
+        Renew certificates if needed.
+      summary: |
+        Some OpenVPN client certificates have expired.
+      severity: "4"
+      markupFormat: markdown
+    - name: OpenVPNServerCACertificateExpired
+      sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+      moduleUrl: 500-openvpn
+      module: openvpn
+      edition: ce
+      description: |-
+        The OpenVPN CA certificate has expired.
+
+        Renew it as soon as possible to restore VPN functionality.
+      summary: |
+        OpenVPN CA certificate has expired.
+      severity: "4"
+      markupFormat: markdown
+    - name: OpenVPNServerCACertificateExpiringInAWeek
+      sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+      moduleUrl: 500-openvpn
+      module: openvpn
+      edition: ce
+      description: |-
+        The OpenVPN CA certificate will expire in less than 7 days.
+
+        Immediate renewal is recommended.
+      summary: |
+        OpenVPN CA certificate expires in less than 7 days.
+      severity: "6"
+      markupFormat: markdown
+    - name: OpenVPNServerCACertificateExpiringSoon
+      sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+      moduleUrl: 500-openvpn
+      module: openvpn
+      edition: ce
+      description: |-
+        The OpenVPN CA certificate will expire in less than 30 days.
+
+        Renew the CA certificate if necessary.
+      summary: |
+        OpenVPN CA certificate expires in less than 30 days.
+      severity: "5"
+      markupFormat: markdown
+    - name: OpenVPNServerCertificateExpired
+      sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+      moduleUrl: 500-openvpn
+      module: openvpn
+      edition: ce
+      description: |-
+        The OpenVPN server certificate has expired.
+
+        Renew it as soon as possible to restore VPN functionality.
+      summary: |
+        OpenVPN server certificate has expired.
+      severity: "4"
+      markupFormat: markdown
+    - name: OpenVPNServerCertificateExpiringInAWeek
+      sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+      moduleUrl: 500-openvpn
+      module: openvpn
+      edition: ce
+      description: |-
+        The OpenVPN server certificate will expire in less than 7 days.
+
+        Immediate renewal is recommended.
+      summary: |
+        OpenVPN server certificate expires in less than 7 days.
+      severity: "6"
+      markupFormat: markdown
+    - name: OpenVPNServerCertificateExpiringSoon
+      sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+      moduleUrl: 500-openvpn
+      module: openvpn
+      edition: ce
+      description: |-
+        The OpenVPN server certificate will expire in less than 30 days.
+
+        Renew the certificate if necessary.
+      summary: |
+        OpenVPN server certificate expires in less than 30 days.
+      severity: "5"
+      markupFormat: markdown
     - name: OperationPolicyViolation
       sourceFile: modules/015-admission-policy-engine/monitoring/prometheus-rules/audit.yaml
       moduleUrl: 015-admission-policy-engine
@@ -5777,6 +5868,7 @@ modules-having-alerts:
     - monitoring-ping
     - node-manager
     - okmeter
+    - openvpn
     - operator-prometheus
     - prometheus
     - runtime-audit-engine

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -5283,7 +5283,7 @@ alerts:
       description: |-
         There are {{ $value }} expired OpenVPN client certificates.
 
-        Renew certificates if needed.
+        Renew the expired certificates if needed.
       summary: |
         Some OpenVPN client certificates have expired.
       severity: "4"
@@ -5296,7 +5296,7 @@ alerts:
       description: |-
         The OpenVPN CA certificate has expired.
 
-        Renew it as soon as possible to restore VPN functionality.
+        To restore VPN functionality, renew the expired certificate as soon as possible.
       summary: |
         OpenVPN CA certificate has expired.
       severity: "4"
@@ -5335,7 +5335,7 @@ alerts:
       description: |-
         The OpenVPN server certificate has expired.
 
-        Renew it as soon as possible to restore VPN functionality.
+        To restore VPN functionality, renew the expired certificate as soon as possible.
       summary: |
         OpenVPN server certificate has expired.
       severity: "4"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -5312,7 +5312,7 @@ alerts:
         Immediate renewal is recommended.
       summary: |
         OpenVPN CA certificate expires in less than 7 days.
-      severity: "6"
+      severity: "5"
       markupFormat: markdown
     - name: OpenVPNServerCACertificateExpiringSoon
       sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
@@ -5351,7 +5351,7 @@ alerts:
         Immediate renewal is recommended.
       summary: |
         OpenVPN server certificate expires in less than 7 days.
-      severity: "6"
+      severity: "5"
       markupFormat: markdown
     - name: OpenVPNServerCertificateExpiringSoon
       sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml

--- a/modules/500-openvpn/hooks/renew_ca_cert.go
+++ b/modules/500-openvpn/hooks/renew_ca_cert.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Schedule: []go_hook.ScheduleConfig{
+		{
+			Name:    "check_server_cert_expiry",
+			Crontab: "* * * * *", // Every minute
+		},
+	},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "openvpn_pki_server",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-openvpn"},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"openvpn-pki-server"},
+			},
+			FilterFunc: applyServerSecretFilter,
+		},
+		{
+			Name:       "openvpn_client_secrets",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-openvpn"},
+				},
+			},
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"type": "clientAuth",
+				},
+			},
+			FilterFunc: applyClientSecretFilter,
+		},
+	},
+}, checkServerCertExpiry)
+
+func applyServerSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var secret v1.Secret
+	err := sdk.FromUnstructured(obj, &secret)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert secret to structured object: %v", err)
+	}
+
+	certData, ok := secret.Data["tls.crt"]
+	if !ok || len(certData) == 0 {
+		return nil, fmt.Errorf("tls.crt not found in secret openvpn-pki-server")
+	}
+
+	return certData, nil
+}
+
+func applyClientSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var secret v1.Secret
+	err := sdk.FromUnstructured(obj, &secret)
+	if err != nil {
+		return nil, err
+	}
+	return secret.Name, nil
+}
+
+type CertInfo struct {
+	CertData []byte
+}
+
+func checkServerCertExpiry(input *go_hook.HookInput) error {
+	snapshots := input.Snapshots["openvpn_pki_server"]
+
+	if len(snapshots) == 0 {
+		input.Logger.Warn("Secret openvpn-pki-server not found, skipping")
+		return nil
+	}
+
+	certData := snapshots[0].([]byte)
+
+	block, _ := pem.Decode(certData)
+	if block == nil || block.Type != "CERTIFICATE" {
+		input.Logger.Errorf("Failed to decode PEM block from tls.crt")
+		return nil
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		input.Logger.Errorf("Failed to parse certificate: %v", err)
+		return nil
+	}
+
+	// Check expired cert
+	now := time.Now()
+	if now.After(cert.NotAfter) {
+		input.Logger.Infof("Server certificate expired at %s, initiating cleanup and restart", cert.NotAfter)
+
+		// Remove openvpn-pki-ca
+		input.PatchCollector.Delete("v1", "Secret", "d8-openvpn", "openvpn-pki-ca")        // Ca cert
+		input.PatchCollector.Delete("v1", "Secret", "d8-openvpn", "openvpn-pki-server")    // Server cert
+		input.PatchCollector.Delete("v1", "Secret", "d8-openvpn", "openvpn-pki-crl")       // Certificate Revocation List
+		input.PatchCollector.Delete("v1", "Secret", "d8-openvpn", "openvpn-pki-index-txt") // list client certs
+		input.Logger.Info("Secret openvpn-pki-ca, openvpn-pki-server, openvpn-pki-crl scheduled for deletion")
+
+		// Remove clients certs
+		snapshotsClients := input.Snapshots["openvpn_client_secrets"]
+		if len(snapshotsClients) == 0 {
+			input.Logger.Warn("No client secrets with type=clientAuth found")
+		}
+		for _, snapshot := range snapshotsClients {
+			clientSecretName := snapshot.(string)
+			input.PatchCollector.Delete("v1", "Secret", "d8-openvpn", clientSecretName)
+			input.Logger.Infof("Client secret %s scheduled for deletion", clientSecretName)
+		}
+
+		// Patch spec.template.metadata.annotations for reload SS
+		patch := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]string{
+							"restart-timestamp": now.Format(time.RFC3339),
+						},
+					},
+				},
+			},
+		}
+		input.PatchCollector.MergePatch(patch, "apps/v1", "StatefulSet", "d8-openvpn", "openvpn")
+		input.Logger.Info("StatefulSet openvpn scheduled for restart")
+	} else {
+		input.Logger.Infof("Server certificate is valid until %s", cert.NotAfter)
+	}
+
+	return nil
+}

--- a/modules/500-openvpn/hooks/renew_ca_cert.go
+++ b/modules/500-openvpn/hooks/renew_ca_cert.go
@@ -22,13 +22,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{

--- a/modules/500-openvpn/hooks/renew_ca_cert.go
+++ b/modules/500-openvpn/hooks/renew_ca_cert.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"github.com/deckhouse/deckhouse/pkg/log"
 	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -80,7 +81,8 @@ func applyServerSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 
 	certData, ok := secret.Data["tls.crt"]
 	if !ok || len(certData) == 0 {
-		return nil, fmt.Errorf("tls.crt not found in secret openvpn-pki-server")
+		log.Info("No tls.crt in secret")
+		return nil, nil
 	}
 
 	return certData, nil

--- a/modules/500-openvpn/hooks/renew_ca_cert.go
+++ b/modules/500-openvpn/hooks/renew_ca_cert.go
@@ -20,9 +20,9 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/deckhouse/deckhouse/pkg/log"
 	"time"
 
+	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"

--- a/modules/500-openvpn/hooks/renew_ca_cert.go
+++ b/modules/500-openvpn/hooks/renew_ca_cert.go
@@ -34,7 +34,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "check_server_cert_expiry",
-			Crontab: "* * * * *", // Every minute
+			Crontab: "0 */6 * * *", // Every 6 hours
 		},
 	},
 	Kubernetes: []go_hook.KubernetesConfig{
@@ -121,9 +121,9 @@ func checkServerCertExpiry(input *go_hook.HookInput) error {
 		return nil
 	}
 
-	// Check expired cert
+	// // Check if cert expires within 6 hours
 	now := time.Now()
-	if now.After(cert.NotAfter) {
+	if cert.NotAfter.Sub(now) <= 6*time.Hour {
 		input.Logger.Infof("Server certificate expired at %s, initiating cleanup and restart", cert.NotAfter)
 
 		// Remove openvpn-pki-ca

--- a/modules/500-openvpn/hooks/renew_ca_cert_test.go
+++ b/modules/500-openvpn/hooks/renew_ca_cert_test.go
@@ -18,7 +18,7 @@ package hooks
 
 import (
 	"context"
-	. "github.com/deckhouse/deckhouse/testing/hooks"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
 var _ = Describe("openvpn :: hooks :: check_server_cert_expiry ::", func() {

--- a/modules/500-openvpn/hooks/renew_ca_cert_test.go
+++ b/modules/500-openvpn/hooks/renew_ca_cert_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("check_server_cert_expiry hook", func() {
+	f := HookExecutionConfigInit(`{}`, `{}`)
+
+	Context("When secret is missing", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(``)
+			f.RunHook()
+		})
+
+		It("Should not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("When tls.crt is missing in the secret", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openvpn-pki-server
+  namespace: d8-openvpn
+type: Opaque
+data: {}
+`)
+			f.RunHook()
+		})
+
+		It("Should not panic and skip", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("When tls.crt contains invalid data", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openvpn-pki-server
+  namespace: d8-openvpn
+type: Opaque
+data:
+  tls.crt: aW52YWxpZCBkYXRhCg==  # "invalid data\n"
+`)
+			f.RunHook()
+		})
+
+		It("Should not panic on invalid certificate", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+})

--- a/modules/500-openvpn/hooks/renew_ca_cert_test.go
+++ b/modules/500-openvpn/hooks/renew_ca_cert_test.go
@@ -17,29 +17,35 @@ limitations under the License.
 package hooks
 
 import (
+	"context"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	. "github.com/deckhouse/deckhouse/testing/hooks"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
-var _ = Describe("check_server_cert_expiry hook", func() {
-	f := HookExecutionConfigInit(`{}`, `{}`)
+var _ = Describe("openvpn :: hooks :: check_server_cert_expiry ::", func() {
 
-	Context("When secret is missing", func() {
-		BeforeEach(func() {
-			f.KubeStateSet(``)
-			f.RunHook()
-		})
-
-		It("Should not fail", func() {
-			Expect(f).To(ExecuteSuccessfully())
-		})
-	})
-
-	Context("When tls.crt is missing in the secret", func() {
-		BeforeEach(func() {
-			f.KubeStateSet(`
+	const (
+		d8OpenvpnNamespace = `
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d8-openvpn
+  labels:
+    heritage: deckhouse
+    module: openvpn
+spec:
+  finalizers:
+  - kubernetes
+`
+		emptySecret = `
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -47,18 +53,9 @@ metadata:
   namespace: d8-openvpn
 type: Opaque
 data: {}
-`)
-			f.RunHook()
-		})
-
-		It("Should not panic and skip", func() {
-			Expect(f).To(ExecuteSuccessfully())
-		})
-	})
-
-	Context("When tls.crt contains invalid data", func() {
-		BeforeEach(func() {
-			f.KubeStateSet(`
+`
+		invalidCertSecret = `
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -66,13 +63,204 @@ metadata:
   namespace: d8-openvpn
 type: Opaque
 data:
-  tls.crt: aW52YWxpZCBkYXRhCg==  # "invalid data\n"
-`)
-			f.RunHook()
+  tls.crt: aW52YWxpZCBkYXRhCg==
+`
+		expiredCertSecret = `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openvpn-pki-server
+  namespace: d8-openvpn
+type: Opaque
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDRENDQWZDZ0F3SUJBZ0lCQVRBTkJna3Foa2lHOXcwQkFRc0ZBREFvTVJJd0VBWURWUVFLRXdsR2JHRnUKZENCS1UwTXhFakFRQmdOVkJBTVRDV1pzWVc1MExtTnZiVEFlRncweU5EQTBNRE14TmpJNE5EaGFGdzB5TkRBMApNREl4TmpJNE5EaGFNQ2d4RWpBUUJnTlZCQW9UQ1Vac1lXNTBJRXBUUXpFU01CQUdBMVVFQXhNSlpteGhiblF1ClkyOXRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQTAzcWNEaEtVZGFHWnp2SGcKNFk2ZkVtclMxN0NMKzl1QWdnWDdlbFJLWXZ6Q3pZTXlNbmNhR08zTGs5cUxJVjZOS0JGTDcrd01qYklnSjV5bwpvcCtZVTVwalFkU3owWnVvRVNyWDd4S05GWnh3cVJZME5KTmtoaTRkVERxWnZ1R1JCeTZVbDVaMFNCSjliRFQzCjVHdkhYMjFtTHJDdmVoZDRBYTZQU05VQXFweG85VGw3elZRS3J5Y2NQTUtvdEE0ZlZ0VkFvOHVkSXZIYVphZFUKMnZZSEFUazc3TGMrRHNjUi9YL2lYcUVMdkozR1VkWGxvNXFpWVZwN0pXZzY2RXRrNm5HWnhaZ2sxNEJHaWw3RQp4bEM1WkJyUWFPTFdwOS84S2ppT0U2MEFKZXdmdXpZdklTQ3RSZVZxSzEwUzExQTd6bUtvOGZvdUgxVGRteDlWCkNrM2Myd0lEQVFBQm96MHdPekFPQmdOVkhROEJBZjhFQkFNQ0JhQXdFd1lEVlIwbEJBd3dDZ1lJS3dZQkJRVUgKQXdFd0ZBWURWUjBSQkEwd0M0SUpabXhoYm5RdVkyOXRNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUI1aW5EcQpYZjR0Nk1rOVQrZHFJR0QwR1pEOE5WNHlOeU9wSmFQaUhIZ0JGVmZMcW1QTlc0aVlQVHVuazc0OVFMOW14dEV6CnRMN1o2bUp0Wnk2Q1NEcEpHRE9pYk5nQ29iaGxqUkhsUkp6S0lZWUxnSHR0a3lYSFNOV1dUeXMzWS81L3ZRTWcKUkxEUmlyUzU4TytvcVp3WTlGZm1lbDNRSU9vVXpBRzU1c2IxRlhLL3Z2MDNMWlhtWnkzZ3d1UEJjbGcrQ0I3eAoweVUyZEF5TmhwM09Jd0hSUWtRUFdHVndUS0IwazFwOHFYcndFdmtnT3FMZ3dhYTdhMThKeTRxZTBkaFpJUFBSCmtvNlNGTksvOWdqY21hZ1BFTGhDTm5kL1pWS1ZhTGtQTzNob2QyOWVUbGg5bkMrbzNRSGlndis5dnc1S3d6WWUKUFlkUnhOZUJILytMcnlpQwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCgo=
+`
+		validCertSecret = `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openvpn-pki-server
+  namespace: d8-openvpn
+type: Opaque
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDekNDQWZPZ0F3SUJBZ0lVTlJLbXJNVEE2bmdUdmtQTGJBUG54M2RLR0tJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZERVNNQkFHQTFVRUF3d0pabXhoYm5RdVkyOXRNQ0FYRFRJMU1EUXdNekUwTURJek9Wb1lEekl4TWpVdwpNekV3TVRRd01qTTVXakFVTVJJd0VBWURWUVFEREFsbWJHRnVkQzVqYjIwd2dnRWlNQTBHQ1NxR1NJYjNEUUVCCkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDNFkzRURERmNWZkhmUXJKcG5NejBRWTRuazVmSFM5OG9XZUpmZUNkSlQKTk9OUTVGd1hCSkM1clBrYXZTRnZIWWprNmEveHROTXM1eVc0bm9wS1VnR1BZU2dUNEd4TWdRZW5YV2F1NmhvVApuT2NsakhVR2o3TlVSS1FKL3lPY1ZKVDl0OW5pYS9ZNHVoOHMxK2VHQ0tOOWZTeDBVbHBEZWtkVTNWQjRuR2VGCmU4VUR0TGlWNm1CbTRndzArUmwrVkQxUkVJYU5iWExHcVMxWUtIcWcvZGhpRHpHVUxRakdhOFZyTU1TbkRHL00KRW8yVjA5VHN2TXh4b04waE9MZUROTjlUZVl6TnVERFRWRkJhT3U0Nk11NmRmUVdLb29leXNET1FpdzRqeGptMgpBU1JqUXdPbisrakxJWlBEUmI0UEhZZ0xBcnlkdkpXNFpUTzErVmh0aDg2WkFnTUJBQUdqVXpCUk1CMEdBMVVkCkRnUVdCQlNONUdYNi8wNE1ITEZUa0hzUmxTZWovMWxKR2pBZkJnTlZIU01FR0RBV2dCU041R1g2LzA0TUhMRlQKa0hzUmxTZWovMWxKR2pBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCOApLd1FmcXQybENMY0xpRUlEZE9hWmNMZ2tRcGZLKzN6aS90bTdDaUNyL0oxSGZkZTZYS29ONTFKQVcwQ1RZdmQyCnNDWWtkTUx6TkR3QlZTZ0lxd3luc3NRMzZTSzFyQWl6YnF2cjZWNUYxd1cwWVMraEhUSWM2cDA3TUpUMFVUdXkKVUg5Vkx5RWR5UnNETDBIbTNCcXR1YU8wcjlGVWw0N3VJVENMa0xVYXI0cTJtYlBFM1YwcFNzWlBXM2tlL0NvWQpEU2U2TUtpVFlHbnBDU3Q1NkY0ZHlnVTBMMVU4SWZsS3dnamx1NEhsazJIRHpMNndoelhCWlVycEFqM3c4dEF2CjJmN2xFZ1RhdDVpV1lNTi9iVDA2R1NsR1hHS0ExTmpQM3g2KzkzV1QzWjdSZzM0ZlRYSDNibFZNYUEzd0hnamwKQjkxeEREMVFWbzVsQkVnU0g0K3AKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+`
+
+		openvpnStatefulSet = `
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openvpn
+  namespace: d8-openvpn
+spec:
+  serviceName: openvpn
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openvpn
+  template:
+    metadata:
+      labels:
+        app: openvpn
+    spec:
+      containers:
+      - name: openvpn
+        image: openvpn:latest
+`
+	)
+
+	f := HookExecutionConfigInit(`{}`, `{}`)
+
+	Context("An empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.KubeStateSet(``)
+			f.RunGoHook()
 		})
 
-		It("Should not panic on invalid certificate", func() {
+		It("Hook is executed successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("Cluster with expired cert", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.BindingContexts.Set(f.GenerateScheduleContext("0 */6 * * *"))
+
+			var ns corev1.Namespace
+			var secret corev1.Secret
+			var statefulSet appsv1.StatefulSet
+
+			_ = yaml.Unmarshal([]byte(d8OpenvpnNamespace), &ns)
+			_ = yaml.Unmarshal([]byte(expiredCertSecret), &secret)
+			_ = yaml.Unmarshal([]byte(openvpnStatefulSet), &statefulSet)
+
+			// Create resources
+			k8sClient := f.BindingContextController.FakeCluster().Client
+			_, err := k8sClient.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			_, err = k8sClient.CoreV1().Secrets("d8-openvpn").Create(context.TODO(), &secret, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			_, err = k8sClient.AppsV1().StatefulSets("d8-openvpn").Create(context.TODO(), &statefulSet, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+
+			f.RunGoHook()
+
+		})
+
+		// Check cert is deleted
+		It("Hook is executed successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			k8sClient := f.BindingContextController.FakeCluster().Client
+			_, err := k8sClient.CoreV1().Namespaces().Get(context.Background(), "openvpn-pki-server", metav1.GetOptions{})
+			Expect(errors.IsNotFound(err)).To(BeTrue(), "Secret 'openvpn-pki-server' should be deleted")
+		})
+	})
+
+	Context("Cluster with valid cert", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.BindingContexts.Set(f.GenerateScheduleContext("0 */6 * * *"))
+
+			var ns corev1.Namespace
+			var secret corev1.Secret
+			var statefulSet appsv1.StatefulSet
+
+			_ = yaml.Unmarshal([]byte(d8OpenvpnNamespace), &ns)
+			_ = yaml.Unmarshal([]byte(validCertSecret), &secret)
+			_ = yaml.Unmarshal([]byte(openvpnStatefulSet), &statefulSet)
+
+			// Create resources
+			k8sClient := f.BindingContextController.FakeCluster().Client
+			_, err := k8sClient.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			_, err = k8sClient.CoreV1().Secrets("d8-openvpn").Create(context.TODO(), &secret, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			_, err = k8sClient.AppsV1().StatefulSets("d8-openvpn").Create(context.TODO(), &statefulSet, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+
+			f.RunGoHook()
+
+		})
+
+		// Check cert is not deleted
+		It("Hook is executed successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			k8sClient := f.BindingContextController.FakeCluster().Client
+			_, err := k8sClient.CoreV1().Secrets("d8-openvpn").Get(context.Background(), "openvpn-pki-server", metav1.GetOptions{})
+			Expect(err).To(BeNil(), "Secret 'openvpn-pki-server' should still exist")
+		})
+	})
+
+	Context("Cluster with empty secret (no cert data)", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.BindingContexts.Set(f.GenerateScheduleContext("0 */6 * * *"))
+
+			var ns corev1.Namespace
+			var secret corev1.Secret
+			var statefulSet appsv1.StatefulSet
+
+			_ = yaml.Unmarshal([]byte(d8OpenvpnNamespace), &ns)
+			_ = yaml.Unmarshal([]byte(emptySecret), &secret)
+			_ = yaml.Unmarshal([]byte(openvpnStatefulSet), &statefulSet)
+
+			// Create resources
+			k8sClient := f.BindingContextController.FakeCluster().Client
+			_, err := k8sClient.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			_, err = k8sClient.CoreV1().Secrets("d8-openvpn").Create(context.TODO(), &secret, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			_, err = k8sClient.AppsV1().StatefulSets("d8-openvpn").Create(context.TODO(), &statefulSet, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+
+			f.RunGoHook()
+		})
+
+		// Check secret is not deleted
+		It("Hook does not delete empty secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			k8sClient := f.BindingContextController.FakeCluster().Client
+			_, err := k8sClient.CoreV1().Secrets("d8-openvpn").Get(context.Background(), "openvpn-pki-server", metav1.GetOptions{})
+			Expect(err).To(BeNil(), "Secret 'openvpn-pki-server' should still exist")
+		})
+	})
+
+	Context("Cluster with invalid cert", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.BindingContexts.Set(f.GenerateScheduleContext("0 */6 * * *"))
+
+			var ns corev1.Namespace
+			var secret corev1.Secret
+			var statefulSet appsv1.StatefulSet
+
+			_ = yaml.Unmarshal([]byte(d8OpenvpnNamespace), &ns)
+			_ = yaml.Unmarshal([]byte(invalidCertSecret), &secret)
+			_ = yaml.Unmarshal([]byte(openvpnStatefulSet), &statefulSet)
+
+			// Create resources
+			k8sClient := f.BindingContextController.FakeCluster().Client
+			_, err := k8sClient.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			_, err = k8sClient.CoreV1().Secrets("d8-openvpn").Create(context.TODO(), &secret, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			_, err = k8sClient.AppsV1().StatefulSets("d8-openvpn").Create(context.TODO(), &statefulSet, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+
+			f.RunGoHook()
+		})
+
+		// Check secret is not deleted
+		It("Hook does not delete invalid certificate secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			k8sClient := f.BindingContextController.FakeCluster().Client
+			_, err := k8sClient.CoreV1().Secrets("d8-openvpn").Get(context.Background(), "openvpn-pki-server", metav1.GetOptions{})
+			Expect(err).To(BeNil(), "Secret 'openvpn-pki-server' should still exist")
 		})
 	})
 })

--- a/modules/500-openvpn/monitoring/grafana-dashboards/ovpn-admin/ovpn-admin.json
+++ b/modules/500-openvpn/monitoring/grafana-dashboards/ovpn-admin/ovpn-admin.json
@@ -1,0 +1,782 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 54,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "d"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 5,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "expr": "ovpn_server_cert_expire",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Server cert valid time",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "d"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "expr": "ovpn_server_ca_cert_expire",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Server CA cert valid time",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-orange",
+                "value": 200
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "expr": "ovpn_clients_total",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Total clients",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 5
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "expr": "ovpn_clients_connected",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Connected clients",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "semi-dark-orange",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 5
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "expr": "ovpn_clients_expired",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Revoked clients",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 5
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.2",
+      "targets": [
+        {
+          "expr": "ovpn_clients_expired",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Expired clients",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "links": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "ovpn_client_bytes_received",
+          "interval": "",
+          "legendFormat": "{{ client }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Client bytes received",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "links": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "ovpn_client_bytes_sent",
+          "interval": "",
+          "legendFormat": "{{ client }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Client bytes sent",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "links": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(ovpn_client_bytes_received[1m])",
+          "interval": "",
+          "legendFormat": "{{ client }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Clients bytes received rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "links": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(ovpn_client_bytes_sent[1m])",
+          "interval": "",
+          "legendFormat": "{{ client }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Client bytes sent rate ",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "value show last connection check time",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "displayMode": "auto",
+            "width": 20
+          },
+          "mappings": [],
+          "noValue": "Currently there are no connections",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "dateTimeAsIso"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 12,
+      "maxDataPoints": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.6",
+      "targets": [
+        {
+          "expr": "ovpn_client_connection_info * 1000",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "{{ client }}-{{ip}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Connection info",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "value shows when connection was started",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "displayMode": "auto",
+            "width": 20
+          },
+          "mappings": [],
+          "noValue": "Currently there are no connections",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "dateTimeAsIso"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 13,
+      "maxDataPoints": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.6",
+      "targets": [
+        {
+          "expr": "ovpn_client_connection_from * 1000",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "{{ client }}-{{ip}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Connection from",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 7
+              },
+              {
+                "color": "dark-orange",
+                "value": 14
+              },
+              {
+                "color": "#EAB839",
+                "value": 30
+              },
+              {
+                "color": "green",
+                "value": 31
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.6",
+      "targets": [
+        {
+          "expr": "ovpn_client_cert_expire ",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "{{ client }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Client cert valid days",
+      "type": "stat"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "label": "Prometheus",
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Ovpn-Admin",
+  "uid": "Z7qmFI0Gk",
+  "version": 1,
+  "weekStart": ""
+}

--- a/modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+++ b/modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
@@ -12,7 +12,7 @@
         description: |-
           There are {{ $value }} expired OpenVPN client certificates.
 
-          Renew certificates if needed.
+          Renew the expired certificates if needed.
 
     - alert: OpenVPNServerCertificateExpiringSoon
       expr: ovpn_server_cert_expire < 30
@@ -54,7 +54,7 @@
         description: |-
           The OpenVPN server certificate has expired.
 
-          Renew it as soon as possible to restore VPN functionality.
+          To restore VPN functionality, renew the expired certificate as soon as possible.
 
     - alert: OpenVPNServerCACertificateExpiringSoon
       expr: ovpn_server_ca_cert_expire < 30
@@ -96,4 +96,4 @@
         description: |-
           The OpenVPN CA certificate has expired.
 
-          Renew it as soon as possible to restore VPN functionality.
+          To restore VPN functionality, renew the expired certificate as soon as possible.

--- a/modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+++ b/modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
@@ -1,0 +1,99 @@
+- name: openvpn.admin.info
+  rules:
+    - alert: OpenVPNClientCertificateExpired
+      expr: ovpn_clients_expired > 0
+      for: 1m
+      labels:
+        severity_level: "4"
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        summary: Some OpenVPN client certificates have expired.
+        description: |-
+          There are {{ $value }} expired OpenVPN client certificates.
+
+          Renew certificates if needed.
+
+    - alert: OpenVPNServerCertificateExpiringSoon
+      expr: ovpn_server_cert_expire < 30
+      for: 1h
+      labels:
+        severity_level: "5"
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        summary: OpenVPN server certificate expires in less than 30 days.
+        description: |-
+          The OpenVPN server certificate will expire in less than 30 days.
+
+          Renew the certificate if necessary.
+
+    - alert: OpenVPNServerCertificateExpiringInAWeek
+      expr: ovpn_server_cert_expire < 7
+      for: 1h
+      labels:
+        severity_level: "6"
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        summary: OpenVPN server certificate expires in less than 7 days.
+        description: |-
+          The OpenVPN server certificate will expire in less than 7 days.
+
+          Immediate renewal is recommended.
+
+    - alert: OpenVPNServerCertificateExpired
+      expr: ovpn_server_cert_expire == 0
+      for: 1m
+      labels:
+        severity_level: "4"
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        summary: OpenVPN server certificate has expired.
+        description: |-
+          The OpenVPN server certificate has expired.
+
+          Renew it as soon as possible to restore VPN functionality.
+
+    - alert: OpenVPNServerCACertificateExpiringSoon
+      expr: ovpn_server_ca_cert_expire < 30
+      for: 1h
+      labels:
+        severity_level: "5"
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        summary: OpenVPN CA certificate expires in less than 30 days.
+        description: |-
+          The OpenVPN CA certificate will expire in less than 30 days.
+
+          Renew the CA certificate if necessary.
+
+    - alert: OpenVPNServerCACertificateExpiringInAWeek
+      expr: ovpn_server_ca_cert_expire < 7
+      for: 1h
+      labels:
+        severity_level: "6"
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        summary: OpenVPN CA certificate expires in less than 7 days.
+        description: |-
+          The OpenVPN CA certificate will expire in less than 7 days.
+
+          Immediate renewal is recommended.
+
+    - alert: OpenVPNServerCACertificateExpired
+      expr: ovpn_server_ca_cert_expire == 0
+      for: 1m
+      labels:
+        severity_level: "4"
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        summary: OpenVPN CA certificate has expired.
+        description: |-
+          The OpenVPN CA certificate has expired.
+
+          Renew it as soon as possible to restore VPN functionality.

--- a/modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+++ b/modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
@@ -32,7 +32,7 @@
       expr: ovpn_server_cert_expire < 7
       for: 1h
       labels:
-        severity_level: "6"
+        severity_level: "5"
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
@@ -74,7 +74,7 @@
       expr: ovpn_server_ca_cert_expire < 7
       for: 1h
       labels:
-        severity_level: "6"
+        severity_level: "5"
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"

--- a/modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+++ b/modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
@@ -1,7 +1,7 @@
 - name: openvpn.admin.info
   rules:
     - alert: OpenVPNClientCertificateExpired
-      expr: ovpn_clients_expired > 0
+      expr: ovpn_client_cert_expire > 0
       for: 1m
       labels:
         severity_level: "4"

--- a/modules/500-openvpn/templates/monitoring.yaml
+++ b/modules/500-openvpn/templates/monitoring.yaml
@@ -1,0 +1,2 @@
+{{- include "helm_lib_grafana_dashboard_definitions" . }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-openvpn") }}

--- a/modules/500-openvpn/templates/openvpn/podmonitor.yaml
+++ b/modules/500-openvpn/templates/openvpn/podmonitor.yaml
@@ -1,0 +1,34 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: openvpn
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main" "app" "openvpn")) | nindent 2 }}
+spec:
+  jobLabel: app
+  podMetricsEndpoints:
+    - port: https
+      scheme: https
+      path: /metrics
+      bearerTokenSecret:
+        name: "prometheus-token"
+        key: "token"
+      tlsConfig:
+        insecureSkipVerify: true
+      relabelings:
+        - regex: endpoint
+          action: labeldrop
+        - targetLabel: tier
+          replacement: cluster
+        - sourceLabels: [__meta_kubernetes_pod_ready]
+          regex: "true"
+          action: keep
+  selector:
+    matchLabels:
+      app: openvpn
+  namespaceSelector:
+    matchNames:
+      - d8-{{ .Chart.Name }}
+{{- end }}

--- a/modules/500-openvpn/templates/openvpn/statefulset.yaml
+++ b/modules/500-openvpn/templates/openvpn/statefulset.yaml
@@ -248,6 +248,8 @@ spec:
         - "8000"
         - --role
         - master
+        - --metrics.path
+        - "/metrics"
         - --ovpn.network
         - "{{ include "get_network_with_bitmask" (list . .Values.openvpn.tunnelNetwork) }}"
         {{- if hasKey .Values.openvpn "inlet" }}
@@ -337,6 +339,8 @@ spec:
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             upstreams:
+            - upstream: http://127.0.0.1:8000/metrics
+              path: /metrics
             - upstream: http://127.0.0.1:8000/
               path: /
               authorization:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added alerts notifying about expiring server certificate and CA certificate validity period, as well as about expired client certificates. Added [dashboard](https://github.com/palark/ovpn-admin/blob/master/dashboard/ovpn-admin.json) for Grafana with more detailed information. Also hook tracking server certificate validity period, after which all server certificates will be reissued and client certificates will be removed.

<details>
  <summary>📸 Screenshots (Click to expand)</summary>

  1. ![Screenshot 1](https://github.com/user-attachments/assets/07d0100a-4fba-4743-9357-a75694931089)  
  2. ![Screenshot 2](https://github.com/user-attachments/assets/837af514-2c22-49a3-bd03-196c2855c7ab)  
  3. ![Screenshot 3](https://github.com/user-attachments/assets/893cda43-9a59-46ba-a435-c4fbf104da3b)

</details>



### Notes

When re-creating a CA certificate, it is required to reissue client certificates.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Some clients have CA and server certificate expiration times, so that this does not happen suddenly, we add tracking as well as automatic control of ovpn-admin server behavior when certificates expire.





## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: openvpn
type: feature
summary: Added end-of-life alerts, CA certificate re-creation and a grafana dashboard.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
