### PR TITLE
[node-manager] UnmetCloudConditions check

### DIFF
--- a/modules/040-node-manager/requirements/check.go
+++ b/modules/040-node-manager/requirements/check.go
@@ -44,7 +44,7 @@ func init() {
 		return baseFuncMinVerOS(requirementValue, getter, "Debian")
 	}
 
-	_ = func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
+	checkUnmetCloudConditionsFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
 		requirementValue = strings.TrimSpace(requirementValue)
 		if requirementValue == "false" || requirementValue == "" {
 			return true, nil
@@ -62,8 +62,7 @@ func init() {
 		return true, nil
 	}
 
-	// TODO: enable this
-	// requirements.RegisterCheck(unmetCloudConditionsRequirementsKey, checkUnmetCloudConditionsFunc)
+	requirements.RegisterCheck(unmetCloudConditionsRequirementsKey, checkUnmetCloudConditionsFunc)
 	requirements.RegisterCheck(requirementsUbuntuKey, checkRequirementUbuntuFunc)
 	requirements.RegisterCheck(requirementsDebianKey, checkRequirementDebianFunc)
 }

--- a/modules/040-node-manager/requirements/check_test.go
+++ b/modules/040-node-manager/requirements/check_test.go
@@ -57,9 +57,6 @@ func TestNodeOSVersionRequirement(t *testing.T) {
 }
 
 func TestUnmetCloudConditionsRequirement(t *testing.T) {
-	// TODO: remove
-	t.Skip("UnmetCloudConditions check is not enabled")
-
 	requirements.RemoveValue(unmetCloudConditionsKey)
 
 	t.Run("unmetCloudConditions requirement runs successfully", func(t *testing.T) {

--- a/release.yaml
+++ b/release.yaml
@@ -34,7 +34,7 @@ requirements:
   "istioMinimalVersion": "1.19" # modules/110-istio/requirements/check.go
   "metallbHasStandardConfiguration": "true" # ee/se/modules/380-metallb/requirements/check.go
   # "checkAdditionalPropertiesDhctlConfigs": "true" # modules/040-node-manager/requirements/check_config.go
-  #"unmetCloudConditions": "true" # modules/040-node-manager/requirements/check.go
+  "unmetCloudConditions": "true" # modules/040-node-manager/requirements/check.go
 
 # map of disruptions, associated with a specific release. You have to register check functions before specified release
 disruptions:

--- a/release.yaml
+++ b/release.yaml
@@ -34,7 +34,7 @@ requirements:
   "istioMinimalVersion": "1.19" # modules/110-istio/requirements/check.go
   "metallbHasStandardConfiguration": "true" # ee/se/modules/380-metallb/requirements/check.go
   # "checkAdditionalPropertiesDhctlConfigs": "true" # modules/040-node-manager/requirements/check_config.go
-  "unmetCloudConditions": "true" # modules/040-node-manager/requirements/check.go
+  #"unmetCloudConditions": "true" # modules/040-node-manager/requirements/check.go
 
 # map of disruptions, associated with a specific release. You have to register check functions before specified release
 disruptions:


### PR DESCRIPTION
## Description
This PR adds new UnmetCloudConditions check, depends on requiement from https://github.com/deckhouse/deckhouse/pull/12530

## Why do we need it, and what problem does it solve?
new versions of AWS TF plugin require additional roles to be able to be executed. we should block the update until user adds this roles to SA. See https://github.com/deckhouse/deckhouse/pull/11546

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: enable UnmetCloudConditions check
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
