### PR TITLE
[docs] Added info about maxPerZone at Getting Started

### DIFF
--- a/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.ce.inc
@@ -203,8 +203,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.other.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.ru.yml.without_nat.other.inc
@@ -201,8 +201,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
@@ -193,8 +193,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.other.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.other.inc
@@ -201,8 +201,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.ce.inc
@@ -186,8 +186,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.ru.yml.standard.other.inc
@@ -185,8 +185,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.yml.standard.ce.inc
@@ -176,8 +176,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/azure/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/azure/partials/config.yml.standard.other.inc
@@ -185,8 +185,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/dynamix/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/dynamix/partials/config.ru.yml.standard.other.inc
@@ -200,8 +200,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
   disruptions:
     approvalMode: Automatic

--- a/docs/site/_includes/getting_started/dynamix/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/dynamix/partials/config.yml.standard.other.inc
@@ -188,8 +188,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
   disruptions:
     approvalMode: Automatic

--- a/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.ce.inc
@@ -192,8 +192,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.other.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.ru.yml.without_nat.other.inc
@@ -188,8 +188,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.ce.inc
@@ -182,8 +182,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.other.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/config.yml.without_nat.other.inc
@@ -188,8 +188,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/huaweicloud/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/huaweicloud/partials/config.ru.yml.standard.other.inc
@@ -224,8 +224,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/huaweicloud/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/huaweicloud/partials/config.yml.standard.other.inc
@@ -224,8 +224,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/openstack/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/config.ru.yml.standard.other.inc
@@ -209,8 +209,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/openstack/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/config.yml.standard.other.inc
@@ -197,8 +197,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/openstack_ovh/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_ovh/partials/config.ru.yml.standard.other.inc
@@ -209,8 +209,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/openstack_ovh/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_ovh/partials/config.yml.standard.other.inc
@@ -209,8 +209,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.other.inc
@@ -239,8 +239,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.other.inc
@@ -239,8 +239,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.other.inc
@@ -230,8 +230,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.other.inc
@@ -230,8 +230,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/vsphere/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/config.ru.yml.standard.other.inc
@@ -216,8 +216,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/vsphere/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/config.yml.standard.other.inc
@@ -216,8 +216,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.ce.inc
@@ -192,8 +192,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.ru.yml.standard.other.inc
@@ -188,8 +188,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ce.inc
@@ -182,8 +182,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.other.inc
@@ -188,8 +188,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
     # [<en>] List of availability zones to create instances in.
     # [<ru>] Список зон, в которых создаются инстансы.

--- a/docs/site/_includes/getting_started/zvirt/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/zvirt/partials/config.ru.yml.standard.other.inc
@@ -190,8 +190,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
   disruptions:
     approvalMode: Automatic

--- a/docs/site/_includes/getting_started/zvirt/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/zvirt/partials/config.yml.standard.other.inc
@@ -190,8 +190,8 @@ spec:
     # [<ru>] Максимальное количество инстансов в каждой зоне (используется при масштабировании).
     # [<ru>] Возможно, захотите изменить.
     maxPerZone: 1
-    # [<en>] The minimum number of instances for the group in each zone.
-    # [<ru>] Минимальное количество инстансов в каждой зоне.
+    # [<en>] The minimum number of instances for the group in each zone. To launch more nodes, increase maxPerZone or add more zones.
+    # [<ru>] Минимальное количество инстансов в каждой зоне. Чтобы запустить больше узлов, увеличьте maxPerZone или добавьте зоны.
     minPerZone: 1
   disruptions:
     approvalMode: Automatic


### PR DESCRIPTION
## Description
Added info about maxPerZone at Getting Started.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Added info about maxPerZone at Getting Started.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
