### PR TITLE
[user-authn] Fix secret with empty data field

### DIFF
--- a/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
+++ b/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
@@ -72,6 +72,12 @@ func kubernetesDexClientAppSecret(input *go_hook.HookInput) error {
 			return fmt.Errorf("cannot conver kubernetes secret to bytes")
 		}
 
+		// if secret field was removed, generate a new one
+		if len(secretContent) == 0 {
+			input.Values.Set(secretPath, pwgen.AlphaNum(20))
+			return nil
+		}
+
 		input.Values.Set(secretPath, string(secretContent))
 		return nil
 	}

--- a/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret_test.go
+++ b/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret_test.go
@@ -66,6 +66,28 @@ data:
 		})
 	})
 
+	Context("With empty secret", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubernetes-dex-client-app-secret
+  namespace: d8-user-authn
+data: {}
+`))
+			f.RunHook()
+		})
+
+		It("Should generate new secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+			Expect(f.ValuesGet("userAuthn.internal.kubernetesDexClientAppSecret").String()).To(HaveLen(20))
+		})
+	})
+
 	Context("With empty cluster", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(""))


### PR DESCRIPTION
## Description
Fix dex client app secret

## Why do we need it, and what problem does it solve?
If the secret doesn't have the data `secret` field:
```
---
apiVersion: v1
kind: Secret
metadata:
  name: kubernetes-dex-client-app-secret
  namespace: d8-user-authn
data: {}
```

we have to generate a new secret.
At now we set an empty string as secret.

## Why do we need it in the patch release (if we do)?
Just a trailer to fix the potential problem.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Fix secret generation on empty data field in the dex client app secret.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
