### PR TITLE
[dhctl] Add preflight check to avoid duplication of StaticInstance IP

### DIFF
--- a/dhctl/pkg/app/preflight.go
+++ b/dhctl/pkg/app/preflight.go
@@ -17,25 +17,26 @@ package app
 import "gopkg.in/alecthomas/kingpin.v2"
 
 var (
-	PreflightSkipAll                        = false
-	PreflightSkipSSHForward                 = false
-	PreflightSkipAvailabilityPorts          = false
-	PreflightSkipResolvingLocalhost         = false
-	PreflightSkipDeckhouseVersionCheck      = false
-	PreflightSkipRegistryThroughProxy       = false
-	PreflightSkipPublicDomainTemplateCheck  = false
-	PreflightSkipSSHCredentialsCheck        = false
-	PreflightSkipRegistryCredentials        = false
-	PreflightSkipContainerdExistCheck       = false
-	PreflightSkipPythonChecks               = false
-	PreflightSkipSudoIsAllowedForUserCheck  = false
-	PreflightSkipSystemRequirementsCheck    = false
-	PreflightSkipOneSSHHost                 = false
-	PreflightSkipCloudAPIAccessibility      = false
-	PreflightSkipTimeDrift                  = false
-	PreflightSkipCIDRIntersection           = false
-	PreflightSkipDeckhouseUserCheck         = false
-	PreflightSkipYandexWithNatInstanceCheck = false
+	PreflightSkipAll                          = false
+	PreflightSkipSSHForward                   = false
+	PreflightSkipAvailabilityPorts            = false
+	PreflightSkipResolvingLocalhost           = false
+	PreflightSkipDeckhouseVersionCheck        = false
+	PreflightSkipRegistryThroughProxy         = false
+	PreflightSkipPublicDomainTemplateCheck    = false
+	PreflightSkipSSHCredentialsCheck          = false
+	PreflightSkipRegistryCredentials          = false
+	PreflightSkipContainerdExistCheck         = false
+	PreflightSkipPythonChecks                 = false
+	PreflightSkipSudoIsAllowedForUserCheck    = false
+	PreflightSkipSystemRequirementsCheck      = false
+	PreflightSkipOneSSHHost                   = false
+	PreflightSkipCloudAPIAccessibility        = false
+	PreflightSkipTimeDrift                    = false
+	PreflightSkipCIDRIntersection             = false
+	PreflightSkipDeckhouseUserCheck           = false
+	PreflightSkipYandexWithNatInstanceCheck   = false
+	PreflightSkipStaticInstancesIPDuplication = false
 )
 
 const (
@@ -57,6 +58,7 @@ const (
 	CIDRIntersection                 = "preflight-skip-cidr-intersection"
 	DeckhouseUserCheckName           = "preflight-skip-deckhouse-user-check"
 	YandexWithNatInstance            = "preflight-skip-yandex-with-nat-instance-check"
+	StaticInstancesIPDuplication     = "preflight-skip-staticinstances-ip-duplication"
 )
 
 var PreflightSkipOptionsMap = map[string]*bool{
@@ -75,6 +77,7 @@ var PreflightSkipOptionsMap = map[string]*bool{
 	SystemRequirementsArgName:        &PreflightSkipSystemRequirementsCheck,
 	OneSSHHostCheckArgName:           &PreflightSkipOneSSHHost,
 	CIDRIntersection:                 &PreflightSkipCIDRIntersection,
+	StaticInstancesIPDuplication:     &PreflightSkipStaticInstancesIPDuplication,
 	DeckhouseUserCheckName:           &PreflightSkipDeckhouseUserCheck,
 	TimeDriftArgName:                 &PreflightSkipTimeDrift,
 	YandexWithNatInstance:            &PreflightSkipYandexWithNatInstanceCheck,
@@ -146,4 +149,7 @@ func DefinePreflight(cmd *kingpin.CmdClause) {
 	cmd.Flag(YandexWithNatInstance, "Skip verifying Yandex Cloud WithNatInstance configuration").
 		Envar(configEnvName("PREFLIGHT_SKIP_YANDEX_WITH_NAT_INSTANCE_CHECK")).
 		BoolVar(PreflightSkipOptionsMap[YandexWithNatInstance])
+	cmd.Flag(StaticInstancesIPDuplication, "Skip verifying StaticInstances IP intersection").
+		Envar(configEnvName("PREFLIGHT_SKIP_SI_IP_DUPLICATION")).
+		BoolVar(PreflightSkipOptionsMap[StaticInstancesIPDuplication])
 }

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -84,6 +84,11 @@ func (pc *Checker) Static(ctx context.Context) error {
 
 	err = pc.do(ctx, "Preflight checks for static-cluster", []checkStep{
 		{
+			fun:            pc.CheckStaticInstancesIPDuplication,
+			successMessage: "IP of StaticInstances are unique",
+			skipFlag:       app.StaticInstancesIPDuplication,
+		},
+		{
 			fun:            pc.CheckSingleSSHHostForStatic,
 			successMessage: "only one --ssh-host parameter used",
 			skipFlag:       app.OneSSHHostCheckArgName,

--- a/dhctl/pkg/preflight/staticinstances_ip_duplication.go
+++ b/dhctl/pkg/preflight/staticinstances_ip_duplication.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func (pc *Checker) CheckStaticInstancesIPDuplication(_ context.Context) error {
+	fmt.Println(pc.metaConfig.ResourcesYAML)
+	documents := strings.Split(pc.metaConfig.ResourcesYAML, "---")
+	instances := make(map[string]string)
+	for _, doc := range documents {
+		var result map[string]interface{}
+		err := yaml.Unmarshal([]byte(doc), &result)
+		if err != nil {
+			return fmt.Errorf("cannot unmarshal YAML: %v", err)
+		}
+
+		if result["kind"] == "StaticInstance" {
+			meta := result["metadata"].(map[string]interface{})
+			name := meta["name"].(string)
+
+			spec := result["spec"].(map[string]interface{})
+			address := spec["address"].(string)
+
+			instName, ok := instances[address]
+			if ok {
+				return fmt.Errorf("Duplicate address for %s: %s and %s\n", address, instName, name)
+			} else {
+				instances[address] = name
+			}
+		}
+	}
+
+	return nil
+}

--- a/dhctl/pkg/preflight/staticinstances_ip_duplication_test.go
+++ b/dhctl/pkg/preflight/staticinstances_ip_duplication_test.go
@@ -1,0 +1,148 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+)
+
+func TestCheckSIIPIntersection(t *testing.T) {
+	type fields struct {
+		metaConfig *config.MetaConfig
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "happy path: 2 instances, different addresses",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ResourcesYAML: `---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: static-0
+spec:
+  address: 10.128.0.22
+  credentialsRef:
+    kind: SSHCredentials
+    name: credentials
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: static-1
+spec:
+  address: 10.128.0.23
+  credentialsRef:
+    kind: SSHCredentials
+    name: credentials
+`,
+			}},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "happy path: no instances",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ResourcesYAML: ``,
+			}},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "happy path: single instance",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ResourcesYAML: `---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: static-0
+spec:
+  address: 10.128.0.22
+  credentialsRef:
+    kind: SSHCredentials
+    name: credentials
+`,
+			}},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "intersects addresses",
+			fields: fields{metaConfig: &config.MetaConfig{
+				ResourcesYAML: `---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: static-0
+spec:
+  address: 10.128.0.22
+  credentialsRef:
+    kind: SSHCredentials
+    name: credentials
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: static-1
+spec:
+  address: 10.128.0.23
+  credentialsRef:
+    kind: SSHCredentials
+    name: credentials
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: static-2
+spec:
+  address: 10.128.0.24
+  credentialsRef:
+    kind: SSHCredentials
+    name: credentials
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: StaticInstance
+metadata:
+  name: static-3
+spec:
+  address: 10.128.0.22
+  credentialsRef:
+    kind: SSHCredentials
+    name: credentials
+`,
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "Duplicate address")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pc := &Checker{
+				metaConfig: tt.fields.metaConfig,
+			}
+			tt.wantErr(t,
+				pc.CheckStaticInstancesIPDuplication(context.Background()),
+				fmt.Sprintf("CheckStaticInstancesIPDuplication()"),
+			)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add preflight check to avoid ip addresses duplication in StaticInstance

## Why do we need it, and what problem does it solve?

Close https://github.com/deckhouse/deckhouse/issues/12594

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Add preflight check to avoid ip addresses duplication in StaticInstances.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
