### PR TITLE
[node-manager] delete cluster-wide proxy from systemd

### DIFF
--- a/candi/bashible/common-steps/all/002_add_system_proxy.sh.tpl
+++ b/candi/bashible/common-steps/all/002_add_system_proxy.sh.tpl
@@ -35,6 +35,14 @@ EOF
 sed -i 's/%/%%/g' /etc/systemd/system/containerd-deckhouse.service.d/proxy-environment.conf
   {{- end }}
 
+mkdir -p /etc/systemd/system/kubelet.service.d/
+bb-sync-file /etc/systemd/system/kubelet.service.d/proxy-environment.conf - << EOF
+[Service]
+Environment="HTTP_PROXY=${HTTP_PROXY}" "http_proxy=${HTTP_PROXY}" "HTTPS_PROXY=${HTTPS_PROXY}" "https_proxy=${HTTPS_PROXY}" "NO_PROXY=${NO_PROXY}" "no_proxy=${NO_PROXY}"
+EOF
+#escape '%' character for systemd
+sed -i 's/%/%%/g' /etc/systemd/system/kubelet.service.d/proxy-environment.conf
+
 bb-unset-proxy
 
 {{- else }}

--- a/candi/bashible/common-steps/all/002_add_system_proxy.sh.tpl
+++ b/candi/bashible/common-steps/all/002_add_system_proxy.sh.tpl
@@ -25,14 +25,6 @@ bb-set-proxy
 
 bb-event-on 'bb-sync-file-changed' '_reload_systemd'
 
-mkdir -p /etc/systemd/system.conf.d/
-bb-sync-file /etc/systemd/system.conf.d/proxy-default-environment.conf - << EOF
-[Manager]
-DefaultEnvironment="HTTP_PROXY=${HTTP_PROXY}" "http_proxy=${HTTP_PROXY}" "HTTPS_PROXY=${HTTPS_PROXY}" "https_proxy=${HTTPS_PROXY}" "NO_PROXY=${NO_PROXY}" "no_proxy=${NO_PROXY}"
-EOF
-#escape '%' character for systemd
-sed -i 's/%/%%/g' /etc/systemd/system.conf.d/proxy-default-environment.conf
-
   {{- if eq .cri "Containerd" }}
 mkdir -p /etc/systemd/system/containerd-deckhouse.service.d/
 bb-sync-file /etc/systemd/system/containerd-deckhouse.service.d/proxy-environment.conf - << EOF
@@ -46,18 +38,18 @@ sed -i 's/%/%%/g' /etc/systemd/system/containerd-deckhouse.service.d/proxy-envir
 bb-unset-proxy
 
 {{- else }}
-if [ -f /etc/systemd/system.conf.d/proxy-default-environment.conf ]; then
-  rm -f /etc/systemd/system.conf.d/proxy-default-environment.conf
-  _reload_systemd
-fi
 
 if [ -f /etc/systemd/system/containerd-deckhouse.service.d/proxy-environment.conf ]; then
   rm -f /etc/systemd/system/containerd-deckhouse.service.d/proxy-environment.conf
   _reload_systemd
 fi
+{{- end }}
 
 if [ -f /etc/profile.d/d8-system-proxy.sh ]; then
   rm -f /etc/profile.d/d8-system-proxy.sh
 fi
 
-{{- end }}
+if [ -f /etc/systemd/system.conf.d/proxy-default-environment.conf ]; then
+  rm -f /etc/systemd/system.conf.d/proxy-default-environment.conf
+  _reload_systemd
+fi


### PR DESCRIPTION
## Description

remove system-wide proxy from `/etc/systemd/system.conf.d/`

We use systemd to run `kubelet.service`. Kubelet usually does not require proxy, but in some cases it may be necessary, so we add proxy directly to `kubelet.service`

## Why do we need it, and what problem does it solve?

fix process of updating modules via proxy in some rare cases

## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->


```changes
section: deckhouse
type: fix
summary: remove system-wide proxy from `/etc/systemd/system.conf.d/`
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
