### PR TITLE
[control-plane-manager]  improve etcd-backup

### DIFF
--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -18,6 +18,7 @@ set -xe
 cd /tmp/
 etcd=etcd-backup.snapshot
 archive=etcd-backup.tar.gz
+backup_dir_on_host=${HOSTPATH}
 etcdctl \
     --endpoints=https://127.0.0.1:2379 \
     --cacert=/etc/kubernetes/pki/etcd/ca.crt \
@@ -26,10 +27,10 @@ etcdctl \
     snapshot save "${etcd}"
 tar -czvf "${archive}" "${etcd}"
 # Check that there is enough free space
-if [ $(df -B1 /var/lib/etcd/ | tail -1 | awk -v ETCDQUOTA="${ETCDQUOTA}" '{printf "%.0f\n", $4 - (ETCDQUOTA * 2)}') -ge 0 ]; then
+if [ $(df -B1 /var/backup | tail -1 | awk -v ETCDQUOTA="${ETCDQUOTA}" '{printf "%.0f\n", $4 - (ETCDQUOTA * 2)}') -ge 0 ]; then
     chmod 0600 "${archive}"
-    mv "${archive}" "/var/lib/etcd/${archive}"
+    mv "${archive}" "/var/backup/${archive}"
 else
-    echo "Free space in /var/lib/etcd/ is too small for backup should be more than double size ETCDQUOTA (${ETCDQUOTA} bytes)"
+    echo "Free space in ${backup_dir_on_host} is too small for backup should be more than double size ETCDQUOTA (${ETCDQUOTA} bytes)"
     exit 1
 fi

--- a/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
@@ -14,6 +14,9 @@ import:
   to: /bin/etcdctl
   before: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  add: /usr/lib/locale/C.utf8
+  before: setup
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /relocate
   to: /
   before: setup

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -267,7 +267,7 @@ properties:
         type: object
         default: {}
         description: |
-          `etcd` backup parameters.
+          etcd backup parameters.
         properties:
           enabled:
             type: boolean
@@ -280,7 +280,7 @@ properties:
             x-examples:
             - "0 1 * * *"
             description: |
-              Backup schedule `etcd` in cron format. The local time zone of the kube-controller-manager is used.
+              Backup schedule etcd in cron format. The local time zone of the `kube-controller-manager` is used.
           hostPath:
             type: string
             default: /var/lib/etcd

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -265,6 +265,7 @@ properties:
     properties:
       backup:
         type: object
+        default: {}
         description: |
           `etcd` backup parameters.
         properties:

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -263,6 +263,28 @@ properties:
     description: |
       `etcd` parameters.
     properties:
