### PR TITLE
[ci] Increase werf verbosity

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -137,6 +137,7 @@ steps:
 
         werf build \
           ${SECONDARY_REPO} \
+          --verbose \
           --parallel=true --parallel-tasks-limit=5 \
           --save-build-report=true \
           --tmp-dir="$TEMP_WORKDIR" \
@@ -149,6 +150,7 @@ steps:
         # - branches to Dev registry to run e2e tests.
         # - semver tags to Github Container Registry for testing release process.
         werf build \
+          --verbose \
           --parallel=true --parallel-tasks-limit=5 \
           --save-build-report=true \
           --tmp-dir="$TEMP_WORKDIR" \
@@ -205,6 +207,7 @@ steps:
           # Copy stages to prod registry from dev registry.
           export WERF_DISABLE_META_TAGS=true
           werf build \
+            --verbose \
             --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
             --secondary-repo $WERF_REPO \
             --parallel=true --parallel-tasks-limit=5 \

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -757,6 +757,7 @@ jobs:
 
             werf build \
               ${SECONDARY_REPO} \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -769,6 +770,7 @@ jobs:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
             werf build \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -454,6 +454,7 @@ jobs:
 
             werf build \
               ${SECONDARY_REPO} \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -466,6 +467,7 @@ jobs:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
             werf build \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -612,6 +612,7 @@ jobs:
 
             werf build \
               ${SECONDARY_REPO} \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -624,6 +625,7 @@ jobs:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
             werf build \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -680,6 +682,7 @@ jobs:
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
               werf build \
+                --verbose \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
@@ -973,6 +976,7 @@ jobs:
 
             werf build \
               ${SECONDARY_REPO} \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -985,6 +989,7 @@ jobs:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
             werf build \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -1041,6 +1046,7 @@ jobs:
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
               werf build \
+                --verbose \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
@@ -1334,6 +1340,7 @@ jobs:
 
             werf build \
               ${SECONDARY_REPO} \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -1346,6 +1353,7 @@ jobs:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
             werf build \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -1402,6 +1410,7 @@ jobs:
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
               werf build \
+                --verbose \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
@@ -1695,6 +1704,7 @@ jobs:
 
             werf build \
               ${SECONDARY_REPO} \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -1707,6 +1717,7 @@ jobs:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
             werf build \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -1763,6 +1774,7 @@ jobs:
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
               werf build \
+                --verbose \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
@@ -2056,6 +2068,7 @@ jobs:
 
             werf build \
               ${SECONDARY_REPO} \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -2068,6 +2081,7 @@ jobs:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
             werf build \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -2124,6 +2138,7 @@ jobs:
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
               werf build \
+                --verbose \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
@@ -2417,6 +2432,7 @@ jobs:
 
             werf build \
               ${SECONDARY_REPO} \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -2429,6 +2445,7 @@ jobs:
             # - branches to Dev registry to run e2e tests.
             # - semver tags to Github Container Registry for testing release process.
             werf build \
+              --verbose \
               --parallel=true --parallel-tasks-limit=5 \
               --save-build-report=true \
               --tmp-dir="$TEMP_WORKDIR" \
@@ -2485,6 +2502,7 @@ jobs:
               # Copy stages to prod registry from dev registry.
               export WERF_DISABLE_META_TAGS=true
               werf build \
+                --verbose \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \


### PR DESCRIPTION
## Description
Increase werf verbosity for build.

## Why do we need it, and what problem does it solve?
Increased verbosity allows to determine whether the local / remote cache are properly utilized.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Increase werf verbosity for build.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
