### PR TITLE
[log-shipper] Socket sink enable TLS if certificates provided

### DIFF
--- a/modules/460-log-shipper/hooks/internal/vector/destination/socket.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/socket.go
@@ -64,7 +64,7 @@ func NewSocket(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Socket {
 		if spec.TCP.TLS.VerifyHostname != nil {
 			tls.VerifyHostname = *spec.TCP.TLS.VerifyHostname
 		}
-		if spec.TCP.TLS.CAFile != "" || spec.TCP.TLS.CertFile != "" || spec.TCP.TLS.KeyFile != "" {
+		if spec.TCP.TLS.CAFile != "" || spec.TCP.TLS.CertFile != "" {
 			tls.Enabled = true
 		}
 

--- a/modules/460-log-shipper/hooks/internal/vector/destination/socket.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/socket.go
@@ -51,7 +51,6 @@ func NewSocket(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Socket {
 
 	if spec.Mode == v1alpha1.SocketModeTCP {
 		tls := CommonTLS{
-			Enabled:           true,
 			CAFile:            decodeB64(spec.TCP.TLS.CAFile),
 			CertFile:          decodeB64(spec.TCP.TLS.CertFile),
 			KeyFile:           decodeB64(spec.TCP.TLS.KeyFile),
@@ -64,6 +63,9 @@ func NewSocket(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Socket {
 		}
 		if spec.TCP.TLS.VerifyHostname != nil {
 			tls.VerifyHostname = *spec.TCP.TLS.VerifyHostname
+		}
+		if spec.TCP.TLS.CAFile != "" || spec.TCP.TLS.CertFile != "" || spec.TCP.TLS.KeyFile != "" {
+			tls.Enabled = true
 		}
 
 		result.TLS = tls

--- a/modules/460-log-shipper/hooks/internal/vector/destination/socket.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/socket.go
@@ -51,6 +51,7 @@ func NewSocket(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Socket {
 
 	if spec.Mode == v1alpha1.SocketModeTCP {
 		tls := CommonTLS{
+			Enabled:           true,
 			CAFile:            decodeB64(spec.TCP.TLS.CAFile),
 			CertFile:          decodeB64(spec.TCP.TLS.CertFile),
 			KeyFile:           decodeB64(spec.TCP.TLS.KeyFile),


### PR DESCRIPTION
## Description

Add condition for enabling [tls.enable](https://vector.dev/docs/reference/configuration/sources/socket/#tls.enabled) in case if certificates provided for a socket sink.

## Why do we need it, and what problem does it solve?
In some cases, we were failing to achieve TLS handshake using socket sink with certificates, since the parameter was turned off by default.

## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: log-shipper
type: fix
summary: Enable TLS for TCP socket if certificates provided.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
