### PR TITLE
[simple-bridge] fix permissions

### DIFF
--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -34,6 +34,8 @@ import:
   before: setup
   includePaths:
   - python3*
+  owner: root
+  group: root
 - image: registrypackages/d8-curl-artifact-8-9-1
   add: /d8-curl
   to: /usr/bin/curl

--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -26,6 +26,8 @@ import:
   includePaths:
   - python3*
   - python3
+  owner: root
+  group: root
 - image: common/python-static
   add: /opt/python-static/lib
   to: /usr/lib
@@ -43,8 +45,6 @@ import:
 imageSpec:
   config:
     entrypoint: ["/sbin/iptables-wrapper"]
-shell:
-  setup:
 ---
 {{ $simpleBridgeBinaries := "/bin/awk /bin/cat /bin/rm /bin/echo /usr/bin/tee /bin/sleep /bin/hostname /bin/bash /bin/grep /sbin/ip /usr/sbin/bridge" }}
 ---

--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -43,6 +43,8 @@ import:
 imageSpec:
   config:
     entrypoint: ["/sbin/iptables-wrapper"]
+shell:
+  setup:
 ---
 {{ $simpleBridgeBinaries := "/bin/awk /bin/cat /bin/rm /bin/echo /usr/bin/tee /bin/sleep /bin/hostname /bin/bash /bin/grep /sbin/ip /usr/sbin/bridge" }}
 ---


### PR DESCRIPTION
## Description
`simple-bridge` crashed as `root` couldn’t access `python3.11` owned by `deckhouse`. This fixes it.

![image](https://github.com/user-attachments/assets/fd2a82bc-fd2e-422c-9308-fc1774abde56)

![image](https://github.com/user-attachments/assets/340e7de9-45d5-42b6-b977-20a8c4383139)

## Why do we need it, and what problem does it solve?

Fixed Python permissions for `simple-bridge` by setting `python3.11` owner to `root`.

```shell
[root@a14057133204-1-con-1-30-master-0 root]# ls -l usr/bin
total 45304
-rwxr-xr-x. 1 root root  5740368 Jan 29 20:43 curl
-rwxr-xr-x. 1 root root  2623744 Jan 29 20:54 jq
lrwxrwxrwx. 1 root root       10 Jan 29 20:35 python3 -> python3.11
lrwxrwxrwx. 1 root root       17 Jan 29 20:35 python3-config -> python3.11-config
-rwx------. 1 root root 37977920 Jan 29 20:35 python3.11
-rwxr-xr-x. 1 root root     3021 Jan 29 20:35 python3.11-config
-rwxr-xr-x. 1 root root    39328 Nov  6  2023 tee

[root@a14057133204-1-con-1-30-master-0 root]# ls -l usr/lib
total 4
drwxr-xr-x. 38 root root 4096 Jan 29 20:35 python3.11
```

```shell
[root@a14059440063-1-con-1-30-master-0 ~]# kubectl -n d8-cni-simple-bridge get pods
NAME                  READY   STATUS    RESTARTS        AGE
simple-bridge-9bsfr   1/1     Running   0               22s
simple-bridge-kt7zm   1/1     Running   2 (8m44s ago)   9m5s
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-simple-bridge
type: fix
summary: Fix a permission issue.
impact_level: low
```

