### PR TITLE
[deckhouse-controller] fix applying releases and their metrics

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -56,7 +56,6 @@ import (
 )
 
 const (
-	metricReleasesGroup = "d8_releases"
 	metricUpdatingGroup = "d8_updating"
 	metricUpdatingName  = "d8_is_updating"
 
@@ -159,8 +158,6 @@ func (r *deckhouseReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		r.logger.Debug("release channel not set")
 		return res, nil
 	}
-
-	r.metricStorage.Grouped().ExpireGroupMetrics(metricReleasesGroup)
 
 	release := new(v1alpha1.DeckhouseRelease)
 	err := r.client.Get(ctx, req.NamespacedName, release)

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -1015,6 +1015,11 @@ func (r *deckhouseReleaseReconciler) reconcileDeployedRelease(ctx context.Contex
 func (r *deckhouseReleaseReconciler) updateReleaseStatus(ctx context.Context, dr *v1alpha1.DeckhouseRelease, status *v1alpha1.DeckhouseReleaseStatus) error {
 	r.logger.Debug("refresh release status", slog.String("name", dr.GetName()))
 
+	switch status.Phase {
+	case v1alpha1.DeckhouseReleasePhaseSuperseded, v1alpha1.DeckhouseReleasePhaseSuspended, v1alpha1.DeckhouseReleasePhaseSkipped:
+		r.metricsUpdater.PurgeReleaseMetric(dr.GetName())
+	}
+
 	return ctrlutils.UpdateStatusWithRetry(ctx, r.client, dr, func() error {
 		if dr.Status.Phase != status.Phase {
 			dr.Status.TransitionTime = metav1.NewTime(r.dc.GetClock().Now().UTC())

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -611,7 +611,7 @@ func (r *deckhouseReleaseReconciler) DeployTimeCalculate(ctx context.Context, dr
 		}
 	}
 
-	processedDTR := timeChecker.ProcessMinorReleaseDeployTime(ctx, dr, deployTimeResult, task.DeployedReleaseInfo)
+	processedDTR := timeChecker.ProcessMinorReleaseDeployTime(dr, deployTimeResult, task.DeployedReleaseInfo)
 	if processedDTR == nil {
 		return nil
 	}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -608,7 +608,7 @@ func (r *deckhouseReleaseReconciler) DeployTimeCalculate(ctx context.Context, dr
 		}
 	}
 
-	processedDTR := timeChecker.ProcessMinorReleaseDeployTime(dr, deployTimeResult, task.DeployedReleaseInfo)
+	processedDTR := timeChecker.ProcessMinorReleaseDeployTime(dr, deployTimeResult)
 	if processedDTR == nil {
 		return nil
 	}
@@ -1005,9 +1005,11 @@ func (r *deckhouseReleaseReconciler) reconcileDeployedRelease(ctx context.Contex
 
 	if dr.GetIsUpdating() {
 		r.metricStorage.Grouped().GaugeSet(metricUpdatingGroup, metricUpdatingName, 1, map[string]string{"releaseChannel": r.updateSettings.Get().ReleaseChannel})
+
+		return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
 	}
 
-	return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
+	return res, nil
 }
 
 func (r *deckhouseReleaseReconciler) updateReleaseStatus(ctx context.Context, dr *v1alpha1.DeckhouseRelease, status *v1alpha1.DeckhouseReleaseStatus) error {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
@@ -446,6 +446,38 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		require.NoError(suite.T(), err)
 	})
 
+	suite.Run("minor release and patch release", func() {
+		dependency.TestDC.HTTPClient.DoMock.
+			Expect(&http.Request{}).
+			Return(&http.Response{
+				StatusCode: http.StatusOK,
+			}, nil)
+
+		suite.setupController("minor-release-and-patch-release.yaml", initValues, embeddedMUP)
+		dr := suite.getDeckhouseRelease("v1.31.0")
+		_, err := suite.ctr.createOrUpdateReconcile(ctx, dr)
+		require.NoError(suite.T(), err)
+		dr = suite.getDeckhouseRelease("v1.32.0")
+		_, err = suite.ctr.createOrUpdateReconcile(ctx, dr)
+		require.NoError(suite.T(), err)
+		dr = suite.getDeckhouseRelease("v1.32.1")
+		_, err = suite.ctr.createOrUpdateReconcile(ctx, dr)
+		require.NoError(suite.T(), err)
+
+		dependency.TestDC.HTTPClient.DoMock.
+			Expect(&http.Request{}).
+			Return(&http.Response{
+				StatusCode: http.StatusOK,
+			}, nil)
+
+		dr = suite.getDeckhouseRelease("v1.32.0")
+		_, err = suite.ctr.createOrUpdateReconcile(ctx, dr)
+		require.NoError(suite.T(), err)
+		dr = suite.getDeckhouseRelease("v1.32.1")
+		_, err = suite.ctr.createOrUpdateReconcile(ctx, dr)
+		require.NoError(suite.T(), err)
+	})
+
 	suite.Run("forced through few minor releases", func() {
 		dependency.TestDC.HTTPClient.DoMock.
 			Expect(&http.Request{}).

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
@@ -447,29 +447,20 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 	})
 
 	suite.Run("minor release and patch release", func() {
+		mup := embeddedMUP.DeepCopy()
+		mup.Update.Mode = v1alpha1.UpdateModeAuto.String()
+		mup.Update.Windows = update.Windows{{From: "8:00", To: "10:00"}}
+
 		dependency.TestDC.HTTPClient.DoMock.
 			Expect(&http.Request{}).
 			Return(&http.Response{
 				StatusCode: http.StatusOK,
 			}, nil)
 
-		suite.setupController("minor-release-and-patch-release.yaml", initValues, embeddedMUP)
+		suite.setupController("minor-release-and-patch-release.yaml", initValues, mup)
 		dr := suite.getDeckhouseRelease("v1.31.0")
 		_, err := suite.ctr.createOrUpdateReconcile(ctx, dr)
 		require.NoError(suite.T(), err)
-		dr = suite.getDeckhouseRelease("v1.32.0")
-		_, err = suite.ctr.createOrUpdateReconcile(ctx, dr)
-		require.NoError(suite.T(), err)
-		dr = suite.getDeckhouseRelease("v1.32.1")
-		_, err = suite.ctr.createOrUpdateReconcile(ctx, dr)
-		require.NoError(suite.T(), err)
-
-		dependency.TestDC.HTTPClient.DoMock.
-			Expect(&http.Request{}).
-			Return(&http.Response{
-				StatusCode: http.StatusOK,
-			}, nil)
-
 		dr = suite.getDeckhouseRelease("v1.32.0")
 		_, err = suite.ctr.createOrUpdateReconcile(ctx, dr)
 		require.NoError(suite.T(), err)

--- a/deckhouse-controller/pkg/controller/deckhouse-release/event.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/event.go
@@ -106,7 +106,7 @@ func (rp releasePhasePredicate) Create(ev event.CreateEvent) bool {
 	}
 
 	switch ev.Object.(*v1alpha1.DeckhouseRelease).Status.Phase {
-	case v1alpha1.ModuleReleasePhaseSkipped, v1alpha1.ModuleReleasePhaseSuperseded, v1alpha1.ModuleReleasePhaseSuspended, v1alpha1.ModuleReleasePhaseDeployed:
+	case v1alpha1.ModuleReleasePhaseSkipped, v1alpha1.ModuleReleasePhaseSuperseded, v1alpha1.ModuleReleasePhaseSuspended:
 		return false
 	}
 	return true
@@ -124,7 +124,7 @@ func (rp releasePhasePredicate) Update(ev event.UpdateEvent) bool {
 	}
 
 	switch ev.ObjectNew.(*v1alpha1.DeckhouseRelease).Status.Phase {
-	case v1alpha1.ModuleReleasePhaseSkipped, v1alpha1.ModuleReleasePhaseSuperseded, v1alpha1.ModuleReleasePhaseSuspended, v1alpha1.ModuleReleasePhaseDeployed:
+	case v1alpha1.ModuleReleasePhaseSkipped, v1alpha1.ModuleReleasePhaseSuperseded, v1alpha1.ModuleReleasePhaseSuspended:
 		return false
 	}
 	return true

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/few-patch-releases.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/few-patch-releases.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: deckhouse
-          image: my.registry.com/deckhouse:v1.25.0
+          image: my.registry.com/deckhouse:v1.31.0
 
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/apply-now-deckhouse-previous-release-is-not-ready.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/apply-now-deckhouse-previous-release-is-not-ready.yaml
@@ -20,11 +20,9 @@ kind: DeckhouseRelease
 metadata:
   annotations:
     release.deckhouse.io/apply-now: "true"
-    release.deckhouse.io/isUpdating: "false"
-    release.deckhouse.io/notified: "true"
   creationTimestamp: null
   name: v1.26.0
-  resourceVersion: "1001"
+  resourceVersion: "1000"
 spec:
   version: v1.26.0
 status:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/deckhouse-previous-release-is-not-ready.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/deckhouse-previous-release-is-not-ready.yaml
@@ -18,12 +18,9 @@ apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
-  annotations:
-    release.deckhouse.io/isUpdating: "false"
-    release.deckhouse.io/notified: "true"
   creationTimestamp: null
   name: v1.26.0
-  resourceVersion: "1001"
+  resourceVersion: "1000"
 spec:
   version: v1.26.0
 status:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/few-minor-releases.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/few-minor-releases.yaml
@@ -39,12 +39,9 @@ apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
-  annotations:
-    release.deckhouse.io/isUpdating: "false"
-    release.deckhouse.io/notified: "true"
   creationTimestamp: null
   name: v1.33.0
-  resourceVersion: "1001"
+  resourceVersion: "1000"
 spec:
   version: v1.33.0
 status:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/few-patch-releases.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/few-patch-releases.yaml
@@ -66,12 +66,9 @@ apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
-  annotations:
-    release.deckhouse.io/isUpdating: "false"
-    release.deckhouse.io/notified: "true"
   creationTimestamp: null
   name: v1.32.0
-  resourceVersion: "1001"
+  resourceVersion: "1000"
 spec:
   version: v1.32.0
 status:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/minor-release-and-patch-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/minor-release-and-patch-release.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deckhouse-6f46df5bd7-nk4j7
+  namespace: d8-system
+  labels:
+    app: deckhouse
+spec:
+  containers:
+    - name: deckhouse
+      image: dev-registry.deckhouse.io/sys/deckhouse-oss:v1.2.3
+status:
+  containerStatuses:
+    - containerID: containerd://9990d3eccb8657d0bfe755672308831b6d0fab7f3aac553487c60bf0f076b2e3
+      imageID: dev-registry.deckhouse.io/sys/deckhouse-oss/dev@sha256:d57f01a88e54f863ff5365c989cb4e2654398fa274d46389e0af749090b862d1
+      ready: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deckhouse
+  namespace: d8-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: deckhouse
+          image: my.registry.com/deckhouse:v1.31.0
+
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.31.0
+spec:
+  version: "v1.31.0"
+status:
+  phase: Deployed
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.0
+spec:
+  version: "v1.32.0"
+status:
+  phase: Pending
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.1
+spec:
+  version: "v1.32.1"
+status:
+  phase: Pending

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/minor-release-and-patch-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/minor-release-and-patch-release.yaml
@@ -1,57 +1,96 @@
 ---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "true"
+  creationTimestamp: null
+  name: v1.31.0
+  resourceVersion: "1000"
+spec:
+  version: v1.31.0
+status:
+  approved: false
+  message: ""
+  phase: Deployed
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.32.0
+  resourceVersion: "1000"
+spec:
+  version: v1.32.0
+status:
+  approved: false
+  message: ""
+  phase: Skipped
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "true"
+  creationTimestamp: null
+  name: v1.32.1
+  resourceVersion: "1001"
+spec:
+  version: v1.32.1
+status:
+  approved: false
+  message: Release is waiting for the update window until 18 Oct 19 08:00 UTC
+  phase: Pending
+  transitionTime: null
+---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: deckhouse-6f46df5bd7-nk4j7
-  namespace: d8-system
+  creationTimestamp: null
   labels:
     app: deckhouse
+  name: deckhouse-6f46df5bd7-nk4j7
+  namespace: d8-system
+  resourceVersion: "999"
 spec:
   containers:
-    - name: deckhouse
-      image: dev-registry.deckhouse.io/sys/deckhouse-oss:v1.2.3
+  - image: dev-registry.deckhouse.io/sys/deckhouse-oss:v1.2.3
+    name: deckhouse
+    resources: {}
 status:
   containerStatuses:
-    - containerID: containerd://9990d3eccb8657d0bfe755672308831b6d0fab7f3aac553487c60bf0f076b2e3
-      imageID: dev-registry.deckhouse.io/sys/deckhouse-oss/dev@sha256:d57f01a88e54f863ff5365c989cb4e2654398fa274d46389e0af749090b862d1
-      ready: true
+  - containerID: containerd://9990d3eccb8657d0bfe755672308831b6d0fab7f3aac553487c60bf0f076b2e3
+    image: ""
+    imageID: dev-registry.deckhouse.io/sys/deckhouse-oss/dev@sha256:d57f01a88e54f863ff5365c989cb4e2654398fa274d46389e0af749090b862d1
+    lastState: {}
+    name: ""
+    ready: true
+    restartCount: 0
+    state: {}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
   name: deckhouse
   namespace: d8-system
+  resourceVersion: "999"
 spec:
+  selector: null
+  strategy: {}
   template:
+    metadata:
+      creationTimestamp: null
     spec:
       containers:
-        - name: deckhouse
-          image: my.registry.com/deckhouse:v1.31.0
-
----
-apiVersion: deckhouse.io/v1alpha1
-kind: DeckhouseRelease
-metadata:
-  name: v1.31.0
-spec:
-  version: "v1.31.0"
-status:
-  phase: Deployed
----
-apiVersion: deckhouse.io/v1alpha1
-kind: DeckhouseRelease
-metadata:
-  name: v1.33.0
-spec:
-  version: "v1.32.0"
-status:
-  phase: Pending
----
-apiVersion: deckhouse.io/v1alpha1
-kind: DeckhouseRelease
-metadata:
-  name: v1.33.1
-spec:
-  version: "v1.32.1"
-status:
-  phase: Pending
+      - image: my.registry.com/deckhouse:v1.25.0
+        name: deckhouse
+        resources: {}
+status: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/minor-release-and-patch-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/minor-release-and-patch-release.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deckhouse-6f46df5bd7-nk4j7
+  namespace: d8-system
+  labels:
+    app: deckhouse
+spec:
+  containers:
+    - name: deckhouse
+      image: dev-registry.deckhouse.io/sys/deckhouse-oss:v1.2.3
+status:
+  containerStatuses:
+    - containerID: containerd://9990d3eccb8657d0bfe755672308831b6d0fab7f3aac553487c60bf0f076b2e3
+      imageID: dev-registry.deckhouse.io/sys/deckhouse-oss/dev@sha256:d57f01a88e54f863ff5365c989cb4e2654398fa274d46389e0af749090b862d1
+      ready: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deckhouse
+  namespace: d8-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: deckhouse
+          image: my.registry.com/deckhouse:v1.25.0
+
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.31.0
+spec:
+  version: "v1.31.0"
+status:
+  phase: Deployed
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.0
+spec:
+  version: "v1.32.0"
+status:
+  phase: Pending
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.1
+spec:
+  version: "v1.32.1"
+status:
+  phase: Pending

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/minor-release-and-patch-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/minor-release-and-patch-release.yaml
@@ -41,7 +41,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1.33.0
+  name: v1.32.0
 spec:
   version: "v1.32.0"
 status:
@@ -50,7 +50,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: DeckhouseRelease
 metadata:
-  name: v1.33.1
+  name: v1.32.1
 spec:
   version: "v1.32.1"
 status:

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -1101,7 +1101,7 @@ func (r *reconciler) DeployTimeCalculate(ctx context.Context, mr v1alpha1.Releas
 		}
 	}
 
-	processedDTR := timeChecker.ProcessMinorReleaseDeployTime(mr, deployTimeResult, task.DeployedReleaseInfo)
+	processedDTR := timeChecker.ProcessMinorReleaseDeployTime(mr, deployTimeResult)
 	if processedDTR == nil {
 		return nil
 	}

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -578,12 +578,12 @@ func (r *reconciler) handlePendingRelease(ctx context.Context, release *v1alpha1
 		return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
 	}
 
-	metricLabels := releaseUpdater.NewReleaseMetricLabels(mr)
+	metricLabels := releaseUpdater.NewReleaseMetricLabels(release)
 	defer func() {
 		if metricLabels[releaseUpdater.ManualApprovalRequired] == "true" {
 			metricLabels[releaseUpdater.ReleaseQueueDepth] = strconv.Itoa(task.QueueDepth)
 		}
-		r.metricsUpdater.UpdateReleaseMetric(mr.GetName(), metricLabels)
+		r.metricsUpdater.UpdateReleaseMetric(release.GetName(), metricLabels)
 	}()
 
 	reasons := checker.MetRequirements(release)
@@ -613,7 +613,7 @@ func (r *reconciler) handlePendingRelease(ctx context.Context, release *v1alpha1
 	}
 
 	// handling error inside function
-	err = r.PreApplyReleaseCheck(ctx, release, task, us)
+	err = r.PreApplyReleaseCheck(ctx, release, task, us, metricLabels)
 	if err != nil {
 		// ignore this err, just requeue because of check failed
 		return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
@@ -1101,7 +1101,7 @@ func (r *reconciler) DeployTimeCalculate(ctx context.Context, mr v1alpha1.Releas
 		}
 	}
 
-	processedDTR := timeChecker.ProcessMinorReleaseDeployTime(ctx, mr, deployTimeResult, task.DeployedReleaseInfo)
+	processedDTR := timeChecker.ProcessMinorReleaseDeployTime(mr, deployTimeResult, task.DeployedReleaseInfo)
 	if processedDTR == nil {
 		return nil
 	}

--- a/deckhouse-controller/pkg/releaseupdater/deploy_time_checker.go
+++ b/deckhouse-controller/pkg/releaseupdater/deploy_time_checker.go
@@ -75,7 +75,7 @@ func (c *DeployTimeService) ProcessPatchReleaseDeployTime(release v1alpha1.Relea
 // for minor release we check:
 // - Deckhouse pod is ready
 // - No delay from calculated deploy time
-func (c *DeployTimeService) ProcessMinorReleaseDeployTime(release v1alpha1.Release, res *DeployTimeResult, dri *ReleaseInfo) *ProcessedDeployTimeResult {
+func (c *DeployTimeService) ProcessMinorReleaseDeployTime(release v1alpha1.Release, res *DeployTimeResult) *ProcessedDeployTimeResult {
 	if release.GetApplyNow() || res.Reason.IsNoDelay() {
 		return nil
 	}

--- a/deckhouse-controller/pkg/releaseupdater/deploy_time_checker.go
+++ b/deckhouse-controller/pkg/releaseupdater/deploy_time_checker.go
@@ -17,7 +17,6 @@ limitations under the License.
 package releaseupdater
 
 import (
-	"context"
 	"log/slog"
 	"time"
 
@@ -76,7 +75,7 @@ func (c *DeployTimeService) ProcessPatchReleaseDeployTime(release v1alpha1.Relea
 // for minor release we check:
 // - Deckhouse pod is ready
 // - No delay from calculated deploy time
-func (c *DeployTimeService) ProcessMinorReleaseDeployTime(ctx context.Context, release v1alpha1.Release, res *DeployTimeResult, dri *ReleaseInfo) *ProcessedDeployTimeResult {
+func (c *DeployTimeService) ProcessMinorReleaseDeployTime(release v1alpha1.Release, res *DeployTimeResult, dri *ReleaseInfo) *ProcessedDeployTimeResult {
 	if release.GetApplyNow() || res.Reason.IsNoDelay() {
 		return nil
 	}

--- a/deckhouse-controller/pkg/releaseupdater/task_calculator.go
+++ b/deckhouse-controller/pkg/releaseupdater/task_calculator.go
@@ -162,6 +162,10 @@ func (p *TaskCalculator) CalculatePendingReleaseTask(ctx context.Context, releas
 	})
 
 	releaseQueueDepth := len(releases) - 1 - releaseIdx
+	// max value for release queue depth is 3 due to the alert's logic, having queue depth greater than 3 breaks this logic
+	if releaseQueueDepth > 3 {
+		releaseQueueDepth = 3
+	}
 	isLatestRelease := releaseQueueDepth == 0
 	isPatch := true
 

--- a/deckhouse-controller/pkg/releaseupdater/task_calculator.go
+++ b/deckhouse-controller/pkg/releaseupdater/task_calculator.go
@@ -84,6 +84,15 @@ type ReleaseInfo struct {
 var ErrReleasePhaseIsNotPending = errors.New("release phase is not pending")
 var ErrReleaseIsAlreadyDeployed = errors.New("release is already deployed")
 
+// isPatchRelease returns true if b is greater only in terms of the patch versions.
+func isPatchRelease(a, b *semver.Version) bool {
+	if b.Major() == a.Major() && b.Minor() == a.Minor() && b.Patch() > a.Patch() {
+		return true
+	}
+
+	return false
+}
+
 // CalculatePendingReleaseTask calculate task with information about current reconcile
 //
 // calculating flow:
@@ -162,13 +171,13 @@ func (p *TaskCalculator) CalculatePendingReleaseTask(ctx context.Context, releas
 		prevRelease := releases[releaseIdx-1]
 
 		// if release version is greater in major or minor version than previous release
-		if release.GetVersion().Major() > prevRelease.GetVersion().Major() ||
-			release.GetVersion().Minor() > prevRelease.GetVersion().Minor() {
+		if !isPatchRelease(prevRelease.GetVersion(), release.GetVersion()) ||
+			(deployedReleaseInfo != nil && !isPatchRelease(deployedReleaseInfo.Version, release.GetVersion())) {
 			isPatch = false
 
 			// it must await if previous release has Deployed state
 			// truncate all not deployed phase releases
-			if prevRelease.GetPhase() != v1alpha1.DeckhouseReleasePhaseDeployed {
+			if prevRelease.GetPhase() == v1alpha1.DeckhouseReleasePhasePending {
 				msg := prevRelease.GetMessage()
 				if !strings.Contains(msg, "awaiting") {
 					msg = fmt.Sprintf("awaiting for v%s release to be deployed", prevRelease.GetVersion().String())

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -139,7 +139,7 @@
         ```
 
   - alert: ModuleReleaseIsWaitingManualApproval
-    expr: sum(deckhouse_mm_module_info{enabled="true"} * on(moduleName) group_left(name) d8_module_release_info{manualApproval="true"}) by (name, moduleName)
+    expr: sum(deckhouse_mm_module_info{enabled="true"} * on(moduleName) group_left(name) sum by (name, moduleName, manualApproval) (d8_module_release_info{manualApproval="true"})) by (name, moduleName)
     labels:
       severity_level: "6"
     annotations:
@@ -179,7 +179,7 @@
         ```
 
   - alert: ModuleReleaseIsBlockedByRequirements
-    expr: sum(deckhouse_mm_module_info{enabled="true"} * on(moduleName) group_left(name) d8_module_release_info{requirementsNotMet="true"}) by (name, moduleName)
+    expr: sum(deckhouse_mm_module_info{enabled="true"} * on(moduleName) group_left(name) sum by (name, moduleName, requirementsNotMet) (d8_module_release_info{requirementsNotMet="true"})) by (name, moduleName)
     labels:
       severity_level: "6"
     annotations:

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -25,7 +25,7 @@
         1. Subscribe to one of the regular release channels by adjusting the [`deckhouse` module configuration](https://deckhouse.io/products/kubernetes-platform/documentation/latest/modules/deckhouse/configuration.html#parameters-releasechannel).
 
   - alert: DeckhouseReleaseIsWaitingManualApproval
-    expr: sum by (name) (d8_release_info{manualApproval="true", releaseQueueDepth=~"(nil|one)"})
+    expr: sum by (name) (d8_release_info{manualApproval="true", releaseQueueDepth=~"(nil|0|1)"})
     labels:
       severity_level: "9"
       d8_module: deckhouse
@@ -47,7 +47,7 @@
         ```
 
   - alert: DeckhouseReleaseIsWaitingManualApproval
-    expr: sum by (name) (d8_release_info{manualApproval="true", releaseQueueDepth="two"})
+    expr: sum by (name) (d8_release_info{manualApproval="true", releaseQueueDepth="2"})
     labels:
       severity_level: "6"
       d8_module: deckhouse
@@ -69,7 +69,7 @@
         ```
 
   - alert: DeckhouseReleaseIsWaitingManualApproval
-    expr: sum by (name) (d8_release_info{manualApproval="true", releaseQueueDepth="three"})
+    expr: sum by (name) (d8_release_info{manualApproval="true", releaseQueueDepth="3"})
     labels:
       severity_level: "3"
       d8_module: deckhouse


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Provides multiples fixes to deckhouse/module release controllers regarding metrics and applying releases.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Closes #12352 
Closes #12353 
The following issues have been fixed:

1) missing/flapping `d8_is_updating` metric. The metrics is set to 1 when deckhouse controller detects that the deployed release has `IsUpdating` annotation set to true and the deckhouse pod isn't ready. As soon as the deckhouse pod becomes ready, the annotations is set to false from the deployed release and the metric is expired. This way, we say the deckhouse is updating only during the first run on a new deployed release. In order to make it work, the deckhouse-controller's `releasePhasePredicate` predicate has been updated to exclude objects at `v1alpha1.ModuleReleasePhaseDeployed` phase.

2) missing `d8_release_info` and `d8_module_release_info` metrics. These metrics should be available for all pending releases, but there was faulty logic in both controllers when to create the metrics so that only applied releases would get their metrics published for a short period of time. Moreover, transitioning a release to such states as Skipped, Suspended , Superseded (and Terminating for module releases) results in purging the release metrics.

3) The `manualApproval` and `requirementsNotMet` alerts have been amended to be able to process metrics from multiple releases.

4) Task calculator's logic has been updated to mark a release as `not a patch` in the situation as shown below:
```
v1.69.1   Deployed
v1.70.3   Pending  Release is waiting for the update window until 23 Mar 25 07:30 UTC
v1.70.4
```
In such situation, if `deckhouse` update mod was set to Auto with windows, `v1.70.4` release would end up being deployed right after creation. An additional conditional has been provided to check if a release can be still considered as a `patch` release to prevent unintended applies.

## Why do we need it in the patch release (if we do)?
Fixing!
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix applying releases and their metrics.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
