### PR TITLE
[dhctl] disable parallel bootstrapping cloud permanent nodes for vcd

### DIFF
--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -575,7 +575,9 @@ func bootstrapAdditionalNodesForCloudCluster(ctx context.Context, kubeCl *client
 
 	terraNodeGroups := metaConfig.GetTerraNodeGroups()
 	bootstrapAdditionalTerraNodeGroups := BootstrapTerraNodes
-	if operations.IsSequentialNodesBootstrap() {
+	if operations.IsSequentialNodesBootstrap() || metaConfig.ProviderName == "vcd" {
+		// vcd doesn't support parrallel creating nodes in same vapp
+		// https://github.com/vmware/terraform-provider-vcd/issues/530
 		bootstrapAdditionalTerraNodeGroups = operations.BootstrapSequentialTerraNodes
 	}
 

--- a/dhctl/pkg/operations/converge/runner.go
+++ b/dhctl/pkg/operations/converge/runner.go
@@ -193,7 +193,9 @@ func (r *runner) convergeTerraNodes(ctx *context.Context, metaConfig *config.Met
 	log.DebugF("NodeGroups for creating %v\n", nodeGroupsWithoutStateInCluster)
 
 	bootstrapNewNodeGroups := operations.ParallelCreateNodeGroup
-	if operations.IsSequentialNodesBootstrap() {
+	if operations.IsSequentialNodesBootstrap() || metaConfig.ProviderName == "vcd" {
+		// vcd doesn't support parrallel creating nodes in same vapp
+		// https://github.com/vmware/terraform-provider-vcd/issues/530
 		bootstrapNewNodeGroups = operations.BootstrapSequentialTerraNodes
 	}
 

--- a/dhctl/pkg/operations/nodebootstrap.go
+++ b/dhctl/pkg/operations/nodebootstrap.go
@@ -34,11 +34,11 @@ import (
 )
 
 func IsSequentialNodesBootstrap() bool {
-	if os.Getenv("DHCTL_PARALLEL_CLOUD_PERMANENT_NODES_BOOTSTRAP") == "yes" {
-		return false
+	if os.Getenv("DHCTL_PARALLEL_CLOUD_PERMANENT_NODES_BOOTSTRAP") == "false" {
+		return true
 	}
 
-	return true
+	return false
 }
 
 func NodeName(cfg *config.MetaConfig, nodeGroupName string, index int) string {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

1. Disable parallel bootstrapping cloud permanent nodes for VCD.
2. Enable parallel bootstrapping cloud permanent nodes for other providers.
3. Keep the option to disable parallel bootstrap for cloud permanent nodes via env variable: `DHCTL_PARALLEL_CLOUD_PERMANENT_NODES_BOOTSTRAP=false` 

## Why do we need it, and what problem does it solve?

VCD doesn't support parallel VM creation in the same vapp.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessary.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Disable parallel bootstrapping cloud permanent nodes for VCD.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
