### PR TITLE
[ingress-nginx] update http3 patch docs

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -67,6 +67,17 @@ Build nginx for controller on ALT Linux.
 
 Add HTTP/3 support.
 
+We have made two PRs in upstream to bump ingress-nginx image and to enable http3 module. 
+But we did not add full support for http3 in upstream, because at that time OpenSSL did not fully support quic.
+
+Bump the image and enable http3 module: https://github.com/kubernetes/ingress-nginx/pull/11470
+README about next steps for upstream: https://github.com/kubernetes/ingress-nginx/pull/11513
+
+README: https://github.com/kubernetes/ingress-nginx/blob/main/images/nginx/README.md
+
+When OpenSSL fully supports quic, the work can be continued. 
+To add fully support - steps from the readme should be accomplished and after this the patch can be deleted.
+
 ### 012-new-metrics.patch
 
 This patch adds worker max connections, worker processes and worker max open files metrics.


### PR DESCRIPTION
## Description
It updates http3 patch doc

## Why do we need it, and what problem does it solve?
To understand the current status of http3 in upstream.

Bump ingress-nginx and enable http3 module: https://github.com/kubernetes/ingress-nginx/pull/11470
Update docs: https://github.com/kubernetes/ingress-nginx/pull/11513

Doc: https://github.com/kubernetes/ingress-nginx/blob/main/images/nginx/README.md

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: chore
summary: Update http3 patch doc.
impact_level: low
```
