### PR TITLE
[candi] Static node cleanup: remove all users created from NodeUser manifests

### DIFF
--- a/candi/bashible/common-steps/all/002_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/002_create_static_node_cleanup_script.sh.tpl
@@ -75,6 +75,9 @@ rm -rf /etc/sudoers.d/sudoers_flant_kubectl
 rm -rf /etc/sudoers.d/30-deckhouse-nodeadmins
 userdel deckhouse
 groupdel nodeadmin
+for user in `cat /etc/passwd |grep "created by deckhouse" |egrep -o "^[^:]+"`; do
+	userdel $user
+done
 rm -rf /home/deckhouse
 
 shutdown -r -t 5


### PR DESCRIPTION
## Description

Add step to cleanup_static_node.sh to remove all users created form NodeUser manifests

## Why do we need it, and what problem does it solve?

We should clean up all the artifacts created by deckhouse by cleaning up static node

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Deleting all users created by deckhouse from NodeUser manifests.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
