### PR TITLE
[docs] Update revision of csi-yadro-tatlin-unified module

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -190,6 +190,11 @@
     "path": "/products/kubernetes-platform/modules/csi-s3/stable/",
     "editionMinimumAvailable": "ee"
   },
+  "csi-yadro-tatlin-unified": {
+      "external": "true",
+      "path": "/products/kubernetes-platform/modules/csi-yadro-tatlin-unified/stable/",
+      "editionMinimumAvailable": "ee"
+  },
   "csi-scsi-generic": {
     "external": "true",
     "path": "/products/kubernetes-platform/modules/csi-scsi-generic/stable/",

--- a/docs/site/backends/docs-builder-template/data/editions.json
+++ b/docs/site/backends/docs-builder-template/data/editions.json
@@ -16,10 +16,7 @@
   },
   "ee": {
     "name": "EE",
-    "title": "Enterprise Edition",
-    "includeModules": [
-      "csi-yadro-tatlin-unified"
-    ]
+    "title": "Enterprise Edition"
   },
   "cse-lite": {
     "name": "CSE Lite",

--- a/docs/site/backends/docs-builder-template/data/editions.json
+++ b/docs/site/backends/docs-builder-template/data/editions.json
@@ -16,7 +16,10 @@
   },
   "ee": {
     "name": "EE",
-    "title": "Enterprise Edition"
+    "title": "Enterprise Edition",
+    "includeModules": [
+      "csi-yadro-tatlin-unified"
+    ]
   },
   "cse-lite": {
     "name": "CSE Lite",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -71,6 +71,14 @@
       "ee"
     ]
   },
+    "csi-yadro-tatlin-unified": {
+      "editionMinimumAvailable": "ee",
+      "external": "true",
+      "path": "/products/kubernetes-platform/modules/csi-yadro-tatlin-unified/stable/",
+      "editions": [
+        "ee"
+    ]
+  },
   "csi-nfs": {
     "editionMinimumAvailable": "ce",
     "external": "true",


### PR DESCRIPTION
## Description
Update revision of csi-yadro-tatlin-unified module.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Update revision of csi-yadro-tatlin-unified module.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
