### PR TITLE
[ingress-nginx] upgrade to 1.12.1

### DIFF
--- a/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
@@ -60,8 +60,6 @@ spec:
                 annotationValidationEnabled:
                   description: |
                     Включить валидацию аннотаций Ingress-правил.
-
-                    Требуется версия контроллера 1.9.
                 nodeSelector:
                   description: |
                     Как в `spec.nodeSelector` у подов.
@@ -337,7 +335,7 @@ spec:
       served: true
       storage: false
       subresources:
-        status: { }
+        status: {}
       schema:
         openAPIV3Schema:
           properties:

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -68,7 +68,7 @@ spec:
                     One of the supported NGINX Ingress controller versions.
 
                     **By default**: the version in the [module settings](configuration.html#parameters-defaultcontrollerversion) is used.
-                  enum: ['1.6','1.9','1.10']
+                  enum: ["1.9", "1.10", "1.12"]
                 enableIstioSidecar:
                   type: boolean
                   description: |
@@ -103,8 +103,6 @@ spec:
                   default: false
                   description: |
                     Enables the annotation validation feature.
-
-                    Requires a controller of 1.9 version.
                 nodeSelector:
                   type: object
                   additionalProperties:
@@ -560,9 +558,6 @@ spec:
                     inlet:
                       enum: ['HostWithFailover']
                     hostWithFailover: {}
-              x-kubernetes-validations:
-                - message: .spec.controllerVersion should be explicitly set to 1.9 for .spec.annotationValidationEnabled to make effect
-                  rule: 'self.annotationValidationEnabled == true ? self.controllerVersion == ''1.9'': true'
       additionalPrinterColumns:
         - jsonPath: .spec.ingressClass
           name: Ingress Class
@@ -664,7 +659,7 @@ spec:
                     One of the supported NGINX Ingress controller versions.
 
                     **By default**: the version in the [module settings](configuration.html#parameters-defaultcontrollerversion) is used.
-                  enum: ['1.9','1.10']
+                  enum: ["1.9", "1.10", "1.12"]
                 enableIstioSidecar:
                   type: boolean
                   description: |
@@ -1247,8 +1242,8 @@ spec:
                       enum: ['HostWithFailover']
                     hostWithFailover: {}
               x-kubernetes-validations:
-                - message: .spec.controllerVersion should be explicitly set to 1.10 for .spec.enableHTTP3 to make effect
-                  rule: 'self.enableHTTP3 == true ? self.controllerVersion == ''1.10'': true'
+                - message: .spec.controllerVersion should be explicitly set to 1.10 or 1.12 for .spec.enableHTTP3 to make effect
+                  rule: 'self.enableHTTP3 == true ? self.controllerVersion in [''1.10'', ''1.12'']: true'
       additionalPrinterColumns:
         - jsonPath: .spec.ingressClass
           name: Ingress Class

--- a/modules/402-ingress-nginx/crds/kruise/crd_daemonsets.yaml
+++ b/modules/402-ingress-nginx/crds/kruise/crd_daemonsets.yaml
@@ -63,13 +63,13 @@ spec:
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
               description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -106,10 +106,10 @@ spec:
                           type: object
                         markPodNotReady:
                           description: 'MarkPodNotReady = true means: - Pod will be
-                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
-                          - Pod will be restored to ''Ready'' at Updated state if
-                          it was set to ''NotReady'' at preparingUpdate state. Default
-                          to false.'
+                            set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                            - Pod will be restored to ''Ready'' at Updated state if
+                            it was set to ''NotReady'' at preparingUpdate state. Default
+                            to false.'
                           type: boolean
                       type: object
                     preDelete:
@@ -125,10 +125,10 @@ spec:
                           type: object
                         markPodNotReady:
                           description: 'MarkPodNotReady = true means: - Pod will be
-                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
-                          - Pod will be restored to ''Ready'' at Updated state if
-                          it was set to ''NotReady'' at preparingUpdate state. Default
-                          to false.'
+                            set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                            - Pod will be restored to ''Ready'' at Updated state if
+                            it was set to ''NotReady'' at preparingUpdate state. Default
+                            to false.'
                           type: boolean
                       type: object
                     preNormal:
@@ -168,8 +168,8 @@ spec:
                   type: integer
                 selector:
                   description: 'A label query over pods that are managed by the daemon
-                  set. Must match in order to be controlled. It must match the pod
-                  template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                    set. Must match in order to be controlled. It must match the pod
+                    template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements.
@@ -215,9 +215,9 @@ spec:
                   x-kubernetes-map-type: atomic
                 template:
                   description: 'An object that describes the pod that will be created.
-                  The DaemonSet will create exactly one copy of this pod on every
-                  node that matches the template''s node selector (or on every node
-                  if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template'
+                    The DaemonSet will create exactly one copy of this pod on every
+                    node that matches the template''s node selector (or on every node
+                    if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template'
                   x-kubernetes-preserve-unknown-fields: true
                 updateStrategy:
                   description: An update strategy to replace existing DaemonSet pods
@@ -232,48 +232,48 @@ spec:
                             - type: integer
                             - type: string
                           description: 'The maximum number of nodes with an existing
-                          available DaemonSet pod that can have an updated DaemonSet
-                          pod during during an update. Value can be an absolute number
-                          (ex: 5) or a percentage of desired pods (ex: 10%). This
-                          can not be 0 if MaxUnavailable is 0. Absolute number is
-                          calculated from percentage by rounding up to a minimum of
-                          1. Default value is 0. Example: when this is set to 30%,
-                          at most 30% of the total number of nodes that should be
-                          running the daemon pod (i.e. status.desiredNumberScheduled)
-                          can have their a new pod created before the old pod is marked
-                          as deleted. The update starts by launching new pods on 30%
-                          of nodes. Once an updated pod is available (Ready for at
-                          least minReadySeconds) the old DaemonSet pod on that node
-                          is marked deleted. If the old pod becomes unavailable for
-                          any reason (Ready transitions to false, is evicted, or is
-                          drained) an updated pod is immediatedly created on that
-                          node without considering surge limits. Allowing surge implies
-                          the possibility that the resources consumed by the daemonset
-                          on any given node can double if the readiness check fails,
-                          and so resource intensive daemonsets should take into account
-                          that they may cause evictions during disruption. This is
-                          beta field and enabled/disabled by DaemonSetUpdateSurge
-                          feature gate.'
+                            available DaemonSet pod that can have an updated DaemonSet
+                            pod during during an update. Value can be an absolute number
+                            (ex: 5) or a percentage of desired pods (ex: 10%). This
+                            can not be 0 if MaxUnavailable is 0. Absolute number is
+                            calculated from percentage by rounding up to a minimum of
+                            1. Default value is 0. Example: when this is set to 30%,
+                            at most 30% of the total number of nodes that should be
+                            running the daemon pod (i.e. status.desiredNumberScheduled)
+                            can have their a new pod created before the old pod is marked
+                            as deleted. The update starts by launching new pods on 30%
+                            of nodes. Once an updated pod is available (Ready for at
+                            least minReadySeconds) the old DaemonSet pod on that node
+                            is marked deleted. If the old pod becomes unavailable for
+                            any reason (Ready transitions to false, is evicted, or is
+                            drained) an updated pod is immediatedly created on that
+                            node without considering surge limits. Allowing surge implies
+                            the possibility that the resources consumed by the daemonset
+                            on any given node can double if the readiness check fails,
+                            and so resource intensive daemonsets should take into account
+                            that they may cause evictions during disruption. This is
+                            beta field and enabled/disabled by DaemonSetUpdateSurge
+                            feature gate.'
                           x-kubernetes-int-or-string: true
                         maxUnavailable:
                           anyOf:
                             - type: integer
                             - type: string
                           description: 'The maximum number of DaemonSet pods that can
-                          be unavailable during the update. Value can be an absolute
-                          number (ex: 5) or a percentage of total number of DaemonSet
-                          pods at the start of the update (ex: 10%). Absolute number
-                          is calculated from percentage by rounding up. This cannot
-                          be 0 if MaxSurge is 0 Default value is 1. Example: when
-                          this is set to 30%, at most 30% of the total number of nodes
-                          that should be running the daemon pod (i.e. status.desiredNumberScheduled)
-                          can have their pods stopped for an update at any given time.
-                          The update starts by stopping at most 30% of those DaemonSet
-                          pods and then brings up new DaemonSet pods in their place.
-                          Once the new pods are available, it then proceeds onto other
-                          DaemonSet pods, thus ensuring that at least 70% of original
-                          number of DaemonSet pods are available at all times during
-                          the update.'
+                            be unavailable during the update. Value can be an absolute
+                            number (ex: 5) or a percentage of total number of DaemonSet
+                            pods at the start of the update (ex: 10%). Absolute number
+                            is calculated from percentage by rounding up. This cannot
+                            be 0 if MaxSurge is 0 Default value is 1. Example: when
+                            this is set to 30%, at most 30% of the total number of nodes
+                            that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                            can have their pods stopped for an update at any given time.
+                            The update starts by stopping at most 30% of those DaemonSet
+                            pods and then brings up new DaemonSet pods in their place.
+                            Once the new pods are available, it then proceeds onto other
+                            DaemonSet pods, thus ensuring that at least 70% of original
+                            number of DaemonSet pods are available at all times during
+                            the update.'
                           x-kubernetes-int-or-string: true
                         partition:
                           description: The number of DaemonSet pods remained to be old
@@ -387,7 +387,7 @@ spec:
                   type: array
                 currentNumberScheduled:
                   description: 'The number of nodes that are running at least 1 daemon
-                  pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                    pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
                   format: int32
                   type: integer
                 daemonSetHash:
@@ -396,8 +396,8 @@ spec:
                   type: string
                 desiredNumberScheduled:
                   description: 'The total number of nodes that should be running the
-                  daemon pod (including nodes correctly running the daemon pod). More
-                  info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                    daemon pod (including nodes correctly running the daemon pod). More
+                    info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
                   format: int32
                   type: integer
                 numberAvailable:
@@ -408,7 +408,7 @@ spec:
                   type: integer
                 numberMisscheduled:
                   description: 'The number of nodes that are running the daemon pod,
-                  but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                    but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
                   format: int32
                   type: integer
                 numberReady:

--- a/modules/402-ingress-nginx/docs/FAQ.md
+++ b/modules/402-ingress-nginx/docs/FAQ.md
@@ -227,8 +227,8 @@ The IngressNginxController is deployed using DaemonSet. DaemonSet does not provi
 
 Notes:
 
-* The minimum actual number of ingressNginxController replicas cannot be less than the minimum number of nodes in the NodeGroup where ingressNginxController is deployed.
-* The maximum actual number of ingressNginxController replicas cannot be greater than the maximum number of nodes in the NodeGroup where ingressNginxController is deployed.
+- The minimum actual number of ingressNginxController replicas cannot be less than the minimum number of nodes in the NodeGroup where ingressNginxController is deployed.
+- The maximum actual number of ingressNginxController replicas cannot be greater than the maximum number of nodes in the NodeGroup where ingressNginxController is deployed.
 
 ## How to use IngressClass with IngressClassParameters?
 

--- a/modules/402-ingress-nginx/docs/README.md
+++ b/modules/402-ingress-nginx/docs/README.md
@@ -63,25 +63,25 @@ The graphs are collected in convenient dashboards in Grafana, and there is a dri
 
 All the collected metrics have service labels that allow you to identify the controller's instance: `controller`, `app`, `instance`, and `endpoint` (displayed in `/prometheus/targets`).
 
-* All metrics (except for geo) exported by protobuf_exporter have three levels of detail:
-  * `ingress_nginx_overall_*` — the "bird's-eye view"; all the metrics have `namespace`, `vhost`, and `content_kind` labels attached;
-  * `ingress_nginx_detail_*` — — in addition to the `overall` level labels, `ingress`, `service`, `service_port` and `location` are added;
-  * `ingress_nginx_detail_backend_*` — some detailed data; they are collected on a per-backend basis. The `pod_ip` label is added to those listed for the detail level.
+- All metrics (except for geo) exported by protobuf_exporter have three levels of detail:
+  - `ingress_nginx_overall_*` — the "bird's-eye view"; all the metrics have `namespace`, `vhost`, and `content_kind` labels attached;
+  - `ingress_nginx_detail_*` — — in addition to the `overall` level labels, `ingress`, `service`, `service_port` and `location` are added;
+  - `ingress_nginx_detail_backend_*` — some detailed data; they are collected on a per-backend basis. The `pod_ip` label is added to those listed for the detail level.
 
-* The following metrics are collected for the overall and detail levels:
-  * `*_requests_total` — the total number of requests (additional labels: `scheme`, `method`);
-  * `*_responses_total` — the total number of responses (additional labels: `status`);
-  * `*_request_seconds_{sum,count,bucket}` — histogram of the response time;
-  * `*_bytes_received_{sum,count,bucket}` — histogram of the request size;
-  * `*_bytes_sent_{sum,count,bucket}` — histogram of the response size;
-  * `*_upstream_response_seconds_{sum,count,bucket}` — histogram of the upstream response time (the sum of the response times of all upstreams is used if several of them are present);
-  * `*_lowres_upstream_response_seconds_{sum,count,bucket}` — the same as above but less detailed (it is suitable for visualization, but not at all for calculating quantiles);
-  * `*_upstream_retries_{count,sum}` — the number of requests for which retries were sent to backends, and the number of retries;
+- The following metrics are collected for the overall and detail levels:
+  - `*_requests_total` — the total number of requests (additional labels: `scheme`, `method`);
+  - `*_responses_total` — the total number of responses (additional labels: `status`);
+  - `*_request_seconds_{sum,count,bucket}` — histogram of the response time;
+  - `*_bytes_received_{sum,count,bucket}` — histogram of the request size;
+  - `*_bytes_sent_{sum,count,bucket}` — histogram of the response size;
+  - `*_upstream_response_seconds_{sum,count,bucket}` — histogram of the upstream response time (the sum of the response times of all upstreams is used if several of them are present);
+  - `*_lowres_upstream_response_seconds_{sum,count,bucket}` — the same as above but less detailed (it is suitable for visualization, but not at all for calculating quantiles);
+  - `*_upstream_retries_{count,sum}` — the number of requests for which retries were sent to backends, and the number of retries;
 
-* The following metrics are collected for the overall level:
-  * `*_geohash_total` — the total number of requests with a specific geohash (additional labels: `geohash`, `place`);
+- The following metrics are collected for the overall level:
+  - `*_geohash_total` — the total number of requests with a specific geohash (additional labels: `geohash`, `place`);
 
-* The following metrics are collected for the detail_backend level:
-  * `*_lowres_upstream_response_seconds` — same as a similar metric for overall and detail;
-  * `*_responses_total` — the total number of responses (additional labels: `status_class` instead of `status`);
-  * `*_upstream_bytes_received_sum` — the sum of the backend's response sizes.
+- The following metrics are collected for the detail_backend level:
+  - `*_lowres_upstream_response_seconds` — same as a similar metric for overall and detail;
+  - `*_responses_total` — the total number of responses (additional labels: `status_class` instead of `status`);
+  - `*_upstream_bytes_received_sum` — the sum of the backend's response sizes.

--- a/modules/402-ingress-nginx/docs/README_RU.md
+++ b/modules/402-ingress-nginx/docs/README_RU.md
@@ -63,25 +63,25 @@ title: "Модуль ingress-nginx"
 
 У всех собираемых метрик есть служебные лейблы, позволяющие идентифицировать экземпляр контроллера: `controller`, `app`, `instance` и `endpoint` (они видны в `/prometheus/targets`).
 
-* Все метрики (кроме geo), экспортируемые protobuf_exporter, представлены в трех уровнях детализации:
-  * `ingress_nginx_overall_*` — «вид с вертолета», у всех метрик есть лейблы `namespace`, `vhost` и `content_kind`;
-  * `ingress_nginx_detail_*` — кроме лейблов уровня `overall`, добавляются `ingress`, `service`, `service_port` и `location`;
-  * `ingress_nginx_detail_backend_*` — ограниченная часть данных, собирается в разрезе по бэкендам. У этих метрик, кроме лейблов уровня detail, добавляется лейбл `pod_ip`.
+- Все метрики (кроме geo), экспортируемые protobuf_exporter, представлены в трех уровнях детализации:
+  - `ingress_nginx_overall_*` — «вид с вертолета», у всех метрик есть лейблы `namespace`, `vhost` и `content_kind`;
+  - `ingress_nginx_detail_*` — кроме лейблов уровня `overall`, добавляются `ingress`, `service`, `service_port` и `location`;
+  - `ingress_nginx_detail_backend_*` — ограниченная часть данных, собирается в разрезе по бэкендам. У этих метрик, кроме лейблов уровня detail, добавляется лейбл `pod_ip`.
 
-* Для уровней overall и detail собираются следующие метрики:
-  * `*_requests_total` — counter количества запросов (дополнительные лейблы — `scheme`, `method`);
-  * `*_responses_total` — counter количества ответов (дополнительный лейбл — `status`);
-  * `*_request_seconds_{sum,count,bucket}` — histogram времени ответа;
-  * `*_bytes_received_{sum,count,bucket}` — histogram размера запроса;
-  * `*_bytes_sent_{sum,count,bucket}` — histogram размера ответа;
-  * `*_upstream_response_seconds_{sum,count,bucket}` — histogram времени ответа upstream'а (используется сумма времен ответов всех upstream'ов, если их было несколько);
-  * `*_lowres_upstream_response_seconds_{sum,count,bucket}` — то же самое, что и предыдущая метрика, только с меньшей детализацией (подходит для визуализации, но не подходит для расчета quantile);
-  * `*_upstream_retries_{count,sum}` — количество запросов, при обработке которых были retry бэкендов, и сумма retry'ев.
+- Для уровней overall и detail собираются следующие метрики:
+  - `*_requests_total` — counter количества запросов (дополнительные лейблы — `scheme`, `method`);
+  - `*_responses_total` — counter количества ответов (дополнительный лейбл — `status`);
+  - `*_request_seconds_{sum,count,bucket}` — histogram времени ответа;
+  - `*_bytes_received_{sum,count,bucket}` — histogram размера запроса;
+  - `*_bytes_sent_{sum,count,bucket}` — histogram размера ответа;
+  - `*_upstream_response_seconds_{sum,count,bucket}` — histogram времени ответа upstream'а (используется сумма времен ответов всех upstream'ов, если их было несколько);
+  - `*_lowres_upstream_response_seconds_{sum,count,bucket}` — то же самое, что и предыдущая метрика, только с меньшей детализацией (подходит для визуализации, но не подходит для расчета quantile);
+  - `*_upstream_retries_{count,sum}` — количество запросов, при обработке которых были retry бэкендов, и сумма retry'ев.
 
-* Для уровня overall собираются следующие метрики:
-  * `*_geohash_total` — counter количества запросов с определенным geohash (дополнительные лейблы — `geohash`, `place`).
+- Для уровня overall собираются следующие метрики:
+  - `*_geohash_total` — counter количества запросов с определенным geohash (дополнительные лейблы — `geohash`, `place`).
 
-* Для уровня detail_backend собираются следующие метрики:
-  * `*_lowres_upstream_response_seconds` — то же самое, что аналогичная метрика для overall и detail;
-  * `*_responses_total` — counter количества ответов (дополнительный лейбл — `status_class`, а не просто `status`);
-  * `*_upstream_bytes_received_sum` — counter суммы размеров ответов бэкенда.
+- Для уровня detail_backend собираются следующие метрики:
+  - `*_lowres_upstream_response_seconds` — то же самое, что аналогичная метрика для overall и detail;
+  - `*_responses_total` — counter количества ответов (дополнительный лейбл — `status_class`, а не просто `status`);
+  - `*_upstream_bytes_received_sum` — counter суммы размеров ответов бэкенда.

--- a/modules/402-ingress-nginx/docs/testing/README.md
+++ b/modules/402-ingress-nginx/docs/testing/README.md
@@ -1,5 +1,5 @@
- # How to test ingress controller build
- 
+# How to test ingress controller build
+
 Apply resources:
 
 ```yaml
@@ -18,7 +18,7 @@ spec:
       application/x-javascript text/plain application/x-font-truetype application/xml+rss
       image/x-icon font/opentype text/css image/x-win-bitmap
     enable-brotli: "true"
-  controllerVersion: "1.9"
+  controllerVersion: "1.10"
   disableHTTP2: false
   hsts: false
   ingressClass: nginx

--- a/modules/402-ingress-nginx/hooks/generate_admission_webhook_cert_test.go
+++ b/modules/402-ingress-nginx/hooks/generate_admission_webhook_cert_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var _ = Describe("ingress-nginx :: hooks :: generate_admission_webhook_cert ::", func() {
-	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.9", "internal": {"admissionCertificate": {}}}}`, "")
+	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.10", "internal": {"admissionCertificate": {}}}}`, "")
 	f.RegisterCRD("deckhouse.io", "v1", "IngressNginxController", false)
 
 	Context("Fresh cluster", func() {

--- a/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
+++ b/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var _ = Describe("ingress-nginx :: hooks :: get_ingress_controllers ::", func() {
-	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.9", "internal": {}}}`, "")
+	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.10", "internal": {}}}`, "")
 	f.RegisterCRD("deckhouse.io", "v1", "IngressNginxController", false)
 
 	Context("Fresh cluster", func() {
@@ -48,7 +48,7 @@ metadata:
 spec:
   ingressClass: nginx
   inlet: LoadBalancer
-  controllerVersion: "1.9"
+  controllerVersion: "1.10"
   acceptRequestsFrom:
   - 127.0.0.1/32
   - 192.168.0.0/24
@@ -70,7 +70,7 @@ spec:
   "annotationValidationEnabled": false,
   "chaosMonkey": false,
   "config": {},
-  "controllerVersion": "1.9",
+  "controllerVersion": "1.10",
   "disableHTTP2": false,
   "enableHTTP3": false,
   "geoIP2": {},

--- a/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version_test.go
+++ b/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 var _ = Describe("Global hooks :: discovery :: minimal_ingress_version ", func() {
-	initValuesString := `{"ingressNginx":{"defaultControllerVersion": "1.9", "internal": {}}}`
+	initValuesString := `{"ingressNginx":{"defaultControllerVersion": "1.10", "internal": {}}}`
 	globalValuesString := `{}`
 	f := HookExecutionConfigInit(initValuesString, globalValuesString)
 	f.RegisterCRD("deckhouse.io", "v1", "IngressNginxController", false)
@@ -51,7 +51,7 @@ kind: IngressNginxController
 metadata:
   name: main
 spec:
-  controllerVersion: "1.9"
+  controllerVersion: "1.10"
   ingressClass: "nginx"
 `))
 			f.RunHook()
@@ -61,7 +61,7 @@ spec:
 			Expect(f).To(ExecuteSuccessfully())
 			value, exists := requirements.GetValue(minVersionValuesKey)
 			Expect(exists).To(BeTrue())
-			Expect(value).To(BeEquivalentTo("1.9.0"))
+			Expect(value).To(BeEquivalentTo("1.10.0"))
 			v, _ := requirements.GetValue(incompatibleVersionsKey)
 			Expect(v).To(BeFalse())
 		})
@@ -84,7 +84,7 @@ spec:
 			Expect(f).To(ExecuteSuccessfully())
 			value, exists := requirements.GetValue(minVersionValuesKey)
 			Expect(exists).To(BeTrue())
-			Expect(value).To(BeEquivalentTo("1.9.0"))
+			Expect(value).To(BeEquivalentTo("1.10.0"))
 			v, _ := requirements.GetValue(incompatibleVersionsKey)
 			Expect(v).To(BeFalse())
 		})
@@ -98,7 +98,7 @@ kind: IngressNginxController
 metadata:
   name: first
 spec:
-  controllerVersion: "1.9"
+  controllerVersion: "1.10"
   ingressClass: "test"
 ---
 apiVersion: deckhouse.io/v1
@@ -138,7 +138,7 @@ kind: IngressNginxController
 metadata:
   name: first
 spec:
-  controllerVersion: "1.9"
+  controllerVersion: "1.10"
   ingressClass: "test"
 ---
 apiVersion: deckhouse.io/v1

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var _ = Describe("ingress-nginx :: hooks :: safe_daemonset_update ::", func() {
-	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.9", "internal": {}}}`, "")
+	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.10", "internal": {}}}`, "")
 	f.RegisterCRD("apps.kruise.io", "v1alpha1", "DaemonSet", true)
 
 	Context("Failover pods are ready, update postponed", func() {

--- a/modules/402-ingress-nginx/hooks/update_ingress_address_test.go
+++ b/modules/402-ingress-nginx/hooks/update_ingress_address_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 var _ = Describe("Modules :: ingress-nginx :: hooks :: update_ingress_address ::", func() {
-	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.9", "internal": {}}}`, "")
+	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "1.10", "internal": {}}}`, "")
 	f.RegisterCRD("deckhouse.io", "v1", "IngressNginxController", false)
 
 	Context("Service with non LoadBalancer type", func() {

--- a/modules/402-ingress-nginx/images/controller-1-12/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-12/README.md
@@ -1,0 +1,5 @@
+This version of the controller has nginx 1.25,
+which supports HTTP3, but it has not been added yet.
+
+We add HTTP3, but the protocol is in experimental state, it is not suitable for use in production.
+For example, the passthrough mechanism will not work, and there may be issues with authorization and proxy functions.

--- a/modules/402-ingress-nginx/images/controller-1-12/curl-chroot-wrapper.sh
+++ b/modules/402-ingress-nginx/images/controller-1-12/curl-chroot-wrapper.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+unshare -S 101 -R /chroot /usr/bin/curl "$@"

--- a/modules/402-ingress-nginx/images/controller-1-12/nginx-chroot-wrapper.sh
+++ b/modules/402-ingress-nginx/images/controller-1-12/nginx-chroot-wrapper.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cat /etc/resolv.conf > /chroot/etc/resolv.conf
+unshare -S 101 -R /chroot /usr/local/nginx/sbin/nginx "$@"

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/001-lua-info.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/001-lua-info.patch
@@ -1,0 +1,168 @@
+diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
+index aa8f4c4b9..8a141f799 100644
+--- a/internal/ingress/controller/controller.go
++++ b/internal/ingress/controller/controller.go
+@@ -773,7 +773,7 @@ func (n *NGINXController) getBackendServers(ingresses []*ingress.Ingress) ([]*in
+ 					continue
+ 				}
+ 
+-				upsName := upstreamName(ing.Namespace, path.Backend.Service)
++				upsName := upstreamName(ing.Namespace, ing.Name, path.Backend.Service)
+ 
+ 				ups := upstreams[upsName]
+ 
+@@ -1005,10 +1005,11 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
+ 
+ 		var defBackend string
+ 		if ing.Spec.DefaultBackend != nil && ing.Spec.DefaultBackend.Service != nil {
+-			defBackend = upstreamName(ing.Namespace, ing.Spec.DefaultBackend.Service)
++			defBackend = upstreamName(ing.Namespace, ing.Name, ing.Spec.DefaultBackend.Service)
+ 
+ 			klog.V(3).Infof("Creating upstream %q", defBackend)
+ 			upstreams[defBackend] = newUpstream(defBackend)
++			upstreams[defBackend].Ingress = &ing.Ingress
+ 
+ 			upstreams[defBackend].UpstreamHashBy.UpstreamHashBy = anns.UpstreamHashBy.UpstreamHashBy
+ 			upstreams[defBackend].UpstreamHashBy.UpstreamHashBySubset = anns.UpstreamHashBy.UpstreamHashBySubset
+@@ -1065,7 +1066,7 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
+ 					continue
+ 				}
+ 
+-				name := upstreamName(ing.Namespace, path.Backend.Service)
++				name := upstreamName(ing.Namespace, ing.Name, path.Backend.Service)
+ 				svcName, svcPort := upstreamServiceNameAndPort(path.Backend.Service)
+ 				if _, ok := upstreams[name]; ok {
+ 					continue
+@@ -1074,6 +1075,7 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
+ 				klog.V(3).Infof("Creating upstream %q", name)
+ 				upstreams[name] = newUpstream(name)
+ 				upstreams[name].Port = svcPort
++				upstreams[name].Ingress = &ing.Ingress
+ 
+ 				upstreams[name].UpstreamHashBy.UpstreamHashBy = anns.UpstreamHashBy.UpstreamHashBy
+ 				upstreams[name].UpstreamHashBy.UpstreamHashBySubset = anns.UpstreamHashBy.UpstreamHashBySubset
+@@ -1306,7 +1308,7 @@ func (n *NGINXController) createServers(data []*ingress.Ingress,
+ 		}
+ 
+ 		if ing.Spec.DefaultBackend != nil && ing.Spec.DefaultBackend.Service != nil {
+-			defUpstream := upstreamName(ing.Namespace, ing.Spec.DefaultBackend.Service)
++			defUpstream := upstreamName(ing.Namespace, ing.Name, ing.Spec.DefaultBackend.Service)
+ 
+ 			if backendUpstream, ok := upstreams[defUpstream]; ok {
+ 				// use backend specified in Ingress as the default backend for all its rules
+@@ -1581,7 +1583,7 @@ func mergeAlternativeBackends(ing *ingress.Ingress, upstreams map[string]*ingres
+ ) {
+ 	// merge catch-all alternative backends
+ 	if ing.Spec.DefaultBackend != nil {
+-		upsName := upstreamName(ing.Namespace, ing.Spec.DefaultBackend.Service)
++		upsName := upstreamName(ing.Namespace, ing.Name, ing.Spec.DefaultBackend.Service)
+ 
+ 		altUps := upstreams[upsName]
+ 
+@@ -1632,7 +1634,7 @@ func mergeAlternativeBackends(ing *ingress.Ingress, upstreams map[string]*ingres
+ 				continue
+ 			}
+ 
+-			upsName := upstreamName(ing.Namespace, path.Backend.Service)
++			upsName := upstreamName(ing.Namespace, ing.Name, path.Backend.Service)
+ 
+ 			altUps := upstreams[upsName]
+ 
+diff --git a/internal/ingress/controller/nginx.go b/internal/ingress/controller/nginx.go
+index 20fad5afb..0b6b3c237 100644
+--- a/internal/ingress/controller/nginx.go
++++ b/internal/ingress/controller/nginx.go
+@@ -40,6 +40,8 @@ import (
+ 	proxyproto "github.com/armon/go-proxyproto"
+ 	"github.com/eapache/channels"
+ 	apiv1 "k8s.io/api/core/v1"
++	networking "k8s.io/api/networking/v1"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/util/intstr"
+ 	"k8s.io/client-go/kubernetes/scheme"
+ 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+@@ -949,8 +951,12 @@ func configureBackends(rawBackends []*ingress.Backend) error {
+ 
+ 	for i, backend := range rawBackends {
+ 		var service *apiv1.Service
++		var networkingIngress *networking.Ingress
+ 		if backend.Service != nil {
+-			service = &apiv1.Service{Spec: backend.Service.Spec}
++			service = &apiv1.Service{ObjectMeta: metav1.ObjectMeta{Name: backend.Service.ObjectMeta.Name}, Spec: backend.Service.Spec}
++		}
++		if backend.Ingress != nil {
++			networkingIngress = &networking.Ingress{ObjectMeta: metav1.ObjectMeta{Name: backend.Ingress.ObjectMeta.Name}}
+ 		}
+ 		luaBackend := &ingress.Backend{
+ 			Name:                 backend.Name,
+@@ -960,6 +966,7 @@ func configureBackends(rawBackends []*ingress.Backend) error {
+ 			UpstreamHashBy:       backend.UpstreamHashBy,
+ 			LoadBalancing:        backend.LoadBalancing,
+ 			Service:              service,
++			Ingress:              networkingIngress,
+ 			NoServer:             backend.NoServer,
+ 			TrafficShapingPolicy: backend.TrafficShapingPolicy,
+ 			AlternativeBackends:  backend.AlternativeBackends,
+diff --git a/internal/ingress/controller/util.go b/internal/ingress/controller/util.go
+index 975fb822a..e461e61fb 100644
+--- a/internal/ingress/controller/util.go
++++ b/internal/ingress/controller/util.go
+@@ -47,13 +47,13 @@ func newUpstream(name string) *ingress.Backend {
+ }
+ 
+ // upstreamName returns a formatted upstream name based on namespace, service, and port
+-func upstreamName(namespace string, service *networking.IngressServiceBackend) string {
++func upstreamName(namespace string, ingress string, service *networking.IngressServiceBackend) string {
+ 	if service != nil {
+ 		if service.Port.Number > 0 {
+-			return fmt.Sprintf("%s-%s-%d", namespace, service.Name, service.Port.Number)
++			return fmt.Sprintf("%s-%s-%s-%d", namespace, ingress, service.Name, service.Port.Number)
+ 		}
+ 		if service.Port.Name != "" {
+-			return fmt.Sprintf("%s-%s-%s", namespace, service.Name, service.Port.Name)
++			return fmt.Sprintf("%s-%s-%s-%s", namespace, ingress, service.Name, service.Port.Name)
+ 		}
+ 	}
+ 	return fmt.Sprintf("%s-INVALID", namespace)
+diff --git a/pkg/apis/ingress/types.go b/pkg/apis/ingress/types.go
+index ccdd49fe9..4926449c0 100644
+--- a/pkg/apis/ingress/types.go
++++ b/pkg/apis/ingress/types.go
+@@ -79,9 +79,10 @@ type Configuration struct {
+ // +k8s:deepcopy-gen=true
+ type Backend struct {
+ 	// Name represents an unique apiv1.Service name formatted as <namespace>-<name>-<port>
+-	Name    string             `json:"name"`
+-	Service *apiv1.Service     `json:"service,omitempty"`
+-	Port    intstr.IntOrString `json:"port"`
++	Name    string              `json:"name"`
++	Service *apiv1.Service      `json:"service,omitempty"`
++	Port    intstr.IntOrString  `json:"port"`
++	Ingress *networking.Ingress `json:"ingress,omitempty"`
+ 	// SSLPassthrough indicates that Ingress controller will delegate TLS termination to the endpoints.
+ 	SSLPassthrough bool `json:"sslPassthrough"`
+ 	// Endpoints contains the list of endpoints currently running
+diff --git a/pkg/apis/ingress/zz_generated.deepcopy.go b/pkg/apis/ingress/zz_generated.deepcopy.go
+index 410173e26..01ad86190 100644
+--- a/pkg/apis/ingress/zz_generated.deepcopy.go
++++ b/pkg/apis/ingress/zz_generated.deepcopy.go
+@@ -23,6 +23,7 @@ package ingress
+ 
+ import (
+ 	v1 "k8s.io/api/core/v1"
++	networking "k8s.io/api/networking/v1"
+ )
+ 
+ // DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
+@@ -33,6 +34,11 @@ func (in *Backend) DeepCopyInto(out *Backend) {
+ 		*out = new(v1.Service)
+ 		(*in).DeepCopyInto(*out)
+ 	}
++	if in.Ingress != nil {
++		in, out := &in.Ingress, &out.Ingress
++		*out = new(networking.Ingress)
++		(*in).DeepCopyInto(*out)
++	}
+ 	out.Port = in.Port
+ 	if in.Endpoints != nil {
+ 		in, out := &in.Endpoints, &out.Endpoints

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/002-makefile.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/002-makefile.patch
@@ -1,0 +1,41 @@
+diff --git a/Makefile b/Makefile
+index 3ff56fc47..8da313266 100644
+--- a/Makefile
++++ b/Makefile
+@@ -27,7 +27,7 @@ endif
+ SHELL=/bin/bash -o pipefail -o errexit
+ 
+ # Use the 0.0 tag for testing, it shouldn't clobber any release builds
+-TAG ?= $(shell cat TAG)
++TAG ?= $(shell git describe --tags HEAD | cut -d- -f2)
+ 
+ # The env below is called GO_VERSION and not GOLANG_VERSION because 
+ # the gcb image we use to build already defines GOLANG_VERSION and is a 
+@@ -42,7 +42,7 @@ E2E_NODES ?= 7
+ # run e2e test suite with tests that check for memory leaks? (default is false)
+ E2E_CHECK_LEAKS ?=
+ 
+-REPO_INFO ?= $(shell git config --get remote.origin.url)
++REPO_INFO ?= "UNKNOWN"
+ COMMIT_SHA ?= git-$(shell git rev-parse --short HEAD)
+ BUILD_ID ?= "UNSET"
+ 
+@@ -110,6 +110,7 @@ clean-chroot-image: ## Removes local image
+ 
+ .PHONY: build
+ build:  ## Build ingress controller, debug tool and pre-stop hook.
++ifeq ($(USE_DOCKER), true)
+ 	E2E_IMAGE=golang:$(GO_VERSION)-alpine3.21 USE_SHELL=/bin/sh build/run-in-docker.sh \
+ 		MAC_OS=$(MAC_OS) \
+ 		PKG=$(PKG) \
+@@ -118,7 +119,9 @@ build:  ## Build ingress controller, debug tool and pre-stop hook.
+ 		REPO_INFO=$(REPO_INFO) \
+ 		TAG=$(TAG) \
+ 		build/build.sh
+-
++else
++	bash build/build.sh
++endif
+ 
+ .PHONY: clean
+ clean: ## Remove .gocache directory.

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/003-healthcheck.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/003-healthcheck.patch
@@ -1,0 +1,15 @@
+diff --git a/internal/ingress/controller/checker.go b/internal/ingress/controller/checker.go
+index d1bf19ddf..7e8ee68e1 100644
+--- a/internal/ingress/controller/checker.go
++++ b/internal/ingress/controller/checker.go
+@@ -34,8 +34,8 @@ func (n *NGINXController) Name() string {
+ }
+ 
+ // Check returns if the nginx healthz endpoint is returning ok (status code 200)
+-func (n *NGINXController) Check(_ *http.Request) error {
+-	if n.isShuttingDown {
++func (n *NGINXController) Check(r *http.Request) error {
++	if r.Header.Get("D8s-External-Check") == "True" && n.isShuttingDown {
+ 		return fmt.Errorf("the ingress controller is shutting down")
+ 	}
+ 

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/004-util.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/004-util.patch
@@ -1,0 +1,13 @@
+diff --git a/internal/ingress/controller/util.go b/internal/ingress/controller/util.go
+index e461e61fb..c6a057c22 100644
+--- a/internal/ingress/controller/util.go
++++ b/internal/ingress/controller/util.go
+@@ -143,7 +143,7 @@ func (nc NginxCommand) ExecCommand(args ...string) *exec.Cmd {
+ // Test checks if config file is a syntax valid nginx configuration
+ func (nc NginxCommand) Test(cfg string) ([]byte, error) {
+ 	//nolint:gosec // Ignore G204 error
+-	return exec.Command(nc.Binary, "-c", cfg, "-t").CombinedOutput()
++	return exec.Command(nc.Binary, "-c", cfg, "-t", "-e", "/dev/null").CombinedOutput()
+ }
+ 
+ // getSysctl returns the value for the specified sysctl setting

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/005-add-http3.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/005-add-http3.patch
@@ -1,0 +1,139 @@
+diff --git a/internal/ingress/controller/config/config.go b/internal/ingress/controller/config/config.go
+index 3864a176a..46b8eea21 100644
+--- a/internal/ingress/controller/config/config.go
++++ b/internal/ingress/controller/config/config.go
+@@ -450,6 +450,11 @@ type Configuration struct {
+ 	// Default: true
+ 	UseHTTP2 bool `json:"use-http2,omitempty"`
+ 
++	// Enables or disables the HTTP/3 support in secure connections
++	// https://nginx.org/ru/docs/http/ngx_http_v3_module.html
++	// Default: true
++	UseHTTP3 bool `json:"use-http3,omitempty"`
++
+ 	// Disables gzipping of responses for requests with "User-Agent" header fields matching any of
+ 	// the specified regular expressions.
+ 	// http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_disable
+@@ -831,6 +836,7 @@ func NewDefault() Configuration {
+ 		VariablesHashBucketSize:          256,
+ 		VariablesHashMaxSize:             2048,
+ 		UseHTTP2:                         true,
++		UseHTTP3:                         false,
+ 		DisableProxyInterceptErrors:      false,
+ 		ProxyStreamTimeout:               "600s",
+ 		ProxyStreamNextUpstream:          true,
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index f6816d70a..e9e33a388 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -324,6 +324,7 @@ var funcMap = text_template.FuncMap{
+ 	"shouldLoadModSecurityModule":        shouldLoadModSecurityModule,
+ 	"buildHTTPListener":                  buildHTTPListener,
+ 	"buildHTTPSListener":                 buildHTTPSListener,
++	"buildHTTP3Listener":                 buildHTTP3Listener,
+ 	"buildOpentelemetryForLocation":      buildOpentelemetryForLocation,
+ 	"shouldLoadOpentelemetryModule":      shouldLoadOpentelemetryModule,
+ 	"buildModSecurityForLocation":        buildModSecurityForLocation,
+@@ -1376,7 +1377,7 @@ func buildHTTPListener(t, s interface{}) string {
+ 		addrV4 = tc.Cfg.BindAddressIpv4
+ 	}
+ 
+-	co := commonListenOptions(&tc, hostname)
++	co := commonListenOptions(&tc, hostname, false)
+ 
+ 	out = append(out, httpListener(addrV4, co, &tc)...)
+ 
+@@ -1409,7 +1410,7 @@ func buildHTTPSListener(t, s interface{}) string {
+ 		return ""
+ 	}
+ 
+-	co := commonListenOptions(&tc, hostname)
++	co := commonListenOptions(&tc, hostname, false)
+ 
+ 	addrV4 := []string{""}
+ 	if len(tc.Cfg.BindAddressIpv4) > 0 {
+@@ -1432,7 +1433,45 @@ func buildHTTPSListener(t, s interface{}) string {
+ 	return strings.Join(out, "\n")
+ }
+ 
+-func commonListenOptions(template *config.TemplateConfig, hostname string) string {
++func buildHTTP3Listener(t, s interface{}) string {
++	var out []string
++
++	tc, ok := t.(config.TemplateConfig)
++	if !ok {
++		klog.Errorf("expected a 'config.TemplateConfig' type but %T was returned", t)
++		return ""
++	}
++
++	hostname, ok := s.(string)
++	if !ok {
++		klog.Errorf("expected a 'string' type but %T was returned", s)
++		return ""
++	}
++
++	co := commonListenOptions(&tc, hostname, true)
++
++	addrV4 := []string{""}
++	if len(tc.Cfg.BindAddressIpv4) > 0 {
++		addrV4 = tc.Cfg.BindAddressIpv4
++	}
++
++	out = append(out, http3Listener(addrV4, co, &tc)...)
++
++	if !tc.IsIPV6Enabled {
++		return strings.Join(out, "\n")
++	}
++
++	addrV6 := []string{"[::]"}
++	if len(tc.Cfg.BindAddressIpv6) > 0 {
++		addrV6 = tc.Cfg.BindAddressIpv6
++	}
++
++	out = append(out, http3Listener(addrV6, co, &tc)...)
++
++	return strings.Join(out, "\n")
++}
++
++func commonListenOptions(template *config.TemplateConfig, hostname string, useHTTP3 bool) string {
+ 	var out []string
+ 
+ 	if template.Cfg.UseProxyProtocol {
+@@ -1451,7 +1490,11 @@ func commonListenOptions(template *config.TemplateConfig, hostname string) strin
+ 		out = append(out, "reuseport")
+ 	}
+ 
+-	out = append(out, fmt.Sprintf("backlog=%v", template.BacklogSize))
++	//filter backlog, due to unavailable to use with quic
++	//https://mailman.nginx.org/pipermail/nginx-devel/2024-January/UM73PXAEESYS36KEQTYMA5HSC2GK2C4L.html
++	if !useHTTP3 {
++		out = append(out, fmt.Sprintf("backlog=%v", template.BacklogSize))
++	}
+ 
+ 	return strings.Join(out, " ")
+ }
+@@ -1505,6 +1548,24 @@ func httpsListener(addresses []string, co string, tc *config.TemplateConfig) []s
+ 	return out
+ }
+ 
++func http3Listener(addresses []string, co string, tc *config.TemplateConfig) []string {
++	out := make([]string, 0)
++	for _, address := range addresses {
++		lo := []string{"listen"}
++
++		if address == "" {
++			lo = append(lo, fmt.Sprintf("%v", tc.ListenPorts.HTTPS))
++		} else {
++			lo = append(lo, fmt.Sprintf("%v:%v", address, tc.ListenPorts.HTTPS))
++		}
++
++		lo = append(lo, "quic", co, ";")
++		out = append(out, strings.Join(lo, " "))
++	}
++
++	return out
++}
++
+ func buildOpentelemetryForLocation(isOTEnabled, isOTTrustSet bool, location *ingress.Location) string {
+ 	isOTEnabledInLoc := location.Opentelemetry.Enabled
+ 	isOTSetInLoc := location.Opentelemetry.Set

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/006-nginx-build.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/006-nginx-build.patch
@@ -1,0 +1,277 @@
+diff --git a/images/nginx/rootfs/build.sh b/images/nginx/rootfs/build.sh
+index e352be10c..c103029b7 100755
+--- a/images/nginx/rootfs/build.sh
++++ b/images/nginx/rootfs/build.sh
+@@ -14,6 +14,9 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
++SOURCE_REPO="${SOURCE_REPO}"
++CONTROLLER_BRANCH="${CONTROLLER_BRANCH}"
++
+ set -o errexit
+ set -o nounset
+ set -o pipefail
+@@ -108,79 +111,10 @@ export OPENTELEMETRY_CPP_VERSION=v1.18.0
+ export OPENTELEMETRY_PROTO_VERSION=v1.5.0
+ 
+ export BUILD_PATH=/tmp/build
++export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64/
+ 
+ ARCH=$(uname -m)
+ 
+-get_src()
+-{
+-  hash="$1"
+-  url="$2"
+-  dest="${3-}"
+-  ARGS=""
+-  f=$(basename "$url")
+-
+-  echo "Downloading $url"
+-
+-  curl -sSL "$url" -o "$f"
+-  # TODO: Reenable checksum verification but make it smarter
+-  # echo "$hash  $f" | sha256sum -c - || exit 10
+-  if [ ! -z "$dest" ]; then
+-        mkdir ${BUILD_PATH}/${dest}
+-        ARGS="-C ${BUILD_PATH}/${dest} --strip-components=1"
+-  fi
+-  tar xvzf "$f" $ARGS
+-  rm -rf "$f"
+-}
+-
+-# install required packages to build
+-# Dependencies from "ninja" and below are OTEL dependencies
+-apk add \
+-  bash \
+-  gcc \
+-  clang \
+-  libc-dev \
+-  make \
+-  automake \
+-  openssl-dev \
+-  pcre-dev \
+-  zlib-dev \
+-  linux-headers \
+-  libxslt-dev \
+-  gd-dev \
+-  perl-dev \
+-  libedit-dev \
+-  mercurial \
+-  alpine-sdk \
+-  findutils \
+-  curl \
+-  ca-certificates \
+-  patch \
+-  libaio-dev \
+-  openssl \
+-  cmake \
+-  util-linux \
+-  lmdb-tools \
+-  wget \
+-  curl-dev \
+-  libprotobuf \
+-  git g++ pkgconf flex bison doxygen yajl-dev lmdb-dev libtool autoconf libxml2 libxml2-dev \
+-  python3 \
+-  libmaxminddb-dev \
+-  bc \
+-  unzip \
+-  dos2unix \
+-  yaml-cpp \
+-  coreutils \
+-  ninja \
+-  gtest-dev \
+-  git \
+-  build-base \
+-  pkgconfig \
+-  c-ares-dev \
+-  re2-dev \
+-  grpc-dev \
+-  protobuf-dev
+-
+ # apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/testing opentelemetry-cpp-dev
+ 
+ mkdir -p /etc/nginx
+@@ -188,90 +122,7 @@ mkdir -p /etc/nginx
+ mkdir --verbose -p "$BUILD_PATH"
+ cd "$BUILD_PATH"
+ 
+-# download, verify and extract the source files
+-get_src 66dc7081488811e9f925719e34d1b4504c2801c81dee2920e5452a86b11405ae \
+-        "https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
+-
+-get_src aa961eafb8317e0eb8da37eb6e2c9ff42267edd18b56947384e719b85188f58b \
+-        "https://github.com/vision5/ngx_devel_kit/archive/$NDK_VERSION.tar.gz" "ngx_devel_kit"
+-
+-get_src abc123 \
+-        "https://github.com/open-telemetry/opentelemetry-cpp/archive/$OPENTELEMETRY_CPP_VERSION.tar.gz" "opentelemetry-cpp"
+-
+-get_src abc123 \
+-        "https://github.com/open-telemetry/opentelemetry-proto/archive/$OPENTELEMETRY_PROTO_VERSION.tar.gz" "opentelemetry-proto"
+-
+-get_src cd5e2cc834bcfa30149e7511f2b5a2183baf0b70dc091af717a89a64e44a2985 \
+-        "https://github.com/openresty/set-misc-nginx-module/archive/$SETMISC_VERSION.tar.gz" "set-misc-nginx-module"
+-
+-get_src 0c0d2ced2ce895b3f45eb2b230cd90508ab2a773299f153de14a43e44c1209b3 \
+-        "https://github.com/openresty/headers-more-nginx-module/archive/$MORE_HEADERS_VERSION.tar.gz" "headers-more-nginx-module"
+-
+-get_src f09851e6309560a8ff3e901548405066c83f1f6ff88aa7171e0763bd9514762b \
+-        "https://github.com/atomx/nginx-http-auth-digest/archive/$NGINX_DIGEST_AUTH.tar.gz" "nginx-http-auth-digest"
+-
+-get_src a98b48947359166326d58700ccdc27256d2648218072da138ab6b47de47fbd8f \
+-        "https://github.com/yaoweibin/ngx_http_substitutions_filter_module/archive/$NGINX_SUBSTITUTIONS.tar.gz" "ngx_http_substitutions_filter_module"
+-
+-get_src 32a42256616cc674dca24c8654397390adff15b888b77eb74e0687f023c8751b \
+-        "https://github.com/SpiderLabs/ModSecurity-nginx/archive/$MODSECURITY_VERSION.tar.gz" "ModSecurity-nginx"
+-
+-get_src bc764db42830aeaf74755754b900253c233ad57498debe7a441cee2c6f4b07c2 \
+-        "https://github.com/openresty/lua-nginx-module/archive/$LUA_NGX_VERSION.tar.gz" "lua-nginx-module"
+-
+-get_src 01b715754a8248cc7228e0c8f97f7488ae429d90208de0481394e35d24cef32f \
+-        "https://github.com/openresty/stream-lua-nginx-module/archive/$LUA_STREAM_NGX_VERSION.tar.gz" "stream-lua-nginx-module"
+-
+-get_src a92c9ee6682567605ece55d4eed5d1d54446ba6fba748cff0a2482aea5713d5f \
+-        "https://github.com/openresty/lua-upstream-nginx-module/archive/$LUA_UPSTREAM_VERSION.tar.gz" "lua-upstream-nginx-module"
+-
+-get_src 77bbcbb24c3c78f51560017288f3118d995fe71240aa379f5818ff6b166712ff \
+-        "https://github.com/openresty/luajit2/archive/$LUAJIT_VERSION.tar.gz" "luajit2"
+-
+-get_src b6c9c09fd43eb34a71e706ad780b2ead26549a9a9f59280fe558f5b7b980b7c6 \
+-        "https://github.com/leev/ngx_http_geoip2_module/archive/$GEOIP2_VERSION.tar.gz" "ngx_http_geoip2_module"
+-
+-get_src deb4ab1ffb9f3d962c4b4a2c4bdff692b86a209e3835ae71ebdf3b97189e40a9 \
+-        "https://github.com/openresty/lua-resty-upload/archive/$LUA_RESTY_UPLOAD_VERSION.tar.gz" "lua-resty-upload"
+-
+-get_src bdbf271003d95aa91cab0a92f24dca129e99b33f79c13ebfcdbbcbb558129491 \
+-        "https://github.com/openresty/lua-resty-string/archive/$LUA_RESTY_STRING_VERSION.tar.gz" "lua-resty-string"
+-
+-get_src 16d72ed133f0c6df376a327386c3ef4e9406cf51003a700737c3805770ade7c5 \
+-        "https://github.com/openresty/lua-resty-balancer/archive/$LUA_RESTY_BALANCER.tar.gz" "lua-resty-balancer"
+-
+-get_src 39baab9e2b31cc48cecf896cea40ef6e80559054fd8a6e440cc804a858ea84d4 \
+-        "https://github.com/openresty/lua-resty-core/archive/$LUA_RESTY_CORE.tar.gz" "lua-resty-core"
+-
+-get_src a77b9de160d81712f2f442e1de8b78a5a7ef0d08f13430ff619f79235db974d4 \
+-        "https://github.com/openresty/lua-cjson/archive/$LUA_CJSON_VERSION.tar.gz" "lua-cjson"
+-
+-get_src 5ed48c36231e2622b001308622d46a0077525ac2f751e8cc0c9905914254baa4 \
+-        "https://github.com/cloudflare/lua-resty-cookie/archive/$LUA_RESTY_COOKIE_VERSION.tar.gz" "lua-resty-cookie"
+-
+-get_src 573184006b98ccee2594b0d134fa4d05e5d2afd5141cbad315051ccf7e9b6403 \
+-        "https://github.com/openresty/lua-resty-lrucache/archive/$LUA_RESTY_CACHE.tar.gz" "lua-resty-lrucache"
+-
+-get_src b4ddcd47db347e9adf5c1e1491a6279a6ae2a3aff3155ef77ea0a65c998a69c1 \
+-        "https://github.com/openresty/lua-resty-lock/archive/$LUA_RESTY_LOCK.tar.gz" "lua-resty-lock"
+-
+-get_src 70e9a01eb32ccade0d5116a25bcffde0445b94ad35035ce06b94ccd260ad1bf0 \
+-        "https://github.com/openresty/lua-resty-dns/archive/$LUA_RESTY_DNS.tar.gz" "lua-resty-dns"
+-
+-get_src 9fcb6db95bc37b6fce77d3b3dc740d593f9d90dce0369b405eb04844d56ac43f \
+-        "https://github.com/ledgetech/lua-resty-http/archive/$LUA_RESTY_HTTP.tar.gz" "lua-resty-http"
+-
+-get_src 02733575c4aed15f6cab662378e4b071c0a4a4d07940c4ef19a7319e9be943d4 \
+-        "https://github.com/openresty/lua-resty-memcached/archive/$LUA_RESTY_MEMCACHED_VERSION.tar.gz" "lua-resty-memcached"
+-
+-get_src c15aed1a01c88a3a6387d9af67a957dff670357f5fdb4ee182beb44635eef3f1 \
+-        "https://github.com/openresty/lua-resty-redis/archive/$LUA_RESTY_REDIS_VERSION.tar.gz" "lua-resty-redis"
+-
+-get_src efb767487ea3f6031577b9b224467ddbda2ad51a41c5867a47582d4ad85d609e \
+-        "https://github.com/api7/lua-resty-ipmatcher/archive/$LUA_RESTY_IPMATCHER_VERSION.tar.gz" "lua-resty-ipmatcher"
+-
+-get_src d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da \
+-        "https://github.com/microsoft/mimalloc/archive/${MIMALOC_VERSION}.tar.gz" "mimalloc"
++git clone -b "controller-v1.12.1" "${SOURCE_REPO}/kubernetes/ingress-nginx-deps.git" .
+ 
+ # improve compilation times
+ CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))
+@@ -295,7 +146,7 @@ cd "$BUILD_PATH/opentelemetry-cpp"
+ export CXXFLAGS="-DBENCHMARK_HAS_NO_INLINE_ASSEMBLY"
+ cmake -B build -G Ninja -Wno-dev \
+         -DOTELCPP_PROTO_PATH="${BUILD_PATH}/opentelemetry-proto/" \
+-        -DCMAKE_INSTALL_PREFIX=/usr \
++        -DCMAKE_INSTALL_PREFIX=/usr/local \
+         -DBUILD_SHARED_LIBS=ON \
+         -DBUILD_TESTING="OFF" \
+         -DBUILD_W3CTRACECONTEXT_TEST="OFF" \
+@@ -318,15 +169,16 @@ git config --global --add core.compression -1
+ 
+ # Get Brotli source and deps
+ cd "$BUILD_PATH"
+-git clone --depth=100 https://github.com/google/ngx_brotli.git
++git clone --depth=100 "${SOURCE_REPO}/google/ngx_brotli.git"
+ cd ngx_brotli
+ # https://github.com/google/ngx_brotli/issues/156
+ git reset --hard 63ca02abdcf79c9e788d2eedcc388d2335902e52
+ git submodule init
++git submodule set-url deps/brotli "${SOURCE_REPO}/google/brotli.git"
+ git submodule update
+ 
+ cd "$BUILD_PATH"
+-git clone --depth=1 https://github.com/ssdeep-project/ssdeep
++git clone --depth=1 "${SOURCE_REPO}/ssdeep-project/ssdeep"
+ cd ssdeep/
+ 
+ ./bootstrap
+@@ -337,10 +189,17 @@ make install
+ 
+ # build modsecurity library
+ cd "$BUILD_PATH"
+-git clone -n https://github.com/SpiderLabs/ModSecurity
++git clone -n "${SOURCE_REPO}/SpiderLabs/ModSecurity"
+ cd ModSecurity/
+ git checkout $MODSECURITY_LIB_VERSION
+ git submodule init
++git submodule set-url test/test-cases/secrules-language-tests "${SOURCE_REPO}/SpiderLabs/secrules-language-tests"
++git submodule set-url others/libinjection "${SOURCE_REPO}/libinjection/libinjection.git"
++git submodule set-url bindings/python "${SOURCE_REPO}/SpiderLabs/ModSecurity-Python-bindings.git"
++git submodule set-url others/mbedtls "${SOURCE_REPO}/Mbed-TLS/mbedtls.git"
++git submodule set-url others/mbedtls/framework "${SOURCE_REPO}/Mbed-TLS/mbedtls-framework"
++git submodule set-url others/mbedtls/tf-psa-crypto "${SOURCE_REPO}/Mbed-TLS/TF-PSA-Crypto.git"
++git submodule set-url others/mbedtls/tf-psa-crypto/framework "${SOURCE_REPO}/Mbed-TLS/mbedtls-framework"
+ git submodule update
+ 
+ sh build.sh
+@@ -370,7 +229,7 @@ echo "SecAuditLogStorageDir /var/log/audit/" >> /etc/nginx/modsecurity/modsecuri
+ # Download owasp modsecurity crs
+ cd /etc/nginx/
+ 
+-git clone -b $OWASP_MODSECURITY_CRS_VERSION https://github.com/coreruleset/coreruleset
++git clone -b $OWASP_MODSECURITY_CRS_VERSION "${SOURCE_REPO}/coreruleset/coreruleset"
+ mv coreruleset owasp-modsecurity-crs
+ cd owasp-modsecurity-crs
+ 
+@@ -528,7 +387,7 @@ make install
+ export OPENTELEMETRY_CONTRIB_COMMIT=8933841f0a7f8737f61404cf0a64acf6b079c8a5
+ cd "$BUILD_PATH"
+ 
+-git clone https://github.com/open-telemetry/opentelemetry-cpp-contrib.git opentelemetry-cpp-contrib-${OPENTELEMETRY_CONTRIB_COMMIT}
++git clone "${SOURCE_REPO}/open-telemetry/opentelemetry-cpp-contrib.git" opentelemetry-cpp-contrib-${OPENTELEMETRY_CONTRIB_COMMIT}
+ 
+ cd ${BUILD_PATH}/opentelemetry-cpp-contrib-${OPENTELEMETRY_CONTRIB_COMMIT}
+ git reset --hard ${OPENTELEMETRY_CONTRIB_COMMIT}
+@@ -537,7 +396,15 @@ export OTEL_TEMP_INSTALL=/tmp/otel
+ mkdir -p ${OTEL_TEMP_INSTALL}
+ 
+ cd ${BUILD_PATH}/opentelemetry-cpp-contrib-${OPENTELEMETRY_CONTRIB_COMMIT}/instrumentation/nginx
++# remove downloading nginx from cmake and clone it manually
++# by default cmake download nginx from internet
++# and change cmake NGINX_DIR
++sed -e "35d" nginx.cmake | sed -e "35i set(NGINX_DIR \"${BUILD_PATH}/opentelemetry-cpp-contrib-${OPENTELEMETRY_CONTRIB_COMMIT}/instrumentation/nginx/build/nginx/\")" | sed -e "27d" | sed -e "27i \ \ SOURCE_DIR nginx" > nginx.cmake.tmp
++rm -f nginx.cmake
++mv nginx.cmake.tmp nginx.cmake
++cat nginx.cmake
+ mkdir -p build
++cp -R "${BUILD_PATH}/nginx-$NGINX_VERSION" build/nginx
+ cd build
+ cmake -DCMAKE_BUILD_TYPE=Release \
+         -G Ninja \
+@@ -618,7 +485,7 @@ writeDirs=( \
+   /var/log/nginx \
+ );
+ 
+-adduser -S -D -H -u 101 -h /usr/local/nginx -s /sbin/nologin -G www-data -g www-data www-data
++adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
+ 
+ for dir in "${writeDirs[@]}"; do
+   mkdir -p ${dir};

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/007-new-metrics.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/007-new-metrics.patch
@@ -1,0 +1,171 @@
+diff --git a/internal/ingress/controller/store/store.go b/internal/ingress/controller/store/store.go
+index 284f53209..3e00ae2b5 100644
+--- a/internal/ingress/controller/store/store.go
++++ b/internal/ingress/controller/store/store.go
+@@ -55,6 +55,7 @@ import (
+ 	ngx_template "k8s.io/ingress-nginx/internal/ingress/controller/template"
+ 	"k8s.io/ingress-nginx/internal/ingress/defaults"
+ 	"k8s.io/ingress-nginx/internal/ingress/errors"
++	"k8s.io/ingress-nginx/internal/ingress/metric/collectors"
+ 	"k8s.io/ingress-nginx/internal/ingress/resolver"
+ 	"k8s.io/ingress-nginx/internal/k8s"
+ 	"k8s.io/ingress-nginx/pkg/apis/ingress"
+@@ -269,6 +270,8 @@ func New(
+ 		defaultSSLCertificate: defaultSSLCertificate,
+ 	}
+ 
++	collectors.WorkerStatusInstance.Set(store.backendConfig.MaxWorkerConnections, store.backendConfig.MaxWorkerOpenFiles, store.backendConfig.WorkerProcesses)
++
+ 	eventBroadcaster := record.NewBroadcaster()
+ 	eventBroadcaster.StartLogging(klog.Infof)
+ 	if !disableSyncEvents {
+@@ -1215,6 +1218,8 @@ func (s *k8sStore) setConfig(cmap *corev1.ConfigMap) {
+ 		s.backendConfig.UseGeoIP2 = false
+ 	}
+ 
++	collectors.WorkerStatusInstance.Set(s.backendConfig.MaxWorkerConnections, s.backendConfig.MaxWorkerOpenFiles, s.backendConfig.WorkerProcesses)
++
+ 	s.writeSSLSessionTicketKey(cmap, "/etc/ingress-controller/tickets.key")
+ }
+ 
+diff --git a/internal/ingress/metric/collectors/nginx_status.go b/internal/ingress/metric/collectors/nginx_status.go
+index f3afdc334..c9fe50594 100644
+--- a/internal/ingress/metric/collectors/nginx_status.go
++++ b/internal/ingress/metric/collectors/nginx_status.go
+@@ -17,13 +17,15 @@ limitations under the License.
+ package collectors
+ 
+ import (
+-	"log"
+-	"regexp"
+-	"strconv"
+-
+ 	"github.com/prometheus/client_golang/prometheus"
+ 	"k8s.io/ingress-nginx/internal/nginx"
+ 	"k8s.io/klog/v2"
++	"log"
++	"regexp"
++	"runtime"
++	"strconv"
++	"sync"
++	"syscall"
+ )
+ 
+ var (
+@@ -34,6 +36,53 @@ var (
+ 	waiting = regexp.MustCompile(`Waiting: (\d+)`)
+ )
+ 
++type WorkerStatus struct {
++	WorkerConnections  int
++	WorkerProcesses    int
++	WorkerRlimitNofile int
++	Lock               sync.Mutex
++}
++
++func rlimitMaxNumFiles() int {
++	var rLimit syscall.Rlimit
++	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit); err != nil {
++		return 0
++	}
++	return int(rLimit.Max)
++}
++
++func (w *WorkerStatus) Set(workerConnections, workerRlimitNofile int, workerProcesses string) {
++	w.Lock.Lock()
++	defer w.Lock.Unlock()
++	if workerRlimitNofile == 0 {
++		maxOpenFiles := rlimitMaxNumFiles() - 1024
++		if maxOpenFiles < 1024 {
++			maxOpenFiles = 1024
++		}
++		workerRlimitNofile = maxOpenFiles
++	}
++	w.WorkerRlimitNofile = workerRlimitNofile
++
++	if workerConnections == 0 {
++		workerConnections = int(float64(workerRlimitNofile * 3.0 / 4))
++	}
++	w.WorkerConnections = workerConnections
++
++	if n, err := strconv.Atoi(workerProcesses); err == nil {
++		w.WorkerProcesses = n
++	} else {
++		w.WorkerProcesses = runtime.NumCPU()
++	}
++}
++
++func (w *WorkerStatus) Get() (int, int, int) {
++	w.Lock.Lock()
++	defer w.Lock.Unlock()
++	return w.WorkerConnections, w.WorkerProcesses, w.WorkerRlimitNofile
++}
++
++var WorkerStatusInstance = &WorkerStatus{}
++
+ type (
+ 	nginxStatusCollector struct {
+ 		scrapeChan chan scrapeRequest
+@@ -42,9 +91,12 @@ type (
+ 	}
+ 
+ 	nginxStatusData struct {
+-		connectionsTotal *prometheus.Desc
+-		requestsTotal    *prometheus.Desc
+-		connections      *prometheus.Desc
++		workerConnections  *prometheus.Desc
++		workerProcesses    *prometheus.Desc
++		workerRlimitNofile *prometheus.Desc
++		connectionsTotal   *prometheus.Desc
++		requestsTotal      *prometheus.Desc
++		connections        *prometheus.Desc
+ 	}
+ 
+ 	basicStatus struct {
+@@ -86,6 +138,21 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
+ 	}
+ 
+ 	p.data = &nginxStatusData{
++		workerProcesses: prometheus.NewDesc(
++			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_processes"),
++			"worker processes",
++			nil, constLabels),
++
++		workerConnections: prometheus.NewDesc(
++			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_max_connections"),
++			"worker max connections",
++			nil, constLabels),
++
++		workerRlimitNofile: prometheus.NewDesc(
++			prometheus.BuildFQName(PrometheusNamespace, subSystem, "worker_rlimit_nofile"),
++			"worker rlimit nofile",
++			nil, constLabels),
++
+ 		connectionsTotal: prometheus.NewDesc(
+ 			prometheus.BuildFQName(PrometheusNamespace, subSystem, "connections_total"),
+ 			"total number of connections with state {accepted, handled}",
+@@ -107,6 +174,9 @@ func NewNGINXStatus(podName, namespace, ingressClass string) (NGINXStatusCollect
+ 
+ // Describe implements prometheus.Collector.
+ func (p nginxStatusCollector) Describe(ch chan<- *prometheus.Desc) {
++	ch <- p.data.workerProcesses
++	ch <- p.data.workerConnections
++	ch <- p.data.workerRlimitNofile
+ 	ch <- p.data.connectionsTotal
+ 	ch <- p.data.requestsTotal
+ 	ch <- p.data.connections
+@@ -179,6 +249,14 @@ func (p nginxStatusCollector) scrape(ch chan<- prometheus.Metric) {
+ 
+ 	s := parse(string(data))
+ 
++	workerConnections, workerProcesses, workerRlimitNofile := WorkerStatusInstance.Get()
++
++	ch <- prometheus.MustNewConstMetric(p.data.workerConnections,
++		prometheus.GaugeValue, float64(workerConnections))
++	ch <- prometheus.MustNewConstMetric(p.data.workerProcesses,
++		prometheus.GaugeValue, float64(workerProcesses))
++	ch <- prometheus.MustNewConstMetric(p.data.workerRlimitNofile,
++		prometheus.GaugeValue, float64(workerRlimitNofile))
+ 	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,
+ 		prometheus.CounterValue, float64(s.Accepted), "accepted")
+ 	ch <- prometheus.MustNewConstMetric(p.data.connectionsTotal,

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/008-default-backend-fix.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/008-default-backend-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
+index ea178a7c7..ae8c79bd9 100644
+--- a/internal/ingress/controller/controller.go
++++ b/internal/ingress/controller/controller.go
+@@ -942,6 +942,7 @@ func (n *NGINXController) getBackendServers(ingresses []*ingress.Ingress) ([]*in
+ 					nb := upstream.DeepCopy()
+ 					nb.Name = name
+ 					nb.Endpoints = endps
++					nb.Service = location.DefaultBackend
+ 					aUpstreams = append(aUpstreams, nb)
+ 					location.DefaultBackendUpstreamName = name
+ 

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/009-balancer-lua.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/009-balancer-lua.patch
@@ -1,0 +1,45 @@
+diff --git a/rootfs/etc/nginx/lua/balancer.lua b/rootfs/etc/nginx/lua/balancer.lua
+index e6ddc1907..389dd799b 100644
+--- a/rootfs/etc/nginx/lua/balancer.lua
++++ b/rootfs/etc/nginx/lua/balancer.lua
+@@ -126,6 +126,13 @@ local function sync_backend(backend)
+ 
+   if not balancer then
+     balancers[backend.name] = implementation:new(backend)
++    if backend.ingress then
++      balancers[backend.name]["ingress_name"] = backend.ingress.metadata.name
++    end
++    if backend.service then
++      balancers[backend.name]["backend_name"] = backend.service.metadata.name
++      balancers[backend.name]["backend_port"] = backend.port
++    end
+     return
+   end
+ 
+@@ -137,6 +144,13 @@ local function sync_backend(backend)
+         string.format("LB algorithm changed from %s to %s, resetting the instance",
+                       balancer.name, implementation.name))
+     balancers[backend.name] = implementation:new(backend)
++    if backend.ingress then
++      balancers[backend.name]["ingress_name"] = backend.ingress.metadata.name
++    end
++    if backend.service then
++      balancers[backend.name]["backend_name"] = backend.service.metadata.name
++      balancers[backend.name]["backend_port"] = backend.port
++    end
+     return
+   end
+ 
+@@ -336,6 +350,12 @@ function _M.balance()
+     return
+   end
+ 
++  if balancer["ingress_name"] then ngx.var.ingress_name = balancer["ingress_name"]:gsub("%-rwr", "") end
++  if not (ngx.var.proxy_upstream_name == "upstream-default-backend") then
++    if balancer["backend_name"] then ngx.var.service_name = balancer["backend_name"] end
++    if balancer["backend_port"] then ngx.var.service_port = balancer["backend_port"] end
++  end
++
+   local peer = balancer:balance()
+   if not peer then
+     ngx.log(ngx.WARN, "no peer was returned, balancer: " .. balancer.name)

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/010-nginx-tmpl.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/010-nginx-tmpl.patch
@@ -1,0 +1,210 @@
+diff --git a/rootfs/etc/nginx/lua/nginx/ngx_conf_log.lua b/rootfs/etc/nginx/lua/nginx/ngx_conf_log.lua
+index 8f3d57be6..5ea886093 100644
+--- a/rootfs/etc/nginx/lua/nginx/ngx_conf_log.lua
++++ b/rootfs/etc/nginx/lua/nginx/ngx_conf_log.lua
+@@ -1,2 +1,2 @@
+-local monitor = require("monitor")
+-monitor.call()
+\ No newline at end of file
++local monitor = require("pbmetrics")
++pbmetrics.call()
+diff --git a/rootfs/etc/nginx/lua/nginx/ngx_conf_log_block.lua b/rootfs/etc/nginx/lua/nginx/ngx_conf_log_block.lua
+index 72f6a6430..d667871c6 100644
+--- a/rootfs/etc/nginx/lua/nginx/ngx_conf_log_block.lua
++++ b/rootfs/etc/nginx/lua/nginx/ngx_conf_log_block.lua
+@@ -1,5 +1,5 @@
+ local balancer = require("balancer")
+-local monitor = require("monitor")
++local pbmetrics = require("pbmetrics")
+ 
+ local luaconfig = ngx.shared.luaconfig
+ local enablemetrics = luaconfig:get("enablemetrics")
+@@ -7,5 +7,5 @@ local enablemetrics = luaconfig:get("enablemetrics")
+ balancer.log()
+ 
+ if enablemetrics then
+-    monitor.call()
+-end
+\ No newline at end of file
++    pbmetrics.call()
++end
+diff --git a/rootfs/etc/nginx/lua/ngx_conf_init.lua b/rootfs/etc/nginx/lua/ngx_conf_init.lua
+index 9789386ac..25bdc7939 100644
+--- a/rootfs/etc/nginx/lua/ngx_conf_init.lua
++++ b/rootfs/etc/nginx/lua/ngx_conf_init.lua
+@@ -35,11 +35,11 @@ else
+   balancer = res
+ end
+ if configfile.enable_metrics then
+-    ok, res = pcall(require, "monitor")
++    ok, res = pcall(require, "pbmetrics")
+     if not ok then
+         error("require failed: " .. tostring(res))
+     else
+-        monitor = res
++        pbmetrics = res
+     end
+ end
+ ok, res = pcall(require, "certificate")
+@@ -50,4 +50,4 @@ else
+   if configfile.enable_ocsp then
+     certificate.is_ocsp_stapling_enabled = configfile.enable_ocsp
+   end
+-end
+\ No newline at end of file
++end
+diff --git a/rootfs/etc/nginx/lua/ngx_conf_init_worker.lua b/rootfs/etc/nginx/lua/ngx_conf_init_worker.lua
+index cba866136..da6c2569b 100644
+--- a/rootfs/etc/nginx/lua/ngx_conf_init_worker.lua
++++ b/rootfs/etc/nginx/lua/ngx_conf_init_worker.lua
+@@ -7,9 +7,7 @@ local configfile = cjson.decode(content)
+ 
+ local lua_ingress = require("lua_ingress")
+ local balancer = require("balancer")
+-local monitor = require("monitor")
++local pbmetrics = require("pbmetrics")
+ lua_ingress.init_worker()
+ balancer.init_worker()
+-if configfile.enable_metrics and configfile.monitor_batch_max_size then
+-  monitor.init_worker(configfile.monitor_batch_max_size)
+-end
+\ No newline at end of file
++pbmetrics.init_worker()
+diff --git a/rootfs/etc/nginx/template/nginx.tmpl b/rootfs/etc/nginx/template/nginx.tmpl
+index 1f17952a1..e3ff6408d 100644
+--- a/rootfs/etc/nginx/template/nginx.tmpl
++++ b/rootfs/etc/nginx/template/nginx.tmpl
+@@ -12,6 +12,9 @@
+ # setup custom paths that do not require root access
+ pid {{ .PID }};
+ 
++# enables the use of “just-in-time compilation” for the regular expressions known by the time of configuration parsing
++pcre_jit on;
++
+ {{ if $cfg.UseGeoIP2 }}
+ load_module /etc/nginx/modules/ngx_http_geoip2_module.so;
+ {{ end }}
+@@ -355,6 +358,15 @@ http {
+         {{ $reqUri }} 0;{{ end }}
+         default 1;
+     }
++    map $server_name $total_upstream_response_time {
++        default 0;
++    }
++    map $server_name $upstream_retries {
++        default 0;
++    }
++    map $server_name $formatted_status {
++        default $status;
++    }
+ 
+     {{ if or $cfg.DisableAccessLog $cfg.DisableHTTPAccessLog }}
+     access_log off;
+@@ -554,6 +566,9 @@ http {
+ 
+         {{ buildHTTPListener  $all $redirect.From }}
+         {{ buildHTTPSListener $all $redirect.From }}
++        {{ if $cfg.UseHTTP3 }}
++        {{ buildHTTP3Listener $all $redirect.From }}
++        {{ end }}
+ 
+         ssl_certificate_by_lua_file /etc/nginx/lua/nginx/ngx_conf_certificate.lua;
+ 
+@@ -568,7 +583,7 @@ http {
+         }
+         {{ end }}
+ 
+-        set_by_lua_file $redirect_to /etc/nginx/lua/nginx/ngx_srv_redirect.lua {{ $redirect.To }}; 
++        set_by_lua_file $redirect_to /etc/nginx/lua/nginx/ngx_srv_redirect.lua {{ $redirect.To }};
+ 
+         return {{ $all.Cfg.HTTPRedirectCode }} $redirect_to;
+     }
+@@ -688,7 +703,7 @@ stream {
+     lua_package_path "/etc/nginx/lua/?.lua;/etc/nginx/lua/vendor/?.lua;;";
+ 
+     lua_shared_dict tcp_udp_configuration_data 5M;
+-    
++
+     {{ buildResolvers $cfg.Resolver $cfg.DisableIpv6DNS }}
+ 
+     init_by_lua_file /etc/nginx/lua/ngx_conf_init_stream.lua;
+@@ -819,13 +834,14 @@ stream {
+             proxy_set_header       Host               $best_http_host;
+ 
+             set $proxy_upstream_name {{ $upstreamName | quote }};
++            set $formatted_status $status;
++            set $upstream_retries "0";
++            set $total_upstream_response_time "0";
+ 
+             rewrite                (.*) / break;
+ 
+             proxy_pass            http://upstream_balancer;
+-            {{ if $enableMetrics }}
+             log_by_lua_file /etc/nginx/lua/nginx/ngx_conf_log.lua;
+-            {{ end }}
+         }
+         {{ end }}
+ {{ end }}
+@@ -870,8 +886,14 @@ stream {
+ 
+         {{ buildHTTPListener  $all $server.Hostname }}
+         {{ buildHTTPSListener $all $server.Hostname }}
++        {{ if $all.Cfg.UseHTTP3 }}
++        {{ buildHTTP3Listener $all $server.Hostname }}
++        {{ end }}
+ 
+         set $proxy_upstream_name "-";
++        set $formatted_status $status;
++        set $upstream_retries "0";
++        set $total_upstream_response_time "0";
+ 
+         {{ if not ( empty $server.CertificateAuth.MatchCN ) }}
+         {{ if gt (len $server.CertificateAuth.MatchCN) 0 }}
+@@ -1030,6 +1052,10 @@ stream {
+             proxy_set_header            X-Auth-Request-Redirect $request_uri;
+             {{ end }}
+ 
++            {{ if not (contains $externalAuth.AuthSnippet "proxy_connect_timeout") }}
++            proxy_connect_timeout                   15s;
++            {{ end }}
++
+             {{ if $externalAuth.AuthCacheKey }}
+             proxy_buffering                         "on";
+             {{ else }}
+@@ -1105,6 +1131,9 @@ stream {
+         {{ end }}
+ 
+         location {{ $path }} {
++            {{ if $all.Cfg.UseHTTP3 }}
++            add_header Alt-Svc 'h3=":{{ $all.ListenPorts.HTTPS }}"; ma=86400';
++            {{ end }}
+             {{ $ing := (getIngressInformation $location.Ingress $server.Hostname $location.IngressPath) }}
+             set $namespace      {{ $ing.Namespace | quote}};
+             set $ingress_name   {{ $ing.Rule | quote }};
+@@ -1112,6 +1141,8 @@ stream {
+             set $service_port   {{ $ing.ServicePort | quote }};
+             set $location_path  {{ $ing.Path | escapeLiteralDollar | quote }};
+ 
++            set $content_kind "";
++
+             {{ buildOpentelemetryForLocation $all.Cfg.EnableOpentelemetry $all.Cfg.OpentelemetryTrustIncomingSpan $location }}
+ 
+             {{ if $location.Mirror.Source }}
+@@ -1412,14 +1443,15 @@ stream {
+ 
+         {{ if eq $server.Hostname "_" }}
+         # health checks in cloud providers require the use of port {{ $all.ListenPorts.HTTP }}
+-        location {{ $all.HealthzURI }} {
++        location = {{ $all.HealthzURI }} {
+ 
+             {{ if $all.Cfg.EnableOpentelemetry }}
+             opentelemetry off;
+             {{ end }}
+ 
+             access_log off;
+-            return 200;
++            proxy_set_header D8s-External-Check "True";
++            proxy_pass http://127.0.0.1:10254;
+         }
+ 
+         # this is required to avoid error if nginx is being monitored

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/011-auth-cookie-always.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/011-auth-cookie-always.patch
@@ -1,0 +1,16 @@
+diff --git a/rootfs/etc/nginx/template/nginx.tmpl b/rootfs/etc/nginx/template/nginx.tmpl
+index a43d3054a..881b4d6d0 100644
+--- a/rootfs/etc/nginx/template/nginx.tmpl
++++ b/rootfs/etc/nginx/template/nginx.tmpl
+@@ -1233,11 +1233,7 @@ stream {
+             {{ else }}
+             auth_request        {{ $authPath }};
+             auth_request_set    $auth_cookie $upstream_http_set_cookie;
+-            {{ if $externalAuth.AlwaysSetCookie }}
+             add_header          Set-Cookie $auth_cookie always;
+-            {{ else }}
+-            add_header          Set-Cookie $auth_cookie;
+-            {{ end }}
+             {{- range $line := buildAuthResponseHeaders $proxySetHeader $externalAuth.ResponseHeaders false }}
+             {{ $line }}
+             {{- end }}

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
@@ -1,0 +1,77 @@
+## Patches
+
+### 001-lua-info.patch
+
+There are two patches to fix the problem with ingress names in logs and metrics.
+Unfortunately, the PR was declined in the upstream.
+<https://github.com/kubernetes/ingress-nginx/pull/4367>
+
+### 002-makefile.patch
+
+Run the build locally, not inside the container.
+
+### 003-healthcheck.patch
+
+After catching SIGTERM, ingress stops responding to the readiness probe.
+The combination of this patch and the `EndpointSliceTerminatingCondition` feature gate for kube-proxy helps us avoid
+traffic loss on rollout updates.
+Update: for external load balancers it's advisable to get 5xx if a SIGTERM was sent to the controller, we control this logic by applying/checking `D8s-External-Check` http header.
+
+Backport of the behavior of the later versions of ingress nginx controller.
+The `sleep` is needed to gracefully shut down ingress controllers behind a cloud load balancer.
+
+### 004-util.patch
+
+Adds "-e /dev/null" flags to the "nginx -t" invocations so that "nginx -t" logs aren't got saved to /var/log/nginx/error.log file, preventing fs bloating.
+
+### 005-add-http3.patch
+
+Add HTTP/3 support.
+
+We have made two PRs in upstream to bump ingress-nginx image and to enable http3 module.
+But we did not add full support for http3 in upstream, because at that time OpenSSL did not fully support quic.
+
+Bump the image and enable http3 module: <https://github.com/kubernetes/ingress-nginx/pull/11470>
+README about next steps for upstream: <https://github.com/kubernetes/ingress-nginx/pull/11513>
+
+README: <https://github.com/kubernetes/ingress-nginx/blob/main/images/nginx/README.md>
+
+When OpenSSL fully supports quic, the work can be continued.
+To add fully support - steps from the readme should be accomplished and after this the patch can be deleted.
+
+### 006-nginx-build.patch
+
+Build nginx for controller on ALT Linux.
+
+### 007-new-metrics.patch
+
+This patch adds worker max connections, worker processes and worker max open files metrics.
+
+### 008-default-backend-fix.patch
+
+Fixes the problem with the controller when Ingress specifies `Service` with the `ExternalName` type as the main backend, and the default backend (using an annotation `nginx.ingress.kubernetes.io/default-backend`) - with the ClusterIP type. You can see the detailed cases here:
+<https://github.com/kubernetes/ingress-nginx/issues/12158>
+<https://github.com/kubernetes/ingress-nginx/issues/12173>
+<https://github.com/deckhouse/deckhouse/issues/9933>
+
+### 009-balancer-lua.patch
+
+TODO: update readme with patch description
+
+### 010-nginx-tmpl.patch
+
+- Enable our metrics collector instead of the default one.
+- Enable pcre_jit.
+- Add the health check server to provide the way for an external load balancer to check that the ingress controller will be terminated soon.
+- Set default values for upstream_retries and total_upstream_response_time to avoid incorrect logs when it is a raw tcp request.
+- Set proxy connect timeout for auth locations.
+- Replace the status field with formatted status field which is explicitly converted to number to avoid incorrect logs when response status is 009.
+
+We do not intend to make a PR to the upstream with these changes, because there are only our custom features.
+
+### 011-auth-cookie-always.patch
+
+Without always option toggled, ingress-nginx does not set the cookie in case if backend returns >=400 code, which may lead to dex refresh token invalidation.
+Annotation `nginx.ingress.kubernetes.io/auth-always-set-cookie` does not work. Anyway, we can't use it, because we need this behavior for all ingresses.
+
+<https://github.com/kubernetes/ingress-nginx/pull/8213>

--- a/modules/402-ingress-nginx/images/controller-1-12/rootfs/etc/nginx/lua/geohash.lua
+++ b/modules/402-ingress-nginx/images/controller-1-12/rootfs/etc/nginx/lua/geohash.lua
@@ -1,0 +1,175 @@
+local GeoHash = {}
+
+--[[
+-- Private Attributes
+]]--
+
+local _map = {}
+      _map['0'] = '00000'
+      _map['1'] = '00001'
+      _map['2'] = '00010'
+      _map['3'] = '00011'
+      _map['4'] = '00100'
+      _map['5'] = '00101'
+      _map['6'] = '00110'
+      _map['7'] = '00111'
+      _map['8'] = '01000'
+      _map['9'] = '01001'
+      _map['b'] = '01010'
+      _map['c'] = '01011'
+      _map['d'] = '01100'
+      _map['e'] = '01101'
+      _map['f'] = '01110'
+      _map['g'] = '01111'
+      _map['h'] = '10000'
+      _map['j'] = '10001'
+      _map['k'] = '10010'
+      _map['m'] = '10011'
+      _map['n'] = '10100'
+      _map['p'] = '10101'
+      _map['q'] = '10110'
+      _map['r'] = '10111'
+      _map['s'] = '11000'
+      _map['t'] = '11001'
+      _map['u'] = '11010'
+      _map['v'] = '11011'
+      _map['w'] = '11100'
+      _map['x'] = '11101'
+      _map['y'] = '11110'
+      _map['z'] = '11111'
+
+local _precision = nil
+local _digits    = 0
+
+--[[
+-- Private Methods
+]]--
+
+local function _decode(coord, min, max)
+    local mid = 0.0
+    local val = 0.0
+    for i = 1, #coord do
+        if coord:sub(i, i) == '1' then
+            min = mid
+            val = (mid + max) / 2
+            mid = val
+        else
+            max = mid
+            val = (mid + min) / 2
+            mid = val
+        end
+    end
+    -- We want number of decimals according to hash length
+    val = tonumber(string.format("%.".. (#coord / 5) .. "f", val))
+    return val
+end
+
+local function _encode(coord, min, max)
+    local mid =   0.0
+    local x   =   0.0
+    local y   =   0.0
+    local p   = ((_precision or _digits) * 5)
+    local result = ''
+    for i = 1, p do
+        if coord <= max and coord >= mid then
+            result = result .. '1'
+            x = mid
+            y = max
+        else
+            result = result .. '0'
+            x = min
+            y = mid
+        end
+        min = x
+        mid = x + ((y - x) / 2)
+        max = y
+    end
+    return result
+end
+
+local function _merge(latbin, longbin)
+    local res = ''
+    for i = 1, #latbin do
+        res = res .. longbin:sub(i, i)  .. latbin:sub(i, i)
+    end
+    return res
+end
+
+local function _swap(tbl)
+    local table = {}
+    for key, val in pairs(tbl) do
+        table[val] = key
+    end
+    return table
+end
+
+local function _translate(bstr)
+    local hash = ''
+    local t = _swap(_map)
+    for i = 1, #bstr, 5 do
+        hash = hash .. t[bstr:sub(i, i + 4)]
+    end
+    return hash
+end
+
+local function _decimals(lat, long)
+     local d1 = tostring(string.match(tostring(lat), "%d+.(%d+)") or '')
+     local d2 = tostring(string.match(tostring(long), "%d+.(%d+)") or '')
+     local ret = #d2
+     if #d1 > #d2 then
+         ret = #d1
+     elseif #d1 == 0 and #d2 == 0 then
+         -- if no digits default to 2
+         ret = 2
+     end
+     return ret
+end
+
+--[[
+-- Public Methods
+]]--
+
+function GeoHash.decode(hash)
+    local bin  = ''
+    local long = ''
+    local lat  = ''
+    local c    = ''
+    -- Convert hash to binary string
+    for i = 1, #hash do
+        c = hash:sub(i, i)
+        if _map[c] ~= nil then
+            bin = bin .. _map[c]
+        else
+            -- Invalid hash character, return nil
+            return nil, nil
+        end
+    end
+    -- Split binary string into latitude and longitude parts
+    for i = 1, #bin do
+        c = bin:sub(i, i)
+        if i % 2 == 0 then
+            lat = lat .. c
+        else
+            long = long .. c
+        end
+    end
+    return _decode(lat, -90.0, 90.0), _decode(long, -180.0, 180.0)
+end
+
+function GeoHash.encode(lat, long)
+    -- Find precision
+    _digits = _decimals(lat, long)
+    -- Translate coordinates to binary string format
+    local a = _encode(lat, -90.0, 90.0)
+    local b = _encode(long, -180.0, 180.0)
+    -- Merge the two binary string
+    local binstr = _merge(a, b)
+    -- Calculate GeoHash for binary string
+    return _translate(binstr)
+end
+
+function GeoHash.precision(p)
+    _precision = p
+end
+
+return GeoHash

--- a/modules/402-ingress-nginx/images/controller-1-12/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-12/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -1,0 +1,442 @@
+--[[
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+
+local socket = ngx.socket.tcp
+local parse_http_time = ngx.parse_http_time
+-- local timer_at = ngx.timer.at
+local timer_every = ngx.timer.every
+-- local worker_id = ngx.worker.id
+-- local running_timers = ngx.timer.running_count
+-- local pending_timers = ngx.timer.pending_count
+local now = ngx.now
+local update_time = ngx.update_time
+
+local log = ngx.log
+local ERROR = ngx.ERR
+local WARNING = ngx.WARN
+
+local get_env = os.getenv
+
+local new_tab = require "table.new"
+local clear_tab = require "table.clear"
+local nkeys = require "table.nkeys"
+local remove = table.remove
+local insert_tab = table.insert
+
+local match = string.match
+local gmatch = string.gmatch
+local sub = string.sub
+local format = string.format
+
+local iconv = require "iconv"
+local utf8enc = iconv.new("utf-8", "latin1")
+
+local GeoHash = require "geohash"
+GeoHash.precision(2)
+local geohash_encode = GeoHash.encode
+
+local buffer = new_tab(0, 100000)
+local debug_enabled = get_env("LUA_DEBUG")
+local use_geoip2 = get_env("LUA_USE_GEOIP2")
+
+-- setup protobuf
+local pb = require "pb"
+local protoc = require "protoc"
+local pbuff = require "pb.buffer"
+
+local p = protoc.new()
+
+p:load([[
+syntax="proto3";
+
+package proto;
+
+message HistogramMessage {
+    int32 MappingIndex = 1;
+    repeated string Labels = 2;
+    map<string, uint64> Buckets = 3;
+    double Sum = 4;
+    uint64 Count = 5;
+    map<string, string> Annotations = 6;
+}
+
+message CounterMessage {
+    int32 MappingIndex = 1;
+    repeated string Labels = 2;
+    uint64 Value = 3;
+    map<string, string> Annotations = 4;
+}
+
+message GaugeMessage {
+    int32 MappingIndex = 1;
+    repeated string Labels = 2;
+    double Value = 3;
+    map<string, string> Annotations = 4;
+}
+]])
+
+local _HISTOGRAM_TYPE = 1
+local _GAUGE_TYPE = 2
+local _COUNTER_TYPE = 3
+
+local function encode_buffer(buf, type, bytes)
+  buf:pack("u", type)
+  buf:pack("s", bytes)
+end
+
+local function protohist(buf, value)
+  local bytes = pb.encode("proto.HistogramMessage", value)
+  encode_buffer(buf, _HISTOGRAM_TYPE, bytes)
+end
+
+local function protogauge(buf, value)
+  local bytes = pb.encode("proto.GaugeMessage", value)
+  encode_buffer(buf, _GAUGE_TYPE, bytes)
+end
+
+local function protocounter(buf, value)
+  local bytes = pb.encode("proto.CounterMessage", value)
+  encode_buffer(buf, _COUNTER_TYPE, bytes)
+end
+
+local function _extract_labels(line)
+  local t = {}
+  for token in gmatch(line, "[^#]+") do
+    t[#t + 1] = token
+  end
+  remove(t, 1)
+  return t
+end
+
+-- _add() adds value to the metric
+local function _add(metrichash, annotations, mapping, value)
+  local metric_data = buffer[metrichash] or { MappingIndex = mapping, Value = 0, Labels = _extract_labels(metrichash), Annotations = annotations }
+  metric_data["Value"] = metric_data["Value"] + value
+  buffer[metrichash] = metric_data
+end
+
+-- _increment() adds one to the metric
+local function _increment(metrichash, annotations, mapping)
+  _add(metrichash, annotations, mapping, 1)
+end
+
+local function _observe(buckets, metrichash, annotations, mapping, value)
+  local metric_data = buffer[metrichash] or { MappingIndex = mapping, Sum = 0, Count = 0, Labels = _extract_labels(metrichash), Annotations = annotations }
+  metric_data["Sum"] = metric_data["Sum"] + value
+  metric_data["Count"] = metric_data["Count"] + 1
+
+  if not metric_data["Buckets"] then
+    metric_data["Buckets"] = {}
+  end
+
+  for _, bucket in pairs(buckets) do
+    if value <= bucket then
+      local bucket_name = tostring(bucket)
+      metric_data["Buckets"][bucket_name] = (metric_data["Buckets"][bucket_name] or 0) + 1
+      break
+    end
+  end
+  buffer[metrichash] = metric_data
+end
+
+local _TIME_BUCKETS = { 0.001, 0.002, 0.003, 0.004, 0.005, 0.01, 0.015, 0.02, 0.025, 0.03, 0.035, 0.04, 0.045, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 90, 120, 180, 240, 270, 300, 360, 420, 480, 540, 600, 900, 1200, 1500, 1800, 3600 }
+
+-- _time_observe() prepares histogram metrics for time buckets
+local function _time_observe(metrichash, annotations, mapping, value)
+  _observe(_TIME_BUCKETS, metrichash, annotations, mapping, value)
+end
+
+local _BYTES_BUCKETS = { 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456, 536870912, 1073741824, 2147483648, 4294967296 }
+
+-- _bytes_observe() prepares histogram metrics for bytes buckets
+local function _bytes_observe(metrichash, annotations, mapping, value)
+  _observe(_BYTES_BUCKETS, metrichash, annotations, mapping, tonumber(value))
+end
+
+local _LOWRES_BUCKETS = { 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 1.5, 2, 3, 4, 5, 10 }
+
+-- _lowres_observe() prepares histogram metrics for lowres time buckets
+local function _lowres_observe(metrichash, annotations, mapping, value)
+  _observe(_LOWRES_BUCKETS, metrichash, annotations, mapping, value)
+end
+
+local function _increment_geohash(overall_key, geoip_latitude, geoip_longitude, var_geoip_city, var_geoip_region_name, var_geoip_country_name, annotations)
+  local geoip_latitude = tonumber(geoip_latitude)
+  local geoip_longitude = tonumber(geoip_longitude)
+
+  if geoip_latitude and geoip_longitude then
+    local geohash = geohash_encode(geoip_latitude, geoip_longitude)
+
+    local place = "Unknown"
+    if var_geoip_city then
+      place = var_geoip_city
+    elseif var_geoip_region_name then
+      place = var_geoip_region_name
+    elseif var_geoip_country_name then
+      place = var_geoip_country_name
+    end
+
+    local coded_place, err = utf8enc:iconv(place)
+    if err then
+      coded_place = place -- Try to send place as it is, exporter prepare propper metric for invalid place name
+    end
+
+    -- geohash
+    _increment("c21#" .. overall_key .. "#" .. geohash .. "#" .. coded_place, annotations, 21)
+  end
+end
+
+-- fill_buffer() prepares metrics
+local function fill_buffer()
+  local start_time = now()
+
+  -- default values
+  ngx.var.total_upstream_response_time = 0
+  ngx.var.upstream_retries = 0
+
+  -- Since the 0.41 version ingress controller renders weird vhost for wildcard hosts like ~^(?<subdomain>[\w-]+)\.example\.com$
+  -- For older versions we just cut of the asterisk from vhost
+  local var_server_name = ngx.var.server_name:gsub("^*", ""):gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("$$", ""):gsub("\\", "")
+
+  local content_kind
+  local var_upstream_x_content_kind = ngx.var.upstream_x_content_kind
+  local var_upstream_addr = ngx.var.upstream_addr
+  local var_http_upgrade = ngx.var.http_upgrade
+  local var_upstream_http_cache_control = ngx.var.upstream_http_cache_control
+  local var_upstream_http_expires = ngx.var.upstream_http_expires
+
+  if var_upstream_x_content_kind then
+    content_kind = var_upstream_x_content_kind
+
+  elseif not var_upstream_addr then
+    content_kind = 'served-without-upstream'
+
+  elseif var_http_upgrade then
+    content_kind = string.lower(var_http_upgrade)
+
+  elseif var_upstream_http_cache_control or var_upstream_http_expires then
+    local cacheable = true
+    if var_upstream_http_cache_control then
+      if match(var_upstream_http_cache_control, "no-cache") or match(var_upstream_http_cache_control, "no-store") or match(var_upstream_http_cache_control, "private") then
+        cacheable = false
+      end
+    end
+
+    if var_upstream_http_expires then
+      local var_upstream_http_expires_parsed = parse_http_time(var_upstream_http_expires)
+      if not var_upstream_http_expires_parsed or var_upstream_http_expires_parsed <= ngx.time() then
+        cacheable = false
+      end
+    end
+
+    local var_upstream_http_vary = ngx.var.upstream_http_vary
+    if var_upstream_http_vary and var_upstream_http_vary == "*" then
+      cacheable = false
+    end
+
+    if ngx.var.upstream_http_set_cookie then
+      cacheable = false
+    end
+
+    if cacheable then
+      content_kind = 'cacheable'
+    else
+      content_kind = 'non-cacheable'
+    end
+  else
+    content_kind = 'cache-headers-not-present'
+  end
+
+  ngx.var.content_kind = content_kind
+
+  local var_namespace = ngx.var.namespace == "" and "-" or ngx.var.namespace
+  local var_ingress_name = ngx.var.ingress_name == "" and "-" or ngx.var.ingress_name
+  local var_service_name = ngx.var.service_name == "" and "-" or ngx.var.service_name
+  local var_service_port = ngx.var.service_port == "" and "-" or ngx.var.service_port
+  local var_location_path = ngx.var.location_path == "" and "-" or ngx.var.location_path
+  local var_annotations = { namespace = var_namespace, ingress = var_ingress_name }
+
+  local overall_key = content_kind .. "#" .. var_namespace .. "#" .. var_server_name
+  local detail_key = content_kind .. "#" .. var_namespace .. "#" .. var_ingress_name .. "#" .. var_service_name .. "#" .. var_service_port .. "#" .. var_server_name .. "#" .. var_location_path
+  local backend_key = var_namespace .. "#" .. var_ingress_name .. "#" .. var_service_name .. "#" .. var_service_port .. "#" .. var_server_name .. "#" .. var_location_path
+  -- requests
+  local var_scheme = ngx.var.scheme
+  local var_request_method = ngx.var.request_method
+  _increment("c00#" .. overall_key .. "#" .. var_scheme .. "#" .. var_request_method, var_annotations, 0)
+  _increment("c01#" .. detail_key .. "#" .. var_scheme .. "#" .. var_request_method, var_annotations, 1)
+
+  -- responses
+  ngx.var.formatted_status = tonumber(ngx.var.status)
+  local var_status = tonumber(ngx.var.status)
+  _increment("c02#" .. overall_key .. "#" .. var_status, var_annotations, 2)
+  _increment("c03#" .. detail_key .. "#" .. var_status, var_annotations, 3)
+
+  -- request time
+  local var_request_time = tonumber(ngx.var.request_time)
+  _time_observe("h04#" .. overall_key, var_annotations, 4, var_request_time)
+  _time_observe("h05#" .. detail_key, var_annotations, 5, var_request_time)
+
+  -- bytes sent
+  local var_bytes_sent = ngx.var.bytes_sent
+  _bytes_observe("h06#" .. overall_key, var_annotations, 6, var_bytes_sent)
+  _bytes_observe("h07#" .. detail_key, var_annotations, 7, var_bytes_sent)
+
+  -- bytes received (according to https://serverfault.com/questions/346853/logging-request-response-size-in-access-log-of-nginx)
+  local var_request_length = ngx.var.request_length
+  _bytes_observe("h08#" .. overall_key, var_annotations, 8, var_request_length)
+  _bytes_observe("h09#" .. detail_key, var_annotations, 9, var_request_length)
+
+  -- upstreams
+  if var_upstream_addr then
+    local backends = {}
+    for backend in gmatch(var_upstream_addr, "([%d.]+):") do
+      insert_tab(backends, backend)
+    end
+
+    local n = 0
+    local var_upstream_response_time = ngx.var.upstream_response_time
+    local upstream_response_time = 0.0
+    local upstream_requests = 0
+    for t in gmatch(var_upstream_response_time, "[%d.]+") do
+      local response_time = tonumber(t)
+      n = n + 1
+
+      upstream_response_time = upstream_response_time + response_time
+      upstream_requests = upstream_requests + 1
+
+      -- upstream response time (for each backend)
+      _lowres_observe("h18#" .. backend_key .. "#" .. backends[n], var_annotations, 18, response_time)
+    end
+    ngx.var.total_upstream_response_time = upstream_response_time
+
+    -- upstream response time
+    _time_observe("h10#" .. overall_key, var_annotations, 10, upstream_response_time)
+    _time_observe("h11#" .. detail_key, var_annotations, 11, upstream_response_time)
+    _lowres_observe("h12#" .. overall_key, var_annotations, 12, upstream_response_time)
+    _lowres_observe("h13#" .. detail_key, var_annotations, 13, upstream_response_time)
+
+    local upstream_redirects = 0
+    for _ in gmatch(var_upstream_response_time, ":") do
+      upstream_redirects = upstream_redirects + 1
+    end
+
+    local upstream_retries = upstream_requests - upstream_redirects - 1
+    ngx.var.upstream_retries = upstream_retries
+    if upstream_retries > 0 then
+      -- upstream retries (count)
+      _increment("c14#" .. overall_key, var_annotations, 14)
+      _increment("c15#" .. detail_key, var_annotations, 15)
+
+      -- upstream retries (sum)
+      _add("g16#" .. overall_key, var_annotations, 16, upstream_retries)
+      _add("g17#" .. detail_key, var_annotations, 17, upstream_retries)
+    end
+
+    n = 0
+    for status in gmatch(ngx.var.upstream_status, "[%d]+") do
+      -- responses (for each backend)
+      n = n + 1
+      _increment("c19#" .. backend_key .. "#" .. backends[n] .. "#" .. sub(status, 1, 1) .. "xx", var_annotations, 19)
+    end
+
+    n = 0
+    for upstream_bytes_received in gmatch(ngx.var.upstream_bytes_received, "[%d]+") do
+      -- upstream bytes received (for each backend)
+      n = n + 1
+      _add("g20#" .. backend_key .. "#" .. backends[n], var_annotations, 20, upstream_bytes_received)
+    end
+  end
+
+  if use_geoip2 then
+    _increment_geohash(overall_key, ngx.var.geoip2_latitude, ngx.var.geoip2_longitude, ngx.var.geoip2_city, ngx.var.geoip2_region_name, ngx.var.geoip2_city_country_code, var_annotations)
+  else
+    _increment_geohash(overall_key, ngx.var.geoip_latitude, ngx.var.geoip_longitude, ngx.var.geoip_city, ngx.var.geoip_region_name, ngx.var.geoip_city_country_code, var_annotations)
+  end
+
+  if debug_enabled then
+    update_time()
+    log(WARNING, format("lua parse seconds: %s", tostring(now() - start_time)))
+  end
+end
+
+-- send() sends buffer data to protobuf exporter via tcp socket
+local function send(premature)
+  if nkeys(buffer) == 0 then
+    return
+  end
+
+  local start_time = now()
+
+  local pbbuff = pbuff.new()
+  for k, v in pairs(buffer) do
+    local metric_type = k:sub(1, 1)
+    if metric_type == "g" then
+      protogauge(pbbuff, v)
+    elseif metric_type == "c" then
+      protocounter(pbbuff, v)
+    elseif metric_type == "h" then
+      protohist(pbbuff, v)
+    end
+  end
+  clear_tab(buffer)
+
+
+  local sock = socket()
+  sock:settimeout(10000)
+  local ok, err = sock:connect("127.0.0.1", "9090")
+  if not ok then
+    log(ERROR, format("failed to connect to the tcp socket, metrcis buffer will be lost: %s", tostring(err)))
+    return
+  end
+  local ok, err = sock:setoption("keepalive", true)
+  if not ok then
+    log(ERROR, format("setoption keepalive failed: %s", tostring(err)))
+  end
+
+  ok, err = sock:send(pbbuff:result())
+  if not ok then
+    log(ERROR, format("error while sending data via tcp socket: %s", tostring(err)))
+  end
+  sock:setkeepalive(0)
+
+  if premature then
+    -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
+    sock:close()
+    return
+  end
+
+  if debug_enabled then
+    update_time()
+    log(WARNING, format("lua send seconds: %s", tostring(now() - start_time)))
+  end
+end
+
+local _M = {}
+
+-- init_worker() used at init_worker_by_lua_block stage to send buffer data to protobuf-exporter
+function _M.init_worker()
+  local _, err = timer_every(1, send)
+  if err then
+    log(ERROR, format("error while sending data: %s", tostring(err)))
+  end
+end
+
+-- call() used at log_by_lua stage to save request data to the buffer
+function _M.call()
+  fill_buffer()
+end
+
+return _M

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -1,0 +1,342 @@
+{{- $controllerBranch := "controller-v1.12.1" }}
+
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+fromImage: common/src-artifact
+fromCacheVersion: "2025-03-28.1"
+final: false
+git:
+- add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+      - '**/*'
+- add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/rootfs
+  to: /src/rootfs
+  stageDependencies:
+    install:
+      - '**/*'
+- add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/curl-chroot-wrapper.sh
+  to: /src/curl-chroot-wrapper.sh
+  stageDependencies:
+    install:
+      - '**/*'
+- add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/nginx-chroot-wrapper.sh
+  to: /src/nginx-chroot-wrapper.sh
+  stageDependencies:
+    install:
+      - '**/*'
+shell:
+  setup:
+  - mkdir -p /src
+  - cd /src
+  - git clone --branch v1.2.5 --depth 1 {{ $.SOURCE_REPO }}/yelp/dumb-init.git
+  - git clone --branch 0.5.1 {{ $.SOURCE_REPO }}/starwing/lua-protobuf
+  - git clone --branch 7-3 {{ $.SOURCE_REPO }}/luarocks-sorces/lua-iconv
+  - git clone --branch {{ $controllerBranch }} --depth 1 {{$.SOURCE_REPO}}/kubernetes/ingress-nginx.git
+  - cd /src/ingress-nginx
+  - git apply /patches/*.patch --verbose
+  # pass env for build
+  - echo "export COMMIT_SHA=git-$(git rev-parse --short HEAD)" > .env_pass
+  - echo "export REPO_INFO=$(git config --get remote.origin.url)" >> .env_pass
+  - echo "export TAG=$(git describe --tags --always)" >> .env_pass
+  - rm -rf /src/dumb-init/.git
+  - rm -rf /src/lua-protobuf/.git
+  - rm -rf /src/lua-iconv/.git
+  - rm -rf /src/ingress-nginx/.git
+
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-dumb-init-artifact
+fromImage: common/alt-p11-artifact
+final: false
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  add: /src/dumb-init
+  to: /src
+  before: install
+shell:
+  beforeInstall:
+  - apt-get install -y gcc glibc-core glibc-devel-static
+  setup:
+  - cd /src/
+  - cc -std=gnu99 -static -s -Wall -Werror -O3 -o dumb-init dumb-init.c
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-lua-rocks-artifact
+fromImage: common/alt-p11-artifact
+final: false
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  add: /src/lua-protobuf
+  to: /src/lua-protobuf
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  add: /src/lua-iconv
+  to: /src/lua-iconv
+  before: install
+shell:
+  install:
+  {{- include "alt packages proxy" . | nindent 2 }}
+  - apt-get install -y gcc lua5.1-devel lua5.1 lua5.1-luarocks
+  - apt-get install -y liblua5.1-devel --download-only
+  setup:
+  - cd /src/lua-protobuf
+  - luarocks-5.1 make rockspecs/lua-protobuf-scm-1.rockspec
+  - cd /src/lua-iconv
+  - luarocks-5.1 install lua-iconv-7-3.src.rock
+---
+image: {{ .ModuleName }}/{{ $.ImageName }}-controller-artifact
+from: {{ .Images.BASE_GOLANG_23_ALPINE }}
+final: false
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  add: /src/ingress-nginx
+  to: /src
+  before: install
+mount:
+- fromPath: ~/go-pkg-cache
+  to: /go/pkg
+shell:
+  install:
+  {{- include "alpine packages proxy" . | nindent 2 }}
+  # git needs for getting tag and commit sha for build purposes
+  - apk --no-cache add make bash git
+  setup:
+  - export GOPROXY={{ $.GOPROXY }}
+  - export GOARCH=amd64
+  - export PKG="k8s.io/ingress-nginx"
+  - cd /src/
+  - go mod edit -go=1.23.6
+  - go mod tidy
+  - |
+    source /src/.env_pass && \
+    echo "Loaded: COMMIT_SHA=$COMMIT_SHA, REPO_INFO=$REPO_INFO, ARCH=$GOARCH, PKG=$PKG TAG=$TAG" && \
+    make GO111MODULE=on USE_DOCKER=false build
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-artifact
+fromImage: common/alt-p11-artifact
+final: false
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  add: /src/ingress-nginx/images/nginx/rootfs/
+  to: /
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  add: /src/rootfs/etc
+  to: /src/etc
+  before: install
+shell:
+  install:
+  # git needs for getting dependencies from our repo
+  - apt-get install -y liblua5.3-devel lua5.3 libaio-devel libaom3 libbrotli-devel libcap-utils libcurl-devel libgrpc++-devel libgrpc++ libre2-devel libre2 libgrpc libgrpc-devel libssl-devel libmaxminddb libmaxminddb-devel libpcre-devel libpcre16 git cmake ninja-build libabseil-cpp-devel build-essential libgrpc-devel libprotobuf-devel grpc-plugins openssl libpcre2-devel libcares-devel
+  - apt-get install -y liblua5.1-devel --download-only
+  setup:
+  - export SOURCE_REPO={{ $.SOURCE_REPO }}
+  - git config --global url."{{ .SOURCE_REPO }}".insteadOf https://github.com
+  - cp -R /src/etc/* /etc/
+  - rm -rf /src/etc
+  - /build.sh
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
+fromImage: common/alt-p11-artifact
+final: false
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-artifact
+  add: /usr/local
+  to: /usr/local
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-artifact
+  add: /opt
+  to: /opt
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-artifact
+  add: /etc/nginx
+  to: /etc/nginx
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-artifact
+  add: /usr/lib
+  to: /chroot/usr/lib64
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-dumb-init-artifact
+  add: /src/dumb-init
+  to: /usr/bin/dumb-init
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-lua-rocks-artifact
+  add: /usr/lib64/lua/5.1/iconv.so
+  to: /usr/local/lib/lua/5.1/iconv.so
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-lua-rocks-artifact
+  add: /usr/lib64/lua/5.1/pb.so
+  to: /usr/local/lib/lua/5.1/pb.so
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-lua-rocks-artifact
+  add: /usr/share/lua/5.1/protoc.lua
+  to: /usr/local/share/lua/5.1/protoc.lua
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-artifact
+  add: /src/rootfs/etc
+  to: /src/rootfs/etc
+  before: install
+shell:
+  install:
+  {{- include "alt packages proxy" . | nindent 2 }}
+  - apt-get -y install ca-certificates curl libxml2-devel libyajl libyajl-devel libmaxminddb libmaxminddb-devel iptables iptables-nft nfs-utils conntrack-tools glibc-gconv-modules libgrpc++-devel libgrpc++ libbrotli-devel libpcre-devel
+  setup:
+  - cp -R /usr/lib64 /chroot/usr/lib64
+  - ln -s /usr/local/nginx/sbin/nginx /sbin/nginx
+  - adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
+  - |
+    bash -eu -c '
+    writeDirs=(
+      /chroot/etc/nginx
+      /chroot/usr/local/nginx
+      /chroot/usr/share
+      /chroot/usr/bin
+      /chroot/etc/ingress-controller
+      /chroot/etc/ingress-controller/ssl
+      /chroot/etc/ingress-controller/auth
+      /chroot/etc/ingress-controller/telemetry
+      /chroot/etc/ingress-controller/geoip
+      /chroot/opt/modsecurity/var/log
+      /chroot/opt/modsecurity/var/upload
+      /chroot/opt/modsecurity/var/audit
+      /chroot/var/log/audit
+      /chroot/var/lib/nginx
+      /chroot/var/log/nginx
+      /chroot/var/lib/nginx/body
+      /chroot/var/lib/nginx/fastcgi
+      /chroot/var/lib/nginx/proxy
+      /chroot/var/lib/nginx/scgi
+      /chroot/var/lib/nginx/uwsgi
+      /chroot/tmp/nginx
+    );
+    for dir in "${writeDirs[@]}"; do
+      mkdir -p ${dir};
+      chown -R www-data:www-data ${dir};
+    done'
+  - mkdir -p /chroot/lib /chroot/lib64 /chroot/proc /chroot/usr /chroot/bin /chroot/dev /chroot/run /chroot/usr/lib64 /chroot/usr/local/modsecurity /chroot/usr/local/share
+  - cp /etc/passwd /etc/group /etc/hosts /chroot/etc/
+  # Create opentelemetry.toml file as it doesn't present in controller_image
+  - touch /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml
+  - chown -R www-data:www-data /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml
+  - cp -a /etc/pki /chroot/etc/pki
+  - cp -a /usr/share/ca-certificates /chroot/usr/share/ca-certificates
+  - cp -a /usr/bin/curl /chroot/usr/bin/curl
+  - cp -a /lib64/* /chroot/lib64/
+  - rm -rf /chroot/lib64/apt /chroot/lib64/debug /chroot/lib64/games
+  - cp -a /usr/lib64/libcurl* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libstdc++* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libbrotli* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libxml2.so* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libyajl.so* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libmaxminddb.* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libgsasl.so* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libnfnetlink.so* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libntlm.so* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libnetfilter_conntrack.so* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libnghttp2.so* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libpsl.so* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libssh2.so* /chroot/usr/lib64/
+  - cp -a /usr/lib64/gconv /chroot/usr/lib64/
+  - cp -a /usr/lib64/libgrpc++.so* /chroot/usr/lib64/
+  - cp -a /usr/lib64/libpcre.so* /chroot/usr/lib64/
+  - cp -a /etc/nginx/* /chroot/etc/nginx/
+  - cp -a /usr/local/bin /chroot/usr/local/
+  - cp -a /usr/local/lib /chroot/usr/local/
+  - cp -a /usr/local/share/lua* /chroot/usr/local/share/
+  - cp -a /usr/local/lib64 /chroot/usr/local/
+  - cp -a /usr/local/modsecurity/bin /chroot/usr/local/modsecurity/
+  - cp -a /usr/local/modsecurity/lib/libmodsecurity.* /chroot/usr/lib64/
+  - cp -a /usr/local/nginx /chroot/usr/local/
+  - chown www-data:www-data /chroot/etc
+  - cp -R /src/rootfs/etc/* /chroot/etc
+  - rm -rf /src/rootfs/etc
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}
+fromImage: common/alt-p11-artifact
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
+  add: /chroot
+  to: /chroot
+  before: setup
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-artifact
+  add: /src/rootfs/bin/amd64/dbg
+  to: /dbg
+  before: setup
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-artifact
+  add: /src/rootfs/bin/amd64/nginx-ingress-controller
+  to: /nginx-ingress-controller
+  before: setup
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-artifact
+  add: /src/rootfs/bin/amd64/wait-shutdown
+  to: /wait-shutdown
+  before: setup
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  add: /src/curl-chroot-wrapper.sh
+  to: /usr/bin/curl
+  before: setup
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  add: /src/nginx-chroot-wrapper.sh
+  to: /usr/bin/nginx
+  before: setup
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-dumb-init-artifact
+  add: /src/dumb-init
+  to: /usr/bin/dumb-init
+  before: setup
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  add: /src/rootfs/etc
+  to: /src/rootfs/etc
+  before: setup
+shell:
+  setup:
+  - export PATH="$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin"
+  - export LUA_PATH="/usr/local/share/luajit-2.1/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/lib/lua/?.lua;;"
+  - export LUA_CPATH="/usr/local/lib/lua/?/?.so;/usr/local/lib/lua/?.so;;"
+  - cp -R /src/rootfs/etc/* /chroot/etc
+  - rm -rf /src/rootfs/etc/
+  - ln -s /usr/local/nginx/sbin/nginx /sbin/nginx
+  - adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
+  - chown www-data:www-data /usr/bin/nginx
+  - chown www-data:www-data /usr/bin/curl
+  - chown www-data:www-data /chroot/etc
+  - chmod 1777 /tmp
+  - setcap     cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - rm -rf /etc/pki
+  - ln -sf /chroot/etc/pki /etc/pki
+  - ln -sf /chroot/usr/share/ca-certificates /usr/share/ca-certificates
+  - ln -sf /chroot/etc/nginx /etc/nginx
+  - ln -sf /chroot/tmp/nginx /tmp/nginx
+  - ln -sf /chroot/etc/ingress-controller /etc/ingress-controller
+  - ln -sf /chroot/var/log/nginx /var/log/nginx
+  - touch /chroot/var/log/nginx/access.log
+  - chown www-data:www-data /chroot/var/log/nginx/access.log
+  - echo "" > /chroot/etc/resolv.conf
+  - chown -R www-data:www-data /var/log /chroot/var/log /chroot/etc/resolv.conf
+  - mknod -m 0666 /chroot/dev/null c 1 3
+  - mknod -m 0666 /chroot/dev/random c 1 8
+  - mknod -m 0666 /chroot/dev/urandom c 1 9
+  - mknod -m 0666 /chroot/dev/full c 1 7
+  - mknod -m 0666 /chroot/dev/ptmx c 5 2
+  - mknod -m 0666 /chroot/dev/zero c 1 5
+  - mknod -m 0666 /chroot/dev/tty c 5 0
+  - echo -e "/lib\n/lib64\n/usr/local/lib\n/usr/local/lib64\n/etc/nginx/modules" > /etc/ld.so.conf.d/local.conf
+  - ldconfig
+# Create ld.so.cache inside chroot
+  - cp -a /etc/ld.so.conf* /chroot/etc/ && ldconfig -r /chroot
+# remove ruby from libs because it has cve's but not using in image
+# ruby install with grpc-plugins packet it needs for building nginx
+  - rm -rf /chroot/usr/lib64/ruby
+imageSpec:
+  config:
+    workingDir: /
+    user: "www-data"
+    expose: ["80", "443"]
+    entrypoint: ["/usr/bin/dumb-init", "--"]
+    cmd: ["/nginx-ingress-controller"]
+    env: { "PATH": "$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin", "LUA_PATH": "/usr/local/share/luajit-2.1/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/lib/lua/?.lua;;", "LUA_CPATH": "/usr/local/lib/lua/?/?.so;/usr/local/lib/lua/?.so;;" }

--- a/modules/402-ingress-nginx/openapi/config-values.yaml
+++ b/modules/402-ingress-nginx/openapi/config-values.yaml
@@ -1,7 +1,7 @@
 type: object
 properties:
   defaultControllerVersion:
-    default: "1.9"
+    default: "1.10"
     oneOf:
       - type: string
         enum: ["1.9", "1.10", "1.12"]

--- a/modules/402-ingress-nginx/openapi/config-values.yaml
+++ b/modules/402-ingress-nginx/openapi/config-values.yaml
@@ -4,7 +4,7 @@ properties:
     default: "1.9"
     oneOf:
       - type: string
-        enum: ["1.9", "1.10"]
+        enum: ["1.9", "1.10", "1.12"]
     description: |
       The version of the ingress-nginx controller that is used for all controllers by default if the `controllerVersion` parameter is omitted in the IngressNginxController CR.
   highAvailability:

--- a/modules/402-ingress-nginx/openapi/values.yaml
+++ b/modules/402-ingress-nginx/openapi/values.yaml
@@ -6,7 +6,7 @@ properties:
     type: object
     default: {}
     x-required-for-helm:
-    - ingressControllers
+      - ingressControllers
     properties:
       admissionCertificate:
         type: object
@@ -18,15 +18,15 @@ properties:
         properties:
           ca:
             type: string
-            x-examples: [ "testca" ]
+            x-examples: ["testca"]
           key:
             type: string
-            x-examples: [ "testkey" ]
+            x-examples: ["testkey"]
           cert:
             type: string
-            x-examples: [ "testcrt" ]
+            x-examples: ["testcrt"]
       nginxAuthTLS:
-        type: ['null', array]
+        type: ["null", array]
         default: []
         items:
           type: object
@@ -52,7 +52,7 @@ properties:
                   type: string
                   x-examples: ["---certificate-string---"]
       ingressControllers:
-        type: ['null', array]
+        type: ["null", array]
         default: []
         items:
           type: object
@@ -76,7 +76,7 @@ properties:
                   x-examples: ["HostWithFailover"]
                 controllerVersion:
                   type: string
-                  x-examples: ["1.9", "1.10"]
+                  x-examples: ["1.9", "1.10", "1.12"]
                 enableIstioSidecar:
                   type: boolean
                 waitLoadBalancerOnTerminating:
@@ -95,33 +95,33 @@ properties:
                   description: |
                     Custom annotations for pods nginx controller.
                 nodeSelector:
-                    type: object
-                    additionalProperties:
-                      type: string
-                    description: |
-                      The same as the `spec.nodeSelector` pod parameter in Kubernetes.
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: |
+                    The same as the `spec.nodeSelector` pod parameter in Kubernetes.
 
-                      If the parameter is omitted or `false`, it will be determined [automatically](https://deckhouse.io/products/kubernetes-platform/documentation/v1/#advanced-scheduling).
+                    If the parameter is omitted or `false`, it will be determined [automatically](https://deckhouse.io/products/kubernetes-platform/documentation/v1/#advanced-scheduling).
                 tolerations:
-                    type: array
-                    description: |
-                      The same as `spec.tolerations` for the Kubernetes pod.
+                  type: array
+                  description: |
+                    The same as `spec.tolerations` for the Kubernetes pod.
 
-                      Use [automatic](https://deckhouse.io/products/kubernetes-platform/documentation/v1/#advanced-scheduling) if not specified. Set `false` to turn off automatic.
-                    items:
-                      type: object
-                      properties:
-                        effect:
-                          type: string
-                        key:
-                          type: string
-                        operator:
-                          type: string
-                        tolerationSeconds:
-                          type: integer
-                          format: int64
-                        value:
-                          type: string
+                    Use [automatic](https://deckhouse.io/products/kubernetes-platform/documentation/v1/#advanced-scheduling) if not specified. Set `false` to turn off automatic.
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                        format: int64
+                      value:
+                        type: string
                 loadBalancer:
                   type: object
                   default: {}
@@ -311,7 +311,7 @@ properties:
       upmeterDiscovery:
         type: object
         required:
-        - controllerNames
+          - controllerNames
         properties:
           controllerNames:
             type: array

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/configmap.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/configmap.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
+  annotations-risk-level: Critical
   body-size: 64m
   gzip-level: "1"
   hsts: "false"

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/configmap.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/configmap.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
+  annotations-risk-level: Critical
   body-size: 64m
   gzip-level: "1"
   hsts: "false"
@@ -50,6 +51,7 @@ metadata:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
+  annotations-risk-level: Critical
   body-size: 64m
   gzip-level: "1"
   hsts: "false"

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/configmap.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/configmap.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
+  annotations-risk-level: Critical
   body-size: 64m
   gzip-level: "1"
   hsts: "false"

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/configmap.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/configmap.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
+  annotations-risk-level: Critical
   body-size: 64m
   gzip-level: "1"
   hsts: "false"

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/configmap.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/configmap.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
+  annotations-risk-level: Critical
   body-size: 64m
   gzip-level: "1"
   hsts: "false"

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/configmap.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/configmap.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
+  annotations-risk-level: Critical
   body-size: 64m
   gzip-level: "1"
   hsts: "true"

--- a/modules/402-ingress-nginx/templates/controller/configmap.yaml
+++ b/modules/402-ingress-nginx/templates/controller/configmap.yaml
@@ -17,8 +17,11 @@ metadata:
   namespace: d8-ingress-nginx
   {{- include "helm_lib_module_labels" (list $context) | nindent 2 }}
 data:
-  # User snippets are disabled by default since v1.9 due to substantial security concerns
+  # User snippets are disabled by default due to substantial security concerns
   allow-snippet-annotations: "true"
+  # The default annotation risk level has been lowered to High in v1.12. Snippet annotations have an annotation risk level of Critical.
+  # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations-risk/
+  annotations-risk-level: Critical
   # Additional headers config map name in format namespace/name
   proxy-set-headers: "d8-ingress-nginx/{{ $crd.name }}-custom-headers"
   proxy-connect-timeout: "2"

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -207,6 +207,9 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        {{- if eq $controllerVersion "1.12" }}
+        - --enable-metrics=true
+        {{- end }}
         {{- if $loadBalancer }}
         - --publish-service=d8-ingress-nginx/{{ $crd.name }}-load-balancer
         {{- end }}
@@ -225,7 +228,7 @@ spec:
         {{- if eq "nginx" $crd.spec.ingressClass }}
         - --watch-ingress-without-class=true
         {{- end }}
-        {{- if and $crd.spec.annotationValidationEnabled (or (eq $controllerVersion "1.9") (eq $controllerVersion "1.10")) }}
+        {{- if $crd.spec.annotationValidationEnabled }}
         - --enable-annotation-validation=true
         {{- end }}
   {{- if $crd.spec.customErrors }}
@@ -319,7 +322,6 @@ spec:
           name: webhook
   {{- end }}
         volumeMounts:
-  {{- if or (eq $controllerVersion "1.9") (eq $controllerVersion "1.10") }}
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path
         - mountPath: /chroot/var/lib/nginx/fastcgi
@@ -337,25 +339,6 @@ spec:
         - mountPath: /chroot/etc/nginx/webhook-ssl/
           name: webhook-cert
           readOnly: true
-  {{- else }}
-        - mountPath: /var/lib/nginx/body
-          name: client-body-temp-path
-        - mountPath: /var/lib/nginx/fastcgi
-          name: fastcgi-temp-path
-        - mountPath: /var/lib/nginx/proxy
-          name: proxy-temp-path
-        - mountPath: /var/lib/nginx/scgi
-          name: scgi-temp-path
-        - mountPath: /var/lib/nginx/uwsgi
-          name: uwsgi-temp-path
-        - mountPath: /etc/nginx/ssl/
-          name: secret-nginx-auth-tls
-        - mountPath: /tmp/nginx/
-          name: tmp-nginx
-        - mountPath: /etc/nginx/webhook-ssl/
-          name: webhook-cert
-          readOnly: true
-  {{- end }}
       - image: {{ include "helm_lib_module_image" (list $context "protobufExporter") }}
         name: protobuf-exporter
         resources:

--- a/modules/402-ingress-nginx/webhooks/validating/ingressnginxcontroller
+++ b/modules/402-ingress-nginx/webhooks/validating/ingressnginxcontroller
@@ -68,4 +68,4 @@ function __main__() {
   jq -nc '{"allowed": true}' > $VALIDATING_RESPONSE_PATH
 }
 
-hook::run $@
+hook::run "$@"

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -247,6 +247,7 @@ var DefaultImagesDigests = map[string]interface{}{
 	},
 	"ingressNginx": map[string]interface{}{
 		"controller110":         "imageHash-ingressNginx-controller110",
+		"controller112":         "imageHash-ingressNginx-controller112",
 		"controller19":          "imageHash-ingressNginx-controller19",
 		"kruise":                "imageHash-ingressNginx-kruise",
 		"kruiseStateMetrics":    "imageHash-ingressNginx-kruiseStateMetrics",


### PR DESCRIPTION
## Description
Upgrade ingress-nginx to version 1.12.1.

## Why do we need it, and what problem does it solve?
Version 1.12.1 fixes many issues and adds new features.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: chore
summary: Added ingress-nginx version 1.12. The defaultControllerVersion is set to 1.10, all ingress controllers without specified version will restart.
impact_level: default
```
