### PR TITLE
[monitoring-custom] Exclude d8-observability namespace from collecting Prometheus Operator CRs

### DIFF
--- a/modules/340-monitoring-custom/hooks/metrics.go
+++ b/modules/340-monitoring-custom/hooks/metrics.go
@@ -51,8 +51,21 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			},
 			NamespaceSelector: &types.NamespaceSelector{
 				LabelSelector: &v1.LabelSelector{
-					MatchLabels: map[string]string{
-						"heritage": "deckhouse",
+					MatchExpressions: []v1.LabelSelectorRequirement{
+						{
+							Key:      "heritage",
+							Operator: v1.LabelSelectorOpIn,
+							Values: []string{
+								"deckhouse",
+							},
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: v1.LabelSelectorOpNotIn,
+							Values: []string{
+								"d8-observability",
+							},
+						},
 					},
 				},
 			},
@@ -78,8 +91,21 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			},
 			NamespaceSelector: &types.NamespaceSelector{
 				LabelSelector: &v1.LabelSelector{
-					MatchLabels: map[string]string{
-						"heritage": "deckhouse",
+					MatchExpressions: []v1.LabelSelectorRequirement{
+						{
+							Key:      "heritage",
+							Operator: v1.LabelSelectorOpIn,
+							Values: []string{
+								"deckhouse",
+							},
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: v1.LabelSelectorOpNotIn,
+							Values: []string{
+								"d8-observability",
+							},
+						},
 					},
 				},
 			},
@@ -106,8 +132,21 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			},
 			NamespaceSelector: &types.NamespaceSelector{
 				LabelSelector: &v1.LabelSelector{
-					MatchLabels: map[string]string{
-						"heritage": "deckhouse",
+					MatchExpressions: []v1.LabelSelectorRequirement{
+						{
+							Key:      "heritage",
+							Operator: v1.LabelSelectorOpIn,
+							Values: []string{
+								"deckhouse",
+							},
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: v1.LabelSelectorOpNotIn,
+							Values: []string{
+								"d8-observability",
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Description
Currently, the deckhouse controller watches for the Prometheus Operator CRs without a `heritage: deckhouse` label in `d8-` prefixed namespaces. All such resources are treated as unsolicited, and the corresponding alert is fired if they exist.

The `observability` module resides in the `d8-observability` namespace and creates the resources during its normal workflow. However, it cannot set the `heritage: deckhouse` label to the created resources. Hence, we have to exclude the namespace from the checks.

## Why do we need it, and what problem does it solve?
This PR prevents the alert for the resources in `d8-observability` namespace from firing.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->
 
```changes
section: monitoring-custom
type: chore
summary: exclude d8-observability namespace from D8CustomPrometheusRuleFoundInCluster alert
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
