### PR TITLE
[deckhouse] explicitly set ports for kube dns deployment

### DIFF
--- a/modules/042-kube-dns/hooks/migration_deployment.go
+++ b/modules/042-kube-dns/hooks/migration_deployment.go
@@ -1,0 +1,121 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	snap          = "d8-kube-dns"
+	containerName = "coredns"
+)
+
+/*
+patch{
+										"containerPort": 5353,
+										"name":          "dns",
+										"protocol":      "UDP",
+									},
+									patch{
+										"containerPort": 5353,
+										"name":          "dns-tcp",
+										"protocol":      "TCP",
+									},
+								},
+*/
+
+var ports = []v1.ContainerPort{
+	{
+		ContainerPort: 5353,
+		Name:          "dns",
+		Protocol:      "UDP",
+	},
+	{
+		ContainerPort: 5353,
+		Name:          "dns-tcp",
+		Protocol:      "TCP",
+	},
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       snap,
+			ApiVersion: "apps/v1",
+			Kind:       "Deployment",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"d8-kube-dns"},
+			},
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"kube-system"},
+				},
+			},
+			FilterFunc: applyDeploymentCorednsPortsFilter,
+		},
+	},
+}, ensureCorednsPorts)
+
+func applyDeploymentCorednsPortsFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var depl appsv1.Deployment
+	err := sdk.FromUnstructured(obj, &depl)
+	if err != nil {
+		return nil, err
+	}
+	ports := []v1.ContainerPort{}
+	for _, v := range depl.Spec.Template.Spec.Containers {
+		if v.Name == containerName {
+			ports = append(ports, v.Ports...)
+		}
+	}
+	return ports, nil
+}
+
+func ensureCorednsPorts(input *go_hook.HookInput) error {
+	fmt.Println("imput", input)
+
+	portsSnap := input.Snapshots[snap]
+	if len(portsSnap) == 0 {
+		return nil
+	}
+
+	fmt.Println(portsSnap)
+
+	applyPorts := func(u *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+		var depl appsv1.Deployment
+		err := sdk.FromUnstructured(u, &depl)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Println(u)
+		for i, v := range depl.Spec.Template.Spec.Containers {
+			if v.Name == containerName {
+				depl.Spec.Template.Spec.Containers[i].Ports = ports
+			}
+		}
+
+		return sdk.ToUnstructured(&depl)
+	}
+	input.PatchCollector.PatchWithMutatingFunc(applyPorts, "apps/v1", "Deployment", "kube-system", "d8-kube-dns")
+	return nil
+}

--- a/modules/042-kube-dns/hooks/migration_deployment_test.go
+++ b/modules/042-kube-dns/hooks/migration_deployment_test.go
@@ -44,9 +44,9 @@ spec:
         imagePullPolicy: IfNotPresent
         name: coredns
         ports:
-        - containerPort: 5353
-          name: dns
-          protocol: UDP`
+          - containerPort: 5353
+            name: dns-tcp
+            protocol: TCP`
 
 	deploymentRightPorts = `
   - image: deckhouse
@@ -67,7 +67,8 @@ var _ = Describe("KubeDns hooks :: migration_deployment", func() {
 
 	Context("There are broken deployment", func() {
 		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(deploymentYAML))
+			f.KubeStateSet(deploymentYAML)
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
 			f.RunHook()
 		})
 		It("Deployment has been fixed", func() {
@@ -76,7 +77,5 @@ var _ = Describe("KubeDns hooks :: migration_deployment", func() {
 
 			Expect(deployment.Field("spec.template.spec.containers").String()).To(MatchYAML(deploymentRightPorts))
 		})
-
 	})
-
 })

--- a/modules/042-kube-dns/hooks/migration_deployment_test.go
+++ b/modules/042-kube-dns/hooks/migration_deployment_test.go
@@ -1,0 +1,82 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	deploymentYAML = `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: d8-kube-dns
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+    spec:
+      containers:
+      - args: []
+        image: deckhouse
+        imagePullPolicy: IfNotPresent
+        name: coredns
+        ports:
+        - containerPort: 5353
+          name: dns
+          protocol: UDP`
+
+	deploymentRightPorts = `
+  - image: deckhouse
+    imagePullPolicy: IfNotPresent
+    name: coredns
+    ports:
+      - containerPort: 5353
+        name: dns
+        protocol: UDP
+      - containerPort: 5353
+        name: dns-tcp
+        protocol: TCP
+    resources: {}`
+)
+
+var _ = Describe("KubeDns hooks :: migration_deployment", func() {
+	f := HookExecutionConfigInit("{}", "{}")
+
+	Context("There are broken deployment", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(deploymentYAML))
+			f.RunHook()
+		})
+		It("Deployment has been fixed", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			deployment := f.KubernetesResource("Deployment", "kube-system", "d8-kube-dns")
+
+			Expect(deployment.Field("spec.template.spec.containers").String()).To(MatchYAML(deploymentRightPorts))
+		})
+
+	})
+
+})

--- a/modules/042-kube-dns/hooks/migration_service_with_many_ports.go
+++ b/modules/042-kube-dns/hooks/migration_service_with_many_ports.go
@@ -91,5 +91,6 @@ func patchServiceWithManyPorts(input *go_hook.HookInput) error {
 			service.name,
 		)
 	}
+
 	return nil
 }

--- a/modules/042-kube-dns/hooks/migration_service_with_many_ports.go
+++ b/modules/042-kube-dns/hooks/migration_service_with_many_ports.go
@@ -91,6 +91,5 @@ func patchServiceWithManyPorts(input *go_hook.HookInput) error {
 			service.name,
 		)
 	}
-
 	return nil
 }


### PR DESCRIPTION
## Description
Fix problem with absent kube-dns port

## Why do we need it, and what problem does it solve?

Explicitly set ports in d8-kube-dns deployment, kubernetes uses StrategicMergePatch and the key for merge patch is the containerPort, but we need to have the same containerPort with only different protocols, so when we try to patch old deployment with only one port set kuberentes thinks that we already have that port and we don't need to patch anything.

## Why do we need it in the patch release (if we do)?

We need this because in old clusters there are deployments with only one container port
## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Explicitly set ports in d8-kube-dns deployment.
```
