### PR TITLE
[ingress-nginx] fix missing libraries for ingress-nginx v1.9

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
@@ -240,11 +240,11 @@ import:
   to: /chroot/lib64
   before: install
   includePaths:
-  - libpcre.so.1.2.13
-  - libpcre16.so.0.2.13
-  - libpcre32.so.0.0.13
-  - libpcrecpp.so.0.0.2
-  - libpcreposix.so.0.0.7
+  - libpcre.so*
+  - libpcre16.so*
+  - libpcre32.so*
+  - libpcrecpp.so*
+  - libpcreposix.so*
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-opentelemetry-artifact
   add: /etc/nginx/modules
   to: /chroot/modules_mount/etc/nginx/modules/otel
@@ -254,14 +254,14 @@ import:
   to: /chroot/lib64
   before: install
   includePaths:
-    - libcares.so.2
-    - libre2.so.9
-    - libgpr.so.16
-    - libaddress_sorting.so.16
-    - libgrpc++.so.1.38.0
-    - libprotobuf.so.27.0.0
-    - libgrpc.so.16
-    - libupb.so.16
+    - libcares.so*
+    - libre2.so*
+    - libgpr.so*
+    - libaddress_sorting.so*
+    - libgrpc++.so*
+    - libprotobuf.so*
+    - libgrpc.so*
+    - libupb.so*
 shell:
   install:
   {{- include "alt packages proxy" . | nindent 2 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The build procedure of ingress-nginx 1.9 was wrongly refactored some time ago and now ingress-nginx containers are missing some key shared libraries like grpc, resulting in controllers` pods crashing with the following errors:

```
-------------------------------------------------------------------------------
Error: exit status 1
nginx: [emerg] dlopen() "/modules_mount/etc/nginx/modules/otel/otel_ngx_module.so" failed (libgrpc.so.16: cannot open shared object file: No such file or directory) in /tmp/nginx/nginx-cfg3397002933:15
nginx: configuration file /tmp/nginx/nginx-cfg3397002933 test failed

-------------------------------------------------------------------------------
E0421 14:08:07.026288       7 queue.go:131] "requeuing" err=<
```

It fixes ingress-nginx controller build by copying all necessary share libraries into the final container.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

It fixes ingress-nginx controller 1.9 build inconsistency by copying all necessary share libraries into the final container.

## Why do we need it in the patch release (if we do)?

Currently, in v1.69.2, ingress-nginx controller 1.9 is crashing if some additional nginx modules are enabled (like opentelemetry).  This fix is required for users who are still using ingress-nginx controllers of 1.9 version.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: All necessary shared libraries are added to the container image.
impact: Ingress-nginx controller pods of v1.9 will be restated.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
