### PR TITLE
[deckhouse] delete deckhouse epslices

### DIFF
--- a/global-hooks/migrate/delete_deckhouse_epslices.go
+++ b/global-hooks/migrate/delete_deckhouse_epslices.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package hooks
 
 import (

--- a/global-hooks/migrate/delete_deckhouse_epslices.go
+++ b/global-hooks/migrate/delete_deckhouse_epslices.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"context"
 	"fmt"
+
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"

--- a/global-hooks/migrate/delete_deckhouse_epslices.go
+++ b/global-hooks/migrate/delete_deckhouse_epslices.go
@@ -1,0 +1,23 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 10},
+}, dependency.WithExternalDependencies(removeDeckhouseEpslices))
+
+func removeDeckhouseEpslices(_ *go_hook.HookInput, dc dependency.Container) error {
+	kubeClient, err := dc.GetK8sClient()
+	if err != nil {
+		return fmt.Errorf("get kubernetes client: %v", err)
+	}
+
+	return kubeClient.DiscoveryV1().EndpointSlices("d8-system").Delete(context.TODO(), "deckhouse", metav1.DeleteOptions{})
+}

--- a/modules/002-deckhouse/hooks/migrate/delete_deckhouse_epslices.go
+++ b/modules/002-deckhouse/hooks/migrate/delete_deckhouse_epslices.go
@@ -17,25 +17,16 @@ limitations under the License.
 package migrate
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/deckhouse/deckhouse/go_lib/dependency"
 )
 
+// TODO(ipaqsa): Can be removed after 1.70
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnAfterHelm: &go_hook.OrderedConfig{Order: 10},
-}, dependency.WithExternalDependencies(removeDeckhouseEpslices))
+}, removeDeckhouseEpslices)
 
-func removeDeckhouseEpslices(_ *go_hook.HookInput, dc dependency.Container) error {
-	kubeClient, err := dc.GetK8sClient()
-	if err != nil {
-		return fmt.Errorf("get kubernetes client: %v", err)
-	}
-
-	return kubeClient.DiscoveryV1().EndpointSlices("d8-system").Delete(context.TODO(), "deckhouse", metav1.DeleteOptions{})
+func removeDeckhouseEpslices(input *go_hook.HookInput) error {
+	input.PatchCollector.Delete("discovery.k8s.io/v1", "endpointslices", "d8-system", "deckhouse")
+	return nil
 }

--- a/modules/002-deckhouse/hooks/migrate/delete_deckhouse_epslices.go
+++ b/modules/002-deckhouse/hooks/migrate/delete_deckhouse_epslices.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package hooks
+package migrate
 
 import (
 	"context"
@@ -27,7 +27,7 @@ import (
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnStartup: &go_hook.OrderedConfig{Order: 10},
+	OnAfterHelm: &go_hook.OrderedConfig{Order: 10},
 }, dependency.WithExternalDependencies(removeDeckhouseEpslices))
 
 func removeDeckhouseEpslices(_ *go_hook.HookInput, dc dependency.Container) error {

--- a/modules/002-deckhouse/hooks/migrate/delete_deckhouse_epslices.go
+++ b/modules/002-deckhouse/hooks/migrate/delete_deckhouse_epslices.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{


### PR DESCRIPTION
## Description
It deletes useless deckhouse epslices.

## Why do we need it, and what problem does it solve?
Deckhouse epslices was created manually before 1.69, now it is created by kubernetes. So we need to delete the stale resource.

## Why do we need it in the patch release (if we do)?
It can cause connectivity problem.

Before:
```
root@dev-master-0:~# k get endpointslices.discovery.k8s.io -n d8-system
NAME                                      ADDRESSTYPE   PORTS            ENDPOINTS         AGE
conversion-webhook-handler-7hsmn          IPv4          9681             10.111.0.201      411d
deckhouse                                 IPv4          4222,4223,9652   192.168.199.201   411d
deckhouse-leader-4ccfq                    IPv4          4222,4223        192.168.199.201   42d
deckhouse-tools-6gng5                     IPv4          8080             10.111.2.18       223d
```

After:
```
root@dev-master-0:~# k get endpointslices.discovery.k8s.io -n d8-system
NAME                                      ADDRESSTYPE   PORTS       ENDPOINTS         AGE
conversion-webhook-handler-7hsmn          IPv4          9681        10.111.0.22       411d
deckhouse-leader-4ccfq                    IPv4          4222,4223   192.168.199.201   42d
deckhouse-tools-6gng5                     IPv4          8080        10.111.2.18       223d
deckhouse-tools-dex-authenticator-kgrzz   IPv4          8443        10.111.2.59       83d
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix 
summary: Delete deckhouse epslices.
impact_level: low
```
