### PR TITLE
[dhctl]  Skip  PV's provided manually or with reclaimPolicy other than delete.

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -225,27 +225,6 @@ func DeletePVC(ctx context.Context, kubeCl *client.KubernetesClient) error {
 	})
 }
 
-func DeletePV(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete PersistentVolumes provided manually or contain reclaimPolicy other than Delete.", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
-		persistentVolumes, err := kubeCl.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return err
-		}
-
-		annotationKey := "pv.kubernetes.io/provisioned-by"
-		for _, volume := range persistentVolumes.Items {
-			if _, exists := volume.Annotations[annotationKey]; !exists || volume.Spec.PersistentVolumeReclaimPolicy != v1.PersistentVolumeReclaimDelete {
-				err := kubeCl.CoreV1().PersistentVolumes().Delete(ctx, volume.Name, metav1.DeleteOptions{})
-				if err != nil {
-					return err
-				}
-				log.InfoF("%s\n", volume.Name)
-			}
-		}
-		return nil
-	})
-}
-
 func WaitForDeckhouseDeploymentDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
 	return retry.NewLoop("Wait for Deckhouse Deployment deletion", 30, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		_, err := kubeCl.AppsV1().Deployments(deckhouseDeploymentNamespace).Get(ctx, deckhouseDeploymentName, metav1.GetOptions{})
@@ -297,24 +276,23 @@ func WaitForPVDeletion(ctx context.Context, kubeCl *client.KubernetesClient) err
 			return err
 		}
 
-		count := len(resources.Items)
+		// Skip PV's provided manually or with reclaimPolicy other than Delete
+		annotationKey := "pv.kubernetes.io/provisioned-by"
+		var filteredResources []v1.PersistentVolume
+		for _, resource := range resources.Items {
+			if _, exists := resource.Annotations[annotationKey]; exists || resource.Spec.PersistentVolumeReclaimPolicy == v1.PersistentVolumeReclaimDelete {
+				filteredResources = append(filteredResources, resource)
+			}
+		}
+
+		count := len(filteredResources)
 		if count != 0 {
 			var (
-				pvsWithnonDeleteReclaimPolicy strings.Builder
-				remainingPVs                  strings.Builder
+				remainingPVs strings.Builder
 			)
 
 			for _, item := range resources.Items {
-				if item.Spec.PersistentVolumeReclaimPolicy != v1.PersistentVolumeReclaimDelete {
-					pvsWithnonDeleteReclaimPolicy.WriteString(fmt.Sprintf("\t\t%s | %s\n", item.Name, item.Status.Phase))
-				}
-
 				remainingPVs.WriteString(fmt.Sprintf("\t\t%s | %s\n", item.Name, item.Status.Phase))
-			}
-
-			if pvsWithnonDeleteReclaimPolicy.Len() != 0 {
-				return fmt.Errorf("%d PersistentVolumes with reclaimPolicy other than Delete in the cluster. Set their reclaim policy to Delete or remove them manually\n%s",
-					count, strings.TrimSuffix(remainingPVs.String(), "\n"))
 			}
 
 			return fmt.Errorf("%d PersistentVolumes left in the cluster\n%s", count, strings.TrimSuffix(remainingPVs.String(), "\n"))

--- a/dhctl/pkg/operations/destroy/deckhouse.go
+++ b/dhctl/pkg/operations/destroy/deckhouse.go
@@ -160,11 +160,6 @@ func (g *DeckhouseDestroyer) deleteEntities(ctx context.Context, kubeCl *client.
 		return err
 	}
 
-	err = deckhouse.DeletePV(ctx, kubeCl)
-	if err != nil {
-		return err
-	}
-
 	err = deckhouse.WaitForPVDeletion(ctx, kubeCl)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This pr allow skip PV's provided manually or with reclaimPolicy other than delete to destroy dkp cluster continuously.
```
kubectl -nd8-stronghold get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                        STORAGECLASS    VOLUMEATTRIBUTESCLASS   REASON   AGE
d8-stronghold-data-0                       1Gi        RWO            Delete           Bound    d8-stronghold/data-stronghold-0                              local-storage   <unset>                          18m
pvc-1c1ac48c-c076-4edb-b535-50b599c11f0b   40Gi       RWO            Delete           Bound    d8-monitoring/prometheus-main-db-prometheus-main-0           network-hdd     <unset>                          28m
pvc-3a1f5e0a-b3c4-439d-99d9-68975e6f66b0   1Gi        RWO            Delete           Bound    d8-upmeter/data-upmeter-0                                    network-hdd     <unset>                          27m
pvc-585a06a5-f00b-47ff-baff-9a4c8ae2fe28   40Gi       RWO            Delete           Bound    d8-monitoring/prometheus-longterm-db-prometheus-longterm-0   network-hdd     <unset>                          28m
...
dhctl destroy...
│ ┌ Wait for PersistentVolumes deletion
│ │ 1 PersistentVolumes provided manually or with reclaimPolicy other than Delete was skipped.
│ │             d8-stronghold-data-0 | Failed
│ │ ️⛱️️ Attempt #1 of 45 |
│ │     Wait for PersistentVolumes deletion failed, next attempt will be in 15s"
│ │     3 PersistentVolumes left in the cluster
│ │             pvc-6bfa1bab-af92-41d5-89eb-7d25632709ff | Released
│ │             pvc-aeee9bf2-601a-4a89-92c4-b0b240c097ed | Released
│ │             pvc-c15a91d6-a58b-439c-8181-59f50f4a7b2b | Released
...
│ │ 1 PersistentVolumes provided manually or with reclaimPolicy other than Delete was skipped.
│ │             d8-stronghold-data-0 | Failed
│ │ All PersistentVolumes are deleted from the cluster
│ │ 🎉 Succeeded!
│ └ Wait for PersistentVolumes deletion (30.10 seconds)
```
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this partly modified [pr11878](https://github.com/deckhouse/deckhouse/pull/11878) and allow to skip(not delete) pv's provided manually or with reclaimPolicy other than delete.
ex. pv's provided by stronghold
```
stronghold/templates/stronghold/pvc.yaml
---
apiVersion: v1
kind: PersistentVolume
metadata:
  name: d8-stronghold-data-{{ $i }}
...
  storageClassName: local-storage
  local:
    path: /var/lib/deckhouse/stronghold
...
{{- end }}
---
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fixed a bug that prevented PersistentVolumes from being properly deleted by the `dhctl destroy` command in Stronghold.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
