### PR TITLE
[ci] Disable notification on failed daily e2e

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -726,7 +726,6 @@ check_e2e_labels:
   {!{- $labels := dict "trigger" "CloudLayoutTestFailed" "provider" $ctx.providerName "layout" $ctx.layout "cri" $ctx.criName "kube_version" $ctx.kubernetesVersion -}!}
   {!{- $annotations := dict "summary" "Cloud Layout Test failed" "description" "Check Github workflow log for more information" -}!}
   {!{- $if := "github.ref == 'refs/heads/main' && (cancelled() || failure())" -}!}
-  {!{- tmpl.Exec "e2e_send_alert_template" (slice (dict "labels" $labels "annotations" $annotations "if" $if )) | strings.Indent 4 }!}
 
 {!{- end }!}
 # </template: e2e_run_job_template>

--- a/.github/workflow_templates/e2e-daily.yml
+++ b/.github/workflow_templates/e2e-daily.yml
@@ -81,6 +81,4 @@ jobs:
 {!{- $annotations := dict "summary" "Daily e2e tests workflow failed" -}!}
 {!{- $annotations = coll.Merge $annotations (dict "description" "Check Daily e2e workflow log for more information or see another alerts in this group.") -}!}
 
-{!{- tmpl.Exec "e2e_send_alert_template" (slice (dict "labels" $labels "annotations" $annotations )) | strings.Indent 4 -}!}
-
 {!{- tmpl.Exec "send_alert_loop_template" (slice (dict "labels" $labels "annotations" $annotations )) | strings.Indent 4 -}!}

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -535,62 +535,6 @@ jobs:
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
           fi
