### PR TITLE
[user-authz] permit unknown group/resource

### DIFF
--- a/ee/be/modules/140-user-authz/images/webhook/src/internal/cache/cache.go
+++ b/ee/be/modules/140-user-authz/images/webhook/src/internal/cache/cache.go
@@ -44,8 +44,11 @@ type Cache interface {
 	Check() error
 }
 
-var _ Cache = (*NamespacedDiscoveryCache)(nil)
-var ErrNotFound = errors.New("not found")
+var (
+	_                           Cache = (*NamespacedDiscoveryCache)(nil)
+	ErrNotFound                       = errors.New("not found")
+	ErrPreferredVersionNotFound       = errors.New("preferred version not found")
+)
 
 type cacheEntry struct {
 	TTL     time.Duration
@@ -279,7 +282,7 @@ func (c *NamespacedDiscoveryCache) requestPreferredVersion(group, resource strin
 	}
 
 	if preferredVersion == "" {
-		return "", fmt.Errorf("failed to discover preferred version for %s.%s", resource, group)
+		return "", ErrPreferredVersionNotFound
 	}
 
 	return preferredVersion, nil


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authz
type: chore
summary: User-authz hook permits requests for unknown group/resources.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
