### PR TITLE
[deckhouse] module config ignored

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -51,6 +51,8 @@ const (
 
 	maxConcurrentReconciles = 3
 
+	moduleNotFoundInterval = 3 * time.Minute
+
 	moduleDeckhouse = "deckhouse"
 	moduleGlobal    = "global"
 )
@@ -140,7 +142,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, nil
 		}
 		r.log.Error("failed to get module config", slog.String("name", req.Name), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, err
 	}
 
 	// handle delete event
@@ -198,12 +200,12 @@ func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alp
 				})
 				if err != nil {
 					r.log.Error("failed to update module config", slog.String("name", moduleConfig.Name), log.Err(err))
-					return ctrl.Result{Requeue: true}, nil
+					return ctrl.Result{}, err
 				}
 			}
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: moduleNotFoundInterval}, nil
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, err
 	}
 
 	return r.processModule(ctx, moduleConfig, module)
@@ -219,7 +221,7 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 	if !moduleConfig.IsEnabled() {
 		if err := r.disableModule(ctx, module); err != nil {
 			r.log.Error("failed to disable the module", slog.String("module", module.Name), log.Err(err))
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{}, err
 		}
 
 		err := utils.Update[*v1alpha1.ModuleConfig](ctx, r.client, moduleConfig, func(moduleConfig *v1alpha1.ModuleConfig) bool {
@@ -231,7 +233,7 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 		})
 		if err != nil {
 			r.log.Error("failed to remove allow disabled annotation for module config", slog.String("name", moduleConfig.Name), log.Err(err))
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{}, err
 		}
 
 		// skip disabled modules
@@ -242,13 +244,13 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 	if moduleConfig.IsEnabled() {
 		if err := r.enableModule(ctx, module); err != nil {
 			r.log.Error("failed to enable the module", slog.String("module", module.Name), log.Err(err))
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{}, err
 		}
 	}
 
 	if err := r.addFinalizer(ctx, moduleConfig); err != nil {
 		r.log.Error("failed to add finalizer", slog.String("module", module.Name), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, err
 	}
 
 	// skip system modules
@@ -273,7 +275,7 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 	if moduleConfig.Spec.Source != "" && module.Properties.Source != moduleConfig.Spec.Source {
 		if err := r.changeModuleSource(ctx, module, moduleConfig.Spec.Source, updatePolicy); err != nil {
 			r.log.Debug("failed to change source for the module", slog.String("name", module.Name), log.Err(err))
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -282,7 +284,7 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 		if len(module.Properties.AvailableSources) == 1 {
 			if err := r.changeModuleSource(ctx, module, module.Properties.AvailableSources[0], updatePolicy); err != nil {
 				r.log.Debug("failed to change source for module", slog.String("name", module.Name), log.Err(err))
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{}, err
 			}
 		}
 
@@ -295,8 +297,8 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 				return true
 			})
 			if err != nil {
-				r.log.Error("failed to set conlflict to module", slog.String("name", module.Name), log.Err(err))
-				return ctrl.Result{Requeue: true}, nil
+				r.log.Error("failed to set conflict to module", slog.String("name", module.Name), log.Err(err))
+				return ctrl.Result{}, err
 			}
 			// fire alert at Conflict
 			r.metricStorage.Grouped().GaugeSet(metricGroup, "d8_module_at_conflict", 1.0, map[string]string{
@@ -315,7 +317,7 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 	})
 	if err != nil {
 		r.log.Error("failed to update module`s update policy", slog.String("name", module.Name), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
@@ -331,12 +333,12 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 			r.log.Warn("module not found", slog.String("name", moduleConfig.Name))
 			if err = r.removeFinalizer(ctx, moduleConfig); err != nil {
 				r.log.Error("failed to remove finalizer", slog.String("module", moduleConfig.Name), log.Err(err))
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, nil
 		}
 		r.log.Error("failed to get module", slog.String("name", moduleConfig.Name), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, err
 	}
 
 	// skip system modules
@@ -348,7 +350,7 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 	// disable module
 	if err := r.disableModule(ctx, module); err != nil {
 		r.log.Error("failed to disable the module", slog.String("module", module.Name), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, err
 	}
 
 	// clear downloaded module
@@ -360,13 +362,13 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 		})
 		if err != nil {
 			r.log.Error("failed to update the module", slog.String("module", module.Name), log.Err(err))
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{}, err
 		}
 	}
 
 	if err := r.removeFinalizer(ctx, moduleConfig); err != nil {
-		r.log.Error("failed to remove finalizer from ModuleConfig", slog.String("module", moduleConfig.Name), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+		r.log.Error("failed to remove finalizer from config", slog.String("module", moduleConfig.Name), log.Err(err))
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -367,7 +367,7 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 	}
 
 	if err := r.removeFinalizer(ctx, moduleConfig); err != nil {
-		r.log.Error("failed to remove finalizer from config", slog.String("module", moduleConfig.Name), log.Err(err))
+		r.log.Error("failed to remove finalizer from ModuleConfig", slog.String("module", moduleConfig.Name), log.Err(err))
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
## Description
It fixes the case when a module config ignored because the module is discovered after the config created.

Prev fix: https://github.com/deckhouse/deckhouse/pull/12039

## Why do we need it, and what problem does it solve?
If a module is discovered after the module config created, the config is ignored because the controller cannot find the module. When the module created - nothing triggers the config to reconcile(watcher mechanism doesn't always work) so we set interval in 3 minutes to trigger the config by it. 

## Why do we need it in the patch release (if we do)?
Flaky error, it can appear when a cluster is setting up by commander. Only reboot or trigger config fixed it.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix module config ignored.
impact_level: low
```
