### PR TITLE
[cloud-provider-vsphere] Fix null storageclasses vsphere

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
@@ -51,7 +51,7 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 		return fmt.Errorf("no providerClusterConfiguration present, discovery is not possible")
 	}
 
-	storageClasses := []vsphere.ZonedDataStore{}
+	var storageClasses []vsphere.ZonedDataStore
 
 	var c v1.VsphereProviderClusterConfiguration
 	err := json.Unmarshal([]byte(configJSON.String()), &c)
@@ -85,9 +85,7 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 		Zones:      output.Zones,
 	})
 
-	if output.ZonedDataStores != nil {
-		storageClasses = output.ZonedDataStores
-	}
+	storageClasses = output.ZonedDataStores
 
 	if exclude, ok := input.Values.GetOk("cloudProviderVsphere.storageClass.exclude"); ok {
 		var excludes []string
@@ -104,7 +102,9 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 			})
 		}
 	}
-
+	if storageClasses == nil {
+		storageClasses = []vsphere.ZonedDataStore{}
+	}
 	input.Values.Set("cloudProviderVsphere.internal.storageClasses", storageClasses)
 
 	return nil

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
@@ -36,7 +36,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, dependency.WithExternalDependencies(doDiscover))
 
 func filter(arr []vsphere.ZonedDataStore, cond func(vsphere.ZonedDataStore) bool) []vsphere.ZonedDataStore {
-	var result []vsphere.ZonedDataStore
+	result := []vsphere.ZonedDataStore{}
 	for _, x := range arr {
 		if cond(x) {
 			result = append(result, x)

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
@@ -51,6 +51,8 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 		return fmt.Errorf("no providerClusterConfiguration present, discovery is not possible")
 	}
 
+	storageClasses := []vsphere.ZonedDataStore{}
+
 	var c v1.VsphereProviderClusterConfiguration
 	err := json.Unmarshal([]byte(configJSON.String()), &c)
 	if err != nil {
@@ -83,7 +85,6 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 		Zones:      output.Zones,
 	})
 
-	storageClasses := []vsphere.ZonedDataStore{}
 	if output.ZonedDataStores != nil {
 		storageClasses = output.ZonedDataStores
 	}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
@@ -100,7 +100,9 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 			})
 		}
 	}
-
+	if storageClasses == nil {
+		storageClasses = []vsphere.ZonedDataStore{}
+	}
 	input.Values.Set("cloudProviderVsphere.internal.storageClasses", storageClasses)
 
 	return nil

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
@@ -51,7 +51,7 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 		return fmt.Errorf("no providerClusterConfiguration present, discovery is not possible")
 	}
 
-	var storageClasses []vsphere.ZonedDataStore
+	storageClasses := []vsphere.ZonedDataStore{}
 
 	var c v1.VsphereProviderClusterConfiguration
 	err := json.Unmarshal([]byte(configJSON.String()), &c)
@@ -85,7 +85,9 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 		Zones:      output.Zones,
 	})
 
-	storageClasses = output.ZonedDataStores
+	if output.ZonedDataStores != nil {
+		storageClasses = output.ZonedDataStores
+	}
 
 	if exclude, ok := input.Values.GetOk("cloudProviderVsphere.storageClass.exclude"); ok {
 		var excludes []string
@@ -102,9 +104,7 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 			})
 		}
 	}
-	if storageClasses == nil {
-		storageClasses = []vsphere.ZonedDataStore{}
-	}
+
 	input.Values.Set("cloudProviderVsphere.internal.storageClasses", storageClasses)
 
 	return nil

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
@@ -83,7 +83,10 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 		Zones:      output.Zones,
 	})
 
-	storageClasses := output.ZonedDataStores
+	storageClasses := []vsphere.ZonedDataStore{}
+	if output.ZonedDataStores != nil {
+		storageClasses = output.ZonedDataStores
+	}
 
 	if exclude, ok := input.Values.GetOk("cloudProviderVsphere.storageClass.exclude"); ok {
 		var excludes []string
@@ -100,9 +103,7 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 			})
 		}
 	}
-	if storageClasses == nil {
-		storageClasses = []vsphere.ZonedDataStore{}
-	}
+
 	input.Values.Set("cloudProviderVsphere.internal.storageClasses", storageClasses)
 
 	return nil

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores_test.go
@@ -99,6 +99,26 @@ cloudProviderVsphere:
     - bar
     default: other-bar
 `
+
+		initValuesStringE = `
+cloudProviderVsphere:
+  internal:
+    providerClusterConfiguration:
+      provider:
+        server: test.test.com
+        username: test
+        password: test
+        insecure: true
+      region: Test
+      regionTagCategory: test-region
+      zoneTagCategory: test-zone
+      sshPublicKey: test
+      vmFolderPath: test
+  storageClass:
+    exclude:
+    - .*
+    default: other-bar
+`
 	)
 
 	f := HookExecutionConfigInit(initValuesStringA, `{}`)
@@ -176,6 +196,20 @@ cloudProviderVsphere:
   }
 ]
 `))
+		})
+	})
+
+	e := HookExecutionConfigInit(initValuesStringE, `{}`)
+
+	Context("When all discovered storage classes are excluded", func() {
+		BeforeEach(func() {
+			e.BindingContexts.Set(e.GenerateBeforeHelmContext())
+			e.RunHook()
+		})
+
+		It("Should result empty storageClasses list", func() {
+			Expect(e).To(ExecuteSuccessfully())
+			Expect(e.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(MatchJSON(`[]`))
 		})
 	})
 })


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix [issue](https://github.com/deckhouse/deckhouse/issues/8090)
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: Fix null storageclasses vsphere on exclude storageclasses from discovery
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
