### PR TITLE
[ingress-nginx] add patch to kruise validation handler

### DIFF
--- a/modules/402-ingress-nginx/images/kruise/patches/008-fix-ads-validation.patch
+++ b/modules/402-ingress-nginx/images/kruise/patches/008-fix-ads-validation.patch
@@ -1,0 +1,18 @@
+diff --git a/pkg/webhook/daemonset/validating/daemonset_create_update_handler.go b/pkg/webhook/daemonset/validating/daemonset_create_update_handler.go
+index 2a269f52..912790ef 100644
+--- a/pkg/webhook/daemonset/validating/daemonset_create_update_handler.go
++++ b/pkg/webhook/daemonset/validating/daemonset_create_update_handler.go
+@@ -49,11 +49,12 @@ func (h *DaemonSetCreateUpdateHandler) validateDaemonSetUpdate(ds, oldDs *appsv1
+ 	daemonset.Spec.UpdateStrategy = oldDs.Spec.UpdateStrategy
+ 	daemonset.Spec.Lifecycle = oldDs.Spec.Lifecycle
+ 	daemonset.Spec.BurstReplicas = oldDs.Spec.BurstReplicas
++	daemonset.Spec.Replicas = oldDs.Spec.Replicas
+ 	daemonset.Spec.MinReadySeconds = oldDs.Spec.MinReadySeconds
+ 	daemonset.Spec.RevisionHistoryLimit = oldDs.Spec.RevisionHistoryLimit
+ 
+ 	if !apiequality.Semantic.DeepEqual(daemonset.Spec, oldDs.Spec) {
+-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to daemonset spec for fields other than 'BurstReplicas', 'template', 'lifecycle',  'updateStrategy', 'minReadySeconds', and 'revisionHistoryLimit' are forbidden"))
++		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to daemonset spec for fields other than 'BurstReplicas', 'Replicas', 'template', 'lifecycle',  'updateStrategy', 'minReadySeconds', and 'revisionHistoryLimit' are forbidden"))
+ 	}
+ 	allErrs = append(allErrs, validateDaemonSetSpec(&ds.Spec, field.NewPath("spec"))...)
+ 	return allErrs

--- a/modules/402-ingress-nginx/images/kruise/patches/README.md
+++ b/modules/402-ingress-nginx/images/kruise/patches/README.md
@@ -41,3 +41,8 @@ Remove CRD check of `BroadcastJob` and `ImagePullJob`. We don't need them for Da
 ### 007-fix-informer.patch
 
 Addopts multi-namespace cache instead of using sharedindexinformer for getting necessary listers, as controller-runtime since v0.15.0+ doesn't provide sharedindexinformers for namespaced caches anymore, breaking openkruise logic https://github.com/openkruise/kruise/issues/1764.
+
+### 008-fix-ads-validation.patch
+
+This patch update kruise controller's validation handler in a way that it becomes possible to update .spec.replicas field in AdvacnedDaemonSet manifests.
+Without it, applying updates to a new AdvancedDaemonSet manifest might fail with the error: "admission webhook "vdaemonset.kb.io" denied the request: spec: Forbidden: updates to daemonset spec for fields other than 'BurstReplicas', 'template', 'lifecycle',  'updateStrategy', 'minReadySeconds', and 'revisionHistoryLimit' are forbidden"

--- a/modules/402-ingress-nginx/images/kruise/patches/README.md
+++ b/modules/402-ingress-nginx/images/kruise/patches/README.md
@@ -44,5 +44,5 @@ Addopts multi-namespace cache instead of using sharedindexinformer for getting n
 
 ### 008-fix-ads-validation.patch
 
-This patch update kruise controller's validation handler in a way that it becomes possible to update .spec.replicas field in AdvacnedDaemonSet manifests.
+This patch updates the kruise controller's validation handler in a way that it becomes possible to update .spec.replicas field in AdvacnedDaemonSet manifests.
 Without it, applying updates to a new AdvancedDaemonSet manifest might fail with the error: "admission webhook "vdaemonset.kb.io" denied the request: spec: Forbidden: updates to daemonset spec for fields other than 'BurstReplicas', 'template', 'lifecycle',  'updateStrategy', 'minReadySeconds', and 'revisionHistoryLimit' are forbidden"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This pr provides a patch to Kruise valiadtion handler that permits changing the .spec.replicas field of AdvancedDaemonSets.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

After enabling ["replace --force"](https://github.com/deckhouse/deckhouse/pull/12731) helm strategy, there might be an issue when applying a new helm releases of Ingress-nginx module ending up with the following error:
```
admission webhook "vdaemonset.kb.io" denied the request: spec: Forbidden: updates to daemonset spec for fields other than 'BurstReplicas', 'template', 'lifecycle',  'updateStrategy', 'minReadySeconds', and 'revisionHistoryLimit' are forbidden
```
It seems that the new helm strategy makes helm reapply manifests as they are, missing calculated fields set by different controllers inside the cluster, as the `spec.replicas` field in case of AdvancedDaemonSets.

Permitting updating .spec.replicas field resolves the issue.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: chore
summary: Replicas validaion patch is applied to Kruise validation handler.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
