### PR TITLE
[candi] return support criSocketPath for notManaged cri

### DIFF
--- a/candi/bashible/common-steps/all/068_configure_kubelet_systemd_unit.sh.tpl
+++ b/candi/bashible/common-steps/all/068_configure_kubelet_systemd_unit.sh.tpl
@@ -20,12 +20,12 @@ rm -f /var/lib/kubelet/kubeadm-flags.env
 # Read previously discovered IP
 discovered_node_ip="$(</var/lib/bashible/discovered-node-ip)"
 
-cri_config=""
-
 {{- if eq .cri "Containerd" }}
-cri_config="--container-runtime=remote --container-runtime-endpoint=unix:/var/run/containerd/containerd.sock"
-{{- else if eq .cri "NotManaged" }}
-  {{- if (and .nodeGroup.cri.notManaged .nodeGroup.cri.notManaged.criSocketPath) }}
+cri_socket_path="/run/containerd/containerd.sock"
+{{- end }}
+
+{{- if eq .cri "NotManaged" }}
+  {{- if (((.nodeGroup.cri).notManaged).criSocketPath) }}
 cri_socket_path={{ .nodeGroup.cri.notManaged.criSocketPath | quote }}
   {{- else }}
   if [[ -S "/run/containerd/containerd.sock" ]]; then
@@ -38,9 +38,9 @@ if [[ -z "${cri_socket_path}" ]]; then
   bb-log-error 'CRI socket is not found, need to manually set "nodeGroup.cri.notManaged.criSocketPath"'
   exit 1
 fi
-
-cri_config="--container-runtime=remote --container-runtime-endpoint=unix:${cri_socket_path}"
 {{- end }}
+
+cri_config="--container-runtime-endpoint=unix://${cri_socket_path}"
 
 credential_provider_flags=""
 {{- if semverCompare ">=1.28" .kubernetesVersion }}
@@ -87,6 +87,7 @@ $([ -n "$discovered_node_ip" ] && echo -e "\n    --node-ip=${discovered_node_ip}
 {{- if hasKey .nodeGroup "kubelet" }}
     --root-dir={{ .nodeGroup.kubelet.rootDir | default "/var/lib/kubelet" }} \\
 {{- end }}
+    ${cri_config} \\
     ${credential_provider_flags} \\
     --v=2
 EOF


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Return support `.cri.notManaged.criSocketPath`. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Probably support for this functionality was limited to Kubernetes version <1.27 by mistake and removed with eol:

https://github.com/deckhouse/deckhouse/commit/8d52e086113ff41284200fddd88ec9cb01b0c98e#diff-f64efc9c61452b3eb9e3bf9220130c3666b96837a313e1105c8b7baa4ef94c20R94-R96

https://github.com/deckhouse/deckhouse/commit/b676c8841d1f130d0de45176d1172cc42f5b9939#diff-a3108429fddd29708f27c209c6f167f0efa34eea3fed2ec0b1f3f2c61a29f779L90-L91

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not neccary.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Return support `.cri.notManaged.criSocketPath`. 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
