### PR TITLE
Add base images from external base images repo

### DIFF
--- a/.werf/defines/parse-base-images-map.tmpl
+++ b/.werf/defines/parse-base-images-map.tmpl
@@ -1,11 +1,18 @@
 {{- define "parse_base_images_map" }}
-
-# Base Images
-  {{- $_ := set . "Images" (.Files.Get "candi/image_versions.yml" | fromYaml) }}
-    {{- range $k, $v := .Images }}
-      {{ $baseImagePath := (printf "%s%s" $.Images.REGISTRY_PATH (trimSuffix "/" $v)) }}
-      {{- if ne $k "REGISTRY_PATH" }}
-        {{- $_ := set $.Images $k $baseImagePath }}
-      {{- end }}
+  {{- $image_versions := .Files.Get "candi/image_versions.yml" | fromYaml }}
+  {{- $base_images := .Files.Get "candi/base_images.yml" | fromYaml }}
+    {{- $_ := set . "Images" (mustMerge $image_versions $base_images) }}
+  {{- range $k, $v := .Images }}
+    {{ $baseImagePath := (printf "%s%s" $.Images.REGISTRY_PATH (trimSuffix "/" $v)) }}
+    {{- if ne $k "REGISTRY_PATH" }}
+      {{- $_ := set $.Images $k $baseImagePath }}
     {{- end }}
+  {{- end }}
+  # base images artifacts
+  {{- range $k, $v := .Images }}
+---
+image: {{ $k }}
+from: {{ $v }}
+final: false
+  {{- end }}
 {{- end }}

--- a/.werf/defines/parse-base-images-map.tmpl
+++ b/.werf/defines/parse-base-images-map.tmpl
@@ -7,12 +7,15 @@
       {{- $_ := set $imageVersions $k $baseImagePath }}
     {{- end }}
   {{- end }}
+  {{- $_ := unset $imageVersions "REGISTRY_PATH" }}
+
   {{- range $k, $v := $baseImages }}
     {{ $baseImagePath := (printf "%s@%s" $baseImages.REGISTRY_PATH (trimSuffix "/" $v)) }}
     {{- if ne $k "REGISTRY_PATH" }}
       {{- $_ := set $baseImages $k $baseImagePath }}
     {{- end }}
   {{- end }}
+  {{- $_ := unset $baseImages "REGISTRY_PATH" }}
 
   {{- $_ := set . "Images" (mustMerge $imageVersions $baseImages) }}
   # base images artifacts

