### PR TITLE
[runtime-audit-engine] fix crashLoopBack due to invalid config

### DIFF
--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/lib/convert.py
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/lib/convert.py
@@ -40,7 +40,7 @@ def convert_spec(spec: dict) -> list:
 
             priority = item["rule"].get("priority")
             if priority is not None:
-                converted_item["priority"] = priority.capitalize()
+                converted_item["priority"] = priority.upper()
 
             result.append(converted_item)
             continue

--- a/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/lib/convert.py
+++ b/ee/modules/650-runtime-audit-engine/images/rules-loader/hooks/lib/convert.py
@@ -38,6 +38,10 @@ def convert_spec(spec: dict) -> list:
             if source is not None:
                 converted_item["source"] = snakecase(source)
 
+            priority = item["rule"].get("priority")
+            if priority is not None:
+                converted_item["priority"] = priority.capitalize()
+
             result.append(converted_item)
             continue
         if item.get("macro") is not None:

--- a/ee/modules/650-runtime-audit-engine/templates/configmap.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/configmap.yaml
@@ -253,27 +253,6 @@ data:
     # @ Duration in milliseconds to wait before considering the output timeout deadline exceed.
     output_timeout: 2000
 
-    # A throttling mechanism implemented as a token bucket limits the
-    # rate of Falco notifications. One rate limiter is assigned to each event
-    # source, so that alerts coming from one can't influence the throttling
-    # mechanism of the others. This is controlled by the following options:
-    #  - rate: the number of tokens (i.e. right to send a notification)
-    #    gained per second. When 0, the throttling mechanism is disabled.
-    #    Defaults to 0.
-    #  - max_burst: the maximum number of tokens outstanding. Defaults to 1000.
-    #
-    # With these defaults, the throttling mechanism is disabled.
-    # For example, by setting rate to 1 Falco could send up to 1000 notifications
-    # after an initial quiet period, and then up to 1 notification per second
-    # afterward. It would gain the full burst back after 1000 seconds of
-    # no activity.
-
-    outputs:
-      # @ Number of tokens gained per second.
-      rate: 1
-      # @ Maximum number of tokens outstanding.
-      max_burst: 1000
-
     # Where security notifications should go.
     # Multiple outputs can be enabled.
 
@@ -391,14 +370,6 @@ data:
       # @ Enable the gRPC output and events will be kept in memory until you read them with a gRPC client.
       enabled: false
 
-    # Container orchestrator metadata fetching params
-    metadata_download:
-      # @ Max allowed response size (in Mb) when fetching metadata from Kubernetes.
-      max_mb: 100
-      # @ Sleep time (in μs) for each download chunck when fetching metadata from Kubernetes.
-      chunk_wait_us: 1000
-      # @ Watch frequency (in seconds) when fetching metadata from Kubernetes.
-      watch_freq_sec: 1
     # [Experimental] `rule_matching`
     #
     # The `rule_matching` configuration key's values are:

--- a/ee/modules/650-runtime-audit-engine/templates/configmap.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/configmap.yaml
@@ -19,6 +19,61 @@ data:
     # Choose the appropriate engine kind based on your system's configuration and requirements.
     engine:
       kind: modern_ebpf
