### PR TITLE
tests with reverted commit for VCD independent disk

### DIFF
--- a/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/master-node/main.tf
@@ -11,11 +11,6 @@ locals {
   placement_policy = lookup(local.master_instance_class, "placementPolicy", "")
 }
 
-// hack to recreate VM when changing kubernetes_data.id, must be replaced with replace_triggered_by after tf upgrade
-locals {
-  disk_hash    = md5(vcd_independent_disk.kubernetes_data.id)
-  disk_offset  = parseint(local.disk_hash, 16) % 21 + 1
-}
 
 data "vcd_catalog" "catalog" {
   org  = local.org
@@ -47,19 +42,24 @@ data "vcd_vm_placement_policy" "vmpp" {
   vdc_id = data.vcd_org_vdc.vdc[0].id
 }
 
-resource "vcd_independent_disk" "kubernetes_data" {
-  name             = "${local.prefix}-master-${var.nodeIndex}-etcd-disk"
-  size_in_mb       = local.master_instance_class.etcdDiskSizeGb * 1024
-  storage_profile  = data.vcd_storage_profile.sp.name
-  bus_type        = "SCSI"
-  bus_sub_type    = "VirtualSCSI"
+resource "vcd_vm_internal_disk" "kubernetes_data"{
+  vapp_name       = local.vapp_name
+  vm_name         = vcd_vapp_vm.master.name
+  size_in_mb      = local.master_instance_class.etcdDiskSizeGb * 1024
+  iops            = data.vcd_storage_profile.sp.iops_settings[0].disk_iops_per_gb_max > 0 ? data.vcd_storage_profile.sp.iops_settings[0].disk_iops_per_gb_max * local.master_instance_class.etcdDiskSizeGb : null
+  storage_profile = data.vcd_storage_profile.sp.name
+  bus_number      = 0
+  unit_number     = 1
+  bus_type        = "paravirtual"
 }
 
 resource "vcd_vapp_vm" "master" {
   vapp_name        = local.vapp_name
   name             = join("-", [local.prefix, "master", var.nodeIndex])
-  computer_name = join("-", [local.prefix, "master", var.nodeIndex])
+  computer_name    = join("-", [local.prefix, "master", var.nodeIndex])
   vapp_template_id = data.vcd_catalog_vapp_template.template.id
+
+
   sizing_policy_id = data.vcd_vm_sizing_policy.vmsp.id
   placement_policy_id = local.placement_policy == "" ? "" : data.vcd_vm_placement_policy.vmpp[0].id
 
@@ -74,19 +74,11 @@ resource "vcd_vapp_vm" "master" {
 
   override_template_disk {
     bus_type        = "paravirtual"
-    // disk_offset is just a hack to recreate VM when changing kubernetes_data.id, must be replaced with replace_triggered_by after tf upgrade
-    // this will add 0-20 mbytes to root disk size
-    size_in_mb      = (local.master_instance_class.rootDiskSizeGb * 1024) + local.disk_offset
+    size_in_mb      = local.master_instance_class.rootDiskSizeGb * 1024
     bus_number      = 0
     unit_number     = 0
     storage_profile = data.vcd_storage_profile.sp.name
     iops            = data.vcd_storage_profile.sp.iops_settings[0].disk_iops_per_gb_max > 0 ? data.vcd_storage_profile.sp.iops_settings[0].disk_iops_per_gb_max * local.master_instance_class.rootDiskSizeGb : ( data.vcd_storage_profile.sp.iops_settings[0].default_disk_iops > 0 ?  data.vcd_storage_profile.sp.iops_settings[0].default_disk_iops : 0)
-  }
-
-  disk {
-    name        = vcd_independent_disk.kubernetes_data.name
-    bus_number  = 0
-    unit_number = 1
   }
 
   customization {
@@ -97,13 +89,10 @@ resource "vcd_vapp_vm" "master" {
   lifecycle {
     ignore_changes = [
       guest_properties,
+      disk,
       metadata
     ]
   }
-
-  depends_on = [
-    vcd_independent_disk.kubernetes_data
-  ]
 
   guest_properties = merge({
     "instance-id"         = join("-", [local.prefix, "master", var.nodeIndex])


### PR DESCRIPTION
… disk type from vcd_vm_internal_disk to vcd_independent_disk  (#12651)"

This reverts commit 31308a997f7b77b0b2ffc735f441ab155e36046d.

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