--- a/.werf/defines/parse-base-images-map.tmpl
+++ b/.werf/defines/parse-base-images-map.tmpl
@@ -1,0 +1,11 @@
+{{- define "parse_base_images_map" }}
+
+# Base Images
+  {{- $_ := set . "Images" (.Files.Get "candi/image_versions.yml" | fromYaml) }}
+    {{- range $k, $v := .Images }}
+      {{ $baseImagePath := (printf "%s%s" $.Images.REGISTRY_PATH (trimSuffix "/" $v)) }}
+      {{- if ne $k "REGISTRY_PATH" }}
+        {{- $_ := set $.Images $k $baseImagePath }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/.werf/defines/parse-base-images-map.tmpl
+++ b/.werf/defines/parse-base-images-map.tmpl
@@ -1,13 +1,20 @@
 {{- define "parse_base_images_map" }}
-  {{- $image_versions := .Files.Get "candi/image_versions.yml" | fromYaml }}
-  {{- $base_images := .Files.Get "candi/base_images.yml" | fromYaml }}
-    {{- $_ := set . "Images" (mustMerge $image_versions $base_images) }}
-  {{- range $k, $v := .Images }}
-    {{ $baseImagePath := (printf "%s%s" $.Images.REGISTRY_PATH (trimSuffix "/" $v)) }}
+  {{- $imageVersions := .Files.Get "candi/image_versions.yml" | fromYaml }}
+  {{- $baseImages := .Files.Get "candi/base_images.yml" | fromYaml }}
+  {{- range $k, $v := $imageVersions }}
+    {{ $baseImagePath := (printf "%s%s" $imageVersions.REGISTRY_PATH (trimSuffix "/" $v)) }}
     {{- if ne $k "REGISTRY_PATH" }}
-      {{- $_ := set $.Images $k $baseImagePath }}
+      {{- $_ := set $imageVersions $k $baseImagePath }}
     {{- end }}
   {{- end }}
+  {{- range $k, $v := $baseImages }}
+    {{ $baseImagePath := (printf "%s@%s" $baseImages.REGISTRY_PATH (trimSuffix "/" $v)) }}
+    {{- if ne $k "REGISTRY_PATH" }}
+      {{- $_ := set $baseImages $k $baseImagePath }}
+    {{- end }}
+  {{- end }}
+
+  {{- $_ := set . "Images" (mustMerge $imageVersions $baseImages) }}
   # base images artifacts
   {{- range $k, $v := .Images }}
 ---

--- a/Makefile
+++ b/Makefile
@@ -330,6 +330,11 @@ update-lib-helm: ## Update lib-helm.
 	##~ Options: version=MAJOR.MINOR.PATCH
 	cd helm_lib/ && yq -i '.dependencies[0].version = "$(version)"' Chart.yaml && helm dependency update && tar -xf charts/deckhouse_lib_helm-*.tgz -C charts/ && rm charts/deckhouse_lib_helm-*.tgz && git add Chart.yaml Chart.lock charts/*
 
+.PHONY: update-base-images-versions
+update-base-images-versions:
+	##~ Options: version=vMAJOR.MINOR.PATCH
+	cd candi && curl --fail -sSLO https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$(version)/base_images.yml
+
 ##@ Build
 .PHONY: build
 set-build-envs:

--- a/candi/README.md
+++ b/candi/README.md
@@ -1,0 +1,8 @@
+# base_images.yml
+ATTENTION! DO NOT CHANGE FILE `base_images.yml` DIRECTLY!
+
+To update `base_images.yml` in the Deckhouse repo, use the next command (in the repo root):
+
+```bash
+make version=DESIRED_VERSION update-base-images-versions
+```

--- a/candi/base_images.yml
+++ b/candi/base_images.yml
@@ -1,5 +1,5 @@
 # REGISTRY_PATH is a special key which is concatenated with other base images
-REGISTRY_PATH: $(echo ${WERF_REPO} | sed "s|-write||")
+REGISTRY_PATH: registry.deckhouse.io/base_images
 BASE_DISTROLESS: "base/distroless@sha256:f2ac3320ce677484d7aef4608f99ddf0055d8907cc3509f8cccc8513f314c31a" # fromImage: builder/scratch
 BASE_NGINX_STATIC: "base/nginx-static@sha256:28a844d4ff777dc704d3808bdd1240108315f4d1ed1668e762627b9c4ddc8d66" # fromImage: base/distroless
 BASE_PYTHON: "base/python@sha256:432f19eaeb5035ea38e3fbc721576e6802c679fd0fb7a8e6d441fdb36944c180" # fromImage: base/distroless
@@ -11,6 +11,7 @@ BUILDER_GOLANG_BULLSEYE: "builder/golang-bullseye@sha256:7f2838a3779bb9759accba1
 BUILDER_NODE_ALPINE: "builder/node-alpine@sha256:f09f957ee8e960c7afee93d7a30f20116e76660c0408d35109ee9a9fa2a4d5b0" # from: node:23.10.0-alpine3.20
 BUILDER_SCRATCH: "builder/scratch@sha256:10b5855ae3e20ecc2ba6eb3d7f8365ee2facc98a62c9e4840927ad4074bd2317" # from: registry.werf.io/werf/scratch
 TOOLS_BASH: "tools/bash@sha256:892cd63bafb70b529377833c374009db5e9759c0aa72b165aff4ba52b59a45c6" # fromImage: builder/scratch
+TOOLS_COSIGN: "tools/cosign@sha256:d62c8deb048d9d02e5ea3b9f1efa9a940625c746f3c568a283c346c844a8acf8" # fromImage: builder/scratch
 TOOLS_GREP: "tools/grep@sha256:48e485161d6cec13d5283d03e69e2d1ff9e1c6146d040dc3bf623d856b62a636" # fromImage: builder/scratch
 TOOLS_JQ: "tools/jq@sha256:71aac8b711bef4dbef462d6309e283812358b9920301ad3de23a5734a18a23f2" # fromImage: builder/scratch
 TOOLS_LESS: "tools/less@sha256:259d88c1a732e7d3fc8d067ea0324684e1fe73a3bbb3eb7e2a9d88212a4ee2a0" # fromImage: builder/scratch

--- a/candi/base_images.yml
+++ b/candi/base_images.yml
@@ -1,19 +1,19 @@
 # REGISTRY_PATH is a special key which is concatenated with other base images
 REGISTRY_PATH: registry.deckhouse.io/base_images
-BASE_DISTROLESS: "base/distroless@sha256:f2ac3320ce677484d7aef4608f99ddf0055d8907cc3509f8cccc8513f314c31a" # fromImage: builder/scratch
-BASE_NGINX_STATIC: "base/nginx-static@sha256:28a844d4ff777dc704d3808bdd1240108315f4d1ed1668e762627b9c4ddc8d66" # fromImage: base/distroless
-BASE_PYTHON: "base/python@sha256:432f19eaeb5035ea38e3fbc721576e6802c679fd0fb7a8e6d441fdb36944c180" # fromImage: base/distroless
-BUILDER_ALPINE: "builder/alpine@sha256:92adb9e8a387c645ba4eeedb08f9a6de0583c5d1d496bf9c9b3a89fe963a6a06" # from: alpine:3.20.6
-BUILDER_ALT: "builder/alt@sha256:6fe06774a942e293e28b85cf3307e0f6e79a1593352c9c5ca97a6cbefdce0a55" # from: registry.altlinux.org/p11/alt:20241211
-BUILDER_GOLANG_ALPINE: "builder/golang-alpine@sha256:482aab8cb49614acb14ce9397861b02d05cc222d893d689abd205c9bd2c17b46" # from: golang:1.24.2-alpine3.20
-BUILDER_GOLANG_BOOKWORM: "builder/golang-bookworm@sha256:3755a67e7d3f16995b1615694a2aae7a95618a1ff9603b23f347764dfa0242b2" # from: golang:1.24.2-bookworm
-BUILDER_GOLANG_BULLSEYE: "builder/golang-bullseye@sha256:7f2838a3779bb9759accba1cbea7ea7aa086cc67ec763718004febb47948570c" # from: golang:1.24.2-bullseye
-BUILDER_NODE_ALPINE: "builder/node-alpine@sha256:f09f957ee8e960c7afee93d7a30f20116e76660c0408d35109ee9a9fa2a4d5b0" # from: node:23.10.0-alpine3.20
-BUILDER_SCRATCH: "builder/scratch@sha256:10b5855ae3e20ecc2ba6eb3d7f8365ee2facc98a62c9e4840927ad4074bd2317" # from: registry.werf.io/werf/scratch
-TOOLS_BASH: "tools/bash@sha256:892cd63bafb70b529377833c374009db5e9759c0aa72b165aff4ba52b59a45c6" # fromImage: builder/scratch
-TOOLS_COSIGN: "tools/cosign@sha256:d62c8deb048d9d02e5ea3b9f1efa9a940625c746f3c568a283c346c844a8acf8" # fromImage: builder/scratch
-TOOLS_GREP: "tools/grep@sha256:48e485161d6cec13d5283d03e69e2d1ff9e1c6146d040dc3bf623d856b62a636" # fromImage: builder/scratch
-TOOLS_JQ: "tools/jq@sha256:71aac8b711bef4dbef462d6309e283812358b9920301ad3de23a5734a18a23f2" # fromImage: builder/scratch
-TOOLS_LESS: "tools/less@sha256:259d88c1a732e7d3fc8d067ea0324684e1fe73a3bbb3eb7e2a9d88212a4ee2a0" # fromImage: builder/scratch
-TOOLS_VIM: "tools/vim@sha256:66db26b1475c389df02b8a8f9b98ff6993b2a2b51085f88a0cf618b915086de6" # fromImage: builder/scratch
-TOOLS_YQ4: "tools/yq4@sha256:35911ea155806ec3b29c5d6eec90184d3d836bb42037f9865fb5949ab7a4cd6c" # fromImage: builder/scratch
+base/distroless: "sha256:f2ac3320ce677484d7aef4608f99ddf0055d8907cc3509f8cccc8513f314c31a" # fromImage: builder/scratch
+base/nginx-static: "sha256:28a844d4ff777dc704d3808bdd1240108315f4d1ed1668e762627b9c4ddc8d66" # fromImage: base/distroless
+base/python: "sha256:432f19eaeb5035ea38e3fbc721576e6802c679fd0fb7a8e6d441fdb36944c180" # fromImage: base/distroless
+builder/alpine: "sha256:92adb9e8a387c645ba4eeedb08f9a6de0583c5d1d496bf9c9b3a89fe963a6a06" # from: alpine:3.20.6
+builder/alt: "sha256:6fe06774a942e293e28b85cf3307e0f6e79a1593352c9c5ca97a6cbefdce0a55" # from: registry.altlinux.org/p11/alt:20241211
+builder/golang-alpine: "sha256:482aab8cb49614acb14ce9397861b02d05cc222d893d689abd205c9bd2c17b46" # from: golang:1.24.2-alpine3.20
+builder/golang-bookworm: "sha256:3755a67e7d3f16995b1615694a2aae7a95618a1ff9603b23f347764dfa0242b2" # from: golang:1.24.2-bookworm
+builder/golang-bullseye: "sha256:7f2838a3779bb9759accba1cbea7ea7aa086cc67ec763718004febb47948570c" # from: golang:1.24.2-bullseye
+builder/node-alpine: "sha256:f09f957ee8e960c7afee93d7a30f20116e76660c0408d35109ee9a9fa2a4d5b0" # from: node:23.10.0-alpine3.20
+builder/scratch: "sha256:10b5855ae3e20ecc2ba6eb3d7f8365ee2facc98a62c9e4840927ad4074bd2317" # from: registry.werf.io/werf/scratch
+tools/bash: "sha256:892cd63bafb70b529377833c374009db5e9759c0aa72b165aff4ba52b59a45c6" # fromImage: builder/scratch
+tools/cosign: "sha256:d62c8deb048d9d02e5ea3b9f1efa9a940625c746f3c568a283c346c844a8acf8" # fromImage: builder/scratch
+tools/grep: "sha256:48e485161d6cec13d5283d03e69e2d1ff9e1c6146d040dc3bf623d856b62a636" # fromImage: builder/scratch
+tools/jq: "sha256:71aac8b711bef4dbef462d6309e283812358b9920301ad3de23a5734a18a23f2" # fromImage: builder/scratch
+tools/less: "sha256:259d88c1a732e7d3fc8d067ea0324684e1fe73a3bbb3eb7e2a9d88212a4ee2a0" # fromImage: builder/scratch
+tools/vim: "sha256:66db26b1475c389df02b8a8f9b98ff6993b2a2b51085f88a0cf618b915086de6" # fromImage: builder/scratch
+tools/yq4: "sha256:35911ea155806ec3b29c5d6eec90184d3d836bb42037f9865fb5949ab7a4cd6c" # fromImage: builder/scratch

--- a/candi/base_images.yml
+++ b/candi/base_images.yml
@@ -1,0 +1,18 @@
+# REGISTRY_PATH is a special key which is concatenated with other base images
+REGISTRY_PATH: $(echo ${WERF_REPO} | sed "s|-write||")
+BASE_DISTROLESS: "base/distroless@sha256:f2ac3320ce677484d7aef4608f99ddf0055d8907cc3509f8cccc8513f314c31a" # fromImage: builder/scratch
+BASE_NGINX_STATIC: "base/nginx-static@sha256:28a844d4ff777dc704d3808bdd1240108315f4d1ed1668e762627b9c4ddc8d66" # fromImage: base/distroless
+BASE_PYTHON: "base/python@sha256:432f19eaeb5035ea38e3fbc721576e6802c679fd0fb7a8e6d441fdb36944c180" # fromImage: base/distroless
+BUILDER_ALPINE: "builder/alpine@sha256:92adb9e8a387c645ba4eeedb08f9a6de0583c5d1d496bf9c9b3a89fe963a6a06" # from: alpine:3.20.6
+BUILDER_ALT: "builder/alt@sha256:6fe06774a942e293e28b85cf3307e0f6e79a1593352c9c5ca97a6cbefdce0a55" # from: registry.altlinux.org/p11/alt:20241211
+BUILDER_GOLANG_ALPINE: "builder/golang-alpine@sha256:482aab8cb49614acb14ce9397861b02d05cc222d893d689abd205c9bd2c17b46" # from: golang:1.24.2-alpine3.20
+BUILDER_GOLANG_BOOKWORM: "builder/golang-bookworm@sha256:3755a67e7d3f16995b1615694a2aae7a95618a1ff9603b23f347764dfa0242b2" # from: golang:1.24.2-bookworm
+BUILDER_GOLANG_BULLSEYE: "builder/golang-bullseye@sha256:7f2838a3779bb9759accba1cbea7ea7aa086cc67ec763718004febb47948570c" # from: golang:1.24.2-bullseye
+BUILDER_NODE_ALPINE: "builder/node-alpine@sha256:f09f957ee8e960c7afee93d7a30f20116e76660c0408d35109ee9a9fa2a4d5b0" # from: node:23.10.0-alpine3.20
+BUILDER_SCRATCH: "builder/scratch@sha256:10b5855ae3e20ecc2ba6eb3d7f8365ee2facc98a62c9e4840927ad4074bd2317" # from: registry.werf.io/werf/scratch
+TOOLS_BASH: "tools/bash@sha256:892cd63bafb70b529377833c374009db5e9759c0aa72b165aff4ba52b59a45c6" # fromImage: builder/scratch
+TOOLS_GREP: "tools/grep@sha256:48e485161d6cec13d5283d03e69e2d1ff9e1c6146d040dc3bf623d856b62a636" # fromImage: builder/scratch
+TOOLS_JQ: "tools/jq@sha256:71aac8b711bef4dbef462d6309e283812358b9920301ad3de23a5734a18a23f2" # fromImage: builder/scratch
+TOOLS_LESS: "tools/less@sha256:259d88c1a732e7d3fc8d067ea0324684e1fe73a3bbb3eb7e2a9d88212a4ee2a0" # fromImage: builder/scratch
+TOOLS_VIM: "tools/vim@sha256:66db26b1475c389df02b8a8f9b98ff6993b2a2b51085f88a0cf618b915086de6" # fromImage: builder/scratch
+TOOLS_YQ4: "tools/yq4@sha256:35911ea155806ec3b29c5d6eec90184d3d836bb42037f9865fb5949ab7a4cd6c" # fromImage: builder/scratch

--- a/werf.yaml
+++ b/werf.yaml
@@ -40,13 +40,7 @@ cleanup:
 
 ---
 # Base Images
-{{- $_ := set . "Images" (.Files.Get "candi/image_versions.yml" | fromYaml) }}
-  {{- range $k, $v := .Images }}
-    {{ $baseImagePath := (printf "%s%s" $.Images.REGISTRY_PATH (trimSuffix "/" $v)) }}
-    {{- if ne $k "REGISTRY_PATH" }}
-      {{- $_ := set $.Images $k $baseImagePath }}
-    {{- end }}
-  {{- end }}
+{{- include "parse_base_images_map" . }}
 ---
 # Version Map
 {{- $versionMap := dict }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR is the first step of the move from images_versions.yml to use external base images library.
This PR adds images from external base_images.yml file and adds artifacts for every base image.

Example of base_images.yml:
```yaml
REGISTRY_PATH: registry.deckhouse.io/base_images
base/distroless: "sha256:f2ac3320ce677484d7aef4608f99ddf0055d8907cc3509f8cccc8513f314c31a" # fromImage: builder/scratch
base/nginx-static: "sha256:28a844d4ff777dc704d3808bdd1240108315f4d1ed1668e762627b9c4ddc8d66" # fromImage: base/distroless
base/python: "sha256:432f19eaeb5035ea38e3fbc721576e6802c679fd0fb7a8e6d441fdb36944c180" # fromImage: base/distroless
builder/alpine: "sha256:92adb9e8a387c645ba4eeedb08f9a6de0583c5d1d496bf9c9b3a89fe963a6a06" # from: alpine:3.20.6
builder/alt: "sha256:6fe06774a942e293e28b85cf3307e0f6e79a1593352c9c5ca97a6cbefdce0a55" # from: registry.altlinux.org/p11/alt:20241211
builder/golang-alpine: "sha256:482aab8cb49614acb14ce9397861b02d05cc222d893d689abd205c9bd2c17b46" # from: golang:1.24.2-alpine3.20
builder/golang-bookworm: "sha256:3755a67e7d3f16995b1615694a2aae7a95618a1ff9603b23f347764dfa0242b2" # from: golang:1.24.2-bookworm
builder/golang-bullseye: "sha256:7f2838a3779bb9759accba1cbea7ea7aa086cc67ec763718004febb47948570c" # from: golang:1.24.2-bullseye
builder/node-alpine: "sha256:f09f957ee8e960c7afee93d7a30f20116e76660c0408d35109ee9a9fa2a4d5b0" # from: node:23.10.0-alpine3.20
builder/scratch: "sha256:10b5855ae3e20ecc2ba6eb3d7f8365ee2facc98a62c9e4840927ad4074bd2317" # from: registry.werf.io/werf/scratch
tools/bash: "sha256:892cd63bafb70b529377833c374009db5e9759c0aa72b165aff4ba52b59a45c6" # fromImage: builder/scratch
tools/cosign: "sha256:d62c8deb048d9d02e5ea3b9f1efa9a940625c746f3c568a283c346c844a8acf8" # fromImage: builder/scratch
tools/grep: "sha256:48e485161d6cec13d5283d03e69e2d1ff9e1c6146d040dc3bf623d856b62a636" # fromImage: builder/scratch
tools/jq: "sha256:71aac8b711bef4dbef462d6309e283812358b9920301ad3de23a5734a18a23f2" # fromImage: builder/scratch
tools/less: "sha256:259d88c1a732e7d3fc8d067ea0324684e1fe73a3bbb3eb7e2a9d88212a4ee2a0" # fromImage: builder/scratch
tools/vim: "sha256:66db26b1475c389df02b8a8f9b98ff6993b2a2b51085f88a0cf618b915086de6" # fromImage: builder/scratch
tools/yq4: "sha256:35911ea155806ec3b29c5d6eec90184d3d836bb42037f9865fb5949ab7a4cd6c" # fromImage: builder/scratch
```

Generated artifacts:
```yaml
  # base images artifacts
---
image: BASE_ALPINE
from: registry.deckhouse.io/base_images/alpine:3.20.3@sha256:41628df7c9b935d248f64542634e7a843f9bc7f2252d7f878e77f7b79a947466
final: false
---
image: BASE_ALT_DEV
from: registry.deckhouse.io/base_images/dev-alt:p10@sha256:76e6e163fa982f03468166203488b569e6d9fc10855d6a259c662706436cdcad
final: false
---
image: BASE_ALT_P11
from: registry.deckhouse.io/base_images/alt:p11@sha256:b630220d83798057e1c67fe6f712a49e9c3abb377f0bd7183bba0ba541fc4081
final: false
---
image: BASE_GOLANG_23_ALPINE
from: registry.deckhouse.io/base_images/golang:1.23.6-alpine3.20@sha256:3058c63e0e2532881949c4186414baa24a0f9a8f9349b1853daa49be816f42e9
final: false
---
image: BASE_GOLANG_23_BOOKWORM
from: registry.deckhouse.io/base_images/golang:1.23.6-bookworm@sha256:ca569d98545ab5a090449da29d637fb3f5a273d3a002554af328be9873777cef
final: false
---
image: BASE_GOLANG_23_BULLSEYE
from: registry.deckhouse.io/base_images/golang:1.23.6-bullseye@sha256:fad5b33791a319ba1c910a03a33575ea34fc8e142695a64be9a1a228e74af11e
final: false
---
image: BASE_JEKYLL
from: registry.deckhouse.io/base_images/jekyll:4.3.4-alpine@sha256:bc24cdaea4fa9ea14068440d53dcab6881018d77526e7b9a0574f6ff03f0945f
final: false
---
image: BASE_NODE_16_ALPINE
from: registry.deckhouse.io/base_images/node:16.13.0-alpine3.14@sha256:5277c7d171e02ee76417bb290ef488aa80e4e64572119eec0cb9fffbcffb8f6a
final: false
---
image: BASE_NODE_20_ALPINE
from: registry.deckhouse.io/base_images/node:20.11.0-alpine3.18@sha256:bd2eb17dcdc3541d4986bebcfc997a24c499358827899b1029af3601d4c4569d
final: false
---
image: BASE_NODE_23_ALPINE
from: registry.deckhouse.io/base_images/node:23.6.1-alpine3.20@sha256:afe80e0dd357fc69595bc54a813dd992248fa3063448e2a1fa77ff47534ff51d
final: false
---
image: BASE_SCRATCH
from: registry.deckhouse.io/base_images/scratch@sha256:653ae76965c98c8cd1c8c9ff7725316d2983986f896655b30e0f44d2f8b2dd7e
final: false
---
image: BASE_UBUNTU
from: registry.deckhouse.io/base_images/ubuntu:jammy-20221130@sha256:c14c3b1242536729ce5227ff833144977b4e378723858fb73a4cf40ea6daaf6a
final: false
---
image: base/distroless
from: registry.deckhouse.io/base_images@sha256:f2ac3320ce677484d7aef4608f99ddf0055d8907cc3509f8cccc8513f314c31a
final: false
---
image: base/nginx-static
from: registry.deckhouse.io/base_images@sha256:28a844d4ff777dc704d3808bdd1240108315f4d1ed1668e762627b9c4ddc8d66
final: false
---
image: base/python
from: registry.deckhouse.io/base_images@sha256:432f19eaeb5035ea38e3fbc721576e6802c679fd0fb7a8e6d441fdb36944c180
final: false
---
image: builder/alpine
from: registry.deckhouse.io/base_images@sha256:92adb9e8a387c645ba4eeedb08f9a6de0583c5d1d496bf9c9b3a89fe963a6a06
final: false
---
image: builder/alt
from: registry.deckhouse.io/base_images@sha256:6fe06774a942e293e28b85cf3307e0f6e79a1593352c9c5ca97a6cbefdce0a55
final: false
---
image: builder/golang-alpine
from: registry.deckhouse.io/base_images@sha256:482aab8cb49614acb14ce9397861b02d05cc222d893d689abd205c9bd2c17b46
final: false
---
image: builder/golang-bookworm
from: registry.deckhouse.io/base_images@sha256:3755a67e7d3f16995b1615694a2aae7a95618a1ff9603b23f347764dfa0242b2
final: false
---
image: builder/golang-bullseye
from: registry.deckhouse.io/base_images@sha256:7f2838a3779bb9759accba1cbea7ea7aa086cc67ec763718004febb47948570c
final: false
---
image: builder/node-alpine
from: registry.deckhouse.io/base_images@sha256:f09f957ee8e960c7afee93d7a30f20116e76660c0408d35109ee9a9fa2a4d5b0
final: false
---
image: builder/scratch
from: registry.deckhouse.io/base_images@sha256:10b5855ae3e20ecc2ba6eb3d7f8365ee2facc98a62c9e4840927ad4074bd2317
final: false
---
image: tools/bash
from: registry.deckhouse.io/base_images@sha256:892cd63bafb70b529377833c374009db5e9759c0aa72b165aff4ba52b59a45c6
final: false
---
image: tools/cosign
from: registry.deckhouse.io/base_images@sha256:d62c8deb048d9d02e5ea3b9f1efa9a940625c746f3c568a283c346c844a8acf8
final: false
---
image: tools/grep
from: registry.deckhouse.io/base_images@sha256:48e485161d6cec13d5283d03e69e2d1ff9e1c6146d040dc3bf623d856b62a636
final: false
---
image: tools/jq
from: registry.deckhouse.io/base_images@sha256:71aac8b711bef4dbef462d6309e283812358b9920301ad3de23a5734a18a23f2
final: false
---
image: tools/less
from: registry.deckhouse.io/base_images@sha256:259d88c1a732e7d3fc8d067ea0324684e1fe73a3bbb3eb7e2a9d88212a4ee2a0
final: false
---
image: tools/vim
from: registry.deckhouse.io/base_images@sha256:66db26b1475c389df02b8a8f9b98ff6993b2a2b51085f88a0cf618b915086de6
final: false
---
image: tools/yq4
from: registry.deckhouse.io/base_images@sha256:35911ea155806ec3b29c5d6eec90184d3d836bb42037f9865fb5949ab7a4cd6c
final: false
---
```
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
After this PR we will be able to use external base images in the Deckhouse build. 
External base images repo will be moved forward separately.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Add base images from external base images repo
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
