### PR TITLE
[dhctl] fix preflightcheck localhost

### DIFF
--- a/candi/bashible/preflight/check_localhost.sh.tpl
+++ b/candi/bashible/preflight/check_localhost.sh.tpl
@@ -14,7 +14,7 @@
 # limitations under the License.
 */}}
 
-if ! getent ahosts localhost; then
+if ! getent ahosts localhost | grep -q 127.0.0.1; then
   echo "localhost domain is not resolved. You should add a line '127.0.0.1 localhost' to this node's /etc/hosts file."
   exit 1
 fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Make preflight check localhost more accurate.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Current localhost check can give false positives in some cases:

1. If `/etc/hosts` doesn't contain "127.0.0.1 localhost" and system dns resolve `localhost` to another IP.
2. If `localhost` resolve to only IPv6 addr.

For example:
```console
[root@dev-master-0 ~]# cat /etc/hosts
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
[root@dev-master-0 ~]# getent ahosts localhost; echo $?
::1             STREAM localhost
::1             DGRAM
::1             RAW
0
```

that will broke bootstrap:

```log
│ ┌ Waiting for Kubernetes API to become Ready
│ │ ️⛱️️ Attempt #1 of 45 |
│ │ 	Waiting for Kubernetes API to become Ready failed, next attempt will be in 5s"
│ │ 	Error: kubernetes API is not Ready: Get "http://localhost:22322/version": read tcp [::1]:36912->[::1]:22322: read: connection reset   ↵
│ │ by peer - error from a previous attempt: read tcp [::1]:36902->[::1]:22322: read: connection reset by peer
│ │
│ │ ️⛱️️ Attempt #2 of 45 |
│ │ 	Waiting for Kubernetes API to become Ready failed, next attempt will be in 5s"
│ │ 	Error: kubernetes API is not Ready: Get "http://localhost:22322/version": read tcp [::1]:42972->[::1]:22322: read: connection reset   ↵
│ │ by peer - error from a previous attempt: read tcp [::1]:42970->[::1]:22322: read: connection reset by peer
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessary.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Make preflight check more accurate.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
