### PR TITLE
[ingress-nginx] backport latest cve fixes to v1.9 and v1.10 to release-1.67

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-10/Dockerfile
@@ -48,6 +48,7 @@ COPY patches/util.patch /
 COPY patches/fix-cleanup.patch /
 COPY patches/add-http3.patch /
 COPY patches/new-metrics.patch /
+COPY patches/fix-validating-webhook-cve.patch /
 ENV GOARCH=amd64
 RUN --mount=type=ssh git clone --branch $CONTROLLER_BRANCH --depth 1 ${SOURCE_REPO}/kubernetes/ingress-nginx.git /src
 RUN patch -p1 < /lua-info.patch && \
@@ -57,7 +58,8 @@ RUN patch -p1 < /lua-info.patch && \
     patch -p1 < /util.patch && \
     patch -p1 < /fix-cleanup.patch && \
     patch -p1 < /add-http3.patch && \
-    patch -p1 < /new-metrics.patch
+    patch -p1 < /new-metrics.patch && \
+    patch -p1 < /fix-validating-webhook-cve.patch
 RUN make GO111MODULE=on USE_DOCKER=false build
 
 # Build nginx for ingress controller

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -65,3 +65,14 @@ Add HTTP/3 support.
 ### new metrics
 
 This patch adds worker max connections, worker processes and worker max open files metrics.
