### PR TITLE
[candi] bashible configure-kubelet step fix

### DIFF
--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -158,7 +158,7 @@ def numfmt_to_bytes(human_number: str, multiplier: float = 1) -> Decimal:
     }
     for unit, factor in units.items():
         if human_number.endswith(unit):
-            return Decimal(int(human_number[: -len(unit)]) * factor * m).quantize(1)
+            return Decimal(float(human_number[: -len(unit)]) * factor * m).quantize(1)
     return Decimal(float(human_number) * m).quantize(1)
 
 human_number = sys.argv[1]

--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -166,7 +166,7 @@ multiplier = 1
 if len(sys.argv) > 2:
     if len(sys.argv[2]) > 0:
         multiplier = float(sys.argv[2])
-print(numfmt_to_bytes(human_number, multiplier))"
+print(numfmt_to_bytes(human_number, multiplier))" $1 $2
 }
 
 total_memory=$(free -m|awk '/^Mem:/{print $2}')

--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -136,15 +136,37 @@ fi
 check_python
 function resources_management_memory_units_to_bytes {
   $python_binary -c "
-from decimal import *
-getcontext().prec = 100
-def numfmt_to_bytes(human_number):
-    units = {'Ki': 1024, 'Mi': 1024**2, 'Gi': 1024**3, 'Ti': 1024**4, 'Pi': 1024**5, 'Ei': 1024**6, 'k': 1000, 'M': 1000**2, 'G': 1000**3, 'T': 1000**4, 'P': 1000**5, 'E': 1000**6, 'm': 0.001}
+import sys
+from decimal import Decimal
+
+def numfmt_to_bytes(human_number: str, multiplier: float = 1) -> Decimal:
+    m = float(multiplier)
+    units = {
+        'Ki': 1024,
+        'Mi': 1024**2,
+        'Gi': 1024**3,
+        'Ti': 1024**4,
+        'Pi': 1024**5,
+        'Ei': 1024**6,
+        'k': 1000,
+        'M': 1000**2,
+        'G': 1000**3,
+        'T': 1000**4,
+        'P': 1000**5,
+        'E': 1000**6,
+        'm': 0.001,
+    }
     for unit, factor in units.items():
         if human_number.endswith(unit):
-            return Decimal(Decimal(human_number[:-len(unit)]) * Decimal(factor)).quantize(1)
-    return Decimal(human_number).quantize(1)
-print(numfmt_to_bytes('$1'))"
+            return Decimal(int(human_number[: -len(unit)]) * factor * m).quantize(1)
+    return Decimal(float(human_number) * m).quantize(1)
+
+human_number = sys.argv[1]
+multiplier = 1
+if len(sys.argv) > 2:
+    if len(sys.argv[2]) > 0:
+        multiplier = float(sys.argv[2])
+print(numfmt_to_bytes(human_number, multiplier))"
 }
 
 total_memory=$(free -m|awk '/^Mem:/{print $2}')
@@ -187,7 +209,7 @@ function dynamic_memory_sizing {
     if (($t_memory >= 0)); then # 1% of any memory above 128GB
         recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $t_memory 0.01 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
     fi
-    recommended_systemreserved_memory=$(resources_management_memory_units_to_bytes $(echo $recommended_systemreserved_memory | awk '{printf("%.0fMi",$1)}'))
+    recommended_systemreserved_memory=$(resources_management_memory_units_to_bytes "${recommended_systemreserved_memory}Mi")
     echo -n "${recommended_systemreserved_memory}"
 }
 {{- else if eq $resourceReservationMode "Static" }}
