### PR TITLE
[deckhouse] add module version to module source

### DIFF
--- a/deckhouse-controller/crds/doc-ru-module-source.yaml
+++ b/deckhouse-controller/crds/doc-ru-module-source.yaml
@@ -43,6 +43,9 @@ spec:
                       name:
                         type: string
                         description: Имя модуля.
+                      version:
+                        type: string
+                        description: Версия модуля
                       pullError:
                         type: string
                         description: Ошибка скачивания модуля.

--- a/deckhouse-controller/crds/module-source.yaml
+++ b/deckhouse-controller/crds/module-source.yaml
@@ -95,6 +95,9 @@ spec:
                       name:
                         type: string
                         description: The module name.
+                      version:
+                        type: string
+                        description: The module version.
                       checksum:
                         type: string
                         description: The module checksum.

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
@@ -61,7 +61,6 @@ const (
 	ModuleReasonDisabled                    = "Disabled"
 	ModuleReasonConflict                    = "Conflict"
 	ModuleReasonDownloading                 = "Downloading"
-	ModuleReasonDownloadingError            = "DownloadingError"
 	ModuleReasonHookError                   = "HookError"
 	ModuleReasonModuleError                 = "ModuleError"
 	ModuleReasonReconciling                 = "Reconciling"

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_source.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_source.go
@@ -105,6 +105,7 @@ type ModuleSourceStatus struct {
 
 type AvailableModule struct {
 	Name       string `json:"name"`
+	Version    string `json:"version,omitempty"`
 	Policy     string `json:"policy,omitempty"`
 	Checksum   string `json:"checksum,omitempty"`
 	PullError  string `json:"pullError,omitempty"`

--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/flant/shell-operator/pkg/utils/measure"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	crv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/iancoleman/strcase"
 	"gopkg.in/yaml.v3"
 
@@ -114,7 +114,7 @@ func (md *ModuleDownloader) DownloadByModuleVersion(moduleName, moduleVersion st
 // DownloadMetadataFromReleaseChannel downloads only module release image with metadata: version.json, checksum.json(soon)
 // does not fetch and install the desired version on the module, only fetches its module definition
 func (md *ModuleDownloader) DownloadMetadataFromReleaseChannel(moduleName, releaseChannel, moduleChecksum string) (ModuleDownloadResult, error) {
-	res := ModuleDownloadResult{}
+	var res ModuleDownloadResult
 
 	moduleVersion, checksum, changelog, err := md.fetchModuleReleaseMetadataFromReleaseChannel(moduleName, releaseChannel, moduleChecksum)
 	if err != nil {
@@ -169,7 +169,7 @@ func (md *ModuleDownloader) GetDocumentationArchive(moduleName, moduleVersion st
 	return moduletools.ExtractDocs(img)
 }
 
-func (md *ModuleDownloader) fetchImage(moduleName, imageTag string) (v1.Image, error) {
+func (md *ModuleDownloader) fetchImage(moduleName, imageTag string) (crv1.Image, error) {
 	regCli, err := md.dc.GetRegistryClient(path.Join(md.ms.Spec.Registry.Repo, moduleName), md.registryOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("fetch module error: %v", err)
@@ -178,7 +178,7 @@ func (md *ModuleDownloader) fetchImage(moduleName, imageTag string) (v1.Image, e
 	return regCli.Image(context.TODO(), imageTag)
 }
 
-func (md *ModuleDownloader) storeModule(moduleStorePath string, img v1.Image) (*DownloadStatistic, error) {
+func (md *ModuleDownloader) storeModule(moduleStorePath string, img crv1.Image) (*DownloadStatistic, error) {
 	_ = os.RemoveAll(moduleStorePath)
 
 	ds, err := md.copyModuleToFS(moduleStorePath, img)
@@ -206,7 +206,7 @@ func (md *ModuleDownloader) fetchAndCopyModuleByVersion(moduleName, moduleVersio
 	return md.storeModule(moduleVersionPath, img)
 }
 
-func (md *ModuleDownloader) copyModuleToFS(rootPath string, img v1.Image) (*DownloadStatistic, error) {
+func (md *ModuleDownloader) copyModuleToFS(rootPath string, img crv1.Image) (*DownloadStatistic, error) {
 	rc, err := cr.Extract(img)
 	if err != nil {
 		return nil, err
@@ -351,7 +351,7 @@ func (md *ModuleDownloader) fetchModuleDefinitionFromFS(name, path string) *modu
 	return def
 }
 
-func (md *ModuleDownloader) fetchModuleDefinitionFromImage(moduleName string, img v1.Image) (*moduletypes.Definition, error) {
+func (md *ModuleDownloader) fetchModuleDefinitionFromImage(moduleName string, img crv1.Image) (*moduletypes.Definition, error) {
 	def := &moduletypes.Definition{
 		Name:   moduleName,
 		Weight: defaultModuleWeight,
@@ -380,7 +380,7 @@ func (md *ModuleDownloader) fetchModuleDefinitionFromImage(moduleName string, im
 	return def, nil
 }
 
-func (md *ModuleDownloader) fetchModuleReleaseMetadata(img v1.Image) (ModuleReleaseMetadata, error) {
+func (md *ModuleDownloader) fetchModuleReleaseMetadata(img crv1.Image) (ModuleReleaseMetadata, error) {
 	var meta ModuleReleaseMetadata
 
 	rc, err := cr.Extract(img)

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -332,7 +332,7 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 		// download module metadata from the specified release channel
 		meta, err := md.DownloadMetadataFromReleaseChannel(moduleName, policy.Spec.ReleaseChannel, cachedChecksum)
 		if err != nil {
-			if module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+			if module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) && module.Properties.Source == source.Name {
 				r.logger.Warn("failed to download module", slog.String("name", moduleName), log.Err(err))
 				availableModule.PullError = err.Error()
 				pullErrorsExist = true

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -384,6 +384,7 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 				return fmt.Errorf("ensure module release for the '%s' module: %w", moduleName, err)
 			}
 			availableModule.Checksum = meta.Checksum
+			availableModule.Version = meta.ModuleVersion
 		}
 		availableModules = append(availableModules, availableModule)
 	}

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -335,10 +335,10 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 			if module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
 				r.logger.Warn("failed to download module", slog.String("name", moduleName), log.Err(err))
 				availableModule.PullError = err.Error()
-				availableModules = append(availableModules, availableModule)
 				pullErrorsExist = true
 			}
 			availableModule.Version = "unknown"
+			availableModules = append(availableModules, availableModule)
 			continue
 		}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -332,7 +332,7 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 		// download module metadata from the specified release channel
 		meta, err := md.DownloadMetadataFromReleaseChannel(moduleName, policy.Spec.ReleaseChannel, cachedChecksum)
 		if err != nil {
-			if module.HasCondition(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+			if module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
 				r.logger.Warn("failed to download module", slog.String("name", moduleName), log.Err(err))
 				availableModule.PullError = err.Error()
 				availableModules = append(availableModules, availableModule)

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -333,7 +333,7 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 		if err != nil {
 			return fmt.Errorf("check if the '%s' module has a release: %w", moduleName, err)
 		}
-		if !exists {
+		if !exists || availableModule.Version == "" {
 			// if release does not exist, clear checksum to trigger meta downloading
 			cachedChecksum = ""
 		}

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -334,7 +334,7 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 			return fmt.Errorf("check if the '%s' module has a release: %w", moduleName, err)
 		}
 		if !exists || availableModule.Version == "" {
-			// if release does not exist, clear checksum to trigger meta downloading
+			// if release does not exist or the version is unset, clear checksum to trigger meta downloading
 			cachedChecksum = ""
 		}
 
@@ -384,10 +384,6 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 				return fmt.Errorf("ensure module release for the '%s' module: %w", moduleName, err)
 			}
 			availableModule.Checksum = meta.Checksum
-		}
-
-		// set module version
-		if meta.ModuleVersion != "" {
 			availableModule.Version = meta.ModuleVersion
 		}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -384,8 +384,13 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 				return fmt.Errorf("ensure module release for the '%s' module: %w", moduleName, err)
 			}
 			availableModule.Checksum = meta.Checksum
+		}
+
+		// set module version
+		if meta.ModuleVersion != "" {
 			availableModule.Version = meta.ModuleVersion
 		}
+
 		availableModules = append(availableModules, availableModule)
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -386,6 +386,10 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 			availableModule.Checksum = meta.Checksum
 			availableModule.Version = meta.ModuleVersion
 		}
+		// set module version
+		if meta.ModuleVersion != "" {
+			availableModule.Version = meta.ModuleVersion
+		}
 
 		availableModules = append(availableModules, availableModule)
 	}

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -257,7 +257,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		require.NoError(suite.T(), err)
 	})
 
-	suite.Run("source with module with pull error", func() {
+	suite.Run("source with pull error", func() {
 		dependency.TestDC.CRClient.ListTagsMock.Return([]string{"enabledmodule", "errormodule"}, nil)
 		dependency.TestDC.CRClient.ImageMock.Set(func(tag string) (crv1.Image, error) {
 			if tag == "alpha" {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	crv1 "github.com/google/go-containerregistry/pkg/v1"
 	crfake "github.com/google/go-containerregistry/pkg/v1/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,9 +51,9 @@ import (
 var (
 	generateGolden     bool
 	manifestsDelimiter *regexp.Regexp
-	manifestStub       = func() (*v1.Manifest, error) {
-		return &v1.Manifest{
-			Layers: []v1.Descriptor{},
+	manifestStub       = func() (*crv1.Manifest, error) {
+		return &crv1.Manifest{
+			Layers: []crv1.Descriptor{},
 		}, nil
 	}
 )
@@ -244,11 +244,11 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		dependency.TestDC.CRClient.ListTagsMock.Return([]string{"enabledmodule", "disabledmodule", "withpolicymodule", "notthissourcemodule"}, nil)
 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
 			ManifestStub: manifestStub,
-			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&utils.FakeLayer{}, &utils.FakeLayer{FilesContent: map[string]string{"version.json": `{"version": "v1.2.3"}`}}}, nil
+			LayersStub: func() ([]crv1.Layer, error) {
+				return []crv1.Layer{&utils.FakeLayer{}, &utils.FakeLayer{FilesContent: map[string]string{"version.json": `{"version": "crv1.2.3"}`}}}, nil
 			},
-			DigestStub: func() (v1.Hash, error) {
-				return v1.Hash{Algorithm: "sha256"}, nil
+			DigestStub: func() (crv1.Hash, error) {
+				return crv1.Hash{Algorithm: "sha256"}, nil
 			},
 		}, nil)
 
@@ -259,18 +259,18 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 
 	suite.Run("source with module with pull error", func() {
 		dependency.TestDC.CRClient.ListTagsMock.Return([]string{"enabledmodule", "errormodule"}, nil)
-		dependency.TestDC.CRClient.ImageMock.Set(func(tag string) (v1.Image, error) {
+		dependency.TestDC.CRClient.ImageMock.Set(func(tag string) (crv1.Image, error) {
 			if tag == "alpha" {
 				return nil, errors.New("GET https://registry.deckhouse.io/v2/deckhouse/ee/modules/errormodule/release/manifests/alpha:\n      MANIFEST_UNKNOWN: manifest unknown; map[Tag:alpha]")
 			}
 
 			return &crfake.FakeImage{
 				ManifestStub: manifestStub,
-				LayersStub: func() ([]v1.Layer, error) {
-					return []v1.Layer{&utils.FakeLayer{}, &utils.FakeLayer{FilesContent: map[string]string{"version.json": `{"version": "v1.2.3"}`}}}, nil
+				LayersStub: func() ([]crv1.Layer, error) {
+					return []crv1.Layer{&utils.FakeLayer{}, &utils.FakeLayer{FilesContent: map[string]string{"version.json": `{"version": "crv1.2.3"}`}}}, nil
 				},
-				DigestStub: func() (v1.Hash, error) {
-					return v1.Hash{Algorithm: "sha256"}, nil
+				DigestStub: func() (crv1.Hash, error) {
+					return crv1.Hash{Algorithm: "sha256"}, nil
 				},
 			}, nil
 		})

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -245,7 +245,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
 			ManifestStub: manifestStub,
 			LayersStub: func() ([]crv1.Layer, error) {
-				return []crv1.Layer{&utils.FakeLayer{}, &utils.FakeLayer{FilesContent: map[string]string{"version.json": `{"version": "crv1.2.3"}`}}}, nil
+				return []crv1.Layer{&utils.FakeLayer{}, &utils.FakeLayer{FilesContent: map[string]string{"version.json": `{"version": "v1.2.3"}`}}}, nil
 			},
 			DigestStub: func() (crv1.Hash, error) {
 				return crv1.Hash{Algorithm: "sha256"}, nil
@@ -267,7 +267,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 			return &crfake.FakeImage{
 				ManifestStub: manifestStub,
 				LayersStub: func() ([]crv1.Layer, error) {
-					return []crv1.Layer{&utils.FakeLayer{}, &utils.FakeLayer{FilesContent: map[string]string{"version.json": `{"version": "crv1.2.3"}`}}}, nil
+					return []crv1.Layer{&utils.FakeLayer{}, &utils.FakeLayer{FilesContent: map[string]string{"version.json": `{"version": "v1.2.3"}`}}}, nil
 				},
 				DigestStub: func() (crv1.Hash, error) {
 					return crv1.Hash{Algorithm: "sha256"}, nil

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodulepullerror.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodulepullerror.yaml
@@ -26,6 +26,7 @@ status:
     pullError: |-
       fetch image error: GET https://registry.deckhouse.io/v2/deckhouse/ee/modules/errormodule/release/manifests/alpha:
             MANIFEST_UNKNOWN: manifest unknown; map[Tag:alpha]
+    version: unknown
   modulesCount: 2
   phase: Active
   syncTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodulepullerror.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodulepullerror.yaml
@@ -18,8 +18,9 @@ spec:
 status:
   message: Some errors occurred. Inspect status for details
   modules:
-  - name: enabledmodule
-    pullError: 'fetch release metadata error: Invalid Semantic Version'
+  - checksum: 'sha256:'
+    name: enabledmodule
+    version: v1.2.3
   - name: errormodule
     policy: test-alpha
     pullError: |-
@@ -28,3 +29,33 @@ status:
   modulesCount: 2
   phase: Active
   syncTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/apply-now: "true"
+  creationTimestamp: null
+  labels:
+    module: enabledmodule
+    modules.deckhouse.io/update-policy: ""
+    release-checksum: 1beb143dffb1b662137094e7faea1e17
+    source: test-source-1
+  name: enabledmodule-v1.2.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: test-source-1
+    uid: ""
+  resourceVersion: "1"
+spec:
+  moduleName: enabledmodule
+  version: 1.2.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  pullDuration: 0s
+  size: 0
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodulepullerror.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodulepullerror.yaml
@@ -18,8 +18,8 @@ spec:
 status:
   message: Some errors occurred. Inspect status for details
   modules:
-  - checksum: 'sha256:'
-    name: enabledmodule
+  - name: enabledmodule
+    pullError: 'fetch release metadata error: Invalid Semantic Version'
   - name: errormodule
     policy: test-alpha
     pullError: |-
@@ -28,33 +28,3 @@ status:
   modulesCount: 2
   phase: Active
   syncTime: "2019-10-17T15:33:00Z"
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleRelease
-metadata:
-  annotations:
-    modules.deckhouse.io/apply-now: "true"
-  creationTimestamp: null
-  labels:
-    module: enabledmodule
-    modules.deckhouse.io/update-policy: ""
-    release-checksum: 1beb143dffb1b662137094e7faea1e17
-    source: test-source-1
-  name: enabledmodule-v1.2.3
-  ownerReferences:
-  - apiVersion: deckhouse.io/v1alpha1
-    controller: true
-    kind: ModuleSource
-    name: test-source-1
-    uid: ""
-  resourceVersion: "1"
-spec:
-  moduleName: enabledmodule
-  version: 1.2.3
-  weight: 900
-status:
-  approved: false
-  message: ""
-  pullDuration: 0s
-  size: 0
-  transitionTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodules.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodules.yaml
@@ -19,10 +19,12 @@ status:
   message: ""
   modules:
   - name: disabledmodule
+    version: v1.2.3
   - checksum: 'sha256:'
     name: enabledmodule
     version: v1.2.3
   - name: notthissourcemodule
+    version: v1.2.3
   - checksum: 'sha256:'
     name: withpolicymodule
     policy: test-alpha

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodules.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodules.yaml
@@ -16,75 +16,15 @@ spec:
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
 status:
-  message: ""
+  message: Some errors occurred. Inspect status for details
   modules:
   - name: disabledmodule
-  - checksum: 'sha256:'
-    name: enabledmodule
+  - name: enabledmodule
+    pullError: 'fetch release metadata error: Invalid Semantic Version'
   - name: notthissourcemodule
-  - checksum: 'sha256:'
-    name: withpolicymodule
+  - name: withpolicymodule
     policy: test-alpha
+    pullError: 'fetch release metadata error: Invalid Semantic Version'
   modulesCount: 4
   phase: Active
   syncTime: "2019-10-17T15:33:00Z"
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleRelease
-metadata:
-  annotations:
-    modules.deckhouse.io/apply-now: "true"
-  creationTimestamp: null
-  labels:
-    module: enabledmodule
-    modules.deckhouse.io/update-policy: ""
-    release-checksum: 1beb143dffb1b662137094e7faea1e17
-    source: test-source-1
-  name: enabledmodule-v1.2.3
-  ownerReferences:
-  - apiVersion: deckhouse.io/v1alpha1
-    controller: true
-    kind: ModuleSource
-    name: test-source-1
-    uid: ""
-  resourceVersion: "1"
-spec:
-  moduleName: enabledmodule
-  version: 1.2.3
-  weight: 900
-status:
-  approved: false
-  message: ""
-  pullDuration: 0s
-  size: 0
-  transitionTime: null
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleRelease
-metadata:
-  annotations:
-    modules.deckhouse.io/apply-now: "true"
-  creationTimestamp: null
-  labels:
-    module: withpolicymodule
-    modules.deckhouse.io/update-policy: test-alpha
-    release-checksum: 1beb143dffb1b662137094e7faea1e17
-    source: test-source-1
-  name: withpolicymodule-v1.2.3
-  ownerReferences:
-  - apiVersion: deckhouse.io/v1alpha1
-    controller: true
-    kind: ModuleSource
-    name: test-source-1
-    uid: ""
-  resourceVersion: "1"
-spec:
-  moduleName: withpolicymodule
-  version: 1.2.3
-  weight: 900
-status:
-  approved: false
-  message: ""
-  pullDuration: 0s
-  size: 0
-  transitionTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodules.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodules.yaml
@@ -16,15 +16,77 @@ spec:
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
 status:
-  message: Some errors occurred. Inspect status for details
+  message: ""
   modules:
   - name: disabledmodule
-  - name: enabledmodule
-    pullError: 'fetch release metadata error: Invalid Semantic Version'
+  - checksum: 'sha256:'
+    name: enabledmodule
+    version: v1.2.3
   - name: notthissourcemodule
-  - name: withpolicymodule
+  - checksum: 'sha256:'
+    name: withpolicymodule
     policy: test-alpha
-    pullError: 'fetch release metadata error: Invalid Semantic Version'
+    version: v1.2.3
   modulesCount: 4
   phase: Active
   syncTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/apply-now: "true"
+  creationTimestamp: null
+  labels:
+    module: enabledmodule
+    modules.deckhouse.io/update-policy: ""
+    release-checksum: 1beb143dffb1b662137094e7faea1e17
+    source: test-source-1
+  name: enabledmodule-v1.2.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: test-source-1
+    uid: ""
+  resourceVersion: "1"
+spec:
+  moduleName: enabledmodule
+  version: 1.2.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  pullDuration: 0s
+  size: 0
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/apply-now: "true"
+  creationTimestamp: null
+  labels:
+    module: withpolicymodule
+    modules.deckhouse.io/update-policy: test-alpha
+    release-checksum: 1beb143dffb1b662137094e7faea1e17
+    source: test-source-1
+  name: withpolicymodule-v1.2.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: test-source-1
+    uid: ""
+  resourceVersion: "1"
+spec:
+  moduleName: withpolicymodule
+  version: 1.2.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  pullDuration: 0s
+  size: 0
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodules.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/withmodules.yaml
@@ -18,12 +18,14 @@ spec:
 status:
   message: ""
   modules:
-  - name: disabledmodule
+  - checksum: 'sha256:'
+    name: disabledmodule
     version: v1.2.3
   - checksum: 'sha256:'
     name: enabledmodule
     version: v1.2.3
-  - name: notthissourcemodule
+  - checksum: 'sha256:'
+    name: notthissourcemodule
     version: v1.2.3
   - checksum: 'sha256:'
     name: withpolicymodule

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/withmodulepullerror.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/withmodulepullerror.yaml
@@ -30,7 +30,7 @@ properties:
   availableSources:
     - test-source-1
 status:
-  phase: NotInstalled
+  phase: Available
   conditions:
     - type: EnabledByModuleConfig
       status: "True"
@@ -44,7 +44,7 @@ properties:
   availableSources:
     - test-source-1
 status:
-  phase: NotInstalled
+  phase: Available
   conditions:
     - type: EnabledByModuleConfig
       status: "True"

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/withmodules.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/withmodules.yaml
@@ -10,6 +10,10 @@ spec:
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: enabledmodule
 ---
 apiVersion: deckhouse.io/v1alpha2
 kind: ModuleUpdatePolicy
@@ -29,7 +33,7 @@ properties:
   availableSources:
     - test-source-1
 status:
-  phase: NotInstalled
+  phase: Available
   conditions:
     - type: EnabledByModuleConfig
       status: "False"
@@ -43,7 +47,7 @@ properties:
   availableSources:
     - test-source-1
 status:
-  phase: NotInstalled
+  phase: Available
   conditions:
     - type: EnabledByModuleConfig
       status: "True"
@@ -58,7 +62,7 @@ properties:
   availableSources:
     - test-source-1
 status:
-  phase: NotInstalled
+  phase: Available
   conditions:
     - type: EnabledByModuleConfig
       status: "True"
@@ -72,7 +76,7 @@ properties:
   availableSources:
     - test-source-1
 status:
-  phase: NotInstalled
+  phase: Available
   conditions:
     - type: EnabledByModuleConfig
       status: "True"


### PR DESCRIPTION
## Description
It provides module version for module source.

## Why do we need it, and what problem does it solve?
Help to learn module versions in modules sources.

```
root@dev-master-0:~# k get ms test -oyaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleSource
metadata:
  creationTimestamp: "2025-03-19T10:32:06Z"
  finalizers:
  - modules.deckhouse.io/module-exists
  - modules.deckhouse.io/release-exists
  generation: 1
  name: test
...
status:
  message: ""
  modules:
  - name: csi-yadro-tatlin-unified
    version: unknown
  - name: data-exporter
    version: unknown
  - checksum: sha256:e66cfcec0dec60a3f0a3d6dc59be7bc31090f8ad15d8fb961d5df9cc9c2eedf1
    name: development-platform
    version: v0.1.1
  - name: managed-postgres
    version: unknown
  - name: observability
    version: unknown
  - checksum: sha256:f0678a62316dd5debd6d22601270ace0c3e9b617a2db413659dfd960a1cdb944
    name: prompp
    version: v0.0.0-394f09b0
  - name: sds-elastic
    version: unknown
  - name: sds-local-volume
    version: unknown
  - name: sds-node-configurator
    version: unknown
  - name: sds-replicated-volume
    version: unknown
  - name: secrets-store-integration
    version: unknown
  - checksum: sha256:ebaffe13dc04a3cc9790c695168c5d930d4ca359c41f3f62e24fe073424c50d9
    name: stronghold
    version: v1.15.2
  - name: virtualization
    version: unknown
  modulesCount: 2
  phase: Active
  syncTime: "2025-04-21T18:39:41Z"
```

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Add module version to module source.
```