### PR TITLE
Fix trivy db download

### DIFF
--- a/.github/scripts/trivy-db-update-vulnerability-references.sh
+++ b/.github/scripts/trivy-db-update-vulnerability-references.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Function to pull or push with retry logic
+perform_oras_command() {
+  command="$1"
+  echo "[*] Running oras command: $command"
+
+  retries=3
+  attempt=0
+
+  while [ $attempt -lt $retries ]; do
+    set +e
+    $command
+    status=$?
+    set -e
+
+    if [ $status -eq 0 ]; then
+      echo "[+] Command successful."
+      return 0
+    else
+      echo "[!] $command failed with code $status"
+      login_to_registry
+      attempt=$((attempt + 1))
+      echo "[*] Retry attempt $attempt/$retries"
+    fi
+  done
+
+  echo "[!] Failed after $retries attempts."
+  return 1
+}
+
+if [ ! -f ./export.tar.gz ]; then
+  echo "bdu not found"
+  ./bdu-to-json/bdu-to-json
+else
+  if [ "$(( `date +%s` - `stat -L --format %Y ./export.tar.gz` ))" -gt "300" ]; then
+    echo "Remove stale bdu"
+    rm -rf ./export.tar.gz
+    ./bdu-to-json/bdu-to-json
+  fi
+fi
+
+host=$(echo "$1" | awk -F/ '{print $1}')
+case "$host" in
+  "$DECKHOUSE_REGISTRY_HOST")
+    auth="-u $DECKHOUSE_REGISTRY_USER -p $DECKHOUSE_REGISTRY_PASSWORD"
+    ;;
+  "$GHCR_HOST")
+    auth="-u $GHCR_IO_REGISTRY_USER -p $GHCR_IO_REGISTRY_PASSWORD"
+    ;;
+  "$DECKHOUSE_CSE_REGISTRY_HOST")
+    auth="-u $DECKHOUSE_CSE_REGISTRY_USER -p $DECKHOUSE_CSE_REGISTRY_PASSWORD"
+    ;;
+  "$DECKHOUSE_DEV_CSE_REGISTRY_HOST")
+    auth="-u $DECKHOUSE_CSE_DEV_REGISTRY_USER -p $DECKHOUSE_CSE_DEV_REGISTRY_PASSWORD"
+    ;;
+  "$DECKHOUSE_DEV_REGISTRY_HOST")
+    auth="-u $DECKHOUSE_DEV_REGISTRY_USER -p $DECKHOUSE_DEV_REGISTRY_PASSWORD"
+    ;;
+  *)
+    echo "[!] Unknown registry: $host"
+    exit 1
+    ;;
+esac
+perform_oras_command "./oras push -d -v $auth --artifact-type application/octet-stream ${1} export.tar.gz:application/deckhouse.io.bdu.layer.v1.tar+gzip"

