### PR TITLE
[deckhouse-controller] Feature/1.68 restore release with dc only

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -181,12 +181,6 @@ func (f *DeckhouseReleaseFetcher) GetReleaseChannel() string {
 
 // fetchDeckhouseRelease is a complete flow for loop
 func (f *DeckhouseReleaseFetcher) fetchDeckhouseRelease(ctx context.Context) error {
-	// get image info from release channel
-	imageInfo, imageErr := f.GetNewImageInfo(ctx, f.releaseVersionImageHash)
-	if imageErr != nil && !errors.Is(imageErr, ErrImageNotChanged) {
-		return fmt.Errorf("get new image: %w", imageErr)
-	}
-
 	releases, err := f.listDeckhouseReleases(ctx)
 	if err != nil {
 		return fmt.Errorf("list deckhouse releases: %w", err)
@@ -230,8 +224,14 @@ func (f *DeckhouseReleaseFetcher) fetchDeckhouseRelease(ctx context.Context) err
 		}
 	}
 
+	// get image info from release channel
+	imageInfo, err := f.GetNewImageInfo(ctx, f.releaseVersionImageHash)
+	if err != nil && !errors.Is(err, ErrImageNotChanged) {
+		return fmt.Errorf("get new image: %w", err)
+	}
+
 	// no new image found
-	if errors.Is(imageErr, ErrImageNotChanged) {
+	if err != nil {
 		return nil
 	}
 
@@ -389,6 +389,15 @@ func (f *DeckhouseReleaseFetcher) restoreCurrentDeployedRelease(ctx context.Cont
 	err = client.IgnoreAlreadyExists(f.k8sClient.Create(ctx, release))
 	if err != nil {
 		return nil, fmt.Errorf("create release: %w", err)
+	}
+
+	patch := client.MergeFrom(release.DeepCopy())
+
+	release.Status.Phase = v1alpha1.DeckhouseReleasePhaseDeployed
+
+	err = f.k8sClient.Status().Patch(ctx, release, patch)
+	if err != nil {
+		return nil, fmt.Errorf("patch release status: %w", err)
 	}
 
 	return release, nil

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -321,12 +321,8 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 	if r.registrySecret == nil {
 		// TODO: make registry service to check secrets in it (make issue)
 		registrySecret, err := r.getRegistrySecret(ctx)
-		if err != nil && !errors.Is(err, utils.ErrClusterIsBootstrappedFieldIsNotFound) {
-			return res, fmt.Errorf("get registry secret: %w", err)
-		}
-
 		if err != nil {
-			r.registrySecret.ClusterIsBootstrapped = true
+			return res, fmt.Errorf("get registry secret: %w", err)
 		}
 
 		r.registrySecret = registrySecret
@@ -437,19 +433,6 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 		}
 
 		return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
-	}
-
-	// TODO: it's maybe deprecated history about bootstrap deploying. delete???
-	//
-	// if cluster needs bootstrap and we found only one release - apply release
-	if !r.registrySecret.ClusterIsBootstrapped && task.IsSingle {
-		err := r.ApplyRelease(ctx, dr, task)
-		if err != nil {
-			return res, fmt.Errorf("run single bootstrapping release deploy: %w", err)
-		}
-
-		// stop requeue because we restart deckhouse (deployment)
-		return ctrl.Result{}, nil
 	}
 
 	// handling error inside function

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
@@ -347,19 +347,6 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		require.NoError(suite.T(), err)
 	})
 
-	suite.Run("First Release with manual mode", func() {
-		mup := embeddedMUP.DeepCopy()
-		mup.Update.Mode = v1alpha1.UpdateModeManual.String()
-
-		values, err := sjson.Delete(initValues, "global.clusterIsBootstrapped")
-		require.NoError(suite.T(), err)
-
-		suite.setupController("first-release-with-manual-mode.yaml", values, mup)
-		dr := suite.getDeckhouseRelease("v1.25.1")
-		_, err = suite.ctr.createOrUpdateReconcile(ctx, dr)
-		require.NoError(suite.T(), err)
-	})
-
 	suite.Run("Few patch releases", func() {
 		dependency.TestDC.HTTPClient.DoMock.
 			Expect(&http.Request{}).

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/existed-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/existed-release-suspended.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-0.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-canary-release-wave-4.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/have-new-deckhouse-image.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/image-hash-not-changed.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/image-hash-not-changed.yaml
@@ -12,10 +12,11 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/inherit-release-cooldown.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/new-release-suspended.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-has-own-cooldown.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-canary.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-cooldown.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-disruptions.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-has-requirements.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-changelog.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/resume-suspended-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/resume-suspended-release.yaml
@@ -12,12 +12,13 @@ metadata:
   labels:
     heritage: deckhouse
   name: v1.15.0
-  resourceVersion: "1"
+  resourceVersion: "2"
 spec:
   version: v1.15.0
 status:
   approved: false
   message: ""
+  phase: Deployed
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -857,11 +857,6 @@ func RunPostInstallTasks(kubeCl *client.KubernetesClient, result *InstallDeckhou
 	}
 
 	return log.Process("bootstrap", "Run post bootstrap actions", func() error {
-		err := deckhouse.ConfigureDeckhouseRelease(kubeCl)
-		if err != nil {
-			return err
-		}
-
 		return applyPostBootstrapModuleConfigs(kubeCl, result.ManifestResult.PostBootstrapMCTasks)
 	})
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add patch restored release status with Deployed Phase
Remove old deckhouse-controller deploy when only one release in cluster (because of restored release by check-release)
Remove old dhctl deckhouse-release create method (because of restored release by check-release)
Remove useless test for deckhouse-controller

Move registry work inside check-release after restore release

Add utils tests (parsing deckhouse registry secret)

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Now we can restore deckhouse-release without dhctl. We have an check-release process which restore release automatically and makes it "Deployed" phase.

### Before
```
NAME      PHASE      TRANSITIONTIME   MESSAGE
v1.69.0   Pending   12m              Release object was restored
```

### After
```
NAME      PHASE      TRANSITIONTIME   MESSAGE
v1.69.0   Deployed   12m              Release object was restored
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: restore releases only by deckhouse-controller and in deployed state
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
