### PR TITLE
[dhctl] fix(dhctl-for-commander): skip empty config files in bootstrap and abort

### DIFF
--- a/dhctl/pkg/server/rpc/dhctl/abort.go
+++ b/dhctl/pkg/server/rpc/dhctl/abort.go
@@ -178,6 +178,10 @@ func (s *Service) abort(
 			request.InitResources,
 			request.Resources,
 		} {
+			if len(cfg) == 0 {
+				continue
+			}
+
 			configPath, cleanup, err = util.WriteDefaultTempFile([]byte(cfg))
 			cleanuper.Add(cleanup)
 			if err != nil {

--- a/dhctl/pkg/server/rpc/dhctl/bootstrap.go
+++ b/dhctl/pkg/server/rpc/dhctl/bootstrap.go
@@ -178,6 +178,10 @@ func (s *Service) bootstrap(
 			request.InitResources,
 			request.Resources,
 		} {
+			if len(cfg) == 0 {
+				continue
+			}
+
 			configPath, cleanup, err = util.WriteDefaultTempFile([]byte(cfg))
 			cleanuper.Add(cleanup)
 			if err != nil {


### PR DESCRIPTION
## Description
Fixed configuration preparation for bootstrap and bootstrap abort of a cluster. Now, empty config files are ignored. This bug was introduced here: https://github.com/deckhouse/deckhouse/pull/12400

Installation error log caused by the bug:

```
Config document validation failed: document must contain "kind" and "apiVersion" fields:
apiVersion:
kind:

data:
1 ---
```

## Why do we need it, and what problem does it solve?
Currently, bootstrap and abort of clusters in Commander do not work if they have an empty configuration: ClusterConfig, InitConfig, ProviderSpecificClusterConfig, InitResources.


## Why do we need it in the patch release (if we do)?
To fix cluster bootstrap functionality.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: fix bootstrap and abort config preparation
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