--- a/.github/scripts/trivy-db-update.sh
+++ b/.github/scripts/trivy-db-update.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Function to pull or push with retry logic
+perform_oras_command() {
+  command="$1"
+  echo "[*] Running oras command: $command"
+
+  retries=3
+  attempt=0
+
+  while [ $attempt -lt $retries ]; do
+    set +e
+    $command
+    status=$?
+    set -e
+
+    if [ $status -eq 0 ]; then
+      echo "[+] Command successful."
+      return 0
+    else
+      echo "[!] $command failed with code $status"
+      echo "[!] timeout 5s before retry"
+      sleep 5
+      attempt=$((attempt + 1))
+      echo "[*] Retry attempt $attempt/$retries"
+    fi
+  done
+
+  echo "[!] Failed after $retries attempts."
+  return 1
+}
+
+
+get_vulnerabilities () {
+    # List of ALT Linux branches to download
+    alt_versions=("c9f2" "c10f1" "p11" "p10" "p9")
+
+    for version in "${alt_versions[@]}"; do
+      echo "[*] Processing ALT version: $version"
+      dir="cache/vuln-list/alt/$version"
+      zip_file="$dir/$version.zip"
+      url="https://rdb.altlinux.org/api/errata/export/oval/$version"
+
+      mkdir -p "$dir"
+
+      # Try initial download
+      if ! wget -qO "$zip_file" "$url"; then
+        echo "[!] Initial download for $version failed, starting retry loop..."
+
+        while ! wget -O "$zip_file" --tries=5 --waitretry=10 --timeout=30 --read-timeout=30 "$url"; do
+          echo "[!] Download failed for $version, retrying in 15 seconds..."
+          sleep 15
+        done
+      fi
+
+      # Unzip and clean up
+      (
+        cd "$dir" && unzip -oq "$version.zip" && rm -f "$version.zip"
+      )
+    done
+
+    # Download RedOS OVAL file
+    redos_dir="cache/vuln-list/redos"
+    redos_file="$redos_dir/oval.xml"
+    redos_url="https://redos.red-soft.ru/support/secure/redos.xml"
+
+    mkdir -p "$redos_dir"
+
+    # Try initial download
+    if ! wget -qO "$redos_file" "$redos_url"; then
+      echo "[!] Initial download for RedOS failed, starting retry loop..."
+
+      while ! wget -O "$redos_file" --tries=5 --waitretry=10 --timeout=30 --read-timeout=30 "$redos_url"; do
+        echo "[!] Download failed for RedOS, retrying in 15 seconds..."
+        sleep 15
+      done
+    fi
+
+    # sanitize redos oval from incorrect entries of &lt/&gt
+    sed -i '/\&lt[^;]/s/\&lt/\&lt;/g' cache/vuln-list/redos/oval.xml
+    sed -i '/\&gt[^;]/s/\&gt/\&gt;/g' cache/vuln-list/redos/oval.xml
+
+    mkdir -p ./cache/vuln-list/astra
+    mkdir -p ./cache/db
+    mkdir -p ./cache/policies
+
+    # Try a single quiet attempt to download the file
+    if ! wget -qO cache/vuln-list/astra/scanovalcontent_alse17.deb \
+      --ca-certificate=./misc/russian_trusted_sub_ca.cer \
+      --no-check-certificate \
+      https://bdu.fstec.ru/files/scanovalcontent_alse17.deb; then
+
+      echo "[!] Initial attempt failed, starting retry loop..."
+      # Retry loop with verbose output and retry logic
+      while ! wget -vdO cache/vuln-list/astra/scanovalcontent_alse17.deb \
+        --ca-certificate=./misc/russian_trusted_sub_ca.cer \
+        --no-check-certificate \
+        --tries=5 \
+        --waitretry=10 \
+        --timeout=30 \
+        --read-timeout=30 \
+        https://bdu.fstec.ru/files/scanovalcontent_alse17.deb; do
+          echo "[!] Download failed, retrying in 15 seconds..."
+          sleep 15
+      done
+
+    else
+      echo "[+] Successfully downloaded on first attempt."
+    fi
+    dpkg -x cache/vuln-list/astra/scanovalcontent_alse17.deb cache/vuln-list/astra/; mv cache/vuln-list/astra/var/lib/scanoval/data/AstraSE17VulnsOVAL.xml cache/vuln-list/astra/AstraOVAL.xml
+    rm -rf cache/vuln-list/astra/scanovalcontent_alse17.deb cache/vuln-list/astra/var 
+}
+
+prepare_db () {
+    cd ./cache/db
+    docker logout ghcr.io
+    perform_oras_command "../../oras pull -d -v ghcr.io/aquasecurity/trivy-db:2"
+    docker logout ghcr.io
+    perform_oras_command "../../oras pull -d -v ghcr.io/aquasecurity/trivy-java-db:1"
+    tar zxvf db.tar.gz && rm db.tar.gz
+    ../../trivy-db build --cache-dir ../ --output-dir . --update-interval 6h
+    tar cvzf db.tar.gz -C ./ trivy.db metadata.json
+}
+
+prepare_policies () {
+    cd ../policies
+    docker logout ghcr.io
+    perform_oras_command "../../oras pull -d -v ghcr.io/aquasecurity/trivy-checks:0"
+    tar zxvf bundle.tar.gz && rm bundle.tar.gz
+    # relax etcd directory ownership check
+    sed -i 's/audit: stat -c %U:%G $etcd.datadirs/audit: stat -c %U:%G $etcd.datadirs \| sed '\''s\/root\/etcd\/g'\''/g' commands/kubernetes/etcdDataDirectoryOwnership.yaml
+    # relax cni directory permissions check
+    sed -i 's/audit: stat -c %a \/\*\/cni\/\*/audit: stat -c %a \/\*\/cni\/net.d\/\*/g' commands/kubernetes/containerNetworkInterfaceFilePermissions.yaml
+    tar cvzf ../db/bundle.tar.gz ./
+    cd ../db
+}
+
+
+if [ ! -f ./oras ]; then
+  echo "[*] oras binary not found, downloading..."
+
+  url="https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_amd64.tar.gz"
+
+  # Retry loop for curl download and extract
+  while ! curl -sSfL "$url" | tar -xzf -; do
+    echo "[!] oras download failed, retrying in 15 seconds..."
+    sleep 15
+  done
+
+  chmod +x oras
+  echo "[+] oras downloaded and ready."
+fi
+
+if [ ! -d ./cache ]; then
+  echo "Cache not found"
+  get_vulnerabilities
+  prepare_db
+  prepare_policies
+else
+  if [ "$(( `date +%s` - `stat -L --format %Y ./cache` ))" -gt "300" ]; then
+    echo "Remove stale cache"
+    rm -rf ./cache
+    get_vulnerabilities
+    prepare_db
+    prepare_policies
+  else
+    cd ./cache/db
+  fi
+fi
+host=$(echo "$1" | awk -F/ '{print $1}')
+case "$host" in
+  "$DECKHOUSE_REGISTRY_HOST")
+    auth="-u $DECKHOUSE_REGISTRY_USER -p $DECKHOUSE_REGISTRY_PASSWORD"
+    ;;
+  "$GHCR_HOST")
+    auth="-u $GHCR_IO_REGISTRY_USER -p $GHCR_IO_REGISTRY_PASSWORD"
+    ;;
+  "$DECKHOUSE_CSE_REGISTRY_HOST")
+    auth="-u $DECKHOUSE_CSE_REGISTRY_USER -p $DECKHOUSE_CSE_REGISTRY_PASSWORD"
+    ;;
+  "$DECKHOUSE_DEV_CSE_REGISTRY_HOST")
+    auth="-u $DECKHOUSE_CSE_DEV_REGISTRY_USER -p $DECKHOUSE_CSE_DEV_REGISTRY_PASSWORD"
+    ;;
+  "$DECKHOUSE_DEV_REGISTRY_HOST")
+    auth="-u $DECKHOUSE_DEV_REGISTRY_USER -p $DECKHOUSE_DEV_REGISTRY_PASSWORD"
+    ;;
+  *)
+    echo "[!] Unknown registry: $host"
+    exit 1
+    ;;
+esac
+
+perform_oras_command "../../oras push -d -v $auth --artifact-type application/vnd.aquasec.trivy.config.v1+json ${1}/security/trivy-db:2 db.tar.gz:application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
+perform_oras_command "../../oras push -d -v $auth --artifact-type application/octet-stream ${1}/security/trivy-checks:0 bundle.tar.gz:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip"
+perform_oras_command "../../oras push -d -v $auth --artifact-type application/vnd.aquasec.trivy.config.v1+json ${1}/security/trivy-java-db:1 javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"