+      modern_ebpf:
+        # @- [Description]
+        #
+        # This is an index that controls the dimension of the syscall buffers.
+        # The syscall buffer is the shared space between Falco and its drivers where all the syscall events
+        # are stored.
+        # Falco uses a syscall buffer for every online CPU, and all these buffers share the same dimension.
+        # So this parameter allows you to control the size of all the buffers!
+        #
+        # @- [Usage]
+        #
+        # You can choose between different indexes: from `1` to `10` (`0` is reserved for future uses).
+        # Every index corresponds to a dimension in bytes:
+        #
+        # [(*), 1 MB, 2 MB, 4 MB, 8 MB, 16 MB, 32 MB, 64 MB, 128 MB, 256 MB, 512 MB]
+        #   ^    ^     ^     ^     ^     ^      ^      ^       ^       ^       ^
+        #   |    |     |     |     |     |      |      |       |       |       |
+        #   0    1     2     3     4     5      6      7       8       9       10
+        #
+        # As you can see the `0` index is reserved, while the index `1` corresponds to
+        # `1 MB` and so on.
+        #
+        # These dimensions in bytes derive from the fact that the buffer size must be:
+        # (1) a power of 2.
+        # (2) a multiple of your system_page_dimension.
+        # (3) greater than `2 * (system_page_dimension)`.
+        #
+        # According to these constraints, it is possible that sometimes you cannot use all the indexes, let's consider an
+        # example to better understand it:
+        # If you have a `page_size` of 1 MB the first available buffer size is 4 MB because 2 MB is exactly
+        # `2 * (system_page_size)` -> `2 * 1 MB`, but this is not enough we need more than `2 * (system_page_size)`!
+        # So from this example, it is clear that if you have a page size of 1 MB the first index that you can use is `3`.
+        #
+        # Please note: this is a very extreme case just to let you understand the mechanism, usually the page size is something
+        # like 4 KB so you have no problem at all, and you can use all the indexes (from `1` to `10`).
+        #
+        # To check your system page size, use the Falco `@page-size` command line option. The output on a system with a page
+        # size of 4096 Bytes (4 KB) should be the following:
+        #
+        # "Your system page size is: 4096 bytes."
+        #
+        # @- [Suggestions]
+        #
+        # Before the introduction of this param the buffer size was fixed to 8 MB (so index `4`, as you can see
+        # in the default value below).
+        # You can increase the buffer size when you face syscall drops. A size of 16 MB (so index `5`) can reduce
+        # syscall drops in production-heavy systems without noticeable impact. Very large buffers, however, could
+        # slow down the entire machine.
+        # On the other side, you can try to reduce the buffer size to speed up the system, but this could
+        # increase the number of syscall drops!
+        # As a final remark, consider that the buffer size is mapped twice in the process' virtual memory, so a buffer of 8 MB
+        # will result in a 16 MB area in the process virtual memory.
+        # Please pay attention when you use this parameter and change it only if the default size doesn't fit your use case.
+        # @ This is an index that controls the dimension of the syscall buffers.
+        buf_size_preset: 4
 
     #
     # Plugins that are available for use. These plugins are not loaded by
@@ -180,61 +235,6 @@ data:
       # @ Maximum number of consecutive timeouts without an event
       # after which you want Falco to alert.
       max_consecutives: 1000
-
-    # @- [Description]
-    #
-    # This is an index that controls the dimension of the syscall buffers.
-    # The syscall buffer is the shared space between Falco and its drivers where all the syscall events
-    # are stored.
-    # Falco uses a syscall buffer for every online CPU, and all these buffers share the same dimension.
-    # So this parameter allows you to control the size of all the buffers!
-    #
-    # @- [Usage]
-    #
-    # You can choose between different indexes: from `1` to `10` (`0` is reserved for future uses).
-    # Every index corresponds to a dimension in bytes:
-    #
-    # [(*), 1 MB, 2 MB, 4 MB, 8 MB, 16 MB, 32 MB, 64 MB, 128 MB, 256 MB, 512 MB]
-    #   ^    ^     ^     ^     ^     ^      ^      ^       ^       ^       ^
-    #   |    |     |     |     |     |      |      |       |       |       |
-    #   0    1     2     3     4     5      6      7       8       9       10
-    #
-    # As you can see the `0` index is reserved, while the index `1` corresponds to
-    # `1 MB` and so on.
-    #
-    # These dimensions in bytes derive from the fact that the buffer size must be:
-    # (1) a power of 2.
-    # (2) a multiple of your system_page_dimension.
-    # (3) greater than `2 * (system_page_dimension)`.
-    #
-    # According to these constraints is possible that sometimes you cannot use all the indexes, let's consider an
-    # example to better understand it:
-    # If you have a `page_size` of 1 MB the first available buffer size is 4 MB because 2 MB is exactly
-    # `2 * (system_page_size)` -> `2 * 1 MB`, but this is not enough we need more than `2 * (system_page_size)`!
-    # So from this example is clear that if you have a page size of 1 MB the first index that you can use is `3`.
-    #
-    # Please note: this is a very extreme case just to let you understand the mechanism, usually the page size is something
-    # like 4 KB so you have no problem at all and you can use all the indexes (from `1` to `10`).
-    #
-    # To check your system page size use the Falco `@page-size` command line option. The output on a system with a page
-    # size of 4096 Bytes (4 KB) should be the following:
-    #
-    # "Your system page size is: 4096 bytes."
-    #
-    # @- [Suggestions]
-    #
-    # Before the introduction of this param the buffer size was fixed to 8 MB (so index `4`, as you can see
-    # in the default value below).
-    # You can increase the buffer size when you face syscall drops. A size of 16 MB (so index `5`) can reduce
-    # syscall drops in production-heavy systems without noticeable impact. Very large buffers however could
-    # slow down the entire machine.
-    # On the other side you can try to reduce the buffer size to speed up the system, but this could
-    # increase the number of syscall drops!
-    # As a final remark consider that the buffer size is mapped twice in the process' virtual memory so a buffer of 8 MB
-    # will result in a 16 MB area in the process virtual memory.
-    # Please pay attention when you use this parameter and change it only if the default size doesn't fit your use case.
-    # @ This is an index that controls the dimension of the syscall buffers.
-    syscall_buf_size_preset: 4
 
     # Falco continuously monitors outputs performance. When an output channel does not allow
     # to deliver an alert within a given deadline, an error is reported indicating

