### PR TITLE
[service-with-healthchecks] fix README.md for image patches

### DIFF
--- a/ee/modules/610-service-with-healthchecks/images/artifact/cmd/agent/main.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/cmd/agent/main.go
@@ -2,6 +2,7 @@
 Copyright 2024 Flant JSC
 Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
+// fake modification
 
 package main
 

--- a/ee/modules/610-service-with-healthchecks/images/artifact/cmd/agent/main.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/cmd/agent/main.go
@@ -2,7 +2,6 @@
 Copyright 2024 Flant JSC
 Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
-// fake modification
 
 package main
 

--- a/ee/modules/610-service-with-healthchecks/images/artifact/patches/README.md
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/patches/README.md
@@ -1,5 +1,11 @@
 ## Patches
 
-### 001-dictionary.patch and 002-dictionary_hash.patch
+### 001-dictionary.patch
 
 The patches remove a dictionary containing HTML and JS code potentially containing vulnerabilities from the brotli library included in fasthttp.
+(Part 1).
+
+### 002-dictionary_hash.patch
+
+The patches remove a dictionary containing HTML and JS code potentially containing vulnerabilities from the brotli library included in fasthttp.
+(Part 2).


### PR DESCRIPTION
## Description
Fix README.md for image patches to solve linter issues.

Note: I had to make some fake code modifications to initiate the DMT Lint job and than revert it.
<img width="270" alt="image" src="https://github.com/user-attachments/assets/ed5420db-8d05-4008-b972-4f53bdab70c9" />

## Why do we need it, and what problem does it solve?
There are some new linter issues was added after the pr was registered.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: service-with-healthchecks
type: fix
summary: Fixed README.md for image patches.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
