### PR TITLE
[prometheus] Fix grafana sqlite locking errors (#13063)

### DIFF
--- a/modules/300-prometheus/templates/grafana/deployment-v10.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment-v10.yaml
@@ -151,6 +151,8 @@ spec:
           value: "{{- range $i, $v := .Values.prometheus.grafana.customPlugins }}{{- if ne $i 0 -}},{{- end -}}{{- $v -}}{{- end }}"
           {{- end }}
         {{- end }}
+        - name: GF_DATABASE_WAL
+          value: "true"
         - name: PROMETHEUS_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Description
Grafana uses a SQLite database as a backend for storing data. There is only one database file, and it appears that  Grafana executes transactions from the different code parts concurrently, hence leading to high database access contention. If some part of the code cannot take an exclusive lock, it fails and retries. When there are a lot of dashboards, alerts, etc., this particular code may exhaust all retries and fail, leading to errors. 

There is a consistency mechanism better than exclusive locking - WAL.

Backports #13063 

## Why do we need it, and what problem does it solve?
It has been found that dashboards with alerts cannot be provisioned, or the alerts are never executed due to the issue described above.

## Why do we need it in the patch release (if we do)?
We do, as several setups use alerts on the dashboards, and confirmed to have this issue.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: fix
summary: enable WAL for the grafana SQLite database to prevent locking errors, thus fixing in-dashboard alerting.
impact: the grafana deployment will be rollout restarted
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