+
+### fix-validating-webhook-cve.patch
+
+Backports several security fixes for the following CVE:
+CVE-2025-1097
+CVE-2025-1098
+CVE-2025-1974
+CVE-2025-24513
+CVE-2025-24514
+
+Sourced from https://github.com/kubernetes/ingress-nginx/commit/cfe3923bd657a82226eb58d3307204a8a8802db4

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/fix-validating-webhook-cve.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/fix-validating-webhook-cve.patch
@@ -1,0 +1,121 @@
+diff --git a/internal/ingress/annotations/auth/main.go b/internal/ingress/annotations/auth/main.go
+index 7c7fde7b8..79e3ce5d3 100644
+--- a/internal/ingress/annotations/auth/main.go
++++ b/internal/ingress/annotations/auth/main.go
+@@ -19,6 +19,7 @@ package auth
+ import (
+ 	"fmt"
+ 	"os"
++	"path/filepath"
+ 	"regexp"
+ 	"strings"
+ 
+@@ -203,16 +204,24 @@ func (a auth) Parse(ing *networking.Ingress) (interface{}, error) {
+ 		return nil, err
+ 	}
+ 
+-	passFilename := fmt.Sprintf("%v/%v-%v-%v.passwd", a.authDirectory, ing.GetNamespace(), ing.UID, secret.UID)
++	passFileName := fmt.Sprintf("%v-%v-%v.passwd", ing.GetNamespace(), ing.UID, secret.UID)
++	passFilePath := filepath.Join(a.authDirectory, passFileName)
++
++	// Ensure password file name does not contain any path traversal characters.
++	if a.authDirectory != filepath.Dir(passFilePath) || passFileName != filepath.Base(passFilePath) {
++		return nil, ing_errors.LocationDeniedError{
++			Reason: fmt.Errorf("invalid password file name: %s", passFileName),
++		}
++	}
+ 
+ 	switch secretType {
+ 	case fileAuth:
+-		err = dumpSecretAuthFile(passFilename, secret)
++		err = dumpSecretAuthFile(passFilePath, secret)
+ 		if err != nil {
+ 			return nil, err
+ 		}
+ 	case mapAuth:
+-		err = dumpSecretAuthMap(passFilename, secret)
++		err = dumpSecretAuthMap(passFilePath, secret)
+ 		if err != nil {
+ 			return nil, err
+ 		}
+@@ -225,9 +234,9 @@ func (a auth) Parse(ing *networking.Ingress) (interface{}, error) {
+ 	return &Config{
+ 		Type:       at,
+ 		Realm:      realm,
+-		File:       passFilename,
++		File:       passFilePath,
+ 		Secured:    true,
+-		FileSHA:    file.SHA1(passFilename),
++		FileSHA:    file.SHA1(passFilePath),
+ 		Secret:     name,
+ 		SecretType: secretType,
+ 	}, nil
+diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
+index 652a80e49..5a263551e 100644
+--- a/internal/ingress/controller/controller.go
++++ b/internal/ingress/controller/controller.go
+@@ -420,11 +420,15 @@ func (n *NGINXController) CheckIngress(ing *networking.Ingress) error {
+ 		return err
+ 	}
+ 
++	/* Deactivated to mitigate CVE-2025-1974
++	// TODO: Implement sandboxing so this test can be done safely
+ 	err = n.testTemplate(content)
+ 	if err != nil {
+ 		n.metricCollector.IncCheckErrorCount(ing.ObjectMeta.Namespace, ing.Name)
+ 		return err
+ 	}
++	*/
++
+ 	n.metricCollector.IncCheckCount(ing.ObjectMeta.Namespace, ing.Name)
+ 	endCheck := time.Now().UnixNano() / 1000000
+ 	n.metricCollector.SetAdmissionMetrics(
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index ed052e4ec..0e0300743 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -1622,11 +1622,11 @@ func buildMirrorLocations(locs []*ingress.Location) string {
+ 		mapped.Insert(loc.Mirror.Source)
+ 		buffer.WriteString(fmt.Sprintf(`location = %v {
+ internal;
+-proxy_set_header Host "%v";
+-proxy_pass "%v";
++proxy_set_header Host %v;
++proxy_pass %v;
+ }
+ 
+-`, loc.Mirror.Source, loc.Mirror.Host, loc.Mirror.Target))
++`, strconv.Quote(loc.Mirror.Source), strconv.Quote(loc.Mirror.Host), strconv.Quote(loc.Mirror.Target)))
+ 	}
+ 
+ 	return buffer.String()
+diff --git a/rootfs/etc/nginx/template/nginx.tmpl b/rootfs/etc/nginx/template/nginx.tmpl
+index 6b8e750b0..0a87de5ee 100644
+--- a/rootfs/etc/nginx/template/nginx.tmpl
++++ b/rootfs/etc/nginx/template/nginx.tmpl
+@@ -879,7 +879,7 @@ stream {
+ 
+         {{ if not ( empty $server.CertificateAuth.MatchCN ) }}
+         {{ if gt (len $server.CertificateAuth.MatchCN) 0 }}
+-        if ( $ssl_client_s_dn !~ {{ $server.CertificateAuth.MatchCN }} ) {
++        if ( $ssl_client_s_dn !~ {{ $server.CertificateAuth.MatchCN | quote }} ) {
+             return 403 "client certificate unauthorized";
+         }
+         {{ end }}
+@@ -1082,7 +1082,7 @@ stream {
+             set $target {{ changeHostPort $externalAuth.URL $authUpstreamName }};
+             {{ else }}
+             proxy_http_version {{ $location.Proxy.ProxyHTTPVersion }};
+-            set $target {{ $externalAuth.URL }};
++            set $target {{ $externalAuth.URL | quote }};
+             {{ end }}
+             proxy_pass $target;
+         }
+@@ -1120,7 +1120,7 @@ stream {
+             {{ buildOpentelemetryForLocation $all.Cfg.EnableOpentelemetry $all.Cfg.OpentelemetryTrustIncomingSpan $location }}
+ 
+             {{ if $location.Mirror.Source }}
+-            mirror {{ $location.Mirror.Source }};
++            mirror {{ $location.Mirror.Source | quote }};
+             mirror_request_body {{ $location.Mirror.RequestBody }};
+             {{ end }}

--- a/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-9/Dockerfile
@@ -65,6 +65,7 @@ COPY patches/util.patch /
 COPY patches/fix-cleanup.patch /
 COPY patches/geoip.patch /
 COPY patches/new-metrics.patch /
+COPY patches/fix-validating-webhook-cve.patch /
 ENV GOARCH=amd64
 RUN mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
 RUN --mount=type=ssh git clone --branch $CONTROLLER_BRANCH --depth 1 ${SOURCE_REPO}/kubernetes/ingress-nginx.git /src && \
@@ -77,7 +78,8 @@ RUN patch -p1 < /lua-info.patch && \
     patch -p1 < /util.patch && \
     patch -p1 < /fix-cleanup.patch && \
     patch -p1 < /geoip.patch && \
-    patch -p1 < /new-metrics.patch
+    patch -p1 < /new-metrics.patch && \
+    patch -p1 < /fix-validating-webhook-cve.patch
 RUN make GO111MODULE=on USE_DOCKER=false build
 
 # Build nginx for ingress controller

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/README.md
@@ -65,3 +65,14 @@ https://github.com/kubernetes/ingress-nginx/pull/10495
 ### new metrics
 
 This patch adds worker max connections, worker processes and worker max open files metrics.
+
+### fix-validating-webhook-cve.patch
+
+Backports several security fixes for the following CVE:
+CVE-2025-1097
+CVE-2025-1098
+CVE-2025-1974
+CVE-2025-24513
+CVE-2025-24514
+
+Sourced from https://github.com/kubernetes/ingress-nginx/commit/cfe3923bd657a82226eb58d3307204a8a8802db4

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/fix-validating-webhook-cve.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/fix-validating-webhook-cve.patch
@@ -1,0 +1,121 @@
+diff --git a/internal/ingress/annotations/auth/main.go b/internal/ingress/annotations/auth/main.go
+index 7c7fde7b8..79e3ce5d3 100644
+--- a/internal/ingress/annotations/auth/main.go
++++ b/internal/ingress/annotations/auth/main.go
+@@ -19,6 +19,7 @@ package auth
+ import (
+ 	"fmt"
+ 	"os"
++	"path/filepath"
+ 	"regexp"
+ 	"strings"
+ 
+@@ -203,16 +204,24 @@ func (a auth) Parse(ing *networking.Ingress) (interface{}, error) {
+ 		return nil, err
+ 	}
+ 
+-	passFilename := fmt.Sprintf("%v/%v-%v-%v.passwd", a.authDirectory, ing.GetNamespace(), ing.UID, secret.UID)
++	passFileName := fmt.Sprintf("%v-%v-%v.passwd", ing.GetNamespace(), ing.UID, secret.UID)
++	passFilePath := filepath.Join(a.authDirectory, passFileName)
++
++	// Ensure password file name does not contain any path traversal characters.
++	if a.authDirectory != filepath.Dir(passFilePath) || passFileName != filepath.Base(passFilePath) {
++		return nil, ing_errors.LocationDeniedError{
++			Reason: fmt.Errorf("invalid password file name: %s", passFileName),
++		}
++	}
+ 
+ 	switch secretType {
+ 	case fileAuth:
+-		err = dumpSecretAuthFile(passFilename, secret)
++		err = dumpSecretAuthFile(passFilePath, secret)
+ 		if err != nil {
+ 			return nil, err
+ 		}
+ 	case mapAuth:
+-		err = dumpSecretAuthMap(passFilename, secret)
++		err = dumpSecretAuthMap(passFilePath, secret)
+ 		if err != nil {
+ 			return nil, err
+ 		}
+@@ -225,9 +234,9 @@ func (a auth) Parse(ing *networking.Ingress) (interface{}, error) {
+ 	return &Config{
+ 		Type:       at,
+ 		Realm:      realm,
+-		File:       passFilename,
++		File:       passFilePath,
+ 		Secured:    true,
+-		FileSHA:    file.SHA1(passFilename),
++		FileSHA:    file.SHA1(passFilePath),
+ 		Secret:     name,
+ 		SecretType: secretType,
+ 	}, nil
+diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
+index 652a80e49..5a263551e 100644
+--- a/internal/ingress/controller/controller.go
++++ b/internal/ingress/controller/controller.go
+@@ -420,11 +420,15 @@ func (n *NGINXController) CheckIngress(ing *networking.Ingress) error {
+ 		return err
+ 	}
+ 
++	/* Deactivated to mitigate CVE-2025-1974
++	// TODO: Implement sandboxing so this test can be done safely
+ 	err = n.testTemplate(content)
+ 	if err != nil {
+ 		n.metricCollector.IncCheckErrorCount(ing.ObjectMeta.Namespace, ing.Name)
+ 		return err
+ 	}
++	*/
++
+ 	n.metricCollector.IncCheckCount(ing.ObjectMeta.Namespace, ing.Name)
+ 	endCheck := time.Now().UnixNano() / 1000000
+ 	n.metricCollector.SetAdmissionMetrics(
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index ed052e4ec..0e0300743 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -1622,11 +1622,11 @@ func buildMirrorLocations(locs []*ingress.Location) string {
+ 		mapped.Insert(loc.Mirror.Source)
+ 		buffer.WriteString(fmt.Sprintf(`location = %v {
+ internal;
+-proxy_set_header Host "%v";
+-proxy_pass "%v";
++proxy_set_header Host %v;
++proxy_pass %v;
+ }
+ 
+-`, loc.Mirror.Source, loc.Mirror.Host, loc.Mirror.Target))
++`, strconv.Quote(loc.Mirror.Source), strconv.Quote(loc.Mirror.Host), strconv.Quote(loc.Mirror.Target)))
+ 	}
+ 
+ 	return buffer.String()
+diff --git a/rootfs/etc/nginx/template/nginx.tmpl b/rootfs/etc/nginx/template/nginx.tmpl
+index 6b8e750b0..0a87de5ee 100644
+--- a/rootfs/etc/nginx/template/nginx.tmpl
++++ b/rootfs/etc/nginx/template/nginx.tmpl
+@@ -879,7 +879,7 @@ stream {
+ 
+         {{ if not ( empty $server.CertificateAuth.MatchCN ) }}
+         {{ if gt (len $server.CertificateAuth.MatchCN) 0 }}
+-        if ( $ssl_client_s_dn !~ {{ $server.CertificateAuth.MatchCN }} ) {
++        if ( $ssl_client_s_dn !~ {{ $server.CertificateAuth.MatchCN | quote }} ) {
+             return 403 "client certificate unauthorized";
+         }
+         {{ end }}
+@@ -1082,7 +1082,7 @@ stream {
+             set $target {{ changeHostPort $externalAuth.URL $authUpstreamName }};
+             {{ else }}
+             proxy_http_version {{ $location.Proxy.ProxyHTTPVersion }};
+-            set $target {{ $externalAuth.URL }};
++            set $target {{ $externalAuth.URL | quote }};
+             {{ end }}
+             proxy_pass $target;
+         }
+@@ -1120,7 +1120,7 @@ stream {
+             {{ buildOpentelemetryForLocation $all.Cfg.EnableOpentelemetry $all.Cfg.OpentelemetryTrustIncomingSpan $location }}
+ 
+             {{ if $location.Mirror.Source }}
+-            mirror {{ $location.Mirror.Source }};
++            mirror {{ $location.Mirror.Source | quote }};
+             mirror_request_body {{ $location.Mirror.RequestBody }};
+             {{ end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Backports several security fixes to release-1.67 by means of applying patches to v1.9 and v1.10 of ingress-nginx controller. 

The source of the patches can be found [here](https://github.com/kubernetes/ingress-nginx/pull/13068).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The following CVEs of ingress-nginx are concerned:
CVE-2025-1097
CVE-2025-1098
CVE-2025-1974
CVE-2025-24513
CVE-2025-24514

Regarding CVE-2025-1974, it was necessary to disable the validation of the generated NGINX configuration during the validation of Ingress resources.

The resulting NGINX configuration is still checked before the actual loading, so that there are no failures of the underlying NGINX. However, invalid Ingress resources can lead to the NGINX configuration no longer being able to be updated.

In case of doubt, nginx configuration issues can be determined from the logs of the Ingress NGINX Controller. Watch out for a line of dashes followed by "Error:" telling you what went wrong.

## Why do we need it in the patch release (if we do)?
To mitigate the aforementioned CVEs as soon as possible.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: latest CVE fixes backported.
impact: Ingress-nginx pods will restart. The validation of the generated NGINX configuration during the validation of `Ingress` resources is disabled until finding a way of running validations safely.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
