### PR TITLE
[tools][docs] Add script to run documentation of an external module

### DIFF
--- a/tools/docs/run_external_modules.sh
+++ b/tools/docs/run_external_modules.sh
@@ -18,10 +18,6 @@ EXT_MODULES_DIR=$PWD/external_modules
 BUILDER_TEMPLATE_PATH=$PWD/docs/site/backends/docs-builder-template
 CONTENT_PATH=$BUILDER_TEMPLATE_PATH/content/modules
 CRDS_PATH=$BUILDER_TEMPLATE_PATH/data/modules
-MODULES=(
-    "https://github.com/deckhouse/sds-replicated-volume"
-    "https://github.com/deckhouse/sds-node-configurator"
-)
 
 function create_ext_modules_path () {
     test -e $EXT_MODULES_DIR || mkdir $EXT_MODULES_DIR
@@ -31,75 +27,64 @@ function clean () {
     rm -rf $EXT_MODULES_DIR
 }
 
-function get_modules () {
-    for ix in ${!MODULES[*]}
-    do
-        unset MODULE_NAME
-        MODULE_NAME=$(echo ${MODULES[$ix]} | sed 's/.*\///')
-        echo "Getting module $MODULE_NAME"
-        module_path=$(echo $EXT_MODULES_DIR/$MODULE_NAME)
-        test -e $module_path || mkdir $CONTENT_PATH/$MODULE_NAME
-        test -e $module_path || git clone ${MODULES[$ix]} $module_path
-    done
-}
+function prepare_template () {
+    echo "Preparing docs of module $MODULE_NAME..."
+    module_path=$(echo $EXT_MODULES_DIR/$MODULE_NAME)
+    module_content_path=$(echo "$module_path/docs")
+    template_content_path=$(echo "$CONTENT_PATH/$MODULE_NAME/alpha")
+    test -e $template_content_path || mkdir -p $template_content_path
+    cp -r $module_content_path/*.md $template_content_path
+    find $template_content_path -name '*_RU.md' | sed 'p;s:_RU:.ru:g' | xargs -n2 mv
 
-function prepare_templates () {
-    for ix in ${!MODULES[*]}
-    do
-        unset MODULE_NAME
-        MODULE_NAME=$(echo ${MODULES[$ix]} | sed 's/.*\///')
-        echo "Preparing docs of module $MODULE_NAME..."
-        module_path=$(echo $EXT_MODULES_DIR/$MODULE_NAME)
-        module_content_path=$(echo "$module_path/docs")
-        template_content_path=$(echo "$CONTENT_PATH/$MODULE_NAME/alpha")
-        test -e $template_content_path || mkdir -p $template_content_path
-        cp -r $module_content_path/*.md $template_content_path
-        find $template_content_path -name '*_RU.md' | sed 'p;s:_RU:.ru:g' | xargs -n2 mv
+    echo "Preparing CRDs of module $MODULE_NAME..."
+    template_crds_path=$(echo "$CRDS_PATH/$MODULE_NAME/alpha/crds")
+    module_crds_path=$(echo "$module_path/crds")
+    test -e $template_crds_path || mkdir -p $template_crds_path
+    cp -r $module_crds_path/*.yaml $template_crds_path
 
-        echo "Preparing CRDs of module $MODULE_NAME..."
-        template_crds_path=$(echo "$CRDS_PATH/$MODULE_NAME/alpha/crds")
-        module_crds_path=$(echo "$module_path/crds")
-        test -e $template_crds_path || mkdir -p $template_crds_path
-        cp -r $module_crds_path/*.yaml $template_crds_path
-
-        echo "Preparing OpenAPI of module $MODULE_NAME..."
-        template_openapi_path=$(echo "$CRDS_PATH/$MODULE_NAME/alpha/openapi")
-        module_openapi_path=$(echo "$module_path/openapi")
-        test -e $template_openapi_path || mkdir -p $template_openapi_path
-        cp -r $module_openapi_path/*.yaml $template_openapi_path
-    done
+    echo "Preparing OpenAPI of module $MODULE_NAME..."
+    template_openapi_path=$(echo "$CRDS_PATH/$MODULE_NAME/alpha/openapi")
+    module_openapi_path=$(echo "$module_path/openapi")
+    test -e $template_openapi_path || mkdir -p $template_openapi_path
+    cp -r $module_openapi_path/*.yaml $template_openapi_path
 }
 
 function prepare_channels() {
     rm $CRDS_PATH/channels.yaml
     touch $CRDS_PATH/channels.yaml
-    for ix in ${!MODULES[*]}
-    do
-        unset MODULE_NAME
-        MODULE_NAME=$(echo ${MODULES[$ix]} | sed 's/.*\///')
-        echo "Preparing channels.yaml for $MODULE_NAME..."
-        echo "$MODULE_NAME:" >> $CRDS_PATH/channels.yaml
-        echo "  channels:" >> $CRDS_PATH/channels.yaml
-        echo "    alpha:" >> $CRDS_PATH/channels.yaml
-        echo "      version: v1.1" >> $CRDS_PATH/channels.yaml
-    done
+    echo "Preparing channels.yaml for $MODULE_NAME..."
+    echo "$MODULE_NAME:" >> $CRDS_PATH/channels.yaml
+    echo "  channels:" >> $CRDS_PATH/channels.yaml
+    echo "    alpha:" >> $CRDS_PATH/channels.yaml
+    echo "      version: v1.1" >> $CRDS_PATH/channels.yaml
 }
 
 function run_hugo() {
     docker run --rm -p 1313:1313 -v $BUILDER_TEMPLATE_PATH:/src klakegg/hugo:0.111.3-ext-alpine server --renderToDisk --disableFastRender --environment production
 }
 
-if [ "$#" -eq 0 ]; then
+if [ "$1" = "clean" ]; then
+    echo "Cleaning $EXT_MODULES_DIR..."
+    rm -rf $EXT_MODULES_DIR
+elif [ "$1" = "run" ]; then
+    run_hugo
+else
+    unset MODULE_NAME
+    repo_name=$(echo $1 | sed 's/.*\///')
+    MODULE_NAME="${repo_name%.*}"
+
     create_ext_modules_path
-    get_modules
-    prepare_templates
+
+    echo "Getting module $MODULE_NAME"
+    module_path=$(echo $EXT_MODULES_DIR/$MODULE_NAME)
+    test -e $module_path || mkdir $CONTENT_PATH/$MODULE_NAME
+    if [ $# -lt 2 ]; then
+      test -e $module_path || git clone $1 $module_path
+    else
+      test -e $module_path || git clone --branch $2 --single-branch $1 $module_path
+    fi
+
+    prepare_template
     prepare_channels
     clean
-else
-    if [ "$1" = "clean" ]; then
-        echo "Cleaning $EXT_MODULES_DIR..."
-        rm -rf $EXT_MODULES_DIR
-    elif [ "$1" = "run" ]; then
-        run_hugo
-    fi
 fi

--- a/tools/docs/run_external_modules.sh
+++ b/tools/docs/run_external_modules.sh
@@ -94,6 +94,7 @@ if [ "$#" -eq 0 ]; then
     get_modules
     prepare_templates
     prepare_channels
+    clean
 else
     if [ "$1" = "clean" ]; then
         echo "Cleaning $EXT_MODULES_DIR..."

--- a/tools/docs/run_external_modules.sh
+++ b/tools/docs/run_external_modules.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+EXT_MODULES_DIR=$PWD/external_modules
+BUILDER_TEMPLATE_PATH=$PWD/docs/site/backends/docs-builder-template
+CONTENT_PATH=$BUILDER_TEMPLATE_PATH/content/modules
+CRDS_PATH=$BUILDER_TEMPLATE_PATH/data/modules
+MODULES=(
+    "https://github.com/deckhouse/sds-replicated-volume"
+    "https://github.com/deckhouse/sds-node-configurator"
+)
+
+function create_ext_modules_path () {
+    test -e $EXT_MODULES_DIR || mkdir $EXT_MODULES_DIR
+}
+
+function clean () {
+    rm -rf $EXT_MODULES_DIR
+}
+
+function get_modules () {
+    for ix in ${!MODULES[*]}
+    do
+        unset MODULE_NAME
+        MODULE_NAME=$(echo ${MODULES[$ix]} | sed 's/.*\///')
+        echo "Getting module $MODULE_NAME"
+        module_path=$(echo $EXT_MODULES_DIR/$MODULE_NAME)
+        test -e $module_path || mkdir $CONTENT_PATH/$MODULE_NAME
+        test -e $module_path || git clone ${MODULES[$ix]} $module_path
+    done
+}
+
+function prepare_templates () {
+    for ix in ${!MODULES[*]}
+    do
+        unset MODULE_NAME
+        MODULE_NAME=$(echo ${MODULES[$ix]} | sed 's/.*\///')
+        echo "Preparing docs of module $MODULE_NAME..."
+        module_path=$(echo $EXT_MODULES_DIR/$MODULE_NAME)
+        module_content_path=$(echo "$module_path/docs")
+        template_content_path=$(echo "$CONTENT_PATH/$MODULE_NAME/alpha")
+        test -e $template_content_path || mkdir -p $template_content_path
+        cp -r $module_content_path/*.md $template_content_path
+        find $template_content_path -name '*_RU.md' | sed 'p;s:_RU:.ru:g' | xargs -n2 mv
+
+        echo "Preparing CRDs of module $MODULE_NAME..."
+        template_crds_path=$(echo "$CRDS_PATH/$MODULE_NAME/alpha/crds")
+        module_crds_path=$(echo "$module_path/crds")
+        test -e $template_crds_path || mkdir -p $template_crds_path
+        cp -r $module_crds_path/*.yaml $template_crds_path
+
+        echo "Preparing OpenAPI of module $MODULE_NAME..."
+        template_openapi_path=$(echo "$CRDS_PATH/$MODULE_NAME/alpha/openapi")
+        module_openapi_path=$(echo "$module_path/openapi")
+        test -e $template_openapi_path || mkdir -p $template_openapi_path
+        cp -r $module_openapi_path/*.yaml $template_openapi_path
+    done
+}
+
+function prepare_channels() {
+    rm $CRDS_PATH/channels.yaml
+    touch $CRDS_PATH/channels.yaml
+    for ix in ${!MODULES[*]}
+    do
+        unset MODULE_NAME
+        MODULE_NAME=$(echo ${MODULES[$ix]} | sed 's/.*\///')
+        echo "Preparing channels.yaml for $MODULE_NAME..."
+        echo "$MODULE_NAME:" >> $CRDS_PATH/channels.yaml
+        echo "  channels:" >> $CRDS_PATH/channels.yaml
+        echo "    alpha:" >> $CRDS_PATH/channels.yaml
+        echo "      version: v1.1" >> $CRDS_PATH/channels.yaml
+    done
+}
+
+function run_hugo() {
+    docker run --rm -p 1313:1313 -v $BUILDER_TEMPLATE_PATH:/src klakegg/hugo:0.111.3-ext-alpine server --renderToDisk --disableFastRender --environment production
+}
+
+if [ "$#" -eq 0 ]; then
+    create_ext_modules_path
+    get_modules
+    prepare_templates
+    prepare_channels
+else
+    if [ "$1" = "clean" ]; then
+        echo "Cleaning $EXT_MODULES_DIR..."
+        rm -rf $EXT_MODULES_DIR
+    elif [ "$1" = "run" ]; then
+        run_hugo
+    fi
+fi


### PR DESCRIPTION
## Description

This pull request introduces a new script, `run_external_modules.sh`, to streamline the management and documentation of external modules for the project. The script provides functionality for setting up module directories, preparing documentation and CRDs, managing OpenAPI specs, and running a local Hugo server for documentation previews.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: chore
summary: [tools][docs] Add script to run documentation of an external module.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
