### PR TITLE
[tools] update helm_lib to 1.44.5

### DIFF
--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.44.2
-digest: sha256:2119d89782d355e92a473ac9bae054998a07e60ec10f06865b2dc2b93249e538
-generated: "2025-03-06T14:45:38.907999+03:00"
+  version: 1.44.5
+digest: sha256:7ee8a1c201b29f2d3ef6eff404f5ac8bd5708e0ff167e0108a84e210972e00c9
+generated: "2025-03-21T12:50:27.109285+03:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: "Helm helpers"
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.44.2"
+    version: "1.44.5"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.44.2
+version: 1.44.5

--- a/helm_lib/charts/deckhouse_lib_helm/README.md
+++ b/helm_lib/charts/deckhouse_lib_helm/README.md
@@ -35,6 +35,8 @@
 | [helm_lib_module_image_no_fail](#helm_lib_module_image_no_fail) |
 | [helm_lib_module_common_image](#helm_lib_module_common_image) |
 | [helm_lib_module_common_image_no_fail](#helm_lib_module_common_image_no_fail) |
+| [helm_lib_module_image_digest](#helm_lib_module_image_digest) |
+| [helm_lib_module_image_digest_no_fail](#helm_lib_module_image_digest_no_fail) |
 | **Module Ingress Class** |
 | [helm_lib_module_ingress_class](#helm_lib_module_ingress_class) |
 | **Module Init Container** |
@@ -408,6 +410,36 @@ list:
 #### Usage
 
 `{{ include "helm_lib_module_common_image_no_fail" (list . "<container-name>") }} `
+
+#### Arguments
+
+list:
+-  Template context with .Values, .Chart, etc 
+-  Container name 
+
+
+### helm_lib_module_image_digest
+
+ returns image digest 
+
+#### Usage
+
+`{{ include "helm_lib_module_image_digest" (list . "<container-name>" "<module-name>(optional)") }} `
+
+#### Arguments
+
+list:
+-  Template context with .Values, .Chart, etc 
+-  Container name 
+
+
+### helm_lib_module_image_digest_no_fail
+
+ returns image digest if found 
+
+#### Usage
+
+`{{ include "helm_lib_module_image_digest_no_fail" (list . "<container-name>" "<module-name>(optional)") }} `
 
 #### Arguments
 
@@ -1027,7 +1059,7 @@ list:
 
 ### helm_lib_priority_class
 
- returns priority class
+ returns priority class 
 
 #### Arguments
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
@@ -24,7 +24,8 @@ memory: 25Mi
   {{- $additionalNodeLivenessProbesCmd := $config.additionalNodeLivenessProbesCmd }}
   {{- $additionalNodeSelectorTerms := $config.additionalNodeSelectorTerms }}
   {{- $customNodeSelector := $config.customNodeSelector }}
-  {{- $additionalContainers := $config.additionalContainers }}
+  {{- $forceCsiNodeAndStaticNodesDepoloy := $config.forceCsiNodeAndStaticNodesDepoloy | default false }}
+  {{- $additionalContainers := $config.additionalContainers }} 
   {{- $initContainers := $config.initContainers }}
   {{- $additionalPullSecrets := $config.additionalPullSecrets }}
 
@@ -32,7 +33,7 @@ memory: 25Mi
   {{- $driverRegistrarImageName := join "" (list "csiNodeDriverRegistrar" $kubernetesSemVer.Major $kubernetesSemVer.Minor) }}
   {{- $driverRegistrarImage := include "helm_lib_module_common_image_no_fail" (list $context $driverRegistrarImageName) }}
   {{- if $driverRegistrarImage }}
-    {{- if or (include "_helm_lib_cloud_or_hybrid_cluster" $context) ($context.Values.global.enabledModules | has "ceph-csi") ($context.Values.global.enabledModules | has "csi-nfs") ($context.Values.global.enabledModules | has "csi-ceph") ($context.Values.global.enabledModules | has "csi-yadro") ($context.Values.global.enabledModules | has "csi-scsi-generic") ($context.Values.global.enabledModules | has "csi-hpe") ($context.Values.global.enabledModules | has "csi-s3") ($context.Values.global.enabledModules | has "csi-huawei") }}
+    {{- if or $forceCsiNodeAndStaticNodesDepoloy (include "_helm_lib_cloud_or_hybrid_cluster" $context) ($context.Values.global.enabledModules | has "ceph-csi") ($context.Values.global.enabledModules | has "csi-nfs") ($context.Values.global.enabledModules | has "csi-ceph") ($context.Values.global.enabledModules | has "csi-scsi-generic") ($context.Values.global.enabledModules | has "csi-hpe") ($context.Values.global.enabledModules | has "csi-s3") ($context.Values.global.enabledModules | has "csi-huawei") }}
       {{- if ($context.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -101,7 +102,7 @@ spec:
                 - CloudEphemeral
                 - CloudPermanent
                 - CloudStatic
-                {{- if or (eq $fullname "csi-node-rbd") (eq $fullname "csi-node-cephfs") (eq $fullname "csi-nfs") (eq $fullname "csi-yadro") (eq $fullname "csi-scsi-generic") (eq $fullname "csi-hpe") (eq $fullname "csi-s3") (eq $fullname "csi-huawei") }}
+                {{- if or $forceCsiNodeAndStaticNodesDepoloy (eq $fullname "csi-node-rbd") (eq $fullname "csi-node-cephfs") (eq $fullname "csi-nfs") (eq $fullname "csi-scsi-generic") (eq $fullname "csi-hpe") (eq $fullname "csi-s3") (eq $fullname "csi-huawei") }}
                 - Static
                 {{- end }}
               {{- if $additionalNodeSelectorTerms }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_priority_class.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_priority_class.tpl
@@ -1,5 +1,5 @@
 {{- /* Usage: {{ include "helm_lib_priority_class" (tuple . "priority-class-name") }} /* -}}
-{{- /* returns priority class  */ -}}
+{{- /* returns priority class */ -}}
 {{- define "helm_lib_priority_class" }}
   {{- $context := index . 0 -}} {{- /* Template context with .Values, .Chart, etc */ -}}
   {{- $priorityClassName := index . 1 }}  {{- /* Priority class name */ -}}


### PR DESCRIPTION
## Description

Update helm_lib to 1.44.5

## Why do we need it, and what problem does it solve?

Added new functions:
- helm_lib_module_image_digest
- helm_lib_module_image_digest_no_fail

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: chore
summary: update lib_helm to 1.44.5
impact_level: low
```
