### PR TITLE
[dhctl] fix(dhctl-for-commander-cancels-bashible-2): fix bashible cancellation

### DIFF
--- a/dhctl/pkg/operations/bootstrap/post-script.go
+++ b/dhctl/pkg/operations/bootstrap/post-script.go
@@ -74,7 +74,7 @@ func (e *PostBootstrapScriptExecutor) run(ctx context.Context) (string, error) {
 
 	createOUtFileCmd := fmt.Sprintf("touch %s && chmod 644 %s", outputFile, outputFile)
 	cmd := frontend.NewCommand(e.sshClient.Settings, createOUtFileCmd)
-	cmd.Sudo()
+	cmd.Sudo(ctx)
 	cmd.WithStderrHandler(nil)
 	cmd.WithStdoutHandler(nil)
 	err := cmd.Run(ctx)
@@ -86,7 +86,7 @@ func (e *PostBootstrapScriptExecutor) run(ctx context.Context) (string, error) {
 	defer func() {
 		// remove out file on server because it can contain non-safe information
 		cmd = frontend.NewCommand(e.sshClient.Settings, fmt.Sprintf("rm %s", outputFile))
-		cmd.Sudo()
+		cmd.Sudo(ctx)
 		cmd.WithStderrHandler(nil)
 		cmd.WithStdoutHandler(nil)
 		err = cmd.Run(ctx)

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -141,7 +141,7 @@ func checkBashibleAlreadyRun(ctx context.Context, nodeInterface node.Interface) 
 	isReady := false
 	err := log.Process("bootstrap", "Checking bashible is ready", func() error {
 		cmd := nodeInterface.Command("cat", DHCTLEndBootstrapBashiblePipeline)
-		cmd.Sudo()
+		cmd.Sudo(ctx)
 		cmd.WithTimeout(10 * time.Second)
 		if err := cmd.Run(ctx); err != nil {
 			isReady = false
@@ -165,7 +165,7 @@ func getBashiblePIDs(ctx context.Context, nodeInterface node.Interface) ([]strin
 		psStrings = append(psStrings, l)
 	}
 	cmd := nodeInterface.Command("bash", "-c", `ps a --no-headers -o args:64 -o "|%p"`)
-	cmd.Sudo()
+	cmd.Sudo(ctx)
 	cmd.WithTimeout(10 * time.Second)
 	cmd.WithStdoutHandler(h)
 	if err := cmd.Run(ctx); err != nil {
@@ -206,7 +206,7 @@ func getBashiblePIDs(ctx context.Context, nodeInterface node.Interface) ([]strin
 
 func killBashible(ctx context.Context, nodeInterface node.Interface, pids []string) error {
 	cmd := nodeInterface.Command("kill", pids...)
-	cmd.Sudo()
+	cmd.Sudo(ctx)
 	cmd.WithTimeout(10 * time.Second)
 	if err := cmd.Run(ctx); err != nil {
 		var ee *exec.ExitError
@@ -226,7 +226,7 @@ func killBashible(ctx context.Context, nodeInterface node.Interface, pids []stri
 
 func unlockBashible(ctx context.Context, NodeInterface node.Interface) error {
 	cmd := NodeInterface.Command("rm", "-f", "/var/lock/bashible")
-	cmd.Sudo()
+	cmd.Sudo(ctx)
 	cmd.WithTimeout(10 * time.Second)
 	if err := cmd.Run(ctx); err != nil {
 		return err
@@ -443,7 +443,7 @@ func RunBashiblePipeline(ctx context.Context, nodeInterface node.Interface, cfg 
 
 		err := retry.NewLoop(fmt.Sprintf("Prepare %s", app.NodeDeckhouseDirectoryPath), 30, 10*time.Second).RunContext(ctx, func() error {
 			cmd := nodeInterface.Command("sh", "-c", fmt.Sprintf("umask 0022 ; mkdir -p -m 0755 %s", app.DeckhouseNodeBinPath))
-			cmd.Sudo()
+			cmd.Sudo(ctx)
 			if err = cmd.Run(ctx); err != nil {
 				return fmt.Errorf("ssh: mkdir -p %s -m 0755: %w", app.DeckhouseNodeBinPath, err)
 			}
@@ -456,7 +456,7 @@ func RunBashiblePipeline(ctx context.Context, nodeInterface node.Interface, cfg 
 
 		err = retry.NewLoop(fmt.Sprintf("Prepare %s", app.DeckhouseNodeTmpPath), 30, 10*time.Second).RunContext(ctx, func() error {
 			cmd := nodeInterface.Command("sh", "-c", fmt.Sprintf("umask 0022 ; mkdir -p -m 1777 %s", app.DeckhouseNodeTmpPath))
-			cmd.Sudo()
+			cmd.Sudo(ctx)
 			if err := cmd.Run(ctx); err != nil {
 				return fmt.Errorf("ssh: mkdir -p -m 1777 %s: %w", app.DeckhouseNodeTmpPath, err)
 			}
@@ -471,7 +471,7 @@ func RunBashiblePipeline(ctx context.Context, nodeInterface node.Interface, cfg 
 		// we need creating it before because we do not want handle errors from cat
 		return retry.NewLoop(fmt.Sprintf("Prepare %s", DHCTLEndBootstrapBashiblePipeline), 30, 10*time.Second).RunContext(ctx, func() error {
 			cmd := nodeInterface.Command("touch", DHCTLEndBootstrapBashiblePipeline)
-			cmd.Sudo()
+			cmd.Sudo(ctx)
 			if err := cmd.Run(ctx); err != nil {
 				return fmt.Errorf("touch error %s: %w", DHCTLEndBootstrapBashiblePipeline, err)
 			}

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -307,7 +307,7 @@ func processStaticHosts(ctx context.Context, hosts []session.Host, s *session.Se
 		settings.SetAvailableHosts([]session.Host{host})
 		err := retry.NewLoop(fmt.Sprintf("Clear master %s", host), 5, 10*time.Second).RunContext(ctx, func() error {
 			cmd := frontend.NewCommand(settings, cmd)
-			cmd.Sudo()
+			cmd.Sudo(ctx)
 			cmd.WithTimeout(5 * time.Minute)
 			cmd.WithStdoutHandler(stdOutErrHandler)
 			cmd.WithStderrHandler(stdOutErrHandler)

--- a/dhctl/pkg/system/node/interface.go
+++ b/dhctl/pkg/system/node/interface.go
@@ -27,8 +27,8 @@ type Interface interface {
 
 type Command interface {
 	Run(ctx context.Context) error
-	Cmd()
-	Sudo()
+	Cmd(ctx context.Context)
+	Sudo(ctx context.Context)
 
 	StdoutBytes() []byte
 	StderrBytes() []byte

--- a/dhctl/pkg/system/node/local/command.go
+++ b/dhctl/pkg/system/node/local/command.go
@@ -198,7 +198,7 @@ func (c *Command) prepareCmd(ctx context.Context) (*exec.Cmd, context.CancelFunc
 	return cmd, cancel
 }
 
-func (c *Command) Sudo() {
+func (c *Command) Sudo(_ context.Context) {
 	c.sudo = true
 }
 
@@ -228,5 +228,5 @@ func (c *Command) StderrBytes() []byte {
 
 // The rest are no-ops for local execution
 
-func (c *Command) Cmd()                    {}
+func (c *Command) Cmd(_ context.Context)   {}
 func (c *Command) WithSSHArgs(_ ...string) {}

--- a/dhctl/pkg/system/node/local/script.go
+++ b/dhctl/pkg/system/node/local/script.go
@@ -46,7 +46,7 @@ func NewScript(path string, args ...string) *Script {
 func (s *Script) Execute(ctx context.Context) (stdout []byte, err error) {
 	cmd := NewCommand(s.scriptPath, s.args...)
 	if s.sudo {
-		cmd.Sudo()
+		cmd.Sudo(ctx)
 	}
 
 	if s.timeout > 0 {
@@ -95,7 +95,7 @@ func (s *Script) ExecuteBundle(ctx context.Context, parentDir, bundleDir string)
 		cmd.WithStdoutHandler(s.stdoutLineHandler)
 	}
 	if s.sudo {
-		cmd.Sudo()
+		cmd.Sudo(ctx)
 	}
 
 	if err = cmd.Run(ctx); err != nil {

--- a/dhctl/pkg/system/node/ssh/cmd/ssh.go
+++ b/dhctl/pkg/system/node/ssh/cmd/ssh.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -64,7 +65,7 @@ func (s *SSH) WithCommand(name string, arg ...string) *SSH {
 }
 
 // TODO move connection settings from ExecuteCmd
-func (s *SSH) Cmd() *exec.Cmd {
+func (s *SSH) Cmd(ctx context.Context) *exec.Cmd {
 	env := append(os.Environ(), s.Env...)
 	env = append(env, s.Session.AgentSettings.AuthSockEnv())
 
@@ -152,7 +153,7 @@ func (s *SSH) Cmd() *exec.Cmd {
 
 	log.DebugF("SSH arguments %v\n", args)
 
-	sshCmd := exec.Command("ssh", args...)
+	sshCmd := exec.CommandContext(ctx, "ssh", args...)
 	sshCmd.Env = env
 	// Start ssh with the new process group to prevent early stop by SIGINT from the shell.
 	sshCmd.SysProcAttr = &syscall.SysProcAttr{

--- a/dhctl/pkg/system/node/ssh/frontend/kube-proxy.go
+++ b/dhctl/pkg/system/node/ssh/frontend/kube-proxy.go
@@ -15,6 +15,7 @@
 package frontend
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -182,7 +183,7 @@ func (k *KubeProxy) proxyCMD(startID int) *Command {
 	log.DebugF("[%d] Proxy command for start: %s\n", startID, command)
 
 	cmd := NewCommand(k.Session, command)
-	cmd.Sudo()
+	cmd.Sudo(context.Background())
 	cmd.Executor = cmd.Executor.CaptureStderr(nil).CaptureStdout(nil)
 	return cmd
 }

--- a/dhctl/pkg/system/node/ssh/frontend/reverse-tunnel.go
+++ b/dhctl/pkg/system/node/ssh/frontend/reverse-tunnel.go
@@ -88,7 +88,7 @@ func (t *ReverseTunnel) upNewTunnel(oldId int) (int, error) {
 			"-R", t.Address,
 		).
 		WithExitWhenTunnelFailure(true).
-		Cmd()
+		Cmd(context.Background())
 
 	err := t.sshCmd.Start()
 	if err != nil {

--- a/dhctl/pkg/system/node/ssh/frontend/tunnel.go
+++ b/dhctl/pkg/system/node/ssh/frontend/tunnel.go
@@ -16,6 +16,7 @@ package frontend
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -59,7 +60,7 @@ func (t *Tunnel) Up() error {
 			fmt.Sprintf("-%s", t.Type), t.Address,
 		).
 		WithCommand("echo", "SUCCESS", "&&", "cat").
-		Cmd()
+		Cmd(context.Background())
 
 	stdoutReadPipe, stdoutWritePipe, err := os.Pipe()
 	if err != nil {

--- a/dhctl/pkg/system/node/ssh/frontend/upload-script.go
+++ b/dhctl/pkg/system/node/ssh/frontend/upload-script.go
@@ -98,11 +98,11 @@ func (u *UploadScript) Execute(ctx context.Context) (stdout []byte, err error) {
 	if u.sudo {
 		scriptFullPath = u.pathWithEnv(filepath.Join(app.DeckhouseNodeTmpPath, scriptName))
 		cmd = NewCommand(u.Session, scriptFullPath, u.Args...)
-		cmd.Sudo()
+		cmd.Sudo(ctx)
 	} else {
 		scriptFullPath = u.pathWithEnv("./" + scriptName)
 		cmd = NewCommand(u.Session, scriptFullPath, u.Args...)
-		cmd.Cmd()
+		cmd.Cmd(ctx)
 	}
 
 	scriptCmd := cmd.CaptureStdout(nil).CaptureStderr(nil)
@@ -191,7 +191,7 @@ func (u *UploadScript) ExecuteBundle(ctx context.Context, parentDir, bundleDir s
 		strings.Join(u.Args, " "),
 	)
 	bundleCmd := NewCommand(u.Session, tarCmdline)
-	bundleCmd.Sudo()
+	bundleCmd.Sudo(ctx)
 
 	// Buffers to implement output handler logic
 	lastStep := ""

--- a/dhctl/pkg/system/node/ssh/frontend/waiting.go
+++ b/dhctl/pkg/system/node/ssh/frontend/waiting.go
@@ -80,7 +80,7 @@ func (c *Check) CheckAvailability(ctx context.Context) error {
 
 func (c *Check) ExpectAvailable(ctx context.Context) ([]byte, error) {
 	cmd := NewCommand(c.Session, "echo SUCCESS")
-	cmd.Cmd()
+	cmd.Cmd(ctx)
 	output, err := cmd.CombinedOutput(ctx)
 	if err != nil {
 		return output, err

--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -16,14 +16,13 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"os"
 	"strconv"
-
-	"github.com/pkg/errors"
 
 	"github.com/deckhouse/deckhouse/go_lib/registry-packages-proxy/cache"
 	"github.com/deckhouse/deckhouse/go_lib/registry-packages-proxy/log"
@@ -133,6 +132,15 @@ func (p *Proxy) Serve() {
 	p.logger.Debugf("Starting packages proxy listener: %s", p.listener.Addr())
 
 	if err := p.server.Serve(p.listener); err != nil && err != http.ErrServerClosed {
+		p.logger.Error(err.Error())
+	}
+}
+
+// StopProxy stops proxy server but does not call os.Exit
+func (p *Proxy) StopProxy() {
+	p.logger.Infof("graceful shutdown packages proxy listener: %s", p.listener.Addr())
+	err := p.server.Shutdown(context.Background())
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		p.logger.Error(err.Error())
 	}
 }


### PR DESCRIPTION
## Description
Extended use of context in bashible operations (exec.Command -> exec.CommandContext

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix bashible cancellation, use context in commands
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
