### PR TITLE
[extended-monitoring] Resolve missing resource config for x509_certificate_exporter

### DIFF
--- a/modules/340-extended-monitoring/templates/x509-certificate-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/x509-certificate-exporter/deployment.yaml
@@ -66,7 +66,7 @@ spec:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
             {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
-            {{- include "cert_exporter_resources" . | nindent 12 }}
+            {{- include "x509_certificate_exporter_resources" . | nindent 12 }}
             {{- end }}
         image: {{ include "helm_lib_module_image" (list . "x509CertificateExporter") }}
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Description

During the migration from `cert_exporter` to `x509_certificate_exporter`, the `resources` section in the deployment manifest was not updated.  
This PR fixes that by renaming the resource reference from `certificate_exporter_resources` to `x509_certificate_exporter_resources` in `deployment.yaml`.

## Why we need it?

Currently, if VPA (Vertical Pod Autoscaler) is not used, the deployment manifest includes a non-existent resource reference (certificate_exporter_resources).
As a result, the x509_certificate_exporter cannot be deployed.
This fix ensures the correct resource values are used, allowing the exporter to start properly.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: fix 
summary: Fix x509_certificate_exporter_resources deployment
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