--- a/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
@@ -44,10 +44,6 @@ spec:
         name: package_mgmt_ancestor_procs
         condition: proc.pname in (package_mgmt_binaries) or proc.aname[2] in (package_mgmt_binaries) or proc.aname[3] in (package_mgmt_binaries) or proc.aname[4] in (package_mgmt_binaries)
     - macro:
-        name: bin_dir_mkdir
-        condition: |
-          (evt.arg.path startswith /bin/ or evt.arg.path startswith /sbin/ or evt.arg.path startswith /usr/bin/ or evt.arg.path startswith /usr/sbin/)
-    - macro:
         name: bin_dir_rename
         condition: |
           (evt.arg.path startswith /bin/ or evt.arg.path startswith /sbin/ or evt.arg.path startswith /usr/bin/ or evt.arg.path startswith /usr/sbin/ or evt.arg.name startswith /bin/ or evt.arg.name startswith /sbin/ or evt.arg.name startswith /usr/bin/ or evt.arg.name startswith /usr/sbin/ or evt.arg.oldpath startswith /bin/ or evt.arg.oldpath startswith /sbin/ or evt.arg.oldpath startswith /usr/bin/ or evt.arg.oldpath startswith /usr/sbin/ or evt.arg.newpath startswith /bin/ or evt.arg.newpath startswith /sbin/ or evt.arg.newpath startswith /usr/bin/ or evt.arg.newpath startswith /usr/sbin/)
@@ -139,7 +135,7 @@ spec:
         desc: Package management process ran inside container
         output: |
           Package management process launched in container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag exe_flags=%evt.arg.flags)
-        priority: Error
+        priority: ERROR
         tags:
           - fstec
           - container_drift
@@ -150,7 +146,7 @@ spec:
         desc: Detect if an executable not belonging to the base image of a container is being executed. The drop and execute pattern can be observed very often after an attacker gained an initial foothold. is_exe_upper_layer filter field only applies for container runtimes that use overlayfs as union mount filesystem.
         output: |
           Executing binary not part of base image (user=%user.name user_loginuid=%user.loginuid user_uid=%user.uid comm=%proc.cmdline exe=%proc.exe container_id=%container.id image=%container.image.repository proc.name=%proc.name proc.sname=%proc.sname proc.pname=%proc.pname proc.aname[2]=%proc.aname[2] exe_flags=%evt.arg.flags proc.exe_ino=%proc.exe_ino proc.exe_ino.ctime=%proc.exe_ino.ctime proc.exe_ino.mtime=%proc.exe_ino.mtime proc.exe_ino.ctime_duration_proc_start=%proc.exe_ino.ctime_duration_proc_start proc.exepath=%proc.exepath proc.cwd=%proc.cwd proc.tty=%proc.tty container.start_ts=%container.start_ts proc.sid=%proc.sid proc.vpgid=%proc.vpgid evt.res=%evt.res)
