### PR TITLE
[candi](vcd) Increase `network_dhcp_wait_seconds`

### DIFF
--- a/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
@@ -70,7 +70,7 @@ resource "vcd_vapp_vm" "master" {
     is_primary         = true
     ip                 = local.ip_address
   }
-  network_dhcp_wait_seconds = 60
+  network_dhcp_wait_seconds = 120
 
   override_template_disk {
     bus_type        = "paravirtual"

--- a/ee/candi/cloud-providers/vcd/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/static-node/main.tf
@@ -57,7 +57,7 @@ resource "vcd_vapp_vm" "node" {
     is_primary         = true
     ip                 = local.ip_address
   }
-  network_dhcp_wait_seconds = 60
+  network_dhcp_wait_seconds = 120
 
   override_template_disk {
     bus_type        = "paravirtual"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Increase `network_dhcp_wait_seconds` in the `vcd_vapp_vm` resource from 60 to 120 seconds.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

`dhctl bootstrap` exited with an error:
 
<img width="914" alt="Screenshot 2025-03-18 at 18 28 11" src="https://github.com/user-attachments/assets/087e9da7-1f4a-442f-b1fb-f47671a1f91f" />


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Increase `network_dhcp_wait_seconds` in the `vcd_vapp_vm` resource from 60 to 120 seconds.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
