### PR TITLE
[dhctl] validate provider-specific InstanceClass

### DIFF
--- a/dhctl/pkg/config/validation.go
+++ b/dhctl/pkg/config/validation.go
@@ -53,6 +53,19 @@ var cloudProviderToProviderKind = map[string]string{
 	"Dynamix":     "DynamixClusterConfiguration",
 }
 
+var cloudProviderToProviderInstanceClassKind = map[string]string{
+	"OpenStack":   "OpenStackInstanceClass",
+	"AWS":         "AWSInstanceClass",
+	"GCP":         "GCPInstanceClass",
+	"Yandex":      "YandexInstanceClass",
+	"vSphere":     "VsphereInstanceClass",
+	"Azure":       "AzureInstanceClass",
+	"VCD":         "VCDInstanceClass",
+	"Zvirt":       "ZvirtInstanceClass",
+	"Huaweicloud": "HuaweiCloudInstanceClass",
+	"Dynamix":     "DynamixInstanceClass",
+}
+
 var cloudProviderSpecificClusterPrefix = map[string]interface{}{
 	"OpenStack":   regexp.MustCompile(".+"),
 	"AWS":         regexp.MustCompile(".+"),
@@ -542,6 +555,109 @@ func ValidateClusterSettingsChanges(
 			})
 			continue
 		}
+	}
+
+	return errs.ErrorOrNil()
+}
+
+// ValidateProviderSpecificInstanceClass parses and validates cluster InstanceClass
+// It requires one doc with kind in
+// [
+// "OpenStackInstanceClass",
+// "AWSInstanceClass",
+// "GCPInstanceClass",
+// "YandexInstanceClass",
+// "VsphereInstanceClass",
+// "AzureInstanceClass",
+// "VCDInstanceClass",
+// "ZvirtInstanceClass",
+// "HuaweiCloudInstanceClass",
+// "DynamixInstanceClass",
+// ]
+func ValidateProviderSpecificInstanceClass(
+	providerSpecificInstanceClass string,
+	clusterConfig ClusterConfig,
+	schemaStore *SchemaStore,
+	opts ...ValidateOption,
+) error {
+	options := applyOptions(opts...)
+	if !options.commanderMode {
+		panic("ValidateProviderSpecificInstanceClass operation currently supported only in commander mode")
+	}
+
+	if clusterConfig.ClusterType == "Static" {
+		return nil
+	}
+
+	docs := input.YAMLSplitRegexp.Split(strings.TrimSpace(providerSpecificInstanceClass), -1)
+	errs := &ValidationError{}
+	var clusterConfigDocsCount int
+
+	providerKind, ok := cloudProviderToProviderInstanceClassKind[clusterConfig.Cloud.Provider]
+	if !ok {
+		errs.Append(ErrKindValidationFailed, Error{
+			Messages: []string{fmt.Sprintf(
+				"unknown cloud provider '%s', check if 'InstanceClass' is valid",
+				clusterConfig.Cloud.Provider,
+			)},
+		})
+	}
+
+	for i, doc := range docs {
+		if doc == "" {
+			continue
+		}
+
+		docData := []byte(doc)
+
+		obj := unstructured.Unstructured{}
+		err := yaml.Unmarshal(docData, &obj)
+		if err != nil {
+			errs.Append(ErrKindInvalidYAML, Error{
+				Index:    ptr.To(i),
+				Messages: []string{fmt.Errorf("unmarshal: %w", err).Error()},
+			})
+			continue
+		}
+
+		gvk := obj.GroupVersionKind()
+		index := SchemaIndex{
+			Kind:    gvk.Kind,
+			Version: gvk.GroupVersion().String(),
+		}
+
+		var errMessages []string
+
+		err = schemaStore.ValidateWithIndex(&index, &docData, opts...)
+		if err != nil {
+			errMessages = append(errMessages, err.Error())
+		}
+
+		if providerKind != "" {
+			switch index.Kind {
+			case providerKind:
+				clusterConfigDocsCount++
+			default:
+				errMessages = append(errMessages, fmt.Errorf("unknown kind, expected %q", providerKind).Error())
+			}
+		}
+
+		if len(errMessages) != 0 {
+			errs.Append(ErrKindValidationFailed, Error{
+				Index:    ptr.To(i),
+				Group:    gvk.Group,
+				Version:  gvk.Version,
+				Kind:     gvk.Kind,
+				Name:     obj.GetName(),
+				Messages: errMessages,
+			})
+		}
+	}
+
+	if providerKind != "" && clusterConfigDocsCount > 1 {
+		errs.Append(ErrKindValidationFailed, Error{
+			Messages: []string{fmt.Errorf("no more than one %q required", providerKind).Error()},
+		})
 	}
 
 	return errs.ErrorOrNil()


### PR DESCRIPTION
## Description
This PR adds schema validation of InstanceClass resource. 

## Why do we need it, and what problem does it solve?
User can pass invalid InstanceClass in config.yml and cluster will not be fully bootstrapped. 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: validate provider-specific InstanceClass
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