-        priority: Critical
+        priority: CRITICAL
         tags:
           - fstec
           - container_drift
@@ -164,7 +160,7 @@ spec:
           )
         desc: New executable created in a container due to chmod
         output: Drift detected (chmod), new executable created in a container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid filename=%evt.arg.filename name=%evt.arg.name mode=%evt.arg.mode event=%evt.type)
-        priority: Error
+        priority: ERROR
         tags:
           - fstec
           - container_drift
@@ -183,7 +179,7 @@ spec:
           evt.type in (open,openat,openat2,creat) and evt.is_open_exec=true and container and not runc_writing_exec_fifo and not runc_writing_var_lib_docker and not runc_writing_var_lib_containerd and not user_known_container_drift_activities and evt.rawres>=0
         desc: New executable created in a container due to open+create
         output: Drift detected (open+create), new executable created in a container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid filename=%evt.arg.filename name=%evt.arg.name mode=%evt.arg.mode event=%evt.type)
-        priority: Error
+        priority: ERROR
         tags:
           - fstec
           - container_drift
@@ -194,7 +190,7 @@ spec:
         desc: an attempt to modify any file below a set of binary directories.
         output: |
           File below known binary directory renamed/removed (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid pcmdline=%proc.pcmdline operation=%evt.type file=%fd.name %evt.args container_id=%container.id image=%container.image.repository)
-        priority: Error
+        priority: ERROR
         tags:
           - fstec
           - container_drift
