### PR TITLE
[loki] Fix storage capacity calculation hook

### DIFF
--- a/modules/462-loki/hooks/calculate_storage_capacity.go
+++ b/modules/462-loki/hooks/calculate_storage_capacity.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/deckhouse/module-sdk/pkg/utils/ptr"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
@@ -50,7 +49,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 					"app": "loki",
 				},
 			},
-			ExecuteHookOnSynchronization: ptr.Bool(false),
+			ExecuteHookOnSynchronization: go_hook.Bool(false),
 			FilterFunc:                   persistentVolumeClaimFilter,
 		},
 		{
@@ -67,7 +66,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 					"app": "loki",
 				},
 			},
-			ExecuteHookOnSynchronization: ptr.Bool(false),
+			ExecuteHookOnSynchronization: go_hook.Bool(false),
 			FilterFunc:                   statefulSetFilter,
 		},
 	},
@@ -142,10 +141,8 @@ func persistentVolumeClaimFilter(obj *unstructured.Unstructured) (go_hook.Filter
 func lokiDisk(input *go_hook.HookInput) error {
 	var stsStorageSize, pvcSize, cleanupThreshold uint64
 
-	defaultDiskSize := uint64(input.ConfigValues.Get("loki.diskSizeGigabytes").Int() << 30)
-	ingestionRate := input.ConfigValues.Get("loki.lokiConfig.ingestionRateMB").Float()
-
-	fmt.Printf("defaultDiskSize: %d, ingestionRate: %f\n", defaultDiskSize, ingestionRate)
+	defaultDiskSize := uint64(input.Values.Get("loki.diskSizeGigabytes").Int() << 30)
+	ingestionRate := input.Values.Get("loki.lokiConfig.ingestionRateMB").Float()
 
 	for _, obj := range input.Snapshots["pvcs"] {
 		pvc := obj.(PersistentVolumeClaim)

--- a/modules/462-loki/hooks/calculate_storage_capacity.go
+++ b/modules/462-loki/hooks/calculate_storage_capacity.go
@@ -139,8 +139,8 @@ func persistentVolumeClaimFilter(obj *unstructured.Unstructured) (go_hook.Filter
 func lokiDisk(input *go_hook.HookInput) error {
 	var stsStorageSize, pvcSize, cleanupThreshold uint64
 
-	defaultDiskSize := uint64(input.ConfigValues.Get("loki.diskSizeGigabytes").Int() << 30)
-	ingestionRate := input.ConfigValues.Get("loki.lokiConfig.ingestionRateMB").Float()
+	defaultDiskSize := uint64(input.Values.Get("loki.diskSizeGigabytes").Int() << 30)
+	ingestionRate := input.Values.Get("loki.lokiConfig.ingestionRateMB").Float()
 
 	for _, obj := range input.Snapshots["pvcs"] {
 		pvc := obj.(PersistentVolumeClaim)

--- a/modules/462-loki/hooks/calculate_storage_capacity_test.go
+++ b/modules/462-loki/hooks/calculate_storage_capacity_test.go
@@ -74,6 +74,7 @@ spec:
 	Context("Cluster with PVCs", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(pvcs))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
 
@@ -86,7 +87,7 @@ spec:
 
 	Context("Cluster with PVC and high logs throughput", func() {
 		BeforeEach(func() {
-			f.ConfigValuesSet("loki.lokiConfig.ingestionRateMB", highLogsThroughputRate)
+			f.ValuesSet("loki.lokiConfig.ingestionRateMB", highLogsThroughputRate)
 			f.BindingContexts.Set(f.KubeStateSet(pvcs))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()


### PR DESCRIPTION
## Description
When Loki uses emptyDir (no PVC found in the cluster) and the `diskSizeGigabytes` setting is not explicitly set in the ModuleConfig, the storage capacity hook enters error state and halts the Deckhouse controller modules reconciliation loop.

## Why do we need it, and what problem does it solve?
This PR fixes the bug described above.

## Why do we need it in the patch release (if we do)?
Even though the emptyDir use is rear and there is a workaround available, It's good to have this bug fixed in the nearest patch release.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: loki
type: fix
summary: fix storage capacity calculator hook for Loki
impact: fixes the bug introduced in v1.69.0
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
