### PR TITLE
[multitenancy-manager] patch instead of update

### DIFF
--- a/modules/160-multitenancy-manager/crds/projects.yaml
+++ b/modules/160-multitenancy-manager/crds/projects.yaml
@@ -149,6 +149,8 @@ spec:
                           items:
                             type: string
                 conditions:
+                  x-kubernetes-patch-strategy: merge
+                  x-kubernetes-patch-merge-key: type
                   type: array
                   items:
                     type: object
@@ -166,5 +168,5 @@ spec:
                         format: date-time
                         type: string
                 state:
-                  description: Brief description of the project status, such as Error, Deploying, Deployed, etc.
+                  description: Brief description of the project status, such as Error, Deployed, etc.
                   type: string

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/manager/project/manager.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/manager/project/manager.go
@@ -187,7 +187,7 @@ func (m *Manager) HandleVirtual(ctx context.Context, project *v1alpha2.Project) 
 		}
 	}
 
-	if err := m.updateVirtualProject(ctx, project, involvedNamespaces); err != nil {
+	if err := m.updateVirtualProjectStatus(ctx, project, involvedNamespaces); err != nil {
 		m.logger.Error(err, "failed to update the virtual project", "project", project.Name)
 		return ctrl.Result{}, err
 	}

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/manager/template/utils.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/manager/template/utils.go
@@ -103,9 +103,13 @@ func (m *Manager) setTemplateStatus(ctx context.Context, template *v1alpha1.Proj
 		if err := m.client.Get(ctx, client.ObjectKey{Name: template.Name}, template); err != nil {
 			return fmt.Errorf("get the '%s' project template: %w", template.Name, err)
 		}
+
+		original := template.DeepCopy()
+
 		template.Status.Message = message
 		template.Status.Ready = ready
-		return m.client.Status().Update(ctx, template)
+
+		return m.client.Status().Patch(ctx, template, client.StrategicMergeFrom(original))
 	})
 }
 
@@ -117,9 +121,11 @@ func (m *Manager) projectsByTemplate(ctx context.Context, template *v1alpha1.Pro
 	if len(projects.Items) == 0 {
 		return nil, nil
 	}
+
 	var result []*v1alpha2.Project
 	for _, project := range projects.Items {
 		result = append(result, project.DeepCopy())
 	}
+
 	return result, nil
 }


### PR DESCRIPTION
## Description
It replaces update with patch.

## Why do we need it, and what problem does it solve?
Patch is a more lightweight operation and it is more preferable in most cases.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: multitenancy-manager
type: chore
summary: Replace update with patch.
impact_level: low
```
