### PR TITLE
[cloud-provider-openstack] fix terraform bastion default root_disk_size

### DIFF
--- a/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
@@ -62,7 +62,7 @@ locals {
   zone               = lookup(local.bastion_instance, "zone", null) != null ? local.bastion_instance.zone : local.actual_zones[0]
   metadata_tags      = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.instance_class, "additionalTags", {}))
   config_drive       = false
-  root_disk_size     = lookup(local.instance_class, "rootDiskSize", "50")
+  root_disk_size     = lookup(local.instance_class, "rootDiskSize", "30")
   volume_type        = lookup(local.bastion_instance, "volumeType", null)
 }
 

--- a/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
@@ -62,7 +62,7 @@ locals {
   zone               = lookup(local.bastion_instance, "zone", null) != null ? local.bastion_instance.zone : local.actual_zones[0]
   metadata_tags      = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.instance_class, "additionalTags", {}))
   config_drive       = false
-  root_disk_size     = lookup(local.instance_class, "rootDiskSize", "")
+  root_disk_size     = lookup(local.instance_class, "rootDiskSize", "50")
   volume_type        = lookup(local.bastion_instance, "volumeType", null)
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
bastion's root_disk_size doesn't have a default value though it is not a required value

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: fix terraform bastion default root_disk_size
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
