### PR TITLE
[deckhouse] fix checking automatic kubernetes version in managed clusters

### DIFF
--- a/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
+++ b/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 

--- a/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
+++ b/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
@@ -189,6 +189,7 @@ func (c *kubernetesVersionCheck) initClusterKubernetesVersion(ctx context.Contex
 	key := client.ObjectKey{Namespace: systemNamespace, Name: deckhouseClusterConfigurationConfig}
 	secret := new(corev1.Secret)
 	if err := c.k8sclient.Get(ctx, key, secret); err != nil {
+		// the secret does not exist in managed cluster
 		if apierrors.IsNotFound(err) {
 			return nil
 		}


### PR DESCRIPTION
## Description
It fixes checking automatic kubernetes version in managed clusters.

## Why do we need it, and what problem does it solve?
In managed clusters there is no cluster configuration secret.

## Why do we need it in the patch release (if we do)?
Deckhouse update failed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix checking automatic kubernetes version in managed clusters.
```
