### PR TITLE
[node-manager] fix template for managed k8s

### DIFF
--- a/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
@@ -97,7 +97,7 @@ spec:
           value: "{{ $.Values.global.enabledModules | join " " }}"
         - name: DECKHOUSE_CONFIG_MAP
           value: deckhouse-generated-config-do-not-edit
-        {{- if .Values.global.clusterConfiguration.cloud }}
+        {{- if (((.Values.global).clusterConfiguration).cloud) }}
         - name: INSTANCE_CLASS_NAME
           value: "{{ .Values.global.clusterConfiguration.cloud.provider | lower }}instanceclasses"
         {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix for [PR](https://github.com/deckhouse/deckhouse/pull/11830)
```changes
section: node-manager
type: fix
summary: fix template for managed k8s
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
