### PR TITLE
[admission-policy-engine][docs] Add SecurityPolicies examples that match PSS

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -435,10 +435,10 @@ entries:
                     en: Examples
                     ru: Примеры
                   url: /modules/cloud-provider-vcd/examples.html
-                - title:
-                    en: FAQ
-                    ru: FAQ
-                  url: /modules/cloud-provider-vcd/faq.html
+                #- title:
+                    #en: FAQ
+                    #ru: FAQ
+                  #url: /modules/cloud-provider-vcd/faq.html
             - title:
                 en: VMware vSphere
                 ru: VMware vSphere

--- a/modules/015-admission-policy-engine/docs/FAQ.md
+++ b/modules/015-admission-policy-engine/docs/FAQ.md
@@ -82,6 +82,148 @@ The [Gatekeeper documentation](https://open-policy-agent.github.io/gatekeeper/we
 
 Find more examples of checks for policy extension in the [Gatekeeper Library](https://github.com/open-policy-agent/gatekeeper-library/tree/master/src/general).
 
+## How to allow some Pod Security Standards policies without disabling whole list?
+
+1. Add the `security.deckhouse.io/pod-policy: privileged` label to your namespace in order to disable built-in policies.
+1. Create a `SecurityPolicy` resource that matches the `baseline` or `restricted` policy while also editing the list of `policies` elements as you see fit.
+1. Add a label to your namespace that matches the `namespaceSelector` in the `SecurityPolicy` resource. In the examples below, the label is `operation-policy.deckhouse.io/baseline-enabled: "true"` or `operation-policy.deckhouse.io/restricted-enabled: "true"`.
+
+`SecurityPolicy` that matches [baseline](https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline) standard:
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: baseline
+spec:
+  enforcementAction: Deny
+  policies:
+    allowHostIPC: false
+    allowHostNetwork: false
+    allowHostPID: false
+    allowPrivilegeEscalation: true
+    allowPrivileged: false
+    allowedAppArmor:
+      - runtime/default
+      - localhost/*
+    allowedCapabilities:
+      - AUDIT_WRITE
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - FSETID
+      - KILL
+      - MKNOD
+      - NET_BIND_SERVICE
+      - SETFCAP
+      - SETGID
+      - SETPCAP
+      - SETUID
+      - SYS_CHROOT
+    allowedHostPaths: []
+    allowedHostPorts:
+      - max: 0
+        min: 0
+    allowedProcMount: Default
+    allowedUnsafeSysctls:
+      - kernel.shm_rmid_forced
+      - net.ipv4.ip_local_port_range
+      - net.ipv4.ip_unprivileged_port_start
+      - net.ipv4.tcp_syncookies
+      - net.ipv4.ping_group_range
+      - net.ipv4.ip_local_reserved_ports
+      - net.ipv4.tcp_keepalive_time
+      - net.ipv4.tcp_fin_timeout
+      - net.ipv4.tcp_keepalive_intvl
+      - net.ipv4.tcp_keepalive_probes
+    seLinux:
+      - type: ""
+      - type: container_t
+      - type: container_init_t
+      - type: container_kvm_t
+      - type: container_engine_t
+    seccompProfiles:
+      allowedProfiles:
+        - RuntimeDefault
+        - Localhost
+        - undefined
+        - ''
+      allowedLocalhostFiles:
+        - '*'
+  match:
+    namespaceSelector:
+      labelSelector:
+        matchLabels:
+          operation-policy.deckhouse.io/baseline-enabled: "true"
+
+```
+
+`SecurityPolicy` that matches [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) standard:
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: restricted
+spec:
+  enforcementAction: Deny
+  policies:
+    allowHostIPC: false
+    allowHostNetwork: false
+    allowHostPID: false
+    allowPrivilegeEscalation: false
+    allowPrivileged: false
+    allowedAppArmor:
+      - runtime/default
+      - localhost/*
+    allowedCapabilities:
+      - NET_BIND_SERVICE
+    allowedHostPaths: []
+    allowedHostPorts:
+      - max: 0
+        min: 0
+    allowedProcMount: Default
+    allowedUnsafeSysctls:
+      - kernel.shm_rmid_forced
+      - net.ipv4.ip_local_port_range
+      - net.ipv4.ip_unprivileged_port_start
+      - net.ipv4.tcp_syncookies
+      - net.ipv4.ping_group_range
+      - net.ipv4.ip_local_reserved_ports
+      - net.ipv4.tcp_keepalive_time
+      - net.ipv4.tcp_fin_timeout
+      - net.ipv4.tcp_keepalive_intvl
+      - net.ipv4.tcp_keepalive_probes
+    allowedVolumes:
+      - configMap
+      - csi
+      - downwardAPI
+      - emptyDir
+      - ephemeral
+      - persistentVolumeClaim
+      - projected
+      - secret
+    requiredDropCapabilities:
+      - ALL
+    runAsUser:
+      rule: MustRunAsNonRoot
+    seLinux:
+      - type: ""
+      - type: container_t
+      - type: container_init_t
+      - type: container_kvm_t
+      - type: container_engine_t
+    seccompProfiles:
+      allowedProfiles:
+        - RuntimeDefault
+        - Localhost
+      allowedLocalhostFiles:
+        - '*'
+  match:
+    namespaceSelector:
+      labelSelector:
+        matchLabels:
+          operation-policy.deckhouse.io/restricted-enabled: "true"
+```
+
 ## What if there are multiple policies (operational or security) that are applied to the same object?
 
 In that case the object's specification have to fulfil all the requirements imposed by the policies.

--- a/modules/015-admission-policy-engine/docs/FAQ.md
+++ b/modules/015-admission-policy-engine/docs/FAQ.md
@@ -89,6 +89,7 @@ Find more examples of checks for policy extension in the [Gatekeeper Library](ht
 1. Add a label to your namespace that matches the `namespaceSelector` in the `SecurityPolicy` resource. In the examples below, the label is `operation-policy.deckhouse.io/baseline-enabled: "true"` or `operation-policy.deckhouse.io/restricted-enabled: "true"`.
 
 `SecurityPolicy` that matches [baseline](https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline) standard:
+
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
 kind: SecurityPolicy
@@ -154,10 +155,10 @@ spec:
       labelSelector:
         matchLabels:
           operation-policy.deckhouse.io/baseline-enabled: "true"
-
 ```
 
 `SecurityPolicy` that matches [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) standard:
+
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
 kind: SecurityPolicy

--- a/modules/015-admission-policy-engine/docs/FAQ.md
+++ b/modules/015-admission-policy-engine/docs/FAQ.md
@@ -84,11 +84,13 @@ Find more examples of checks for policy extension in the [Gatekeeper Library](ht
 
 ## How to allow some Pod Security Standards policies without disabling whole list?
 
-1. Add the `security.deckhouse.io/pod-policy: privileged` label to your namespace in order to disable built-in policies.
-1. Create a `SecurityPolicy` resource that matches the `baseline` or `restricted` policy while also editing the list of `policies` elements as you see fit.
-1. Add a label to your namespace that matches the `namespaceSelector` in the `SecurityPolicy` resource. In the examples below, the label is `operation-policy.deckhouse.io/baseline-enabled: "true"` or `operation-policy.deckhouse.io/restricted-enabled: "true"`.
+To apply only the required security policies without turning off the entire built-in set:
 
-`SecurityPolicy` that matches [baseline](https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline) standard:
+1. Add the `security.deckhouse.io/pod-policy: privileged` label to your namespace in order to disable built-in policies.
+1. Create a SecurityPolicy resource that matches the [baseline](https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline) or [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) policy while also editing the list of `policies` elements as you see fit.
+1. Add a label to your namespace that matches the `namespaceSelector` in the SecurityPolicy resource. In the examples below, the label is `operation-policy.deckhouse.io/baseline-enabled: "true"` or `operation-policy.deckhouse.io/restricted-enabled: "true"`.
+
+SecurityPolicy that matches baseline standard:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
@@ -157,7 +159,7 @@ spec:
           operation-policy.deckhouse.io/baseline-enabled: "true"
 ```
 
-`SecurityPolicy` that matches [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) standard:
+`SecurityPolicy` that matches restricted standard:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1

--- a/modules/015-admission-policy-engine/docs/FAQ_RU.md
+++ b/modules/015-admission-policy-engine/docs/FAQ_RU.md
@@ -86,6 +86,148 @@ spec:
 
 Больше примеров описания проверок для расширения политики можно найти [в библиотеке Gatekeeper](https://github.com/open-policy-agent/gatekeeper-library/tree/master/src/general).
 
+## Как разрешить одну или несколько политик Pod Security Standards, не отключая весь набор?
+
+1. Добавьте на ваш namespace метку `security.deckhouse.io/pod-policy: privileged`, чтобы отключить встроенный набор политик.
+1. Создайте ресурс `SecurityPolicy`, соответствующий политикам baseline либо restricted, при этом отредактируйте список `policies` под ваши нужды.
+1. Добавьте на свой namespace метку, соответствующую `namespaceSelector` в `SecurityPolicy`. В примерах ниже это `operation-policy.deckhouse.io/baseline-enabled: "true"` либо `operation-policy.deckhouse.io/restricted-enabled: "true"`
+
+`SecurityPolicy`, соответствующая [baseline](https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline):
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: baseline
+spec:
+  enforcementAction: Deny
+  policies:
+    allowHostIPC: false
+    allowHostNetwork: false
+    allowHostPID: false
+    allowPrivilegeEscalation: true
+    allowPrivileged: false
+    allowedAppArmor:
+      - runtime/default
+      - localhost/*
+    allowedCapabilities:
+      - AUDIT_WRITE
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - FSETID
+      - KILL
+      - MKNOD
+      - NET_BIND_SERVICE
+      - SETFCAP
+      - SETGID
+      - SETPCAP
+      - SETUID
+      - SYS_CHROOT
+    allowedHostPaths: []
+    allowedHostPorts:
+      - max: 0
+        min: 0
+    allowedProcMount: Default
+    allowedUnsafeSysctls:
+      - kernel.shm_rmid_forced
+      - net.ipv4.ip_local_port_range
+      - net.ipv4.ip_unprivileged_port_start
+      - net.ipv4.tcp_syncookies
+      - net.ipv4.ping_group_range
+      - net.ipv4.ip_local_reserved_ports
+      - net.ipv4.tcp_keepalive_time
+      - net.ipv4.tcp_fin_timeout
+      - net.ipv4.tcp_keepalive_intvl
+      - net.ipv4.tcp_keepalive_probes
+    seLinux:
+      - type: ""
+      - type: container_t
+      - type: container_init_t
+      - type: container_kvm_t
+      - type: container_engine_t
+    seccompProfiles:
+      allowedProfiles:
+        - RuntimeDefault
+        - Localhost
+        - undefined
+        - ''
+      allowedLocalhostFiles:
+        - '*'
+  match:
+    namespaceSelector:
+      labelSelector:
+        matchLabels:
+          operation-policy.deckhouse.io/baseline-enabled: "true"
+
+```
+
+`SecurityPolicy`, соответствующая [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted):
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: restricted
+spec:
+  enforcementAction: Deny
+  policies:
+    allowHostIPC: false
+    allowHostNetwork: false
+    allowHostPID: false
+    allowPrivilegeEscalation: false
+    allowPrivileged: false
+    allowedAppArmor:
+      - runtime/default
+      - localhost/*
+    allowedCapabilities:
+      - NET_BIND_SERVICE
+    allowedHostPaths: []
+    allowedHostPorts:
+      - max: 0
+        min: 0
+    allowedProcMount: Default
+    allowedUnsafeSysctls:
+      - kernel.shm_rmid_forced
+      - net.ipv4.ip_local_port_range
+      - net.ipv4.ip_unprivileged_port_start
+      - net.ipv4.tcp_syncookies
+      - net.ipv4.ping_group_range
+      - net.ipv4.ip_local_reserved_ports
+      - net.ipv4.tcp_keepalive_time
+      - net.ipv4.tcp_fin_timeout
+      - net.ipv4.tcp_keepalive_intvl
+      - net.ipv4.tcp_keepalive_probes
+    allowedVolumes:
+      - configMap
+      - csi
+      - downwardAPI
+      - emptyDir
+      - ephemeral
+      - persistentVolumeClaim
+      - projected
+      - secret
+    requiredDropCapabilities:
+      - ALL
+    runAsUser:
+      rule: MustRunAsNonRoot
+    seLinux:
+      - type: ""
+      - type: container_t
+      - type: container_init_t
+      - type: container_kvm_t
+      - type: container_engine_t
+    seccompProfiles:
+      allowedProfiles:
+        - RuntimeDefault
+        - Localhost
+      allowedLocalhostFiles:
+        - '*'
+  match:
+    namespaceSelector:
+      labelSelector:
+        matchLabels:
+          operation-policy.deckhouse.io/restricted-enabled: "true"
+```
+
 ## Что, если несколько политик (операционных или безопасности) применяются на один объект?
 
 В этом случае необходимо, чтобы конфигурация объекта соответствовала всем политикам, которые на него распространяются.

--- a/modules/015-admission-policy-engine/docs/FAQ_RU.md
+++ b/modules/015-admission-policy-engine/docs/FAQ_RU.md
@@ -93,6 +93,7 @@ spec:
 1. Добавьте на свой namespace метку, соответствующую `namespaceSelector` в `SecurityPolicy`. В примерах ниже это `operation-policy.deckhouse.io/baseline-enabled: "true"` либо `operation-policy.deckhouse.io/restricted-enabled: "true"`
 
 `SecurityPolicy`, соответствующая [baseline](https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline):
+
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
 kind: SecurityPolicy
@@ -158,10 +159,10 @@ spec:
       labelSelector:
         matchLabels:
           operation-policy.deckhouse.io/baseline-enabled: "true"
-
 ```
 
 `SecurityPolicy`, соответствующая [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted):
+
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
 kind: SecurityPolicy

--- a/modules/015-admission-policy-engine/docs/FAQ_RU.md
+++ b/modules/015-admission-policy-engine/docs/FAQ_RU.md
@@ -86,13 +86,15 @@ spec:
 
 Больше примеров описания проверок для расширения политики можно найти [в библиотеке Gatekeeper](https://github.com/open-policy-agent/gatekeeper-library/tree/master/src/general).
 
-## Как разрешить одну или несколько политик Pod Security Standards, не отключая весь набор?
+## Как включить одну или несколько политик Pod Security Standards, не отключая весь набор?
 
-1. Добавьте на ваш namespace метку `security.deckhouse.io/pod-policy: privileged`, чтобы отключить встроенный набор политик.
-1. Создайте ресурс `SecurityPolicy`, соответствующий политикам baseline либо restricted, при этом отредактируйте список `policies` под ваши нужды.
-1. Добавьте на свой namespace метку, соответствующую `namespaceSelector` в `SecurityPolicy`. В примерах ниже это `operation-policy.deckhouse.io/baseline-enabled: "true"` либо `operation-policy.deckhouse.io/restricted-enabled: "true"`
+Чтобы применить только нужные политики безопасности, не отключая весь предустановленный набор:
 
-`SecurityPolicy`, соответствующая [baseline](https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline):
+1. Добавьте в нужное пространство имён метку: `security.deckhouse.io/pod-policy: privileged`, чтобы отключить встроенный набор политик.
+1. Создайте ресурс SecurityPolicy, соответствующий уровню [baseline](https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline) или [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted). В секции `policies` укажите только необходимые вам настройки.
+1. Добавьте в пространство имён дополнительную метку, которая будет соответствовать селектору `namespaceSelector` в SecurityPolicy. В примерах ниже это `operation-policy.deckhouse.io/baseline-enabled: "true"` либо `operation-policy.deckhouse.io/restricted-enabled: "true"`
+
+SecurityPolicy, соответствующая baseline:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
@@ -161,7 +163,7 @@ spec:
           operation-policy.deckhouse.io/baseline-enabled: "true"
 ```
 
-`SecurityPolicy`, соответствующая [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted):
+SecurityPolicy, соответствующая restricted:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1


### PR DESCRIPTION
## Description
Added SecurityPolicies examples that match our baseline and restricted lists from [Kubernetes PSS](https://kubernetes.io/docs/concepts/security/pod-security-standards/) with a deployment guide to FAQ

## Why do we need it, and what problem does it solve?
We need a way to allow some existing policies without just enabling `privileged` policy. Examples and the guide should help with that.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: chore
summary: Added SecurityPolicies examples for baseline and restricted policy standards.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
