### PR TITLE
[deckhouse-controller] fix usage of DefaultKubernetesVersion var

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_kubernetes_version.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_kubernetes_version.go
@@ -29,8 +29,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/extenders/kubernetesversion"
+	ctrl "github.com/deckhouse/deckhouse/modules/040-control-plane-manager/hooks"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
@@ -59,7 +59,7 @@ func kubernetesVersionHandler(mm moduleManager) http.Handler {
 		}
 
 		if clusterConf.KubernetesVersion == "Automatic" {
-			clusterConf.KubernetesVersion = config.DefaultKubernetesVersion
+			clusterConf.KubernetesVersion = ctrl.DefaultKubernetesVersion
 		}
 
 		if moduleName, err := kubernetesversion.Instance().ValidateBaseVersion(clusterConf.KubernetesVersion); err != nil {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_kubernetes_version.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_kubernetes_version.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency/extenders/kubernetesversion"
-	ctrl "github.com/deckhouse/deckhouse/modules/040-control-plane-manager/hooks"
+	"github.com/deckhouse/deckhouse/modules/040-control-plane-manager/hooks"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
@@ -59,7 +59,7 @@ func kubernetesVersionHandler(mm moduleManager) http.Handler {
 		}
 
 		if clusterConf.KubernetesVersion == "Automatic" {
-			clusterConf.KubernetesVersion = ctrl.DefaultKubernetesVersion
+			clusterConf.KubernetesVersion = hooks.DefaultKubernetesVersion
 		}
 
 		if moduleName, err := kubernetesversion.Instance().ValidateBaseVersion(clusterConf.KubernetesVersion); err != nil {

--- a/global-hooks/discovery/cluster_configuration.go
+++ b/global-hooks/discovery/cluster_configuration.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	ctrl "github.com/deckhouse/deckhouse/modules/040-control-plane-manager/hooks"
 )
 
 type ClusterConfigurationYaml struct {
@@ -91,7 +92,7 @@ func clusterConfiguration(input *go_hook.HookInput) error {
 		}
 
 		if kubernetesVersionFromMetaConfig == "Automatic" {
-			b, _ := json.Marshal(config.DefaultKubernetesVersion)
+			b, _ := json.Marshal(ctrl.DefaultKubernetesVersion)
 			metaConfig.ClusterConfig["kubernetesVersion"] = b
 		}
 

--- a/global-hooks/discovery/cluster_configuration.go
+++ b/global-hooks/discovery/cluster_configuration.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
-	ctrl "github.com/deckhouse/deckhouse/modules/040-control-plane-manager/hooks"
+	"github.com/deckhouse/deckhouse/modules/040-control-plane-manager/hooks"
 )
 
 type ClusterConfigurationYaml struct {
@@ -92,7 +92,7 @@ func clusterConfiguration(input *go_hook.HookInput) error {
 		}
 
 		if kubernetesVersionFromMetaConfig == "Automatic" {
-			b, _ := json.Marshal(ctrl.DefaultKubernetesVersion)
+			b, _ := json.Marshal(hooks.DefaultKubernetesVersion)
 			metaConfig.ClusterConfig["kubernetesVersion"] = b
 		}
 

--- a/global-hooks/discovery/cluster_configuration_test.go
+++ b/global-hooks/discovery/cluster_configuration_test.go
@@ -186,7 +186,7 @@ data:
 		})
 	})
 
-	FContext("Cluster has a d8-cluster-configuration Secret with kubernetesVersion = `Automatic`", func() {
+	Context("Cluster has a d8-cluster-configuration Secret with kubernetesVersion = `Automatic`", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(stateC, 1))
 			f.RunHook()

--- a/global-hooks/discovery/cluster_configuration_test.go
+++ b/global-hooks/discovery/cluster_configuration_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/modules/040-control-plane-manager/hooks"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
@@ -100,7 +100,7 @@ data:
 	)
 
 	// Set default value for test purposes. Normally this var set to specific kubernetes version on the build stage.
-	config.DefaultKubernetesVersion = "1.32"
+	hooks.DefaultKubernetesVersion = "1.32"
 
 	f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
 
@@ -186,7 +186,7 @@ data:
 		})
 	})
 
-	Context("Cluster has a d8-cluster-configuration Secret with kubernetesVersion = `Automatic`", func() {
+	FContext("Cluster has a d8-cluster-configuration Secret with kubernetesVersion = `Automatic`", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(stateC, 1))
 			f.RunHook()
@@ -201,7 +201,7 @@ data:
 			Expect(f.ValuesGet("global.clusterConfiguration.podSubnetCIDR").String()).To(Equal("10.122.0.0/16"))
 			Expect(f.ValuesGet("global.clusterConfiguration.podSubnetNodeCIDRPrefix").String()).To(Equal("26"))
 			Expect(f.ValuesGet("global.clusterConfiguration.serviceSubnetCIDR").String()).To(Equal("10.213.0.0/16"))
-			Expect(f.ValuesGet("global.clusterConfiguration.kubernetesVersion").String()).To(Equal(config.DefaultKubernetesVersion))
+			Expect(f.ValuesGet("global.clusterConfiguration.kubernetesVersion").String()).To(Equal(hooks.DefaultKubernetesVersion))
 
 			Expect(f.ValuesGet("global.discovery.podSubnet").String()).To(Equal("10.122.0.0/16"))
 			Expect(f.ValuesGet("global.discovery.serviceSubnet").String()).To(Equal("10.213.0.0/16"))

--- a/global-hooks/migrate/migrate_k8s_upgrade.go
+++ b/global-hooks/migrate/migrate_k8s_upgrade.go
@@ -35,8 +35,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	dhctlconfig "github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	ctrl "github.com/deckhouse/deckhouse/modules/040-control-plane-manager/hooks"
 )
 
 const clusterAdminsGroupAndClusterRoleBinding = "kubeadm:cluster-admins"
@@ -103,7 +103,7 @@ func k8sPostUpgrade(input *go_hook.HookInput, dc dependency.Container) error {
 		return fmt.Errorf("unmarshal 'cluster-configuration.yaml' failed: %w", err)
 	}
 
-	var kubernetesVersion = dhctlconfig.DefaultKubernetesVersion
+	var kubernetesVersion = ctrl.DefaultKubernetesVersion
 
 	if config.KubernetesVersion != "Automatic" {
 		kubernetesVersion = config.KubernetesVersion

--- a/global-hooks/migrate/migrate_k8s_upgrade.go
+++ b/global-hooks/migrate/migrate_k8s_upgrade.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
-	ctrl "github.com/deckhouse/deckhouse/modules/040-control-plane-manager/hooks"
+	"github.com/deckhouse/deckhouse/modules/040-control-plane-manager/hooks"
 )
 
 const clusterAdminsGroupAndClusterRoleBinding = "kubeadm:cluster-admins"
@@ -103,7 +103,7 @@ func k8sPostUpgrade(input *go_hook.HookInput, dc dependency.Container) error {
 		return fmt.Errorf("unmarshal 'cluster-configuration.yaml' failed: %w", err)
 	}
 
-	var kubernetesVersion = ctrl.DefaultKubernetesVersion
+	var kubernetesVersion = hooks.DefaultKubernetesVersion
 
 	if config.KubernetesVersion != "Automatic" {
 		kubernetesVersion = config.KubernetesVersion


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix work when kubernetesVersion = 'Automatic'.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
in https://github.com/deckhouse/deckhouse/pull/12853 we autoset variable DefaultKubernetesVersion on the build stage. This PR fixes some cases which cannot work properly after that PR.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: fix usage of DefaultKubernetesVersion var
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
