### PR TITLE
[chore][docs] Fix cleanup when using local registry for building documentation

### DIFF
--- a/docs/documentation/Makefile
+++ b/docs/documentation/Makefile
@@ -12,7 +12,7 @@ network:
 registry:
 		@if ! docker ps | grep -q registry ; then \
 			docker rm -f registry 2>/dev/null 1>/dev/null; \
-			docker run -d -p 4999:5000 --restart=always --name registry registry:2 ; \
+			docker run -d -p 4999:5000 -e REGISTRY_STORAGE_DELETE_ENABLED=true --restart=always --name registry registry:2 ; \
 		fi
 
 .PHONY:

--- a/docs/site/Makefile
+++ b/docs/site/Makefile
@@ -8,7 +8,7 @@ all: up
 registry:
 		@if ! docker ps | grep -q registry ; then \
 			docker rm -f registry 2>/dev/null 1>/dev/null; \
-			docker run -d -p 4999:5000 --restart=always --name registry registry:2 ; \
+			docker run -d -p 4999:5000 -e REGISTRY_STORAGE_DELETE_ENABLED=true --restart=always --name registry registry:2 ; \
 		fi
 
 .PHONY:


### PR DESCRIPTION
## Description

Run local registry with deletion images enabled, to allow using werf cleanup.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Run local registry with deletion images enabled, to allow using werf cleanup.
impact_level: low
```
