### PR TITLE
[deckhouse] exclude conversion test from docs

### DIFF
--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -253,9 +253,9 @@ func NewDeckhouseController(ctx context.Context, version string, operator *addon
 		return nil, fmt.Errorf("register module pull override controller: %w", err)
 	}
 
-	err = docbuilder.NewModuleDocumentationController(runtimeManager, dc, logger.Named("module-documentation-controller"))
+	err = docbuilder.RegisterController(runtimeManager, dc, logger.Named("module-documentation-controller"))
 	if err != nil {
-		return nil, fmt.Errorf("create module documentation controller: %w", err)
+		return nil, fmt.Errorf("register module documentation controller: %w", err)
 	}
 
 	validation.RegisterAdmissionHandlers(

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller_test.go
@@ -60,7 +60,7 @@ type ControllerTestSuite struct {
 	suite.Suite
 
 	kubeClient client.Client
-	ctr        *moduleDocumentationReconciler
+	ctr        *reconciler
 
 	tmpDir           string
 	testDataFileName string
@@ -278,7 +278,7 @@ func (suite *ControllerTestSuite) setupController(yamlDoc string) {
 	_ = coordv1.AddToScheme(sc)
 	cl := fake.NewClientBuilder().WithScheme(sc).WithObjects(initObjects...).WithStatusSubresource(&v1alpha1.ModuleDocumentation{}).Build()
 	dc := dependency.NewDependencyContainer()
-	rec := &moduleDocumentationReconciler{
+	rec := &reconciler{
 		client:               cl,
 		downloadedModulesDir: d8env.GetDownloadedModulesDir(),
 		logger:               log.NewNop(),

--- a/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scanner/process.go
+++ b/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scanner/process.go
@@ -22,11 +22,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"registry-modules-watcher/internal"
 	"registry-modules-watcher/internal/backends"
 	"strings"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	crv1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/deckhouse/module-sdk/pkg/dependency/cr"
@@ -171,7 +172,7 @@ func (s *registryscanner) extractTar(ctx context.Context, version *internal.Vers
 	return tarFile, nil
 }
 
-func (s *registryscanner) extractDocumentation(image v1.Image) ([]byte, error) {
+func (s *registryscanner) extractDocumentation(image crv1.Image) ([]byte, error) {
 	readCloser, err := cr.Extract(image)
 	if err != nil {
 		return nil, fmt.Errorf("extract: %w", err)
@@ -222,20 +223,19 @@ func (s *registryscanner) copyDocumentationFiles(source io.Reader, tarWriter *ta
 
 		if isDocumentationFile(hdr.Name) {
 			buf := bytes.NewBuffer(nil)
-			if _, err := io.Copy(buf, tarReader); err != nil {
+			if _, err = io.Copy(buf, tarReader); err != nil {
 				return fmt.Errorf("copy file content: %w", err)
 			}
 
-			if err := tarWriter.WriteHeader(hdr); err != nil {
+			if err = tarWriter.WriteHeader(hdr); err != nil {
 				return fmt.Errorf("write file header: %w", err)
 			}
 
-			if _, err := tarWriter.Write(buf.Bytes()); err != nil {
+			if _, err = tarWriter.Write(buf.Bytes()); err != nil {
 				return fmt.Errorf("write file content: %w", err)
 			}
 
-			s.logger.Debug("copied file",
-				slog.String("file", hdr.Name))
+			s.logger.Debug("copied file", slog.String("file", hdr.Name))
 		}
 	}
 
@@ -243,6 +243,10 @@ func (s *registryscanner) copyDocumentationFiles(source io.Reader, tarWriter *ta
 }
 
 func isDocumentationFile(filename string) bool {
+	if filepath.Ext(filename) == ".go" {
+		return false
+	}
+
 	for _, dir := range documentationDirs {
 		if strings.Contains(filename, dir+"/") {
 			return true
@@ -251,7 +255,7 @@ func isDocumentationFile(filename string) bool {
 	return false
 }
 
-func getVersionFromImage(releaseImage v1.Image) (string, error) {
+func getVersionFromImage(releaseImage crv1.Image) (string, error) {
 	readCloser, err := cr.Extract(releaseImage)
 	if err != nil {
 		return "", fmt.Errorf("extract image: %w", err)


### PR DESCRIPTION
## Description
It excludes conversion tests from docs

## Why do we need it, and what problem does it solve?
Tests have go ext, it is not allowed for doc rendering.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Exclude conversions test from docs.
impact_level: low
```