### PR TITLE
[docs] Fix getting started for kind

### DIFF
--- a/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA.md
+++ b/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA.md
@@ -22,6 +22,11 @@ When using kind on Windows, monitoring (Grafana, Prometheus) may not be availabl
 
 ## Installing
 
+{% alert level="warning" %}
+If you are installing Deckhouse Kubernetes Platform in kind on an Apple computer with an ARM processor, disable Rosetta for Docker Desktop.
+To do this, in the Docker Desktop interface, go to `Settings > General > Virtual Machine Options` and disable the `Use Rosetta for x86_64/amd64 emulation on Apple Silicon` option.
+{% endalert %}
+
 A Kubernetes cluster will be deployed and Deckhouse will be installed into a cluster using [the Shell script](https://github.com/deckhouse/deckhouse/blob/main/tools/kind-d8.sh):
 - Run the following command for installing Deckhouse **Community Edition**:
 ```shell

--- a/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA_RU.md
+++ b/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA_RU.md
@@ -22,6 +22,11 @@ Deckhouse будет установлен в **минимальной** конф
 
 ## Установка
 
+{% alert level="warning" %}
+Если вы устанавливаете Deckhouse Kubernetes Platform в kind на компьютер Apple с процессором с архитектурой ARM, отключите Rosetta для Docker Desktop.
+Для этого в интерфейсе Docker Desktop перейдите в `Settings > General > Virtual Machine Options` и отключите опцию `Use Rosetta for x86_64/amd64 emulation on Apple Silicon`.
+{% endalert %}
+
 Развертывание кластера Kubernetes и установка в него Deckhouse выполняются с помощью [Shell-скрипта](https://github.com/deckhouse/deckhouse/blob/main/tools/kind-d8.sh):
 - Выполните следующую команду для установки Deckhouse **Community Edition**:
 ```shell

--- a/tools/kind-d8.sh
+++ b/tools/kind-d8.sh
@@ -14,6 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Colors to identify the chip
+BOLD='\033[1m'
+GREEN='\033[0;32m'
+PURPLE='\033[0;35m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Getting a chip name
+chip_info=$(sysctl -n machdep.cpu.brand_string)
+
+if [[ "$chip_info" == *"Apple M"* ]]; then
+  # Retrieving the processor generation for Apple on the M
+  chip_model=$(echo "$chip_info" | awk -F'Apple ' '{print $2}' | cut -d' ' -f1-2 | sed 's/ / /')
+  # Display an alert for Apple on M
+  echo -e "${BOLD}${PURPLE}Warning. ${CYAN}Your computer has been identified as: ${GREEN}Apple $chip_model ${NC}
+  ${YELLOW}Disable Rosetta support in Docker Desktop before installation.
+  To do this, in Docker Desktop go to ${CYAN}Settings > General > Virtual Machine Options ${YELLOW}and uncheck the ${CYAN}Use Rosetta for x86_64/amd64 emulation on Apple Silicon ${YELLOW}option.${NC}"
+fi
+
 CONFIG_DIR=~/.kind-d8
 KIND_IMAGE=kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
 D8_RELEASE_CHANNEL_TAG=stable

--- a/tools/kind-d8.sh
+++ b/tools/kind-d8.sh
@@ -22,16 +22,17 @@ YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
-# Getting a chip name
-chip_info=$(sysctl -n machdep.cpu.brand_string)
-
-if [[ "$chip_info" == *"Apple M"* ]]; then
-  # Retrieving the processor generation for Apple on the M
-  chip_model=$(echo "$chip_info" | awk -F'Apple ' '{print $2}' | cut -d' ' -f1-2 | sed 's/ / /')
-  # Display an alert for Apple on M
-  echo -e "${BOLD}${PURPLE}Warning. ${CYAN}Your computer has been identified as: ${GREEN}Apple $chip_model ${NC}
-  ${YELLOW}Disable Rosetta support in Docker Desktop before installation.
-  To do this, in Docker Desktop go to ${CYAN}Settings > General > Virtual Machine Options ${YELLOW}and uncheck the ${CYAN}Use Rosetta for x86_64/amd64 emulation on Apple Silicon ${YELLOW}option.${NC}"
+#  Checking OS and getting a chip name
+if uname -s | grep -q "Darwin"; then
+    chip_info=$(sysctl -n machdep.cpu.brand_string)
+    if [[ "$chip_info" == *"Apple M"* ]]; then
+    # Retrieving the processor generation for Apple on the M
+    chip_model=$(echo "$chip_info" | awk -F'Apple ' '{print $2}' | cut -d' ' -f1-2 | sed 's/ / /')
+    # Display an alert for Apple on M
+    echo -e "${BOLD}${PURPLE}Warning. ${CYAN}Your computer has been identified as: ${GREEN}Apple $chip_model ${NC}
+    ${YELLOW}Disable Rosetta support in Docker Desktop before installation.
+    To do this, in Docker Desktop go to ${CYAN}Settings > General > Virtual Machine Options ${YELLOW}and uncheck the ${CYAN}Use Rosetta for x86_64/amd64 emulation on Apple Silicon ${YELLOW}option.${NC}"
+    fi
 fi
 
 CONFIG_DIR=~/.kind-d8


### PR DESCRIPTION
## Description

Fix getting started for kind.
Added an alert to disable rosetta for Apple with ARM processors.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix getting started for kind.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
