### PR TITLE
[upmeter] sa token rotation

### DIFF
--- a/modules/500-upmeter/images/upmeter/src/pkg/agent/agent.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/agent/agent.go
@@ -118,7 +118,7 @@ func (a *Agent) Start(ctx context.Context) error {
 
 	ch := make(chan []check.Episode)
 
-	client := sender.NewClient(a.config.ClientConfig)
+	client := sender.NewClient(a.config.ClientConfig, kubeAccess)
 	storage := sender.NewStorage(dbctx)
 
 	a.sender = sender.New(client, ch, storage, a.config.Interval)

--- a/modules/500-upmeter/images/upmeter/src/pkg/agent/sender/client.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/agent/sender/client.go
@@ -188,6 +188,9 @@ type KubeBearerTransport struct {
 func (t *KubeBearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	kubeAccess := &kubernetes.Accessor{}
 	token := kubeAccess.ServiceAccountToken()
+	if token == "" {
+		log.Error("httpClient RoundTrip: cannot read service account token")
+	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	return t.next.RoundTrip(req)
 }

--- a/modules/500-upmeter/images/upmeter/src/pkg/kubernetes/access.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/kubernetes/access.go
@@ -17,8 +17,14 @@ limitations under the License.
 package kubernetes
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	kube "github.com/flant/kube-client/client"
 	v1 "k8s.io/api/core/v1"
@@ -89,16 +95,14 @@ type Config struct {
 
 // Accessor provides Kubernetes access in pod
 type Accessor struct {
-	client    kube.Client
-	saToken   string
-	userAgent string
-
-	schedulerProbeImage *ProbeImage
-	schedulerProbeNode  string
-
+	client                          kube.Client
+	saToken                         string
+	userAgent                       string
+	schedulerProbeImage             *ProbeImage
+	schedulerProbeNode              string
 	cloudControllerManagerNamespace string
-
-	kubernetesDomain string
+	kubernetesDomain                string
+	tokenExpire                     int64
 }
 
 func (a *Accessor) Init(config *Config, userAgent string) error {
@@ -109,17 +113,11 @@ func (a *Accessor) Init(config *Config, userAgent string) error {
 	a.client.WithRateLimiterSettings(config.ClientQps, config.ClientBurst)
 	// TODO(nabokihms): add kubernetes client metrics
 	err := a.client.Init()
-	if err != nil {
+	// first start
+	token := a.ServiceAccountToken()
+	if err != nil || len(token) == 0 {
 		return fmt.Errorf("cannot init kuberbetes client: %v", err)
 	}
-
-	// Service account token
-	token, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
-	if err != nil {
-		return fmt.Errorf("pod expected, cannot read service account token: %v", err)
-	}
-	a.saToken = string(token)
-
 	a.schedulerProbeImage = NewProbeImage(&config.SchedulerProbeImage)
 	a.schedulerProbeNode = config.SchedulerProbeNode
 
@@ -135,7 +133,53 @@ func (a *Accessor) Kubernetes() kube.Client {
 	return a.client
 }
 
+func (a *Accessor) loadServiceAccountToken() error {
+	tokenData, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if err != nil {
+		return fmt.Errorf("cannot read service account token: %v", err)
+	}
+	token := string(tokenData)
+	expire, err := GetWarnafter(token)
+	if err != nil {
+		return err
+	}
+	a.saToken = token
+	a.tokenExpire = expire
+	return nil
+}
+
+func GetWarnafter(token string) (int64, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return 0, fmt.Errorf("invalid token format: expected 3 parts, got %d", len(parts))
+	}
+	payloadB64 := parts[1]
+	data, err := base64.RawURLEncoding.DecodeString(payloadB64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to base64-decode payload: %w", err)
+	}
+
+	var sa ServiceAccountTokenStruct
+	if err := json.Unmarshal(data, &sa); err != nil {
+		return 0, fmt.Errorf("failed to unmarshal ServiceAccountToken: %w", err)
+	}
+
+	return sa.Kubernetes.Warnafter, nil
+}
+
 func (a *Accessor) ServiceAccountToken() string {
+	if a.saToken == "" {
+		if err := a.loadServiceAccountToken(); err != nil {
+			log.Error(err)
+			return ""
+		}
+		return a.saToken
+	}
+	if time.Now().Unix() >= a.tokenExpire {
+		if err := a.loadServiceAccountToken(); err != nil {
+			log.Error(err)
+		}
+	}
 	return a.saToken
 }
 

--- a/modules/500-upmeter/images/upmeter/src/pkg/kubernetes/types.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/kubernetes/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2025 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/500-upmeter/images/upmeter/src/pkg/kubernetes/types.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/kubernetes/types.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+type ServiceAccountTokenStruct struct {
+	Kubernetes struct {
+		Warnafter int64 `json:"warnafter"`
+	} `json:"kubernetes.io"`
+}

--- a/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/http.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/http.go
@@ -19,7 +19,7 @@ package checker
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -81,7 +81,7 @@ func doRequest(client *http.Client, req *http.Request) ([]byte, check.Error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, check.ErrFail("cannot read response body: %v", err)
 	}

--- a/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/smoke_mini_test.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/smoke_mini_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package checker
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -166,7 +166,7 @@ func newDummyLogger() *logrus.Entry {
 	logger := logrus.New()
 
 	// logger.Level = logrus.DebugLevel
-	logger.SetOutput(ioutil.Discard)
+	logger.SetOutput(io.Discard)
 
 	return logrus.NewEntry(logger)
 }


### PR DESCRIPTION
## Description

Now upmeter rereads the Kubernetes token if the token's warnafter timestamp is greater than the current time. In short, the token is reread every hour. This is done to avoid the stale-token issue
Now we read the token, store it and its warnafter value, and if the current time is greater than warnafter, we reread the token.

## Why do we need it, and what problem does it solve?

Currently, upmeter reads the token only at application startup and ignores its rotation

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: upmeter
type: fix
summary: upmeter sa token rotation
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
