### PR TITLE
[docs] Add displaying conversions for external modules

### DIFF
--- a/docs/site/.helm/values.yaml
+++ b/docs/site/.helm/values.yaml
@@ -16,9 +16,6 @@ moduleWatcher:
     _default:
       - dev-registry.deckhouse.io/sys/deckhouse-oss/modules
       - registry.flant.com/team/foxtrot/docs-example
-    web-stage:
-      - registry.deckhouse.io/deckhouse/fe/modules
-      - registry.flant.com/team/foxtrot/docs-example
     web-production:
       - registry.deckhouse.io/deckhouse/fe/modules
   scanInterval:

--- a/docs/site/.helm/values.yaml
+++ b/docs/site/.helm/values.yaml
@@ -16,6 +16,9 @@ moduleWatcher:
     _default:
       - dev-registry.deckhouse.io/sys/deckhouse-oss/modules
       - registry.flant.com/team/foxtrot/docs-example
+    web-stage:
+      - registry.deckhouse.io/deckhouse/fe/modules
+      - registry.flant.com/team/foxtrot/docs-example
     web-production:
       - registry.deckhouse.io/deckhouse/fe/modules
   scanInterval:

--- a/docs/site/backends/docs-builder-template/i18n/en.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/en.yaml
@@ -65,4 +65,5 @@ version: version
 version_of_module: "### module version"
 version_of_schema: Schema version
 required_value_sentence: Required value
+parameters: parameters
 

--- a/docs/site/backends/docs-builder-template/i18n/en.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/en.yaml
@@ -6,6 +6,12 @@ deckhouse: deckhouse
 documentation: documentation
 modules_documentation: Modules documentation
 core: core
+conversions_title: Conversions
+conversion_action_message: Perform the following actions if you need to convert data from one version of the module parameter schema to another
+conversion_from_version: From version
+conversion_to: to
+conversion_expressions: Actions performed by the conversion (jq syntax)
+conversion_missing_description: Conversion description is missing
 currency_sign: "$"
 commercial: Available in some commercial editions.
 notAvailableInThisEdition: Available in other commercial editions.

--- a/docs/site/backends/docs-builder-template/i18n/ru.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/ru.yaml
@@ -6,6 +6,12 @@ deckhouse: deckhouse
 documentation: документация
 modules_documentation: Документация модулей
 core: ядро
+conversions_title: Конверсии
+conversion_action_message: При необходимости преобразования данных из одной версии схемы параметров модуля в другую, выполните следующие действия
+conversion_from_version: Из версии
+conversion_to: в
+conversion_expressions: Преобразования, выполняемые конверсией (синтаксис jq)
+conversion_missing_description: Описание конверсии отсутствует
 currency_sign: "₽"
 commercial: Доступно в некоторых коммерческих редакциях.
 notAvailableInThisEdition: Доступно в других коммерческих редакциях.

--- a/docs/site/backends/docs-builder-template/i18n/ru.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/ru.yaml
@@ -65,3 +65,4 @@ version: версия
 version_of_module: "Версия модуля ###"
 version_of_schema: Версия схемы
 required_value_sentence: Обязательный параметр
+parameters: параметры

--- a/docs/site/backends/docs-builder-template/layouts/partials/module-resources.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/module-resources.html
@@ -11,9 +11,6 @@ Context:
 {{- $moduleData := .data }}
 {{- $lang := .lang }}
 
-<h2>$moduleData</h2>
-{{ $moduleData }}
-<hr />
 {{- if and (eq .type "crds") $moduleData.crds }}
   {{- range $crdName, $crdData := $moduleData.crds }}
     {{- if hasPrefix $crdName "doc-" }}{{ continue }}{{ end }}

--- a/docs/site/backends/docs-builder-template/layouts/partials/module-resources.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/module-resources.html
@@ -19,6 +19,7 @@ Context:
   {{- end }}
 {{- else if and (eq .type "configuration") $moduleData.openapi }}
     {{- $cfgData := index $moduleData.openapi "config-values" }}
+    {{- $cfgConversions := index $moduleData.openapi "conversions" }}
     {{- $langData := index $moduleData.openapi (printf "doc-%s-config-values" $lang ) }}
-    {{- partial "openapi/format-configuration" ( dict "data" $cfgData "langData" $langData ) }}
+    {{- partial "openapi/format-configuration" ( dict "data" $cfgData "conversions" $cfgConversions "langData" $langData ) }}
 {{- end }}

--- a/docs/site/backends/docs-builder-template/layouts/partials/module-resources.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/module-resources.html
@@ -11,6 +11,9 @@ Context:
 {{- $moduleData := .data }}
 {{- $lang := .lang }}
 
+<h2>$moduleData</h2>
+{{ $moduleData }}
+<hr />
 {{- if and (eq .type "crds") $moduleData.crds }}
   {{- range $crdName, $crdData := $moduleData.crds }}
     {{- if hasPrefix $crdName "doc-" }}{{ continue }}{{ end }}

--- a/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-configuration.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-configuration.html
@@ -15,6 +15,87 @@ Context:
 
 {{/* TODO: format_examples $data */}}
 
