### PR TITLE
Trivy error handling improvements

### DIFF
--- a/.github/ci_templates/cve_tests.yaml
+++ b/.github/ci_templates/cve_tests.yaml
@@ -9,6 +9,8 @@
     TRIVY_DB_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-db:2
     TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-java-db:1
     TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-bdu:1
+    REGISTRY_USER: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+    REGISTRY_PASSWORD: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
   run: |
     echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
     make cve-report

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -82,6 +82,8 @@ jobs:
           TRIVY_DB_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-db:2
           TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-java-db:1
           TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-bdu:1
+          REGISTRY_USER: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          REGISTRY_PASSWORD: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
         run: |
           echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
           make cve-report

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -135,6 +135,8 @@ jobs:
           TRIVY_DB_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-db:2
           TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-java-db:1
           TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-bdu:1
+          REGISTRY_USER: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          REGISTRY_PASSWORD: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
         run: |
           echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
           make cve-report

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ help:
 
 
 GOLANGCI_VERSION = 1.54.2
-TRIVY_VERSION= 0.55.0
+TRIVY_VERSION= 0.60.0
 PROMTOOL_VERSION = 2.37.0
 GATOR_VERSION = 3.9.0
 GH_VERSION = 2.52.0
@@ -218,7 +218,7 @@ bin/regcopy: bin ## App to copy docker images to the Deckhouse registry
 bin/trivy-${TRIVY_VERSION}/trivy:
 	mkdir -p bin/trivy-${TRIVY_VERSION}
 	# curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ./bin/trivy-${TRIVY_VERSION} v${TRIVY_VERSION}
-	curl https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_PROJECT_ID}/packages/generic/deckhouse-trivy/v${TRIVY_VERSION}/trivy -o bin/trivy-${TRIVY_VERSION}/trivy
+	curl https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_PROJECT_ID}/packages/generic/trivy-v${TRIVY_VERSION}/v${TRIVY_VERSION}/trivy -o bin/trivy-${TRIVY_VERSION}/trivy
 
 .PHONY: trivy
 bin/trivy: bin bin/trivy-${TRIVY_VERSION}/trivy

--- a/Makefile
+++ b/Makefile
@@ -433,4 +433,3 @@ build-render: set-build-envs ## render werf.yaml for build Deckhouse images.
 .PHONY: go-module-version
 go-module-version:
 	@echo "go get $(shell go list ./deckhouse-controller/cmd/deckhouse-controller)@$(shell git rev-parse HEAD)"
-

--- a/Makefile
+++ b/Makefile
@@ -433,3 +433,4 @@ build-render: set-build-envs ## render werf.yaml for build Deckhouse images.
 .PHONY: go-module-version
 go-module-version:
 	@echo "go get $(shell go list ./deckhouse-controller/cmd/deckhouse-controller)@$(shell git rev-parse HEAD)"
+

--- a/tools/cve/d8-images.sh
+++ b/tools/cve/d8-images.sh
@@ -38,9 +38,7 @@ fi
 if [ -z "$SEVERITY" ]; then
   SEVERITY="UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
 fi
-upload(){
-  
-}
+
 function __main__() {
   echo "Deckhouse image to check: $IMAGE:$TAG"
   echo "Severity: $SEVERITY"
@@ -62,6 +60,7 @@ function __main__() {
 
   IMAGE_REPORT_NAME="deckhouse::$(echo "$IMAGE:$TAG" | sed 's/^.*\/\(.*\)/\1/')"
   mkdir -p out/json
+  touch out/.trivyignore
 
   date_iso=$(date -I)
 

--- a/tools/cve/d8-images.sh
+++ b/tools/cve/d8-images.sh
@@ -38,7 +38,9 @@ fi
 if [ -z "$SEVERITY" ]; then
   SEVERITY="UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
 fi
-
+upload(){
+  
+}
 function __main__() {
   echo "Deckhouse image to check: $IMAGE:$TAG"
   echo "Severity: $SEVERITY"
@@ -134,7 +136,7 @@ function __main__() {
       echo ""
       echo " Uploading trivy CVE report for image ${IMAGE_NAME} of ${MODULE_NAME} module"
       echo ""
-      curl -s -X POST \
+      curl --retry 5 --retry-delay 5 --retry-all-errors -s -X POST \
         https://${DEFECTDOJO_HOST}/api/v2/reimport-scan/ \
         -H "accept: application/json" \
         -H "Content-Type: multipart/form-data"  \
@@ -161,8 +163,7 @@ function __main__() {
         -F "build_id=${IMAGE_HASH}" \
         -F "commit_hash=${GITHUB_SHA}" \
         -F "branch_tag=${TAG}" \
-        -F "apply_tags_to_findings=true" \
-      > /dev/null
+        -F "apply_tags_to_findings=true"
     done
   done
 }


### PR DESCRIPTION
## Description
This PR improves error handling when scanning images using Trivy.  
A retry mechanism was added: the first attempt uses `--quiet`, subsequent retries switch to `--debug` mode if the initial scan fails.

## Why do we need it, and what problem does it solve?
Previously, transient Trivy failures (network issues, registry errors) caused immediate job failures.  
With retries (5 attempts, 5-second delay), the process becomes more stable and resilient to temporary problems.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Trivy error handling improvements
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
