### PR TITLE
[docs] FIx local docimentation build and run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ set-build-envs:
   ifeq ($(DECKHOUSE_PRIVATE_REPO),)
   	export DECKHOUSE_PRIVATE_REPO=https://github.com
   endif
-  
+
 	export WERF_REPO=$(DEV_REGISTRY_PATH)
 	export REGISTRY_SUFFIX=$(shell echo $(WERF_ENV) | tr '[:upper:]' '[:lower:]')
 	export SECONDARY_REPO=--secondary-repo $(DECKHOUSE_REGISTRY_HOST)/deckhouse/$(REGISTRY_SUFFIX)

--- a/docs/site/.werf/nginx-dev.conf
+++ b/docs/site/.werf/nginx-dev.conf
@@ -9,6 +9,8 @@ events {
 }
 
 http {
+    proxy_cache_path /cache keys_zone=dcache:10m max_size=200m inactive=30d;
+
     log_format json_combined escape=json '{ "time_local": "$time_local", '
      '"host": "$host", '
      '"remote_addr": "$remote_addr", '

--- a/docs/site/.werf/nginx.conf
+++ b/docs/site/.werf/nginx.conf
@@ -111,24 +111,24 @@ http {
             proxy_pass              https://github.com;
         }
 
-        	location ~* ^/downloads/deckhouse-cli-trdl/(.*)  {
-                    rewrite ^/downloads/deckhouse-cli-trdl/(.*)$ /$1  break;
+        location ~* ^/downloads/deckhouse-cli-trdl/(.*)  {
+            rewrite ^/downloads/deckhouse-cli-trdl/(.*)$ /$1  break;
 
-                    proxy_cache             dcache;
-                    proxy_cache_key         $uri;
-                    proxy_cache_methods     GET;
-                    proxy_set_header        X-Real-IP         $remote_addr;
-                    proxy_set_header        X-Original-URI    $request_uri;
-                    proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
-                    proxy_buffer_size       16k;
-                    proxy_buffers           4 16k;
-                    proxy_ignore_headers    Set-Cookie;
-                    proxy_ignore_headers    Cache-Control;
-                    proxy_intercept_errors  on;
+            proxy_cache             dcache;
+            proxy_cache_key         $uri;
+            proxy_cache_methods     GET;
+            proxy_set_header        X-Real-IP         $remote_addr;
+            proxy_set_header        X-Original-URI    $request_uri;
+            proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_buffer_size       16k;
+            proxy_buffers           4 16k;
+            proxy_ignore_headers    Set-Cookie;
+            proxy_ignore_headers    Cache-Control;
+            proxy_intercept_errors  on;
 
-                    error_page              301 302 307 = @handle_redirects;
-                    proxy_pass              https://tuf.deckhouse.ru;
-                }
+            error_page              301 302 307 = @handle_redirects;
+            proxy_pass              https://tuf.deckhouse.ru;
+        }
 
         location @handle_redirects {
             set                     $original_uri  $uri;


### PR DESCRIPTION
## Description

This pull request includes a change to the `docs/site/.werf/nginx-dev.conf` file to improve caching configuration.

* [`docs/site/.werf/nginx-dev.conf`](diffhunk://#diff-782094ed4212f4e56e86e3119bdc6b2cec16c66914304440d2e927ea006b8bfcR12-R13): Added `proxy_cache_path` directive to set up caching with a specified location, size, and inactivity period.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
