### PR TITLE
[multitenancy-manager] get rid of resource labels/annotations

### DIFF
--- a/modules/160-multitenancy-manager/crds/doc-ru-projects.yaml
+++ b/modules/160-multitenancy-manager/crds/doc-ru-projects.yaml
@@ -36,12 +36,6 @@ spec:
                 description:
                   description: |
                     Произвольное описание назначения проекта. Укажите пустую строку, если описание не требуется.
-                resourceLabels:
-                  description: |
-                    Метки которые будут применены ко всем ресурсам созданным для этого проекта.
-                resourceAnnotations:
-                  description: |
-                    Аннотации которые будут применены ко всем ресурсам созданным для этого проекта.
                 projectTemplateName:
                   description: |
                     Имя ресурса [ProjectTemplate](cr.html#projecttemplate), который определяет, какие ресурсы будут созданы в проекте.

--- a/modules/160-multitenancy-manager/crds/projects.yaml
+++ b/modules/160-multitenancy-manager/crds/projects.yaml
@@ -93,18 +93,6 @@ spec:
                   description: |
                     Arbitrary description of the project's purpose. Specify an empty string if no description is required.
                   type: string
-                resourceLabels:
-                  description: |
-                    Labels to be applied to all resources created by the project.
-                  type: object
-                  additionalProperties:
-                    type: string
-                resourceAnnotations:
-                  description: |
-                    Annotations to be applied to all resources created by the project.
-                  type: object
-                  additionalProperties:
-                    type: string
                 projectTemplateName:
                   description: |
                     The name of the [ProjectTemplate](cr.html#projecttemplate) resource that defines which resources will be created in the project.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/apis/deckhouse.io/v1alpha2/project.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/apis/deckhouse.io/v1alpha2/project.go
@@ -119,12 +119,6 @@ type ProjectSpec struct {
 	// Description of the Project
 	Description string `json:"description,omitempty"`
 
-	// Labels that will be set for all project resources
-	ResourceLabels map[string]string `json:"resourceLabels,omitempty"`
-
-	// Annotations that will be set for all project resources
-	ResourceAnnotations map[string]string `json:"resourceAnnotations,omitempty"`
-
 	// Name of ProjectTemplate to use to create Project
 	ProjectTemplateName string `json:"projectTemplateName,omitempty"`
 
@@ -147,20 +141,6 @@ func (p *ProjectSpec) DeepCopyInto(newObj *ProjectSpec) {
 	newObj.Parameters = make(map[string]interface{})
 	for key, value := range p.Parameters {
 		newObj.Parameters[key] = value
-	}
-	if p.ResourceLabels != nil {
-		in, out := &p.ResourceLabels, &newObj.ResourceLabels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
-	if p.ResourceAnnotations != nil {
-		in, out := &p.ResourceAnnotations, &newObj.ResourceAnnotations
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
 	}
 }
 

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/client.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/client.go
@@ -267,9 +267,6 @@ func buildValues(project *v1alpha2.Project, template *v1alpha1.ProjectTemplate) 
 	return map[string]interface{}{
 		"projectTemplate": structs.Map(template.Spec),
 		"project":         structs.Map(preparedProject),
-		// this helps to trigger project rendering when resource labels/annotations changed
-		"_projectLabels":      project.Spec.ResourceLabels,
-		"_projectAnnotations": project.Spec.ResourceAnnotations,
 	}
 }
 

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/renderer.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/renderer.go
@@ -75,26 +75,9 @@ func (r *postRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, erro
 			}
 		}
 
-		annotations := object.GetAnnotations()
-		if len(annotations) == 0 {
-			annotations = make(map[string]string)
-		}
-
-		// inject project annotations
-		for k, v := range r.project.Spec.ResourceAnnotations {
-			annotations[k] = v
-		}
-
-		object.SetAnnotations(annotations)
-
 		labels := object.GetLabels()
 		if len(labels) == 0 {
 			labels = make(map[string]string)
-		}
-
-		// inject project labels
-		for k, v := range r.project.Spec.ResourceLabels {
-			labels[k] = v
 		}
 
 		// inject multitenancy-manager
@@ -146,16 +129,6 @@ func (r *postRenderer) newNamespace(name string) []byte {
 			Name:   name,
 			Labels: map[string]string{},
 		},
-	}
-
-	// inject project annotations
-	if len(r.project.Spec.ResourceAnnotations) != 0 {
-		obj.SetAnnotations(r.project.Spec.ResourceAnnotations)
-	}
-
-	// inject project labels
-	if len(r.project.Spec.ResourceLabels) != 0 {
-		obj.SetLabels(r.project.Spec.ResourceLabels)
 	}
 
 	obj.Labels[v1alpha2.ResourceLabelHeritage] = v1alpha2.ResourceHeritageMultitenancy


### PR DESCRIPTION
## Description
It gets rid of resource labels/annotations

## Why do we need it, and what problem does it solve?
This mechanism will be replaced.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: chore
summary: Get rid of resource labels/annotations.
impact_level: low
```