### PR TITLE
[deckhouse-controller]: prevent unconditional module delete

### DIFF
--- a/modules/002-deckhouse/module.yaml
+++ b/modules/002-deckhouse/module.yaml
@@ -3,3 +3,6 @@ weight: 2
 subsystems:
   - deckhouse
 namespace: d8-system
+disable:
+  confirmation: true
+  message: "Disabling this module will completely stop normal operation of Deckhouse Kubernetes Platform."

--- a/modules/002-deckhouse/module.yaml
+++ b/modules/002-deckhouse/module.yaml
@@ -5,4 +5,4 @@ subsystems:
 namespace: d8-system
 disable:
   confirmation: true
-  message: "Disabling this module will completely stop normal operation of Deckhouse Kubernetes Platform."
+  message: "Disabling this module will completely stop normal operation of the Deckhouse Kubernetes Platform."

--- a/modules/002-deckhouse/templates/admission/secret.yaml
+++ b/modules/002-deckhouse/templates/admission/secret.yaml
@@ -4,6 +4,8 @@ metadata:
   name: admission-webhook-certs
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse")) | nindent 2 }}
+  annotations:
+    helm.sh/resource-policy: keep
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.deckhouse.internal.admissionWebhookCert.crt | b64enc | quote }}

--- a/modules/002-deckhouse/templates/namespace.yaml
+++ b/modules/002-deckhouse/templates/namespace.yaml
@@ -3,18 +3,24 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-monitoring
+  annotations:
+    helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true" "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true" "prometheus.deckhouse.io/scrape-configs-watcher-enabled" "true")) | nindent 2 }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-service-accounts
+  annotations:
+    helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-instance-manager
+  annotations:
+    helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-system") }}

--- a/modules/002-deckhouse/templates/service.yaml
+++ b/modules/002-deckhouse/templates/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: deckhouse
   namespace: d8-system
+  annotations:
+    helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse" "migration.deckhouse.io/fix-services-broken-by-helm" "done")) | nindent 2 }}
 spec:
   publishNotReadyAddresses: true

--- a/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
@@ -33,6 +33,8 @@ apiVersion: apps/v1
 metadata:
   name: webhook-handler
   namespace: d8-system
+  annotations:
+    helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list . (dict "app" "webhook-handler")) | nindent 2 }}
 spec:
   replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}

--- a/modules/002-deckhouse/templates/webhook-handler/secret.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/secret.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: webhook-handler-certs
   namespace: d8-system
+  annotations:
+    helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list . (dict "app" "webhook-handler")) | nindent 2 }}
 type: kubernetes.io/tls
 data:

--- a/modules/002-deckhouse/templates/webhook-handler/service.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: validating-webhook-handler
   namespace: d8-system
+  annotations:
+    helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list . (dict "app" "webhook-handler")) | nindent 2 }}
 spec:
   ports:
@@ -19,6 +21,8 @@ kind: Service
 metadata:
   name: conversion-webhook-handler
   namespace: d8-system
+  annotations:
+    helm.sh/resource-policy: keep
   {{- include "helm_lib_module_labels" (list . (dict "app" "webhook-handler")) | nindent 2 }}
 spec:
   ports:


### PR DESCRIPTION
## Description
This pull request introduces a set of changes aimed at preventing the accidental deletion of the Deckhouse module. These protections are implemented using Helm annotations and adding delete options to module to preserve critical resources that are essential to the platform’s functionality.

## Why do we need it, and what problem does it solve?
Removing or disabling the deckhouse module can completely paralyze a cluster and render it unmanageable. To mitigate this risk, this PR adds multiple safety measures that ensure critical resources remain untouched unless explicitly overridden.

All important Kubernetes objects (e.g. services, secrets, deployments, namespaces) now have:

```yaml
annotations:
  "helm.sh/resource-policy": keep
```
Resources with this protection include:

- Namespaces: d8-monitoring, d8-service-accounts, d8-cloud-instance-manager
- Services: deckhouse, validating-webhook-handler, conversion-webhook-handler
- Secrets: webhook-handler-certs, admission-webhook-certs
- Deployment: webhook-handler


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: prevent unconditional module delete
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
