### PR TITLE
[docs] Remove the information label with the editions from the global settings page

### DIFF
--- a/docs/documentation/_includes/module-editions.liquid
+++ b/docs/documentation/_includes/module-editions.liquid
@@ -5,6 +5,7 @@
 {%- assign editionsWithRestrictionsComments = site.data['modules']['all'][moduleKebabName]['editionsWithRestrictionsComments'] %}
 {%- assign editionsWithoutRestrictions = "#" |  split: "#" %}
 
+{% unless page.module-kebab-name contains "/installing/configuration.html" %}
 <div class="info alert__wrap">
   <svg class="alert__icon icon--info">
     <use xlink:href="/images/sprite.svg#info-icon"></use>
@@ -73,3 +74,4 @@
   {%- endif %}
 </div>
 </div>
+{% endunless %}


### PR DESCRIPTION
## Description

The information label with the editions has been removed from the global settings page.

Changes include:

* Added a conditional statement to check if the `page.module-kebab-name` contains "/installing/configuration.html" before rendering the informational alert. [[1]](diffhunk://#diff-0aef491f0fc3be1c79963fef942c0d9933668428286c9bfce719a2b47e2e2f7fR8) [[2]](diffhunk://#diff-0aef491f0fc3be1c79963fef942c0d9933668428286c9bfce719a2b47e2e2f7fR77)

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: The information label with the editions has been removed from the global settings page.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
