### PR TITLE
[dhctl] Add deny additional properties for validation schema eg module config

### DIFF
--- a/dhctl/pkg/config/connection_test.go
+++ b/dhctl/pkg/config/connection_test.go
@@ -183,7 +183,6 @@ func TestParseConnectionConfig(t *testing.T) {
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			config, err := ParseConnectionConfig(tt.config, newStore, tt.opts...)
 			if tt.errContains == "" {
 				require.NoError(t, err)

--- a/dhctl/pkg/config/deckhouse_config_test.go
+++ b/dhctl/pkg/config/deckhouse_config_test.go
@@ -133,7 +133,7 @@ spec:
 	})
 
 	t.Run("Forbid to use configOverrides", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
+		generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
 			"configOverrides": `
 configOverrides:
   istioEnabled: false
@@ -147,36 +147,24 @@ configOverrides:
     testString: aaaaa
 `,
 		})
-
-		_, err := PrepareDeckhouseInstallConfig(metaConfig)
-		require.Error(t, err)
 	})
 
 	t.Run("Forbid to use releaseChannel", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
+		generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
 			"releaseChannel": "Beta",
 		})
-
-		_, err := PrepareDeckhouseInstallConfig(metaConfig)
-		require.Error(t, err)
 	})
 
 	t.Run("Forbid to use bundle", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
+		generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
 			"bundle": "Default",
 		})
-
-		_, err := PrepareDeckhouseInstallConfig(metaConfig)
-		require.Error(t, err)
 	})
 
 	t.Run("Forbid to use logLevel", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
+		generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
 			"logLevel": "Info",
 		})
