### PR TITLE
[admission-policy-engine] Add new baseline policies

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-selinux/constraint_pss_baseline.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-selinux/constraint_pss_baseline.yaml
@@ -21,3 +21,4 @@ spec:
     - type: container_t
     - type: container_init_t
     - type: container_kvm_t
+    - type: container_engine_t

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-sysctls/constraint_pss_baseline.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-sysctls/constraint_pss_baseline.yaml
@@ -12,7 +12,7 @@ spec:
       matchExpressions:
         - key: security.deckhouse.io/pod-policy
           operator: In
-          values: 
+          values:
           - baseline
           - restricted
   parameters:
@@ -21,4 +21,9 @@ spec:
     - net.ipv4.ip_local_port_range
     - net.ipv4.ip_unprivileged_port_start
     - net.ipv4.tcp_syncookies
-    - net.ipv4.ping_group_range"
+    - net.ipv4.ping_group_range
+    - net.ipv4.ip_local_reserved_ports
+    - net.ipv4.tcp_keepalive_time
+    - net.ipv4.tcp_fin_timeout
+    - net.ipv4.tcp_keepalive_intvl
+    - net.ipv4.tcp_keepalive_probes

--- a/modules/015-admission-policy-engine/templates/policies/pod-security-standards/baseline/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/pod-security-standards/baseline/constraint.yaml
@@ -27,10 +27,10 @@
   {{- $parameters := dict "allowedProcMount" "Default" }} # Proc Mount
   {{- include "pod_security_standard_baseline" (list $context "D8AllowedProcMount" $enforcementAction $parameters)}}
 
-  {{- $parameters := dict "allowedSELinuxOptions" (list (dict "type" "") (dict "type" "container_t") (dict "type" "container_init_t") (dict "type" "container_kvm_t")) }} # Selinux
+  {{- $parameters := dict "allowedSELinuxOptions" (list (dict "type" "") (dict "type" "container_t") (dict "type" "container_init_t") (dict "type" "container_kvm_t") (dict "type" "container_engine_t")) }} # Selinux
   {{- include "pod_security_standard_baseline" (list $context "D8SeLinux" $enforcementAction $parameters) }}
 
-  {{- $parameters := dict "allowedSysctls" (list "kernel.shm_rmid_forced" "net.ipv4.ip_local_port_range" "net.ipv4.ip_unprivileged_port_start" "net.ipv4.tcp_syncookies" "net.ipv4.ping_group_range") }} # Sysctls
+  {{- $parameters := dict "allowedSysctls" (list "kernel.shm_rmid_forced" "net.ipv4.ip_local_port_range" "net.ipv4.ip_unprivileged_port_start" "net.ipv4.tcp_syncookies" "net.ipv4.ping_group_range" "net.ipv4.ip_local_reserved_ports" "net.ipv4.tcp_keepalive_time" "net.ipv4.tcp_fin_timeout" "net.ipv4.tcp_keepalive_intvl" "net.ipv4.tcp_keepalive_probes") }} # Sysctls
   {{- include "pod_security_standard_baseline" (list $context "D8AllowedSysctls" $enforcementAction $parameters) }}
 
   {{- $parameters := dict "allowedProfiles" (list "RuntimeDefault" "Localhost" "" "undefined") "allowedLocalhostFiles" (list "*") }} # Seccomp Profiles


### PR DESCRIPTION
## Description
New baseline policies were added in Pod Security Standards https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline

```
SELinux

- container_engine_t (since Kubernetes 1.31)

Sysctl

- net.ipv4.ip_local_reserved_ports (since Kubernetes 1.27)
- net.ipv4.tcp_keepalive_time (since Kubernetes 1.29)
- net.ipv4.tcp_fin_timeout (since Kubernetes 1.29)
- net.ipv4.tcp_keepalive_intvl (since Kubernetes 1.29)
- net.ipv4.tcp_keepalive_probes (since Kubernetes 1.29)

```





<br class="Apple-interchange-newline">

## Why do we need it, and what problem does it solve?
We should keep Pod Security Standards policies up to date

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: chore
summary: Added pod security standards policies that were added since 1.27
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
