### PR TITLE
[deckhouse] enrich DeckhouseUpdating alert

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -999,7 +999,7 @@ func (r *deckhouseReleaseReconciler) reconcileDeployedRelease(ctx context.Contex
 	}
 
 	if dr.GetIsUpdating() {
-		r.metricStorage.Grouped().GaugeSet(metricUpdatingGroup, metricUpdatingName, 1, map[string]string{"releaseChannel": r.updateSettings.Get().ReleaseChannel})
+		r.metricStorage.Grouped().GaugeSet(metricUpdatingGroup, metricUpdatingName, 1, map[string]string{"deployingRelease": dr.GetName()})
 
 		return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
 	}

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3250,7 +3250,7 @@ alerts:
       edition: ce
       description: ""
       summary: |
-        Deckhouse is being updated.
+        Deckhouse is being updated to {{ $labels.deployingRelease }}.
       severity: "4"
       markupFormat: markdown
     - name: DeckhouseUpdatingFailed

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -396,7 +396,7 @@
            ```
 
   - alert: DeckhouseUpdating
-    expr: max (d8_is_updating) == 1
+    expr: max by (deployingRelease) (d8_is_updating) == 1
     labels:
       severity_level: "4"
       tier: cluster
@@ -405,7 +405,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      summary: Deckhouse is being updated.
+      summary: Deckhouse is being updated to {{ $labels.deployingRelease }}.
 
   - alert: DeckhouseUpdatingFailed
     expr: max (d8_updating_is_failed) == 1


### PR DESCRIPTION
## Description
It enriches DeckhouseUpdating alert to show the deploying version.

## Why do we need it, and what problem does it solve?
It helps to learn which version is deploying.

```
❯ kubectl get clusteralert 1db478a4d9ee998e -o yaml
alert:
  labels:
    d8_component: deckhouse
    d8_module: deckhouse
    deployingRelease: v1.71.0
    prometheus: deckhouse
    tier: cluster
  name: DeckhouseUpdating
  severityLevel: "4"
  summary: Deckhouse is being updated to v1.71.0.
apiVersion: deckhouse.io/v1alpha1
kind: ClusterAlert
metadata:
  creationTimestamp: "2025-04-24T11:16:34Z"
  generation: 1
  labels:
    app: prometheus
    heritage: deckhouse
  name: 1db478a4d9ee998e
  resourceVersion: "524443047"
  uid: 667aaf6d-e805-4c52-9771-f500405f60ee
status:
  alertStatus: firing
  lastUpdateTime: "2025-04-24T11:16:29Z"
  startsAt: "2025-04-24T11:16:29Z"
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Enrich DeckhouseUpdating alert.
impact_level: low
```