### PR TITLE
[deckhouse] fix enabling helper

### DIFF
--- a/deckhouse-controller/pkg/debug/module_enable.go
+++ b/deckhouse-controller/pkg/debug/module_enable.go
@@ -68,8 +68,9 @@ func moduleSwitch(kubeClient *kubeclient.Client, moduleName string, enabled bool
 	logger.SetLevel(log.LevelError)
 
 	if err := setModuleConfigEnabled(context.TODO(), kubeClient, moduleName, enabled); err != nil {
-		return fmt.Errorf("%s module failed: %w", actionDesc, err)
+		return fmt.Errorf("%s module: %w", actionDesc, err)
 	}
+
 	fmt.Printf("Module %s %sd\n", moduleName, actionDesc)
 	return nil
 }
@@ -83,7 +84,7 @@ func setModuleConfigEnabled(ctx context.Context, kubeClient k8s.Client, name str
 
 	if _, err := kubeClient.Dynamic().Resource(v1alpha1.ModuleConfigGVR).Get(ctx, name, metav1.GetOptions{}); err != nil {
 		if apierrors.IsNotFound(err) {
-			return errors.New("not found")
+			return errors.New("module not found")
 		}
 		return fmt.Errorf("get the '%s' module: %w", name, err)
 	}

--- a/deckhouse-controller/pkg/debug/module_enable.go
+++ b/deckhouse-controller/pkg/debug/module_enable.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/flant/addon-operator/sdk"
 	kubeclient "github.com/flant/kube-client/client"
 	"gopkg.in/alecthomas/kingpin.v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"


### PR DESCRIPTION
## Description
It fixes enabling helper, it forbids to enable a module that does not exist.

## Why do we need it, and what problem does it solve?
Closes #6198

The enabling helper enabled all modules even they don`t exist, now it returns error:
```
root@dev-master-0:~# dcme test2
deckhouse-controller: error: enable module: module not found, try --help
command terminated with exit code 1
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix enabling helper.
impact_level: low
```
