### PR TITLE
[docs] Fix a warning about using alerts in the dashboard

### DIFF
--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -72,11 +72,11 @@ spec:
 ...
 ```
 
-{% alert level="warning" %}
-System dashboards and dashboards added using [GrafanaDashboardDefinition](cr.html#grafanadashboarddefinition) cannot be modified via the Grafana interface.
-
-Alerts configured in the dashboard do not work with datasource templates - such a dashboard is invalid and cannot be imported. In Grafana 9.0, the legacy alerting functionality was [deprecated](https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v10-0/#description) and replaced with Grafana Alerting. Therefore, we do not recommend using legacy alerting in dashboards.
-{% endalert %}
+> **Caution!** 
+>
+> System dashboards and dashboards added using [GrafanaDashboardDefinition](cr.html#grafanadashboarddefinition) cannot be modified via the Grafana interface.
+>
+> Alerts configured in the dashboard do not work with datasource templates - such a dashboard is invalid and cannot be imported. In Grafana 9.0, the legacy alerting functionality was [deprecated](https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v10-0/#description) and replaced with Grafana Alerting. Therefore, we do not recommend using legacy alerting in dashboards.
 
 ## How do I add alerts and/or recording rules?
 

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -72,11 +72,15 @@ spec:
 ...
 ```
 
-> **Caution!** 
->
-> System dashboards and dashboards added using [GrafanaDashboardDefinition](cr.html#grafanadashboarddefinition) cannot be modified via the Grafana interface.
->
-> Alerts configured in the dashboard do not work with datasource templates - such a dashboard is invalid and cannot be imported. In Grafana 9.0, the legacy alerting functionality was [deprecated](https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v10-0/#description) and replaced with Grafana Alerting. Therefore, we do not recommend using legacy alerting in dashboards.
+{% endraw %}
+
+{% alert level="warning" %}
+System dashboards and dashboards added using [GrafanaDashboardDefinition](cr.html#grafanadashboarddefinition) cannot be modified via the Grafana interface.
+
+Alerts configured in the dashboard do not work with datasource templates - such a dashboard is invalid and cannot be imported. In Grafana 9.0, the legacy alerting functionality was [deprecated](https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v10-0/#description) and replaced with Grafana Alerting. Therefore, we do not recommend using legacy alerting in dashboards.
+{% endalert %}
+
+{% raw %}
 
 ## How do I add alerts and/or recording rules?
 

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -75,7 +75,7 @@ spec:
 {% endraw %}
 
 {% alert level="warning" %}
-Системные и добавленные через [GrafanaDashboardDefinition](cr.html#grafanadashboarddefinition) dashboard'ы нельзя изменить через интерфейс Grafana.
+Системные и добавленные через [GrafanaDashboardDefinition](cr.html#grafanadashboarddefinition) дашборды нельзя изменить через интерфейс Grafana.
 
 Алерты, настроенные в панели dashboard, не работают с шаблонами datasource — такой dashboard является невалидным и не импортируется. В версии Grafana 9.0 функционал legacy alerting был признан [устаревшим](https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v10-0/#description) и заменён на Grafana Alerting. В связи с этим, мы не рекомендуем использовать legacy alerting (оповещения панели мониторинга) в dashboards.
 {% endalert %}

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -72,11 +72,11 @@ spec:
 ...
 ```
 
-{% alert level="warning" %}
-Системные и добавленные через [GrafanaDashboardDefinition](cr.html#grafanadashboarddefinition) дашборды нельзя изменить через интерфейс Grafana.
-
-Алерты, настроенные в панели dashboard, не работают с шаблонами datasource — такой dashboard является невалидным и не импортируется. В версии Grafana 9.0 функционал legacy alerting был признан [устаревшим](https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v10-0/#description) и заменён на Grafana Alerting. В связи с этим, мы не рекомендуем использовать legacy alerting (оповещения панели мониторинга) в dashboards.
-{% endalert %}
+> **Важно!** 
+>
+> Системные и добавленные через [GrafanaDashboardDefinition](cr.html#grafanadashboarddefinition) dashboard'ы нельзя изменить через интерфейс Grafana.
+>
+> Алерты, настроенные в панели dashboard, не работают с шаблонами datasource — такой dashboard является невалидным и не импортируется. В версии Grafana 9.0 функционал legacy alerting был признан [устаревшим](https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v10-0/#description) и заменён на Grafana Alerting. В связи с этим, мы не рекомендуем использовать legacy alerting (оповещения панели мониторинга) в dashboards.
 
 ## Как добавить алерты и/или recording-правила для вашего проекта?
 

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -72,11 +72,15 @@ spec:
 ...
 ```
 
-> **Важно!** 
->
-> Системные и добавленные через [GrafanaDashboardDefinition](cr.html#grafanadashboarddefinition) dashboard'ы нельзя изменить через интерфейс Grafana.
->
-> Алерты, настроенные в панели dashboard, не работают с шаблонами datasource — такой dashboard является невалидным и не импортируется. В версии Grafana 9.0 функционал legacy alerting был признан [устаревшим](https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v10-0/#description) и заменён на Grafana Alerting. В связи с этим, мы не рекомендуем использовать legacy alerting (оповещения панели мониторинга) в dashboards.
+{% endraw %}
+
+{% alert level="warning" %}
+Системные и добавленные через [GrafanaDashboardDefinition](cr.html#grafanadashboarddefinition) dashboard'ы нельзя изменить через интерфейс Grafana.
+
+Алерты, настроенные в панели dashboard, не работают с шаблонами datasource — такой dashboard является невалидным и не импортируется. В версии Grafana 9.0 функционал legacy alerting был признан [устаревшим](https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v10-0/#description) и заменён на Grafana Alerting. В связи с этим, мы не рекомендуем использовать legacy alerting (оповещения панели мониторинга) в dashboards.
+{% endalert %}
+
+{% raw %}
 
 ## Как добавить алерты и/или recording-правила для вашего проекта?
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
The layout of the alert on the site has been corrected

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: the layout of the alert on the site has been corrected
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
