### PR TITLE
[dhctl] Add waiting for become ready first master node

### DIFF
--- a/dhctl/pkg/kubernetes/actions/entity/node.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node.go
@@ -206,7 +206,7 @@ func UpdateNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeG
 }
 
 func WaitForSingleNodeBecomeReady(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string) error {
-	return retry.NewLoop(fmt.Sprintf("Waiting for  Node %s to become Ready", nodeName), 100, 20*time.Second).
+	return retry.NewLoop(fmt.Sprintf("Waiting for Node %s to become Ready", nodeName), 100, 20*time.Second).
 		RunContext(ctx, func() error {
 			node, err := kubeCl.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 			if err != nil {

--- a/dhctl/pkg/operations/bootstrap/checks.go
+++ b/dhctl/pkg/operations/bootstrap/checks.go
@@ -63,7 +63,7 @@ Please check hostname.`, uuidInCluster, config.UUID)
 }
 
 func WaitFirstMasterNodeBecomeReady(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Waiting while first master node become ready", 45, 3*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop("Waiting for first master node become ready", 45, 3*time.Second).RunContext(ctx, func() error {
 		var nodeName string
 		err := retry.NewSilentLoop("Get master node name", 45, 3*time.Second).RunContext(ctx, func() error {
 			nodes, err := kubeCl.CoreV1().Nodes().List(ctx, metav1.ListOptions{})

--- a/dhctl/pkg/operations/bootstrap/checks.go
+++ b/dhctl/pkg/operations/bootstrap/checks.go
@@ -62,7 +62,7 @@ Please check hostname.`, uuidInCluster, config.UUID)
 	})
 }
 
-func WaitFirstMasterNodeBecomeReady(ctx context.Context, kubeCl *client.KubernetesClient) error {
+func WaitForFirstMasterNodeBecomeReady(ctx context.Context, kubeCl *client.KubernetesClient) error {
 	return retry.NewLoop("Waiting for first master node become ready", 45, 3*time.Second).RunContext(ctx, func() error {
 		var nodeName string
 		err := retry.NewSilentLoop("Get master node name", 45, 3*time.Second).RunContext(ctx, func() error {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -427,7 +427,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		return err
 	}
 
-	err = WaitFirstMasterNodeBecomeReady(ctx, kubeCl)
+	err = WaitForFirstMasterNodeBecomeReady(ctx, kubeCl)
 	if err != nil {
 		return err
 	}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -427,6 +427,11 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		return err
 	}
 
+	err = WaitFirstMasterNodeBecomeReady(ctx, kubeCl)
+	if err != nil {
+		return err
+	}
+
 	if metaConfig.ClusterType == config.CloudClusterType {
 		if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.InstallAdditionalMastersAndStaticNodes, true, stateCache, nil); err != nil {
 			return err


### PR DESCRIPTION
## Description

Waiting for become ready first master node

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
If we will add another cloud permanent nodes, we will have error for connection to bashible api server because first masteer node is not ready and bashible api server pod is in the Pending status

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Add waiting for become ready first master node
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
