### PR TITLE
[cloud-provider-vcd] trim trailing `/` from `VCDClusterConfiguration.provider.server`

### DIFF
--- a/ee/candi/cloud-providers/vcd/terraform-modules/providers.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/providers.tf
@@ -2,7 +2,7 @@
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 
 provider "vcd" {
-  url = join("/", [trimsuffix(var.providerClusterConfiguration.provider.server, "/api"), "api"])
+  url = join("/", [trimsuffix(trimsuffix(var.providerClusterConfiguration.provider.server, "/"), "/api"), "api"])
   org = var.providerClusterConfiguration.organization
   vdc = var.providerClusterConfiguration.virtualDataCenter
   user = lookup(var.providerClusterConfiguration.provider, "username", "none")

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/secret.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/secret.yaml
@@ -1,7 +1,7 @@
 {{- define "ccm_cloud_config" }}
   {{- $providerClusterConfiguration := .Values.cloudProviderVcd.internal.providerClusterConfiguration | required "internal.providerClusterConfiguration is required" -}}
 vcd:
-  host: {{ $providerClusterConfiguration.provider.server }}
+  host: {{ $providerClusterConfiguration.provider.server | trimSuffix "/" }}
   org: {{ $providerClusterConfiguration.organization }}
   vdc: {{ $providerClusterConfiguration.virtualDataCenter }}
 vAppName: {{ $providerClusterConfiguration.virtualApplicationName }}

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-data-discoverer/secret.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-data-discoverer/secret.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
 type: Opaque
 data:
-  host: {{ $providerClusterConfiguration.provider.server | toString | b64enc | quote }}
+  host: {{ $providerClusterConfiguration.provider.server | toString | trimSuffix "/" | b64enc | quote }}
   org: {{ $providerClusterConfiguration.organization | toString | b64enc | quote }}
   vdc: {{ $providerClusterConfiguration.virtualDataCenter | toString | b64enc | quote }}
   vAppName: {{ $providerClusterConfiguration.virtualApplicationName | toString | b64enc | quote }}

--- a/ee/modules/030-cloud-provider-vcd/templates/csi/secret.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/csi/secret.yaml
@@ -1,7 +1,7 @@
 {{- define "csi_cloud_config" }}
   {{- $providerClusterConfiguration := .Values.cloudProviderVcd.internal.providerClusterConfiguration | required "internal.providerClusterConfiguration is required" -}}
 vcd:
-  host: {{ $providerClusterConfiguration.provider.server }}
+  host: {{ $providerClusterConfiguration.provider.server | trimSuffix "/" }}
   org: {{ $providerClusterConfiguration.organization }}
   vdc: {{ $providerClusterConfiguration.virtualDataCenter }}
   vAppName: {{ $providerClusterConfiguration.virtualApplicationName }}

--- a/ee/modules/030-cloud-provider-vcd/templates/registration.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/registration.yaml
@@ -29,7 +29,7 @@ data:
   {{- $_ := set $vcdValues "virtualDataCenter" $providerClusterConfiguration.virtualDataCenter  }}
   {{- $_ := set $vcdValues "mainNetwork" $providerClusterConfiguration.mainNetwork  }}
   {{- $_ := set $vcdValues "virtualApplicationName" $providerClusterConfiguration.virtualApplicationName }}
-  {{- $_ := set $vcdValues "server" $providerClusterConfiguration.provider.server }}
+  {{- $_ := set $vcdValues "server" ($providerClusterConfiguration.provider.server | trimSuffix "/") }}
   {{- $_ := set $vcdValues "username" $providerClusterConfiguration.provider.username }}
   {{- $_ := set $vcdValues "password" $providerClusterConfiguration.provider.password }}
   {{- $_ := set $vcdValues "apiToken" $providerClusterConfiguration.provider.apiToken }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove trailing `/` from the `VCDClusterConfiguration.provider.server` field to ensure consistent URL handling.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

`cloud-data-discoverer` log an error when API URL contains a trailing `/`:
```
{"level":"error","msg":"Getting instance types error: failed to create vcd client: unable to authenticate: error finding LoginUrl: could not find valid version for login: could not retrieve supported versions: error fetching versions: 404 Not Found\n","time":"2025-04-24T10:01:15Z"}
```
 
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: Trim trailing slash from `VCDClusterConfiguration.provider.server`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
