### PR TITLE
Backport: [cert-manager] Bump cert-manager components to 1.17.1

### DIFF
--- a/modules/101-cert-manager/crds/crd-certificaterequests.yaml
+++ b/modules/101-cert-manager/crds/crd-certificaterequests.yaml
@@ -8,7 +8,7 @@ metadata:
     module: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/version: 'v1.16.1'
+    app.kubernetes.io/version: 'v1.17.1'
 spec:
   group: cert-manager.io
   names:

--- a/modules/101-cert-manager/crds/crd-certificates.yaml
+++ b/modules/101-cert-manager/crds/crd-certificates.yaml
@@ -8,7 +8,7 @@ metadata:
     module: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/version: 'v1.16.1'
+    app.kubernetes.io/version: 'v1.17.1'
 spec:
   group: cert-manager.io
   names:

--- a/modules/101-cert-manager/crds/crd-challenges.yaml
+++ b/modules/101-cert-manager/crds/crd-challenges.yaml
@@ -8,7 +8,7 @@ metadata:
     module: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/version: 'v1.16.1'
+    app.kubernetes.io/version: 'v1.17.1'
 spec:
   group: acme.cert-manager.io
   names:

--- a/modules/101-cert-manager/crds/crd-clusterissuers.yaml
+++ b/modules/101-cert-manager/crds/crd-clusterissuers.yaml
@@ -8,7 +8,7 @@ metadata:
     module: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/version: 'v1.16.1'
+    app.kubernetes.io/version: 'v1.17.1'
     backup.deckhouse.io/cluster-config: "true"
 spec:
   group: cert-manager.io

--- a/modules/101-cert-manager/crds/crd-issuers.yaml
+++ b/modules/101-cert-manager/crds/crd-issuers.yaml
@@ -8,7 +8,7 @@ metadata:
     module: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/version: 'v1.16.1'
+    app.kubernetes.io/version: 'v1.17.1'
     backup.deckhouse.io/cluster-config: "true"
 spec:
   group: cert-manager.io

--- a/modules/101-cert-manager/crds/crd-orders.yaml
+++ b/modules/101-cert-manager/crds/crd-orders.yaml
@@ -8,7 +8,7 @@ metadata:
     module: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/version: 'v1.16.1'
+    app.kubernetes.io/version: 'v1.17.1'
 spec:
   group: acme.cert-manager.io
   names:

--- a/modules/101-cert-manager/crds/pull_crds.sh
+++ b/modules/101-cert-manager/crds/pull_crds.sh
@@ -19,7 +19,7 @@
 # Helper - pull all cert-manager crds and mutate their labels and annotations
 # also injects certificateOwnerRef patch
 
-version="v1.16.1"
+version="v1.17.1"
 name="cert-manager"
 
 repo="https://raw.githubusercontent.com/cert-manager/cert-manager/${version}/deploy/crds"

--- a/modules/101-cert-manager/docs/README.md
+++ b/modules/101-cert-manager/docs/README.md
@@ -2,7 +2,7 @@
 title: "The cert-manager module"
 ---
 
