### PR TITLE
[docs] Fixed errors at Huawei Cloud Getting Started

### DIFF
--- a/docs/site/_includes/getting_started/huaweicloud/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/huaweicloud/partials/config.ru.yml.standard.other.inc
@@ -6,7 +6,7 @@ apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
 clusterType: Cloud
 cloud:
-  provider: HuaweiCloud
+  provider: Huaweicloud
   # [<en>] A prefix of objects that are created in the cloud during the installation.
   # [<en>] You might consider changing this.
   # [<ru>] Префикс объектов, создаваемых в облаке при установке.
@@ -170,10 +170,7 @@ masterNodeGroup:
     imageName: ubuntu-22-04-cloud-amd64
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.
-    rootDiskSize: 40
-    # [<en>] The type of a root disk.
-    # [<ru>] Тип root-диска.
-    rootDiskType: SSD
+    rootDiskSize: 50
 # [<en>] Public SSH key for accessing cloud nodes.
 # [<en>] This key will be added to the user on created nodes (the user name depends on the image used).
 # [<ru>] Публичная часть SSH-ключа для доступа к узлам облака.
@@ -196,10 +193,7 @@ spec:
   flavorName: Standard-2-4-50
   # [<en>] The size of a root disk in gigabytes.
   # [<ru>] Размер root-диска. Значение указывается в гигабайтах.
-  rootDiskSize: 30
-  # [<en>] The type of a root disk.
-  # [<ru>] Тип root-диска.
-  rootDiskType: SSD
+  rootDiskSize: 40
   # [<en>] VM image in use.
   # [<ru>] Используемый образ виртуальной машины.
   # [<en>] You might consider changing this.

--- a/docs/site/_includes/getting_started/huaweicloud/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/huaweicloud/partials/config.yml.standard.other.inc
@@ -6,7 +6,7 @@ apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
 clusterType: Cloud
 cloud:
-  provider: HuaweiCloud
+  provider: Huaweicloud
   # [<en>] A prefix of objects that are created in the cloud during the installation.
   # [<en>] You might consider changing this.
   # [<ru>] Префикс объектов, создаваемых в облаке при установке.
@@ -171,9 +171,6 @@ masterNodeGroup:
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.
     rootDiskSize: 40
-    # [<en>] The type of a root disk.
-    # [<ru>] Тип root-диска.
-    rootDiskType: SSD
 # [<en>] Public SSH key for accessing cloud nodes.
 # [<en>] This key will be added to the user on created nodes (the user name depends on the image used).
 # [<ru>] Публичная часть SSH-ключа для доступа к узлам облака.
@@ -196,10 +193,7 @@ spec:
   flavorName: Standard-2-4-50
   # [<en>] The size of a root disk in gigabytes.
   # [<ru>] Размер root-диска. Значение указывается в гигабайтах.
-  rootDiskSize: 30
-  # [<en>] The type of a root disk.
-  # [<ru>] Тип root-диска.
-  rootDiskType: SSD
+  rootDiskSize: 40
   # [<en>] VM image in use.
   # [<ru>] Используемый образ виртуальной машины.
   # [<en>] You might consider changing this.

--- a/docs/site/_includes/getting_started/vcd/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/vcd/partials/config.ru.yml.standard.other.inc
@@ -158,7 +158,7 @@ masterNodeGroup:
     # [<ru>] Рекомендуем использовать .2, .3 .4 адреса, например: 10.15.11.2.
     mainNetworkIPAddresses:
     - !CHANGE_SUBNET*.2
-    rootDiskSizeGb: 40
+    rootDiskSizeGb: 50
     sizingPolicy: *!CHANGE_SIZING_POLICY*
     storageProfile: *!CHANGE_STORAGE_PROFILE*
     # [<en>] The name of the image, taking into account the vCloudDirector catalog path.
@@ -171,7 +171,7 @@ nodeGroups:
 - instanceClass:
     mainNetworkIPAddresses:
     - !CHANGE_SUBNET*.11
-    rootDiskSizeGb: 40
+    rootDiskSizeGb: 50
     sizingPolicy: *!CHANGE_SIZING_POLICY*
     storageProfile: *!CHANGE_STORAGE_PROFILE*
     # [<en>] The name of the image, taking into account the vCloudDirector catalog path.

--- a/docs/site/_includes/getting_started/vcd/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/vcd/partials/config.yml.standard.other.inc
@@ -158,7 +158,7 @@ masterNodeGroup:
     # [<ru>] Рекомендуем использовать .2, .3 .4 адреса, например: 10.15.11.2.
     mainNetworkIPAddresses:
     - !CHANGE_SUBNET*.2
-    rootDiskSizeGb: 40
+    rootDiskSizeGb: 50
     sizingPolicy: *!CHANGE_SIZING_POLICY*
     storageProfile: *!CHANGE_STORAGE_PROFILE*
     # [<en>] The name of the image, taking into account the vCloudDirector catalog path.
@@ -171,7 +171,7 @@ nodeGroups:
 - instanceClass:
     mainNetworkIPAddresses:
     - !CHANGE_SUBNET*.11
-    rootDiskSizeGb: 40
+    rootDiskSizeGb: 50
     sizingPolicy: *!CHANGE_SIZING_POLICY*
     storageProfile: *!CHANGE_STORAGE_PROFILE*
     # [<en>] The name of the image, taking into account the vCloudDirector catalog path.


### PR DESCRIPTION
## Description
Fixed errors at Huawei Cloud Getting Started.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Fixed errors at Huawei Cloud Getting Started.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
