### PR TITLE
[doсs] Fix d8 install commands

### DIFF
--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -73,7 +73,7 @@
 1. {% if page.lang == 'ru' -%}Распакуйте архив{% else %}Extract the archive{% endif %}:
 
    ```bash
-   tar -xvf "d8-{{ site.data.supported_versions.d8.d8CliVersion }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz" "{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}/d8"
+   tar -xvf "d8-{{ site.data.supported_versions.d8.d8CliVersion }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz" "{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}/bin/d8"
    ```
 
 1. {% if page.lang == 'ru' -%}
@@ -83,7 +83,7 @@ Move the file `d8` to the directory listed in the `PATH` system environment vari
 {%- endif %}:
 
    ```bash
-   sudo mv "{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}/d8" /usr/local/bin/
+   sudo mv "{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}/bin/d8" /usr/local/bin/
    ```
 
    > {%- if page.lang == 'ru' -%}

--- a/docs/site/_includes/d8-cli-install/content.liquid
+++ b/docs/site/_includes/d8-cli-install/content.liquid
@@ -73,7 +73,7 @@
 1. {% if page.lang == 'ru' -%}Распакуйте архив{% else %}Extract the archive{% endif %}:
 
    ```bash
-   tar -xvf "d8-{{ site.data.supported_versions.d8.d8CliVersion }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz" "{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}/d8"
+   tar -xvf "d8-{{ site.data.supported_versions.d8.d8CliVersion }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz" "{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}/bin/d8"
    ```
 
 1. {% if page.lang == 'ru' -%}
@@ -83,7 +83,7 @@ Move the file `d8` to the directory listed in the `PATH` system environment vari
 {%- endif %}:
 
    ```bash
-   sudo mv "{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}/d8" /usr/local/bin/
+   sudo mv "{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}/bin/d8" /usr/local/bin/
    ```
 
    > {%- if page.lang == 'ru' -%}


### PR DESCRIPTION
## Description

This pull request includes updates to the CLI installation documentation to correct the file paths used in the extraction and moving commands. The changes ensure that the correct directory structure is referenced.

Changes to CLI installation documentation:

* Updated the extraction command to include the `bin` directory in the target path in `docs/documentation/_includes/d8-cli-install/content.liquid`.
* Updated the move command to include the `bin` directory in the source path in `docs/documentation/_includes/d8-cli-install/content.liquid`.
* Updated the extraction command to include the `bin` directory in the target path in `docs/site/_includes/d8-cli-install/content.liquid`.
* Updated the move command to include the `bin` directory in the source path in `docs/site/_includes/d8-cli-install/content.liquid`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fix d8 install commands.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
