### PR TITLE
[deckhouse] prevent crash when source not found

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -134,7 +134,7 @@ func (l *Loader) restoreAbsentModulesFromOverrides(ctx context.Context) error {
 
 		// skip embedded module
 		if module.IsEmbedded() {
-			l.logger.Info("the module is embbedded, skip restoring module pull override process", slog.String("name", mpo.Name))
+			l.logger.Info("the module is embedded, skip restoring module pull override process", slog.String("name", mpo.Name))
 			continue
 		}
 
@@ -161,7 +161,8 @@ func (l *Loader) restoreAbsentModulesFromOverrides(ctx context.Context) error {
 		// get relevant module source
 		source := new(v1alpha1.ModuleSource)
 		if err = l.client.Get(ctx, client.ObjectKey{Name: module.Properties.Source}, source); err != nil {
-			return fmt.Errorf("get the '%s' module source for the '%s' module: %w", module.Properties.Source, mpo.Name, err)
+			l.logger.Warn("failed to get module source for the module", slog.String("name", mpo.GetModuleName()), log.Err(err))
+			return nil
 		}
 
 		// mpo's status.weight field isn't set - get it from the module's definition
@@ -306,7 +307,8 @@ func (l *Loader) restoreAbsentModulesFromReleases(ctx context.Context) error {
 		// get relevant module source
 		source := new(v1alpha1.ModuleSource)
 		if err = l.client.Get(ctx, client.ObjectKey{Name: release.GetModuleSource()}, source); err != nil {
-			return fmt.Errorf("get the '%s' module source for the '%s' module: %w", source.Name, release.Spec.ModuleName, err)
+			l.logger.Warn("failed to get module source for the module", slog.String("name", release.GetModuleName()), log.Err(err))
+			return nil
 		}
 
 		moduleSymLink := filepath.Join(l.symlinksDir, fmt.Sprintf("%d-%s", release.Spec.Weight, release.Spec.ModuleName))


### PR DESCRIPTION
## Description
It prevents deckhouse from crash when during restoring it can not find source for mpo/release.

## Why do we need it, and what problem does it solve?
If the active source of a module is deleted, restoring process ends with deckhouse crash, skipping this releases/mpo keeps deckhouse alive.

## Why do we need it in the patch release (if we do)?
It is difficult to get out of this situation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Prevent crash when source not found
impact_level: low
```
