### PR TITLE
[istio] Collecting debugging resources in collect-debug-info

### DIFF
--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -211,7 +211,7 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "d8-istio-envoy-config.json",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl exec daemonsets/ingressgateway -n d8-istio -- curl http://localhost:15000/config_dump?include_eds=true`},
+			Args: []string{"-c", `kubectl port-forward daemonset/ingressgateway -n d8-istio 15000:15000 & sleep 5 && curl http://localhost:15000/config_dump?include_eds=true && kill $!`},
 		},
 		{
 			File: "d8-istio-system-logs.txt",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -211,7 +211,7 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "d8-istio-envoy-config.json",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl exec daemonsets/ingressgateway -n d8-istio -- curl http://localhost:15000/config_dump`},
+			Args: []string{"-c", `kubectl exec daemonsets/ingressgateway -n d8-istio -- curl http://localhost:15000/config_dump?include_eds=true`},
 		},
 		{
 			File: "d8-istio-system-logs.txt",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -206,7 +206,7 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "d8-istio-custom-resources.json",
 			Cmd:  "bash",
-			Args: []string{"-c", `for crd in $(kubectl get crds | grep 'istio.io' | awk '{print $1}'); do echo "Listing resources for CRD: $crd" && kubectl get $crd -A -o json; done`},
+			Args: []string{"-c", `for crd in $(kubectl get crds | grep -E 'istio.io|gateway.networking.k8s.io' | awk '{print $1}'); do echo "Listing resources for CRD: $crd" && kubectl get $crd -A -o json; done`},
 		},
 		{
 			File: "d8-istio-system-logs.txt",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -211,7 +211,7 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "d8-istio-envoy-config.json",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl port-forward daemonset/ingressgateway -n d8-istio 15000:15000 & sleep 5; (curl http://localhost:15000/config_dump?include_eds=true && kill $!) || { kill $!; exit 1; }`},
+			Args: []string{"-c", `kubectl port-forward daemonset/ingressgateway -n d8-istio 15000:15000 & sleep 5; (curl http://localhost:15000/config_dump?include_eds=true | jq 'del(.configs[6].dynamic_active_secrets)' && kill $!) || { kill $!; exit 1; }`},
 		},
 		{
 			File: "d8-istio-system-logs.txt",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -209,9 +209,19 @@ func createTarball() *bytes.Buffer {
 			Args: []string{"-c", `for crd in $(kubectl get crds | grep 'istio.io' | awk '{print $1}'); do echo "Listing resources for CRD: $crd" && kubectl get $crd -A -o json; done`},
 		},
 		{
-			File: "d8-istio-logs.txt",
+			File: "d8-istio-system-logs.txt",
 			Cmd:  "bash",
 			Args: []string{"-c", `for deployment in istiod-v1x21 istiod-v1x19; do echo "Logs for $deployment:" && kubectl -n d8-istio logs deployments/$deployment; done`},
+		},
+		{
+			File: "d8-istio-ingress-logs.txt",
+			Cmd:  "bash",
+			Args: []string{"-c", `kubectl -n d8-istio logs daemonset/ingressgateway`},
+		},
+		{
+			File: "d8-istio-users-logs.txt",
+			Cmd:  "bash",
+			Args: []string{"-c", `kubectl get pods --all-namespaces -o jsonpath='{range .items[?(@.metadata.annotations.istio\.io/rev)]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.containers[*].name}{"\n"}{end}' | awk '/istio-proxy/ {print $0}' | shuf -n 1 | while read namespace pod_name containers; do echo "Collecting logs from istio-proxy in Pod $pod_name (Namespace: $namespace)"; kubectl logs "$pod_name" -n "$namespace" -c istio-proxy; done`},
 		},
 	}
 

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -216,7 +216,7 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "d8-istio-system-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `for deployment in istiod-v1x21 istiod-v1x19; do echo "Logs for $deployment:" && kubectl -n d8-istio logs deployments/$deployment; done || true`},
+			Args: []string{"-c", `for deployment in $(kubectl -n d8-istio get deployments -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep '^istiod-v'); do echo "Logs for $deployment:" && kubectl -n d8-istio logs deployments/$deployment; done || true`},
 		},
 		{
 			File: "d8-istio-ingress-logs.txt",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -211,17 +211,17 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "d8-istio-envoy-config.json",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl port-forward daemonset/ingressgateway -n d8-istio 15000:15000 & sleep 5 && curl http://localhost:15000/config_dump?include_eds=true && kill $!`},
+			Args: []string{"-c", `kubectl port-forward daemonset/ingressgateway -n d8-istio 15000:15000 & sleep 5; (curl http://localhost:15000/config_dump?include_eds=true && kill $!) || { kill $!; exit 1; }`},
 		},
 		{
 			File: "d8-istio-system-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `for deployment in istiod-v1x21 istiod-v1x19; do echo "Logs for $deployment:" && kubectl -n d8-istio logs deployments/$deployment; done`},
+			Args: []string{"-c", `for deployment in istiod-v1x21 istiod-v1x19; do echo "Logs for $deployment:" && kubectl -n d8-istio logs deployments/$deployment; done || true`},
 		},
 		{
 			File: "d8-istio-ingress-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl -n d8-istio logs daemonset/ingressgateway`},
+			Args: []string{"-c", `kubectl -n d8-istio logs daemonset/ingressgateway || true`},
 		},
 		{
 			File: "d8-istio-users-logs.txt",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -216,7 +216,7 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "d8-istio-system-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `for deployment in $(kubectl -n d8-istio get deployments -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep '^istiod-v'); do echo "Logs for $deployment:" && kubectl -n d8-istio logs deployments/$deployment; done || true`},
+			Args: []string{"-c", `kubectl -n d8-istio logs deployments -l app=istiod`},
 		},
 		{
 			File: "d8-istio-ingress-logs.txt",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -209,6 +209,11 @@ func createTarball() *bytes.Buffer {
 			Args: []string{"-c", `for crd in $(kubectl get crds | grep -E 'istio.io|gateway.networking.k8s.io' | awk '{print $1}'); do echo "Listing resources for CRD: $crd" && kubectl get $crd -A -o json; done`},
 		},
 		{
+			File: "d8-istio-envoy-config.json",
+			Cmd:  "bash",
+			Args: []string{"-c", `kubectl exec daemonsets/ingressgateway -n d8-istio -- curl http://localhost:15000/config_dump`},
+		},
+		{
 			File: "d8-istio-system-logs.txt",
 			Cmd:  "bash",
 			Args: []string{"-c", `for deployment in istiod-v1x21 istiod-v1x19; do echo "Logs for $deployment:" && kubectl -n d8-istio logs deployments/$deployment; done`},

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -198,6 +198,21 @@ func createTarball() *bytes.Buffer {
 			Cmd:  "kubectl",
 			Args: []string{"get", "moduleconfig", "-o", "json"},
 		},
+		{
+			File: "d8-istio-resources.json",
+			Cmd:  "kubectl",
+			Args: []string{"-n", "d8-istio", "get", "all", "-o", "json"},
+		},
+		{
+			File: "d8-istio-custom-resources.json",
+			Cmd:  "bash",
+			Args: []string{"-c", `for crd in $(kubectl get crds | grep 'istio.io' | awk '{print $1}'); do echo "Listing resources for CRD: $crd" && kubectl get $crd -A -o json; done`},
+		},
+		{
+			File: "d8-istio-logs.txt",
+			Cmd:  "bash",
+			Args: []string{"-c", `for deployment in istiod-v1x21 istiod-v1x19; do echo "Logs for $deployment:" && kubectl -n d8-istio logs deployments/$deployment; done`},
+		},
 	}
 
 	for _, cmd := range debugCommands {


### PR DESCRIPTION
## Description
Modification of the `deckhouse-controller collect-debug-info` command to collect debugging information about Istio. The following data was collected:
1. Configuration for all resources in namespace d8-into
2. Configuration for all custom resources with istio.io CRD
3. Istio logs
4. Sidecar logs in random user application

## Why do we need it, and what problem does it solve?
We will not need to clarify additional information from the client in case of problems in closed environments where we do not have access.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: feature
summary: Added Istio debugging resources to collect-debug-info
impact_level: default
```
