### PR TITLE
[kube-dns] Update CoreDNS dashboards

### DIFF
--- a/ee/be/modules/350-node-local-dns/monitoring/grafana-dashboards/kubernetes-cluster/dns-node-local.json
+++ b/ee/be/modules/350-node-local-dns/monitoring/grafana-dashboards/kubernetes-cluster/dns-node-local.json
@@ -673,7 +673,7 @@
           "datasource": {
             "uid": "$ds_prometheus"
           },
-          "expr": "sum(rate(coredns_forward_requests_total{node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (node)",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (node)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -685,7 +685,7 @@
           "datasource": {
             "uid": "$ds_prometheus"
           },
-          "expr": "sum(rate(coredns_forward_requests_total{node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval]))",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Total",
@@ -785,7 +785,7 @@
           "datasource": {
             "uid": "$ds_prometheus"
           },
-          "expr": "sum(rate(coredns_forward_request_duration_seconds_sum{node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (node) / sum(rate(coredns_forward_requests_total{node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (node)",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_sum{proxy_name=\"forward\", node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (node) / sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (node)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{node}}",
@@ -884,7 +884,7 @@
             "type": "prometheus",
             "uid": "$ds_prometheus"
           },
-          "expr": "sum(rate(coredns_forward_request_duration_seconds_bucket{node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (le)",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_bucket{proxy_name=\"forward\", node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (le)",
           "format": "heatmap",
           "intervalFactor": 1,
           "legendFormat": "{{le}}",
@@ -1032,7 +1032,7 @@
           "datasource": {
             "uid": "$ds_prometheus"
           },
-          "expr": "sum(rate(coredns_forward_healthcheck_failures_total{job=\"node-local-dns\", node=~\"$node\"}[$__rate_interval])) by (node)",
+          "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\", job=\"node-local-dns\", node=~\"$node\"}[$__rate_interval])) by (node)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}",
@@ -1043,7 +1043,7 @@
           "datasource": {
             "uid": "$ds_prometheus"
           },
-          "expr": "sum(rate(coredns_forward_healthcheck_failures_total{job=\"node-local-dns\", node=~\"$node\"}[$__rate_interval]))",
+          "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\", job=\"node-local-dns\", node=~\"$node\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Total",
@@ -1842,7 +1842,7 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_requests_total{node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (to)",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (to)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1854,7 +1854,7 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_requests_total{node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval]))",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
@@ -1988,7 +1988,7 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_responses_total{node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (rcode)",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (rcode)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -2000,7 +2000,7 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_responses_total{node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval]))",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
@@ -2135,7 +2135,7 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_healthcheck_failures_total{job=\"node-local-dns\", node=~\"$node\"}[$__rate_interval])) by (upstream)",
+              "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\", proxy_name=\"forward\", job=\"node-local-dns\", node=~\"$node\"}[$__rate_interval])) by (upstream)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{pod}}",
@@ -2146,7 +2146,7 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_healthcheck_failures_total{job=\"node-local-dns\", node=~\"$node\"}[$__rate_interval]))",
+              "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\", job=\"node-local-dns\", node=~\"$node\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
@@ -2851,7 +2851,7 @@
                 "type": "prometheus",
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_request_duration_seconds_bucket{node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (le)",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_bucket{proxy_name=\"forward\", node=~\"$node\", job=\"node-local-dns\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",
@@ -3025,7 +3025,7 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_requests_total{node=~\"$node\", to=~\"$upstream\"}[$__rate_interval]))",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", node=~\"$node\", to=~\"$upstream\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
@@ -3036,7 +3036,7 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_requests_total{node=~\"$node\", to=~\"$upstream\"}[$__rate_interval])) by (node)",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", node=~\"$node\", to=~\"$upstream\"}[$__rate_interval])) by (node)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{node}}",
@@ -3169,7 +3169,7 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_responses_total{node=~\"$node\", to=~\"$upstream\"}[$__rate_interval])) by (rcode)",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", node=~\"$node\", to=~\"$upstream\"}[$__rate_interval])) by (rcode)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -3181,7 +3181,7 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_responses_total{node=~\"$node\", to=~\"$upstream\"}[$__rate_interval]))",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", node=~\"$node\", to=~\"$upstream\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
@@ -3279,7 +3279,7 @@
                 "type": "prometheus",
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_request_duration_seconds_bucket{node=~\"$node\", to=~\"$upstream\"}[$__rate_interval])) by (le)",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_bucket{proxy_name=\"forward\", node=~\"$node\", to=~\"$upstream\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",
@@ -3427,7 +3427,7 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_healthcheck_failures_total{job=\"node-local-dns\", node=~\"$node\", to=~\"$upstream\"}[$__rate_interval])) by (node)",
+              "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\", job=\"node-local-dns\", node=~\"$node\", to=~\"$upstream\"}[$__rate_interval])) by (node)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{pod}}",
@@ -3438,7 +3438,7 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_healthcheck_failures_total{job=\"node-local-dns\", node=~\"$node\", to=~\"$upstream\"}[$__rate_interval]))",
+              "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\", proxy_name=\"forward\", job=\"node-local-dns\", node=~\"$node\", to=~\"$upstream\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
@@ -3561,13 +3561,17 @@
           "type": "prometheus",
           "uid": "$ds_prometheus"
         },
-        "definition": "label_values(coredns_forward_request_duration_seconds_sum,to)",
+        "definition": "label_values(coredns_proxy_request_duration_seconds_sum{proxy_name=\"forward\"},to)",
         "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "upstream",
         "options": [],
-        "query": "label_values(coredns_forward_request_duration_seconds_sum,to)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(coredns_proxy_request_duration_seconds_sum{proxy_name=\"forward\"},to)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/modules/042-kube-dns/monitoring/grafana-dashboards/kubernetes-cluster/dns/dns-coredns.json
+++ b/modules/042-kube-dns/monitoring/grafana-dashboards/kubernetes-cluster/dns/dns-coredns.json
@@ -606,7 +606,7 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 16
       },
@@ -634,11 +634,11 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (pod, to)",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "__auto",
+          "legendFormat": "{{pod}}",
           "refId": "A",
           "step": 60
         },
@@ -658,6 +658,222 @@
       ],
       "title": "Forwarded requests count",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_sum{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"()\"}[$__rate_interval])) by (pod)  / sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"()\"}[$__rate_interval])) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ pod }}",
+          "range": true,
+          "refId": "C",
+          "step": 40
+        }
+      ],
+      "title": "Forwarded requests duration",
+      "type": "timeseries"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateMagma",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 98,
+      "legend": {
+        "show": false
+      },
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Magma",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": false
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "10.4.15",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_bucket{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Forward duration",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "s",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
     },
     {
       "datasource": {
@@ -745,7 +961,7 @@
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 28
       },
       "id": 203,
       "options": {
@@ -772,10 +988,10 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\",job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (pod, to, rcode)\n",
+          "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "__auto",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A",
           "step": 40
@@ -785,7 +1001,7 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\",job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Total",
@@ -860,7 +1076,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 31
       },
       "id": 16,
       "options": {
@@ -960,7 +1176,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 31
       },
       "id": 15,
       "options": {
@@ -1078,9 +1294,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 33
+        "y": 38
       },
       "id": 36,
       "options": {
@@ -1193,7 +1409,7 @@
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 42
       },
       "id": 14,
       "options": {
@@ -1249,7 +1465,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 45
       },
       "id": 38,
       "panels": [
@@ -1317,7 +1533,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 46
           },
           "id": 12,
           "options": {
@@ -1417,7 +1633,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 46
           },
           "id": 5,
           "options": {
@@ -1538,7 +1754,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 48
+            "y": 53
           },
           "id": 47,
           "options": {
@@ -1577,7 +1793,7 @@
                 "uid": "$ds_prometheus"
               },
               "editorMode": "code",
-              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\",job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
@@ -1674,7 +1890,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 48
+            "y": 53
           },
           "id": 49,
           "options": {
@@ -1810,7 +2026,7 @@
             "h": 3,
             "w": 24,
             "x": 0,
-            "y": 55
+            "y": 60
           },
           "id": 204,
           "options": {
@@ -1837,10 +2053,10 @@
                 "uid": "$ds_prometheus"
               },
               "editorMode": "code",
-              "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (to, rcode)",
+              "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (upstream)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "__auto",
+              "legendFormat": "{{pod}}",
               "range": true,
               "refId": "A",
               "step": 40
@@ -1850,7 +2066,7 @@
                 "uid": "$ds_prometheus"
               },
               "editorMode": "code",
-              "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\",job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
@@ -1926,7 +2142,7 @@
             "h": 3,
             "w": 24,
             "x": 0,
-            "y": 58
+            "y": 63
           },
           "id": 135,
           "options": {
@@ -2036,7 +2252,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 66
           },
           "id": 80,
           "options": {
@@ -2156,7 +2372,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 61
+            "y": 66
           },
           "id": 81,
           "options": {
@@ -2285,7 +2501,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 68
+            "y": 73
           },
           "id": 2,
           "options": {
@@ -2364,7 +2580,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 75
+            "y": 80
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -2429,6 +2645,119 @@
           "tooltip": {
             "show": true,
             "showHistogram": true
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "yAxis": {
+            "format": "s",
+            "logBase": 1,
+            "show": true
+          },
+          "yBucketBound": "auto"
+        },
+        {
+          "cards": {},
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateMagma",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 87
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 20,
+          "legend": {
+            "show": false
+          },
+          "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+              "exponent": 0.5,
+              "fill": "#b4ff00",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Magma",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "s"
+            }
+          },
+          "pluginVersion": "10.4.15",
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$ds_prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_bucket{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Forward duration",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
           },
           "type": "heatmap",
           "xAxis": {
@@ -2554,13 +2883,17 @@
           "type": "prometheus",
           "uid": "$ds_prometheus"
         },
-        "definition": "label_values(coredns_forward_request_duration_seconds_sum,to)",
+        "definition": "label_values(coredns_proxy_request_duration_seconds_sum{proxy_name=\"forward\"},to)",
         "hide": 2,
         "includeAll": true,
         "multi": true,
         "name": "upstream",
         "options": [],
-        "query": "label_values(coredns_forward_request_duration_seconds_sum,to)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(coredns_proxy_request_duration_seconds_sum{proxy_name=\"forward\"},to)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/modules/042-kube-dns/monitoring/grafana-dashboards/kubernetes-cluster/dns/dns-coredns.json
+++ b/modules/042-kube-dns/monitoring/grafana-dashboards/kubernetes-cluster/dns/dns-coredns.json
@@ -489,7 +489,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "10.4.14",
+      "pluginVersion": "10.4.15",
       "reverseYBuckets": false,
       "targets": [
         {
@@ -835,7 +835,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "10.4.14",
+      "pluginVersion": "10.4.15",
       "reverseYBuckets": false,
       "targets": [
         {
@@ -868,6 +868,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds_prometheus"
       },
       "description": "If the graph is non-empty, it means that some CoreDNS requests resulted in panic. You can see a specific error in the container logs.",
@@ -977,10 +978,12 @@
           "datasource": {
             "uid": "$ds_prometheus"
           },
-          "expr": "sum(rate(coredns_forward_healthcheck_failures_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
+          "editorMode": "code",
+          "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\",job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (pod, to, rcode)\n",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{pod}}",
+          "legendFormat": "__auto",
+          "range": true,
           "refId": "A",
           "step": 40
         },
@@ -988,10 +991,12 @@
           "datasource": {
             "uid": "$ds_prometheus"
           },
-          "expr": "sum(rate(coredns_forward_healthcheck_failures_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
+          "editorMode": "code",
+          "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Total",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -1280,7 +1285,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 38
       },

--- a/modules/042-kube-dns/monitoring/grafana-dashboards/kubernetes-cluster/dns/dns-coredns.json
+++ b/modules/042-kube-dns/monitoring/grafana-dashboards/kubernetes-cluster/dns/dns-coredns.json
@@ -521,6 +521,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds_prometheus"
       },
       "fieldConfig": {
@@ -605,7 +606,7 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 16
       },
@@ -632,11 +633,12 @@
           "datasource": {
             "uid": "$ds_prometheus"
           },
-          "expr": "sum(rate(coredns_forward_requests_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
+          "editorMode": "code",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (pod, to)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "{{pod}}",
+          "legendFormat": "__auto",
           "refId": "A",
           "step": 60
         },
@@ -644,227 +646,18 @@
           "datasource": {
             "uid": "$ds_prometheus"
           },
-          "expr": "sum(rate(coredns_forward_requests_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
+          "editorMode": "code",
+          "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Total",
+          "range": true,
           "refId": "B",
           "step": 60
         }
       ],
       "title": "Forwarded requests count",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "uid": "$ds_prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      },
-      "id": 35,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "max",
-            "min"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "10.4.5",
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$ds_prometheus"
-          },
-          "expr": "sum(rate(coredns_forward_request_duration_seconds_sum{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (pod) / sum(rate(coredns_forward_requests_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{pod}}",
-          "refId": "C",
-          "step": 40
-        }
-      ],
-      "title": "Forwarded requests duration",
-      "type": "timeseries"
-    },
-    {
-      "cards": {},
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateMagma",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "tsbuckets",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 23
-      },
-      "heatmap": {},
-      "hideZeroBuckets": false,
-      "highlightCards": true,
-      "id": 98,
-      "legend": {
-        "show": false
-      },
-      "options": {
-        "calculate": false,
-        "calculation": {},
-        "cellGap": 2,
-        "cellValues": {},
-        "color": {
-          "exponent": 0.5,
-          "fill": "#b4ff00",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Magma",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": false
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "showValue": "never",
-        "tooltip": {
-          "mode": "single",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false,
-          "unit": "s"
-        }
-      },
-      "pluginVersion": "10.4.15",
-      "reverseYBuckets": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "expr": "sum(rate(coredns_forward_request_duration_seconds_bucket{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (le)",
-          "format": "heatmap",
-          "intervalFactor": 1,
-          "legendFormat": "{{le}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Forward duration",
-      "tooltip": {
-        "show": true,
-        "showHistogram": false
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "format": "s",
-        "logBase": 1,
-        "show": true
-      },
-      "yBucketBound": "auto"
     },
     {
       "datasource": {
@@ -952,7 +745,7 @@
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 23
       },
       "id": 203,
       "options": {
@@ -1067,7 +860,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 31
+        "y": 26
       },
       "id": 16,
       "options": {
@@ -1167,7 +960,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 31
+        "y": 26
       },
       "id": 15,
       "options": {
@@ -1287,7 +1080,7 @@
         "h": 4,
         "w": 12,
         "x": 0,
-        "y": 38
+        "y": 33
       },
       "id": 36,
       "options": {
@@ -1400,7 +1193,7 @@
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 37
       },
       "id": 14,
       "options": {
@@ -1456,7 +1249,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 40
       },
       "id": 38,
       "panels": [
@@ -1507,7 +1300,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1523,7 +1317,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 41
           },
           "id": 12,
           "options": {
@@ -1606,7 +1400,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1622,7 +1417,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 46
+            "y": 41
           },
           "id": 5,
           "options": {
@@ -1660,6 +1455,7 @@
         },
         {
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds_prometheus"
           },
           "fieldConfig": {
@@ -1705,7 +1501,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1741,7 +1538,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 53
+            "y": 48
           },
           "id": 47,
           "options": {
@@ -1766,7 +1563,8 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_requests_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (to)",
+              "editorMode": "code",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\",job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (to)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1778,10 +1576,12 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_requests_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
+              "range": true,
               "refId": "B",
               "step": 60
             }
@@ -1791,6 +1591,7 @@
         },
         {
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds_prometheus"
           },
           "fieldConfig": {
@@ -1836,7 +1637,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1872,7 +1674,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 53
+            "y": 48
           },
           "id": 49,
           "options": {
@@ -1897,7 +1699,8 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_responses_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (rcode)",
+              "editorMode": "code",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (rcode)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1909,10 +1712,12 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_responses_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum(rate(coredns_proxy_request_duration_seconds_count{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -1921,6 +1726,7 @@
         },
         {
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds_prometheus"
           },
           "description": "If the graph is non-empty, it means that some CoreDNS requests resulted in panic. You can see a specific error in the container logs.",
@@ -1967,7 +1773,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2003,7 +1810,7 @@
             "h": 3,
             "w": 24,
             "x": 0,
-            "y": 60
+            "y": 55
           },
           "id": 204,
           "options": {
@@ -2029,10 +1836,12 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_healthcheck_failures_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (upstream)",
+              "editorMode": "code",
+              "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (to, rcode)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}}",
+              "legendFormat": "__auto",
+              "range": true,
               "refId": "A",
               "step": 40
             },
@@ -2040,10 +1849,12 @@
               "datasource": {
                 "uid": "$ds_prometheus"
               },
-              "expr": "sum(rate(coredns_forward_healthcheck_failures_total{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
+              "editorMode": "code",
+              "expr": "sum(rate(coredns_proxy_healthcheck_failures_total{proxy_name=\"forward\", job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -2098,7 +1909,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2114,7 +1926,7 @@
             "h": 3,
             "w": 24,
             "x": 0,
-            "y": 63
+            "y": 58
           },
           "id": 135,
           "options": {
@@ -2207,7 +2019,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2223,7 +2036,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 66
+            "y": 61
           },
           "id": 80,
           "options": {
@@ -2306,7 +2119,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2342,7 +2156,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 66
+            "y": 61
           },
           "id": 81,
           "options": {
@@ -2434,7 +2248,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2470,7 +2285,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 73
+            "y": 68
           },
           "id": 2,
           "options": {
@@ -2549,7 +2364,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 80
+            "y": 75
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -2596,7 +2411,7 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "10.4.5",
+          "pluginVersion": "10.4.15",
           "reverseYBuckets": false,
           "targets": [
             {
@@ -2614,117 +2429,6 @@
           "tooltip": {
             "show": true,
             "showHistogram": true
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "s",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
-        },
-        {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateMagma",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "scaleDistribution": {
-                  "type": "linear"
-                }
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 87
-          },
-          "heatmap": {},
-          "hideZeroBuckets": false,
-          "highlightCards": true,
-          "id": 20,
-          "legend": {
-            "show": false
-          },
-          "options": {
-            "calculate": false,
-            "calculation": {},
-            "cellGap": 2,
-            "cellValues": {},
-            "color": {
-              "exponent": 0.5,
-              "fill": "#b4ff00",
-              "mode": "scheme",
-              "reverse": false,
-              "scale": "exponential",
-              "scheme": "Magma",
-              "steps": 128
-            },
-            "exemplars": {
-              "color": "rgba(255,0,255,0.7)"
-            },
-            "filterValues": {
-              "le": 1e-9
-            },
-            "legend": {
-              "show": false
-            },
-            "rowsFrame": {
-              "layout": "auto"
-            },
-            "showValue": "never",
-            "tooltip": {
-              "mode": "single",
-              "showColorScale": false,
-              "yHistogram": false
-            },
-            "yAxis": {
-              "axisPlacement": "left",
-              "reverse": false,
-              "unit": "s"
-            }
-          },
-          "pluginVersion": "10.4.5",
-          "reverseYBuckets": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$ds_prometheus"
-              },
-              "expr": "sum(rate(coredns_forward_request_duration_seconds_bucket{job=\"kube-dns\", pod=~\"$pod\"}[$__rate_interval])) by (le)",
-              "format": "heatmap",
-              "intervalFactor": 1,
-              "legendFormat": "{{le}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Forward duration",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
           },
           "type": "heatmap",
           "xAxis": {


### PR DESCRIPTION
## Description
This change removes outdated panels from the CoreDNS dashboard. These panels were consistently showing "No data" because certain metrics (`coredns_forward_*`) have been deprecated in recent versions of CoreDNS.  
Reference: [CoreDNS forward plugin - deprecated metrics](https://coredns.io/plugins/forward/#:~:text=The%20following%20metrics%20have%20recently%20been%20deprecated)

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?
Not necessarily.  

## Checklist
- [ ] The code is covered by unit tests. 
- [ ] e2e tests passed. 
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: kube-dns
type: fix
summary: Removed CoreDNS dashboard panels referencing deprecated metrics (`coredns_forward_*`).
impact_level: low