### PR TITLE
[docs] Fix config duplication problem in Getting Started for zVirt and vSphere

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
@@ -7,7 +7,7 @@ Log in on the **personal computer** to the container image registry you specifie
 
 Run the installer on the **personal computer**.
 
-{%- if revision == 'ee' %}
+{%- if revision == 'be' or revision == 'se' or revision == 'se-plus' or revision == 'ee' %}
 
 <a id='tab_installer_linux_{{ revision }}' href="javascript:void(0)" class="tabs__btn tabs__btn_installer_{{ revision }} active"
    onclick="openTabAndSaveStatus(event, 'tabs__btn_installer_{{ revision }}', 'tabs__content_installer_{{ revision }}', 'block_installer_linux_{{ revision }}');" >
@@ -19,9 +19,14 @@ Run the installer on the **personal computer**.
 </a>
 
 <div id='block_installer_linux_{{ revision }}' class="tabs__content tabs__content_installer_{{ revision }} active" markdown="1">
-<!-- Linux or macOS install, EE -->
+<!-- Linux or macOS install, BE, SE, SE+, EE -->
+Log in on the **personal computer** to the container image registry:
 ```shell
- echo <LICENSE_TOKEN> | docker login -u license-token --password-stdin registry.deckhouse.io
+echo <LICENSE_TOKEN> | docker login -u license-token --password-stdin registry.deckhouse.io
+```
+
+Run a container with the installer:
+```shell
 docker run --pull=always {% if page.platform_code == "kind" %} --network host {% endif %}-it -v "$PWD/config.yml:/config.yml"{%- if page.platform_type != 'existing' %} -v "$HOME/.ssh/:/tmp/.ssh/"{% endif %}
 {%- if page.platform_type == "existing" or page.platform_code == "kind" %} \
   -v "$HOME/.kube/config:/kubeconfig"{% endif %}
@@ -30,7 +35,7 @@ docker run --pull=always {% if page.platform_code == "kind" %} --network host {%
 ```
 </div>
 <div id='block_installer_windows_{{ revision }}' class="tabs__content tabs__content_installer_{{ revision }}" markdown="1">
-<!-- Windows install, EE -->
+<!-- Windows install, BE, SE, SE+, EE -->
 Log in on the **personal computer** to the container image registry by providing the license key as a password:
 ```text
 docker login -u license-token registry.deckhouse.io

--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
@@ -16,7 +16,7 @@ pdpl-user -i 63 <USERNAME>
 
 Запустите установщик на **персональном компьютере**.
 
-{%- if revision == 'ee' %}
+{%- if revision == 'be' or revision == 'se' or revision == 'se-plus' or revision == 'ee' %}
 
 <a id='tab_installer_linux_{{ revision }}' href="javascript:void(0)" class="tabs__btn tabs__btn_installer_{{ revision }} active"
    onclick="openTabAndSaveStatus(event, 'tabs__btn_installer_{{ revision }}', 'tabs__content_installer_{{ revision }}', 'block_installer_linux_{{ revision }}');" >
@@ -28,9 +28,14 @@ pdpl-user -i 63 <USERNAME>
 </a>
 
 <div id='block_installer_linux_{{ revision }}' class="tabs__content tabs__content_installer_{{ revision }} active" markdown="1">
-<!-- Linux or macOS install, EE -->
+<!-- Linux or macOS install, BE, SE, SE+, EE -->
+Авторизуйтесь на **персональном компьютере** в container image registry:
 ```shell
- echo <LICENSE_TOKEN> | docker login -u license-token --password-stdin registry.deckhouse.ru
+echo <LICENSE_TOKEN> | docker login -u license-token --password-stdin registry.deckhouse.ru
+```
+
+Запустите контейнер с установщиком:
+```shell
 docker run --pull=always {% if page.platform_code == "kind" %} --network host {% endif %}-it -v "$PWD/config.yml:/config.yml"{%- if page.platform_type != 'existing' %} -v "$HOME/.ssh/:/tmp/.ssh/"{% endif %}
 {%- if page.platform_type == "existing" or page.platform_code == "kind" %} \
   -v "$HOME/.kube/config:/kubeconfig"{% endif %}
@@ -39,7 +44,7 @@ docker run --pull=always {% if page.platform_code == "kind" %} --network host {%
 ```
 </div>
 <div id='block_installer_windows_{{ revision }}' class="tabs__content tabs__content_installer_{{ revision }}" markdown="1">
-<!-- Windows install, EE -->
+<!-- Windows install, BE, SE, SE+, EE -->
 Авторизуйтесь на **персональном компьютере** в container image registry, введя лицензионный ключ на запрос пароля:
 ```text
 docker login -u license-token registry.deckhouse.ru

--- a/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
+++ b/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
@@ -28,6 +28,11 @@
 </div>
 {%- endunless %}
 {%- if page.ee_only == true and page.se_support == true %}
+{% if page.lang == 'ru' %}
+  <h4>Выберите редакцию Deckhouse Kubernetes Platform</h4>
+  {% else %}
+  <h4>Select the Deckhouse Kubernetes Platform revision</h4>
+{% endif %}
   <div class="tabs">
     {%- for revision in site.data.getting_started.dkp_data.global.revisions %}
       {%  if revision == "se" or revision == "se-plus" or revision == "ee" %}
@@ -40,6 +45,21 @@
       {% endif %}
     {%- endfor %}
   </div>
+
+  <script>
+    // Function for initializing tabs on page load
+    function initializeTabs() {
+      // Set active tab
+      const defaultTab = 'se';
+      const defaultTabElement = document.getElementById(`tab_layout_${defaultTab}`);
+      if (defaultTabElement) {
+        defaultTabElement.click();
+      }
+    }
+
+    // Call the initialization function on page load
+    window.addEventListener('load', initializeTabs);
+  </script>
 {% endif %}
 
 {%- for revision in site.data.getting_started.dkp_data.global.revisions %}


### PR DESCRIPTION
## Description
Fixed a problem with config duplication for zvirt and vSphere.
Added login step in registry for BE, CE, CE+, EE.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fixed a problem with config duplication for zVirt and vSphere.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
