### PR TITLE
DefectDojo Reports Rotator

### DIFF
--- a/.github/scripts/python/defectdojo_dev_tests_rotator.py
+++ b/.github/scripts/python/defectdojo_dev_tests_rotator.py
@@ -14,13 +14,15 @@
 # limitations under the License.
 
 import os
+import re
 import requests
 from datetime import datetime
 
 # Env vars
 defectdojo_host = os.getenv('DEFECTDOJO_HOST')
 defectdojo_token = os.getenv('DEFECTDOJO_API_TOKEN')
-days_to_keep = int(os.getenv('DEFECTDOJO_DEV_TESTS_ROTATION_DAYS', 7))
+days_to_keep = int(os.getenv('DEFECTDOJO_DEV_TESTS_ROTATION_DAYS', 3))
+release_versions_to_keep = int(os.getenv('DEFECTDOJO_RELEASE_TESTS_ROTATION_VERSIONS_AMOUNT', 3))
 
 # Static vars
 defectdojo_proto = "https://"
@@ -30,26 +32,79 @@ headers = {"accept": "application/json", "Content-Type": "application/json", "Au
 current_date=datetime.now().date()
 
 
-def get_old_tests():
-    engage_id = requests.get(defectdojo_api_url+"engagements", headers=headers, params={"name": defectdojo_deckhouse_images_engagement}).json()["results"][0]["id"]
-    old_dev_tests = requests.get(defectdojo_api_url+"tests", headers=headers, params={"engagement": engage_id, "limit": "10000", "not_tag": "main"}).json()["results"]
-    return old_dev_tests
 
-def remove_old_tests(old_dev_tests):
-    old_tests_counter = 0
-    for test in old_dev_tests:
-        if (current_date - datetime.fromisoformat(test["created"]).date()).days > days_to_keep:
-            deleted_result = requests.delete(defectdojo_api_url+"tests/"+str(test["id"])+"/", headers=headers)
-            if deleted_result.status_code == 204:
-                old_tests_counter += 1
-                print("Test: "+str(test["id"])+" "+str(test["title"])+" was successfully removed")
-            else:
-                print("Test: "+str(test["id"])+" "+str(test["title"])+" was NOT REMOVED, response code: "+str(deleted_result.status_code))
-    if old_tests_counter > 0:
-        print("Dev tests were removed: "+str(old_tests_counter))
+def delete_test(test, removed_tests_counter):
+    deleted_result = requests.delete(defectdojo_api_url+"tests/"+str(test["id"])+"/", headers=headers)
+    if deleted_result.status_code == 204:
+        removed_tests_counter += 1
+        print("Test: "+str(test["id"])+" "+str(test["title"])+" was successfully removed")
     else:
-        print("Nothing to remove as there are no dev tests older than "+str(days_to_keep)+" days")
+        print("Test: "+str(test["id"])+" "+str(test["title"])+" was NOT REMOVED, response code: "+str(deleted_result.status_code))
+    return removed_tests_counter
+
+
+def get_releases_to_keep(eng_tests):
+    releases_to_keep=[]
+    release_versions=[]
+    v_versions=[]
+    for item in eng_tests:
+        if re.match(r"^release-*", item["version"]):
+            release_versions.append(item["version"])
+        elif re.match(r"^v\d+[\.\d+]*$", item["version"]):
+            v_versions.append(item["version"])
+    if release_versions:
+        # uniquify and sort if list not empty
+        release_versions = list(set(release_versions))
+        release_versions.sort(reverse=True)
+        if len(release_versions) > release_versions_to_keep:
+            releases_to_keep.extend(release_versions[:release_versions_to_keep])
+        else:
+            releases_to_keep.extend(release_versions)
+    if v_versions:
+        # uniquify and sort if list not empty
+        v_versions = list(set(v_versions))
+        v_versions.sort(reverse=True)
+        if len(v_versions) > release_versions_to_keep:
+            releases_to_keep.extend(v_versions[:release_versions_to_keep])
+        else:
+            releases_to_keep.extend(v_versions)
+    return releases_to_keep
+
+
+def get_old_tests():
+    removed_tests_counter = 0
+    obsolete_tests_counter = 0
+    for product in requests.get(defectdojo_api_url+"products", headers=headers).json()["results"]:
+        for eng in requests.get(defectdojo_api_url+"engagements", headers=headers, params={"product": product["id"]}).json()["results"]:
+            print("======================================================")
+            print(f'Product: \"{product["name"]}\", Engagement: \"{eng["name"]}\"')
+            eng_tests=requests.get(defectdojo_api_url+"tests", headers=headers, params={"engagement": eng["id"], "limit": "10000", "not_tags": "branch:main,branch:master"}).json()["results"]
+            releases_to_keep = get_releases_to_keep(eng_tests)
+            print(f'The following release versions for product \"{product["name"]}\" will be kept:')
+            print(f'{releases_to_keep}')
+            for test in eng_tests:
+                #if version == mr* or pr* and older then days_to_keep_dev - delete
+                if re.match(r"^mr*|^pr*", test["version"]):
+                    if (current_date - datetime.fromisoformat(test["created"]).date()).days > days_to_keep:
+                        obsolete_tests_counter += 1
+                        removed_tests_counter = delete_test(test, removed_tests_counter)
+
+                #if version == release-* or ^v\d+[\.\d+]*$ and older then 3 releases - delete
+                elif re.match(r"^release-*|^v\d+[\.\d+]*$", test["version"]):
+                    if test["version"] not in releases_to_keep:
+                        obsolete_tests_counter += 1
+                        removed_tests_counter = delete_test(test, removed_tests_counter)
+
+                #if other version - delete as most likely it is from dev branch
+                else:
+                    obsolete_tests_counter += 1
+                    removed_tests_counter = delete_test(test, removed_tests_counter)
+    if obsolete_tests_counter > 0:
+        print(f'"Obsolete tests were removed: {removed_tests_counter}/{obsolete_tests_counter}')
+    else:
+        print("Nothing to remove")
+
 
 
 if __name__ == "__main__":
-    remove_old_tests(get_old_tests())
+    get_old_tests()


### PR DESCRIPTION
## Description
Rotate DefectDojo obsolete reports by rules:
1. Dev reports older than 3 days
2. Release reports older than 3 latest releases

## Why do we need it, and what problem does it solve?
Too many garbage reports from dev branches

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: tools
type: chore
summary: Rotate DefectDojo obsolete reports
impact: none
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