--- a/.github/workflow_templates/trivy-db-schedule.yml
+++ b/.github/workflow_templates/trivy-db-schedule.yml
@@ -40,14 +40,34 @@ jobs:
 {!{ tmpl.Exec "login_git_step" . | strings.Indent 6 }!}
       - name: Download custom trivy-db binary and copy image
         env:
-          TRIVY_VERSION: v0.55.2
+          TRIVY_VERSION: v0.60.0
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          DECKHOUSE_REGISTRY_USER: ${{secrets.DECKHOUSE_REGISTRY_USER}}
+          DECKHOUSE_REGISTRY_PASSWORD: ${{secrets.DECKHOUSE_REGISTRY_PASSWORD}}
+  
+          DECKHOUSE_CSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}
+          DECKHOUSE_CSE_REGISTRY_USER: ${{secrets.DECKHOUSE_CSE_REGISTRY_USER}}
+          DECKHOUSE_CSE_REGISTRY_PASSWORD: ${{secrets.DECKHOUSE_CSE_REGISTRY_PASSWORD}}
+
+          DECKHOUSE_DEV_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+          DECKHOUSE_DEV_REGISTRY_USER: ${{secrets.DECKHOUSE_DEV_REGISTRY_USER}}
+          DECKHOUSE_DEV_REGISTRY_PASSWORD: ${{secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD}}
+
+          DECKHOUSE_DEV_CSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_CSE_REGISTRY_HOST}}
+          DECKHOUSE_CSE_DEV_REGISTRY_USER: ${{secrets.DECKHOUSE_CSE_DEV_REGISTRY_USER}}
+          DECKHOUSE_CSE_DEV_REGISTRY_PASSWORD: ${{secrets.DECKHOUSE_CSE_DEV_REGISTRY_PASSWORD}}
+
+          GHCR_HOST: "ghcr.io"
+          GHCR_IO_REGISTRY_USER: ${{secrets.GHCR_IO_REGISTRY_USER}}
+          GHCR_IO_REGISTRY_PASSWORD: ${{secrets.GHCR_IO_REGISTRY_PASSWORD}}
         run: |
           rm -rf ./trivy-db
