### PR TITLE
[docs] Add trdl nginx path deckhouse-cli-trdl to ingress docs deckhouse.ru

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -218,6 +218,13 @@ spec:
             name: frontend
             port:
               name: http
+      - path: /downloads/deckhouse-cli-trdl
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend
+            port:
+              name: http
       - path: /documentation/v1
         pathType: Prefix
         backend:
@@ -238,7 +245,7 @@ spec:
           service:
             name: frontend
             port:
-              name: http        
+              name: http
       - path: /products/virtualization-platform/documentation/
         pathType: Prefix
         backend:

--- a/docs/site/.werf/nginx-dev.conf
+++ b/docs/site/.werf/nginx-dev.conf
@@ -83,6 +83,25 @@ http {
             try_files /$lang/sitemap.xml =404;
         }
 
+        location ~* ^/downloads/deckhouse-cli-trdl/(.*)  {
+            rewrite ^/downloads/deckhouse-cli-trdl/(.*)$ /$1  break;
+
+            proxy_cache             dcache;
+            proxy_cache_key         $uri;
+            proxy_cache_methods     GET;
+            proxy_set_header        X-Real-IP         $remote_addr;
+            proxy_set_header        X-Original-URI    $request_uri;
+            proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_buffer_size       16k;
+            proxy_buffers           4 16k;
+            proxy_ignore_headers    Set-Cookie;
+            proxy_ignore_headers    Cache-Control;
+            proxy_intercept_errors  on;
+
+            error_page              301 302 307 = @handle_redirects;
+            proxy_pass              https://tuf.deckhouse.ru;
+        }
+
         # DVP documentation
         location ~* ^/products/(virtualization-platform/(documentation|guides|modules|gs|reference)/.*)$  {
             try_files /$lang/$1 /$lang/$1/index.html /$lang/$1/ $1 $1/index.html $1/ =404;


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
this mr allow ingress traffic in localtion /downloads/deckhouse-cli-trdl to proxy frontend with nginx configuration in this mr [mr12704](https://github.com/deckhouse/deckhouse/pull/12704)
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this partly resolv issue to download d8 bin artifacts through trdl from deckhouse.ru domain, not trrr.flant.dev.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: feature
summary: add trdl nginx path deckhouse-cli-trdl to ingress docs deckhouse.ru
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