+{{/* Reading all conversions files */}}
+{{- $modulePath := path.Dir (path.Dir (path.Dir (path.Dir .Page.File.Dir))) -}}
+{{- $moduleName := path.Base $modulePath -}}
+{{- $channel := path.Base (path.Dir .Page.File.Dir) -}}
+<!-- {{- $conversionsDir := printf "data/modules/%s/%s/openapi/conversions/" $moduleName $channel -}} -->
+{{- $conversionsDir := "data/modules/observability-platform/alpha/openapi/conversions/" }}
+{{- if fileExists $conversionsDir }}
+  {{- $conversionFiles := readDir $conversionsDir }}
+  {{- $conversionData := slice }}
+
+{{/* Filtering with layout v<number>.yaml и v<number>.yml */}}
+{{- range $file := $conversionFiles }}
+  {{- if hasPrefix $file.Name "v" }}
+    {{- if or (hasSuffix $file.Name ".yaml") (hasSuffix $file.Name ".yml") }}
+      {{- $yamlPath := path.Join $conversionsDir $file.Name }}
+      {{- $yamlContent := readFile $yamlPath }}
+      {{- $conversionData = $conversionData | append (dict "file" $file.Name "content" (unmarshal $yamlContent)) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{/* Conversions rendering */}}
+{{- if gt (len $conversionData) 0 }}
+    <h2>{{ T "conversions_title" }}</h2>
+    
+    <p>{{ T "conversion_action_message" }}:</p>
+    
+    {{- range $conv := $conversionData }}
+      {{- if $conv.content }}
+      <ul>
+        <li>
+          <p>{{ T "conversion_from_version" }} <b>{{ sub $conv.content.version 1 }}</b> {{ T "conversion_to" }} <b>{{ $conv.content.version }}</b>:</p>
+          
+          {{/* Check description availability*/}}
+          {{- $currentLang := site.Language.Lang | default "en" -}}
+          {{- $hasDescription := false -}}
+          
+          {{- if $conv.content.description -}}
+            {{- if reflect.IsMap $conv.content.description -}}
+              {{- $description := index $conv.content.description $currentLang | default $conv.content.description.en -}}
+              {{- if $description -}}
+                <p>{{ $description | markdownify }}</p>
+                {{- $hasDescription = true -}}
+              {{- end -}}
+            {{- else -}}
+              <p>{{ $conv.content.description | markdownify }}</p>
+              {{- $hasDescription = true -}}
+            {{- end -}}
+          {{- end -}}
+          
+          {{/* If no description */}}
+          {{- if not $hasDescription -}}
+            <p>{{ T "conversion_missing_description" }}</p>
+            
+            {{/* Rendering details block only if there is no description, but there are expressions */}}
+            {{- if $conv.content.conversions -}}
+            <div class="details" markdown="0">
+              <p class="details__lnk">
+                <a href="javascript:void(0)" class="details__summary">
+                  {{ T "conversion_expressions" }}
+                </a>
+              </p>
+              <div class="details__content" markdown="0">
+                <div class="expand" markdown="0">
+                  <ul>
+                    {{- range $conversion := $conv.content.conversions }}
+                    <li><code class="language-plaintext highlighter-rouge">{{ $conversion }}</code></li>
+                    {{- end }}
+                  </ul>
+                </div>
+              </div>
+            </div>
+            {{- end -}}
+          {{- end -}}
+        </li>
+      </ul>
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 {{- if $data.properties }}
 <p><font size="-1">{{ T "version_of_schema" }}: {{ $configVersion }}</font></p>
 

--- a/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-configuration.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-configuration.html
@@ -6,6 +6,7 @@ Context:
 */}}
 
 {{- $data := .data }}
+{{- $conversions := .conversions }}
 {{- $langData := .langData }}
 
 {{- $configVersion := 1 }}
@@ -16,61 +17,42 @@ Context:
 {{/* TODO: format_examples $data */}}
 
 {{/* Reading all conversions files */}}
-{{- $modulePath := path.Dir (path.Dir (path.Dir (path.Dir .Page.File.Dir))) -}}
-{{- $moduleName := path.Base $modulePath -}}
-{{- $channel := path.Base (path.Dir .Page.File.Dir) -}}
-<!-- {{- $conversionsDir := printf "data/modules/%s/%s/openapi/conversions/" $moduleName $channel -}} -->
-{{- $conversionsDir := "data/modules/observability-platform/alpha/openapi/conversions/" }}
-{{- if fileExists $conversionsDir }}
-  {{- $conversionFiles := readDir $conversionsDir }}
-  {{- $conversionData := slice }}
-
-{{/* Filtering with layout v<number>.yaml и v<number>.yml */}}
-{{- range $file := $conversionFiles }}
-  {{- if hasPrefix $file.Name "v" }}
-    {{- if or (hasSuffix $file.Name ".yaml") (hasSuffix $file.Name ".yml") }}
-      {{- $yamlPath := path.Join $conversionsDir $file.Name }}
-      {{- $yamlContent := readFile $yamlPath }}
-      {{- $conversionData = $conversionData | append (dict "file" $file.Name "content" (unmarshal $yamlContent)) }}
-    {{- end }}
-  {{- end }}
-{{- end }}
 
 {{/* Conversions rendering */}}
