### PR TITLE
[bashible] Add cgroup version label on node step bashible

### DIFF
--- a/candi/bashible/common-steps/all/092_set_cgroup_type.sh.tpl
+++ b/candi/bashible/common-steps/all/092_set_cgroup_type.sh.tpl
@@ -1,0 +1,42 @@
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if eq .runType "Normal" }}
+# If there is no kubelet.conf than node is not bootstrapped and there is nothing to do
+kubeconfig="/etc/kubernetes/kubelet.conf"
+if [ ! -f "$kubeconfig" ]; then
+  exit 0
+fi
+
+node=${D8_NODE_HOSTNAME}
+cgroup="$(stat -fc %T /sys/fs/cgroup)" || {
+  bb-log-error "failed to get cgroup version from node $node"
+  exit 1
+}
+
+if [[ "$cgroup" != "cgroup2fs" && "$cgroup" != "tmpfs" ]]; then
+  cgroup="unknown"
+fi
+
+max_attempts=5
+until bb-kubectl --kubeconfig $kubeconfig label --overwrite=true node "$node" node.deckhouse.io/cgroup="$cgroup"; do
+  attempt=$(( attempt + 1 ))
+  if [ "$attempt" -gt "$max_attempts" ]; then
+    bb-log-error "failed to label node $node after $max_attempts attempts"
+    exit 1
+  fi
+  echo "Waiting for label node $node (attempt $attempt of $max_attempts)..."
+  sleep 5
+done
+{{- end  }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
this mr add step label node from cgroup version on current node 
```
stat -fc %T /sys/fs/cgroup/
For cgroup v2, the output is cgroup2fs.
For cgroup v1, the output is tmpfs.

kubectl describe no master | grep cgroup
   node.deckhouse.io/cgroup=cgroup2fs

curl deckhouse.d8-system.svc.cluster.local:8080/metrics/hooks | grep cgroup
# HELP d8_telemetry_node_cgroup d8_telemetry_node_cgroup
# TYPE d8_telemetry_node_cgroup gauge
d8_telemetry_node_cgroup{hook="dev/hooks/cgroup_metrics.py",module="flant-integration",type="cgroup2fs"} 1
d8_telemetry_node_cgroup{hook="dev/hooks/cgroup_metrics.py",module="flant-integration",type="tmpfs"} 0
d8_telemetry_node_cgroup{hook="dev/hooks/cgroup_metrics.py",module="flant-integration",type="unknown"} 0
```
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this partly resolve this [mr](https://fox.flant.com/deckhouse/flant-integration/-/merge_requests/31)

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: add cgroup version step bashible label on node
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
