### PR TITLE
[ingress-nginx] add cve fixer cleanup hook

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -82,6 +82,7 @@ import (
 	_ "github.com/deckhouse/deckhouse/modules/400-descheduler/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/400-descheduler/hooks/migrate"
 	_ "github.com/deckhouse/deckhouse/modules/402-ingress-nginx/hooks"
+	_ "github.com/deckhouse/deckhouse/modules/402-ingress-nginx/hooks/migration"
 	_ "github.com/deckhouse/deckhouse/modules/402-ingress-nginx/requirements"
 	_ "github.com/deckhouse/deckhouse/modules/460-log-shipper/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/462-loki/hooks"

--- a/modules/402-ingress-nginx/hooks/migration/common_test.go
+++ b/modules/402-ingress-nginx/hooks/migration/common_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}

--- a/modules/402-ingress-nginx/hooks/migration/migrate_remove_ingress_validation_cve_fixer.go
+++ b/modules/402-ingress-nginx/hooks/migration/migrate_remove_ingress_validation_cve_fixer.go
@@ -19,12 +19,12 @@ package hooks
 import (
 	"context"
 
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
-	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
-	"github.com/flant/addon-operator/sdk"
 )
 
 // This migration hooks deletes resources related to CVE-2025-1974 fix

--- a/modules/402-ingress-nginx/hooks/migration/migrate_remove_ingress_validation_cve_fixer.go
+++ b/modules/402-ingress-nginx/hooks/migration/migrate_remove_ingress_validation_cve_fixer.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+)
+
+// This migration hooks deletes resources related to CVE-2025-1974 fix
+// (https://github.com/deckhouse/deckhouse/blob/main/modules/402-ingress-nginx/docs/internal/VALIDATIONS_CVE_FIXUP_RU.md)
+// TODO: Remove this migration hook in v1.70+
+
+const (
+	ingressNginxValidationCveAnnotation = "igress-nginx.deckhouse.io/cve-2025-1974-fixer-deleted"
+	fixerRBACName                       = "d8:ingress-validation-cve-fixer"
+	fixerName                           = "d8-ingress-validation-cve-fixer"
+
+	d8SystemNs = "d8-system"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 0},
+}, dependency.WithExternalDependencies(removeFixer))
+
+func removeFixer(_ *go_hook.HookInput, dc dependency.Container) error {
+	kubeClient := dc.MustGetK8sClient()
+
+	if err := kubeClient.CoreV1().ServiceAccounts(d8SystemNs).Delete(context.Background(), fixerName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if err := kubeClient.CoreV1().Secrets(d8SystemNs).Delete(context.Background(), fixerName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if err := kubeClient.CoreV1().Services(d8SystemNs).Delete(context.Background(), fixerName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if err := kubeClient.CoreV1().ConfigMaps(d8SystemNs).Delete(context.Background(), fixerName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if err := kubeClient.AppsV1().Deployments(d8SystemNs).Delete(context.Background(), fixerName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if err := kubeClient.RbacV1().ClusterRoles().Delete(context.Background(), fixerRBACName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if err := kubeClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), fixerRBACName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.Background(), fixerName+"-hooks", metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}

--- a/modules/402-ingress-nginx/hooks/migration/migrate_remove_ingress_validation_cve_fixer_test.go
+++ b/modules/402-ingress-nginx/hooks/migration/migrate_remove_ingress_validation_cve_fixer_test.go
@@ -19,6 +19,8 @@ package hooks
 import (
 	"context"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,11 +29,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	. "github.com/deckhouse/deckhouse/testing/hooks"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
 const (

--- a/modules/402-ingress-nginx/hooks/migration/migrate_remove_ingress_validation_cve_fixer_test.go
+++ b/modules/402-ingress-nginx/hooks/migration/migrate_remove_ingress_validation_cve_fixer_test.go
@@ -1,0 +1,316 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+)
+
+const (
+	nsYaml = `
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d8-system
+`
+
+	depYaml = `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ingress-validation-cve-fixer
+  name: d8-ingress-validation-cve-fixer
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ingress-validation-cve-fixer
+  template:
+    metadata:
+      labels:
+        app: ingress-validation-cve-fixer
+    spec:
+      containers:
+      - image: $shellOperatorImage
+`
+	cmYaml = `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: d8-ingress-validation-cve-fixer
+  namespace: d8-system
+data:
+  disable-ingress-validation.sh: |
+    #!/usr/bin/env bash
+`
+	svcYaml = `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: d8-ingress-validation-cve-fixer
+  namespace: d8-system
+spec:
+  type: ClusterIP
+  ports:
+    - name: mutating-http
+      port: 443
+      targetPort: 9680
+      protocol: TCP
+`
+	secretYaml = `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-ingress-validation-cve-fixer
+  namespace: d8-system
+type: kubernetes.io/tls
+data:
+  ca.crt: dGVzdAo=
+  tls.crt: dGVzdAo=
+  tls.key: dGVzdAo=
+`
+	crbYaml = `
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:ingress-validation-cve-fixer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:ingress-validation-cve-fixer
+subjects:
+- kind: ServiceAccount
+  name: d8-ingress-validation-cve-fixer
+  namespace: d8-system
+`
+	crYaml = `
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: d8:ingress-validation-cve-fixer
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - create
+  - list
+  - update
+`
+	saYaml = `
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: d8-ingress-validation-cve-fixer
+  namespace: d8-system
+`
+	mutatingwcYaml = `
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: d8-ingress-validation-cve-fixer-hooks
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    caBundle: dGVzdAo=
+    service:
+      name: d8-ingress-validation-cve-fixer
+      namespace: d8-system
+      path: /hooks/disable-ingress-validation
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: disable.ingress.validation
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - d8-ingress-nginx
+  objectSelector:
+    matchLabels:
+      app: controller
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+    scope: Namespaced
+  sideEffects: None
+  timeoutSeconds: 10
+`
+)
+
+var _ = Describe("ingress-nginx :: hooks :: remove_ingress_nginx_validation_cve_fixer_migration ::", func() {
+	f := HookExecutionConfigInit("", "")
+
+	Context("An empty cluster", func() {
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.RunGoHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("Cluster with ingress-nginx validation CVE fixer installed", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+
+			createNs(f.KubeClient(), nsYaml)
+			createDeployment(f.KubeClient(), depYaml)
+			createCm(f.KubeClient(), cmYaml)
+			createSvc(f.KubeClient(), svcYaml)
+			createSecret(f.KubeClient(), secretYaml)
+			createCrb(f.KubeClient(), crbYaml)
+			createCr(f.KubeClient(), crYaml)
+			createSa(f.KubeClient(), saYaml)
+			createMutatingwc(f.KubeClient(), mutatingwcYaml)
+
+			f.RunGoHook()
+		})
+
+		It("Fixer must be deleted ", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			_, err := f.KubeClient().CoreV1().Namespaces().Get(context.TODO(), d8SystemNs, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			_, err = f.KubeClient().AppsV1().Deployments(d8SystemNs).Get(context.TODO(), fixerName, metav1.GetOptions{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			_, err = f.KubeClient().CoreV1().ConfigMaps(d8SystemNs).Get(context.TODO(), fixerName, metav1.GetOptions{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			_, err = f.KubeClient().CoreV1().Services(d8SystemNs).Get(context.TODO(), fixerName, metav1.GetOptions{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			_, err = f.KubeClient().CoreV1().Secrets(d8SystemNs).Get(context.TODO(), fixerName, metav1.GetOptions{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			_, err = f.KubeClient().RbacV1().ClusterRoleBindings().Get(context.TODO(), fixerRBACName, metav1.GetOptions{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			_, err = f.KubeClient().RbacV1().ClusterRoles().Get(context.TODO(), fixerRBACName, metav1.GetOptions{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			_, err = f.KubeClient().CoreV1().ServiceAccounts(d8SystemNs).Get(context.TODO(), fixerName, metav1.GetOptions{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			_, err = f.KubeClient().AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(), fixerName+"-hooks", metav1.GetOptions{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+})
+
+func createNs(kubeClient client.KubeClient, spec string) {
+	ns := new(corev1.Namespace)
+	if err := yaml.Unmarshal([]byte(spec), ns); err != nil {
+		panic(err)
+	}
+	_, _ = kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+}
+
+func createDeployment(kubeClient client.KubeClient, spec string) {
+	dep := new(appsv1.Deployment)
+	if err := yaml.Unmarshal([]byte(spec), dep); err != nil {
+		panic(err)
+	}
+	_, _ = kubeClient.AppsV1().Deployments(d8SystemNs).Create(context.TODO(), dep, metav1.CreateOptions{})
+}
+
+func createCm(kubeClient client.KubeClient, spec string) {
+	cm := new(corev1.ConfigMap)
+	if err := yaml.Unmarshal([]byte(spec), cm); err != nil {
+		panic(err)
+	}
+	_, _ = kubeClient.CoreV1().ConfigMaps(d8SystemNs).Create(context.TODO(), cm, metav1.CreateOptions{})
+}
+
+func createSvc(kubeClient client.KubeClient, spec string) {
+	svc := new(corev1.Service)
+	if err := yaml.Unmarshal([]byte(spec), svc); err != nil {
+		panic(err)
+	}
+	_, _ = kubeClient.CoreV1().Services(d8SystemNs).Create(context.TODO(), svc, metav1.CreateOptions{})
+}
+
+func createSecret(kubeClient client.KubeClient, spec string) {
+	secret := new(corev1.Secret)
+	if err := yaml.Unmarshal([]byte(spec), secret); err != nil {
+		panic(err)
+	}
+	_, _ = kubeClient.CoreV1().Secrets(d8SystemNs).Create(context.TODO(), secret, metav1.CreateOptions{})
+}
+
+func createCrb(kubeClient client.KubeClient, spec string) {
+	crb := new(rbacv1.ClusterRoleBinding)
+	if err := yaml.Unmarshal([]byte(spec), crb); err != nil {
+		panic(err)
+	}
+	_, _ = kubeClient.RbacV1().ClusterRoleBindings().Create(context.TODO(), crb, metav1.CreateOptions{})
+}
+
+func createCr(kubeClient client.KubeClient, spec string) {
+	cr := new(rbacv1.ClusterRole)
+	if err := yaml.Unmarshal([]byte(spec), cr); err != nil {
+		panic(err)
+	}
+	_, _ = kubeClient.RbacV1().ClusterRoles().Create(context.TODO(), cr, metav1.CreateOptions{})
+}
+
+func createSa(kubeClient client.KubeClient, spec string) {
+	sa := new(corev1.ServiceAccount)
+	if err := yaml.Unmarshal([]byte(spec), sa); err != nil {
+		panic(err)
+	}
+	_, _ = kubeClient.CoreV1().ServiceAccounts(d8SystemNs).Create(context.TODO(), sa, metav1.CreateOptions{})
+}
+
+func createMutatingwc(kubeClient client.KubeClient, spec string) {
+	mutatingwc := new(admissionregistrationv1.MutatingWebhookConfiguration)
+	if err := yaml.Unmarshal([]byte(spec), mutatingwc); err != nil {
+		panic(err)
+	}
+	_, _ = kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.TODO(), mutatingwc, metav1.CreateOptions{})
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This pr adds a hook to clean up the resources created to implement the fix for CVE-2025-1974 described [here](https://github.com/deckhouse/deckhouse/blob/main/modules/402-ingress-nginx/docs/internal/VALIDATIONS_CVE_FIXUP_RU.md) from the cluster.
Also, an extra "containers" section is deleted from the deployment manifest of the fix.

The fixer was brought here:
https://github.com/deckhouse/deckhouse/pull/12779
https://github.com/deckhouse/deckhouse/pull/12785
https://github.com/deckhouse/deckhouse/pull/12795

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This hook cleans up the resources that might have been created to mitigate CVE-2025-1974 in clusters running Deckhouse versions below v1.67. As Deckhouse isn't exposed to the CVE-2025-1974 since v1.67 and greater, these resources aren't longer needed.

## Why do we need it in the patch release (if we do)?

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: chore
summary: A hook to clean up ingress-validation-cve-fixer's resources added.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
