### PR TITLE
[deckhouse-controller] Add verbose to registry client, fix tests and darwin compile

### DIFF
--- a/deckhouse-controller/pkg/controller/chroot_object_desctiptors.go
+++ b/deckhouse-controller/pkg/controller/chroot_object_desctiptors.go
@@ -1,5 +1,21 @@
 //go:build !linux
 
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (

--- a/deckhouse-controller/pkg/controller/chroot_object_desctiptors.go
+++ b/deckhouse-controller/pkg/controller/chroot_object_desctiptors.go
@@ -1,0 +1,27 @@
+//go:build !linux
+
+package controller
+
+import (
+	envmgr "github.com/flant/addon-operator/pkg/module_manager/environment_manager"
+)
+
+func getChrootObjectDescriptors() []envmgr.ObjectDescriptor {
+	return []envmgr.ObjectDescriptor{
+		{
+			Source:            "/proc/sys/kernel/cap_last_cap",
+			Type:              envmgr.File,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+		{
+			Source:            "/deckhouse/shell_lib.sh",
+			Type:              envmgr.File,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+		{
+			Target:            "/dev/null",
+			Type:              envmgr.DevNull,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+	}
+}

--- a/deckhouse-controller/pkg/controller/chroot_object_desctiptors_linux.go
+++ b/deckhouse-controller/pkg/controller/chroot_object_desctiptors_linux.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (

--- a/deckhouse-controller/pkg/controller/chroot_object_desctiptors_linux.go
+++ b/deckhouse-controller/pkg/controller/chroot_object_desctiptors_linux.go
@@ -1,0 +1,88 @@
+package controller
+
+import (
+	"syscall"
+
+	envmgr "github.com/flant/addon-operator/pkg/module_manager/environment_manager"
+)
+
+func getChrootObjectDescriptors() []envmgr.ObjectDescriptor {
+	return []envmgr.ObjectDescriptor{
+		{
+			Source:            "/deckhouse/python_lib",
+			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
+			Type:              envmgr.Mount,
+			TargetEnvironment: envmgr.ShellHookEnvironment,
+		},
+		{
+			Source:            "/deckhouse/candi",
+			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
+			Type:              envmgr.Mount,
+			TargetEnvironment: envmgr.ShellHookEnvironment,
+		},
+		{
+			Source:            "/deckhouse/helm_lib",
+			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
+			Type:              envmgr.Mount,
+			TargetEnvironment: envmgr.ShellHookEnvironment,
+		},
+		{
+			Source:            "/chroot/tmp",
+			Target:            "/tmp",
+			Flags:             syscall.MS_BIND,
+			Type:              envmgr.Mount,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+		{
+			Source:            "/usr",
+			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
+			Type:              envmgr.Mount,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+		{
+			Source:            "/bin",
+			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
+			Type:              envmgr.Mount,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+		{
+			Source:            "/lib",
+			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
+			Type:              envmgr.Mount,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+		{
+			Source:            "/lib64",
+			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
+			Type:              envmgr.Mount,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+		{
+			Source:            "/deckhouse/shell_lib",
+			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
+			Type:              envmgr.Mount,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+		{
+			Source:            "/deckhouse/shell-operator",
+			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
+			Type:              envmgr.Mount,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+		{
+			Source:            "/proc/sys/kernel/cap_last_cap",
+			Type:              envmgr.File,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+		{
+			Source:            "/deckhouse/shell_lib.sh",
+			Type:              envmgr.File,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+		{
+			Target:            "/dev/null",
+			Type:              envmgr.DevNull,
+			TargetEnvironment: envmgr.EnabledScriptEnvironment,
+		},
+	}
+}

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -22,11 +22,9 @@ import (
 	"log/slog"
 	"os"
 	"sync"
-	"syscall"
 	"time"
 
 	addonoperator "github.com/flant/addon-operator/pkg/addon-operator"
-	envmgr "github.com/flant/addon-operator/pkg/module_manager/environment_manager"
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules/events"
 	"github.com/flant/addon-operator/pkg/utils"
 	"github.com/go-logr/logr"
@@ -284,84 +282,7 @@ func NewDeckhouseController(ctx context.Context, version string, operator *addon
 }
 
 func setModulesEnvironment(operator *addonoperator.AddonOperator) {
-	operator.ModuleManager.AddObjectsToChrootEnvironment([]envmgr.ObjectDescriptor{
-		{
-			Source:            "/deckhouse/python_lib",
-			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
-			Type:              envmgr.Mount,
-			TargetEnvironment: envmgr.ShellHookEnvironment,
-		},
-		{
-			Source:            "/deckhouse/candi",
-			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
-			Type:              envmgr.Mount,
-			TargetEnvironment: envmgr.ShellHookEnvironment,
-		},
-		{
-			Source:            "/deckhouse/helm_lib",
-			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
-			Type:              envmgr.Mount,
-			TargetEnvironment: envmgr.ShellHookEnvironment,
-		},
-		{
-			Source:            "/chroot/tmp",
-			Target:            "/tmp",
-			Flags:             syscall.MS_BIND,
-			Type:              envmgr.Mount,
-			TargetEnvironment: envmgr.EnabledScriptEnvironment,
-		},
-		{
-			Source:            "/usr",
-			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
-			Type:              envmgr.Mount,
-			TargetEnvironment: envmgr.EnabledScriptEnvironment,
-		},
-		{
-			Source:            "/bin",
-			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
-			Type:              envmgr.Mount,
-			TargetEnvironment: envmgr.EnabledScriptEnvironment,
-		},
-		{
-			Source:            "/lib",
-			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
-			Type:              envmgr.Mount,
-			TargetEnvironment: envmgr.EnabledScriptEnvironment,
-		},
-		{
-			Source:            "/lib64",
-			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
-			Type:              envmgr.Mount,
-			TargetEnvironment: envmgr.EnabledScriptEnvironment,
-		},
-		{
-			Source:            "/deckhouse/shell_lib",
-			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
-			Type:              envmgr.Mount,
-			TargetEnvironment: envmgr.EnabledScriptEnvironment,
-		},
-		{
-			Source:            "/deckhouse/shell-operator",
-			Flags:             syscall.MS_BIND | syscall.MS_RDONLY,
-			Type:              envmgr.Mount,
-			TargetEnvironment: envmgr.EnabledScriptEnvironment,
-		},
-		{
-			Source:            "/proc/sys/kernel/cap_last_cap",
-			Type:              envmgr.File,
-			TargetEnvironment: envmgr.EnabledScriptEnvironment,
-		},
-		{
-			Source:            "/deckhouse/shell_lib.sh",
-			Type:              envmgr.File,
-			TargetEnvironment: envmgr.EnabledScriptEnvironment,
-		},
-		{
-			Target:            "/dev/null",
-			Type:              envmgr.DevNull,
-			TargetEnvironment: envmgr.EnabledScriptEnvironment,
-		},
-	}...)
+	operator.ModuleManager.AddObjectsToChrootEnvironment(getChrootObjectDescriptors()...)
 }
 
 // Start loads and ensures modules from FS, starts controllers and runs deckhouse config event loop

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -466,18 +466,20 @@ func (f *DeckhouseReleaseFetcher) createReleases(
 		notificationShiftTime = &metav1.Time{Time: *actual.GetApplyAfter()}
 	}
 
+	metricLabels := map[string]string{
+		"version": releaseForUpdate.GetVersion().Original(),
+	}
+
 	metas, err := f.GetNewReleasesMetadata(ctx, actual.GetVersion(), newSemver)
 	if err != nil {
 		f.logger.Error("step by step update failed", log.Err(err))
 
-		labels := map[string]string{
-			"version": releaseForUpdate.GetVersion().Original(),
-		}
-
-		f.metricStorage.Grouped().GaugeSet(metricUpdatingFailedGroup, "d8_updating_is_failed", 1, labels)
+		f.metricStorage.Grouped().GaugeSet(metricUpdatingFailedGroup, "d8_updating_is_failed", 1, metricLabels)
 
 		return nil, fmt.Errorf("get new releases metadata: %w", err)
 	}
+
+	f.metricStorage.Grouped().GaugeSet(metricUpdatingFailedGroup, "d8_updating_is_failed", 0, metricLabels)
 
 	for _, meta := range metas {
 		releaseMetadata = &meta

--- a/go_lib/dependency/dependency_test.go
+++ b/go_lib/dependency/dependency_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 // nolint: govet
-func ExampleMockedHTTPClient() {
+func Test_ExampleMockedHTTPClient(_ *testing.T) {
 	prev := os.Getenv("D8_IS_TESTS_ENVIRONMENT")
 	os.Setenv("D8_IS_TESTS_ENVIRONMENT", "true")
 
@@ -51,7 +51,7 @@ func ExampleMockedHTTPClient() {
 }
 
 // nolint: govet
-func ExampleK8sClient() {
+func Test_ExampleK8sClient(_ *testing.T) {
 	prev := os.Getenv("D8_IS_TESTS_ENVIRONMENT")
 	os.Setenv("D8_IS_TESTS_ENVIRONMENT", "true")
 	dependency.TestDC.SetK8sVersion(k8s.V117)
@@ -67,7 +67,7 @@ func ExampleK8sClient() {
 }
 
 // nolint: govet
-func ExampleVersionedK8sClient() {
+func Test_ExampleVersionedK8sClient(_ *testing.T) {
 	prev := os.Getenv("D8_IS_TESTS_ENVIRONMENT")
 	os.Setenv("D8_IS_TESTS_ENVIRONMENT", "true")
 
@@ -85,7 +85,7 @@ func ExampleVersionedK8sClient() {
 }
 
 // nolint: govet
-func ExampleEtcdClient() {
+func Test_ExampleEtcdClient(_ *testing.T) {
 	prev := os.Getenv("D8_IS_TESTS_ENVIRONMENT")
 	os.Setenv("D8_IS_TESTS_ENVIRONMENT", "true")
 	dependency.TestDC.EtcdClient.GetMock.
@@ -98,7 +98,7 @@ func ExampleEtcdClient() {
 	os.Setenv("D8_IS_TESTS_ENVIRONMENT", prev)
 }
 
-func TestRace(_ *testing.T) {
+func Test_Race(_ *testing.T) {
 	prev := os.Getenv("D8_IS_TESTS_ENVIRONMENT")
 	os.Setenv("D8_IS_TESTS_ENVIRONMENT", "true")
 	dc := dependency.NewDependencyContainer()


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add more verbose errors to registry client
Add set metric d8_updating_is_failed to 0 if update was complete
Fix compilation on darwin
Fix dependency tests naming to resolve this testing errors
```
go_lib/dependency/dependency_test.go:38:1: ExampleMockedHTTPClient refers to unknown identifier: MockedHTTPClient
go_lib/dependency/dependency_test.go:54:1: ExampleK8sClient refers to unknown identifier: K8sClient
go_lib/dependency/dependency_test.go:70:1: ExampleVersionedK8sClient refers to unknown identifier: VersionedK8sClient
go_lib/dependency/dependency_test.go:88:1: ExampleEtcdClient refers to unknown identifier: EtcdClient
FAIL    github.com/deckhouse/deckhouse/go_lib/dependency [build failed]
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: add verbosity to registry client
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
