### PR TITLE
[openvpn] Added e2e test

### DIFF
--- a/modules/500-openvpn/templates/openvpn/configmap.yaml
+++ b/modules/500-openvpn/templates/openvpn/configmap.yaml
@@ -19,6 +19,7 @@ data:
     client-config-dir /etc/openvpn/ccd
     key-direction 0
     data-ciphers AES-256-GCM:AES-128-GCM:AES-128-CBC
+    data-ciphers-fallback AES-128-CBC # for e2e
     keepalive 10 60
     persist-key
     persist-tun

--- a/modules/500-openvpn/templates/openvpn/configmap.yaml
+++ b/modules/500-openvpn/templates/openvpn/configmap.yaml
@@ -19,7 +19,7 @@ data:
     client-config-dir /etc/openvpn/ccd
     key-direction 0
     data-ciphers AES-256-GCM:AES-128-GCM:AES-128-CBC
-    data-ciphers-fallback AES-128-CBC # for e2e
+    data-ciphers-fallback AES-128-CBC # for getting rid of "Note: --cipher is not set. OpenVPN versions before 2.5 defaulted to BF-CBC as fallback when cipher negotiation failed in this case." error message in logs 
     keepalive 10 60
     persist-key
     persist-tun

--- a/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/configuration.tpl.yaml
@@ -102,3 +102,12 @@ spec:
   version: 2
   enabled: true
   settings:
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/Azure/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Azure/Standard/configuration.tpl.yaml
@@ -101,3 +101,12 @@ spec:
   version: 2
   enabled: true
   settings:
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
@@ -98,3 +98,12 @@ metadata:
 spec:
   version: 2
   enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/GCP/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/GCP/WithoutNAT/configuration.tpl.yaml
@@ -89,3 +89,12 @@ spec:
   version: 2
   enabled: true
   settings:
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -85,3 +85,12 @@ spec:
         customTolerationKeys:
           - node
   version: 1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/Static/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Static/configuration.tpl.yaml
@@ -85,3 +85,13 @@ spec:
   settings:
     ebpfExporterEnabled: false
   version: 1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:
+

--- a/testing/cloud_layouts/VCD/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/VCD/Standard/configuration.tpl.yaml
@@ -88,3 +88,12 @@ spec:
   version: 2
   enabled: true
   settings:
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_openvpn_ready.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_openvpn_ready.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export LANG=C
+set -Eeuo pipefail
+
+namespace="d8-openvpn"
+statefulset="openvpn"
+secrets=(
+  openvpn-pki-ca
+  openvpn-pki-crl
+  openvpn-pki-index-txt
+  openvpn-pki-server
+)
+
+echo "🔍 [1/3] Checking OpenVPN StatefulSet readiness..."
+
+for i in {1..20}; do
+  sleep 30
+  replicas=$(kubectl -n "$namespace" get statefulset "$statefulset" -o jsonpath='{.spec.replicas}' || echo "0")
+  ready=$(kubectl -n "$namespace" get statefulset "$statefulset" -o jsonpath='{.status.readyReplicas}' || echo "0")
+  echo "[$i/20] StatefulSet ready: $ready/$replicas"
+
+  if [[ "$replicas" == "$ready" && "$replicas" -gt 0 ]]; then
+    echo "✅ StatefulSet is fully ready."
+    break
+  fi
+
+  if [[ "$i" == 20 ]]; then
+    echo "❌ StatefulSet did not become ready in time."
+    exit 1
+  fi
+done
+
+echo ""
+echo "🔍 [2/3] Checking OpenVPN container logs for common errors..."
+
+log=$(kubectl -n "$namespace" logs "$statefulset-0" -c openvpn-tcp 2>&1 || true)
+if echo "$log" | grep -Eiq "(error|fail|denied|not permitted|operation not permitted)"; then
+  echo "❌ Detected suspicious entries in OpenVPN logs:"
+  echo "$log" | grep -Ei "(error|fail|denied|not permitted|operation not permitted)"
+  exit 1
+else
+  echo "✅ No suspicious log entries found."
+fi
+
+echo ""
+echo "🔍 [3/3] Checking required OpenVPN Secrets..."
+
+missing=()
+for secret in "${secrets[@]}"; do
+  if ! kubectl -n "$namespace" get secret "$secret" >/dev/null 2>&1; then
+    echo "❌ Missing secret: $secret"
+    missing+=("$secret")
+  else
+    echo "✅ Secret exists: $secret"
+  fi
+done
+
+if [[ ${#missing[@]} -ne 0 ]]; then
+  echo "❌ One or more required secrets are missing: ${missing[*]}"
+  exit 1
+fi
+
+echo ""
+echo "🎉 All OpenVPN readiness checks passed successfully."
+

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -1264,7 +1264,6 @@ function wait_cluster_ready() {
       sudo su -c /bin/bash <<<"${testOpenvpnReady}"; then
       test_failed=""
     else
-      test_failed="true"
       >&2 echo "OpenVPN test failed for Static provider. Sleeping 30 seconds..."
       sleep 30
     fi

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -1257,6 +1257,22 @@ function wait_cluster_ready() {
       return 1
   fi
 
+  testOpenvpnReady=$(cat "/deckhouse/testing/cloud_layouts/script.d/wait_cluster_ready/test_openvpn_ready.sh")
+
+  test_failed="true"
+    if $ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" \
+      sudo su -c /bin/bash <<<"${testOpenvpnReady}"; then
+      test_failed=""
+    else
+      test_failed="true"
+      >&2 echo "OpenVPN test failed for Static provider. Sleeping 30 seconds..."
+      sleep 30
+    fi
+
+    if [[ $test_failed == "true" ]]; then
+      return 1
+    fi
+
   if [[ $CIS_ENABLED == "true" ]]; then
     testCisScript=$(cat "$(pwd)/deckhouse/testing/cloud_layouts/script.d/wait_cluster_ready/test_cis.sh")
     REPORT=$($ssh_command -i "$ssh_private_key_path" $ssh_bastion "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${testCisScript}")

--- a/testing/cloud_layouts/vSphere/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/vSphere/Standard/configuration.tpl.yaml
@@ -95,3 +95,12 @@ spec:
   version: 2
   enabled: true
   settings:
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

* Added E2E tests to validate OpenVPN Admin pod startup and initialization of required secrets.
* Fixed path to scripts test_nodeuser.sh, test_script.sh, test_alerts.sh

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We verify that the openvpn server is initialized correctly to avoid a repeat of the case
#11280 

<details>
  <summary>📸 Screens E2E </summary>

![image](https://github.com/user-attachments/assets/c5ba11db-d944-45a4-968a-0863aa59b352)
![image](https://github.com/user-attachments/assets/a66f0c96-731e-4347-9b40-5275841ea582)

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: openvpn
type: chore
summary: Added e2e test for openvpn
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