-
-
-      # <template: send_alert_template>
-      - name: Check alerting credentials
-        id: check_alerting
-        if: always()
-        env:
-          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          if [[ -n $KEY ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
-      - name: Send alert on fail
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
-        env:
-          CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          echo $WORKFLOW_URL
-
-          alertData=$(cat <<EOF
-          {
-            "labels": {
-              "cri": "Containerd",
-              "kube_version": "1.29",
-              "layout": "WithoutNAT",
-              "provider": "AWS",
-              "trigger": "CloudLayoutTestFailed",
-
-              "severity_level": 7
-            },
-            "annotations": {
-              "description": "Check Github workflow log for more information",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "summary": "Cloud Layout Test failed",
-
-              "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_protocol_version": "1",
-              "plk_link_title_en/job": "Github job run"
-            }
-          }
-          EOF
-          )
-
-          for (( iter = 1; iter < 60; iter++ )); do
-            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
-              exit 0
-            fi
-
-            echo "Alert was not sent. Wait 5 seconds before next attempt"
-            sleep 5
-          done
-
-          echo "Alert was not sent. Timeout"
-          exit 1
-        # </template: send_alert_template>
-
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1042,62 +986,6 @@ jobs:
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
           fi
-
-
-      # <template: send_alert_template>
-      - name: Check alerting credentials
-        id: check_alerting
-        if: always()
-        env:
-          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          if [[ -n $KEY ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
-      - name: Send alert on fail
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
-        env:
-          CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          echo $WORKFLOW_URL
-
-          alertData=$(cat <<EOF
-          {
-            "labels": {
-              "cri": "Containerd",
-              "kube_version": "1.29",
-              "layout": "WithoutNAT",
-              "provider": "EKS",
-              "trigger": "CloudLayoutTestFailed",
-
-              "severity_level": 7
-            },
-            "annotations": {
-              "description": "Check Github workflow log for more information",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "summary": "Cloud Layout Test failed",
-
-              "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_protocol_version": "1",
-              "plk_link_title_en/job": "Github job run"
-            }
-          }
-          EOF
-          )
-
-          for (( iter = 1; iter < 60; iter++ )); do
-            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
-              exit 0
-            fi
-
-            echo "Alert was not sent. Wait 5 seconds before next attempt"
-            sleep 5
-          done
-
-          echo "Alert was not sent. Timeout"
-          exit 1
-        # </template: send_alert_template>
-
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1498,62 +1386,6 @@ jobs:
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
           fi
-
-
-      # <template: send_alert_template>
-      - name: Check alerting credentials
-        id: check_alerting
-        if: always()
-        env:
-          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          if [[ -n $KEY ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
-      - name: Send alert on fail
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
-        env:
-          CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          echo $WORKFLOW_URL
-
-          alertData=$(cat <<EOF
-          {
-            "labels": {
-              "cri": "Containerd",
-              "kube_version": "1.29",
-              "layout": "WithoutNAT",
-              "provider": "GCP",
-              "trigger": "CloudLayoutTestFailed",
-
-              "severity_level": 7
-            },
-            "annotations": {
-              "description": "Check Github workflow log for more information",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "summary": "Cloud Layout Test failed",
-
-              "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_protocol_version": "1",
-              "plk_link_title_en/job": "Github job run"
-            }
-          }
-          EOF
-          )
-
-          for (( iter = 1; iter < 60; iter++ )); do
-            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
-              exit 0
-            fi
-
-            echo "Alert was not sent. Wait 5 seconds before next attempt"
-            sleep 5
-          done
-
-          echo "Alert was not sent. Timeout"
-          exit 1
-        # </template: send_alert_template>
-
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1840,62 +1672,6 @@ jobs:
           else
             echo Not a directory.
           fi
-
-
-      # <template: send_alert_template>
-      - name: Check alerting credentials
-        id: check_alerting
-        if: always()
-        env:
-          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          if [[ -n $KEY ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
-      - name: Send alert on fail
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
-        env:
-          CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          echo $WORKFLOW_URL
-
-          alertData=$(cat <<EOF
-          {
-            "labels": {
-              "cri": "Containerd",
-              "kube_version": "1.29",
-              "layout": "WithoutNAT",
-              "provider": "Yandex.Cloud",
-              "trigger": "CloudLayoutTestFailed",
-
-              "severity_level": 7
-            },
-            "annotations": {
-              "description": "Check Github workflow log for more information",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "summary": "Cloud Layout Test failed",
-
-              "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_protocol_version": "1",
-              "plk_link_title_en/job": "Github job run"
-            }
-          }
-          EOF
-          )
-
-          for (( iter = 1; iter < 60; iter++ )); do
-            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
-              exit 0
-            fi
-
-            echo "Alert was not sent. Wait 5 seconds before next attempt"
-            sleep 5
-          done
-
-          echo "Alert was not sent. Timeout"
-          exit 1
-        # </template: send_alert_template>
-
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2296,62 +2072,6 @@ jobs:
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
           fi
-
-
-      # <template: send_alert_template>
-      - name: Check alerting credentials
-        id: check_alerting
-        if: always()
-        env:
-          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          if [[ -n $KEY ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
-      - name: Send alert on fail
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
-        env:
-          CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          echo $WORKFLOW_URL
-
-          alertData=$(cat <<EOF
-          {
-            "labels": {
-              "cri": "Containerd",
-              "kube_version": "1.29",
-              "layout": "Standard",
-              "provider": "OpenStack",
-              "trigger": "CloudLayoutTestFailed",
-
-              "severity_level": 7
-            },
-            "annotations": {
-              "description": "Check Github workflow log for more information",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "summary": "Cloud Layout Test failed",
-
-              "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_protocol_version": "1",
-              "plk_link_title_en/job": "Github job run"
-            }
-          }
-          EOF
-          )
-
-          for (( iter = 1; iter < 60; iter++ )); do
-            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
-              exit 0
-            fi
-
-            echo "Alert was not sent. Wait 5 seconds before next attempt"
-            sleep 5
-          done
-
-          echo "Alert was not sent. Timeout"
-          exit 1
-        # </template: send_alert_template>
-
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2756,62 +2476,6 @@ jobs:
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
           fi
-
-
-      # <template: send_alert_template>
-      - name: Check alerting credentials
-        id: check_alerting
-        if: always()
-        env:
-          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          if [[ -n $KEY ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
-      - name: Send alert on fail
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
-        env:
-          CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          echo $WORKFLOW_URL
-
-          alertData=$(cat <<EOF
-          {
-            "labels": {
-              "cri": "Containerd",
-              "kube_version": "1.29",
-              "layout": "Standard",
-              "provider": "vSphere",
-              "trigger": "CloudLayoutTestFailed",
-
-              "severity_level": 7
-            },
-            "annotations": {
-              "description": "Check Github workflow log for more information",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "summary": "Cloud Layout Test failed",
-
-              "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_protocol_version": "1",
-              "plk_link_title_en/job": "Github job run"
-            }
-          }
-          EOF
-          )
-
-          for (( iter = 1; iter < 60; iter++ )); do
-            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
-              exit 0
-            fi
-
-            echo "Alert was not sent. Wait 5 seconds before next attempt"
-            sleep 5
-          done
-
-          echo "Alert was not sent. Timeout"
-          exit 1
-        # </template: send_alert_template>
-
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3228,62 +2892,6 @@ jobs:
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
           fi
-
-
-      # <template: send_alert_template>
-      - name: Check alerting credentials
-        id: check_alerting
-        if: always()
-        env:
-          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          if [[ -n $KEY ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
-      - name: Send alert on fail
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
-        env:
-          CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          echo $WORKFLOW_URL
-
-          alertData=$(cat <<EOF
-          {
-            "labels": {
-              "cri": "Containerd",
-              "kube_version": "1.29",
-              "layout": "Standard",
-              "provider": "VCD",
-              "trigger": "CloudLayoutTestFailed",
-
-              "severity_level": 7
-            },
-            "annotations": {
-              "description": "Check Github workflow log for more information",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "summary": "Cloud Layout Test failed",
-
-              "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_protocol_version": "1",
-              "plk_link_title_en/job": "Github job run"
-            }
-          }
-          EOF
-          )
-
-          for (( iter = 1; iter < 60; iter++ )); do
-            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
-              exit 0
-            fi
-
-            echo "Alert was not sent. Wait 5 seconds before next attempt"
-            sleep 5
-          done
-
-          echo "Alert was not sent. Timeout"
-          exit 1
-        # </template: send_alert_template>
-
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3684,62 +3292,6 @@ jobs:
             chmod -f -R 777 "/deckhouse/testing" || true
             chmod -f -R 777 /tmp || true
           fi
-
-
-      # <template: send_alert_template>
-      - name: Check alerting credentials
-        id: check_alerting
-        if: always()
-        env:
-          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          if [[ -n $KEY ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
-      - name: Send alert on fail
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
-        env:
-          CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-        run: |
-          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          echo $WORKFLOW_URL
-
-          alertData=$(cat <<EOF
-          {
-            "labels": {
-              "cri": "Containerd",
-              "kube_version": "1.29",
-              "layout": "Static",
-              "provider": "Static",
-              "trigger": "CloudLayoutTestFailed",
-
-              "severity_level": 7
-            },
-            "annotations": {
-              "description": "Check Github workflow log for more information",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-              "summary": "Cloud Layout Test failed",
-
-              "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_protocol_version": "1",
-              "plk_link_title_en/job": "Github job run"
-            }
-          }
-          EOF
-          )
-
-          for (( iter = 1; iter < 60; iter++ )); do
-            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
-              exit 0
-            fi
-
-            echo "Alert was not sent. Wait 5 seconds before next attempt"
-            sleep 5
-          done
-
-          echo "Alert was not sent. Timeout"
-          exit 1
-        # </template: send_alert_template>
-
   # </template: e2e_run_job_template>
 
 
@@ -3749,58 +3301,6 @@ jobs:
     needs: ["skip_tests_repos","git_info","run_aws_containerd_1_29","run_eks_containerd_1_29","run_gcp_containerd_1_29","run_yandex_cloud_containerd_1_29","run_openstack_containerd_1_29","run_vsphere_containerd_1_29","run_vcd_containerd_1_29","run_static_containerd_1_29"]
     if: ${{ failure() }}
     steps:
-
-
-    # <template: send_alert_template>
-    - name: Check alerting credentials
-      id: check_alerting
-      if: always()
-      env:
-        KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-      run: |
-        if [[ -n $KEY ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
-    - name: Send alert on fail
-      if: ${{ steps.check_alerting.outputs.has_credentials == 'true' }}
-      env:
-        CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-      run: |
-        WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-        echo $WORKFLOW_URL
-
-        alertData=$(cat <<EOF
-        {
-          "labels": {
-            "trigger": "DailyE2EWorkflowFailed",
-
-            "severity_level": 7
-          },
-          "annotations": {
-            "description": "Check Daily e2e workflow log for more information or see another alerts in this group.",
-            "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-            "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
-            "summary": "Daily e2e tests workflow failed",
-
-            "plk_link_url/job": "${WORKFLOW_URL}",
-            "plk_protocol_version": "1",
-            "plk_link_title_en/job": "Github job run"
-          }
-        }
-        EOF
-        )
-
-        for (( iter = 1; iter < 60; iter++ )); do
-          if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
-            exit 0
-          fi
-
-          echo "Alert was not sent. Wait 5 seconds before next attempt"
-          sleep 5
-        done
-
-        echo "Alert was not sent. Timeout"
-        exit 1
-      # </template: send_alert_template>
-
     # <template: send_alert_loop_template>
     - name: Check loop alerting credentials
       id: check_loop_alerting


### PR DESCRIPTION
## Description
Disable Madison notification on failed daily e2e.

## Why do we need it, and what problem does it solve?
Due to changes in notification system, old notifications are unnecessary.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Disable notification on failed daily e2e.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
