### PR TITLE
[node-local-dns] fix dns-stale-connections-cleaner security context and file permissions

### DIFF
--- a/ee/be/modules/350-node-local-dns/images/stale-dns-connections-cleaner/go.sum
+++ b/ee/be/modules/350-node-local-dns/images/stale-dns-connections-cleaner/go.sum
@@ -3,8 +3,6 @@ github.com/DataDog/gostackparse v0.7.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckhouse/deckhouse/pkg/log v0.0.0-20241203083636-caa103ce9ee1 h1:PO8aMJJnmSyeRHsNLv+6zGsWoSOZSRol7TZdEWL4MQc=
-github.com/deckhouse/deckhouse/pkg/log v0.0.0-20241203083636-caa103ce9ee1/go.mod h1:Mk5HRzkc5pIcDIZ2JJ6DPuuqnwhXVkb3you8M8Mg+4w=
 github.com/deckhouse/deckhouse/pkg/log v0.0.0-20250318101108-490c52ef4de1 h1:6JniPgyKww+JqUb84dLab8/uCIUqPJ8GgCH9dXUCmAI=
 github.com/deckhouse/deckhouse/pkg/log v0.0.0-20250318101108-490c52ef4de1/go.mod h1:pbAxTSDcPmwyl3wwKDcEB3qdxHnRxqTV+J0K+sha8bw=
 github.com/emicklei/go-restful/v3 v3.11.3 h1:yagOQz/38xJmcNeZJtrUcKjkHRltIaIFXKWeG1SkWGE=

--- a/ee/be/modules/350-node-local-dns/images/stale-dns-connections-cleaner/main.go
+++ b/ee/be/modules/350-node-local-dns/images/stale-dns-connections-cleaner/main.go
@@ -33,7 +33,7 @@ const (
 	nldNS            string = "kube-system"
 	nldLabelSelector string = "app=node-local-dns"
 	nldDstPort       uint16 = 53
-	scanInterval            = 30 * time.Second
+	scanInterval            = 10 * time.Second
 	listenAddress           = "127.0.0.1:8001"
 	// netlink const
 	familyIPv4          = syscall.AF_INET
@@ -66,7 +66,7 @@ func main() {
 	log.Infof("This is due to the UDP socket remaining active in the application pods with the destination IP address of the old node-local-dns pod, which has already been deleted.")
 	log.Infof("To prevent this problem, the following actions are taken:")
 	log.Infof("- Obtain the name and PodCidr of the node where the application is running.")
-	log.Infof("- Then every 30 seconds:")
+	log.Infof("- Then every 10 seconds:")
 	log.Infof("  - Retrieve the current IP address of the node-local-dns pod.")
 	log.Infof("  - Retrieve all UDP sockets on the node and search for those with dst_port 53 and dsp_ip belonging to PodCidr, but not equal to the current IP address of the node-local-dns pod.")
 	log.Infof("  - If such sockets are found, delete them.")

--- a/ee/be/modules/350-node-local-dns/images/stale-dns-connections-cleaner/werf.inc.yaml
+++ b/ee/be/modules/350-node-local-dns/images/stale-dns-connections-cleaner/werf.inc.yaml
@@ -38,11 +38,7 @@ shell:
   - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
   - cd /src
   - go build -ldflags="-s -w" -o stale-dns-connections-cleaner .
-  - chmod +x /src/stale-dns-connections-cleaner
-  - setcap    cap_net_admin=+ep /src/stale-dns-connections-cleaner
-  - setcap -v cap_net_admin=+ep /src/stale-dns-connections-cleaner
-  - chmod -R 0700 /src/stale-dns-connections-cleaner
-  - chown -R 64535:64535 /src/stale-dns-connections-cleaner
+  - chmod 0700 /src/stale-dns-connections-cleaner
 ---
 image: {{ $.ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
@@ -51,6 +47,8 @@ import:
   add: /src/stale-dns-connections-cleaner
   to: /stale-dns-connections-cleaner
   before: install
+  owner: root
+  group: root
 imageSpec:
   config:
     entrypoint: ["/stale-dns-connections-cleaner"]

--- a/ee/be/modules/350-node-local-dns/templates/stale-dns-connections-cleaner/daemonset.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/stale-dns-connections-cleaner/daemonset.yaml
@@ -46,7 +46,8 @@ spec:
     spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      # could be run as not root, but, in the first place, a way of setting file capabilities for binaries in distroless images must be developed
+      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Previously, stale-dns-connections-cleaner was updated to run as non-root user and its binary was updated to use file capabilities. In result the capabilities weren't set in the final image because they get deleted when the file is copied from one image to another:
```
# touch /tmp/1
# setcap "cap_sys_chroot=ep cap_sys_admin=ep cap_mknod=ep" /tmp/1
# getcap /tmp/1
/tmp/1 cap_sys_chroot,cap_sys_admin,cap_mknod=ep
# cp /tmp/1 /tmp/2
# getcap /tmp/2
```
Thus, this pr reverts previous changes, making stale-dns-connections-cleaner run as root.
Also, the scan interval has been decreased from 30 to 10 seconds to make it react faster.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Without root permissions and file capabilities set, stale-dns-connections-cleaner doesn't have enough permissions for deleting stale dns sockets. It can affect ingress-nginx controllers running in the cluster when node-local-dns/kube-dns pods are created.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

In latest 1.68.x patch release almost all system components are restarted, including kube-dns/node-local-dns, and it can trigger an issue with ingress-nginx controller unable to reach DNS service.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-local-dns
type: fix
summary: Stale-dns-connection-cleaner file permissions and security context are fixed.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
