### PR TITLE
[docs][istio][ingress-nginx] Fix the display of ports in the examples in the CRDs

### DIFF
--- a/modules/110-istio/crds/ingress-istio.yaml
+++ b/modules/110-istio/crds/ingress-istio.yaml
@@ -31,7 +31,7 @@ spec:
                   type: string
                   description: |
                     Ingress gateway class is used by application [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/) resources for identifying the right Ingress gateway setup.
-                    
+
                     The identification is organized by setting the spec.selector: `istio.deckhouse.io/ingress-gateway-class: <ingressGatewayClass value>`.
                   x-doc-examples: ['istio']
                   pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
@@ -110,7 +110,7 @@ spec:
                         If the parameter is not set, the connection over HTTP cannot be established.
 
                         This parameter is mandatory if `httpsPort` is not set.
-                      x-doc-examples: ['80']
+                      x-doc-examples: [80]
                     httpsPort:
                       type: integer
                       description: |
@@ -119,7 +119,7 @@ spec:
                         If the parameter is not set, the connection over HTTPS cannot be established.
 
                         This parameter is mandatory if `httpPort` is not set.
-                      x-doc-examples: ['443']
+                      x-doc-examples: [443]
                 nodePort:
                   type: object
                   description: |

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -235,7 +235,7 @@ spec:
                         If the parameter is not set, the connection over HTTP cannot be established.
 
                         This parameter is mandatory if `httpsPort` is not set.
-                      x-doc-examples: ['80']
+                      x-doc-examples: [80]
                     httpsPort:
                       type: integer
                       description: |
@@ -244,7 +244,7 @@ spec:
                         If the parameter is not set, the connection over HTTPS cannot be established.
 
                         This parameter is mandatory if `httpPort` is not set.
-                      x-doc-examples: ['443']
+                      x-doc-examples: [443]
                       x-kubernetes-validations:
                         - message: .spec.hostPort.httpsPort can't be 6443, it's reserved for kube-apiserver
                           rule: 'self != 6443'
@@ -278,7 +278,7 @@ spec:
                         If the parameter is not set, the connection over HTTP cannot be established.
 
                         This parameter is mandatory if `httpsPort` is not set.
-                      x-doc-examples: ['80']
+                      x-doc-examples: [80]
                     httpsPort:
                       type: integer
                       description: |
@@ -287,7 +287,7 @@ spec:
                         If the parameter is not set, the connection over HTTPS cannot be established.
 
                         This parameter is mandatory if `httpPort` is not set.
-                      x-doc-examples: ['443']
+                      x-doc-examples: [443]
                       x-kubernetes-validations:
                         - message: .spec.hostPortWithProxyProtocol.httpsPort can't be 6443, it's reserved for kube-apiserver
                           rule: 'self != 6443'
@@ -861,7 +861,7 @@ spec:
                         If the parameter is not set, the connection over HTTP cannot be established.
 
                         This parameter is mandatory if `httpsPort` is not set.
-                      x-doc-examples: ['80']
+                      x-doc-examples: [80]
                     httpsPort:
                       type: integer
                       description: |
@@ -870,7 +870,7 @@ spec:
                         If the parameter is not set, the connection over HTTPS cannot be established.
 
                         This parameter is mandatory if `httpPort` is not set.
-                      x-doc-examples: ['443']
+                      x-doc-examples: [443]
                       x-kubernetes-validations:
                         - message: .spec.hostPort.httpsPort can't be 6443, it's reserved for kube-apiserver
                           rule: 'self != 6443'
@@ -904,7 +904,7 @@ spec:
                         If the parameter is not set, the connection over HTTP cannot be established.
 
                         This parameter is mandatory if `httpsPort` is not set.
-                      x-doc-examples: ['80']
+                      x-doc-examples: [80]
                     httpsPort:
                       type: integer
                       description: |
@@ -913,7 +913,7 @@ spec:
                         If the parameter is not set, the connection over HTTPS cannot be established.
 
                         This parameter is mandatory if `httpPort` is not set.
-                      x-doc-examples: ['443']
+                      x-doc-examples: [443]
                       x-kubernetes-validations:
                         - message: .spec.hostPortWithProxyProtocol.httpsPort can't be 6443, it's reserved for kube-apiserver
                           rule: 'self != 6443'
@@ -933,7 +933,7 @@ spec:
                         If the parameter is not set, the connection over HTTP cannot be established.
 
                         This parameter is mandatory if `httpsPort` is not set.
-                      x-doc-examples: ['80']
+                      x-doc-examples: [80]
                     httpsPort:
                       type: integer
                       description: |
@@ -942,7 +942,7 @@ spec:
                         If the parameter is not set, the connection over HTTPS cannot be established.
 
                         This parameter is mandatory if `httpPort` is not set.
-                      x-doc-examples: ['443']
+                      x-doc-examples: [443]
                       x-kubernetes-validations:
                         - message: .spec.hostPortWithSSLPassthrough.httpsPort can't be 6443, it's reserved for kube-apiserver
                           rule: 'self != 6443'


### PR DESCRIPTION
## Description

This pull request includes changes to the `x-doc-examples` values in the `spec` sections of two YAML files to ensure they are correctly formatted as integers instead of strings. The changes affect multiple instances within the `ingress-istio.yaml` and `ingress-nginx.yaml` files.

Changes to `ingress-istio.yaml`:

* Updated `x-doc-examples` for `httpPort` to use integer values instead of string values.
* Updated `x-doc-examples` for `httpsPort` to use integer values instead of string values.

Changes to `ingress-nginx.yaml`:

* Updated `x-doc-examples` for `httpPort` to use integer values instead of string values. [[1]](diffhunk://#diff-d7ed7f1be5c3c140855d1432c6a4dcb28d1f607d8ff6000ae811c83d5b53dde8L238-R238) [[2]](diffhunk://#diff-d7ed7f1be5c3c140855d1432c6a4dcb28d1f607d8ff6000ae811c83d5b53dde8L281-R281) [[3]](diffhunk://#diff-d7ed7f1be5c3c140855d1432c6a4dcb28d1f607d8ff6000ae811c83d5b53dde8L864-R864) [[4]](diffhunk://#diff-d7ed7f1be5c3c140855d1432c6a4dcb28d1f607d8ff6000ae811c83d5b53dde8L907-R907) [[5]](diffhunk://#diff-d7ed7f1be5c3c140855d1432c6a4dcb28d1f607d8ff6000ae811c83d5b53dde8L936-R936)
* Updated `x-doc-examples` for `httpsPort` to use integer values instead of string values. [[1]](diffhunk://#diff-d7ed7f1be5c3c140855d1432c6a4dcb28d1f607d8ff6000ae811c83d5b53dde8L247-R247) [[2]](diffhunk://#diff-d7ed7f1be5c3c140855d1432c6a4dcb28d1f607d8ff6000ae811c83d5b53dde8L290-R290) [[3]](diffhunk://#diff-d7ed7f1be5c3c140855d1432c6a4dcb28d1f607d8ff6000ae811c83d5b53dde8L873-R873) [[4]](diffhunk://#diff-d7ed7f1be5c3c140855d1432c6a4dcb28d1f607d8ff6000ae811c83d5b53dde8L916-R916) [[5]](diffhunk://#diff-d7ed7f1be5c3c140855d1432c6a4dcb28d1f607d8ff6000ae811c83d5b53dde8L945-R945)

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Fixed the display of ports in the examples in the CRDs.
impact_level: low
---
section: ingress-nginx
type: fix
summary: Fixed the display of ports in the examples in the CRDs.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
