### PR TITLE
[dhctl] Add local kubeconfig k8s proxy

### DIFF
--- a/dhctl/cmd/dhctl/commands/session.go
+++ b/dhctl/cmd/dhctl/commands/session.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Flant JSC
+// Copyright 2025 Flant JSC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,17 +17,18 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 const (

--- a/dhctl/cmd/dhctl/commands/session.go
+++ b/dhctl/cmd/dhctl/commands/session.go
@@ -1,0 +1,105 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+)
+
+const (
+	clusterName = "local"
+	contextName = "local"
+	userName    = "local"
+)
+
+func DefineSessionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
+	app.DefineSSHFlags(cmd, config.ConnectionConfigParser{})
+	app.DefineBecomeFlags(cmd)
+
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		sshClient, err := ssh.NewInitClientFromFlags(true)
+		if err != nil {
+			return err
+		}
+
+		if sshClient == nil {
+			return fmt.Errorf("Not enough flags were provided to perform the operation.\nUse dhctl session --help to get available flags.")
+		}
+
+		kubeCl := client.NewKubernetesClient().WithNodeInterface(ssh.NewNodeInterfaceWrapper(sshClient))
+		apiServerPort, err := kubeCl.StartKubernetesProxy(context.Background())
+		if err != nil {
+			return fmt.Errorf("open kubernetes connection: %v", err)
+		}
+		apiServerURL := fmt.Sprintf("http://localhost:%s", apiServerPort)
+
+		err = localKubeConfig(apiServerURL)
+		if err != nil {
+			return fmt.Errorf("error save kubeconfig: %v", err)
+		}
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+		select {
+		case sig := <-sigChan:
+			fmt.Println("Received signal:", sig)
+			fmt.Println("Exiting SSH tunnel...")
+		}
+		return nil
+	})
+	return cmd
+}
+
+func localKubeConfig(apiServerUrl string) error {
+	kubeconfigDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to open home directory: %w", err)
+	}
+
+	kubeconfigPath := filepath.Join(kubeconfigDir, ".kube", "config")
+	if err := os.MkdirAll(filepath.Dir(kubeconfigPath), 0755); err != nil {
+		return fmt.Errorf("failed to create .kube directory: %w", err)
+	}
+
+	kubeConfig := api.NewConfig()
+	kubeConfig.Clusters[clusterName] = &api.Cluster{
+		Server:                apiServerUrl,
+		InsecureSkipTLSVerify: true,
+	}
+	kubeConfig.AuthInfos[userName] = &api.AuthInfo{}
+	kubeConfig.Contexts[contextName] = &api.Context{
+		Cluster:  clusterName,
+		AuthInfo: userName,
+	}
+	kubeConfig.CurrentContext = contextName
+
+	err = clientcmd.WriteToFile(*kubeConfig, kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to write kubeconfig: %w", err)
+	}
+	fmt.Printf("Kubeconfig successfully saved at: %s\n", kubeconfigPath)
+	return nil
+}

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -125,6 +125,11 @@ var (
 			DefineFunc: commands.DefineDestroyCommand,
 		},
 		{
+			Name:       "session",
+			Help:       "SSH tunnel proxy to Kubernetes cluster and save local kubeconfig for kubectl.",
+			DefineFunc: commands.DefineSessionCommand,
+		},
+		{
 			Name: "terraform",
 			Help: "Terraform commands.",
 		},


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This pr allow dhctl session bind tcp port proxy on local spot to ssh tunnel and generate kubeconfig ~/.kube/config.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When successful bootstrap just done this help use local kubectl without  connecting to a control-plane node via SSH.
resolv [issue](https://github.com/deckhouse/deckhouse/issues/2842)
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: add local kubeconfig k8s proxy
impact_level:  default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
