### PR TITLE
[cloud-provider-vcd] Add a hook to set `legacyMode` based on the `VCD API` version

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/hooks/legacy_mode.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/legacy_mode.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"gopkg.in/yaml.v3"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1alpha1"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "vcd_api_version",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"kube-system"},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"d8-cloud-provider-discovery-data"},
+			},
+			FilterFunc: applyCloudProviderDiscoveryDataSecretVCDAPIVersionFilter,
+		},
+		{
+			Name:       "legacy_mode",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"kube-system"},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"d8-provider-cluster-configuration"},
+			},
+			FilterFunc: applyProviderClusterConfigurationSecretLegacyModeFilter,
+		},
+	},
+}, handleLegacyMode)
+
+func applyProviderClusterConfigurationSecretLegacyModeFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	clusterConfig := &v1.Secret{}
+	err := sdk.FromUnstructured(obj, clusterConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert kubernetes object: %v", err)
+	}
+
+	configDataJSON, ok := clusterConfig.Data["cloud-provider-cluster-configuration.yaml"]
+	if !ok {
+		return nil, fmt.Errorf("failed to find 'cloud-provider-cluster-configuration.yaml' in 'd8-provider-cluster-configuration' secret")
+	}
+
+	var configData map[string]any
+	err = yaml.Unmarshal(configDataJSON, &configData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal 'cloud-provider-cluster-configuration.yaml' from 'd8-provider-cluster-configuration' secret: %v", err)
+	}
+
+	var legacyMode *bool
+
+	value, ok := configData["legacyMode"]
+	if ok {
+		legacyMode = new(bool)
+		*legacyMode = value.(bool)
+	}
+
+	return legacyMode, nil
+}
+
+func applyCloudProviderDiscoveryDataSecretVCDAPIVersionFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	discoveryDataSecret := &v1.Secret{}
+	err := sdk.FromUnstructured(obj, discoveryDataSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert kubernetes object: %v", err)
+	}
+
+	discoveryDataJSON, ok := discoveryDataSecret.Data["discovery-data.json"]
+	if !ok {
+		return nil, fmt.Errorf("failed to find 'discovery-data.json' in 'd8-cloud-provider-discovery-data' secret")
+	}
+
+	var discoveryData v1alpha1.VCDCloudProviderDiscoveryData
+	err = json.Unmarshal(discoveryDataJSON, &discoveryData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal 'discovery-data.json' from 'd8-cloud-provider-discovery-data' secret: %v", err)
+	}
+
+	return discoveryData.VCDAPIVersion, nil
+}
+
+func handleLegacyMode(input *go_hook.HookInput) error {
+	if len(input.Snapshots["legacy_mode"]) == 0 {
+		input.Logger.Warn("Legacy mode not defined")
+
+		return nil
+	}
+
+	legacyMode := input.Snapshots["legacy_mode"][0].(*bool)
+	if legacyMode != nil {
+		// legacyMode is set in the provider cluster configuration secret
+		input.Values.Set("cloudProviderVcd.internal.legacyMode", *legacyMode)
+
+		return nil
+	}
+
+	if len(input.Snapshots["vcd_api_version"]) == 0 {
+		input.Logger.Warn("VCD API version not defined")
+
+		return nil
+	}
+
+	vcdAPIVersion := input.Snapshots["vcd_api_version"][0].(string)
+
+	version, err := semver.NewVersion(vcdAPIVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse VCD API version '%s': %v", vcdAPIVersion, err)
+	}
+
+	versionConstraint, err := semver.NewConstraint("<37.2")
+	if err != nil {
+		return fmt.Errorf("failed to parse version constraint '%s': %v", versionConstraint, err)
+	}
+
+	// Set legacyMode to true if the VCD API version is less than 37.2
+	input.Values.Set("cloudProviderVcd.internal.legacyMode", versionConstraint.Check(version))
+
+	return nil
+}

--- a/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
@@ -432,4 +432,8 @@ properties:
               type: string
             name:
               type: string
-
+      legacyMode:
+        type: boolean
+        description: |
+          If set to `true`, an API version below `37.2` will be used.
+        x-doc-default: false

--- a/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/deployment.yaml
@@ -1,6 +1,6 @@
 {{- define "capcd_controller_manager_args" }}
 - "--leader-elect"
