### PR TITLE
[user-authn] Add ServiceAccount to templates

### DIFF
--- a/modules/040-control-plane-manager/hooks/audit_policy_basic_targets_generated.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_basic_targets_generated.go
@@ -151,6 +151,7 @@ var auditPolicyBasicServiceAccounts = []string{
 	"system:serviceaccount:d8-upmeter:smoke-mini",
 	"system:serviceaccount:d8-upmeter:upmeter",
 	"system:serviceaccount:d8-upmeter:upmeter-agent",
+	"system:serviceaccount:d8-user-authn:basic-auth-proxy",
 	"system:serviceaccount:d8-user-authn:dex",
 	"system:serviceaccount:d8-user-authz:d8-node-local-dns",
 	"system:serviceaccount:d8-user-authz:stale-dns-connections-cleaner",

--- a/modules/150-user-authn/templates/basic-auth-proxy/deployment.yaml
+++ b/modules/150-user-authn/templates/basic-auth-proxy/deployment.yaml
@@ -91,6 +91,8 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "basic-auth-proxy")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      serviceAccountName: basic-auth-proxy
+      automountServiceAccountToken: true
       imagePullSecrets:
       - name: deckhouse-registry
       containers:

--- a/modules/150-user-authn/templates/basic-auth-proxy/rbac-for-us.yaml
+++ b/modules/150-user-authn/templates/basic-auth-proxy/rbac-for-us.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: basic-auth-proxy
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+automountServiceAccountToken: false


### PR DESCRIPTION
## Description

Add separate ServiceAccount to `basic-auth-proxy` template

## Why do we need it, and what problem does it solve?

According to CIS 5.1.5, default service account should not be used for Kubernetes API access

## Why do we need it in the patch release (if we do)?

In v1.69 basic-auth-proxy fails to start, this changes will fix it.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Add separate ServiceAccount to basic-auth-proxy.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
