### PR TITLE
[cloud-provider-vcd] Change the etcd(kubernetes_data) storage disk type from vcd_vm_internal_disk to vcd_independent_disk 

### DIFF
--- a/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
@@ -75,7 +75,7 @@ resource "vcd_vapp_vm" "master" {
   override_template_disk {
     bus_type        = "paravirtual"
     // disk_offset is just a hack to recreate VM when changing kubernetes_data.id, must be replaced with replace_triggered_by after tf upgrade
-    // this will add 0-20 mbytes to etcd disk size
+    // this will add 0-20 mbytes to root disk size
     size_in_mb      = (local.master_instance_class.rootDiskSizeGb * 1024) + local.disk_offset
     bus_number      = 0
     unit_number     = 0

--- a/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
@@ -14,7 +14,7 @@ locals {
 // hack to recreate VM when changing kubernetes_data.id, must be replaced with replace_triggered_by after tf upgrade
 locals {
   disk_hash    = md5(vcd_independent_disk.kubernetes_data.id)
-  disk_offset  = parseint(local.disk_hash, 16) % 21
+  disk_offset  = parseint(local.disk_hash, 16) % 21 + 1
 }
 
 data "vcd_catalog" "catalog" {


### PR DESCRIPTION
## Description

Added hack to migrate etcd data disk to vcd_independent_disk. Master servers are recreated for migration. In case there is only one master server, dhctl suggested to run automatic scaling mechanism to 3.

tested:
- migration from 1 master with internal disk tested
- changing vm template in a  3 master cluster without loss of etcd data
- bootstrap from scratch

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: migrate ETCD disk to VCD Independent Disk to prevent deletion of ETCD data
impact: To migrate you must perform a converge, this will cause the master server to be recreated. If you are using only 1 master server with manual address assignment via `mainNetworkIPAddresses` parameter, you need to add 2 more IP addresses for the migration process.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