-          git clone --depth 1 --branch ${TRIVY_VERSION} git@${{secrets.DECKHOUSE_PRIVATE_REPO}}:deckhouse/trivy-db.git /src/trivy-db-patch
+          git clone --depth 1 --branch ${TRIVY_VERSION} git@${{secrets.DECKHOUSE_PRIVATE_REPO}}:deckhouse/trivy-db.git trivy-db-patch
           git clone --depth 1 --branch ${TRIVY_VERSION} ${{secrets.SOURCE_REPO_GIT}}/aquasecurity/trivy-db.git
-          docker logout ghcr.io
           cd trivy-db
-          git apply --verbose --whitespace=fix /src/trivy-db-patch/patches/${TRIVY_VERSION}/*.patch
+          git apply --verbose --whitespace=fix ../trivy-db-patch/patches/${TRIVY_VERSION}/*.patch
+          cp ../.github/scripts/trivy-db-update-vulnerability-references.sh ./update-vulnerability-references.sh
+          cp ../.github/scripts/trivy-db-update.sh ./update.sh
           ./update.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee 
           ./update.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe 
           ./update.sh ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse 

--- a/.github/workflow_templates/trivy-db-schedule.yml
+++ b/.github/workflow_templates/trivy-db-schedule.yml
@@ -78,12 +78,4 @@ jobs:
           ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse/security/trivy-bdu:1 
           ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-bdu:1 
           ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_DEV_CSE_REGISTRY_HOST}}/sys/deckhouse-cse/security/trivy-bdu:1 
-          ./oras pull ghcr.io/aquasecurity/trivy-java-db:1
-          ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee/security/trivy-java-db:1 javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
-          ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-java-db:1 javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
-          ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse/security/trivy-java-db:1 javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
-          ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-java-db:1 javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
-          ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json ${{secrets.DECKHOUSE_DEV_CSE_REGISTRY_HOST}}/sys/deckhouse-cse/security/trivy-java-db:1 javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
-          rm -f javadb.tar.gz
 {!{ tmpl.Exec "send_fail_report" . | strings.Indent 6 }!}
-

--- a/.github/workflow_templates/trivy-db-schedule.yml
+++ b/.github/workflow_templates/trivy-db-schedule.yml
@@ -39,11 +39,15 @@ jobs:
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_git_step" . | strings.Indent 6 }!}
       - name: Download custom trivy-db binary and copy image
+        env:
+          TRIVY_VERSION: v0.55.2
         run: |
           rm -rf ./trivy-db
-          git clone --depth 1 --branch flant-v2 ${{secrets.SOURCE_REPO_GIT}}/aquasecurity/trivy-db.git
+          git clone --depth 1 --branch ${TRIVY_VERSION} git@${{secrets.DECKHOUSE_PRIVATE_REPO}}:deckhouse/trivy-db.git /src/trivy-db-patch
+          git clone --depth 1 --branch ${TRIVY_VERSION} ${{secrets.SOURCE_REPO_GIT}}/aquasecurity/trivy-db.git
           docker logout ghcr.io
           cd trivy-db
+          git apply --verbose --whitespace=fix /src/trivy-db-patch/patches/${TRIVY_VERSION}/*.patch
           ./update.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee 
           ./update.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe 
           ./update.sh ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse 

--- a/.github/workflows/trivy-db-schedule.yml
+++ b/.github/workflows/trivy-db-schedule.yml
@@ -212,13 +212,6 @@ jobs:
           ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse/security/trivy-bdu:1 
           ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-bdu:1 
           ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_DEV_CSE_REGISTRY_HOST}}/sys/deckhouse-cse/security/trivy-bdu:1 
-          ./oras pull ghcr.io/aquasecurity/trivy-java-db:1
-          ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee/security/trivy-java-db:1 javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
-          ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-java-db:1 javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
-          ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse/security/trivy-java-db:1 javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
-          ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-java-db:1 javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
-          ./oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json ${{secrets.DECKHOUSE_DEV_CSE_REGISTRY_HOST}}/sys/deckhouse-cse/security/trivy-java-db:1 javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
-          rm -f javadb.tar.gz
 
       # <template: send_fail_report>
       - name: Send fail report
@@ -231,4 +224,3 @@ jobs:
         run: |
           bash ./.github/scripts/send-report.sh
       # </template: send_fail_report>
-

--- a/.github/workflows/trivy-db-schedule.yml
+++ b/.github/workflows/trivy-db-schedule.yml
@@ -173,11 +173,15 @@ jobs:
           done <<< "$HOST_KEYS"
       # </template: login_git_step>
       - name: Download custom trivy-db binary and copy image
+        env:
+          TRIVY_VERSION: v0.55.2
         run: |
           rm -rf ./trivy-db
-          git clone --depth 1 --branch flant-v2 ${{secrets.SOURCE_REPO_GIT}}/aquasecurity/trivy-db.git
+          git clone --depth 1 --branch ${TRIVY_VERSION} git@${{secrets.DECKHOUSE_PRIVATE_REPO}}:deckhouse/trivy-db.git /src/trivy-db-patch
+          git clone --depth 1 --branch ${TRIVY_VERSION} ${{secrets.SOURCE_REPO_GIT}}/aquasecurity/trivy-db.git
           docker logout ghcr.io
           cd trivy-db
+          git apply --verbose --whitespace=fix /src/trivy-db-patch/patches/${TRIVY_VERSION}/*.patch
           ./update.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee 
           ./update.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe 
           ./update.sh ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse 

--- a/.github/workflows/trivy-db-schedule.yml
+++ b/.github/workflows/trivy-db-schedule.yml
@@ -174,14 +174,34 @@ jobs:
       # </template: login_git_step>
       - name: Download custom trivy-db binary and copy image
         env:
-          TRIVY_VERSION: v0.55.2
+          TRIVY_VERSION: v0.60.0
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          DECKHOUSE_REGISTRY_USER: ${{secrets.DECKHOUSE_REGISTRY_USER}}
+          DECKHOUSE_REGISTRY_PASSWORD: ${{secrets.DECKHOUSE_REGISTRY_PASSWORD}}
+
+          DECKHOUSE_CSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}
+          DECKHOUSE_CSE_REGISTRY_USER: ${{secrets.DECKHOUSE_CSE_REGISTRY_USER}}
+          DECKHOUSE_CSE_REGISTRY_PASSWORD: ${{secrets.DECKHOUSE_CSE_REGISTRY_PASSWORD}}
+
+          DECKHOUSE_DEV_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+          DECKHOUSE_DEV_REGISTRY_USER: ${{secrets.DECKHOUSE_DEV_REGISTRY_USER}}
+          DECKHOUSE_DEV_REGISTRY_PASSWORD: ${{secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD}}
+
+          DECKHOUSE_DEV_CSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_DEV_CSE_REGISTRY_HOST}}
+          DECKHOUSE_CSE_DEV_REGISTRY_USER: ${{secrets.DECKHOUSE_CSE_DEV_REGISTRY_USER}}
+          DECKHOUSE_CSE_DEV_REGISTRY_PASSWORD: ${{secrets.DECKHOUSE_CSE_DEV_REGISTRY_PASSWORD}}
+
+          GHCR_HOST: "ghcr.io"
+          GHCR_IO_REGISTRY_USER: ${{secrets.GHCR_IO_REGISTRY_USER}}
+          GHCR_IO_REGISTRY_PASSWORD: ${{secrets.GHCR_IO_REGISTRY_PASSWORD}}
         run: |
           rm -rf ./trivy-db
-          git clone --depth 1 --branch ${TRIVY_VERSION} git@${{secrets.DECKHOUSE_PRIVATE_REPO}}:deckhouse/trivy-db.git /src/trivy-db-patch
+          git clone --depth 1 --branch ${TRIVY_VERSION} git@${{secrets.DECKHOUSE_PRIVATE_REPO}}:deckhouse/trivy-db.git trivy-db-patch
           git clone --depth 1 --branch ${TRIVY_VERSION} ${{secrets.SOURCE_REPO_GIT}}/aquasecurity/trivy-db.git
-          docker logout ghcr.io
           cd trivy-db
-          git apply --verbose --whitespace=fix /src/trivy-db-patch/patches/${TRIVY_VERSION}/*.patch
+          git apply --verbose --whitespace=fix ../trivy-db-patch/patches/${TRIVY_VERSION}/*.patch
+          cp ../.github/scripts/trivy-db-update-vulnerability-references.sh ./update-vulnerability-references.sh
+          cp ../.github/scripts/trivy-db-update.sh ./update.sh
           ./update.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee 
           ./update.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe 
           ./update.sh ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse 


### PR DESCRIPTION
## Description
This PR updates the `trivy-db-schedule` workflow to improve how custom changes are applied to the Trivy database.

- Changed the branch used to download the Trivy DB — now it pulls directly from the upstream repository instead of a pre-patched fork.
- Added a step to clone an additional repository containing our custom patch files.
- Applied those patches to the Trivy DB after downloading.

## Why do we need it, and what problem does it solve?
The old setup used a pre-patched fork, which was harder to maintain.  
Now we apply patches during the workflow, making updates and maintenance simpler and more transparent.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix trivy db download
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