@@ -203,7 +199,7 @@ spec:
         condition: (kevt and kcreate and pod and response_successful)
         desc: Detect any attempt to create a pod
         output: K8s Pod Created (user=%ka.user.name pod=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Informational
+        priority: INFORMATIONAL
         tags:
           - fstec
           - container_drift
@@ -213,7 +209,7 @@ spec:
         condition: (kevt and kdelete and pod and response_successful)
         desc: Detect any attempt to delete a pod
         output: K8s Pod Deleted (user=%ka.user.name pod=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Informational
+        priority: INFORMATIONAL
         tags:
           - fstec
           - container_drift
@@ -224,7 +220,7 @@ spec:
           kevt and serviceaccount and kcreate and system_namespace and response_successful
         desc: Detect any attempt to create a serviceaccount in the kube-system or kube-public namespaces
         output: Service account created in kube namespace (user=%ka.user.name serviceaccount=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace)
-        priority: Warning
+        priority: WARNING
         tags:
           - fstec
           - rbac_drift
@@ -235,7 +231,7 @@ spec:
           kevt and clusterrolebinding and kcreate and ka.req.binding.role=cluster-admin
         desc: Detect any attempt to create a ClusterRoleBinding to the cluster-admin user
         output: Cluster Role Binding to cluster-admin role (user=%ka.user.name subject=%ka.req.binding.subjects)
-        priority: Warning
+        priority: WARNING
         tags:
           - fstec
           - rbac_drift
@@ -249,7 +245,7 @@ spec:
           )
         desc: Detect any attempt to create a Role/ClusterRole with wildcard resources or verbs
         output: Created Role/ClusterRole with wildcard (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource rules=%ka.req.role.rules)
-        priority: Warning
+        priority: WARNING
         tags:
           - fstec
           - rbac_drift
@@ -262,7 +258,7 @@ spec:
         desc: |
           Detect any attempt to attach/exec to a pod
         output: Attach/Exec to pod (user=%ka.user.name pod=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace action=%ka.target.subresource command=%ka.uri.param[command])
-        priority: Notice
+        priority: NOTICE
         tags:
           - fstec
           - container_image_access
@@ -274,7 +270,7 @@ spec:
         desc: |
           Detect any ephemeral container created
         output: Ephemeral container is created in pod (user=%ka.user.name pod=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace ephemeral_container_name=%jevt.value[/requestObject/spec/ephemeralContainers/0/name] ephemeral_container_image=%jevt.value[/requestObject/spec/ephemeralContainers/0/image])
-        priority: Notice
+        priority: NOTICE
         tags:
           - fstec
           - container_image_access
@@ -285,7 +281,7 @@ spec:
           kevt and (role or clusterrole) and kcreate and writable_verbs
         desc: Detect any attempt to create a Role/ClusterRole that can perform write-related actions
         output: Created Role/ClusterRole with write privileges (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource rules=%ka.req.role.rules)
-        priority: Notice
+        priority: NOTICE
         tags:
           - fstec
           - rbac_drift
@@ -296,7 +292,7 @@ spec:
           kevt and (role or clusterrole) and kcreate and ka.req.role.rules.resources intersects ("pods/exec")
         desc: Detect any attempt to create a Role/ClusterRole that can exec to pods
         output: Created Role/ClusterRole with pod exec privileges (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource rules=%ka.req.role.rules)
-        priority: Warning
+        priority: WARNING
         tags:
           - fstec
           - rbac_drift
@@ -307,7 +303,7 @@ spec:
           kevt and (role or clusterrole) and (kmodify or kdelete) and (ka.target.name startswith "system:") and not ka.target.name in (system:coredns, system:managed-certificate-controller)
         desc: Detect any attempt to modify/delete a ClusterRole/Role starting with system
         output: System ClusterRole/Role modified or deleted (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource action=%ka.verb)
-        priority: Warning
+        priority: WARNING
         tags:
           - fstec
           - rbac_drift
@@ -318,7 +314,7 @@ spec:
           kactivity and kcreate and serviceaccount and response_successful
         desc: Detect any attempt to create a service account
         output: K8s Serviceaccount Created (user=%ka.user.name serviceaccount=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Notice
+        priority: NOTICE
         tags:
           - fstec
           - rbac_drift
@@ -329,7 +325,7 @@ spec:
           kactivity and kdelete and serviceaccount and response_successful
         desc: Detect any attempt to delete a service account
         output: K8s Serviceaccount Deleted (user=%ka.user.name serviceaccount=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Notice
+        priority: NOTICE
         tags:
           - fstec
           - rbac_drift
@@ -340,7 +336,7 @@ spec:
           kactivity and kcreate and (clusterrole or role) and response_successful
         desc: Detect any attempt to create a cluster role/role
         output: K8s Cluster Role Created (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource rules=%ka.req.role.rules resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Notice
+        priority: NOTICE
         tags:
           - fstec
           - rbac_drift
@@ -350,7 +346,7 @@ spec:
         condition: kactivity and kdelete and (clusterrole or role) and response_successful
         desc: Detect any attempt to delete a cluster role/role
         output: K8s Cluster Role Deleted (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Notice
+        priority: NOTICE
         tags:
           - fstec
           - rbac_drift
@@ -361,7 +357,7 @@ spec:
           kactivity and kcreate and clusterrolebinding and response_successful
         desc: Detect any attempt to create a clusterrolebinding
         output: K8s Cluster Role Binding Created (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource subjects=%ka.req.binding.subjects role=%ka.req.binding.role resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Notice
+        priority: NOTICE
         tags:
           - fstec
           - rbac_drift
@@ -373,7 +369,7 @@ spec:
         desc: Detect any attempt to delete a clusterrolebinding
         output: |
           K8s Cluster Role Binding Deleted (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: Notice
+        priority: NOTICE
         tags:
           - fstec
           - rbac_drift
@@ -385,7 +381,7 @@ spec:
         desc: An attempt to read container image file in the containerd directory
         output: |
           File below a known containerd directory opened for reading (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository)
-        priority: Notice
+        priority: NOTICE
         tags:
           - fstec
           - container_image_access
@@ -396,7 +392,7 @@ spec:
         desc: An attempt to change container image file in the containerd directory
         output: |
           File below a known containerd directory opened for writing (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository)
-        priority: Error
+        priority: ERROR
         tags:
           - fstec
           - container_image_drift
@@ -407,7 +403,7 @@ spec:
         desc: Not all pods are under integrity control in a system namespace
         output: |
           Not all containers are running with the sha256 sum as a tag in a system namespace, which is a potential integrity control mechanism misconfiguration (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason image=%ka.req.pod.containers.image)
-        priority: Notice
+        priority: NOTICE
         tags:
           - fstec
           - integrity_control
@@ -421,7 +417,7 @@ spec:
           ) and fd.sport=22
         desc: Detect Inbound SSH Connection
         output: Inbound SSH Connection (command=%proc.cmdline pid=%proc.pid connection=%fd.name user=%user.name user_loginuid=%user.loginuid type=%evt.type)
-        priority: Notice
+        priority: NOTICE
         tags:
           - fstec
           - auth_attempts

--- a/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/falco-rules.yaml
@@ -135,7 +135,7 @@ spec:
         desc: Package management process ran inside container
         output: |
           Package management process launched in container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag exe_flags=%evt.arg.flags)
-        priority: ERROR
+        priority: Error
         tags:
           - fstec
           - container_drift
@@ -146,7 +146,7 @@ spec:
         desc: Detect if an executable not belonging to the base image of a container is being executed. The drop and execute pattern can be observed very often after an attacker gained an initial foothold. is_exe_upper_layer filter field only applies for container runtimes that use overlayfs as union mount filesystem.
         output: |
           Executing binary not part of base image (user=%user.name user_loginuid=%user.loginuid user_uid=%user.uid comm=%proc.cmdline exe=%proc.exe container_id=%container.id image=%container.image.repository proc.name=%proc.name proc.sname=%proc.sname proc.pname=%proc.pname proc.aname[2]=%proc.aname[2] exe_flags=%evt.arg.flags proc.exe_ino=%proc.exe_ino proc.exe_ino.ctime=%proc.exe_ino.ctime proc.exe_ino.mtime=%proc.exe_ino.mtime proc.exe_ino.ctime_duration_proc_start=%proc.exe_ino.ctime_duration_proc_start proc.exepath=%proc.exepath proc.cwd=%proc.cwd proc.tty=%proc.tty container.start_ts=%container.start_ts proc.sid=%proc.sid proc.vpgid=%proc.vpgid evt.res=%evt.res)
-        priority: CRITICAL
+        priority: Critical
         tags:
           - fstec
           - container_drift
@@ -160,7 +160,7 @@ spec:
           )
         desc: New executable created in a container due to chmod
         output: Drift detected (chmod), new executable created in a container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid filename=%evt.arg.filename name=%evt.arg.name mode=%evt.arg.mode event=%evt.type)
-        priority: ERROR
+        priority: Error
         tags:
           - fstec
           - container_drift
@@ -179,7 +179,7 @@ spec:
           evt.type in (open,openat,openat2,creat) and evt.is_open_exec=true and container and not runc_writing_exec_fifo and not runc_writing_var_lib_docker and not runc_writing_var_lib_containerd and not user_known_container_drift_activities and evt.rawres>=0
         desc: New executable created in a container due to open+create
         output: Drift detected (open+create), new executable created in a container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid filename=%evt.arg.filename name=%evt.arg.name mode=%evt.arg.mode event=%evt.type)
-        priority: ERROR
+        priority: Error
         tags:
           - fstec
           - container_drift
@@ -190,7 +190,7 @@ spec:
         desc: an attempt to modify any file below a set of binary directories.
         output: |
           File below known binary directory renamed/removed (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid pcmdline=%proc.pcmdline operation=%evt.type file=%fd.name %evt.args container_id=%container.id image=%container.image.repository)
-        priority: ERROR
+        priority: Error
         tags:
           - fstec
           - container_drift
@@ -199,7 +199,7 @@ spec:
         condition: (kevt and kcreate and pod and response_successful)
         desc: Detect any attempt to create a pod
         output: K8s Pod Created (user=%ka.user.name pod=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: INFORMATIONAL
+        priority: Informational
         tags:
           - fstec
           - container_drift
@@ -209,7 +209,7 @@ spec:
         condition: (kevt and kdelete and pod and response_successful)
         desc: Detect any attempt to delete a pod
         output: K8s Pod Deleted (user=%ka.user.name pod=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: INFORMATIONAL
+        priority: Informational
         tags:
           - fstec
           - container_drift
@@ -220,7 +220,7 @@ spec:
           kevt and serviceaccount and kcreate and system_namespace and response_successful
         desc: Detect any attempt to create a serviceaccount in the kube-system or kube-public namespaces
         output: Service account created in kube namespace (user=%ka.user.name serviceaccount=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace)
-        priority: WARNING
+        priority: Warning
         tags:
           - fstec
           - rbac_drift
@@ -231,7 +231,7 @@ spec:
           kevt and clusterrolebinding and kcreate and ka.req.binding.role=cluster-admin
         desc: Detect any attempt to create a ClusterRoleBinding to the cluster-admin user
         output: Cluster Role Binding to cluster-admin role (user=%ka.user.name subject=%ka.req.binding.subjects)
-        priority: WARNING
+        priority: Warning
         tags:
           - fstec
           - rbac_drift
@@ -245,7 +245,7 @@ spec:
           )
         desc: Detect any attempt to create a Role/ClusterRole with wildcard resources or verbs
         output: Created Role/ClusterRole with wildcard (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource rules=%ka.req.role.rules)
-        priority: WARNING
+        priority: Warning
         tags:
           - fstec
           - rbac_drift
@@ -258,7 +258,7 @@ spec:
         desc: |
           Detect any attempt to attach/exec to a pod
         output: Attach/Exec to pod (user=%ka.user.name pod=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace action=%ka.target.subresource command=%ka.uri.param[command])
-        priority: NOTICE
+        priority: Notice
         tags:
           - fstec
           - container_image_access
@@ -270,7 +270,7 @@ spec:
         desc: |
           Detect any ephemeral container created
         output: Ephemeral container is created in pod (user=%ka.user.name pod=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace ephemeral_container_name=%jevt.value[/requestObject/spec/ephemeralContainers/0/name] ephemeral_container_image=%jevt.value[/requestObject/spec/ephemeralContainers/0/image])
-        priority: NOTICE
+        priority: Notice
         tags:
           - fstec
           - container_image_access
@@ -281,7 +281,7 @@ spec:
           kevt and (role or clusterrole) and kcreate and writable_verbs
         desc: Detect any attempt to create a Role/ClusterRole that can perform write-related actions
         output: Created Role/ClusterRole with write privileges (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource rules=%ka.req.role.rules)
-        priority: NOTICE
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -292,7 +292,7 @@ spec:
           kevt and (role or clusterrole) and kcreate and ka.req.role.rules.resources intersects ("pods/exec")
         desc: Detect any attempt to create a Role/ClusterRole that can exec to pods
         output: Created Role/ClusterRole with pod exec privileges (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource rules=%ka.req.role.rules)
-        priority: WARNING
+        priority: Warning
         tags:
           - fstec
           - rbac_drift
@@ -303,7 +303,7 @@ spec:
           kevt and (role or clusterrole) and (kmodify or kdelete) and (ka.target.name startswith "system:") and not ka.target.name in (system:coredns, system:managed-certificate-controller)
         desc: Detect any attempt to modify/delete a ClusterRole/Role starting with system
         output: System ClusterRole/Role modified or deleted (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource action=%ka.verb)
-        priority: WARNING
+        priority: Warning
         tags:
           - fstec
           - rbac_drift
@@ -314,7 +314,7 @@ spec:
           kactivity and kcreate and serviceaccount and response_successful
         desc: Detect any attempt to create a service account
         output: K8s Serviceaccount Created (user=%ka.user.name serviceaccount=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: NOTICE
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -325,7 +325,7 @@ spec:
           kactivity and kdelete and serviceaccount and response_successful
         desc: Detect any attempt to delete a service account
         output: K8s Serviceaccount Deleted (user=%ka.user.name serviceaccount=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: NOTICE
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -336,7 +336,7 @@ spec:
           kactivity and kcreate and (clusterrole or role) and response_successful
         desc: Detect any attempt to create a cluster role/role
         output: K8s Cluster Role Created (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource rules=%ka.req.role.rules resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: NOTICE
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -346,7 +346,7 @@ spec:
         condition: kactivity and kdelete and (clusterrole or role) and response_successful
         desc: Detect any attempt to delete a cluster role/role
         output: K8s Cluster Role Deleted (user=%ka.user.name role=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: NOTICE
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -357,7 +357,7 @@ spec:
           kactivity and kcreate and clusterrolebinding and response_successful
         desc: Detect any attempt to create a clusterrolebinding
         output: K8s Cluster Role Binding Created (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource subjects=%ka.req.binding.subjects role=%ka.req.binding.role resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: NOTICE
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -369,7 +369,7 @@ spec:
         desc: Detect any attempt to delete a clusterrolebinding
         output: |
           K8s Cluster Role Binding Deleted (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason)
-        priority: NOTICE
+        priority: Notice
         tags:
           - fstec
           - rbac_drift
@@ -381,7 +381,7 @@ spec:
         desc: An attempt to read container image file in the containerd directory
         output: |
           File below a known containerd directory opened for reading (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository)
-        priority: NOTICE
+        priority: Notice
         tags:
           - fstec
           - container_image_access
@@ -392,7 +392,7 @@ spec:
         desc: An attempt to change container image file in the containerd directory
         output: |
           File below a known containerd directory opened for writing (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid file=%fd.name parent=%proc.pname pcmdline=%proc.pcmdline gparent=%proc.aname[2] container_id=%container.id image=%container.image.repository)
-        priority: ERROR
+        priority: Error
         tags:
           - fstec
           - container_image_drift
@@ -403,7 +403,7 @@ spec:
         desc: Not all pods are under integrity control in a system namespace
         output: |
           Not all containers are running with the sha256 sum as a tag in a system namespace, which is a potential integrity control mechanism misconfiguration (user=%ka.user.name binding=%ka.target.name resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason image=%ka.req.pod.containers.image)
-        priority: NOTICE
+        priority: Notice
         tags:
           - fstec
           - integrity_control
@@ -417,7 +417,7 @@ spec:
           ) and fd.sport=22
         desc: Detect Inbound SSH Connection
         output: Inbound SSH Connection (command=%proc.cmdline pid=%proc.pid connection=%fd.name user=%user.name user_loginuid=%user.loginuid type=%evt.type)
-        priority: NOTICE
+        priority: Notice
         tags:
           - fstec
           - auth_attempts


### PR DESCRIPTION
## Description
It fixes the config.

## Why do we need it, and what problem does it solve?
Runtime audit engine was stuck in CrashLoopBack.

Now the validation is successful:
```
Tue Apr 29 10:51:21 2025: [info] [k8smeta] Start the process scan under: '/host/proc'
Tue Apr 29 10:51:21 2025: [info] [k8smeta] Process scan correctly completed. Found '911' threads inside pods.
Tue Apr 29 10:51:21 2025: Configured rules filenames:
Tue Apr 29 10:51:21 2025:    /etc/falco/rules.d
Tue Apr 29 10:51:21 2025:    /etc/falco/k8s_audit_rules.yaml
Tue Apr 29 10:51:21 2025: Loading rules from:
Tue Apr 29 10:51:21 2025:    /etc/falco/rules.d/fstec.yaml | schema validation: ok
Tue Apr 29 10:51:21 2025:    /etc/falco/k8s_audit_rules.yaml | schema validation: ok
Tue Apr 29 10:51:21 2025: Hostname value has been overridden via environment variable to: dev-master-0
Tue Apr 29 10:51:21 2025: Skipping outputs initialization in dry-run
Tue Apr 29 10:51:21 2025: Skipping signal handlers creation in dry-run
Tue Apr 29 10:51:21 2025: Skipping pidfile creation in dry-run
```

## Why do we need it in the patch release (if we do)?
Runtime audit engine stuck in CrashLoopBack.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: runtime-audit-engine
type: fix
summary: Fix CrashLoopBack due to invalid config.
impact_level: low
```