### PR TITLE
[candi] Support for dnf package manager

### DIFF
--- a/candi/bashible/bashbooster/50_dnf.sh
+++ b/candi/bashible/bashbooster/50_dnf.sh
@@ -45,6 +45,8 @@ bb-dnf-repo?() {
 }
 
 bb-dnf-package?() {
+    bb-set-proxy
+    trap bb-unset-proxy RETURN
     dnf list installed "$1" &>/dev/null
 }
 
@@ -71,7 +73,6 @@ bb-dnf-install() {
             NEED_FIRE=true
         fi
         if ! bb-dnf-package? "$PACKAGE"; then
-            echo "bob"
             PACKAGES_TO_INSTALL+=("$PACKAGE")
         fi
     done
@@ -87,7 +88,9 @@ bb-dnf-install() {
         NEED_FIRE=true
     fi
 
-    [ "$NEED_FIRE" = "true" ] && bb-event-fire "bb-package-installed" "$PACKAGE"
+    if [[ "$NEED_FIRE" == "true" ]]; then
+        bb-event-fire "bb-package-installed" "$PACKAGE"
+    fi
 }
 
 bb-dnf-remove() {

--- a/candi/bashible/bashbooster/50_dnf.sh
+++ b/candi/bashible/bashbooster/50_dnf.sh
@@ -1,0 +1,110 @@
+# Bash Booster 0.6 <http://www.bashbooster.net>
+# =============================================
+#
+# Copyright (c) 2014, Dmitry Vakhrushev <self@kr41.net> and Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+bb-var BB_DNF_UPDATED false
+bb-var BB_DNF_UNHANDLED_PACKAGES_STORE "/var/lib/bashible/bashbooster_unhandled_packages"
+bb-var BB_DNF_INSTALL_EXTRA_ARGS ""
+
+bb-check-dnf() {
+    if bb-exe? dnf; then
+        echo "dnf"
+    elif bb-exe? yum; then
+        echo "yum"
+    else
+        bb-log-error "found neither dnf nor yum"
+        exit 1
+    fi
+}
+
+bb-dnf?() {
+    bb-set-proxy
+    trap bb-unset-proxy RETURN
+    bb-exe? dnf
+}
+
+bb-dnf-repo?() {
+    bb-set-proxy
+    trap bb-unset-proxy RETURN
+    dnf repolist | grep -Ew "^(\W)*${1}"
+}
+
+bb-dnf-package?() {
+    dnf list installed "$1" &>/dev/null
+}
+
+bb-dnf-update() {
+    bb-set-proxy
+    trap bb-unset-proxy RETURN
+    bb-flag? dnf-updated && return 0
+    bb-log-info "Updating dnf cache"
+    dnf clean all
+    dnf makecache
+    bb-flag-set dnf-updated
+}
+
+bb-dnf-install() {
+    if [ "$(bb-check-dnf)" = "yum" ]; then
+        bb-log-info "bb-dnf-install downgraded to yum"
+        bb-yum-install "$@"
+        return
+    fi
+    local PACKAGES_TO_INSTALL=()
+    local NEED_FIRE=false
+    for PACKAGE in "$@"; do
+        if test -f "$BB_DNF_UNHANDLED_PACKAGES_STORE" && grep -Eq "^${PACKAGE}$" "$BB_DNF_UNHANDLED_PACKAGES_STORE"; then
+            NEED_FIRE=true
+        fi
+        if ! bb-dnf-package? "$PACKAGE"; then
+            echo "bob"
+            PACKAGES_TO_INSTALL+=("$PACKAGE")
+        fi
+    done
+
+    if [ "${#PACKAGES_TO_INSTALL[@]}" -gt 0 ]; then
+        bb-dnf-update
+        bb-log-info "Installing packages '${PACKAGES_TO_INSTALL[@]}'"
+        bb-set-proxy
+        trap bb-unset-proxy RETURN
+        dnf install $BB_DNF_INSTALL_EXTRA_ARGS -y "${PACKAGES_TO_INSTALL[@]}"
+        bb-exit-on-error "Failed to install packages '${PACKAGES_TO_INSTALL[@]}'"
+        printf '%s\n' "${PACKAGES_TO_INSTALL[@]}" >> "$BB_DNF_UNHANDLED_PACKAGES_STORE"
+        NEED_FIRE=true
+    fi
+
+    [ "$NEED_FIRE" = "true" ] && bb-event-fire "bb-package-installed" "$PACKAGE"
+}
+
+bb-dnf-remove() {
+    if [ "$(bb-check-dnf)" = "yum" ]; then
+        bb-log-info "bb-dnf-remove downgraded to yum"
+        bb-yum-remove "$@"
+        return
+    fi
+    bb-set-proxy
+    trap bb-unset-proxy RETURN
+    for PACKAGE in "$@"; do
+        if bb-dnf-package? "$PACKAGE"; then
+            bb-dnf-update
+            bb-log-info "Removing package '$PACKAGE'"
+            dnf remove -y "$PACKAGE"
+            bb-exit-on-error "Failed to remove package '$PACKAGE'"
+            bb-event-fire "bb-package-removed" "$PACKAGE"
+        fi
+    done
+}

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/ADVANCED.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/ADVANCED.md
@@ -263,7 +263,7 @@ spec:
       distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
       curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
     fi
-    bb-yum-install nvidia-container-toolkit nvidia-driver
+    bb-dnf-install nvidia-container-toolkit nvidia-driver
     nvidia-ctk config --set nvidia-container-runtime.log-level=error --in-place
   nodeGroups:
   - gpu

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/ADVANCED_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/ADVANCED_RU.md
@@ -259,7 +259,7 @@ spec:
       distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
       curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
     fi
-    bb-yum-install nvidia-container-toolkit nvidia-driver
+    bb-dnf-install nvidia-container-toolkit nvidia-driver
     nvidia-ctk config --set nvidia-container-runtime.log-level=error --in-place
   nodeGroups:
   - gpu

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/OS.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/OS.md
@@ -71,7 +71,7 @@ This function prevents a node from rebooting if it must be confirmed by adding a
 Other Bash Booster functions used:
 
 - [`bb-apt-install`](http://www.bashbooster.net/#apt): To install an apt package and send the `bb-package-installed` event when the package is installed.
-- [`bb-yum-install`](http://www.bashbooster.net/#yum): To install a yum package and send the `bb-package-installed` event when the package is installed.
+- [`bb-dnf-install`](http://www.bashbooster.net/#yum): To install a yum package and send the `bb-package-installed` event when the package is installed.
 - [`bb-event-on`](http://www.bashbooster.net/#event): To notify about a required node reboot if the `bb-package-installed` event has been sent.
 - [`bb-log-info`](http://www.bashbooster.net/#log): For logging.
 - [`bb-flag-set`](http://www.bashbooster.net/#flag): To notify that a node reboot is required.
@@ -141,7 +141,7 @@ spec:
     fi
 
     bb-deckhouse-get-disruptive-update-approval
-    bb-yum-install "kernel-${desired_version}"
+    bb-dnf-install "kernel-${desired_version}"
 ```
 
 ## Adding a root certificate

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/OS_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/OS_RU.md
@@ -65,7 +65,7 @@ spec:
 Помимо этого, используются следующие конструкции Bash Booster:
 
 - [`bb-apt-install`](http://www.bashbooster.net/#apt) для установки apt-пакета и отправки события `bb-package-installed`, если пакет был установлен;
-- [`bb-yum-install`](http://www.bashbooster.net/#yum) для установки yum-пакета и отправки события `bb-package-installed`, если пакет был установлен;
+- [`bb-dnf-install`](http://www.bashbooster.net/#yum) для установки yum-пакета и отправки события `bb-package-installed`, если пакет был установлен;
 - [`bb-event-on`](http://www.bashbooster.net/#event) для сигнализации, что нужна перезагрузка узла, если отправлено событие `bb-package-installed`;
 - [`bb-log-info`](http://www.bashbooster.net/#log) для логирования;
 - [`bb-flag-set`](http://www.bashbooster.net/#flag) для сигнализации, что нужен перезапуск узла.
@@ -135,7 +135,7 @@ spec:
     fi
 
     bb-deckhouse-get-disruptive-update-approval
-    bb-yum-install "kernel-${desired_version}"
+    bb-dnf-install "kernel-${desired_version}"
 ```
 
 ## Добавление корневого сертификата

--- a/ee/fe/modules/040-node-manager/templates/ngc-ca-certificate.yaml
+++ b/ee/fe/modules/040-node-manager/templates/ngc-ca-certificate.yaml
@@ -25,6 +25,6 @@ spec:
     case $(bb-is-bundle) in
       debian|ubuntu-lts|astra)  bb-apt-install ca-certificates ;;
       altlinux)                 bb-apt-rpm-install ca-certificates ;;
-      centos|redos|rosa)        bb-yum-install ca-certificates ;;
+      centos|redos|rosa)        bb-dnf-install ca-certificates ;;
       opensuse)                 bb-zypper-install ca-certificates ;;
     esac

--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -378,7 +378,7 @@ spec:
     fi
 
     bb-deckhouse-get-disruptive-update-approval
-    bb-yum-install "kernel-${desired_version}"
+    bb-dnf-install "kernel-${desired_version}"
 ```
 
 ## NodeGroup parameters and their result
@@ -766,7 +766,7 @@ spec:
       distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
       curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
     fi
-    bb-yum-install nvidia-container-toolkit nvidia-driver
+    bb-dnf-install nvidia-container-toolkit nvidia-driver
     nvidia-ctk config --set nvidia-container-runtime.log-level=error --in-place
   nodeGroups:
   - gpu

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -618,7 +618,7 @@ spec:
    kubectl annotate node <имя master-узла> update.node.deckhouse.io/disruption-approved=
    ```
 
-1. Дождаитесь перехода обновленного master-узла в `Ready`. Выполните итерацию для следующего master-узла.
+1. Дождитесь перехода обновленного master-узла в `Ready`. Выполните итерацию для следующего master-узла.
 
 ## Как добавить шаг для конфигурации узлов?
 

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -387,7 +387,7 @@ spec:
     fi
 
     bb-deckhouse-get-disruptive-update-approval
-    bb-yum-install "kernel-${desired_version}"
+    bb-dnf-install "kernel-${desired_version}"
 ```
 
 ## Какие параметры NodeGroup к чему приводят?
@@ -776,7 +776,7 @@ spec:
       distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
       curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
     fi
-    bb-yum-install nvidia-container-toolkit nvidia-driver
+    bb-dnf-install nvidia-container-toolkit nvidia-driver
     nvidia-ctk config --set nvidia-container-runtime.log-level=error --in-place
   nodeGroups:
   - gpu

--- a/modules/040-node-manager/templates/ngc-nfs-common.yaml
+++ b/modules/040-node-manager/templates/ngc-nfs-common.yaml
@@ -26,6 +26,6 @@ spec:
     case $(bb-is-bundle) in
       debian|ubuntu-lts|astra)  bb-apt-install nfs-common ;;
       altlinux)                 bb-apt-rpm-install nfs-utils ;;
-      centos|redos|rosa)        bb-yum-install nfs-utils ;;
+      centos|redos|rosa)        bb-dnf-install nfs-utils ;;
     esac
 


### PR DESCRIPTION
## Description

Added `bb-dnf` functions. In some distributions (e.g. Red OS) yum is definitively declared deprecated and is not included in the distro package. Now you should use `bb-dnf-install `instead of `bb-yum-install` by default.
`bb-dnf-install` first checks that `dnf` is installed, if `dnf` is missing then downgrade to `yum` is attempted.

## Why do we need it, and what problem does it solve?

Support for dnf package manager in bashible

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix 
summary:  Support for dnf package manager
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