+      backup:
+        type: object
+        description: |
+          `etcd` backup parameters.
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: |
+              Enable etcd backup.
+          cronSchedule:
+            type: string
+            default: "0 0 * * *"
+            x-examples:
+            - "0 1 * * *"
+            description: |
+              Backup schedule `etcd` in cron format. The local time zone of the kube-controller-manager is used.
+          hostPath:
+            type: string
+            default: /var/lib/etcd
+            description: |
+              Host path on masters nodes for etcd backup.
       maxDbSize:
         description: |
           [quota-backend-bytes](https://etcd.io/docs/v3.5/dev-guide/limit/#storage-size-limit) parameter.

--- a/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
@@ -153,21 +153,21 @@ properties:
           > **Важно!** Этот режим нельзя отключить!
   etcd:
     description: |
-      Параметры `etcd`.
+      Параметры etcd.
     properties:
       backup:
         description: |
-          Параметры резервного копирования `etcd`.
+          Параметры резервного копирования etcd.
         properties:
           enabled:
             description: |
-              Включение резервного копирование `etcd`.
+              Включение резервного копирование etcd.
           cronSchedule:
             description: |
-              Расписание резервного копирования `etcd` в формате cron. Используется локальный часовой пояс kube-controller-manager.
+              Расписание резервного копирования etcd в формате cron. Используется локальный часовой пояс `kube-controller-manager`.
           hostPath:
             description: |
-              Путь для хранения резервных копий `etcd` на мастер нодах.
+              Путь для хранения резервных копий etcd на master-узлах.
       maxDbSize:
         description: |
           [quota-backend-bytes](https://etcd.io/docs/v3.5/dev-guide/limit/#storage-size-limit) параметр.

--- a/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
@@ -155,6 +155,19 @@ properties:
     description: |
       Параметры `etcd`.
     properties:
+      backup:
+        description: |
+          Параметры резервного копирования `etcd`.
+        properties:
+          enabled:
+            description: |
+              Включение резервного копирование `etcd`.
+          cronSchedule:
+            description: |
+              Расписание резервного копирования `etcd` в формате cron. Используется локальный часовой пояс kube-controller-manager.
+          hostPath:
+            description: |
+              Путь для хранения резервных копий `etcd` на мастер нодах.
       maxDbSize:
         description: |
           [quota-backend-bytes](https://etcd.io/docs/v3.5/dev-guide/limit/#storage-size-limit) параметр.

--- a/modules/040-control-plane-manager/openapi/openapi-case-tests.yaml
+++ b/modules/040-control-plane-manager/openapi/openapi-case-tests.yaml
@@ -5,6 +5,10 @@ positive:
           sourceRanges:
           - 192.168.0.0/24
           port: 2533
+    - etcd:
+        backup:
+          cronSchedule: "0 0 * * *"
+          hostPath: "/var/backup/etcd"
   values:
     - internal:
         effectiveKubernetesVersion: "1.29"

--- a/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
+++ b/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
@@ -3,14 +3,15 @@ cpu: 25m
 memory: 40Mi
 {{- end }}
 
-{{- $etcdQuotaBackendBytes := "" -}}
-{{- if hasKey .Values.controlPlaneManager.internal "etcdQuotaBackendBytes" -}}
-  {{- $etcdQuotaBackendBytes = .Values.controlPlaneManager.internal.etcdQuotaBackendBytes -}}
-{{- end -}}
+{{- $backupEnabled := (((.Values.controlPlaneManager).etcd).backup).enabled -}}
+{{- $backupSchedule := (((.Values.controlPlaneManager).etcd).backup).cronSchedule | default "0 0 * * *" -}}
+{{- $backupHostPath := (((.Values.controlPlaneManager).etcd).backup).hostPath | default "/var/lib/etcd" -}}
+{{- $etcdQuotaBackendBytes := (.Values.controlPlaneManager.internal).etcdQuotaBackendBytes | default "2147483648" -}}
 
-{{- if .Values.global.clusterIsBootstrapped }}
-  {{- if hasKey .Values.controlPlaneManager.internal "mastersNode" }}
-    {{- range $node := .Values.controlPlaneManager.internal.mastersNode }}
+{{- if $backupEnabled }}
+  {{- if .Values.global.clusterIsBootstrapped }}
+    {{- if hasKey .Values.controlPlaneManager.internal "mastersNode" }}
+      {{- range $node := .Values.controlPlaneManager.internal.mastersNode }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -19,7 +20,7 @@ metadata:
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list $ (dict "app" "d8-etcd-backup")) | nindent 2 }}
 spec:
-  schedule: "0 0 * * *"
+  schedule: {{ $backupSchedule | quote }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
@@ -45,7 +46,9 @@ spec:
             imagePullPolicy: IfNotPresent
             env:
             - name: ETCDQUOTA
-              value: {{ $etcdQuotaBackendBytes | default "2147483648" | quote }}
+              value: {{ $etcdQuotaBackendBytes | quote }}
+            - name: HOSTPATH
+              value: {{ $backupHostPath | quote }}
             resources:
               requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 50 | nindent 16 }}
@@ -56,8 +59,8 @@ spec:
             - mountPath: /etc/kubernetes/pki/etcd
               name: etcd-certs
               readOnly: true
-            - mountPath: /var/lib/etcd
-              name: etcd-data
+            - mountPath: /var/backup
+              name: backup-data
             - mountPath: /tmp
               name: tmp
           volumes:
@@ -66,11 +69,12 @@ spec:
               type: DirectoryOrCreate
             name: etcd-certs
           - hostPath:
-              path: /var/lib/etcd
+              path: {{ $backupHostPath | quote }}
               type: DirectoryOrCreate
-            name: etcd-data
+            name: backup-data
           - name: tmp
             emptyDir: {}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Improve etcd backup. Add option to customise backup job:
- enable/disable
- schedule time
- path for saving backup on host

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Close https://github.com/deckhouse/deckhouse/issues/12984

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: feature
summary: Add settings for etcd backup.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