-{{- if gt (len $conversionData) 0 }}
+{{- if and $conversions (gt (len $conversions) 0) }}
     <h2>{{ T "conversions_title" }}</h2>
-    
+
     <p>{{ T "conversion_action_message" }}:</p>
-    
-    {{- range $conv := $conversionData }}
-      {{- if $conv.content }}
+
+    {{- range $conversion := $conversions }}
+      {{- if $conversion }}
       <ul>
         <li>
-          <p>{{ T "conversion_from_version" }} <b>{{ sub $conv.content.version 1 }}</b> {{ T "conversion_to" }} <b>{{ $conv.content.version }}</b>:</p>
-          
+          <p>{{ T "conversion_from_version" }} <b>{{ sub $conversion.version 1 }}</b> {{ T "conversion_to" }} <b>{{ $conversion.version }}</b>:</p>
+
           {{/* Check description availability*/}}
           {{- $currentLang := site.Language.Lang | default "en" -}}
           {{- $hasDescription := false -}}
-          
-          {{- if $conv.content.description -}}
-            {{- if reflect.IsMap $conv.content.description -}}
-              {{- $description := index $conv.content.description $currentLang | default $conv.content.description.en -}}
+
+          {{- if $conversion.description -}}
+            {{- if reflect.IsMap $conversion.description -}}
+              {{- $description := index $conversion.description $currentLang | default $conversion.description.en -}}
               {{- if $description -}}
                 <p>{{ $description | markdownify }}</p>
                 {{- $hasDescription = true -}}
               {{- end -}}
             {{- else -}}
-              <p>{{ $conv.content.description | markdownify }}</p>
+              <p>{{ $conversion.description | markdownify }}</p>
               {{- $hasDescription = true -}}
             {{- end -}}
           {{- end -}}
-          
+
           {{/* If no description */}}
           {{- if not $hasDescription -}}
             <p>{{ T "conversion_missing_description" }}</p>
-            
+
             {{/* Rendering details block only if there is no description, but there are expressions */}}
-            {{- if $conv.content.conversions -}}
+            {{- if $conversion.conversions -}}
             <div class="details" markdown="0">
               <p class="details__lnk">
                 <a href="javascript:void(0)" class="details__summary">
@@ -80,8 +62,8 @@ Context:
               <div class="details__content" markdown="0">
                 <div class="expand" markdown="0">
                   <ul>
-                    {{- range $conversion := $conv.content.conversions }}
-                    <li><code class="language-plaintext highlighter-rouge">{{ $conversion }}</code></li>
+                    {{- range $conversionExpr := $conversion.conversions }}
+                    <li><code class="language-plaintext highlighter-rouge">{{ $conversionExpr }}</code></li>
                     {{- end }}
                   </ul>
                 </div>
@@ -93,8 +75,10 @@ Context:
       </ul>
       {{- end }}
     {{- end }}
-  {{- end }}
+<h2>{{ T "parameters" | humanize }}</h2>
+
 {{- end }}
+{{/* END Conversions rendering */}}
 
 {{- if $data.properties }}
 <p><font size="-1">{{ T "version_of_schema" }}: {{ $configVersion }}</font></p>

--- a/docs/site/backends/docs-builder/internal/docs/service.go
+++ b/docs/site/backends/docs-builder/internal/docs/service.go
@@ -23,7 +23,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-var docConfValuesRegexp = regexp.MustCompile(`^openapi/doc-.*-config-values\.yaml$`)
+var docConfValuesRegexp = regexp.MustCompile(`^openapi/(doc-.*-config-values\.yaml|conversions/v\d+\.yaml)$`)
 
 // /app/hugo/{data||content}/modules/{module}/{channel}/{brokenFile}:53:1
 // $1 - Module dir path /app/hugo/{data||content}/modules/{module}

--- a/docs/site/backends/docs-builder/internal/docs/upload.go
+++ b/docs/site/backends/docs-builder/internal/docs/upload.go
@@ -136,6 +136,7 @@ func (svc *Service) getLocalPath(moduleName, channel, fileName string) (string, 
 
 	if strings.HasPrefix(fileName, "crds") ||
 		fileName == "openapi" ||
+		fileName == "openapi/conversions" ||
 		fileName == "openapi/config-values.yaml" ||
 		docConfValuesRegexp.MatchString(fileName) {
 		return filepath.Join(svc.baseDir, modulesDir, moduleName, channel, fileName), true

--- a/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scanner/process.go
+++ b/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scanner/process.go
@@ -34,7 +34,7 @@ import (
 
 // Constants for directory structure
 var (
-	documentationDirs = []string{"docs", "openapi", "crds"}
+	documentationDirs = []string{"docs", "openapi", "openapi/conversions", "crds"}
 )
 
 const versionFileName = "version.json"


### PR DESCRIPTION
## Description

Add displaying conversions for external modules.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add displaying conversions for external modules.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
