### PR TITLE
[tools] update DMT version to 0.1.9 in dmt-lint.sh

### DIFF
--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-DMT_VERSION=0.1.8
+DMT_VERSION=0.1.9
 
 function install_dmt() {
   platform_name=$(uname -m)


### PR DESCRIPTION
## Description

Update DMT version to 0.1.9

## Why do we need it, and what problem does it solve?

Use new lint settings

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: chore
summary: update DMT version to 0.1.9
impact_level: low
```
