### PR TITLE
[tools] bump DMT version to 0.1.15

### DIFF
--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-DMT_VERSION=0.1.14
+DMT_VERSION=0.1.15
 
 function install_dmt() {
   platform_name=$(uname -m)


### PR DESCRIPTION
## Description

bump DMT version to 0.1.15

## Why do we need it, and what problem does it solve?

bump DMT version to 0.1.15

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: chore
summary: bump DMT version to 0.1.15
impact_level: low
```
