### PR TITLE
[user-authn] DexAuthenticator with digit name fails

### DIFF
--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -52,7 +52,7 @@ spec:
   selector:
     matchLabels:
       app: dex-authenticator
-      name: {{ $crd.name }}
+      name: {{ $crd.name | quote }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -73,12 +73,12 @@ spec:
   selector:
     matchLabels:
       app: dex-authenticator
-      name: {{ $crd.name }}
+      name: {{ $crd.name | quote }}
   template:
     metadata:
       labels:
         app: dex-authenticator
-        name: {{ $crd.name }}
+        name: {{ $crd.name | quote}}
       annotations:
         checksum/config: {{ $crd.credentials | toJson | b64enc | sha256sum }}
     spec:


### PR DESCRIPTION
## Description

fixed: #12546

## Why do we need it, and what problem does it solve?

Get the ability to create a DexAuthenticator with numbers in the name.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: DexAuthenticator with digit name fails
impact_level: default
```
