### PR TITLE
[log-shipper] fix kafka parsed-data

### DIFF
--- a/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
@@ -58,7 +58,7 @@ func CreateLogDestinationTransforms(name string, dest v1alpha1.ClusterLogDestina
 	}
 
 	switch dest.Spec.Type {
-	case v1alpha1.DestSocket, v1alpha1.DestElasticsearch, v1alpha1.DestLogstash, v1alpha1.DestVector:
+	case v1alpha1.DestSocket, v1alpha1.DestElasticsearch, v1alpha1.DestLogstash, v1alpha1.DestVector, v1alpha1.DestKafka:
 		transforms = append(transforms, CleanUpParsedDataTransform())
 	case v1alpha1.DestLoki:
 		if len(dest.Spec.ExtraLabels) > 0 {

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/result.json
@@ -16,6 +16,14 @@
       "source": "if !exists(.cef) {\n  .cef = {};\n};\n\nif !exists(.cef.name) {\n  .cef.name = \"Deckhouse Event\";\n};\n\nif !exists(.cef.severity) {\n  .cef.severity = \"5\";\n} else if is_string(.cef.severity) {\n  if .cef.severity == \"Debug\" {\n    .cef.severity = \"0\";\n  };\n  if .cef.severity == \"Informational\" {\n    .cef.severity = \"3\";\n  };\n  if .cef.severity == \"Notice\" {\n    .cef.severity = \"4\";\n  };\n  if .cef.severity == \"Warning\" {\n    .cef.severity = \"6\";\n  };\n  if .cef.severity == \"Error\" {\n    .cef.severity = \"7\";\n  };\n  if .cef.severity == \"Critical\" {\n    .cef.severity = \"8\";\n  };\n  if .cef.severity == \"Emergency\" {\n    .cef.severity = \"10\";\n  };\n};",
       "type": "remap"
     },
+    "transform/destination/test-kafka-dest/01_del_parsed_data": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/destination/test-kafka-dest/00_cef_values"
+      ],
+      "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
+      "type": "remap"
+    },
     "transform/source/test-source/00_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
@@ -37,7 +45,7 @@
     "destination/cluster/test-kafka-dest": {
       "type": "kafka",
       "inputs": [
-        "transform/destination/test-kafka-dest/00_cef_values"
+        "transform/destination/test-kafka-dest/01_del_parsed_data"
       ],
       "healthcheck": {
         "enabled": false

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka/result.json
@@ -8,6 +8,14 @@
     }
   },
   "transforms": {
+    "transform/destination/test-kafka-dest/00_del_parsed_data": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-source/01_clean_up"
+      ],
+      "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
+      "type": "remap"
+    },
     "transform/source/test-source/00_local_timezone": {
       "drop_on_abort": false,
       "inputs": [
@@ -29,7 +37,7 @@
     "destination/cluster/test-kafka-dest": {
       "type": "kafka",
       "inputs": [
-        "transform/source/test-source/01_clean_up"
+        "transform/destination/test-kafka-dest/00_del_parsed_data"
       ],
       "healthcheck": {
         "enabled": false


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add delete parsed_data to final kafka transform render
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: fix
summary: Add delete parsed_data to final kafka transform render
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
