### PR TITLE
[deckhouse] Fix deployed module release restoration on HA installations

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -333,8 +333,8 @@ func (l *Loader) restoreAbsentModulesFromReleases(ctx context.Context) error {
 
 			// check if module symlink leads to the current version
 			if moduleVersion != release.GetModuleVersion() {
-				l.logger.Info("module symlink is incorrect, restore it", slog.String("name", release.Spec.ModuleName))
-				if err = l.createModuleSymlink(release.Spec.ModuleName, moduleVersion, source, release.Spec.Weight, false); err != nil {
+				l.logger.Info("module symlink is incorrect, restore it", slog.String("name", release.Spec.ModuleName), slog.String("current_version", moduleVersion), slog.String("desired_version", release.GetModuleVersion()))
+				if err = l.createModuleSymlink(release.Spec.ModuleName, release.GetModuleVersion(), source, release.Spec.Weight, false); err != nil {
 					return fmt.Errorf("create the '%s' module symlink: %w", release.Spec.ModuleName, err)
 				}
 			}
@@ -344,7 +344,7 @@ func (l *Loader) restoreAbsentModulesFromReleases(ctx context.Context) error {
 		if err = utils.SyncModuleRegistrySpec(l.downloadedModulesDir, release.Spec.ModuleName, release.GetModuleVersion(), source); err != nil {
 			return fmt.Errorf("sync the '%s' module's registry settings with the '%s' module source: %w", release.Spec.ModuleName, source.Name, err)
 		}
-		l.logger.Info("resynced module's registry settings with the module source", slog.String("name", release.Spec.ModuleName), slog.String("source_name", source.Name))
+		l.logger.Info("resynced module's registry settings with the module source", slog.String("name", release.Spec.ModuleName), slog.String("version", release.GetReleaseVersion()), slog.String("source_name", source.Name))
 	}
 	return nil
 }
@@ -394,7 +394,11 @@ func (l *Loader) deleteModulesWithAbsentRelease(ctx context.Context) error {
 // createModuleSymlink checks if there are any other symlinks for a module in the symlink dir and deletes them before
 // attempting to download version/tag of the module and creating correct symlink
 func (l *Loader) createModuleSymlink(moduleName, moduleVersion string, moduleSource *v1alpha1.ModuleSource, moduleWeight uint32, mpo bool) error {
-	l.logger.Info("module is absent on filesystem, restore it from source", slog.String("name", moduleName), slog.String("source_name", moduleSource.Name))
+	l.logger.Info("module is absent on filesystem, restore it from source",
+		slog.String("name", moduleName),
+		slog.String("version", moduleVersion),
+		slog.String("source_name", moduleSource.Name),
+	)
 
 	// remove possible symlink doubles
 	if err := deleteModuleSymlinks(l.symlinksDir, moduleName); err != nil {

--- a/deckhouse-controller/pkg/controller/moduleloader/sync_test.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync_test.go
@@ -625,7 +625,6 @@ func (suite *ModuleLoaderTestSuite) TestRestoreAbsentModulesFromReleases() {
 
 		suite.cleanupPaths([]string{symlink, module.downloadedPath, module.symlinkPath})
 	})
-
 }
 
 func (suite *ModuleLoaderTestSuite) modulePullOverride(name string) *v1alpha2.ModulePullOverride {

--- a/deckhouse-controller/pkg/controller/moduleloader/sync_test.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -558,7 +559,36 @@ func (suite *ModuleLoaderTestSuite) TestRestoreAbsentModulesFromReleases() {
 		suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
 	})
 
-	// should remove wrong symlink and ensure new
+	// HA deckhouse installations could have previous version symlink on the standby masters
+	// have to delete it and add an actual one
+	suite.Run("Old version symlink", func() {
+		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
+			ManifestStub: manifestStub,
+			LayersStub: func() ([]crv1.Layer, error) {
+				return []crv1.Layer{&utils.FakeLayer{}}, nil
+			},
+		}, nil)
+
+		require.NoError(suite.T(), module.prepare(true, false))
+
+		require.NoError(suite.T(), os.MkdirAll(filepath.Join(suite.tmpDir, "echo", "v0.9.0"), 0750))
+
+		symlink := filepath.Join(suite.tmpDir, "modules", fmt.Sprintf("900-%s", module.name))
+		require.NoError(suite.T(), os.Symlink(filepath.Join(suite.tmpDir, "echo", "v0.9.0"), symlink))
+
+		time.Sleep(50 * time.Millisecond)
+
+		suite.setupModuleLoader(string(suite.parseTestdata("releases", "release.yaml")))
+		require.NoError(suite.T(), suite.loader.restoreAbsentModulesFromReleases(context.TODO()))
+
+		symlinkTarget, err := filepath.EvalSymlinks(symlink)
+		require.NoError(suite.T(), err)
+
+		assert.True(suite.T(), strings.HasSuffix(symlinkTarget, "echo/v1.0.0"), "module have to be restored to the v1.0.0 version")
+
+		suite.cleanupPaths([]string{symlink, module.downloadedPath, module.symlinkPath})
+	})
+
 	suite.Run("WrongSymlink", func() {
 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
 			ManifestStub: manifestStub,
@@ -595,6 +625,7 @@ func (suite *ModuleLoaderTestSuite) TestRestoreAbsentModulesFromReleases() {
 
 		suite.cleanupPaths([]string{symlink, module.downloadedPath, module.symlinkPath})
 	})
+
 }
 
 func (suite *ModuleLoaderTestSuite) modulePullOverride(name string) *v1alpha2.ModulePullOverride {


### PR DESCRIPTION
## Description
Fix deployed module release restoration on HA installations

## Why do we need it, and what problem does it solve?
HA deckhouse installation could have symlink to an old module version on standby masters.
We have to restore the relevant module version on startup.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Gracefully restore deployed modules on HA installations.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