-This module installs the reliable and highly available cert-manager v1.16.1 [release](https://github.com/jetstack/cert-manager).
+This module installs the reliable and highly available cert-manager v1.17.1 [release](https://github.com/jetstack/cert-manager).
 
 The installation process automatically takes into account cluster aspects:
 - the component (webhook) that the `kube-apiserver` is accessing is installed on master nodes;

--- a/modules/101-cert-manager/docs/README_RU.md
+++ b/modules/101-cert-manager/docs/README_RU.md
@@ -2,7 +2,7 @@
 title: "Модуль cert-manager"
 ---
 
-Устанавливает надежную и высокодоступную инсталляцию cert-manager [release v1.16.1](https://github.com/jetstack/cert-manager).
+Устанавливает надежную и высокодоступную инсталляцию cert-manager [release v1.17.1](https://github.com/jetstack/cert-manager).
 
 При установке модуля автоматически учитываются особенности кластера:
 - компонент (webhook), к которому обращается `kube-apiserver`, устанавливается на master-узлы;

--- a/modules/101-cert-manager/images/cert-manager-acme-solver/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-acme-solver/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "1.16.1" }}
+{{- $version := "1.17.1" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:

--- a/modules/101-cert-manager/images/cert-manager-cainjector/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-cainjector/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "1.16.1" }}
+{{- $version := "1.17.1" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:

--- a/modules/101-cert-manager/images/cert-manager-controller/patches/001-certificate_owner_ref.patch
+++ b/modules/101-cert-manager/images/cert-manager-controller/patches/001-certificate_owner_ref.patch
@@ -1,5 +1,5 @@
 diff --git a/deploy/crds/crd-certificates.yaml b/deploy/crds/crd-certificates.yaml
-index e302f4dd8..63fa8940b 100644
+index 38feef444..bf2a2f74f 100644
 --- a/deploy/crds/crd-certificates.yaml
 +++ b/deploy/crds/crd-certificates.yaml
 @@ -109,6 +109,9 @@ spec:
@@ -13,7 +13,7 @@ index e302f4dd8..63fa8940b 100644
                    description: |-
                      Requested common name X509 certificate subject attribute.
 diff --git a/internal/apis/certmanager/types_certificate.go b/internal/apis/certmanager/types_certificate.go
-index 546cbd67f..2375f4db4 100644
+index 9e6804a88..516d8388e 100644
 --- a/internal/apis/certmanager/types_certificate.go
 +++ b/internal/apis/certmanager/types_certificate.go
 @@ -261,6 +261,11 @@ type CertificateSpec struct {
@@ -29,7 +29,7 @@ index 546cbd67f..2375f4db4 100644
  	// More Info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
  	//
 diff --git a/internal/apis/certmanager/v1/zz_generated.conversion.go b/internal/apis/certmanager/v1/zz_generated.conversion.go
-index 4ca99cb99..1da42f6a3 100644
+index 8970450a2..797154bd9 100644
 --- a/internal/apis/certmanager/v1/zz_generated.conversion.go
 +++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
 @@ -889,6 +889,7 @@ func autoConvert_v1_CertificateSpec_To_certmanager_CertificateSpec(in *v1.Certif
@@ -49,7 +49,7 @@ index 4ca99cb99..1da42f6a3 100644
  	return nil
  }
 diff --git a/internal/apis/certmanager/zz_generated.deepcopy.go b/internal/apis/certmanager/zz_generated.deepcopy.go
-index 571e86535..d63f45995 100644
+index d64f9cd5e..1e9379d05 100644
 --- a/internal/apis/certmanager/zz_generated.deepcopy.go
 +++ b/internal/apis/certmanager/zz_generated.deepcopy.go
 @@ -487,6 +487,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
@@ -63,9 +63,9 @@ index 571e86535..d63f45995 100644
 +	}
  	return
  }
- 
+
 diff --git a/pkg/apis/certmanager/v1/types_certificate.go b/pkg/apis/certmanager/v1/types_certificate.go
-index 68e2ccfb7..64de1e8f2 100644
+index 89979e7ac..f10578840 100644
 --- a/pkg/apis/certmanager/v1/types_certificate.go
 +++ b/pkg/apis/certmanager/v1/types_certificate.go
 @@ -286,6 +286,12 @@ type CertificateSpec struct {
@@ -82,7 +82,7 @@ index 68e2ccfb7..64de1e8f2 100644
  	// More Info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
  	//
 diff --git a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
-index 9c024c6af..cd679953f 100644
+index e889ecf1a..3b29f924f 100644
 --- a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
 +++ b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
 @@ -487,6 +487,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
@@ -98,10 +98,10 @@ index 9c024c6af..cd679953f 100644
  }
  
 diff --git a/pkg/controller/certificates/issuing/internal/secret.go b/pkg/controller/certificates/issuing/internal/secret.go
-index 475585e55..0abb748d7 100644
+index 856e48c9b..1d6194067 100644
 --- a/pkg/controller/certificates/issuing/internal/secret.go
 +++ b/pkg/controller/certificates/issuing/internal/secret.go
-@@ -104,10 +104,16 @@ func (s *SecretsManager) UpdateData(ctx context.Context, crt *cmapi.Certificate,
+@@ -107,10 +107,16 @@ func (s *SecretsManager) UpdateData(ctx context.Context, crt *cmapi.Certificate,
  		WithAnnotations(secret.Annotations).WithLabels(secret.Labels).
  		WithData(secret.Data).WithType(secret.Type)
  
@@ -120,7 +120,7 @@ index 475585e55..0abb748d7 100644
  		applyCnf = applyCnf.WithOwnerReferences(&applymetav1.OwnerReferenceApplyConfiguration{
  			APIVersion: &ref.APIVersion, Kind: &ref.Kind,
 diff --git a/pkg/controller/certificates/issuing/internal/secret_test.go b/pkg/controller/certificates/issuing/internal/secret_test.go
-index 8165247e3..cf09e5c0e 100644
+index 111cff988..597020381 100644
 --- a/pkg/controller/certificates/issuing/internal/secret_test.go
 +++ b/pkg/controller/certificates/issuing/internal/secret_test.go
 @@ -66,6 +66,30 @@ func Test_SecretsManager(t *testing.T) {
@@ -154,7 +154,25 @@ index 8165247e3..cf09e5c0e 100644
  	baseCertWithSecretTemplate := gen.CertificateFrom(baseCertBundle.Certificate,
  		gen.SetCertificateSecretTemplate(map[string]string{
  			"template":  "annotation",
-@@ -155,6 +179,77 @@ func Test_SecretsManager(t *testing.T) {
+@@ -89,16 +113,7 @@ func Test_SecretsManager(t *testing.T) {
+ 			cmapi.CertificateAdditionalOutputFormat{Type: "CombinedPEM"},
+ 		),
+ 	)
+-	keystorePassword := "something"
+-	baseCertWithJKSKeystore := gen.CertificateFrom(baseCertBundle.Certificate,
+-		gen.SetCertificateKeystore(&cmapi.CertificateKeystores{JKS: &cmapi.JKSKeystore{Create: true, Password: &keystorePassword}}),
+-	)
+-
+-	baseCertWithPKCS12Keystore := gen.CertificateFrom(baseCertBundle.Certificate,
+-		gen.SetCertificateKeystore(&cmapi.CertificateKeystores{PKCS12: &cmapi.PKCS12Keystore{Create: true, Password: &keystorePassword}}),
+-	)
+-
+-	block, _, _ := pem.SafeDecodePrivateKey(baseCertBundle.PrivateKeyBytes)
++	block, _ := pem.Decode(baseCertBundle.PrivateKeyBytes)
+ 	tlsDerContent := block.Bytes
+ 
+ 	tests := map[string]struct {
+@@ -166,6 +181,77 @@ func Test_SecretsManager(t *testing.T) {
  			expectedErr: false,
  		},
  
@@ -232,7 +250,7 @@ index 8165247e3..cf09e5c0e 100644
  		"if secret does not exist, create new Secret, with owner enabled": {
  			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: true},
  			certificate:        baseCertBundle.Certificate,
-@@ -241,6 +336,7 @@ func Test_SecretsManager(t *testing.T) {
+@@ -252,6 +338,7 @@ func Test_SecretsManager(t *testing.T) {
  			},
  			expectedErr: false,
  		},
@@ -240,7 +258,7 @@ index 8165247e3..cf09e5c0e 100644
  		"if secret does exist, update existing Secret and leave custom annotations and labels, with owner enabled": {
  			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: true},
  			certificate:        baseCertBundle.Certificate,
-@@ -286,6 +382,103 @@ func Test_SecretsManager(t *testing.T) {
+@@ -297,6 +384,103 @@ func Test_SecretsManager(t *testing.T) {
  						})
  					assert.Equal(t, expCnf, gotCnf)
  
@@ -343,18 +361,20 @@ index 8165247e3..cf09e5c0e 100644
 +
  					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
  					assert.Equal(t, expOpts, gotOpts)
- 
+
 diff --git a/test/unit/gen/certificate.go b/test/unit/gen/certificate.go
-index ca9662ccb..06230c18e 100644
+index 6991f5c16..37f61a8b3 100644
 --- a/test/unit/gen/certificate.go
 +++ b/test/unit/gen/certificate.go
-@@ -291,3 +291,9 @@ func SetCertificateAdditionalOutputFormats(additionalOutputFormats ...v1.Certifi
- 		crt.Spec.AdditionalOutputFormats = additionalOutputFormats
+@@ -292,8 +292,9 @@ func SetCertificateAdditionalOutputFormats(additionalOutputFormats ...v1.Certifi
  	}
  }
-+
-+func SetCertificateOwnerRef(ownerRef bool) CertificateModifier {
-+	return func(crt *v1.Certificate) {
+ 
+-func SetCertificateKeystore(keystores *v1.CertificateKeystores) CertificateModifier {
++func SetCertificateKeystore(ownerRef bool, keystores *v1.CertificateKeystores) CertificateModifier {
+ 	return func(crt *v1.Certificate) {
+ 		crt.Spec.Keystores = keystores
 +		crt.Spec.CertificateOwnerRef = &ownerRef
-+	}
-+}
+ 	}
+ }
+ 

--- a/modules/101-cert-manager/images/cert-manager-controller/patches/README.md
+++ b/modules/101-cert-manager/images/cert-manager-controller/patches/README.md
@@ -1,6 +1,6 @@
 ## Patches
 
-### Certificate owner ref
+### 001-certificate_owner_ref.patch
 
 Adds `CertificateOwnerRef` flag to Certificate CRD. `CertificateOwnerRef` flag is whether to set the certificate resource as an owner of a secret where the TLS certificate is stored. When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.
 https://github.com/cert-manager/cert-manager/pull/5158

--- a/modules/101-cert-manager/images/cert-manager-controller/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-controller/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "1.16.1" }}
+{{- $version := "1.17.1" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:

--- a/modules/101-cert-manager/images/cert-manager-webhook/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-webhook/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "1.16.1" }}
+{{- $version := "1.17.1" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:


### PR DESCRIPTION
## Description
Bump version of cert-manager component up to `v1.17.1`.

## Why do we need it, and what problem does it solve?
Cert-manager has accumulated a lot of bug fixes that are recommended to be included in Deckhouse.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cert-manager
type: feature
summary: Bump cert-manager version up to 1.17.1. This fixes acme confirmation for cloudflare provider.
impact_level: default
```
