### PR TITLE
[deckhouse] module stage column

### DIFF
--- a/deckhouse-controller/crds/module.yaml
+++ b/deckhouse-controller/crds/module.yaml
@@ -133,7 +133,7 @@ spec:
       additionalPrinterColumns:
         - name: Weight
           jsonPath: .properties.weight
-          type: string
+          type: integer
           priority: 1
           description: Module weight
         - name: Stage

--- a/deckhouse-controller/crds/module.yaml
+++ b/deckhouse-controller/crds/module.yaml
@@ -131,10 +131,10 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-        - name: Weight
-          jsonPath: .properties.weight
-          type: integer
-          description: Module _weight_ (priority).
+        - name: Stage
+          jsonPath: .properties.stage
+          type: string
+          description: Module stage
         - name: Release channel
           jsonPath: .properties.releaseChannel
           description: Release channel of the module.

--- a/deckhouse-controller/crds/module.yaml
+++ b/deckhouse-controller/crds/module.yaml
@@ -131,6 +131,11 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
+        - name: Weight
+          jsonPath: .properties.weight
+          type: string
+          priority: 1
+          description: Module weight
         - name: Stage
           jsonPath: .properties.stage
           type: string

--- a/modules/031-ceph-csi/module.yaml
+++ b/modules/031-ceph-csi/module.yaml
@@ -1,6 +1,5 @@
 name: ceph-csi
 weight: 31
-stage: Deprecated
 subsystems:
   - storage
   - infrastructure

--- a/modules/031-ceph-csi/module.yaml
+++ b/modules/031-ceph-csi/module.yaml
@@ -1,5 +1,6 @@
 name: ceph-csi
 weight: 31
+stage: Deprecated
 subsystems:
   - storage
   - infrastructure


### PR DESCRIPTION
## Description
It provides stage column for modules instead of weight.

## Why do we need it, and what problem does it solve?
This column shows module`s lifecycle stage.

```
root@dev-master-0:~# k get module
NAME                                  STAGE        SOURCE     PHASE        ENABLED   READY
admission-policy-engine                            Embedded   Ready        True      True
basic-auth                                         Embedded   Downloaded   False     False
ceph-csi                              Deprecated   Embedded   Downloaded   False     False
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Add module stage column.
```