### PR TITLE
[docs] Add redirect to d8-cli from tuf repo page

### DIFF
--- a/docs/site/.werf/nginx-dev.conf
+++ b/docs/site/.werf/nginx-dev.conf
@@ -85,6 +85,10 @@ http {
             try_files /$lang/sitemap.xml =404;
         }
 
+        location /downloads/deckhouse-cli-trdl {
+            return 302 /products/kubernetes-platform/documentation/v1/deckhouse-cli/;
+        }
+
         location ~* ^/downloads/deckhouse-cli-trdl/(.*)  {
             rewrite ^/downloads/deckhouse-cli-trdl/(.*)$ /$1  break;
 

--- a/docs/site/.werf/nginx.conf
+++ b/docs/site/.werf/nginx.conf
@@ -66,6 +66,10 @@ http {
             return 200;
         }
 
+        location /downloads/deckhouse-cli-trdl {
+            return 302 /products/kubernetes-platform/documentation/v1/deckhouse-cli/;
+        }
+
         location ~* ^/products/kubernetes-platform/((gs|guides|modules)/(.*))$  {
             try_files /$lang/$1 /$lang/$1/index.html /$lang/$1/ $1 $1/index.html $1/ =404;
         }


### PR DESCRIPTION
## Description

This pull request includes changes to the Nginx configuration files to add a new redirect for the `deckhouse-cli-trdl` endpoint. The most important changes are as follows:

### Nginx Configuration Updates

* [`docs/site/.werf/nginx-dev.conf`](diffhunk://#diff-782094ed4212f4e56e86e3119bdc6b2cec16c66914304440d2e927ea006b8bfcR88-R91): Added a new location block to redirect `/downloads/deckhouse-cli-trdl` to `/products/kubernetes-platform/documentation/v1/deckhouse-cli/`.
* [`docs/site/.werf/nginx.conf`](diffhunk://#diff-637da0fa421ec0ecce777fd22d8da392873e8dc1599c2c7527a54bec65fe834bR69-R72): Added a similar location block to redirect `/downloads/deckhouse-cli-trdl` to `/products/kubernetes-platform/documentation/v1/deckhouse-cli/`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Add redirect to d8-cli from tuf repo page.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
