### PR TITLE
[cilium] restoring/hiding network access for cep when higher/lower priority cep was removed/added

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-managment.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-managment.patch
@@ -120,7 +120,7 @@ index de0288ef1f..9acb023a61 100644
  
  var (
 diff --git a/operator/pkg/ciliumendpointslice/manager.go b/operator/pkg/ciliumendpointslice/manager.go
-index 6de6fb7166..3e618b2478 100644
+index 6de6fb7166..4e3a4b5caa 100644
 --- a/operator/pkg/ciliumendpointslice/manager.go
 +++ b/operator/pkg/ciliumendpointslice/manager.go
 @@ -47,7 +47,7 @@ type cesTracker struct {
@@ -150,7 +150,15 @@ index 6de6fb7166..3e618b2478 100644
  	ces.backendMutex.Lock()
  	defer ces.backendMutex.Unlock()
  	// If cep already exists in ces, compare new cep with cached cep.
-@@ -181,7 +181,7 @@ func (c *cesMgr) addCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ces *cesTracker)
+@@ -171,7 +171,6 @@ func (c *cesMgr) addCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ces *cesTracker)
+ 			break
+ 		}
+ 	}
+-
+ 	// Insert the cep in ces endpoints list.
+ 	ces.ces.Endpoints = append(ces.ces.Endpoints, *cep)
+ 	// If this CEP is re-generated again before previous CEP-DELETE completed.
+@@ -181,7 +180,7 @@ func (c *cesMgr) addCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ces *cesTracker)
  	}
  	// Increment the cepInsert counter
  	ces.cepInserted += 1
@@ -159,7 +167,7 @@ index 6de6fb7166..3e618b2478 100644
  	return
  }
  
