### PR TITLE
[docs] Updated information about service account roles at Yandex Cloud

### DIFF
--- a/candi/cloud-providers/yandex/docs/ENVIRONMENT.md
+++ b/candi/cloud-providers/yandex/docs/ENVIRONMENT.md
@@ -25,7 +25,6 @@ You need to create a service account with the editor role with the cloud provide
    yc resource-manager folder add-access-binding --id <folderID> --role connection-manager.editor --subject serviceAccount:<userID>
    yc resource-manager folder add-access-binding --id <folderID> --role vpc.admin --subject serviceAccount:<userID>
    yc resource-manager folder add-access-binding --id <folderID> --role load-balancer.editor --subject serviceAccount:<userID>
-   yc resource-manager folder add-access-binding --id <folderID> --role logging.editor --subject serviceAccount:<userID>
    ```
 
 1. Create a JSON file containing the parameters for user authorization in the cloud. These parameters will be used to log in to the cloud:

--- a/candi/cloud-providers/yandex/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/yandex/docs/ENVIRONMENT_RU.md
@@ -25,7 +25,6 @@ description: "Настройка Yandex Cloud для работы облачно
    yc resource-manager folder add-access-binding --id <folderID> --role connection-manager.editor --subject serviceAccount:<userID>
    yc resource-manager folder add-access-binding --id <folderID> --role vpc.admin --subject serviceAccount:<userID>
    yc resource-manager folder add-access-binding --id <folderID> --role load-balancer.editor --subject serviceAccount:<userID>
-   yc resource-manager folder add-access-binding --id <folderID> --role logging.editor --subject serviceAccount:<userID>
    ```
 
 1. Создайте JSON-файл с параметрами авторизации пользователя в облаке. В дальнейшем с помощью этих данных будет происходить авторизация в облаке:

--- a/docs/site/_includes/getting_started/yandex/STEP_ENV.md
+++ b/docs/site/_includes/getting_started/yandex/STEP_ENV.md
@@ -20,7 +20,6 @@ yc resource-manager folder add-access-binding --id <folderID> --role api-gateway
 yc resource-manager folder add-access-binding --id <folderID> --role connection-manager.editor --subject serviceAccount:<userID>
 yc resource-manager folder add-access-binding --id <folderID> --role vpc.admin --subject serviceAccount:<userID>
 yc resource-manager folder add-access-binding --id <folderID> --role load-balancer.editor --subject serviceAccount:<userID>
-yc resource-manager folder add-access-binding --id <folderID> --role logging.editor --subject serviceAccount:<userID>
 ```
 
 Create a JSON file containing the parameters for user authorization in the cloud. These parameters will be used to log in to the cloud:

--- a/docs/site/_includes/getting_started/yandex/STEP_ENV_RU.md
+++ b/docs/site/_includes/getting_started/yandex/STEP_ENV_RU.md
@@ -20,7 +20,6 @@ yc resource-manager folder add-access-binding --id <folderID> --role api-gateway
 yc resource-manager folder add-access-binding --id <folderID> --role connection-manager.editor --subject serviceAccount:<userID>
 yc resource-manager folder add-access-binding --id <folderID> --role vpc.admin --subject serviceAccount:<userID>
 yc resource-manager folder add-access-binding --id <folderID> --role load-balancer.editor --subject serviceAccount:<userID>
-yc resource-manager folder add-access-binding --id <folderID> --role logging.editor --subject serviceAccount:<userID>
 ```
 
 Создайте JSON-файл с параметрами авторизации пользователя в облаке. В дальнейшем с помощью этих данных будем авторизовываться в облаке:


### PR DESCRIPTION
## Description
Updated information about service account roles at Yandex Cloud.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Updated information about service account roles at Yandex Cloud.
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