-{{- if eq .Values.cloudProviderVcd.internal.providerClusterConfiguration.legacyMode true }}
+{{- if eq .Values.cloudProviderVcd.internal.legacyMode true }}
 - "--metrics-bind-address=127.0.0.1:9446"
 {{- else }}
 - "--diagnostics-address=127.0.0.1:9446"
@@ -15,7 +15,7 @@ memory: 50Mi
 {{- end }}
 
 {{- $capcdImageName := ""}}
-{{- if eq .Values.cloudProviderVcd.internal.providerClusterConfiguration.legacyMode true -}}
+{{- if eq .Values.cloudProviderVcd.internal.legacyMode true -}}
   {{- $capcdImageName = "capcdControllerManagerLegacy" }}
 {{- else -}}
   {{- $capcdImageName = "capcdControllerManager" }}

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/deployment.yaml
@@ -4,7 +4,7 @@ memory: 50Mi
 {{- end }}
 
 {{- $ccmImageName := ""}}
-{{- if eq .Values.cloudProviderVcd.internal.providerClusterConfiguration.legacyMode true -}}
+{{- if eq .Values.cloudProviderVcd.internal.legacyMode true -}}
   {{- $ccmImageName = "cloudControllerManagerLegacy" }}
 {{- else -}}
   {{- $ccmImageName = "cloudControllerManager" }}

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-data-discoverer/deployment.yaml
@@ -4,7 +4,7 @@ memory: 50Mi
 {{- end }}
 
 {{- $cddImageName := ""}}
-{{- if eq .Values.cloudProviderVcd.internal.providerClusterConfiguration.legacyMode true -}}
+{{- if eq .Values.cloudProviderVcd.internal.legacyMode true -}}
   {{- $cddImageName = "cloudDataDiscovererLegacy" }}
 {{- else -}}
   {{- $cddImageName = "cloudDataDiscoverer" }}

--- a/ee/modules/030-cloud-provider-vcd/templates/csi/controller.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/csi/controller.yaml
@@ -63,7 +63,7 @@
 {{- end }}
 
 {{- $csiImageName := ""}}
-{{- if eq .Values.cloudProviderVcd.internal.providerClusterConfiguration.legacyMode true -}}
+{{- if eq .Values.cloudProviderVcd.internal.legacyMode true -}}
   {{- $csiImageName = "vcdCsiPluginLegacy" }}
 {{- else -}}
   {{- $csiImageName = "vcdCsiPlugin" }}
@@ -75,7 +75,7 @@
   {{- $csiControllerConfig := dict }}
   {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
   {{- $_ := set $csiControllerConfig "snapshotterEnabled" false }}
-  {{- $_ := set $csiControllerConfig "resizerEnabled" (ne .Values.cloudProviderVcd.internal.providerClusterConfiguration.legacyMode true) }}
+  {{- $_ := set $csiControllerConfig "resizerEnabled" (ne .Values.cloudProviderVcd.internal.legacyMode true) }}
   {{- $_ := set $csiControllerConfig "topologyEnabled" false }}
   {{- $_ := set $csiControllerConfig "additionalControllerArgs" (include "csi_controller_args" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "additionalControllerEnvs" (include "csi_controller_envs" . | fromYamlArray) }}

--- a/ee/modules/030-cloud-provider-vcd/templates/csi/storage-classes.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/csi/storage-classes.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ $storageClass.name | quote }}
 provisioner: named-disk.csi.cloud-director.vmware.com
 reclaimPolicy: Delete
-allowVolumeExpansion: {{ ne $.Values.cloudProviderVcd.internal.providerClusterConfiguration.legacyMode true }}
+allowVolumeExpansion: {{ ne $.Values.cloudProviderVcd.internal.legacyMode true }}
 volumeBindingMode: WaitForFirstConsumer
 parameters:
   storageProfile: {{ $storageClass.storageProfile | quote }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add a hook to set `legacyMode` based on the detected `VCD API` version:
- Add `.Values.cloudProviderVcd.internal.legacyMode` value to control the selection of container images based on either `legacy` or `latest` `VCD API` versions.
- Set `.Values.cloudProviderVcd.internal.legacyMode` to the value of `VCDClusterConfiguration.legacyMode` if the field is present.  
- If `VCDClusterConfiguration.legacyMode` is not set, assign `.Values.cloudProviderVcd.internal.legacyMode` to `true` when the `VCD API` version is below `37.2`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Add support for setting `legacyMode` either statically (for new clusters) or dynamically (for existing clusters).

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: Add a hook to set `legacyMode` based on the detected `VCD API` version
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
