### PR TITLE
[ingress-nginx] update ingress cve fixer script

### DIFF
--- a/modules/402-ingress-nginx/docs/internal/validations_cve_fixup.sh
+++ b/modules/402-ingress-nginx/docs/internal/validations_cve_fixup.sh
@@ -208,7 +208,7 @@ EOF
 
 imageRegistry=$(kubectl -n d8-system get secrets deckhouse-registry -o json | jq .data.imagesRegistry -r | base64 -d)
 shellOperatorHash=$(kubectl -n d8-system exec deployments/deckhouse -- cat modules/040-node-manager/images_digests.json | jq -r .common.shellOperator)
-image=$imageRegistry:$shellOperatorHash
+image=$imageRegistry@$shellOperatorHash
 
 echo "Creating fixer deployment using \"$image\" as the image for the fixer"
 

--- a/modules/402-ingress-nginx/docs/internal/validations_cve_fixup.sh
+++ b/modules/402-ingress-nginx/docs/internal/validations_cve_fixup.sh
@@ -206,7 +206,7 @@ data:
 EOF
 )
 
-imageRegistry=$(kubectl -n d8-system get secrets deckhouse-registry -o json | jq .data.imagesRegistry -r | base64 -d)
+imageRegistry=$(kubectl -n d8-system get deployment deckhouse -o json | jq -r .spec.template.spec.containers[0].image | awk -F ':' '{print $1}')
 shellOperatorHash=$(kubectl -n d8-system exec deployments/deckhouse -- cat modules/040-node-manager/images_digests.json | jq -r .common.shellOperator)
 image=$imageRegistry@$shellOperatorHash
 

--- a/modules/402-ingress-nginx/docs/internal/validations_cve_fixup.sh
+++ b/modules/402-ingress-nginx/docs/internal/validations_cve_fixup.sh
@@ -206,9 +206,10 @@ data:
 EOF
 )
 
-imageRegistry=$(kubectl -n d8-system get deployment deckhouse -o json | jq -r .spec.template.spec.containers[0].image | awk -F ':' '{print $1}')
+registryAddress=$(kubectl -n d8-system get secrets deckhouse-registry -o json | jq .data.address -r | base64 -d)
+registryPath=$(kubectl -n d8-system get secrets deckhouse-registry -o json | jq .data.path -r | base64 -d)
 shellOperatorHash=$(kubectl -n d8-system exec deployments/deckhouse -- cat modules/040-node-manager/images_digests.json | jq -r .common.shellOperator)
-image=$imageRegistry@$shellOperatorHash
+image=$registryAddress$registryPath@$shellOperatorHash
 
 echo "Creating fixer deployment using \"$image\" as the image for the fixer"
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This pr updates modules/402-ingress-nginx/docs/internal/validations_cve_fixup.sh script to make it compatible with earlier versions of Deckhouse (v1.58 for example).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Current versions of the script doesn't work for v1.63- as the shell-operator images for these versions have no tini binary.
Also, the way of getting shell-operator image's name and hash has been streamlined.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: chore
summary: Ingress validation CVE fixer script is updated to support earlier versions of Deckhouse.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