@@ -197,12 +219,12 @@ function dynamic_memory_sizing {
 {{- end }}
 
 function eviction_hard_threshold_memory_available {
-  return=$(resources_management_memory_units_to_bytes $(echo $total_memory 0.01 | awk '{print $1 * $2}' | awk '{printf("%.0fMi",$1)}'))
+  return=$(resources_management_memory_units_to_bytes "${total_memory}Mi" 0.01)
   echo -n "${return}"
 }
 
 function eviction_soft_threshold_memory_available {
-  return=$(resources_management_memory_units_to_bytes $(echo $total_memory 0.02 | awk '{print $1 * $2}' | awk '{printf("%.0fMi",$1)}'))
+  return=$(resources_management_memory_units_to_bytes "${total_memory}Mi" 0.02)
   echo -n "${return}"
 }
 

--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -153,37 +153,39 @@ total_memory=$(free -m|awk '/^Mem:/{print $2}')
 {{- if eq $resourceReservationMode "Auto" }}
 # https://github.com/openshift/machine-config-operator/blob/bd24f17943eb95309fe78327f8f3eabd104ab577/templates/common/_base/files/kubelet-auto-sizing.yaml / 3
 function dynamic_memory_sizing {
-    recommended_systemreserved_memory=0
-    if (($total_memory <= 4096)); then # 8% of the first 4GB of memory
-        recommended_systemreserved_memory=$(echo $total_memory 0.08 | awk '{print $1 * $2}')
-        total_memory=0
+    local recommended_systemreserved_memory=0
+    local t_memory=$total_memory
+
+    if (($t_memory <= 4096)); then # 8% of the first 4GB of memory
+        recommended_systemreserved_memory=$(echo $t_memory 0.08 | awk '{print $1 * $2}')
+        t_memory=0
     else
         recommended_systemreserved_memory=333
-        total_memory=$((total_memory-4096))
+        t_memory=$((t_memory-4096))
     fi
-    if (($total_memory <= 4096)); then # 6% of the next 4GB of memory (up to 8GB)
-        recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $total_memory 0.06 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-        total_memory=0
+    if (($t_memory <= 4096)); then # 6% of the next 4GB of memory (up to 8GB)
+        recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $t_memory 0.06 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
+        t_memory=0
     else
         recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory 252 | awk '{print $1 + $2}')
-        total_memory=$((total_memory-4096))
+        t_memory=$((t_memory-4096))
     fi
-    if (($total_memory <= 8192)); then # 3% of the next 8GB of memory (up to 16GB)
-        recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $total_memory 0.03 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-        total_memory=0
+    if (($t_memory <= 8192)); then # 3% of the next 8GB of memory (up to 16GB)
+        recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $t_memory 0.03 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
+        t_memory=0
     else
         recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory 246 | awk '{print $1 + $2}')
-        total_memory=$((total_memory-8192))
+        t_memory=$((t_memory-8192))
     fi
-    if (($total_memory <= 114688)); then # 2% of the next 112GB of memory (up to 128GB)
-        recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $total_memory 0.02 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
-        total_memory=0
+    if (($t_memory <= 114688)); then # 2% of the next 112GB of memory (up to 128GB)
+        recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $t_memory 0.02 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
+        t_memory=0
     else
         recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory 2240 | awk '{print $1 + $2}')
-        total_memory=$((total_memory-114688))
+        t_memory=$((t_memory-114688))
     fi
-    if (($total_memory >= 0)); then # 1% of any memory above 128GB
-        recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $total_memory 0.01 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
+    if (($t_memory >= 0)); then # 1% of any memory above 128GB
+        recommended_systemreserved_memory=$(echo $recommended_systemreserved_memory $(echo $t_memory 0.01 | awk '{print $1 * $2}') | awk '{print $1 + $2}')
     fi
     recommended_systemreserved_memory=$(resources_management_memory_units_to_bytes $(echo $recommended_systemreserved_memory | awk '{printf("%.0fMi",$1)}'))
     echo -n "${recommended_systemreserved_memory}"


### PR DESCRIPTION
## Description

1. dynamic_memory_sizing function uses the global variable total_memory, calling the function may result in unexpected behavior.

2. LC_ALL can affect awk, it causes an error in calculations

```shell
apt -y install locales-all > /dev/null
total_memory=$(free -m|awk '/^Mem:/{print $2}')
echo $total_memory 0.02 | awk '{print $1 * $2}'
30

echo $total_memory 0.02 | LC_ALL=ru_RU.UTF-8 awk '{print $1 * $2}'
0 
```


## Why do we need it, and what problem does it solve?

In some rare cases, this will cause `memory.available` prop  to become “0” in the kubelet configuration. Because of this kubelet crashes.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: bashible configure-kubelet step fix
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
