### PR TITLE
[metallb] Add clearing of alert metric group D8MetallbObsoleteLayer2PoolsAreUsed

### DIFF
--- a/ee/se/modules/380-metallb/hooks/alert_for_annotations_and_mc.go
+++ b/ee/se/modules/380-metallb/hooks/alert_for_annotations_and_mc.go
@@ -69,6 +69,7 @@ func applyServiceFilterForAlerts(obj *unstructured.Unstructured) (go_hook.Filter
 func checkServicesForDeprecatedAnnotations(input *go_hook.HookInput) error {
 	// Check ModuleConfig version and pools
 	input.MetricsCollector.Expire("D8MetallbUpdateMCVersionRequired")
+	input.MetricsCollector.Expire("D8MetallbObsoleteLayer2PoolsAreUsed")
 
 	mcSnaps := input.Snapshots["module_config"]
 	if len(mcSnaps) != 1 {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add metric group clearing in the new alert D8MetallbObsoleteLayer2PoolsAreUsed

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In v1.68.0, a new alert `D8MetallbObsoleteLayer2PoolsAreUsed` was added.
https://github.com/deckhouse/deckhouse/pull/11728

A new metric [d8_metallb_obsolete_layer2_pools_are_used](https://github.com/deckhouse/deckhouse/blob/main/ee/se/modules/380-metallb/hooks/alert_for_annotations_and_mc.go#L81) and a new group for this metric [D8MetallbObsoleteLayer2PoolsAreUsed](https://github.com/deckhouse/deckhouse/blob/main/ee/se/modules/380-metallb/hooks/alert_for_annotations_and_mc.go#L83) were created for it, but clearing of metrics from this group was not added to the hook, so if (`d8_metallb_obsolete_layer2_pools_are_used == 1`) repeated triggering of the hook will not reset the metric.

## Why do we need it in the patch release (if we do)?

This is needed in the patch release because now in clusters where the new alert appeared, if you fix ModuleConfig, the `D8MetallbObsoleteLayer2PoolsAreUsed` alert will not go out.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: metallb
type: fix
summary: Add clearing of alert metric group D8MetallbObsoleteLayer2PoolsAreUsed
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
