### PR TITLE
[deckhouse] fix enabling helper

### DIFF
--- a/deckhouse-controller/pkg/debug/module_enable.go
+++ b/deckhouse-controller/pkg/debug/module_enable.go
@@ -82,7 +82,7 @@ func setModuleConfigEnabled(ctx context.Context, kubeClient k8s.Client, name str
 		return fmt.Errorf("kubernetes client is not initialized")
 	}
 
-	if _, err := kubeClient.Dynamic().Resource(v1alpha1.ModuleConfigGVR).Get(ctx, name, metav1.GetOptions{}); err != nil {
+	if _, err := kubeClient.Dynamic().Resource(v1alpha1.ModuleGVR).Get(ctx, name, metav1.GetOptions{}); err != nil {
 		if apierrors.IsNotFound(err) {
 			return errors.New("module not found")
 		}


### PR DESCRIPTION
## Description
It fixes enabling helper.

## Why do we need it, and what problem does it solve?
Fix this [PR](https://github.com/deckhouse/deckhouse/pull/12872)

```
root@dev-master-0:~# dcme xtes
deckhouse-controller: error: enable module: module not found, try --help
command terminated with exit code 1
```
```
root@dev-master-0:~# dcme test
Module test enabled
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix module enabling helper.
impact_level: low
```
