### PR TITLE
[cloud-provider-yandex] fix converge on WithNATInstance clusters

### DIFF
--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -51,11 +51,11 @@ locals {
   # if user set internal subnet id for nat instance get cidr from its subnet
   user_internal_subnet_cidr = var.nat_instance_internal_subnet_id == null ? null : data.yandex_vpc_subnet.user_internal_subnet[0].v4_cidr_blocks[0]
 
-  nat_instance_internal_cidr = var.nat_instance_internal_subnet_cidr != null ? var.nat_instance_internal_subnet_cidr : (local.user_internal_subnet_cidr != null ? local.user_internal_subnet_cidr : try(local.zone_to_cidr[local.internal_subnet_zone]))
+  nat_instance_internal_cidr = var.nat_instance_internal_subnet_cidr != null ? var.nat_instance_internal_subnet_cidr : (local.user_internal_subnet_cidr != null ? local.user_internal_subnet_cidr : local.zone_to_cidr[local.internal_subnet_zone])
 
   # if user passes nat instance internal address directly (deprecated, keep for backward compatibility) use passed address,
   # else get 10 host address from cidr which got in previous step
-  nat_instance_internal_address_calculated = var.nat_instance_internal_address != null ? var.nat_instance_internal_address : try(cidrhost(local.nat_instance_internal_cidr, 10))
+  nat_instance_internal_address_calculated = var.nat_instance_internal_address != null ? var.nat_instance_internal_address : cidrhost(local.nat_instance_internal_cidr, 10)
 
   assign_external_ip_address = var.nat_instance_external_subnet_id == null ? true : false
 

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -51,11 +51,11 @@ locals {
   # if user set internal subnet id for nat instance get cidr from its subnet
   user_internal_subnet_cidr = var.nat_instance_internal_subnet_id == null ? null : data.yandex_vpc_subnet.user_internal_subnet[0].v4_cidr_blocks[0]
 
-  nat_instance_internal_cidr = var.nat_instance_internal_subnet_cidr ? var.nat_instance_internal_subnet_cidr : (local.user_internal_subnet_cidr ? local.user_internal_subnet_cidr : local.zone_to_cidr[local.internal_subnet_zone])
+  nat_instance_internal_cidr = var.nat_instance_internal_subnet_cidr != null ? var.nat_instance_internal_subnet_cidr : (local.user_internal_subnet_cidr != null ? local.user_internal_subnet_cidr : try(local.zone_to_cidr[local.internal_subnet_zone]))
 
   # if user passes nat instance internal address directly (deprecated, keep for backward compatibility) use passed address,
   # else get 10 host address from cidr which got in previous step
-  nat_instance_internal_address_calculated = var.nat_instance_internal_address ? var.nat_instance_internal_address : (local.nat_instance_internal_cidr ? cidrhost(local.nat_instance_internal_cidr, 10): null)
+  nat_instance_internal_address_calculated = var.nat_instance_internal_address != null ? var.nat_instance_internal_address : try(cidrhost(local.nat_instance_internal_cidr, 10))
 
   assign_external_ip_address = var.nat_instance_external_subnet_id == null ? true : false
 
@@ -98,7 +98,7 @@ locals {
 }
 
 resource "yandex_vpc_subnet" "nat_instance" {
-  count = local.is_with_nat_instance ? (var.nat_instance_internal_subnet_cidr ? 1 : 0) : 0
+  count = local.is_with_nat_instance ? (var.nat_instance_internal_subnet_cidr != null ? 1 : 0) : 0
 
   name           = join("-", [var.prefix, "nat"])
   zone           = local.internal_subnet_zone
@@ -131,7 +131,7 @@ resource "yandex_compute_instance" "nat_instance" {
   }
 
   dynamic "network_interface" {
-    for_each = var.nat_instance_external_subnet_id ? [var.nat_instance_external_subnet_id] : []
+    for_each = var.nat_instance_external_subnet_id != null ? [var.nat_instance_external_subnet_id] : []
     content {
       subnet_id = network_interface.value
       ip_address = var.nat_instance_external_address
@@ -140,7 +140,7 @@ resource "yandex_compute_instance" "nat_instance" {
   }
 
   network_interface {
-    subnet_id      = var.nat_instance_internal_subnet_cidr ? yandex_vpc_subnet.nat_instance[0].id: (var.nat_instance_internal_subnet_id ? var.nat_instance_internal_subnet_id: local.zone_to_subnet_id[local.internal_subnet_zone])
+    subnet_id      = var.nat_instance_internal_subnet_cidr != null ? yandex_vpc_subnet.nat_instance[0].id: (var.nat_instance_internal_subnet_id != null ? var.nat_instance_internal_subnet_id: local.zone_to_subnet_id[local.internal_subnet_zone])
     ip_address     = local.nat_instance_internal_address_calculated
     nat            = local.assign_external_ip_address
     nat_ip_address = local.assign_external_ip_address ? var.nat_instance_external_address : null

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -27,24 +27,35 @@ data "yandex_vpc_subnet" "external_subnet" {
   subnet_id = var.nat_instance_external_subnet_id
 }
 
-data "yandex_compute_instance" "nat_instance" {
-  count = local.is_with_nat_instance ? (var.nat_instance_internal_subnet_cidr == null ? 1 : 0) : 0
-  name = join("-", [var.prefix, "nat"])
-}
-
 locals {
   user_internal_subnet_zone = var.nat_instance_internal_subnet_id == null ? null : data.yandex_vpc_subnet.user_internal_subnet[0].zone
   external_subnet_zone = var.nat_instance_external_subnet_id == null ? null : join("", data.yandex_vpc_subnet.external_subnet.*.zone) # https://github.com/hashicorp/terraform/issues/23222#issuecomment-547462883
   internal_subnet_zone = local.user_internal_subnet_zone == null ? (local.external_subnet_zone == null ? "ru-central1-a" : local.external_subnet_zone) : local.user_internal_subnet_zone
 
+  # used for backward compatability
+  zone_to_subnet_id = tomap({
+    "ru-central1-a" = local.should_create_subnets ? yandex_vpc_subnet.kube_a[0].id : (local.not_have_existing_subnet_a ? null : data.yandex_vpc_subnet.kube_a[0].id)
+    "ru-central1-b" = local.should_create_subnets ? yandex_vpc_subnet.kube_b[0].id : (local.not_have_existing_subnet_b ? null : data.yandex_vpc_subnet.kube_b[0].id)
+    "ru-central1-d" = local.should_create_subnets ? yandex_vpc_subnet.kube_d[0].id : (local.not_have_existing_subnet_d ? null : data.yandex_vpc_subnet.kube_d[0].id)
+  })
+
+  # used for backward compatability
+  # we can not use one map because we will get cycle
+  # local.nat_instance_internal_address_calculated uses in route table and yandex_vpc_subnet.kube_* depend on route table
+  zone_to_cidr = tomap({
+    "ru-central1-a" = local.should_create_subnets ? local.kube_a_v4_cidr_block : (local.not_have_existing_subnet_a ? null : data.yandex_vpc_subnet.kube_a[0].v4_cidr_blocks[0])
+    "ru-central1-b" = local.should_create_subnets ? local.kube_b_v4_cidr_block : (local.not_have_existing_subnet_b ? null : data.yandex_vpc_subnet.kube_b[0].v4_cidr_blocks[0])
+    "ru-central1-d" = local.should_create_subnets ? local.kube_d_v4_cidr_block : (local.not_have_existing_subnet_d ? null : data.yandex_vpc_subnet.kube_d[0].v4_cidr_blocks[0])
+  })
+
   # if user set internal subnet id for nat instance get cidr from its subnet
   user_internal_subnet_cidr = var.nat_instance_internal_subnet_id == null ? null : data.yandex_vpc_subnet.user_internal_subnet[0].v4_cidr_blocks[0]
 
-  nat_instance_internal_cidr = var.nat_instance_internal_subnet_cidr != null ? var.nat_instance_internal_subnet_cidr : local.user_internal_subnet_cidr
+  nat_instance_internal_cidr = var.nat_instance_internal_subnet_cidr ? var.nat_instance_internal_subnet_cidr : (local.user_internal_subnet_cidr ? local.user_internal_subnet_cidr : local.zone_to_cidr[local.internal_subnet_zone])
 
-  # if user pass nat instance internal address directly (it for backward compatibility) use passed address,
+  # if user passes nat instance internal address directly (deprecated, keep for backward compatibility) use passed address,
   # else get 10 host address from cidr which got in previous step
-  nat_instance_internal_address_calculated = local.is_with_nat_instance ? (var.nat_instance_internal_address != null ? var.nat_instance_internal_address : (local.nat_instance_internal_cidr != null ? cidrhost(local.nat_instance_internal_cidr, 10): null)) : null
+  nat_instance_internal_address_calculated = var.nat_instance_internal_address ? var.nat_instance_internal_address : (local.nat_instance_internal_cidr ? cidrhost(local.nat_instance_internal_cidr, 10): null)
 
   assign_external_ip_address = var.nat_instance_external_subnet_id == null ? true : false
 
@@ -87,7 +98,7 @@ locals {
 }
 
 resource "yandex_vpc_subnet" "nat_instance" {
-  count = local.is_with_nat_instance ? (var.nat_instance_internal_subnet_cidr != null ? 1 : 0) : 0
+  count = local.is_with_nat_instance ? (var.nat_instance_internal_subnet_cidr ? 1 : 0) : 0
 
   name           = join("-", [var.prefix, "nat"])
   zone           = local.internal_subnet_zone
@@ -120,7 +131,7 @@ resource "yandex_compute_instance" "nat_instance" {
   }
 
   dynamic "network_interface" {
-    for_each = var.nat_instance_external_subnet_id != null ? [var.nat_instance_external_subnet_id] : []
+    for_each = var.nat_instance_external_subnet_id ? [var.nat_instance_external_subnet_id] : []
     content {
       subnet_id = network_interface.value
       ip_address = var.nat_instance_external_address
@@ -129,8 +140,8 @@ resource "yandex_compute_instance" "nat_instance" {
   }
 
   network_interface {
-    subnet_id      = var.nat_instance_internal_subnet_cidr != null ? yandex_vpc_subnet.nat_instance[0].id: (var.nat_instance_internal_subnet_id != null ? var.nat_instance_internal_subnet_id: data.yandex_compute_instance.nat_instance[0].network_interface.0.subnet_id)
-    ip_address     = local.nat_instance_internal_address_calculated != null ? local.nat_instance_internal_address_calculated : data.yandex_compute_instance.nat_instance[0].network_interface.0.ip_address
+    subnet_id      = var.nat_instance_internal_subnet_cidr ? yandex_vpc_subnet.nat_instance[0].id: (var.nat_instance_internal_subnet_id ? var.nat_instance_internal_subnet_id: local.zone_to_subnet_id[local.internal_subnet_zone])
+    ip_address     = local.nat_instance_internal_address_calculated
     nat            = local.assign_external_ip_address
     nat_ip_address = local.assign_external_ip_address ? var.nat_instance_external_address : null
   }


### PR DESCRIPTION
## Description
https://github.com/deckhouse/deckhouse/pull/12301 converges clusters with two-interface NAT-instance incorrectly. This PR brings back previous NAT-instance resource terraform logic as a fallback so that converge should be done correctly. 

## Why do we need it, and what problem does it solve?
Without this fix two-interface NAT instances will be broken during converge. 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: fix
summary: fix WithNATInstance clusters converge
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
