### PR TITLE
[node-manager] handle_node_template hook ignore metallb label

### DIFF
--- a/modules/040-node-manager/hooks/handle_node_templates.go
+++ b/modules/040-node-manager/hooks/handle_node_templates.go
@@ -43,6 +43,7 @@ const (
 	masterNodeRoleKey                 = "node-role.kubernetes.io/master"
 	clusterAPIAnnotationKey           = "cluster.x-k8s.io/machine"
 	HeartbeatAnnotationKey            = "kubevirt.internal.virtualization.deckhouse.io/heartbeat"
+	MetalLBmemberLabelKey             = "l2-load-balancer.network.deckhouse.io/member"
 )
 
 type NodeSettings struct {
@@ -100,6 +101,12 @@ func actualNodeSettingsFilter(obj *unstructured.Unstructured) (go_hook.FilterRes
 	_, isHeartbeat := nodeObj.Annotations[HeartbeatAnnotationKey]
 	if isHeartbeat {
 		delete(nodeObj.Annotations, HeartbeatAnnotationKey)
+	}
+
+	// Ignore labels "l2-load-balancer.network.deckhouse.io/member" on hook execute.
+	_, isMetalLB := nodeObj.Labels[MetalLBmemberLabelKey]
+	if isMetalLB {
+		delete(nodeObj.Labels, MetalLBmemberLabelKey)
 	}
 
 	return settings, nil


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Ignore label `l2-load-balancer.network.deckhouse.io/member` when executing the `handle_node_templates` hook.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Have race condition with set/delete labels between hooks `handle_node_template.go` and  `380-metallb/hooks/node_membership_handler.go`

## Why do we need it in the patch release (if we do)?

Fix race condition between hooks.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->



## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: handle_node_template hook ignore metallb label
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