-@@ -301,7 +301,7 @@ func (c *cesMgr) getCESCopyFromCache(cesName string) (*cilium_v2.CiliumEndpointS
+@@ -301,7 +300,7 @@ func (c *cesMgr) getCESCopyFromCache(cesName string) (*cilium_v2.CiliumEndpointS
  
  // InsertCEPInCache is used to insert CEP in local cache, this may result in creating a new
  // CES object or updating an existing CES object.
@@ -168,7 +176,7 @@ index 6de6fb7166..3e618b2478 100644
  	log.WithFields(logrus.Fields{
  		logfields.CEPName: GetCEPNameFromCCEP(cep, ns),
  	}).Debug("Insert CEP in local cache")
-@@ -312,7 +312,7 @@ func (c *cesMgr) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string)
+@@ -312,7 +311,7 @@ func (c *cesMgr) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string)
  	if cesName, exists := c.desiredCESs.getCESName(cepName); exists {
  		if ces, ok := c.desiredCESs.getCESTracker(cesName); ok {
  			// add a cep into the ces
@@ -177,7 +185,7 @@ index 6de6fb7166..3e618b2478 100644
  			return cesName
  		} else {
  			log.WithFields(logrus.Fields{
-@@ -345,7 +345,7 @@ func (c *cesMgr) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string)
+@@ -345,7 +344,7 @@ func (c *cesMgr) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string)
  	c.updateCEPToCESMapping(GetCEPNameFromCCEP(cep, ns), cesName)
  
  	// Queue the CEP in CES
@@ -186,7 +194,7 @@ index 6de6fb7166..3e618b2478 100644
  	return cesName
  }
  
-@@ -603,7 +603,7 @@ func (c *cesManagerIdentity) deleteCESFromCache(cesName string) {
+@@ -603,7 +602,7 @@ func (c *cesManagerIdentity) deleteCESFromCache(cesName string) {
  
  // InsertCEPInCache is used to insert CEP in local cache, this may result in creating a new
  // CES object or updating an existing CES object. CEPs are grouped based on CEP identity.
@@ -195,7 +203,7 @@ index 6de6fb7166..3e618b2478 100644
  	// check the given cep is already exists in any of the CES.
  	// if yes, compare the given CEP Identity with the CEPs stored in CES.
  	// If they are same UPDATE the CEP in the CES. This will trigger CES UPDATE to k8s-apiserver.
-@@ -618,7 +618,7 @@ func (c *cesManagerIdentity) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint,
+@@ -618,7 +617,7 @@ func (c *cesManagerIdentity) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint,
  		} else {
  			if ces, ok := c.desiredCESs.getCESTracker(cesName); ok {
  				// add a cep into the ces
@@ -204,7 +212,7 @@ index 6de6fb7166..3e618b2478 100644
  				return cesName
  			} else {
  				log.WithFields(logrus.Fields{
-@@ -669,7 +669,7 @@ func (c *cesManagerIdentity) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint,
+@@ -669,7 +668,7 @@ func (c *cesManagerIdentity) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint,
  	c.desiredCESs.insertCEP(GetCEPNameFromCCEP(cep, ns), cesName)
  
  	// Queue the CEP in CES
@@ -318,7 +326,7 @@ index bf47c44de9..ece7d4a286 100644
  		m.RemoveCEPFromCache(GetCEPNameFromCCEP(cep2, "kube-system"), DefaultCESSyncTime)
  		remCEPs := m.getRemovedCEPs(cesName)
 diff --git a/operator/watchers/cilium_endpoint.go b/operator/watchers/cilium_endpoint.go
-index 7c1b240f77..cbba866ac2 100644
+index 7c1b240f77..30b1a2780f 100644
 --- a/operator/watchers/cilium_endpoint.go
 +++ b/operator/watchers/cilium_endpoint.go
 @@ -7,8 +7,11 @@ import (
@@ -333,18 +341,15 @@ index 7c1b240f77..cbba866ac2 100644
  
  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
  	"k8s.io/client-go/tools/cache"
-@@ -19,8 +22,10 @@ import (
+@@ -19,6 +22,7 @@ import (
  	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
  	"github.com/cilium/cilium/pkg/k8s/informer"
  	"github.com/cilium/cilium/pkg/k8s/utils"
 +	"github.com/cilium/cilium/pkg/labels"
  	"github.com/cilium/cilium/pkg/logging/logfields"
  	"github.com/cilium/cilium/pkg/option"
-+	"github.com/sirupsen/logrus"
  )
- 
- const identityIndex = "identity"
-@@ -73,6 +78,10 @@ func identityIndexFunc(obj interface{}) ([]string, error) {
+@@ -73,6 +77,10 @@ func identityIndexFunc(obj interface{}) ([]string, error) {
  // CiliumEndpointsInit starts a CiliumEndpointWatcher
  func CiliumEndpointsInit(ctx context.Context, wg *sync.WaitGroup, clientset k8sClient.Clientset) {
  	once.Do(func() {
@@ -355,7 +360,7 @@ index 7c1b240f77..cbba866ac2 100644
  		CiliumEndpointStore = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, indexers)
  
  		var cacheResourceHandler cache.ResourceEventHandlerFuncs
-@@ -88,7 +97,7 @@ func CiliumEndpointsInit(ctx context.Context, wg *sync.WaitGroup, clientset k8sC
+@@ -88,7 +96,7 @@ func CiliumEndpointsInit(ctx context.Context, wg *sync.WaitGroup, clientset k8sC
  				UpdateFunc: func(oldObj, newObj interface{}) {
  					if oldCEP := objToCiliumEndpoint(oldObj); oldCEP != nil {
  						if newCEP := objToCiliumEndpoint(newObj); newCEP != nil {
@@ -364,7 +369,7 @@ index 7c1b240f77..cbba866ac2 100644
  								return
  							}
  							endpointUpdated(newCEP)
-@@ -139,6 +148,7 @@ func transformToCiliumEndpoint(obj interface{}) (interface{}, error) {
+@@ -139,6 +147,7 @@ func transformToCiliumEndpoint(obj interface{}) (interface{}, error) {
  				ResourceVersion: concreteObj.ResourceVersion,
  				OwnerReferences: concreteObj.OwnerReferences,
  				UID:             concreteObj.UID,
@@ -372,7 +377,7 @@ index 7c1b240f77..cbba866ac2 100644
  			},
  			Status: cilium_api_v2.EndpointStatus{
  				Identity:   concreteObj.Status.Identity,
-@@ -210,14 +220,183 @@ func HasCE(ns, name string) (*cilium_api_v2.CiliumEndpoint, bool, error) {
+@@ -210,15 +219,234 @@ func HasCE(ns, name string) (*cilium_api_v2.CiliumEndpoint, bool, error) {
  	return cep, exists, nil
  }
  
@@ -418,8 +423,7 @@ index 7c1b240f77..cbba866ac2 100644
 +
 +var filter priorityFilter
 +
-+func (c *priorityFilter) filterAddressByPriority(cep *cilium_api_v2.CiliumEndpoint) time.Duration {
-+	delay := ces.DefaultCESSyncTime
++func getCepPriority(cep *cilium_api_v2.CiliumEndpoint) cepPriority {
 +	var priority cepPriority = Default
 +	for _, lbl := range cep.Status.Identity.Labels {
 +		if !strings.Contains(lbl, labels.IDNamePriority) {
@@ -439,105 +443,151 @@ index 7c1b240f77..cbba866ac2 100644
 +		priority = getPriority(lbl)
 +	}
 +
-+	filteredIps := cilium_api_v2.AddressPairList{}
++	return priority
++}
 +
++func getCepAddressPair(cep *cilium_api_v2.CiliumEndpoint) cilium_api_v2.AddressPair {
++	var shared cilium_api_v2.AddressPair
 +	for _, pair := range cep.Status.Networking.Addressing {
 +		if pair.IPV4 == "" {
 +			continue
 +		}
++		shared = *pair
++		break
++	}
++	return shared
++}
 +
-+		hidingAddress := false
++// WARNING this update logic will work only if CEP(new and old) network addresses is not changed !!!
++// If some address was removed in new CEP - it will never removed from map
++func (c *priorityFilter) filterAddressByPriority(cep *cilium_api_v2.CiliumEndpoint) (*cilium_api_v2.CiliumEndpoint, time.Duration, *cilium_api_v2.CiliumEndpoint) {
++	var oldOwner *cilium_api_v2.CiliumEndpoint
++	newOwner := cep
++	delay := ces.DefaultCESSyncTime
++	priority := getCepPriority(cep)
 +
-+		info := coreCiliumEndpointInfo{
-+			cep:      cep,
-+			priority: priority,
-+		}
++	// filter support only one ip4 address for pod
++	shared := getCepAddressPair(cep)
++	if shared.IPV4 == "" {
++		return oldOwner, delay, newOwner
++	}
 +
-+		if cepList, exist := c.ipToCepList[pair.IPV4]; exist {
-+			isInserted := false
-+			for i := range cepList {
-+				if equalCeps(cep, cepList[i].cep) {
-+					// WARNING this update logic will work only if CEP(new and old) network addresses is not changed !!!
-+					// If some address was removed in new CEP - it will never removed from map
-+					isInserted = true
-+					cepList[i].cep = cep
-+					// forced update only on first appearance
-+					if cepList[i].priority != priority && priority == High {
-+						delay = ces.ForceCESSyncTime
-+					}
-+					cepList[i].priority = priority
-+					continue
-+				}
-+				if priority.isLess(cepList[i].priority) {
-+					hidingAddress = true
-+					break
-+				}
++	info := coreCiliumEndpointInfo{
++		cep:      cep,
++		priority: priority,
++	}
++
++	if cepList, exist := c.ipToCepList[shared.IPV4]; exist {
++		isInserted := false
++		// new cep will have higher priority than old ceps with same priority
++		highest := &info
++		currentOwner := cepList[0].cep
++		for i := range cepList {
++			if len(cepList[i].cep.Status.Networking.Addressing) != 0 {
++				currentOwner = cepList[i].cep
 +			}
-+			if !isInserted {
-+				if priority == High {
++			if equalCeps(cep, cepList[i].cep) {
++				isInserted = true
++				cepList[i].cep = cep
++				// forced update only on first appearance
++				if cepList[i].priority != priority && priority == High {
 +					delay = ces.ForceCESSyncTime
 +				}
-+				c.ipToCepList[pair.IPV4] = append(cepList, info)
++				cepList[i].priority = priority
 +			}
-+		} else {
-+			c.ipToCepList[pair.IPV4] = []coreCiliumEndpointInfo{info}
++			if highest.priority.isLess(cepList[i].priority) {
++				highest = &cepList[i]
++			}
++		}
++		if !isInserted {
 +			if priority == High {
 +				delay = ces.ForceCESSyncTime
 +			}
++			c.ipToCepList[shared.IPV4] = append(cepList, info)
 +		}
-+
-+		if hidingAddress {
-+			log.WithFields(logrus.Fields{
-+				logfields.CEPName: cep.Name,
-+				logfields.CESName: cep.Namespace,
-+				"ip4":             pair.IPV4,
-+			}).Debug("hiding cep address by priority reason")
-+			continue
++		// possibly cases:
++		// 1) income cep is highest and already ip4 owner(only update income cep)
++		// 2) income cep is highest and replace other owner cep(hide ip4 address for previous owner and make owner income cep)
++		// 3) income cep is lowest and need to be replaced by other cep
++		// 4) income cep is lowest and other cep is already owner
++		emptyAddrList := cilium_api_v2.AddressPairList{}
++		isOwner := equalCeps(cep, currentOwner)
++		isHighest := equalCeps(cep, highest.cep)
++		if isOwner && isHighest {
++			// just skip
++		} else if isOwner && !isHighest {
++			cep.Status.Networking.Addressing = emptyAddrList
++			addr := &cilium_api_v2.AddressPair{
++				IPV4: shared.IPV4,
++				IPV6: shared.IPV6,
++			}
++			highest.cep.Status.Networking.Addressing = append(emptyAddrList, addr)
++			oldOwner = cep
++			newOwner = highest.cep
++		} else if !isOwner && isHighest {
++			currentOwner.Status.Networking.Addressing = emptyAddrList
++			oldOwner = currentOwner
++		} else { // !isOwner && !isHighest
++			cep.Status.Networking.Addressing = emptyAddrList
 +		}
-+
-+		addr := &cilium_api_v2.AddressPair{
-+			IPV4: pair.IPV4,
-+			IPV6: pair.IPV6,
++	} else {
++		c.ipToCepList[shared.IPV4] = []coreCiliumEndpointInfo{info}
++		if priority == High {
++			delay = ces.ForceCESSyncTime
 +		}
-+
-+		filteredIps = append(filteredIps, addr)
 +	}
-+	cep.Status.Networking.Addressing = filteredIps
-+	return delay
++	return oldOwner, delay, newOwner
 +}
 +
 +func equalCeps(cep0, cep1 *cilium_api_v2.CiliumEndpoint) bool {
 +	return cep0.Name == cep1.Name && cep0.Namespace == cep1.Namespace
 +}
 +
-+func (c *priorityFilter) removeCEPFromFilter(cep *cilium_api_v2.CiliumEndpoint) {
++func (c *priorityFilter) removeCEPFromFilter(cep *cilium_api_v2.CiliumEndpoint) *cilium_api_v2.CiliumEndpoint {
 +	if cep.Status.Networking == nil || cep.GetName() == "" || cep.Namespace == "" {
-+		return
++		return nil
++	}
++	// filter support only one ip4 address for pod
++	shared := getCepAddressPair(cep)
++	if shared.IPV4 == "" {
++		return nil
 +	}
 +
-+	for _, pair := range cep.Status.Networking.Addressing {
-+		if pair.IPV4 == "" {
-+			continue
-+		}
-+
-+		if cepList, exist := c.ipToCepList[pair.IPV4]; exist {
-+			if len(cepList) == 1 {
-+				prev := cepList[0]
-+				if equalCeps(prev.cep, cep) {
-+					delete(filter.ipToCepList, pair.IPV4)
-+				}
-+				continue
++	var hiddenCep *cilium_api_v2.CiliumEndpoint
++	if cepList, exist := c.ipToCepList[shared.IPV4]; exist {
++		if len(cepList) == 1 {
++			prev := cepList[0]
++			if equalCeps(prev.cep, cep) {
++				delete(filter.ipToCepList, shared.IPV4)
 +			}
-+			// remove CEP from slice with several elements
-+			newList := []coreCiliumEndpointInfo{}
-+			for _, prev := range cepList {
-+				if !equalCeps(prev.cep, cep) {
-+					newList = append(newList, prev)
-+				}
-+			}
-+			c.ipToCepList[pair.IPV4] = newList
++			return nil
 +		}
++		needRestoring := false
++		// remove CEP from slice with several elements
++		newList := []coreCiliumEndpointInfo{}
++		for _, prev := range cepList {
++			if !equalCeps(prev.cep, cep) {
++				newList = append(newList, prev)
++			} else {
++				// if removed CEP have address - restoring hidden CEP
++				needRestoring = len(prev.cep.Status.Networking.Addressing) != 0
++			}
++		}
++		c.ipToCepList[shared.IPV4] = newList
++		if !needRestoring {
++			return nil
++		}
++		// find most priorioty hidden cep for restoring its network access
++		highest := &newList[0]
++		for i := 1; i < len(newList); i++ {
++			if newList[i].priority.isLess(highest.priority) {
++				highest = &newList[i]
++			}
++		}
++		hiddenCep = highest.cep
++		hiddenCep.Status.Networking.Addressing = append(hiddenCep.Status.Networking.Addressing, &shared)
 +	}
++	return hiddenCep
 +}
 +
  func endpointUpdated(cep *cilium_api_v2.CiliumEndpoint) {
@@ -546,17 +596,24 @@ index 7c1b240f77..cbba866ac2 100644
  	}
 -	cesController.Manager.InsertCEPInCache(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
 +
-+	delay := filter.filterAddressByPriority(cep)
-+
-+	cesController.Manager.InsertCEPInCache(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace, delay)
++	oldOwner, delay, newOwner := filter.filterAddressByPriority(cep)
++	if oldOwner != nil {
++		cesController.Manager.InsertCEPInCache(k8s.ConvertCEPToCoreCEP(oldOwner), oldOwner.Namespace, ces.DefaultCESSyncTime)
++	}
++	cesController.Manager.InsertCEPInCache(k8s.ConvertCEPToCoreCEP(newOwner), newOwner.Namespace, delay)
  }
  
  func endpointDeleted(cep *cilium_api_v2.CiliumEndpoint) {
-+	filter.removeCEPFromFilter(cep)
+-	cesController.Manager.RemoveCEPFromCache(ces.GetCEPNameFromCCEP(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace), ces.DefaultCESSyncTime)
++	hiddenCep := filter.removeCEPFromFilter(cep)
 +
- 	cesController.Manager.RemoveCEPFromCache(ces.GetCEPNameFromCCEP(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace), ces.DefaultCESSyncTime)
++	cesController.Manager.RemoveCEPFromCache(ces.GetCEPNameFromCCEP(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace), ces.DelayedCESSyncTime)
++	if hiddenCep != nil {
++		cesController.Manager.InsertCEPInCache(k8s.ConvertCEPToCoreCEP(hiddenCep), hiddenCep.Namespace, ces.DefaultCESSyncTime)
++	}
  }
  
+ // objToCiliumEndpoint attempts to cast object to a CiliumEndpoint object
 diff --git a/pkg/datapath/alignchecker/alignchecker.go b/pkg/datapath/alignchecker/alignchecker.go
 index ebf4d4a1bb..b3dd580977 100644
 --- a/pkg/datapath/alignchecker/alignchecker.go
@@ -635,7 +692,7 @@ index 4a2b401797..64b4012b74 100644
  	"github.com/cilium/cilium/pkg/metrics"
  	"github.com/cilium/cilium/pkg/monitor/notifications"
 diff --git a/pkg/ipcache/ipcache.go b/pkg/ipcache/ipcache.go
-index 59f89704c1..cefa7bdf91 100644
+index 59f89704c1..bb61ec3ed9 100644
 --- a/pkg/ipcache/ipcache.go
 +++ b/pkg/ipcache/ipcache.go
 @@ -12,6 +12,10 @@ import (
@@ -649,7 +706,7 @@ index 59f89704c1..cefa7bdf91 100644
  	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
  	"github.com/cilium/cilium/pkg/controller"
  	"github.com/cilium/cilium/pkg/identity"
-@@ -22,12 +26,341 @@ import (
+@@ -22,12 +26,340 @@ import (
  	"github.com/cilium/cilium/pkg/labels/cidr"
  	"github.com/cilium/cilium/pkg/lock"
  	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -708,8 +765,7 @@ index 59f89704c1..cefa7bdf91 100644
 +	}
 +
 +	hostIP4 := hostIP.To4()
-+	oldHostIP4 := oldHostIP.To4()
-+	if hostIP4 == nil || oldHostIP4 == nil {
++	if hostIP4 == nil {
 +		return
 +	}
 +
@@ -991,7 +1047,7 @@ index 59f89704c1..cefa7bdf91 100644
  // Identity is the identity representation of an IP<->Identity cache.
  type Identity struct {
  	// ID is the numeric identity
-@@ -99,6 +432,7 @@ type IPCache struct {
+@@ -99,6 +431,7 @@ type IPCache struct {
  	identityToIPCache map[identity.NumericIdentity]map[string]struct{}
  	ipToHostIPCache   map[string]IPKeyPair
  	ipToK8sMetadata   map[string]K8sMetadata
@@ -999,7 +1055,7 @@ index 59f89704c1..cefa7bdf91 100644
  
  	listeners []IPIdentityMappingListener
  
-@@ -140,6 +474,7 @@ func NewIPCache(c *Configuration) *IPCache {
+@@ -140,6 +473,7 @@ func NewIPCache(c *Configuration) *IPCache {
  		identityToIPCache: map[identity.NumericIdentity]map[string]struct{}{},
  		ipToHostIPCache:   map[string]IPKeyPair{},
  		ipToK8sMetadata:   map[string]K8sMetadata{},
@@ -1007,7 +1063,7 @@ index 59f89704c1..cefa7bdf91 100644
  		controllers:       controller.NewManager(),
  		namedPorts:        types.NewNamedPortMultiMap(),
  		metadata:          newMetadata(),
-@@ -389,6 +724,8 @@ func (ipc *IPCache) upsertLocked(
+@@ -389,6 +723,8 @@ func (ipc *IPCache) upsertLocked(
  
  	scopedLog.Debug("Upserting IP into ipcache layer")
  
@@ -1016,7 +1072,7 @@ index 59f89704c1..cefa7bdf91 100644
  	// Update both maps.
  	ipc.ipToIdentityCache[ip] = newIdentity
  	// Delete the old identity, if any.
-@@ -686,6 +1023,13 @@ func (ipc *IPCache) DeleteOnMetadataMatch(IP string, source source.Source, names
+@@ -686,6 +1022,13 @@ func (ipc *IPCache) DeleteOnMetadataMatch(IP string, source source.Source, names
  	return false
  }
  


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add restoring/hiding network access for cilium endpoint(cep) when higher/lower priority cep was removed/added.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In case VM migration if virtualization controller incorrectly managment priority labels for VM pods - new VM pod may have not network access in cluster. For this case cilium must restore network access for low priority VM pod when more priority VM pod was completed and its cep removed.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: Added restoring/hiding network access to cilium endpoint (cep) when higher/lower priority cep was removed/added.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
