### PR TITLE
[cloud-provider-huaweicloud] Add the `--cluster-name` CLI flag to the `CCM`

### DIFF
--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/002-fix-cluster-name-handling.patch
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/002-fix-cluster-name-handling.patch
@@ -1,0 +1,122 @@
+Subject: [PATCH] Fix incorrect handling of the `--cluster-name` CLI flag
+---
+Index: pkg/cloudprovider/huaweicloud/huaweicloud.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/cloudprovider/huaweicloud/huaweicloud.go b/pkg/cloudprovider/huaweicloud/huaweicloud.go
+--- a/pkg/cloudprovider/huaweicloud/huaweicloud.go	(revision a2521439748697680ba5ab25e693b1125a456b8f)
++++ b/pkg/cloudprovider/huaweicloud/huaweicloud.go	(date 1744916473972)
+@@ -43,7 +43,6 @@
+ 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+ 	"k8s.io/client-go/tools/record"
+ 	"k8s.io/cloud-provider"
+-	"k8s.io/cloud-provider/options"
+ 	servicehelper "k8s.io/cloud-provider/service/helpers"
+ 	"k8s.io/klog/v2"
+ 	"sigs.k8s.io/cloud-provider-huaweicloud/pkg/cloudprovider/huaweicloud/wrapper"
+@@ -113,8 +112,8 @@
+ type ELBAlgorithm string
+
+ type Basic struct {
+-	cloudControllerManagerOpts *options.CloudControllerManagerOptions
+-	cloudConfig                *config.CloudConfig
++	clusterName string
++	cloudConfig *config.CloudConfig
+
+ 	loadbalancerOpts *config.LoadBalancerOptions
+ 	networkingOpts   *config.NetworkingOptions
+@@ -133,6 +132,10 @@
+ 	mutexLock *mutexkv.MutexKV
+ }
+
++func (b *Basic) SetClusterName(clusterName string) {
++	b.clusterName = clusterName
++}
++
+ func (b Basic) listPodsBySelector(ctx context.Context, namespace string, selectors map[string]string) (*v1.PodList, error) {
+ 	labelSelector := labels.SelectorFromSet(selectors)
+ 	opts := metav1.ListOptions{LabelSelector: labelSelector.String()}
+@@ -318,14 +321,8 @@
+ 	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: corev1.New(kubeClient.RESTClient()).Events("")})
+ 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-provider-huaweicloud"})
+
+-	ccmOpts, err := options.NewCloudControllerManagerOptions()
+-	if err != nil {
+-		return nil, fmt.Errorf("failed to init CloudControllerManagerOptions: %s", err)
+-	}
+-
+ 	basic := Basic{
+-		cloudControllerManagerOpts: ccmOpts,
+-		cloudConfig:                cloudConfig,
++		cloudConfig: cloudConfig,
+
+ 		loadbalancerOpts: &elbCfg.LoadBalancerOpts,
+ 		networkingOpts:   &elbCfg.NetworkingOpts,
+@@ -775,7 +772,6 @@
+ 		stopChannel: make(chan struct{}, 1),
+ 	}
+
+-	clusterName := h.cloudControllerManagerOpts.KubeCloudShared.ClusterName
+ 	id, err := os.Hostname()
+ 	if err != nil {
+ 		return fmt.Errorf("failed to elect leader in listener EndpointSlice : %s", err)
+@@ -793,7 +789,7 @@
+ 			}
+
+ 			if isDelete {
+-				err := h.EnsureLoadBalancerDeleted(context.TODO(), clusterName, service)
++				err := h.EnsureLoadBalancerDeleted(context.TODO(), h.clusterName, service)
+ 				if err != nil {
+ 					klog.Errorf("failed to delete loadBalancer, service: %s/%s, error: %s", service.Namespace, service.Name, err)
+ 					eventMsg := fmt.Sprintf("failed to clean listener for service: %s/%s, error: %s", service.Namespace, service.Name, err)
+@@ -814,9 +810,9 @@
+
+ 			h.sendEvent("UpdateLoadBalancer", "Endpoints changed, start updating", service)
+
+-			err = h.UpdateLoadBalancer(context.TODO(), clusterName, service, nodes)
++			err = h.UpdateLoadBalancer(context.TODO(), h.clusterName, service, nodes)
+ 			if err == nil {
+-				lbStatus, exists, err := h.GetLoadBalancer(context.TODO(), clusterName, service)
++				lbStatus, exists, err := h.GetLoadBalancer(context.TODO(), h.clusterName, service)
+ 				if err != nil || !exists {
+ 					klog.Errorf("failed to get loadBalancer, service: %s/%s, exists: %v, error: %s", service.Namespace, service.Name, exists, err)
+ 					return
+@@ -827,7 +823,7 @@
+
+ 			// An error occurred while updating.
+ 			if common.IsNotFound(err) || strings.Contains(err.Error(), "error, can not find a listener matching") {
+-				lbStatus, err := h.EnsureLoadBalancer(context.TODO(), clusterName, service, nodes)
++				lbStatus, err := h.EnsureLoadBalancer(context.TODO(), h.clusterName, service, nodes)
+ 				if err != nil {
+ 					klog.Errorf("failed to ensure loadBalancer, service: %s/%s, error: %s", service.Namespace, service.Name, err)
+ 					return
+Index: cmd/cloud-controller-manager/cloud-controller-manager.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cmd/cloud-controller-manager/cloud-controller-manager.go b/cmd/cloud-controller-manager/cloud-controller-manager.go
+--- a/cmd/cloud-controller-manager/cloud-controller-manager.go	(revision a2521439748697680ba5ab25e693b1125a456b8f)
++++ b/cmd/cloud-controller-manager/cloud-controller-manager.go	(date 1744917762432)
+@@ -40,7 +40,7 @@
+ 	"k8s.io/klog/v2"
+ 	_ "k8s.io/kubernetes/pkg/features" // add the kubernetes feature gates
+
+-	_ "sigs.k8s.io/cloud-provider-huaweicloud/pkg/cloudprovider/huaweicloud"
++	"sigs.k8s.io/cloud-provider-huaweicloud/pkg/cloudprovider/huaweicloud"
+ )
+
+ func main() {
+@@ -90,6 +90,10 @@
+ 			klog.Fatalf("no ClusterID found.  A ClusterID is required for the cloud provider to function properly.  This check can be bypassed by setting the allow-untagged-cloud option")
+ 		}
+ 	}
++
++	cloudProvider := cloud.(*huaweicloud.CloudProvider)
++	cloudProvider.SetClusterName(config.ComponentConfig.KubeCloudShared.ClusterName)
++
+ 	return cloud
+ }
+

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/README.md
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/README.md
@@ -5,3 +5,7 @@ Prevent sending empty shared bandwidth identifier in HTTP requests to create EIP
 ## 001-go-mod.patch
 
 Update dependencies
+
+### 002-fix-cluster-name-handling.patch
+
+For each `Service`, two load balancers were provisioned: one with the correct cluster name and another with the default cluster name. It is incorrect to have two load balancers for the same service. This patch fixes the issue by ensuring that only one load balancer is created with the correct cluster name.

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/deployment.yaml
@@ -77,6 +77,7 @@ spec:
           image: {{ include "helm_lib_module_image" (list . "cloudControllerManager") }}
           args:
           - --leader-elect=true
+          - --cluster-name={{ .Values.global.clusterConfiguration.cloud.prefix }}
           - --cluster-cidr={{ .Values.global.discovery.podSubnet }}
           - --allocate-node-cidrs=true
           - --configure-cloud-routes=true


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

- Add the `--cluster-name` CLI flag to the `cloud-controller-manager`
- Add a patch to `cloud-controller-manager` to fix the handling of the `--cluster-name` CLI flag

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The `cloud-controller-manager` uses the `--cluster-name` CLI flag to generate load balancer names. If this flag is not set, separate clusters may generate identical load balancer names.

For each `Service`, two load balancers were provisioned: one with the correct cluster name and another with the default cluster name. It is incorrect to have two load balancers for the same service. The patch to `cloud-controller-manager` fixes the issue by ensuring that only one load balancer is created with the correct cluster name.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-huaweicloud
type: fix
summary: Add the `--cluster-name` CLI flag to the `cloud-controller-manager`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
