### PR TITLE
[operator-trivy] add proxy env

### DIFF
--- a/ee/modules/500-operator-trivy/templates/trivy-server.yaml
+++ b/ee/modules/500-operator-trivy/templates/trivy-server.yaml
@@ -89,6 +89,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: trivy-operator-trivy-config
+          env:
+            {{- include "helm_lib_envs_for_proxy" . | nindent 12 }}
           ports:
             - name: trivy-http
               containerPort: 4954


### PR DESCRIPTION
## Description
It adds proxy env for operator-trivy to download db in env with configured proxy.

## Why do we need it, and what problem does it solve?
Closes #12983

Trivy cannot download db in env with configured proxy.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: operator-trivy
type: fix
summary: Add proxy env variables support to the trivy server.
```