### PR TITLE
[docs] Add trdl nginx configuration to deckhouse.ru

### DIFF
--- a/docs/site/.werf/nginx.conf
+++ b/docs/site/.werf/nginx.conf
@@ -111,6 +111,25 @@ http {
             proxy_pass              https://github.com;
         }
 
+        	location ~* ^/downloads/deckhouse-cli-trdl/(.*)  {
+                    rewrite ^/downloads/deckhouse-cli-trdl/(.*)$ /$1  break;
+
+                    proxy_cache             dcache;
+                    proxy_cache_key         $uri;
+                    proxy_cache_methods     GET;
+                    proxy_set_header        X-Real-IP         $remote_addr;
+                    proxy_set_header        X-Original-URI    $request_uri;
+                    proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
+                    proxy_buffer_size       16k;
+                    proxy_buffers           4 16k;
+                    proxy_ignore_headers    Set-Cookie;
+                    proxy_ignore_headers    Cache-Control;
+                    proxy_intercept_errors  on;
+
+                    error_page              301 302 307 = @handle_redirects;
+                    proxy_pass              https://tuf.deckhouse.ru;
+                }
+
         location @handle_redirects {
             set                     $original_uri  $uri;
             set                     $orig_loc      $upstream_http_location;


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
this mr allow download d8 cli through trdl client from deckhouse.ru/downloads/deckhouse-cli-trdl

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this allow download d8 bin artifacts through trdl from deckhouse.ru domain, not trrr.flant.dev.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: chore
type: feature
summary: Add trdl Nginx configuration to the site.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
