### PR TITLE
[deckhouse-controller] Add list of unmanaged modules to debug archive

### DIFF
--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -86,7 +86,7 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "deckhouse-unmanaged-modules.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get moduleconfig -ojson | jq -r '.items[] | select(.spec.settings.bundle == "Default") | .metadata.name'`},
+			Args: []string{"-c", `kubectl get moduleconfig -ojson | jq -r '.items[] | select(.spec.managementState == "Unmanaged") | .metadata.name'`},
 		},
 		{
 			File: "events.json",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -84,9 +84,9 @@ func createTarball() *bytes.Buffer {
 			Args: []string{"-c", "kubectl get modules -o json | jq '.items[]'"},
 		},
 		{
-			File: "deckhouse-unmanaged-modules.txt",
+			File: "deckhouse-maintenance-modules.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get moduleconfig -ojson | jq -r '.items[] | select(.spec.managementState == "Unmanaged") | .metadata.name'`},
+			Args: []string{"-c", `kubectl get moduleconfig -ojson | jq -r '.items[] | select(.spec.maintenance == "NoResourceReconciliation") | .metadata.name'`},
 		},
 		{
 			File: "events.json",

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -84,6 +84,11 @@ func createTarball() *bytes.Buffer {
 			Args: []string{"-c", "kubectl get modules -o json | jq '.items[]'"},
 		},
 		{
+			File: "deckhouse-unmanaged-modules.txt",
+			Cmd:  "bash",
+			Args: []string{"-c", `kubectl get moduleconfig -ojson | jq -r '.items[] | select(.spec.settings.bundle == "Default") | .metadata.name'`},
+		},
+		{
 			File: "events.json",
 			Cmd:  "kubectl",
 			Args: []string{"get", "events", "--sort-by=.metadata.creationTimestamp", "-A", "-o", "json"},
@@ -167,11 +172,6 @@ func createTarball() *bytes.Buffer {
 			File: "prometheus-logs.txt",
 			Cmd:  "kubectl",
 			Args: []string{"-n", "d8-monitoring", "logs", "-l", "prometheus=main", "--tail=3000", "-c", "prometheus", "--ignore-errors=true"},
-		},
-		{
-			File: "terraform-check.json",
-			Cmd:  "bash",
-			Args: []string{"-c", `kubectl get modules terraform-manager -o json | jq -r 'select(.status.phase == "Ready") | "kubectl -n d8-system exec deploy/terraform-state-exporter -- dhctl terraform check --logger-type json -o json"' | bash | jq -c '.terraform_plan[]?.variables.providerClusterConfiguration.value.provider = "REDACTED"'`},
 		},
 		{
 			File: "alerts.json",

--- a/modules/002-deckhouse/docs/FAQ.md
+++ b/modules/002-deckhouse/docs/FAQ.md
@@ -52,6 +52,7 @@ Data that will be collected:
 * Deckhouse queue state
 * global Deckhouse values. Except for the values of `kubeRBACProxyCA` and `registry.dockercfg`
 * enabled modules list
+* list of modules in `Unmanaged` mode
 * `events` from all namespaces
 * controllers and pods manifests from namespaces owned by Deckhouse
 * `nodegroups` state
@@ -69,7 +70,6 @@ Data that will be collected:
 * Vertical Pod Autoscaler recommender logs
 * Vertical Pod Autoscaler updater logs
 * Prometheus logs
-* terraform-state-exporter metrics. Except for the values in `provider` from `providerClusterConfiguration`.
 * all firing alerts from Prometheus
 
 ## How to debug pod problems with ephemeral containers?

--- a/modules/002-deckhouse/docs/FAQ.md
+++ b/modules/002-deckhouse/docs/FAQ.md
@@ -52,7 +52,7 @@ Data that will be collected:
 * Deckhouse queue state
 * global Deckhouse values. Except for the values of `kubeRBACProxyCA` and `registry.dockercfg`
 * enabled modules list
-* list of modules in `Unmanaged` mode
+* list of modules in `maintenance` mode
 * `events` from all namespaces
 * controllers and pods manifests from namespaces owned by Deckhouse
 * `nodegroups` state

--- a/modules/002-deckhouse/docs/FAQ_RU.md
+++ b/modules/002-deckhouse/docs/FAQ_RU.md
@@ -53,6 +53,7 @@ title: "Модуль deckhouse: FAQ"
 * состояние очереди Deckhouse;
 * Deckhouse values. За исключением значений `kubeRBACProxyCA` и `registry.dockercfg`;
 * список включенных модулей;
+* список модулей в режиме `Unmanaged`;
 * `events` из всех пространств имен;
 * манифесты controller'ов и подов из всех пространств имен Deckhouse;
 * все объекты `nodegroups`;
@@ -70,7 +71,6 @@ title: "Модуль deckhouse: FAQ"
 * логи Vertical Pod Autoscaler recommender;
 * логи Vertical Pod Autoscaler updater;
 * логи Prometheus;
-* метрики terraform-state-exporter. За исключением значений в `provider` из `providerClusterConfiguration`;
 * все горящие уведомления в Prometheus.
 
 ## Как отлаживать проблемы в подах с помощью ephemeral containers?

--- a/modules/002-deckhouse/docs/FAQ_RU.md
+++ b/modules/002-deckhouse/docs/FAQ_RU.md
@@ -53,7 +53,7 @@ title: "Модуль deckhouse: FAQ"
 * состояние очереди Deckhouse;
 * Deckhouse values. За исключением значений `kubeRBACProxyCA` и `registry.dockercfg`;
 * список включенных модулей;
-* список модулей в режиме `Unmanaged`;
+* список модулей в режиме `maintenance`;
 * `events` из всех пространств имен;
 * манифесты controller'ов и подов из всех пространств имен Deckhouse;
 * все объекты `nodegroups`;


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

- Added creation of list of unmanaged modules to debug archive.

- Removed entry `terraform-check` in debug archive, because in current versions it is impossible to execute terraform-check inside cluster.

- Updated documentation for debug archive.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

After adding [unmanaged modules](https://github.com/deckhouse/deckhouse/pull/12686) (v1.69.0), it will be convenient to see in the debug archive a list of modules that were disconnected by the client from deckhouse management

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: updated the data collected in the debug container
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
