### PR TITLE
[docs] Supporting x-enum-descriptions for hugo added

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-attributes.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-attributes.html
@@ -30,9 +30,24 @@
 {{- end }}
 
 {{- if or (isset $attributes "enum") }}
-<p class="resources__attrs">
-  <span class="resources__attrs_name">{{ T "allowed_values" | humanize }}:</span> <span class="resources__attrs_content"><code>{{ delimit $attributes.enum "</code>, <code>" | safeHTML }}</code></span>
-</p>
+  {{- $enumDescriptions := index $attributes "x-enum-descriptions" }}
+  {{- if and $enumDescriptions (eq (len $attributes.enum) (len $enumDescriptions)) }}
+    <p class="resources__attrs">
+      <span class="resources__attrs_name">{{ T "allowed_values" | humanize }}:</span>
+      <span class="resources__attrs_content">
+        <div style="margin-top: 0; margin-bottom: 0; padding-left: 20px;">
+          {{- range $index, $enumValue := $attributes.enum }}
+            <div style="margin-bottom: 4px;"><code>{{ $enumValue }}</code> — {{ index $enumDescriptions $index }}</div>
+          {{- end }}
+        </div>
+      </span>
+    </p>
+  {{- else }}
+    <p class="resources__attrs">
+      <span class="resources__attrs_name">{{ T "allowed_values" | humanize }}:</span> 
+      <span class="resources__attrs_content"><code>{{ delimit $attributes.enum "</code>, <code>" | safeHTML }}</code></span>
+    </p>
+  {{- end }}
 {{- end }}
 
 {{- if or (isset $attributes "pattern") }}


### PR DESCRIPTION
## Description

Added support for the x-enum-descriptions parameter for Hugo.

## Why do we need it, and what problem does it solve?

This allows to render x-enum-descriptions for external modules.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Supporting x-enum-descriptions for hugo added.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
