### PR TITLE
[operator-trivy][docs] Add information about manual rescan resources

### DIFF
--- a/ee/modules/500-operator-trivy/docs/FAQ.md
+++ b/ee/modules/500-operator-trivy/docs/FAQ.md
@@ -30,3 +30,20 @@ kubectl get clustercompliancereports.aquasecurity.github.io cis -ojson |
 ```
 
 {% endraw %}
+
+## How to manually restart resource scanning, how to understand when a resource will be rescanned?
+
+The module rescans resources every 24 hours, according to the following algorithm:
+
+A `VulnerabilityReport` object is created in the namespace with each scanned resource.  
+This object contains the annotation `trivy-operator.aquasecurity.github.io/report-ttl`, which specifies the report lifetime (default is `24h`).  
+After this time, the operator deletes the object, which triggers a rescan of the resource.  
+
+To force a rescan of the resource, you need to overwrite the annotation `trivy-operator.aquasecurity.github.io/report-ttl`, specifying a short period of time.  
+It is also possible to delete the `VulnerabilityReport` object.
+
+Example of annotation command:
+```bash
+kubectl annotate VulnerabilityReport -n <namespace> <reportName> trivy-operator.aquasecurity.github.io/report-ttl=1s --overwrite
+```
+

--- a/ee/modules/500-operator-trivy/docs/FAQ_RU.md
+++ b/ee/modules/500-operator-trivy/docs/FAQ_RU.md
@@ -30,3 +30,19 @@ kubectl get clustercompliancereports.aquasecurity.github.io cis -ojson |
 ```
 
 {% endraw %}
+
+## Как вручную перезапустить сканирование ресурса, как понять когда ресурс будет просканирован повторно?
+
+Модуль каждые 24 часа выполняет повторное сканирование ресурсов, согласно следующему алгоритму:
+
+В namespace c каждый просканированным ресурсом создается объект `VulnerabilityReport`.  
+В данном объекте присутствует аннотация `trivy-operator.aquasecurity.github.io/report-ttl`, которая указывает время жизни отчета (стандартно - `24h`). 
+По истечении этого времени оператор удаляет объект, что вызывает повторное сканирование ресурса.
+
+Таким образом, для принудительного повторного сканирования ресурса необходимо перезаписать аннотацию `trivy-operator.aquasecurity.github.io/report-ttl`, указав малый промежуток времени.  
+Допустимо также полностью удалить объект `VulnerabilityReport`.
+
+Пример команды указания аннотации:
+```bash
+kubectl annotate VulnerabilityReport -n <namespace> <reportName>  trivy-operator.aquasecurity.github.io/report-ttl=1s --overwrite
+```


### PR DESCRIPTION
## Description

In some cases, customers need to manually launch a resource rescan by operator-trivy.
The documentation does not indicate how this can be done

The added documentation answers this question.

## Why do we need it, and what problem does it solve?

Improving the quality of documentation

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: feature 
summary: added documentation about manual rescan resources
impact_level:  low
```
