### PR TITLE
[docs] Fix typo in NFSStorageClass name

### DIFF
--- a/docs/documentation/pages/storage/external/NFS.md
+++ b/docs/documentation/pages/storage/external/NFS.md
@@ -38,7 +38,7 @@ csi-nfs   910      Enabled   Embedded           Ready
 
 ## Creating the StorageClass
 
-To create a StorageClass, you need to use the [NFSStorageClas](../../../reference/cr/nfsstorageclass/) resource. Manually creating a StorageClass without [NFSStorageClas](../../../reference/cr/nfsstorageclass/) may lead to errors. Example of creating a StorageClass based on NFS:
+To create a StorageClass, you need to use the [NFSStorageClass](../../../reference/cr/nfsstorageclass/) resource. Manually creating a StorageClass without [NFSStorageClass](../../../reference/cr/nfsstorageclass/) may lead to errors. Example of creating a StorageClass based on NFS:
 
 ```yaml
 d8 k apply -f - <<EOF
@@ -67,13 +67,13 @@ spec:
 EOF
 ```
 
-Check that the created [NFSStorageClas](../../../reference/cr/nfsstorageclass/) resource has transitioned to the `Created` phase by running the following command:
+Check that the created [NFSStorageClass](../../../reference/cr/nfsstorageclass/) resource has transitioned to the `Created` phase by running the following command:
 
 ```shell
 d8 k get NFSStorageClass nfs-storage-class -w
 ```
 
-In the output, you should see information about the created [NFSStorageClas](../../../reference/cr/nfsstorageclass/) resource:
+In the output, you should see information about the created [NFSStorageClass](../../../reference/cr/nfsstorageclass/) resource:
 
 ```console
 NAME                PHASE     AGE

--- a/docs/documentation/pages/storage/external/NFS_RU.md
+++ b/docs/documentation/pages/storage/external/NFS_RU.md
@@ -10,7 +10,7 @@ Deckhouse поддерживает работу с NFS (Network File System), о
 
 ## Включение модуля
 
-Для управления томами на основе протокола NFS (Network File System) используется модуль `csi-nfs`, позволяющий создавать StorageClass через создание пользовательских ресурсов [NFSStorageClas](../../../reference/cr/nfsstorageclass/). Чтобы включить модуль выполните команду:
+Для управления томами на основе протокола NFS (Network File System) используется модуль `csi-nfs`, позволяющий создавать StorageClass через создание пользовательских ресурсов [NFSStorageClass](../../../reference/cr/nfsstorageclass/). Чтобы включить модуль выполните команду:
 
 ```yaml
 d8 k apply -f - <<EOF
@@ -39,7 +39,7 @@ csi-nfs   910      Enabled   Embedded           Ready
 
 ## Создание StorageClass
 
-Для создания StorageClass необходимо использовать ресурс [NFSStorageClas](../../../reference/cr/nfsstorageclass/). Ручное создание ресурса StorageClass без [NFSStorageClas](../../../reference/cr/nfsstorageclass/) может привести к ошибкам. Пример команды для создания класса хранения на базе NFS:
+Для создания StorageClass необходимо использовать ресурс [NFSStorageClass](../../../reference/cr/nfsstorageclass/). Ручное создание ресурса StorageClass без [NFSStorageClass](../../../reference/cr/nfsstorageclass/) может привести к ошибкам. Пример команды для создания класса хранения на базе NFS:
 
 ```yaml
 d8 k apply -f - <<EOF
@@ -68,13 +68,13 @@ spec:
 EOF
 ```
 
-Проверьте, что созданный ресурс [NFSStorageClas](../../../reference/cr/nfsstorageclass/) перешел в состояние `Created`, выполнив следующую команду:
+Проверьте, что созданный ресурс [NFSStorageClass](../../../reference/cr/nfsstorageclass/) перешел в состояние `Created`, выполнив следующую команду:
 
 ```shell
 d8 k get NFSStorageClass nfs-storage-class -w
 ```
 
-В результате будет выведена информация о созданном ресурсе [NFSStorageClas](../../../reference/cr/nfsstorageclass/):
+В результате будет выведена информация о созданном ресурсе [NFSStorageClass](../../../reference/cr/nfsstorageclass/):
 
 ```console
 NAME                PHASE     AGE


### PR DESCRIPTION
## Description
Corrected a typo in the NFSStorageClass name in the NFS data storage section.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Corrected a typo in the NFSStorageClass name in the NFS data storage section.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
