### PR TITLE
[deckhouse] limit module name

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -264,8 +264,8 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 	availableModules := make([]v1alpha1.AvailableModule, 0)
 	var pullErrorsExist bool
 	for _, moduleName := range pulledModules {
-		if moduleName == "modules" {
-			r.logger.Warn("the 'modules' is a forbidden name, skip the module.")
+		if moduleName == "modules" || len(moduleName) > 64 {
+			r.logger.Warn("the modules has a forbidden name, skip it.", slog.String("name", moduleName))
 			continue
 		}
 


### PR DESCRIPTION
## Description
It limits module name to avoid ensuring "bad" modules such as blobs.

## Why do we need it, and what problem does it solve?
To avoid ensuring "bad" modules such as blobs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Limit module name.
impact_level: low
```
