### PR TITLE
fix: exclude virtualization from the validation of the admission policy engine

### DIFF
--- a/modules/015-admission-policy-engine/templates/validatingwebhookconfiguration.yaml
+++ b/modules/015-admission-policy-engine/templates/validatingwebhookconfiguration.yaml
@@ -93,8 +93,8 @@ webhooks:
   {{- include "validating.webhook.tracked.resources" . | nindent 2 }}
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
-    - name: 'exclude-virtualization' # Exclude virtualization module's service accounts until their manifests get to comply with the restricted policy
-      expression: '!(["system:serviceaccount:d8-virtualization:kubevirt-internal-virtualization-controller", "system:serviceaccount:d8-virtualization:cdi-sa", "system:serviceaccount:d8-virtualization:virtualization-controller"].exists(e, (e == request.userInfo.username)))'
+    - name: 'exclude-virtualization'
+      expression: '!(request.userInfo.groups.exists(e, (e == "system:serviceaccounts:d8-virtualization")))'
 {{- end }}
   timeoutSeconds: 15
   {{- include "validating.webhook.config" . | nindent 2 }}


### PR DESCRIPTION
## Description

Exclude the virtualization service accounts group from the validation of the admission policy engine.

## Why do we need it, and what problem does it solve?

Specific service accounts were provided to be excluded from the validation. The provided service accounts are insufficient. To avoid updating the sa list every time, it was decided to exclude by group "system:serviceaccounts:d8-virtualization".

## Why do we need it in the patch release (if we do)?

Due to this, the core functionality of virtualization doesn't work: migration of virtual machines created in the project

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: fix
summary: exclude virtualization from the validation of the admission policy engine
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
