### PR TITLE
[deckhouse] 1.68 module config ignored

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -54,6 +54,8 @@ const (
 
 	maxConcurrentReconciles = 3
 
+	moduleNotFoundInterval = 3 * time.Minute
+
 	moduleDeckhouse = "deckhouse"
 	moduleGlobal    = "global"
 )
@@ -184,7 +186,7 @@ func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alp
 					return ctrl.Result{Requeue: true}, nil
 				}
 			}
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: moduleNotFoundInterval}, nil
 		}
 		return ctrl.Result{Requeue: true}, nil
 	}


### PR DESCRIPTION
## Description
It fixes the case when a module config ignored because the module is discovered after the config created.

Prev fix: https://github.com/deckhouse/deckhouse/pull/12039

## Why do we need it, and what problem does it solve?
If a module is discovered after the module config created, the config is ignored because the controller cannot find the module. When the module created - nothing triggers the config to reconcile(watcher mechanism doesn't always work) so we set interval in 3 minutes to trigger the config by it. 

## Why do we need it in the patch release (if we do)?
Flaky error, it can appear when a cluster is setting up by commander. Only reboot or trigger config fixed it.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix module config ignored.
impact_level: low
```