### PR TITLE
[docs] Remove deprecated csi-yadro and sds-drbd modules. Add redirects.

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -108,11 +108,6 @@
     "path": "/products/kubernetes-platform/modules/sds-node-configurator/stable/",
     "editionMinimumAvailable": "ce"
   },
-  "sds-drbd": {
-    "external": "true",
-    "path": "/products/kubernetes-platform/modules/sds-drbd/stable/",
-    "editionMinimumAvailable": "ee"
-  },
   "sds-replicated-volume": {
     "external": "true",
     "path": "/products/kubernetes-platform/modules/sds-replicated-volume/stable/",
@@ -160,9 +155,9 @@
     "path": "/products/kubernetes-platform/modules/secrets-store-integration/stable/",
     "editionMinimumAvailable": "be"
   },
-  "csi-yadro": {
+  "csi-yadro-tatlin-unified": {
     "external": "true",
-    "path": "/products/kubernetes-platform/modules/csi-yadro/stable/",
+    "path": "/products/kubernetes-platform/modules/csi-yadro-tatlin-unified/stable/",
     "editionMinimumAvailable": "ee"
   },
   "csi-huawei": {

--- a/docs/site/.helm/templates/_rewrites.tpl
+++ b/docs/site/.helm/templates/_rewrites.tpl
@@ -11,6 +11,8 @@ rewrite ^/source/modules/(.*)$ /modules/$1 redirect;
 rewrite ^/platform/(.*)$ /products/kubernetes-platform/documentation/v1/$1 redirect;
 rewrite ^.*/documentation/v1/modules/490-virtualization/(examples|configuration|cr|faq).html(.*)$ /modules/virtualization/stable/$1.html$2 permanent;
 rewrite ^.*/documentation/v1/modules/490-virtualization/.*$ /modules/virtualization/stable/ permanent;
+rewrite ^/products/kubernetes-platform/modules/csi-yadro(/.*)?$ /products/kubernetes-platform/modules/csi-yadro-tatlin-unified$1 permanent;
+rewrite ^/products/kubernetes-platform/modules/sds-drbd(/.*)?$ /products/kubernetes-platform/modules/sds-replicated-volume$1 permanent;
 rewrite ^/modules/([^./]+)/?$ /modules/$1/stable/ permanent;
 rewrite ^/modules/([^./]+)/((?!(alpha|beta|early-access|stable|rock-solid)).+)$ /modules/$1/stable/$2 permanent;
 rewrite ^(/en|/ru)?(/documentation/v1\.[0-9]+)\.[0-9]+(/.*)$ /products/kubernetes-platform$2$3 permanent;

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -143,18 +143,10 @@
       "ee"
     ]
   },
-  "csi-yadro": {
+  "csi-yadro-tatlin-unified": {
     "editionMinimumAvailable": "ee",
     "external": "true",
-    "path": "/products/kubernetes-platform/modules/csi-yadro/stable/",
-    "editions": [
-      "ee"
-    ]
-  },
-  "sds-drbd": {
-    "editionMinimumAvailable": "ee",
-    "external": "true",
-    "path": "/products/kubernetes-platform/modules/sds-drbd/stable/",
+    "path": "/products/kubernetes-platform/modules/csi-yadro-tatlin-unified/stable/",
     "editions": [
       "ee"
     ]


### PR DESCRIPTION
## Description
Remove deprecated csi-yadro and sds-drbd modules. Add redirects.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Remove deprecated csi-yadro and sds-drbd modules. Add redirects.
impact_level: low
```