-
-		_, err := PrepareDeckhouseInstallConfig(metaConfig)
-		require.Error(t, err)
 	})
 
 	t.Run("Correct parse module configs", func(t *testing.T) {

--- a/dhctl/pkg/config/load.go
+++ b/dhctl/pkg/config/load.go
@@ -265,6 +265,7 @@ func (s *SchemaStore) ValidateWithIndex(index *SchemaIndex, doc *[]byte, opts ..
 			return err
 		}
 		mcName := mc.GetName()
+		log.DebugF("Found module config for validate %s\n", mcName)
 		if mc.Spec.Enabled == nil && mcName != "global" {
 			// we need return error because on top level we want filter module configs from modulesources and move into resources
 			// global is special mc without module
@@ -305,6 +306,8 @@ func (s *SchemaStore) ValidateWithIndex(index *SchemaIndex, doc *[]byte, opts ..
 		// we need return error because on top level we want filter documents without index and move into resources
 		return ErrSchemaNotFound
 	}
+
+	schema = transformer.TransformSchema(schema, &transformer.AdditionalPropertiesTransformer{})
 
 	isValid, err := openAPIValidate(&docForValidate, schema, options)
 	if !isValid {

--- a/dhctl/pkg/config/validation_rules_test.go
+++ b/dhctl/pkg/config/validation_rules_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestValidateClusterSettingsChanges(t *testing.T) {
-	t.Parallel()
-
 	tests := map[string]struct {
 		phase       phases.OperationPhase
 		oldConfig   string
@@ -325,7 +323,6 @@ masterNodeGroup:
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			err := ValidateClusterSettingsChanges(tt.phase, tt.oldConfig, tt.newConfig, tt.schema, validateOpts...)
 			if tt.errContains == "" {
 				require.NoError(t, err)

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -79,7 +79,7 @@ metadata:
 func TestValidateInitConfiguration(t *testing.T) {
 	const schemasDir = "./../../../candi/openapi"
 	const deckhouseSchemasDir = "./../../../modules/002-deckhouse/openapi"
-	newStore := newSchemaStore(false, []string{schemasDir, deckhouseSchemasDir})
+	newStore := newSchemaStore([]string{schemasDir, deckhouseSchemasDir})
 
 	tests := map[string]struct {
 		config      string
@@ -177,7 +177,7 @@ metadata:
 
 func TestValidateClusterConfiguration(t *testing.T) {
 	const schemasDir = "./../../../candi/openapi"
-	newStore := newSchemaStore(false, []string{schemasDir})
+	newStore := newSchemaStore([]string{schemasDir})
 
 	tests := map[string]struct {
 		config      string
@@ -271,7 +271,7 @@ clusterType: Static
 
 func TestValidateProviderSpecificClusterConfiguration(t *testing.T) {
 	const schemasDir = "./../../../candi/cloud-providers"
-	newStore := newSchemaStore(false, []string{schemasDir})
+	newStore := newSchemaStore([]string{schemasDir})
 
 	tests := map[string]struct {
 		config        string
@@ -458,7 +458,7 @@ sshPublicKey: ssh-key`,
 
 func TestValidateStaticClusterConfiguration(t *testing.T) {
 	const schemasDir = "./../../../candi/openapi"
-	newStore := newSchemaStore(false, []string{schemasDir})
+	newStore := newSchemaStore([]string{schemasDir})
 
 	tests := map[string]struct {
 		config      string

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -17,13 +17,10 @@ package config
 import (
 	"testing"
 
-	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/require"
 )
 
 func TestValidateResources(t *testing.T) {
-	t.Parallel()
-
 	tests := map[string]struct {
 		config      string
 		errContains string
@@ -69,7 +66,6 @@ metadata:
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			err := ValidateResources(tt.config, validateOpts...)
 			if tt.errContains == "" {
 				require.NoError(t, err)
@@ -81,12 +77,9 @@ metadata:
 }
 
 func TestValidateInitConfiguration(t *testing.T) {
-	t.Parallel()
-
 	const schemasDir = "./../../../candi/openapi"
-	newStore := newSchemaStore([]string{schemasDir})
-	newStore.moduleConfigsCache["deckhouse"] = &spec.Schema{}
-	newStore.modulesCache["deckhouse"] = struct{}{}
+	const deckhouseSchemasDir = "./../../../modules/002-deckhouse/openapi"
+	newStore := newSchemaStore(false, []string{schemasDir, deckhouseSchemasDir})
 
 	tests := map[string]struct {
 		config      string
@@ -172,7 +165,6 @@ metadata:
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			err := ValidateInitConfiguration(tt.config, newStore, validateOpts...)
 			if tt.errContains == "" {
 				require.NoError(t, err)
@@ -184,10 +176,8 @@ metadata:
 }
 
 func TestValidateClusterConfiguration(t *testing.T) {
-	t.Parallel()
-
 	const schemasDir = "./../../../candi/openapi"
-	newStore := newSchemaStore([]string{schemasDir})
+	newStore := newSchemaStore(false, []string{schemasDir})
 
 	tests := map[string]struct {
 		config      string
@@ -268,7 +258,6 @@ clusterType: Static
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			clusterConfig, err := ValidateClusterConfiguration(tt.config, newStore, validateOpts...)
 			require.Equal(t, tt.expected, clusterConfig)
 			if tt.errContains == "" {
@@ -281,10 +270,8 @@ clusterType: Static
 }
 
 func TestValidateProviderSpecificClusterConfiguration(t *testing.T) {
-	t.Parallel()
-
 	const schemasDir = "./../../../candi/cloud-providers"
-	newStore := newSchemaStore([]string{schemasDir})
+	newStore := newSchemaStore(false, []string{schemasDir})
 
 	tests := map[string]struct {
 		config        string
@@ -459,7 +446,6 @@ sshPublicKey: ssh-key`,
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			err := ValidateProviderSpecificClusterConfiguration(tt.config, tt.clusterConfig, newStore, validateOpts...)
 			if tt.errContains == "" {
 				require.NoError(t, err)
@@ -471,10 +457,8 @@ sshPublicKey: ssh-key`,
 }
 
 func TestValidateStaticClusterConfiguration(t *testing.T) {
-	t.Parallel()
-
 	const schemasDir = "./../../../candi/openapi"
-	newStore := newSchemaStore([]string{schemasDir})
+	newStore := newSchemaStore(false, []string{schemasDir})
 
 	tests := map[string]struct {
 		config      string
@@ -526,7 +510,6 @@ internalNetworkCIDRs:
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			err := ValidateStaticClusterConfiguration(tt.config, newStore, validateOpts...)
 			if tt.errContains == "" {
 				require.NoError(t, err)

--- a/dhctl/pkg/operations/check/check_test.go
+++ b/dhctl/pkg/operations/check/check_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestStatistics_Format(t *testing.T) {
-	t.Parallel()
-
 	var statistics Statistics
 	err := yaml.Unmarshal([]byte(statisticsYAML), &statistics)
 	require.NoError(t, err)

--- a/dhctl/pkg/operations/check/destructive_change_id_test.go
+++ b/dhctl/pkg/operations/check/destructive_change_id_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestDestructiveChangeID(t *testing.T) {
-	t.Parallel()
-
 	tests := map[string]struct {
 		statistics *Statistics
 		expected   string
@@ -271,8 +269,6 @@ func TestDestructiveChangeID(t *testing.T) {
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			id, err := destructiveChangeID(tt.statistics)
 			require.NoError(t, err)
 

--- a/dhctl/pkg/operations/converge/controller/node_group_controller_test.go
+++ b/dhctl/pkg/operations/converge/controller/node_group_controller_test.go
@@ -55,8 +55,6 @@ func Test_sortNodeNames(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(strings.Join(test.unsorted, " "), func(t *testing.T) {
-			t.Parallel()
-
 			state := make(map[string][]byte)
 
 			for _, node := range test.unsorted {
@@ -124,8 +122,6 @@ func Test_getNodesToDeleteInfo(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
 			state := make(map[string][]byte)
 
 			for _, node := range test.nodes {

--- a/dhctl/pkg/server/pkg/fsm/fsm_test.go
+++ b/dhctl/pkg/server/pkg/fsm/fsm_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestFiniteStateMachine(t *testing.T) {
-	t.Parallel()
-
 	type event struct {
 		event       fsm.Event
 		stateBefore fsm.State
@@ -111,8 +109,6 @@ func TestFiniteStateMachine(t *testing.T) {
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			f := fsm.New(tt.initialState, tt.transitions)
 			for _, e := range tt.events {
 				assert.Equal(t, e.stateBefore, f.State())

--- a/dhctl/pkg/server/pkg/logger/writer_test.go
+++ b/dhctl/pkg/server/pkg/logger/writer_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestLogWriter(t *testing.T) {
-	t.Parallel()
-
 	tests := map[string]struct {
 		input [][]byte
 		lines [][]string
@@ -90,8 +88,6 @@ func TestLogWriter(t *testing.T) {
 		tt := tt
 
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			sendCh := make(chan []string)
 			defer close(sendCh)
 

--- a/dhctl/pkg/server/pkg/requests_counter/requests_counter_test.go
+++ b/dhctl/pkg/server/pkg/requests_counter/requests_counter_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestRequestsCounter(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/dhctl/pkg/util/input/yaml_test.go
+++ b/dhctl/pkg/util/input/yaml_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestCombineYAMLs(t *testing.T) {
-	t.Parallel()
-
 	tests := map[string]struct {
 		in  []string
 		out string
@@ -164,8 +162,6 @@ kind: ModuleConfig
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			out := input.CombineYAMLs(tt.in...)
 			assert.Equal(t, tt.out, out)
 		})


### PR DESCRIPTION
## Description

Add deny additional properties for validation schema eg module config

## Why do we need it, and what problem does it solve?
Some module config was allowed with additional fields which not in the schema

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Add deny additional properties for validation schema eg module config
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
