### PR TITLE
[node-manager] partial rollback of changes in images cluster-autoscaler

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -61,7 +61,7 @@ k8s:
     status: available
     patch: 14
     bashible: *bashible
-    clusterAutoscalerPatch: 2
+    clusterAutoscalerPatch: 1
     crictlPatch: 0
     ccm:
       openstack: v1.29.1

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/001-go-mod.patch
@@ -1,8 +1,8 @@
 diff --git i/cluster-autoscaler/go.mod w/cluster-autoscaler/go.mod
-index 777c3c9a8..c5468b471 100644
+index 777c3c9a8..e6f3fa054 100644
 --- i/cluster-autoscaler/go.mod
 +++ w/cluster-autoscaler/go.mod
-@@ -1,6 +1,6 @@
+@@ -1,6 +1,8 @@
  module k8s.io/autoscaler/cluster-autoscaler
  
 -go 1.21
@@ -10,7 +10,7 @@ index 777c3c9a8..c5468b471 100644
  
  require (
  	cloud.google.com/go/compute/metadata v0.2.3
-@@ -21,7 +21,7 @@ require (
+@@ -21,7 +23,7 @@ require (
  	github.com/golang/mock v1.6.0
  	github.com/google/go-cmp v0.6.0
  	github.com/google/go-querystring v1.0.0
@@ -19,7 +19,7 @@ index 777c3c9a8..c5468b471 100644
  	github.com/jmespath/go-jmespath v0.4.0
  	github.com/json-iterator/go v1.1.12
  	github.com/onsi/ginkgo/v2 v2.13.0
-@@ -30,11 +30,11 @@ require (
+@@ -30,11 +32,11 @@ require (
  	github.com/prometheus/client_golang v1.16.0
  	github.com/satori/go.uuid v1.2.0
  	github.com/spf13/pflag v1.0.5
@@ -27,24 +27,24 @@ index 777c3c9a8..c5468b471 100644
 -	golang.org/x/crypto v0.16.0
 -	golang.org/x/net v0.19.0
 +	github.com/stretchr/testify v1.9.0
-+	golang.org/x/crypto v0.31.0
-+	golang.org/x/net v0.33.0
++	golang.org/x/crypto v0.35.0
++	golang.org/x/net v0.36.0
  	golang.org/x/oauth2 v0.10.0
 -	golang.org/x/sys v0.15.0
-+	golang.org/x/sys v0.28.0
++	golang.org/x/sys v0.30.0
  	google.golang.org/api v0.126.0
  	google.golang.org/grpc v1.58.3
  	google.golang.org/protobuf v1.33.0
-@@ -105,7 +105,7 @@ require (
+@@ -105,7 +107,7 @@ require (
  	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
  	github.com/godbus/dbus/v5 v5.1.0 // indirect
  	github.com/gogo/protobuf v1.3.2 // indirect
 -	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
-+	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
++	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
  	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
  	github.com/golang/protobuf v1.5.4 // indirect
  	github.com/google/cadvisor v0.48.1 // indirect
-@@ -137,19 +137,20 @@ require (
+@@ -137,19 +139,20 @@ require (
  	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
  	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
  	github.com/opencontainers/go-digest v1.0.0 // indirect
@@ -67,7 +67,7 @@ index 777c3c9a8..c5468b471 100644
  	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
  	github.com/vishvananda/netlink v1.1.0 // indirect
  	github.com/vishvananda/netns v0.0.4 // indirect
-@@ -172,12 +173,12 @@ require (
+@@ -172,12 +175,12 @@ require (
  	go.uber.org/multierr v1.11.0 // indirect
  	go.uber.org/zap v1.24.0 // indirect
  	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
@@ -76,9 +76,9 @@ index 777c3c9a8..c5468b471 100644
 -	golang.org/x/term v0.15.0 // indirect
 -	golang.org/x/text v0.14.0 // indirect
 +	golang.org/x/mod v0.17.0 // indirect
-+	golang.org/x/sync v0.10.0 // indirect
-+	golang.org/x/term v0.27.0 // indirect
-+	golang.org/x/text v0.21.0 // indirect
++	golang.org/x/sync v0.11.0 // indirect
++	golang.org/x/term v0.29.0 // indirect
++	golang.org/x/text v0.22.0 // indirect
  	golang.org/x/time v0.3.0 // indirect
 -	golang.org/x/tools v0.16.1 // indirect
 +	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
@@ -86,7 +86,7 @@ index 777c3c9a8..c5468b471 100644
  	google.golang.org/genproto v0.0.0-20230803162519-f966b187b2e5 // indirect
  	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e // indirect
 diff --git i/cluster-autoscaler/go.sum w/cluster-autoscaler/go.sum
-index 4c5e460af..107d84e28 100644
+index 4c5e460af..f1c81306a 100644
 --- i/cluster-autoscaler/go.sum
 +++ w/cluster-autoscaler/go.sum
 @@ -271,8 +271,9 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
@@ -95,8 +95,8 @@ index 4c5e460af..107d84e28 100644
  github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 -github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
  github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-+github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
-+github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
++github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
++github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
  github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
  github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
  github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
@@ -161,8 +161,8 @@ index 4c5e460af..107d84e28 100644
  golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 -golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
 -golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
-+golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
-+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
++golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
++golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
  golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -183,8 +183,8 @@ index 4c5e460af..107d84e28 100644
  golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 -golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
 -golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
-+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
-+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
++golang.org/x/net v0.36.0 h1:vWF2fRbw4qslQsQzgFqZff+BItCvGFQqKzKIzx1rmoA=
++golang.org/x/net v0.36.0/go.mod h1:bFmbeoIPfrw4sMHNhb4J9f6+tPziuGjq7Jk/38fxi1I=
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
  golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -194,8 +194,8 @@ index 4c5e460af..107d84e28 100644
  golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 -golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
 -golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
-+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
++golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
++golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
  golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -205,16 +205,16 @@ index 4c5e460af..107d84e28 100644
  golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 -golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 -golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
++golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
  golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
  golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
  golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
  golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 -golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
 -golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
-+golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
-+golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
++golang.org/x/term v0.29.0 h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU=
++golang.org/x/term v0.29.0/go.mod h1:6bl4lRlvVuDgSf3179VpIxBF0o10JUpXWOnI7nErv7s=
  golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -224,8 +224,8 @@ index 4c5e460af..107d84e28 100644
  golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 -golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 -golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
-+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
-+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
++golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
++golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
  golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
  golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
  golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/001-go-mod.patch
@@ -1,18 +1,16 @@
 diff --git i/cluster-autoscaler/go.mod w/cluster-autoscaler/go.mod
-index 777c3c9a8..313247d13 100644
+index 777c3c9a8..dcd6436fd 100644
 --- i/cluster-autoscaler/go.mod
 +++ w/cluster-autoscaler/go.mod
-@@ -1,6 +1,8 @@
+@@ -1,6 +1,6 @@
  module k8s.io/autoscaler/cluster-autoscaler
  
 -go 1.21
-+go 1.23.0
-+
-+toolchain go1.23.6
++go 1.23
  
  require (
  	cloud.google.com/go/compute/metadata v0.2.3
-@@ -21,7 +23,7 @@ require (
+@@ -21,7 +21,7 @@ require (
  	github.com/golang/mock v1.6.0
  	github.com/google/go-cmp v0.6.0
  	github.com/google/go-querystring v1.0.0
@@ -21,7 +19,7 @@ index 777c3c9a8..313247d13 100644
  	github.com/jmespath/go-jmespath v0.4.0
  	github.com/json-iterator/go v1.1.12
  	github.com/onsi/ginkgo/v2 v2.13.0
-@@ -30,28 +32,28 @@ require (
+@@ -30,28 +30,28 @@ require (
  	github.com/prometheus/client_golang v1.16.0
  	github.com/satori/go.uuid v1.2.0
  	github.com/spf13/pflag v1.0.5
@@ -64,7 +62,7 @@ index 777c3c9a8..313247d13 100644
  	k8s.io/legacy-cloud-providers v0.0.0
  	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
  	sigs.k8s.io/cloud-provider-azure v1.28.0
-@@ -105,7 +107,7 @@ require (
+@@ -105,7 +105,7 @@ require (
  	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
  	github.com/godbus/dbus/v5 v5.1.0 // indirect
  	github.com/gogo/protobuf v1.3.2 // indirect
@@ -73,7 +71,7 @@ index 777c3c9a8..313247d13 100644
  	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
  	github.com/golang/protobuf v1.5.4 // indirect
  	github.com/google/cadvisor v0.48.1 // indirect
-@@ -137,19 +139,20 @@ require (
+@@ -137,19 +137,20 @@ require (
  	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
  	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
  	github.com/opencontainers/go-digest v1.0.0 // indirect
@@ -96,7 +94,7 @@ index 777c3c9a8..313247d13 100644
  	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
  	github.com/vishvananda/netlink v1.1.0 // indirect
  	github.com/vishvananda/netns v0.0.4 // indirect
-@@ -172,12 +175,12 @@ require (
+@@ -172,12 +173,12 @@ require (
  	go.uber.org/multierr v1.11.0 // indirect
  	go.uber.org/zap v1.24.0 // indirect
  	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
@@ -114,7 +112,7 @@ index 777c3c9a8..313247d13 100644
  	google.golang.org/appengine v1.6.7 // indirect
  	google.golang.org/genproto v0.0.0-20230803162519-f966b187b2e5 // indirect
  	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e // indirect
-@@ -186,16 +189,16 @@ require (
+@@ -186,16 +187,16 @@ require (
  	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
  	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
@@ -136,7 +134,7 @@ index 777c3c9a8..313247d13 100644
  	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
  	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect
  	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
-@@ -207,64 +210,64 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
+@@ -207,64 +208,64 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
  
  replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
  

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/001-go-mod.patch
@@ -1,12 +1,14 @@
 diff --git i/cluster-autoscaler/go.mod w/cluster-autoscaler/go.mod
-index 777c3c9a8..e6f3fa054 100644
+index 777c3c9a8..313247d13 100644
 --- i/cluster-autoscaler/go.mod
 +++ w/cluster-autoscaler/go.mod
 @@ -1,6 +1,8 @@
  module k8s.io/autoscaler/cluster-autoscaler
  
 -go 1.21
-+go 1.23
++go 1.23.0
++
++toolchain go1.23.6
  
  require (
  	cloud.google.com/go/compute/metadata v0.2.3
@@ -19,7 +21,7 @@ index 777c3c9a8..e6f3fa054 100644
  	github.com/jmespath/go-jmespath v0.4.0
  	github.com/json-iterator/go v1.1.12
  	github.com/onsi/ginkgo/v2 v2.13.0
-@@ -30,11 +32,11 @@ require (
+@@ -30,28 +32,28 @@ require (
  	github.com/prometheus/client_golang v1.16.0
  	github.com/satori/go.uuid v1.2.0
  	github.com/spf13/pflag v1.0.5
@@ -35,6 +37,33 @@ index 777c3c9a8..e6f3fa054 100644
  	google.golang.org/api v0.126.0
  	google.golang.org/grpc v1.58.3
  	google.golang.org/protobuf v1.33.0
+ 	gopkg.in/gcfg.v1 v1.2.3
+ 	gopkg.in/yaml.v2 v2.4.0
+-	k8s.io/api v0.29.3
+-	k8s.io/apimachinery v0.29.3
+-	k8s.io/apiserver v0.29.3
+-	k8s.io/client-go v0.29.3
+-	k8s.io/cloud-provider v0.29.3
++	k8s.io/api v0.29.14
++	k8s.io/apimachinery v0.29.14
++	k8s.io/apiserver v0.29.14
++	k8s.io/client-go v0.29.14
++	k8s.io/cloud-provider v0.29.14
+ 	k8s.io/cloud-provider-aws v1.27.0
+-	k8s.io/code-generator v0.29.3
+-	k8s.io/component-base v0.29.3
+-	k8s.io/component-helpers v0.29.3
++	k8s.io/code-generator v0.29.14
++	k8s.io/component-base v0.29.14
++	k8s.io/component-helpers v0.29.14
+ 	k8s.io/klog/v2 v2.110.1
+-	k8s.io/kubelet v0.29.3
+-	k8s.io/kubernetes v1.29.0
++	k8s.io/kubelet v0.29.14
++	k8s.io/kubernetes v1.29.14
+ 	k8s.io/legacy-cloud-providers v0.0.0
+ 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
+ 	sigs.k8s.io/cloud-provider-azure v1.28.0
 @@ -105,7 +107,7 @@ require (
  	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
  	github.com/godbus/dbus/v5 v5.1.0 // indirect
@@ -85,8 +114,124 @@ index 777c3c9a8..e6f3fa054 100644
  	google.golang.org/appengine v1.6.7 // indirect
  	google.golang.org/genproto v0.0.0-20230803162519-f966b187b2e5 // indirect
  	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e // indirect
+@@ -186,16 +189,16 @@ require (
+ 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+ 	gopkg.in/warnings.v0 v0.1.2 // indirect
+ 	gopkg.in/yaml.v3 v3.0.1 // indirect
+-	k8s.io/apiextensions-apiserver v0.29.3 // indirect
+-	k8s.io/controller-manager v0.29.3 // indirect
+-	k8s.io/cri-api v0.29.3 // indirect
++	k8s.io/apiextensions-apiserver v0.29.14 // indirect
++	k8s.io/controller-manager v0.29.14 // indirect
++	k8s.io/cri-api v0.29.14 // indirect
+ 	k8s.io/csi-translation-lib v0.27.0 // indirect
+ 	k8s.io/dynamic-resource-allocation v0.0.0 // indirect
+ 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
+-	k8s.io/kms v0.29.3 // indirect
++	k8s.io/kms v0.29.14 // indirect
+ 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
+ 	k8s.io/kube-scheduler v0.0.0 // indirect
+-	k8s.io/kubectl v0.28.0 // indirect
++	k8s.io/kubectl v0.29.14 // indirect
+ 	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
+ 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect
+ 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
+@@ -207,64 +210,64 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
+ 
+ replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
+ 
+-replace k8s.io/api => k8s.io/api v0.29.0
++replace k8s.io/api => k8s.io/api v0.29.14
+ 
+-replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.29.0
++replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.29.14
+ 
+-replace k8s.io/apimachinery => k8s.io/apimachinery v0.29.0
++replace k8s.io/apimachinery => k8s.io/apimachinery v0.29.14
+ 
+-replace k8s.io/apiserver => k8s.io/apiserver v0.29.0
++replace k8s.io/apiserver => k8s.io/apiserver v0.29.14
+ 
+-replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.29.0
++replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.29.14
+ 
+-replace k8s.io/client-go => k8s.io/client-go v0.29.0
++replace k8s.io/client-go => k8s.io/client-go v0.29.14
+ 
+-replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.29.0
++replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.29.14
+ 
+-replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.29.0
++replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.29.14
+ 
+-replace k8s.io/code-generator => k8s.io/code-generator v0.29.0
++replace k8s.io/code-generator => k8s.io/code-generator v0.29.14
+ 
+-replace k8s.io/component-base => k8s.io/component-base v0.29.0
++replace k8s.io/component-base => k8s.io/component-base v0.29.14
+ 
+-replace k8s.io/component-helpers => k8s.io/component-helpers v0.29.0
++replace k8s.io/component-helpers => k8s.io/component-helpers v0.29.14
+ 
+-replace k8s.io/controller-manager => k8s.io/controller-manager v0.29.0
++replace k8s.io/controller-manager => k8s.io/controller-manager v0.29.14
+ 
+-replace k8s.io/cri-api => k8s.io/cri-api v0.29.0
++replace k8s.io/cri-api => k8s.io/cri-api v0.29.14
+ 
+-replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.29.0
++replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.29.14
+ 
+-replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.29.0
++replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.29.14
+ 
+-replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.29.0
++replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.29.14
+ 
+-replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.29.0
++replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.29.14
+ 
+-replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.29.0
++replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.29.14
+ 
+-replace k8s.io/kubectl => k8s.io/kubectl v0.29.0
++replace k8s.io/kubectl => k8s.io/kubectl v0.29.14
+ 
+-replace k8s.io/kubelet => k8s.io/kubelet v0.29.0
++replace k8s.io/kubelet => k8s.io/kubelet v0.29.14
+ 
+-replace k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.29.0
++replace k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.29.14
+ 
+-replace k8s.io/metrics => k8s.io/metrics v0.29.0
++replace k8s.io/metrics => k8s.io/metrics v0.29.14
+ 
+ replace k8s.io/mount-utils => k8s.io/mount-utils v0.30.0-alpha.0
+ 
+-replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.29.0
++replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.29.14
+ 
+-replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.29.0
++replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.29.14
+ 
+-replace k8s.io/sample-controller => k8s.io/sample-controller v0.29.0
++replace k8s.io/sample-controller => k8s.io/sample-controller v0.29.14
+ 
+-replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.29.0
++replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.29.14
+ 
+-replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.29.0
++replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.29.14
+ 
+-replace k8s.io/kms => k8s.io/kms v0.29.0
++replace k8s.io/kms => k8s.io/kms v0.29.14
+ 
+ replace k8s.io/noderesourcetopology-api => k8s.io/noderesourcetopology-api v0.27.0
+ 
+-replace k8s.io/endpointslice => k8s.io/endpointslice v0.29.0
++replace k8s.io/endpointslice => k8s.io/endpointslice v0.29.14
 diff --git i/cluster-autoscaler/go.sum w/cluster-autoscaler/go.sum
-index 4c5e460af..f1c81306a 100644
+index 4c5e460af..0ed76436b 100644
 --- i/cluster-autoscaler/go.sum
 +++ w/cluster-autoscaler/go.sum
 @@ -271,8 +271,9 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
@@ -240,3 +385,96 @@ index 4c5e460af..f1c81306a 100644
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+@@ -1108,54 +1110,54 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
+ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+-k8s.io/api v0.29.0 h1:NiCdQMY1QOp1H8lfRyeEf8eOwV6+0xA6XEE44ohDX2A=
+-k8s.io/api v0.29.0/go.mod h1:sdVmXoz2Bo/cb77Pxi71IPTSErEW32xa4aXwKH7gfBA=
+-k8s.io/apiextensions-apiserver v0.29.0 h1:0VuspFG7Hj+SxyF/Z/2T0uFbI5gb5LRgEyUVE3Q4lV0=
+-k8s.io/apiextensions-apiserver v0.29.0/go.mod h1:TKmpy3bTS0mr9pylH0nOt/QzQRrW7/h7yLdRForMZwc=
+-k8s.io/apimachinery v0.29.0 h1:+ACVktwyicPz0oc6MTMLwa2Pw3ouLAfAon1wPLtG48o=
+-k8s.io/apimachinery v0.29.0/go.mod h1:eVBxQ/cwiJxH58eK/jd/vAk4mrxmVlnpBH5J2GbMeis=
+-k8s.io/apiserver v0.29.0 h1:Y1xEMjJkP+BIi0GSEv1BBrf1jLU9UPfAnnGGbbDdp7o=
+-k8s.io/apiserver v0.29.0/go.mod h1:31n78PsRKPmfpee7/l9NYEv67u6hOL6AfcE761HapDM=
+-k8s.io/client-go v0.29.0 h1:KmlDtFcrdUzOYrBhXHgKw5ycWzc3ryPX5mQe0SkG3y8=
+-k8s.io/client-go v0.29.0/go.mod h1:yLkXH4HKMAywcrD82KMSmfYg2DlE8mepPR4JGSo5n38=
+-k8s.io/cloud-provider v0.29.0 h1:Qgk/jHsSKGRk/ltTlN6e7eaNuuamLROOzVBd0RPp94M=
+-k8s.io/cloud-provider v0.29.0/go.mod h1:gBCt7YYKFV4oUcJ/0xF9lS/9il4MxKunJ+ZKvh39WGo=
++k8s.io/api v0.29.14 h1:JWFh5ufowH3Y6tCgEzY3URVJHb27f0tEDEej0nCjWDw=
++k8s.io/api v0.29.14/go.mod h1:IV8YqKxMm8JGLBLlHM13Npn5lCITH10XYipWEW+YEOQ=
++k8s.io/apiextensions-apiserver v0.29.14 h1:gw9WXrZJPu5kpI1UC+Wf8BVe9PWwRUB/UZXU8VzBsq4=
++k8s.io/apiextensions-apiserver v0.29.14/go.mod h1:TJ51W+HKW2XqTtAsEFOz1/OohsMtekbKaTXh8ldioL4=
++k8s.io/apimachinery v0.29.14 h1:IDhwnGNCp836SLOwW1SoEfFNV77wxIklhxeAHX9vmSo=
++k8s.io/apimachinery v0.29.14/go.mod h1:i3FJVwhvSp/6n8Fl4K97PJEP8C+MM+aoDq4+ZJBf70Y=
++k8s.io/apiserver v0.29.14 h1:XTo9lDDsG4NkywEuzG0SDLrBv6+AyVIpqVzZjg+pWRs=
++k8s.io/apiserver v0.29.14/go.mod h1:jC0HqUfqFKMp111xs97CXkf8XTQXtnbukRuuwDH74yE=
++k8s.io/client-go v0.29.14 h1:OSnzZ9DClaFRgl3zMAY2kGZhNjdGJkEb+RDz+MW2h6k=
++k8s.io/client-go v0.29.14/go.mod h1:XtZt5n5UxKfPJ+sCoTPcEavWgZbLFFxMnAFFRQGK1RY=
++k8s.io/cloud-provider v0.29.14 h1:c51wR9EO+hHfwwXo4nKpNx2hSpPsnC0K06pNr+LfYT8=
++k8s.io/cloud-provider v0.29.14/go.mod h1:WC35HM3tTzyOCg8+W2exZPKAfSClK3RpTzGXOBpQcbg=
+ k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
+ k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
+-k8s.io/code-generator v0.29.0 h1:2LQfayGDhaIlaamXjIjEQlCMy4JNCH9lrzas4DNW1GQ=
+-k8s.io/code-generator v0.29.0/go.mod h1:5bqIZoCxs2zTRKMWNYqyQWW/bajc+ah4rh0tMY8zdGA=
+-k8s.io/component-base v0.29.0 h1:T7rjd5wvLnPBV1vC4zWd/iWRbV8Mdxs+nGaoaFzGw3s=
+-k8s.io/component-base v0.29.0/go.mod h1:sADonFTQ9Zc9yFLghpDpmNXEdHyQmFIGbiuZbqAXQ1M=
+-k8s.io/component-helpers v0.29.0 h1:Y8W70NGeitKxWwhsPo/vEQbQx5VqJV+3xfLpP3V1VxU=
+-k8s.io/component-helpers v0.29.0/go.mod h1:j2coxVfmzTOXWSE6sta0MTgNSr572Dcx68F6DD+8fWc=
+-k8s.io/controller-manager v0.29.0 h1:kEv9sKLnjDkoSqeouWp2lZ8P33an5wrDJpOMqoyD7pc=
+-k8s.io/controller-manager v0.29.0/go.mod h1:UKtadWkULF5bfX7vu3hHppzY/hz88C03t70GItg/x08=
+-k8s.io/cri-api v0.29.0 h1:atenAqOltRsFqcCQlFFpDnl/R4aGfOELoNLTDJfd7t8=
+-k8s.io/cri-api v0.29.0/go.mod h1:Rls2JoVwfC7kW3tndm7267kriuRukQ02qfht0PCRuIc=
+-k8s.io/csi-translation-lib v0.29.0 h1:we4X1yUlDikvm5Rv0dwMuPHNw6KwjwsQiAuOPWXha8M=
+-k8s.io/csi-translation-lib v0.29.0/go.mod h1:Cp6t3CNBSm1dXS17V8IImUjkqfIB6KCj8Fs8wf6uyTA=
+-k8s.io/dynamic-resource-allocation v0.29.0 h1:JQW5erdoOsvhst7DxMfEpnXhrfm9SmNTnvyaXdqTLAE=
+-k8s.io/dynamic-resource-allocation v0.29.0/go.mod h1:4T9Fg4J8B2SdRVVj5/1hM7hGAUrBqzyEUIGFY+wQl4Q=
++k8s.io/code-generator v0.29.14 h1:Fuhe0MsDWD4kb5s2RKJcZWrAH7KN/60I9goj9kPgy8g=
++k8s.io/code-generator v0.29.14/go.mod h1:7TYnI0dYItL2cKuhhgPSuF3WED9uMdELgbVXFfn/joE=
++k8s.io/component-base v0.29.14 h1:SF1DWN7bc2VloJ/ysegGoi/aHnopEo81aw9CslhqXIw=
++k8s.io/component-base v0.29.14/go.mod h1:FoK1PHhFTaEQVvQLw29/Uyfd8Ug0qUKHrUcXIXJ1VxI=
++k8s.io/component-helpers v0.29.14 h1:xVdPm0SAlQlclESC/3Q3DV6mRkyWZiOfG+jEEaEveyM=
++k8s.io/component-helpers v0.29.14/go.mod h1:vpLvJu1de/+ZCPdj34549/b83FG6/djZsFzCWt6Qses=
++k8s.io/controller-manager v0.29.14 h1:36yBWP2khQ2OiQezHMOoBdlEkUkytBwIApZ5QlN/WYs=
++k8s.io/controller-manager v0.29.14/go.mod h1:VWFCAJrb9umWPKmmus3wgjSdN0wKqgI97Rb5XeukGdQ=
++k8s.io/cri-api v0.29.14 h1:ajYndA+B4nmfHDQ8nN1G+7zsaWFc9lgZS3T30+LvIs4=
++k8s.io/cri-api v0.29.14/go.mod h1:A6pdbjzML2xi9B0Clqn5qt1HJ3Ik12x2j+jv/TkqjRE=
++k8s.io/csi-translation-lib v0.29.14 h1:JMt0DSJZwLL5HmkanWzFwiC/4zPAGeHP0N4cNT52O4U=
++k8s.io/csi-translation-lib v0.29.14/go.mod h1:I4L/fymumNItLZc/eRU87At6+xaVDHJL0Q1QZxLQylE=
++k8s.io/dynamic-resource-allocation v0.29.14 h1:3j4tnpyV/7kMRFKGWDBk9kixnEVos/P101RRensGJrs=
++k8s.io/dynamic-resource-allocation v0.29.14/go.mod h1:771EqFQSUzaGMEjBS88u1QFCH/qRTMlA0iy9jwYfDZM=
+ k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 h1:pWEwq4Asjm4vjW7vcsmijwBhOr1/shsbSYiWXmNGlks=
+ k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+ k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
+ k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
+ k8s.io/klog/v2 v2.110.1 h1:U/Af64HJf7FcwMcXyKm2RPM22WZzyR7OSpYj5tg3cL0=
+ k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=
+-k8s.io/kms v0.29.0 h1:KJ1zaZt74CgvgV3NR7tnURJ/mJOKC5X3nwon/WdwgxI=
+-k8s.io/kms v0.29.0/go.mod h1:mB0f9HLxRXeXUfHfn1A7rpwOlzXI1gIWu86z6buNoYA=
++k8s.io/kms v0.29.14 h1:F5bZZnUtqR7lC9YeXZyaHXNbRo/Lqrrm2BbBcLQ2mhM=
++k8s.io/kms v0.29.14/go.mod h1:vWVImKkJd+1BQY4tBwdfSwjQBiLrnbNtHADcDEDQFtk=
+ k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 h1:aVUu9fTY98ivBPKR9Y5w/AuzbMm96cd3YHRTU83I780=
+ k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00/go.mod h1:AsvuZPBlUDVuCdzJ87iajxtXuR9oktsTctW/R9wwouA=
+-k8s.io/kube-scheduler v0.29.0 h1:n4v68EvxYhy7o5Q/LFPgqBEGi7lKoiAxwQ0gQyMoj9M=
+-k8s.io/kube-scheduler v0.29.0/go.mod h1:mJMGpqS+aC6/Qf6SDpaqvM6/kLENHN5U7SACSdrZV7o=
+-k8s.io/kubectl v0.29.0 h1:Oqi48gXjikDhrBF67AYuZRTcJV4lg2l42GmvsP7FmYI=
+-k8s.io/kubectl v0.29.0/go.mod h1:0jMjGWIcMIQzmUaMgAzhSELv5WtHo2a8pq67DtviAJs=
+-k8s.io/kubelet v0.29.0 h1:SX5hlznTBcGIrS1scaf8r8p6m3e475KMifwt9i12iOk=
+-k8s.io/kubelet v0.29.0/go.mod h1:kvKS2+Bz2tgDOG1S1q0TH2z1DasNuVF+8p6Aw7xvKkI=
+-k8s.io/kubernetes v1.29.0 h1:DOLN7g8+nnAYBi8JHoW0+/MCrZKDPIqAxzLCXDXd0cg=
+-k8s.io/kubernetes v1.29.0/go.mod h1:9kztbUQf9stVDcIYXx+BX3nuGCsAQDsuClkGMpPs3pA=
+-k8s.io/legacy-cloud-providers v0.29.0 h1:fjGV9OhqseUTp3R8xOm2TBoAxyuRTOS6B2zFTSJ80RE=
+-k8s.io/legacy-cloud-providers v0.29.0/go.mod h1:qR0/QoI19+G4zI71hSSZ1SEgiwdV358SU8u3jCwvK8c=
++k8s.io/kube-scheduler v0.29.14 h1:YElox/PlP9gMdOGdmLtXAjseGea0pcU0rbd54HW1SPs=
++k8s.io/kube-scheduler v0.29.14/go.mod h1:DJF/gl9pqOK7Bz1JbaeO8n2vfn7QhU7eLkMOGYYukyY=
++k8s.io/kubectl v0.29.14 h1:aNsAv4S8s6ldP8pPejkgPdNBBTeL/9vnl6j72F3b1z4=
++k8s.io/kubectl v0.29.14/go.mod h1:/fKgBbMs87f5iWI2s2K4IFofr9tpYZ8kE9Q2m6zA4OY=
++k8s.io/kubelet v0.29.14 h1:kkjpSJ6W+jrzr2AwOpVrOMY7iu3uim7RO+EC2zBVOzY=
++k8s.io/kubelet v0.29.14/go.mod h1:4FD4VXVnoCxXv0VnI3LKTYYtGtmWL3UEI/Q6/Y1hskk=
++k8s.io/kubernetes v1.29.14 h1:mbk5M/WaJr/AX7p3p2/7eJjrtI+I3AKu7IEjI8+Ny/U=
++k8s.io/kubernetes v1.29.14/go.mod h1:L6/pfKQZ6Tv2O8gyT4OxhGZp+nNsjV54xtNodRoup9k=
++k8s.io/legacy-cloud-providers v0.29.14 h1:9HI1hO071qO+7cz/FAP/VlzqIvPFPYWqPLG5NpqRH6M=
++k8s.io/legacy-cloud-providers v0.29.14/go.mod h1:RvV5CpFY8/YSTDwUVJb8QsfLK8wrt6X2ZyY+zuBdLM4=
+ k8s.io/mount-utils v0.30.0-alpha.0 h1:hga3HePjAnYTofEKHmjvTZZzSCTV4auLQ9D172n1Gig=
+ k8s.io/mount-utils v0.30.0-alpha.0/go.mod h1:N3lDK/G1B8R/IkAt4NhHyqB07OqEr7P763z3TNge94U=
+ k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/001-go-mod.patch
@@ -1,8 +1,8 @@
-diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index a2e1cfb09..f3ddc08eb 100644
---- a/cluster-autoscaler/go.mod
-+++ b/cluster-autoscaler/go.mod
-@@ -1,13 +1,13 @@
+diff --git i/cluster-autoscaler/go.mod w/cluster-autoscaler/go.mod
+index 777c3c9a8..9c18635f2 100644
+--- i/cluster-autoscaler/go.mod
++++ w/cluster-autoscaler/go.mod
+@@ -1,6 +1,6 @@
  module k8s.io/autoscaler/cluster-autoscaler
  
 -go 1.21
@@ -10,16 +10,7 @@ index a2e1cfb09..f3ddc08eb 100644
  
  require (
  	cloud.google.com/go/compute/metadata v0.2.3
- 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
- 	github.com/Azure/azure-sdk-for-go-extensions v0.1.6
--	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.2
--	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.4.0
-+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1
-+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0
- 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.8.0-beta.1
- 	github.com/Azure/go-autorest/autorest v0.11.29
- 	github.com/Azure/go-autorest/autorest/adal v0.9.23
-@@ -25,7 +25,7 @@ require (
+@@ -21,7 +21,7 @@ require (
  	github.com/golang/mock v1.6.0
  	github.com/google/go-cmp v0.6.0
  	github.com/google/go-querystring v1.0.0
@@ -28,80 +19,59 @@ index a2e1cfb09..f3ddc08eb 100644
  	github.com/jmespath/go-jmespath v0.4.0
  	github.com/json-iterator/go v1.1.12
  	github.com/onsi/ginkgo/v2 v2.13.0
-@@ -34,29 +34,29 @@ require (
+@@ -30,28 +30,28 @@ require (
  	github.com/prometheus/client_golang v1.16.0
  	github.com/satori/go.uuid v1.2.0
  	github.com/spf13/pflag v1.0.5
 -	github.com/stretchr/testify v1.8.4
+-	golang.org/x/crypto v0.16.0
+-	golang.org/x/net v0.19.0
 +	github.com/stretchr/testify v1.9.0
- 	go.uber.org/mock v0.4.0
--	golang.org/x/crypto v0.21.0
--	golang.org/x/net v0.23.0
 +	golang.org/x/crypto v0.31.0
 +	golang.org/x/net v0.33.0
- 	golang.org/x/oauth2 v0.11.0
--	golang.org/x/sys v0.18.0
+ 	golang.org/x/oauth2 v0.10.0
+-	golang.org/x/sys v0.15.0
 +	golang.org/x/sys v0.28.0
  	google.golang.org/api v0.126.0
- 	google.golang.org/grpc v1.59.0
+ 	google.golang.org/grpc v1.58.3
  	google.golang.org/protobuf v1.33.0
  	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
--	k8s.io/api v0.29.6
--	k8s.io/apimachinery v0.29.6
--	k8s.io/apiserver v0.29.6
--	k8s.io/client-go v0.29.6
--	k8s.io/cloud-provider v0.29.6
+-	k8s.io/api v0.29.3
+-	k8s.io/apimachinery v0.29.3
+-	k8s.io/apiserver v0.29.3
+-	k8s.io/client-go v0.29.3
+-	k8s.io/cloud-provider v0.29.3
 +	k8s.io/api v0.29.12
 +	k8s.io/apimachinery v0.29.12
 +	k8s.io/apiserver v0.29.12
 +	k8s.io/client-go v0.29.12
 +	k8s.io/cloud-provider v0.29.12
  	k8s.io/cloud-provider-aws v1.27.0
--	k8s.io/code-generator v0.29.6
--	k8s.io/component-base v0.29.6
--	k8s.io/component-helpers v0.29.6
+-	k8s.io/code-generator v0.29.3
+-	k8s.io/component-base v0.29.3
+-	k8s.io/component-helpers v0.29.3
 +	k8s.io/code-generator v0.29.12
 +	k8s.io/component-base v0.29.12
 +	k8s.io/component-helpers v0.29.12
  	k8s.io/klog/v2 v2.110.1
--	k8s.io/kubelet v0.29.6
--	k8s.io/kubernetes v1.29.6
+-	k8s.io/kubelet v0.29.3
+-	k8s.io/kubernetes v1.29.0
 +	k8s.io/kubelet v0.29.12
 +	k8s.io/kubernetes v1.29.12
  	k8s.io/legacy-cloud-providers v0.0.0
  	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
  	sigs.k8s.io/cloud-provider-azure v1.28.0
-@@ -66,7 +66,7 @@ require (
- 
- require (
- 	cloud.google.com/go/compute v1.23.0 // indirect
--	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
-+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.8.0 // indirect
- 	github.com/Azure/go-armbalancer v0.0.2 // indirect
- 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
- 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.2 // indirect
-@@ -74,7 +74,7 @@ require (
- 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
- 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
- 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
--	github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1 // indirect
-+	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
- 	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.18.1-0.20220218231025-f11817397a1b // indirect
- 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab // indirect
- 	github.com/Microsoft/go-winio v0.6.0 // indirect
-@@ -113,8 +113,8 @@ require (
+@@ -105,7 +105,7 @@ require (
  	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
  	github.com/godbus/dbus/v5 v5.1.0 // indirect
  	github.com/gogo/protobuf v1.3.2 // indirect
 -	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
--	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 +	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
-+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
  	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
  	github.com/golang/protobuf v1.5.4 // indirect
  	github.com/google/cadvisor v0.48.1 // indirect
-@@ -147,10 +147,10 @@ require (
+@@ -137,19 +137,20 @@ require (
  	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
  	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
  	github.com/opencontainers/go-digest v1.0.0 // indirect
@@ -109,12 +79,13 @@ index a2e1cfb09..f3ddc08eb 100644
 +	github.com/opencontainers/runc v1.1.14 // indirect
  	github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78 // indirect
  	github.com/opencontainers/selinux v1.11.0 // indirect
--	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
-+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
  	github.com/pmezard/go-difflib v1.0.0 // indirect
  	github.com/prometheus/client_model v0.4.0 // indirect
  	github.com/prometheus/common v0.44.0 // indirect
-@@ -160,7 +160,7 @@ require (
+ 	github.com/prometheus/procfs v0.10.1 // indirect
++	github.com/rogpeppe/go-internal v1.12.0 // indirect
+ 	github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021 // indirect
+ 	github.com/seccomp/libseccomp-golang v0.10.0 // indirect
  	github.com/sirupsen/logrus v1.9.0 // indirect
  	github.com/spf13/cobra v1.7.0 // indirect
  	github.com/stoewer/go-strcase v1.3.0 // indirect
@@ -123,13 +94,13 @@ index a2e1cfb09..f3ddc08eb 100644
  	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
  	github.com/vishvananda/netlink v1.1.0 // indirect
  	github.com/vishvananda/netns v0.0.4 // indirect
-@@ -183,12 +183,12 @@ require (
+@@ -172,12 +173,12 @@ require (
  	go.uber.org/multierr v1.11.0 // indirect
  	go.uber.org/zap v1.24.0 // indirect
  	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 -	golang.org/x/mod v0.14.0 // indirect
 -	golang.org/x/sync v0.5.0 // indirect
--	golang.org/x/term v0.18.0 // indirect
+-	golang.org/x/term v0.15.0 // indirect
 -	golang.org/x/text v0.14.0 // indirect
 +	golang.org/x/mod v0.17.0 // indirect
 +	golang.org/x/sync v0.10.0 // indirect
@@ -139,167 +110,42 @@ index a2e1cfb09..f3ddc08eb 100644
 -	golang.org/x/tools v0.16.1 // indirect
 +	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
  	google.golang.org/appengine v1.6.7 // indirect
- 	google.golang.org/genproto v0.0.0-20230822172742-b8732ec3820d // indirect
- 	google.golang.org/genproto/googleapis/api v0.0.0-20230822172742-b8732ec3820d // indirect
-@@ -198,12 +198,12 @@ require (
+ 	google.golang.org/genproto v0.0.0-20230803162519-f966b187b2e5 // indirect
+ 	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e // indirect
+@@ -186,13 +187,13 @@ require (
+ 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
  	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
- 	k8s.io/apiextensions-apiserver v0.29.3 // indirect
--	k8s.io/controller-manager v0.29.6 // indirect
--	k8s.io/cri-api v0.29.6 // indirect
+-	k8s.io/apiextensions-apiserver v0.29.3 // indirect
+-	k8s.io/controller-manager v0.29.3 // indirect
+-	k8s.io/cri-api v0.29.3 // indirect
++	k8s.io/apiextensions-apiserver v0.29.12 // indirect
 +	k8s.io/controller-manager v0.29.12 // indirect
 +	k8s.io/cri-api v0.29.12 // indirect
  	k8s.io/csi-translation-lib v0.27.0 // indirect
  	k8s.io/dynamic-resource-allocation v0.0.0 // indirect
  	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
--	k8s.io/kms v0.29.6 // indirect
+-	k8s.io/kms v0.29.3 // indirect
 +	k8s.io/kms v0.29.12 // indirect
  	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
  	k8s.io/kube-scheduler v0.0.0 // indirect
  	k8s.io/kubectl v0.28.0 // indirect
-@@ -218,62 +218,62 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
- 
- replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
- 
--replace k8s.io/api => k8s.io/api v0.29.6
-+replace k8s.io/api => k8s.io/api v0.29.12
- 
--replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.29.6
-+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.29.12
- 
--replace k8s.io/apimachinery => k8s.io/apimachinery v0.29.6
-+replace k8s.io/apimachinery => k8s.io/apimachinery v0.29.12
- 
--replace k8s.io/apiserver => k8s.io/apiserver v0.29.6
-+replace k8s.io/apiserver => k8s.io/apiserver v0.29.12
- 
--replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.29.6
-+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.29.12
- 
--replace k8s.io/client-go => k8s.io/client-go v0.29.6
-+replace k8s.io/client-go => k8s.io/client-go v0.29.12
- 
--replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.29.6
-+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.29.12
- 
--replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.29.6
-+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.29.12
- 
--replace k8s.io/code-generator => k8s.io/code-generator v0.29.6
-+replace k8s.io/code-generator => k8s.io/code-generator v0.29.12
- 
--replace k8s.io/component-base => k8s.io/component-base v0.29.6
-+replace k8s.io/component-base => k8s.io/component-base v0.29.12
- 
--replace k8s.io/component-helpers => k8s.io/component-helpers v0.29.6
-+replace k8s.io/component-helpers => k8s.io/component-helpers v0.29.12
- 
--replace k8s.io/controller-manager => k8s.io/controller-manager v0.29.6
-+replace k8s.io/controller-manager => k8s.io/controller-manager v0.29.12
- 
--replace k8s.io/cri-api => k8s.io/cri-api v0.29.6
-+replace k8s.io/cri-api => k8s.io/cri-api v0.29.12
- 
--replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.29.6
-+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.29.12
- 
--replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.29.6
-+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.29.12
- 
--replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.29.6
-+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.29.12
- 
--replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.29.6
-+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.29.12
- 
--replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.29.6
-+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.29.12
- 
--replace k8s.io/kubectl => k8s.io/kubectl v0.29.6
-+replace k8s.io/kubectl => k8s.io/kubectl v0.29.12
- 
--replace k8s.io/kubelet => k8s.io/kubelet v0.29.6
-+replace k8s.io/kubelet => k8s.io/kubelet v0.29.12
- 
--replace k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.29.6
-+replace k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.29.12
- 
--replace k8s.io/metrics => k8s.io/metrics v0.29.6
-+replace k8s.io/metrics => k8s.io/metrics v0.29.12
- 
--replace k8s.io/mount-utils => k8s.io/mount-utils v0.29.6
-+replace k8s.io/mount-utils => k8s.io/mount-utils v0.29.12
- 
--replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.29.6
-+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.29.12
- 
--replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.29.6
-+replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.29.12
- 
--replace k8s.io/sample-controller => k8s.io/sample-controller v0.29.6
-+replace k8s.io/sample-controller => k8s.io/sample-controller v0.29.12
- 
--replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.29.6
-+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.29.12
- 
--replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.29.6
-+replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.29.12
- 
--replace k8s.io/kms => k8s.io/kms v0.29.6
-+replace k8s.io/kms => k8s.io/kms v0.29.12
- 
--replace k8s.io/endpointslice => k8s.io/endpointslice v0.29.6
-+replace k8s.io/endpointslice => k8s.io/endpointslice v0.29.12
-diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index 720767728..5b67c7658 100644
---- a/cluster-autoscaler/go.sum
-+++ b/cluster-autoscaler/go.sum
-@@ -53,12 +53,12 @@ github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0
- github.com/Azure/azure-sdk-for-go v68.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
- github.com/Azure/azure-sdk-for-go-extensions v0.1.6 h1:EXGvDcj54u98XfaI/Cy65Ds6vNsIJeGKYf0eNLB1y4Q=
- github.com/Azure/azure-sdk-for-go-extensions v0.1.6/go.mod h1:27StPiXJp6Xzkq2AQL7gPK7VC0hgmCnUKlco1dO1jaM=
--github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.2 h1:c4k2FIYIh4xtwqrQwV0Ct1v5+ehlNXj5NI/MWVsiTkQ=
--github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.2/go.mod h1:5FDJtLEO/GxwNgUxbwrY3LP0pEoThTQJtk2oysdXHxM=
--github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.4.0 h1:BMAjVKJM0U/CYF27gA0ZMmXGkOcvfFtD0oHVZ1TIPRI=
--github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.4.0/go.mod h1:1fXstnBMas5kzG+S3q8UoJcmyU6nUeunJcMDHcRYHhs=
--github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 h1:LqbJ/WzJUwBf8UiaSzgX7aMclParm9/5Vgp+TY51uBQ=
--github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2/go.mod h1:yInRyqWXAuaPrgI7p70+lDDgh3mlBohis29jGMISnmc=
-+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 h1:E+OJmp2tPvt1W+amx48v1eqbjDYsgN+RzP4q16yV5eM=
-+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1/go.mod h1:a6xsAQUZg+VsS3TJ05SRp524Hs4pZ/AeFSr5ENf0Yjo=
-+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0 h1:U2rTu3Ef+7w9FHKIAXM6ZyqF3UOWJZ12zIm8zECAFfg=
-+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0/go.mod h1:9kIvujWAA58nmPmWB1m23fyWic1kYZMxD9CxaWn4Qpg=
-+github.com/Azure/azure-sdk-for-go/sdk/internal v1.8.0 h1:jBQA3cKT4L2rWMpgE7Yt3Hwh2aUj8KXjIGLxjHeYNNo=
-+github.com/Azure/azure-sdk-for-go/sdk/internal v1.8.0/go.mod h1:4OG6tQ9EOP/MT0NMjDlRzWoVFxfu9rN9B2X+tlSVktg=
- github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0 h1:1u/K2BFv0MwkG6he8RYuUcbbeK22rkoZbg4lKa/msZU=
- github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2 v2.4.0/go.mod h1:U5gpsREQZE6SLk1t/cFfc1eMhYAlYpEzvaYXuDfefy8=
- github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.8.0-beta.1 h1:6RFNcR7iE8Ka8j76gE0a/b28eAX6AZF4zqSw0XnFWbg=
-@@ -104,8 +104,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
- github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
- github.com/Azure/skewer v0.0.14 h1:0mzUJhspECkajYyynYsOCp//E2PSnYXrgP45bcskqfQ=
- github.com/Azure/skewer v0.0.14/go.mod h1:6WTecuPyfGtuvS8Mh4JYWuHhO4kcWycGfsUBB+XTFG4=
--github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1 h1:WpB/QDNLpMw72xHJc34BNNykqSOeEJDAWkhf0u12/Jk=
--github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
-+github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
-+github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
- github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
- github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
- github.com/GoogleCloudPlatform/k8s-cloud-provider v1.18.1-0.20220218231025-f11817397a1b h1:Heo1J/ttaQFgGJSVnCZquy3e5eH5j1nqxBuomztB3P0=
-@@ -291,10 +291,11 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
+diff --git i/cluster-autoscaler/go.sum w/cluster-autoscaler/go.sum
+index 4c5e460af..ba4112fc1 100644
+--- i/cluster-autoscaler/go.sum
++++ w/cluster-autoscaler/go.sum
+@@ -271,8 +271,9 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
  github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
  github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
  github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 -github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
  github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
--github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
--github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 +github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
 +github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
-+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
  github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
- github.com/golang/glog v1.1.2 h1:DVjP2PbBOzHyzA+dn3WhHIq4NdVu3Q+pvivFICf/7fo=
- github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
-@@ -388,8 +389,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
+ github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
+ github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
+@@ -366,8 +367,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
  github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
  github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
  github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -310,7 +156,7 @@ index 720767728..5b67c7658 100644
  github.com/googleapis/enterprise-certificate-proxy v0.2.3 h1:yk9/cqRKtT9wXZSsRH9aurXEpJX+U6FLtpYTdC3R06k=
  github.com/googleapis/enterprise-certificate-proxy v0.2.3/go.mod h1:AwSRAtLfXpU5Nm3pW+v7rGDHp09LsPtGY9MduiEsR9k=
  github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
-@@ -496,8 +497,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
+@@ -472,8 +473,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
  github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
  github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
  github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
@@ -321,18 +167,7 @@ index 720767728..5b67c7658 100644
  github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
  github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
  github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78 h1:R5M2qXZiK/mWPMT4VldCOiSL9HIAMuxQZWdG0CSM5+4=
-@@ -505,8 +506,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78/go.m
- github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
- github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
- github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
--github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
--github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
-+github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
-+github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
- github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
- github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
- github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-@@ -535,8 +536,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
+@@ -509,8 +510,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
  github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
  github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
  github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -343,7 +178,7 @@ index 720767728..5b67c7658 100644
  github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021 h1:if3/24+h9Sq6eDx8UUz1SO9cT9tizyIsATfB7b4D3tc=
  github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
  github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-@@ -570,8 +571,9 @@ github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8w
+@@ -544,8 +545,9 @@ github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8w
  github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
  github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
  github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -354,7 +189,7 @@ index 720767728..5b67c7658 100644
  github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
  github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
  github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-@@ -582,8 +584,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
+@@ -556,8 +558,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
  github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
  github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
  github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -365,18 +200,18 @@ index 720767728..5b67c7658 100644
  github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
  github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
  github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-@@ -685,8 +687,8 @@ golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5
+@@ -657,8 +659,8 @@ golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5
  golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
--golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
--golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
+-golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
+-golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 +golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 +golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
  golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
-@@ -725,8 +727,8 @@ golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -697,8 +699,8 @@ golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
@@ -387,18 +222,18 @@ index 720767728..5b67c7658 100644
  golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-@@ -769,8 +771,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
+@@ -741,8 +743,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
  golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
  golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
  golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
--golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
--golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+-golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
+-golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
 +golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 +golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
  golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-@@ -802,8 +804,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
+@@ -774,8 +776,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
  golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -409,34 +244,26 @@ index 720767728..5b67c7658 100644
  golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-@@ -853,7 +855,6 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
- golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
- golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
- golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
--golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
- golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
- golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
- golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-@@ -865,14 +866,14 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
+@@ -836,14 +838,14 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
  golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
--golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
--golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 +golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 +golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
  golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
  golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
  golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
  golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
--golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
--golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
+-golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+-golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
 +golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
 +golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
  golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-@@ -884,8 +885,8 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+@@ -855,8 +857,8 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
  golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
  golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
  golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
@@ -447,7 +274,7 @@ index 720767728..5b67c7658 100644
  golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
  golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
  golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-@@ -949,8 +950,8 @@ golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+@@ -920,8 +922,8 @@ golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
  golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
  golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
  golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
@@ -458,100 +285,14 @@ index 720767728..5b67c7658 100644
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-@@ -1137,56 +1138,56 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
- honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
- honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
- honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
--k8s.io/api v0.29.6 h1:eDxIl8+PeEpwbe2YyS5RXJ9vdn4hnKWMBf4WUJP9DQM=
--k8s.io/api v0.29.6/go.mod h1:ZuUPMhJV74DJXapldbg6upaHfiOjrBb+0ffUbBi1jaw=
--k8s.io/apiextensions-apiserver v0.29.6 h1:tUu1N6Zt9GT8KVcPF5aGDqfISz1mveM4yFh7eL5bxmE=
--k8s.io/apiextensions-apiserver v0.29.6/go.mod h1:iw1EbwZat08I219qrQKoFMHGo7J9KxPqMpVKxCbNbCs=
--k8s.io/apimachinery v0.29.6 h1:CLjJ5b0hWW7531n/njRE3rnusw3rhVGCFftPfnG54CI=
--k8s.io/apimachinery v0.29.6/go.mod h1:i3FJVwhvSp/6n8Fl4K97PJEP8C+MM+aoDq4+ZJBf70Y=
--k8s.io/apiserver v0.29.6 h1:JxgDbpgahOgqoDOf+zVl2mI+rQcHcLQnK6YhhtsjbNs=
--k8s.io/apiserver v0.29.6/go.mod h1:HrQwfPWxhwEa+n8/+5YwSF5yT2WXbeyFjqq6KEXHTX8=
--k8s.io/client-go v0.29.6 h1:5E2ebuB/p0F0THuQatyvhDvPL2SIeqwTPrtnrwKob/8=
--k8s.io/client-go v0.29.6/go.mod h1:jHZcrQqDplyv20v7eu+iFM4gTpglZSZoMVcKrh8sRGg=
--k8s.io/cloud-provider v0.29.6 h1:W6dafBlIRQlv8oDkK5UmuM0ZGw1lDCReh+BYtTBsBSI=
--k8s.io/cloud-provider v0.29.6/go.mod h1:+bjtIdnbIW+Ubs5xbnWvYURymR3tcrmxWPgQp4lwoN0=
-+k8s.io/api v0.29.12 h1:SsEEMtFupOAt3pAAtAz0PDu+54g3L5rwbSCi0xQzAJM=
-+k8s.io/api v0.29.12/go.mod h1:QFwqOP+7LNoAG1RI3vKAFxjKSLQTCamcPzAQ0Z/Yhuk=
-+k8s.io/apiextensions-apiserver v0.29.12 h1:xoQfYPwAzfcoH/MVuQiSPTWmFrmblvYbUMODpfYyyw8=
-+k8s.io/apiextensions-apiserver v0.29.12/go.mod h1:L1GHiWK2bkYrZOkFtChfkVpPUh9Ogr6gmShM28Yhqk0=
-+k8s.io/apimachinery v0.29.12 h1:k6OdfK9xaNANQvWkl1pSICJGLjB4jSuJ3gGP9hBKOhE=
-+k8s.io/apimachinery v0.29.12/go.mod h1:i3FJVwhvSp/6n8Fl4K97PJEP8C+MM+aoDq4+ZJBf70Y=
-+k8s.io/apiserver v0.29.12 h1:H/PuktlIJfqjUbJDP3OcPvCbROJPZfKuKtcolaoYSeQ=
-+k8s.io/apiserver v0.29.12/go.mod h1:CvF7GuvJbD3t7n66pj5N0tu8fvcD1yfP+gJo2q9rNow=
-+k8s.io/client-go v0.29.12 h1:PjwJXavmpAqOWBRy4U5V/g3JQBpclIHEn5dvfTfsY+w=
-+k8s.io/client-go v0.29.12/go.mod h1:hRHG6tAKxaLVKF5SlMqgXrbqPEoUcUpJGFFrC3jU69A=
-+k8s.io/cloud-provider v0.29.12 h1:iQqN57I8OHIUQMxtFqecIbWWxMu5XIgw+21O7hvbxbA=
-+k8s.io/cloud-provider v0.29.12/go.mod h1:UaRT0KTCnfG4m9aXfoFCHtPq8zRr9WwCgZ8SCrGXJ3Q=
- k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
- k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
--k8s.io/code-generator v0.29.6 h1:Z8T9VMR0mr7V5GG66c6GVAZrIiEy2uFoQwbeVeWLqPA=
--k8s.io/code-generator v0.29.6/go.mod h1:7TYnI0dYItL2cKuhhgPSuF3WED9uMdELgbVXFfn/joE=
--k8s.io/component-base v0.29.6 h1:XkVJI67FvBgNb/3kKqvaGKokxUrIR0RrksCPNI+JYCs=
--k8s.io/component-base v0.29.6/go.mod h1:kIahZm8aw9lV8Vw17LF89REmeBrv5+QEl3v7HsrmITY=
--k8s.io/component-helpers v0.29.6 h1:kG/tK0gXPXj6n3Oxn5Eul8nYzer3SejZI3ClwiWkreQ=
--k8s.io/component-helpers v0.29.6/go.mod h1:Ltb44cbXci9fy9rytWwYsu8vHfi4fjyQdSwk6UlCR4E=
--k8s.io/controller-manager v0.29.6 h1:bcn/i+8HncLlCbg1ccQxgn9PQ3YDeomDcwGF11a/Svo=
--k8s.io/controller-manager v0.29.6/go.mod h1:LJr7QA1iBNXnoiNb0+oGJv1jHlXcc+cxon5DG2KxzKQ=
--k8s.io/cri-api v0.29.6 h1:95kqUc2TzkxOiRBI9tSA+HY6JA/Zyg5jx6u541oJY9k=
--k8s.io/cri-api v0.29.6/go.mod h1:A6pdbjzML2xi9B0Clqn5qt1HJ3Ik12x2j+jv/TkqjRE=
--k8s.io/csi-translation-lib v0.29.6 h1:a1cs5yob5Nj85gZ7Vlr1IVt/W28Ju0MZS8rzh/K+M1s=
--k8s.io/csi-translation-lib v0.29.6/go.mod h1:SkPOKuBw94YX+DTcSSPeRXkG/sCQfjMnXHA3Q4JZNPQ=
--k8s.io/dynamic-resource-allocation v0.29.6 h1:1/Gx02V5+kdT4fq0wBKqXBEge8WEMtXIXlT3wU755WU=
--k8s.io/dynamic-resource-allocation v0.29.6/go.mod h1:BRaEJZtSil21NNzuhPrFVput+dD8Sr+xG77MsEuxRJw=
-+k8s.io/code-generator v0.29.12 h1:7Hp/lSY3YN0lAzWFZUjtA+fUpKTdolqsHWh9H0dXE7U=
-+k8s.io/code-generator v0.29.12/go.mod h1:7TYnI0dYItL2cKuhhgPSuF3WED9uMdELgbVXFfn/joE=
-+k8s.io/component-base v0.29.12 h1:NuFNzBSF3Iopih6VpvYmtjpdN1MLc9PcByl60fcJ0tQ=
-+k8s.io/component-base v0.29.12/go.mod h1:YHua3E5Lvnva6dXqGqiuRj8CxhBw7g6KgYV/dcS7LBU=
-+k8s.io/component-helpers v0.29.12 h1:uydbjeVATF+JXyRfFZYOAfdkh08DEspKfCecML1zZoQ=
-+k8s.io/component-helpers v0.29.12/go.mod h1:/i/HHykfB8j2tHxo9aR05J5a3zV6ssXKjwnxnjVmcaM=
-+k8s.io/controller-manager v0.29.12 h1:5zWWKsrtV5eUHUz+bYSuGfNXPCyXwrVPw1owGND4xK4=
-+k8s.io/controller-manager v0.29.12/go.mod h1:xW88/0xqFYP1s6auzVdyz1DzLXDK2qH9cSApNbcTk2M=
-+k8s.io/cri-api v0.29.12 h1:d2cCIssF9rCZVssWHrx1Rp5olSX2QI9E4VVAZALnyaU=
-+k8s.io/cri-api v0.29.12/go.mod h1:A6pdbjzML2xi9B0Clqn5qt1HJ3Ik12x2j+jv/TkqjRE=
-+k8s.io/csi-translation-lib v0.29.12 h1:+rHsyXxlp2gyc1W2WDMCHijnEW9bNwhUjveOta03ihk=
-+k8s.io/csi-translation-lib v0.29.12/go.mod h1:m7fQ0+Tv7uKOor+buva+nVyGgnPAfkO5uHs3qHrp0I0=
-+k8s.io/dynamic-resource-allocation v0.29.12 h1:jeJs4L8xJa7a/S/Uj0cNZEB5VSwUcUeb3o72tVrton4=
-+k8s.io/dynamic-resource-allocation v0.29.12/go.mod h1:q7RpZYiPp2UTHkVI90iplMJyywmvYKdOY7OC3Zpb6aA=
- k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 h1:pWEwq4Asjm4vjW7vcsmijwBhOr1/shsbSYiWXmNGlks=
- k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
- k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
- k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
- k8s.io/klog/v2 v2.110.1 h1:U/Af64HJf7FcwMcXyKm2RPM22WZzyR7OSpYj5tg3cL0=
- k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=
--k8s.io/kms v0.29.6 h1:Aa+4zZDqUaFacjNGzCHIC0ilqnEhA1qHqvyn9igirPQ=
--k8s.io/kms v0.29.6/go.mod h1:vWVImKkJd+1BQY4tBwdfSwjQBiLrnbNtHADcDEDQFtk=
-+k8s.io/kms v0.29.12 h1:Ao951Z3P2Ofjlk3mRfBCLxpM3gUxMoFYRgx60MktRLI=
-+k8s.io/kms v0.29.12/go.mod h1:vWVImKkJd+1BQY4tBwdfSwjQBiLrnbNtHADcDEDQFtk=
- k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 h1:aVUu9fTY98ivBPKR9Y5w/AuzbMm96cd3YHRTU83I780=
- k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00/go.mod h1:AsvuZPBlUDVuCdzJ87iajxtXuR9oktsTctW/R9wwouA=
--k8s.io/kube-scheduler v0.29.6 h1:E1J5JIpNx4N+0rCpTtsfl8PFqofcrXhEde+DgwmqhNU=
--k8s.io/kube-scheduler v0.29.6/go.mod h1:TPkLhhoWRwysksJ4LHhW9vbWyHGdDmKaoUD/fm6KLjc=
--k8s.io/kubectl v0.29.6 h1:hmkOMyH2uSUV16gIB3Qp2dv09fM2+PGEXz5SH1gwp7Y=
--k8s.io/kubectl v0.29.6/go.mod h1:IUpyXy2OCbIMuBMAisDHM9shh5/Nseij4w+HIt0aq6A=
--k8s.io/kubelet v0.29.6 h1:jXnnBNHK/KNNEJesmlIZmCvlYC3a5/e04BIS9VPM49M=
--k8s.io/kubelet v0.29.6/go.mod h1:kGEUqodVM120YTTQLSCTXzZP4XMFDp7qLf7iU3hrRE4=
--k8s.io/kubernetes v1.29.6 h1:jn8kA/oVOAWZOeoorx6xZ4d+KgGp+Evgi90x9bEI/DE=
--k8s.io/kubernetes v1.29.6/go.mod h1:28sDhcb87LX5z3GWAKYmLrhrifxi4W9bEWua4DRTIvk=
--k8s.io/legacy-cloud-providers v0.29.6 h1:WvmX09CTrwZd7VfTZviiM9dDDCXqSWDY5EErBb5TzuU=
--k8s.io/legacy-cloud-providers v0.29.6/go.mod h1:K/JsdfhAzfRWclCbLjQaz0CwloAMCDDF3/CWCeF1M7U=
--k8s.io/mount-utils v0.29.6 h1:44NDngKV5z/vt9YsYFVT0mPD68XjSfbqYfBEvUSwKb0=
--k8s.io/mount-utils v0.29.6/go.mod h1:SHUMR9n3b6tLgEmlyT36cL6fV6Sjwa5CJhc0guCXvb0=
-+k8s.io/kube-scheduler v0.29.12 h1:Dv9X4rWUBFn7qQ4596FjzW6yKhjaJdJ9TzxZ8gabgV4=
-+k8s.io/kube-scheduler v0.29.12/go.mod h1:SnWIG4khkzUg+QJV+mtEGPhVXXDlrgiGD2+fsgjXMjQ=
-+k8s.io/kubectl v0.29.12 h1:mn99dTeH2IPcm84W5Jdma7LtGcGOBUqyPjtwH3lDi6c=
-+k8s.io/kubectl v0.29.12/go.mod h1:XsF32H2R12cQ8d4EvxGdlPRIZ59NAiGUrc4LdAIfvcw=
-+k8s.io/kubelet v0.29.12 h1:D57P2U+z6EmIx8Lrq+pnxMEX2qFd4xzN/PMkTq2M1nU=
-+k8s.io/kubelet v0.29.12/go.mod h1:hVFz6Af4e/x1gn8fVoXcDMNK89lSNtWxauSp8DSdmRE=
+@@ -1152,8 +1154,8 @@ k8s.io/kubectl v0.29.0 h1:Oqi48gXjikDhrBF67AYuZRTcJV4lg2l42GmvsP7FmYI=
+ k8s.io/kubectl v0.29.0/go.mod h1:0jMjGWIcMIQzmUaMgAzhSELv5WtHo2a8pq67DtviAJs=
+ k8s.io/kubelet v0.29.0 h1:SX5hlznTBcGIrS1scaf8r8p6m3e475KMifwt9i12iOk=
+ k8s.io/kubelet v0.29.0/go.mod h1:kvKS2+Bz2tgDOG1S1q0TH2z1DasNuVF+8p6Aw7xvKkI=
+-k8s.io/kubernetes v1.29.0 h1:DOLN7g8+nnAYBi8JHoW0+/MCrZKDPIqAxzLCXDXd0cg=
+-k8s.io/kubernetes v1.29.0/go.mod h1:9kztbUQf9stVDcIYXx+BX3nuGCsAQDsuClkGMpPs3pA=
 +k8s.io/kubernetes v1.29.12 h1:w7vXdXGxWDV/Y0tl+H4XRWeORb/b2IfZfmEnJZ/tLRs=
 +k8s.io/kubernetes v1.29.12/go.mod h1:L6/pfKQZ6Tv2O8gyT4OxhGZp+nNsjV54xtNodRoup9k=
-+k8s.io/legacy-cloud-providers v0.29.12 h1:nz1RH0jnpljLfVh8GhexbubCpuDIQF3Wlc4PgFX2vdA=
-+k8s.io/legacy-cloud-providers v0.29.12/go.mod h1:yBS667WKpeCtfnmeX18lb18CIdl3SyEm2CjmB8etgMQ=
-+k8s.io/mount-utils v0.29.12 h1:AW+2+CmP6eVoGE2MAeB7l4jjrGpIXBoKhvBYJhqQt9s=
-+k8s.io/mount-utils v0.29.12/go.mod h1:SHUMR9n3b6tLgEmlyT36cL6fV6Sjwa5CJhc0guCXvb0=
- k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
- k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
- rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+ k8s.io/legacy-cloud-providers v0.29.0 h1:fjGV9OhqseUTp3R8xOm2TBoAxyuRTOS6B2zFTSJ80RE=
+ k8s.io/legacy-cloud-providers v0.29.0/go.mod h1:qR0/QoI19+G4zI71hSSZ1SEgiwdV358SU8u3jCwvK8c=
+ k8s.io/mount-utils v0.30.0-alpha.0 h1:hga3HePjAnYTofEKHmjvTZZzSCTV4auLQ9D172n1Gig=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/001-go-mod.patch
@@ -1,5 +1,5 @@
 diff --git i/cluster-autoscaler/go.mod w/cluster-autoscaler/go.mod
-index 777c3c9a8..9c18635f2 100644
+index 777c3c9a8..c5468b471 100644
 --- i/cluster-autoscaler/go.mod
 +++ w/cluster-autoscaler/go.mod
 @@ -1,6 +1,6 @@
@@ -19,7 +19,7 @@ index 777c3c9a8..9c18635f2 100644
  	github.com/jmespath/go-jmespath v0.4.0
  	github.com/json-iterator/go v1.1.12
  	github.com/onsi/ginkgo/v2 v2.13.0
-@@ -30,28 +30,28 @@ require (
+@@ -30,11 +30,11 @@ require (
  	github.com/prometheus/client_golang v1.16.0
  	github.com/satori/go.uuid v1.2.0
  	github.com/spf13/pflag v1.0.5
@@ -35,33 +35,6 @@ index 777c3c9a8..9c18635f2 100644
  	google.golang.org/api v0.126.0
  	google.golang.org/grpc v1.58.3
  	google.golang.org/protobuf v1.33.0
- 	gopkg.in/gcfg.v1 v1.2.3
- 	gopkg.in/yaml.v2 v2.4.0
--	k8s.io/api v0.29.3
--	k8s.io/apimachinery v0.29.3
--	k8s.io/apiserver v0.29.3
--	k8s.io/client-go v0.29.3
--	k8s.io/cloud-provider v0.29.3
-+	k8s.io/api v0.29.12
-+	k8s.io/apimachinery v0.29.12
-+	k8s.io/apiserver v0.29.12
-+	k8s.io/client-go v0.29.12
-+	k8s.io/cloud-provider v0.29.12
- 	k8s.io/cloud-provider-aws v1.27.0
--	k8s.io/code-generator v0.29.3
--	k8s.io/component-base v0.29.3
--	k8s.io/component-helpers v0.29.3
-+	k8s.io/code-generator v0.29.12
-+	k8s.io/component-base v0.29.12
-+	k8s.io/component-helpers v0.29.12
- 	k8s.io/klog/v2 v2.110.1
--	k8s.io/kubelet v0.29.3
--	k8s.io/kubernetes v1.29.0
-+	k8s.io/kubelet v0.29.12
-+	k8s.io/kubernetes v1.29.12
- 	k8s.io/legacy-cloud-providers v0.0.0
- 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
- 	sigs.k8s.io/cloud-provider-azure v1.28.0
 @@ -105,7 +105,7 @@ require (
  	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
  	github.com/godbus/dbus/v5 v5.1.0 // indirect
@@ -112,26 +85,8 @@ index 777c3c9a8..9c18635f2 100644
  	google.golang.org/appengine v1.6.7 // indirect
  	google.golang.org/genproto v0.0.0-20230803162519-f966b187b2e5 // indirect
  	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e // indirect
-@@ -186,13 +187,13 @@ require (
- 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
- 	gopkg.in/warnings.v0 v0.1.2 // indirect
- 	gopkg.in/yaml.v3 v3.0.1 // indirect
--	k8s.io/apiextensions-apiserver v0.29.3 // indirect
--	k8s.io/controller-manager v0.29.3 // indirect
--	k8s.io/cri-api v0.29.3 // indirect
-+	k8s.io/apiextensions-apiserver v0.29.12 // indirect
-+	k8s.io/controller-manager v0.29.12 // indirect
-+	k8s.io/cri-api v0.29.12 // indirect
- 	k8s.io/csi-translation-lib v0.27.0 // indirect
- 	k8s.io/dynamic-resource-allocation v0.0.0 // indirect
- 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
--	k8s.io/kms v0.29.3 // indirect
-+	k8s.io/kms v0.29.12 // indirect
- 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
- 	k8s.io/kube-scheduler v0.0.0 // indirect
- 	k8s.io/kubectl v0.28.0 // indirect
 diff --git i/cluster-autoscaler/go.sum w/cluster-autoscaler/go.sum
-index 4c5e460af..ba4112fc1 100644
+index 4c5e460af..107d84e28 100644
 --- i/cluster-autoscaler/go.sum
 +++ w/cluster-autoscaler/go.sum
 @@ -271,8 +271,9 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
@@ -285,14 +240,3 @@ index 4c5e460af..ba4112fc1 100644
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-@@ -1152,8 +1154,8 @@ k8s.io/kubectl v0.29.0 h1:Oqi48gXjikDhrBF67AYuZRTcJV4lg2l42GmvsP7FmYI=
- k8s.io/kubectl v0.29.0/go.mod h1:0jMjGWIcMIQzmUaMgAzhSELv5WtHo2a8pq67DtviAJs=
- k8s.io/kubelet v0.29.0 h1:SX5hlznTBcGIrS1scaf8r8p6m3e475KMifwt9i12iOk=
- k8s.io/kubelet v0.29.0/go.mod h1:kvKS2+Bz2tgDOG1S1q0TH2z1DasNuVF+8p6Aw7xvKkI=
--k8s.io/kubernetes v1.29.0 h1:DOLN7g8+nnAYBi8JHoW0+/MCrZKDPIqAxzLCXDXd0cg=
--k8s.io/kubernetes v1.29.0/go.mod h1:9kztbUQf9stVDcIYXx+BX3nuGCsAQDsuClkGMpPs3pA=
-+k8s.io/kubernetes v1.29.12 h1:w7vXdXGxWDV/Y0tl+H4XRWeORb/b2IfZfmEnJZ/tLRs=
-+k8s.io/kubernetes v1.29.12/go.mod h1:L6/pfKQZ6Tv2O8gyT4OxhGZp+nNsjV54xtNodRoup9k=
- k8s.io/legacy-cloud-providers v0.29.0 h1:fjGV9OhqseUTp3R8xOm2TBoAxyuRTOS6B2zFTSJ80RE=
- k8s.io/legacy-cloud-providers v0.29.0/go.mod h1:qR0/QoI19+G4zI71hSSZ1SEgiwdV358SU8u3jCwvK8c=
- k8s.io/mount-utils v0.30.0-alpha.0 h1:hga3HePjAnYTofEKHmjvTZZzSCTV4auLQ9D172n1Gig=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.29/README.md
@@ -7,14 +7,14 @@ To create this patch run commands:
 ```shell
 cd cluster-autoscaler
 go mod edit -go 1.23
-go get github.com/golang-jwt/jwt/v4@v4.5.1
+go get github.com/golang-jwt/jwt/v4@v4.5.2
 go get github.com/opencontainers/runc@v1.1.14
 go get golang.org/x/crypto@v0.31.0
-go get golang.org/x/net@v0.33.0
+go get golang.org/x/net@v0.36.0
 go get github.com/Azure/azure-sdk-for-go/sdk/azidentity@v1.6.0
-go get k8s.io/kubernetes@v1.29.12
-go get k8s.io/kubelet@v0.29.12
-#replase all in k8s.io  v0.29.6 -> v0.29.12
+go get k8s.io/kubernetes@v1.29.14
+go get k8s.io/kubelet@v0.29.14
+#replase all in k8s.io  v0.29.* -> v0.29.14
 go mod tidy
 git diff > patches/001-go_mod.patch
 #git apply patches/001-go_mod.patch


### PR DESCRIPTION
## Description
pr caused regression so we roll back some of the changes.
https://github.com/deckhouse/deckhouse/pull/12024
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
1.68
1.69

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix 
summary: partial rollback of changes in images cluster-autoscaler
impact: 
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
