### PR TITLE
[ci] Update documentation linter message

### DIFF
--- a/tools/docs/spelling/check_diff.sh
+++ b/tools/docs/spelling/check_diff.sh
@@ -78,7 +78,7 @@ done < ${pr_diff}
 check "${file_name}" "${file_changes}"
 
 if [ "${exit_code}" -ne 0 ]; then
-  echo -e "\nFix the problem or use 'docs/documentation-validation' PR label to skip."
+  echo -e "\nFix the problem or skip the linter.\nTo skip the linter set 'skip/documentation-validation' label onto the PR and re-run ALL jobs."
 fi
 
 exit ${exit_code}


### PR DESCRIPTION
## Description


Updated the message displayed when the documentation linter fails to clarify how to skip the linter by using the `skip/documentation-validation` label and re-running all jobs.

## Changelog entries

```changes
section: docs
type: chore
summary: Updated the message displayed when the documentation linter fails.
impact_level: low
```
