### PR TITLE
[docs] Removed info about MaxDiskSizeGigabytes Prometheus parameters and automatic volume expansion

### DIFF
--- a/modules/300-prometheus/docs/README.md
+++ b/modules/300-prometheus/docs/README.md
@@ -9,8 +9,6 @@ webIfaces:
 
 This module installs and configures the [Prometheus](https://prometheus.io/) monitoring system. Also, it configures metrics scraping for many typical applications and provides the basic set of Prometheus alerts and Grafana dashboards.
 
-If a StorageClass supports automatic volume expansion (allowVolumeExpansion: true), it can automatically expand the volume if there is not enough disk space for Prometheus data. Otherwise, you will receive an alert that the volume space in Prometheus is running out.
-
 The [Vertical Pod Autoscaler](../../modules/vertical-pod-autoscaler/) module makes it possible to automatically request CPU and memory resources based on the utilization history when the Pod is recreated. Also, the Prometheus memory consumption is minimized by caching requests to it via [Trickster](https://github.com/trickstercache/trickster).
 
 Both pulling and pushing of metrics are supported.

--- a/modules/300-prometheus/docs/README_RU.md
+++ b/modules/300-prometheus/docs/README_RU.md
@@ -9,8 +9,6 @@ webIfaces:
 
 Модуль устанавливает и настраивает [Prometheus](https://prometheus.io/), а также настраивает сбор метрик из многих приложений и предоставляет минимальный набор алертов для Prometheus и дашбордов Grafana.
 
-Если используется StorageClass с поддержкой автоматического расширения (`allowVolumeExpansion: true`), при нехватке места на диске для данных Prometheus его емкость будет увеличена.
-
 Ресурсы CPU и memory автоматически выставляются при пересоздании пода на основе истории потребления, благодаря модулю [Vertical Pod Autoscaler](../../modules/vertical-pod-autoscaler/). Также, благодаря кэшированию запросов к Prometheus с помощью [Trickster](https://github.com/trickstercache/trickster), потребление памяти Prometheus сильно сокращается.
 
 Поддерживается как pull-, так и push-модель получения метрик.

--- a/modules/300-prometheus/openapi/config-values.yaml
+++ b/modules/300-prometheus/openapi/config-values.yaml
@@ -370,11 +370,9 @@ properties:
     type: integer
     description: |
       Deprecated and will be removed. Doesn't affect anything.
-      The maximum size (in GiB) that the main Prometheus' volume can automatically resize to.
     x-doc-deprecated: true
   longtermMaxDiskSizeGigabytes:
     type: integer
     x-doc-deprecated: true
     description: |
       Deprecated and will be removed. Doesn't affect anything.
-      The maximum size (in GiB) to which the Longterm Prometheus' disk can be automatically resized.

--- a/modules/300-prometheus/openapi/doc-ru-config-values.yaml
+++ b/modules/300-prometheus/openapi/doc-ru-config-values.yaml
@@ -199,8 +199,6 @@ properties:
   mainMaxDiskSizeGigabytes:
     description: |
       Устарел и будет удален. Ни на что не влияет.
-      Максимальный размер в гигабайтах, до которого автоматически может ресайзиться диск Prometheus.
   longtermMaxDiskSizeGigabytes:
     description: |
       Устарел и будет удален. Ни на что не влияет.
-      Максимальный размер в гигабайтах, до которого автоматически может ресайзиться диск Longterm Prometheus.


### PR DESCRIPTION
## Description
Updated info about MaxDiskSizeGigabytes Prometheus parameters and automatic volume expansion.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Updated info about MaxDiskSizeGigabytes Prometheus parameters and automatic volume expansion.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
