### PR TITLE
[tools] bump DMT version to 0.1.18

### DIFF
--- a/ee/be/modules/040-node-manager/openapi/values.yaml
+++ b/ee/be/modules/040-node-manager/openapi/values.yaml
@@ -98,6 +98,7 @@ properties:
           properties:
             name:
               type: string
+              x-dmt-default: name
             standby:
               type: number
             reserveCPU:

--- a/modules/040-node-manager/openapi/values.yaml
+++ b/modules/040-node-manager/openapi/values.yaml
@@ -98,6 +98,7 @@ properties:
           properties:
             name:
               type: string
+              x-dmt-default: name
             standby:
               type: number
             reserveCPU:

--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-DMT_VERSION=0.1.17
+DMT_VERSION=0.1.18
 
 function install_dmt() {
   platform_name=$(uname -m)

--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-DMT_VERSION=0.1.15
+DMT_VERSION=0.1.17
 
 function install_dmt() {
   platform_name=$(uname -m)


### PR DESCRIPTION
## Description

bump DMT version to 0.1.18

## Why do we need it, and what problem does it solve?

bump DMT version to 0.1.18

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: chore
summary: bump DMT version to 0.1.18
impact_level: low
```
