### PR TITLE
Add ceph-csi deprecation alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -517,6 +517,17 @@ alerts:
         Bashible-apiserver is locked for too long
       severity: "6"
       markupFormat: markdown
+    - name: D8CephCsiModuleDeprecated
+      sourceFile: modules/031-ceph-csi/monitoring/prometheus-rules/deprecated-module-alert.yaml
+      moduleUrl: 031-ceph-csi
+      module: ceph-csi
+      edition: ce
+      description: |
+        CephCsi module is deprecated. Please, use [csi-ceph](https://deckhouse.io/products/kubernetes-platform/modules/csi-ceph/stable/) module instead.
+      summary: |
+        CephCsi module is deprecated.
+      severity: "5"
+      markupFormat: markdown      
     - name: D8CertExporterPodIsNotReady
       sourceFile: modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificates-exporter-health.yaml
       moduleUrl: 340-extended-monitoring

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -527,7 +527,7 @@ alerts:
       summary: |
         CephCsi module is deprecated.
       severity: "5"
-      markupFormat: markdown      
+      markupFormat: markdown
     - name: D8CertExporterPodIsNotReady
       sourceFile: modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificates-exporter-health.yaml
       moduleUrl: 340-extended-monitoring
@@ -5776,6 +5776,7 @@ alerts:
       markupFormat: markdown
 modules-having-alerts:
     - admission-policy-engine
+    - ceph-csi
     - cert-manager
     - chrony
     - cloud-provider-yandex

--- a/modules/031-ceph-csi/monitoring/prometheus-rules/deprecated-module-alert.yaml
+++ b/modules/031-ceph-csi/monitoring/prometheus-rules/deprecated-module-alert.yaml
@@ -1,0 +1,16 @@
+- name: d8.ceph-csi-module-deprecated
+  rules:
+    - alert: D8CephCsiModuleDeprecated
+      expr: count(deckhouse_build_info) == 1
+      for: 5m
+      labels:
+        severity_level: "5"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_cni_check: D8ModuleDeprecated,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_cni_check: D8ModuleDeprecated,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        summary: CephCsi module is deprecated.
+        description: |
+          CephCsi module is deprecated. Please, use [csi-ceph](https://deckhouse.io/products/kubernetes-platform/modules/csi-ceph/stable/) module instead.

--- a/modules/031-ceph-csi/templates/monitoring.yaml
+++ b/modules/031-ceph-csi/templates/monitoring.yaml
@@ -1,0 +1,1 @@
+{{- include "helm_lib_prometheus_rules" (list . "d8-ceph-csi") }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add ceph-csi deprecation alert

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Ceph-csi module is deprecated and user must migrate from it.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ceph-csi
type: chore
summary: Add ceph-csi deprecation alert
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
