### PR TITLE
[docs] Translate new DKP structure — Backup and restore

### DIFF
--- a/docs/documentation/pages/admin/configuration/backup/BACKUP_AND_RESTORE.md
+++ b/docs/documentation/pages/admin/configuration/backup/BACKUP_AND_RESTORE.md
@@ -1,0 +1,729 @@
+---
+title: Backup and restore
+permalink: en/admin/configuration/backup/backup-and-restore.html
+---
+
+## Manual cluster restore
+
+### Restoring a cluster with a single control plane node
+
+To properly restore the cluster, follow these steps on the master node:
+
+1. Prepare the `etcdctl` utility. Locate and copy the executable on the node:
+
+   ```shell
+   cp $(find /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/ \
+   -name etcdctl -print | tail -n 1) /usr/local/bin/etcdctl
+   ```
+
+   Check the version of `etcdctl`:
+
+   ```shell
+   etcdctl version
+   ```
+
+   Make sure the output of `etcdctl version` is displayed without errors.
+
+   If `etcdctl` is not found, download the binary from [the official etcd repository]((https://github.com/etcd-io/etcd/releases)), choosing a version that matches your cluster's etcd version:
+
+   ```shell
+   wget "https://github.com/etcd-io/etcd/releases/download/v3.5.16/etcd-v3.5.16-linux-amd64.tar.gz"
+   tar -xzvf etcd-v3.5.16-linux-amd64.tar.gz && mv etcd-v3.5.16-linux-amd64/etcdctl /usr/local/bin/etcdctl
+   ```
+
+1. Check the etcd version in the cluster (if the Kubernetes API is accessible):
+
+   ```shell
+   kubectl -n kube-system exec -ti etcd-$(hostname) -- etcdctl version
+   ```
+
+   If the command executes successfully, it will display the current etcd version.
+
+1. Stop etcd. Move the etcd manifest to prevent kubelet from launching the etcd pod:
+
+   ```shell
+   mv /etc/kubernetes/manifests/etcd.yaml ~/etcd.yaml
+   ```
+
+1. Make sure the etcd pod is stopped:
+
+   ```shell
+   crictl ps | grep etcd
+   ```
+
+   If the command returns nothing, the etcd pod has been successfully stopped.
+
+1. Backup current etcd data. Create a backup copy of the `member` directory:
+
+   ```shell
+   cp -r /var/lib/etcd/member/ /var/lib/deckhouse-etcd-backup
+   ```
+
+   This backup will allow you to roll back in case of issues.
+
+1. Clean the etcd directory. Remove old data to prepare for restore:
+
+   ```shell
+   rm -rf /var/lib/etcd/member/
+   ```
+
+   Verify that `/var/lib/etcd/member/` is now empty or does not exist:
+
+   ```shell
+   ls -la /var/lib/etcd/member/
+   ```
+
+1. Place the etcd snapshot file. Copy or move the `etcd-backup.snapshot` file to the current user's (root) home directory:
+
+   ```shell
+   cp /path/to/backup/etcd-backup.snapshot ~/etcd-backup.snapshot
+   ```
+
+   Ensure the file is readable:
+
+   ```shell
+   ls -la ~/etcd-backup.snapshot
+   ```
+
+1. Restore the etcd database from the snapshot using `etcdctl`:
+
+   ```shell
+   ETCDCTL_API=3 etcdctl snapshot restore ~/etcd-backup.snapshot --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt \
+     --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/  --data-dir=/var/lib/etcd
+   ```
+
+   After the command completes, check that files have appeared in `/var/lib/etcd/`, reflecting the restored state.
+
+1. Start etcd. Move the manifest back so that kubelet relaunches the etcd pod:
+
+   ```shell
+   mv ~/etcd.yaml /etc/kubernetes/manifests/etcd.yaml
+   ```
+
+1. Wait for the pod to be created and reach `Running` state. Make sure it is up and running:
+
+   ```shell
+   crictl ps --label io.kubernetes.pod.name=etcd-$HOSTNAME
+   ```
+
+   Pod startup may take some time. Once etcd is running, the cluster will be restored from the snapshot.
+
+### Restoring a multi-master cluster
+
+To properly restore a multi-master cluster, follow these steps:
+
+1. Enable High Availability (HA) mode. This is necessary to preserve at least one Prometheus replica and its PVC, since HA is disabled by default in single-master clusters.
+
+1. Switch the cluster to single master mode:
+
+   - In a cloud cluster, follow the [instructions](../platform-scaling/control-plane.html#типовые-сценарии-масштабирования).
+   - In a static cluster, manually remove the additional master nodes.
+
+1. Restore etcd from the backup on the only remaining master node. Follow the [instructions](#восстановление-кластера-с-одним-control-plane-узлом) for restoring a cluster with a single control-plane node.
+
+1. Once etcd is restored, remove the records of the previously deleted master nodes from the cluster using the following command (replace with the actual node name):
+
+   ```shell
+   kubectl delete node <MASTER_NODE_NAME>
+   ```
+
+1. Reboot all cluster nodes. Ensure that after the reboot all nodes are available and functioning correctly.
+
+1. Wait for Deckhouse to process all tasks in the queue:
+
+   ```console
+   kubectl -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller queue main
+   ```
+
+1. Switch the cluster back to multi-master mode. For cloud clusters, follow the [instructions](../platform-scaling/control-plane.html#common-scaling-scenarios).
+
+## Restoring Individual Objects
+
+### Restoring Kubernetes Objects from an etcd Backup
+
+To restore individual cluster objects (e.g., specific Deployments, Secrets, or ConfigMaps) from an etcd snapshot, follow these steps:
+
+1. Launch a temporary etcd instance. Create a separate etcd instance that runs independently from the main cluster.
+1. Load data from the etcd snapshot. Use the existing etcd snapshot file to populate the temporary instance with the necessary data.
+1. Export the required objects in JSON format. Select the specific resources (by their etcd keys), then save their definitions as JSON files.
+
+You can perform these actions either [using a script](#automated-object-export) or [manually](#manual-object-export).
+
+### Automated object export
+
+To automatically export cluster objects from an etcd backup, use the script provided below. Before running it, make sure the following variables are configured:
+
+- Path to the etcd snapshot file. Set the correct location of `etcd-backup.snapshot` in the script.
+- Directory for exported JSON files. Define where the extracted manifests will be saved.
+- Object filter (`grep`). Optionally set a string to filter etcd paths so that only specific resources are exported, such as those by namespace or resource type.
+
+{% offtopic title="Object export script" %}
+```shell
+BACKUP_OUTPUT_DIR="/tmp/etc_restore" # Directory to store exported objects (created automatically).
+ETCD_SNAPSHOT_PATH="./etcd-backup.snapshot" # Path to the etcd snapshot file.
+FILTER="verticalpodautoscalers" # Filter for selecting object records.
+
+IMG=$(kubectl -n kube-system get pod -l component=etcd -o jsonpath="{.items[*].spec.containers[*].image}" | cut -f 1 -d ' ')
+
+kubectl delete po etcd-restore --force || true
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd-restore
+spec:
+  volumes:
+  - name: shared-data
+    emptyDir: {}  
+  - name: etcddir
+    emptyDir: {}
+  containers:
+  - name: etcd
+    image: $IMG
+    volumeMounts:
+    - name: shared-data
+      mountPath: /etcd-backup
+    - name: etcddir
+      mountPath: /default.etcd      
+  
+  - name: ubuntu
+    image: ubuntu:latest
+    command: ["/bin/sh", "-c", "sleep 100h"]
+    volumeMounts:
+    - name: shared-data
+      mountPath: /etcd-backup
+
+  restartPolicy: Never
+EOF
+
+kubectl wait --for=condition=Ready pod etcd-restore
+kubectl cp  $ETCD_SNAPSHOT_PATH etcd-restore:/etcd-backup -c ubuntu
+kubectl exec -t etcd-restore -c etcd -- etcdctl snapshot restore /etcd-backup/etcd-backup.snapshot --data-dir=./default.etcd_new
+kubectl exec -t etcd-restore -c etcd -- etcd   --name temp   --data-dir /default.etcd_new   --advertise-client-urls http://localhost:12379   --listen-client-urls http://localhost:12379 --listen-peer-urls http://localhost:12380 &
+
+mkdir -p $BACKUP_OUTPUT_DIR
+files=($(kubectl exec -t etcd-restore -c etcd  -- etcdctl  --endpoints=localhost:12379 get / --prefix --keys-only | grep "$FILTER" )) 
+for file in "${files[@]}"
+do
+  OBJECT=$(kubectl exec -t etcd-restore -c etcd  -- etcdctl  --endpoints=localhost:12379 get "$file" --write-out=json)
+  VALUE=$(echo $OBJECT | jq -r '.kvs[0].value' | base64 --decode | jq )
+  DIR=$(dirname "$file")
+  FILE=$(basename "$file")
+  mkdir -p "$BACKUP_OUTPUT_DIR/$DIR"
+  echo "$VALUE" > "$BACKUP_OUTPUT_DIR/$DIR/$FILE.json"
+  echo $BACKUP_OUTPUT_DIR/$DIR/$FILE.json
+done
+kubectl delete po etcd-restore --force
+```
+{% endofftopic %}
+
+## Manual object export
+
+The steps below describe how to manually launch a temporary etcd instance, restore data from a snapshot into it, and export only the objects you need as JSON files.
+
+1. Prepare a temporary Pod with `etcd` and `ubuntu` containers using the `etcd.pod.yaml` template. The template includes two containers:
+
+   - `etcd` — must match the version of etcd from which the snapshot was created.
+   - `ubuntu` — an auxiliary container for debugging purposes (modern etcd images may not include a shell like `bash` or `sh`).
+
+     Substitute the actual etcd image version (matching your original cluster) into the template and create the Pod using the following commands:
+
+     ```shell
+     IMG=$(kubectl -n kube-system get pod -l component=etcd -o jsonpath="{.items[*].spec.containers[*].image}" | cut -f 1 -d ' ')
+     sed -i -e "s#ETCD_IMAGE#$IMG#" etcd.pod.yaml
+     kubectl create -f etcd.pod.yaml
+     ```
+
+     Example template:
+
+     ```yaml
+     apiVersion: v1
+     kind: Pod
+     metadata:
+       name: etcd-restore
+     spec:
+       volumes:
+       - name: shared-data
+         emptyDir: {}  
+       - name: etcddir
+         emptyDir: {}
+       containers:
+       - name: etcd
+         image: ETCD_IMAGE
+         volumeMounts:
+         - name: shared-data
+           mountPath: /etcd-backup
+         - name: etcddir
+           mountPath: /default.etcd      
+  
+       - name: ubuntu
+         image: ubuntu:latest
+         command: ["/bin/sh", "-c", "sleep 100h"]
+         volumeMounts:
+         - name: shared-data
+           mountPath: /etcd-backup
+
+       restartPolicy: Never
+      ```
+
+1. Copy the etcd snapshot to the temporary pod container. Use the `kubectl cp` command to upload the snapshot file (e.g., `etcd-snapshot.bin`) to the `ubuntu` container:
+
+   ```shell
+   kubectl cp etcd-snapshot.bin etcd-restore:/etcd-backup -c ubuntu
+   ```
+
+   he backup file will now be accessible to the etcd container.
+
+1. Restore data from the snapshot into a new directory. Run the following command inside the etcd container, specifying the snapshot path and a new data directory:
+
+   ```shell
+   kubectl exec -t etcd-restore -c etcd -- etcdctl snapshot restore /etcd-backup/etcd-backup.snapshot --data-dir=./default.etcd_new
+   ```
+
+   After the command completes, the snapshot will be unpacked into the `./default.etcd_new` directory.
+
+1. Start a second etcd instance on a non-default port using the restored data. To avoid conflicts with the running etcd instance in the cluster, use a different data directory and ports:
+
+   ```shell
+   kubectl exec -t etcd-restore -c etcd -- etcd   --name temp   --data-dir /default.etcd_new   --advertise-client-urls http://localhost:12379   --listen-client-urls http://localhost:12379 --listen-peer-urls http://localhost:12380 &
+   ```
+
+   > **Warning.** In this example, the etcd process is started in the background directly from the command line. Use this method only for data recovery purposes.
+
+1. Select and export the required cluster objects:
+
+   - Define a `grep` filter to extract only the resources you need (e.g., a specific namespace or resource type).
+   - Create a directory for saving the JSON files and export the objects in a loop:
+
+      ```shell
+      FILTER="verticalpodautoscalers"
+      BACKUP_OUTPUT_DIR="/tmp/etc_restore"
+      mkdir -p $BACKUP_OUTPUT_DIR
+      files=($(kubectl exec -t etcd-restore -c etcd  -- etcdctl  --endpoints=localhost:12379 get / --prefix --keys-only | grep "$FILTER" )) 
+      for file in "${files[@]}"
+      do
+        OBJECT=$(kubectl exec -t etcd-restore -c etcd  -- etcdctl  --endpoints=localhost:12379 get "$file" --write-out=json)
+        VALUE=$(echo $OBJECT | jq -r '.kvs[0].value' | base64 --decode | jq )
+        DIR=$(dirname "$file")
+        FILE=$(basename "$file")
+        mkdir -p "$BACKUP_OUTPUT_DIR/$DIR"
+        echo "$VALUE" > "$BACKUP_OUTPUT_DIR/$DIR/$FILE.json"
+        echo $BACKUP_OUTPUT_DIR/$DIR/$FILE.json
+      done
+      ```
+
+   - Once completed, the `$BACKUP_OUTPUT_DIR` directory will contain the exported resources in JSON format.
+
+1. Delete the temporary etcd pod:
+
+   ```shell
+   kubectl delete po etcd-restore --force
+   ```
+
+   Pod will be stopped, but the exported resources will remain available for further restoration in the main cluster.
+
+### Restoring cluster objects from exported JSON files
+
+Для восстановления объектов выполните следующие шаги:
+
+To restore Kubernetes objects from exported JSON files, follow these steps:
+
+1. Prepare the JSON files for restoration. Before applying them to the cluster, remove technical fields that may be outdated or interfere with the recovery process:
+
+   - `creationTimestamp`
+   - `UID`
+   - `status`
+
+   You can edit these fields manually or use YAML/JSON processing tools such as `yq` or `jq`.
+
+1. Create the objects in the cluster. To restore individual resources, run:
+
+   ```shell
+   kubectl create -f <PATH_TO_FILE>.json
+   ```
+
+   You can specify either a single file or a directory path.
+
+1. To restore multiple objects at once, use the `find` command:
+
+   ```shell
+   find $BACKUP_OUTPUT_DIR -type f -name "*.json" -exec kubectl create -f {} \;
+   ```
+
+   This will locate all `.json` files within the specified `$BACKUP_OUTPUT_DIR` and apply them sequentially using `kubectl create`.
+
+After completing these steps, the selected objects will be recreated in the cluster based on the definitions in the JSON files.
+
+## Restoring after changing the master node IP address
+
+{% alert level="warning" %}
+This section describes a scenario where only the IP address of the master node has changed, and all other objects in the etcd backup (such as CA certificates) remain valid. It assumes the restoration is performed in a single-master-node cluster.
+{% endalert %}
+
+To restore etcd objects after changing the master node's IP address, follow these steps:
+
+1. Restore etcd from the backup. Use the standard etcd restore procedure with a snapshot. Make sure not to change any parameters during restoration other than the etcd data itself.
+
+1. Update the IP address in static configuration files:
+
+   - Check the Kubernetes component manifest files located in `/etc/kubernetes/manifests/`.
+   - Review kubelet's system configuration files (typically found in `/etc/systemd/system/kubelet.service.d/` or similar directories).
+   - Update the IP address in any other configurations that reference the old address, if necessary.
+
+1. Regenerate certificates that were issued for the old IP. Delete or move old certificates related to the API server and etcd (if applicable). Then generate new certificates, specifying the new master node IP address as a SAN (Subject Alternative Name).
+
+1. Restart all services that use the updated configurations and certificates. Force kubelet to restart control-plane manifests (API server, etcd, etc.). Either restart the system services manually (e.g., `systemctl restart kubelet`) or ensure they restart automatically.
+
+1. Wait for kubelet to regenerate its own certificate.
+
+These actions can be performed either [automatically](#automated-object-extraction-when-changing-the-ip-address) using a script, or [manually](#manual-object-restore-after-changing-the-ip-address) by running the required commands step-by-step.
+
+## Automated object extraction when changing IP address
+
+To simplify cluster recovery after the master node's IP address changes, use the script provided below. Before running the script:
+
+1. Specify the correct paths and IP addresses:
+   - `ETCD_SNAPSHOT_PATH` — the path to the etcd snapshot backup.
+   - `OLD_IP` — the old master node IP address used when the backup was created.
+   - `NEW_IP` — the new IP address of the master node.
+
+2. Make sure the Kubernetes version (`KUBERNETES_VERSION`) matches the one used in the cluster. This is necessary for downloading the correct version of kubeadm.
+
+3. After running the script, wait for the kubelet to regenerate its certificate with the new IP address. You can verify this in the `/var/lib/kubelet/pki/` directory, where a new certificate should appear.
+
+{% offtopic title="Object Extraction Script" %}
+```shell
+ETCD_SNAPSHOT_PATH="./etcd-backup.snapshot" # Path to the etcd snapshot.
+OLD_IP=10.242.32.34                         # Old master node IP address.
+NEW_IP=10.242.32.21                         # New master node IP address.
+KUBERNETES_VERSION=1.28.0                   # Kubernetes version.
+
+mv /etc/kubernetes/manifests/etcd.yaml ~/etcd.yaml 
+mkdir ./etcd_old
+mv /var/lib/etcd ~/etcd_old
+ETCDCTL_PATH=$(find /var/lib/containerd/ -name etcdctl)
+
+ETCDCTL_API=3 $ETCDCTL_PATH snapshot restore etcd-backup.snapshot --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt   --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/  --data-dir=/var/lib/etcd 
+
+mv ~/etcd.yaml /etc/kubernetes/manifests/etcd.yaml
+
+find /etc/kubernetes/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+find /etc/systemd/system/kubelet.service.d -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+find  /var/lib/bashible/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+
+mkdir -p ./old_certs/etcd
+mv /etc/kubernetes/pki/apiserver.* ./old_certs/
+mv /etc/kubernetes/pki/etcd/server.* ./old_certs/etcd/
+mv /etc/kubernetes/pki/etcd/peer.* ./old_certs/etcd/
+
+curl -LO https://dl.k8s.io/v$KUBERNETES_VERSION/bin/linux/amd64/kubeadm
+chmod +x kubeadm
+./kubeadm init phase certs all --config /etc/kubernetes/deckhouse/kubeadm/config.yaml
+
+crictl ps --name 'kube-apiserver' -o json | jq -r '.containers[0].id' | xargs crictl stop
+crictl ps --name 'kubernetes-api-proxy' -o json | jq -r '.containers[0].id' | xargs crictl stop
+crictl ps --name 'etcd' -o json | jq -r '.containers[].id' | xargs crictl stop
+
+systemctl daemon-reload
+systemctl restart kubelet.service
+```
+{% endofftopic %}
+
+### Manual object restore after changing the IP address
+
+If you prefer to manually make changes during cluster recovery after the master node’s IP address has changed, follow these steps:
+
+1. Restore etcd from the backup:
+
+   - Move the etcd manifest so that kubelet stops the corresponding pod:
+
+     ```shell
+     mv /etc/kubernetes/manifests/etcd.yaml ~/etcd.yaml
+     ```
+
+   - Create a directory to temporarily store the previous etcd data:
+
+     ```shell
+     mkdir ./etcd_old
+     mv /var/lib/etcd ./etcd_old
+     ```
+
+   - Find or download the `etcdctl` utility if it’s not available, and perform the snapshot restore:
+
+     ```shell
+     ETCD_SNAPSHOT_PATH="./etcd-backup.snapshot" # Path to the etcd snapshot
+     ETCDCTL_PATH=$(find /var/lib/containerd/ -name etcdctl)
+
+     ETCDCTL_API=3 $ETCDCTL_PATH snapshot restore \
+       etcd-backup.snapshot \
+       --cacert /etc/kubernetes/pki/etcd/ca.crt \
+       --cert /etc/kubernetes/pki/etcd/ca.crt \
+       --key /etc/kubernetes/pki/etcd/ca.key \
+       --endpoints https://127.0.0.1:2379/ \
+       --data-dir=/var/lib/etcd
+     ```
+
+   - Restore the etcd manifest so kubelet starts the etcd pod again:
+
+     ```shell
+     mv ~/etcd.yaml /etc/kubernetes/manifests/etcd.yaml
+     ```
+
+   - Verify etcd is running by checking the pod list using `crictl ps | grep etcd` or reviewing the kubelet logs.
+
+1. Update the IP address in static configuration files. If the old IP address is used in manifests or kubelet services, replace it with the new one:
+
+    ```shell
+    OLD_IP=10.242.32.34                         # Old master node IP address
+    NEW_IP=10.242.32.21                         # New master node IP address
+
+    find /etc/kubernetes/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+    find /etc/systemd/system/kubelet.service.d -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+    find  /var/lib/bashible/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+    ```
+
+1. Regenerate certificates issued for the old IP address:
+
+   - Prepare a directory to store the old certificates:
+
+     ```shell
+     mkdir -p ./old_certs/etcd
+     mv /etc/kubernetes/pki/apiserver.* ./old_certs/
+     mv /etc/kubernetes/pki/etcd/server.* ./old_certs/etcd/
+     mv /etc/kubernetes/pki/etcd/peer.* ./old_certs/etcd/
+     ```
+
+   - Install or download kubeadm to match the current Kubernetes version:
+
+     ```shell
+     KUBERNETES_VERSION=1.28.0 # Kubernetes version
+     curl -LO https://dl.k8s.io/v$KUBERNETES_VERSION/bin/linux/amd64/kubeadm
+     chmod +x kubeadm
+     ```
+
+   - Generate new certificates with the updated IP:
+
+     ```shell
+     ./kubeadm init phase certs all --config /etc/kubernetes/deckhouse/kubeadm/config.yaml
+     ```
+
+1. Restart all services that use the updated configuration and certificates. To immediately stop active containers, run:
+
+    ```shell
+    crictl ps --name 'kube-apiserver' -o json | jq -r '.containers[0].id' | xargs crictl stop
+    crictl ps --name 'kubernetes-api-proxy' -o json | jq -r '.containers[0].id' | xargs crictl stop
+    crictl ps --name 'etcd' -o json | jq -r '.containers[].id' | xargs crictl stop
+
+    systemctl daemon-reload
+    systemctl restart kubelet.service
+    ```
+
+    kubelet will restart the necessary pods, and Kubernetes components will load the new certificates.
+
+1. Wait for kubelet to regenerate its own certificate. kubelet will automatically generate a new certificate with the updated IP address:
+
+   - Check the `/var/lib/kubelet/pki/` directory.
+   - Ensure the new certificate is present and valid.
+
+Once these steps are completed, the cluster will be successfully restored and fully functional with the new master node IP address.
+
+## Creating backups with Deckhouse CLI
+
+Deckhouse CLI (`d8`) provides the `backup` command for creating backups of various cluster components:
+
+- `etcd` — snapshot of the Deckhouse key-value data store;
+- `cluster-config` — archive containing key configuration objects of the cluster;
+- `loki` — export of logs from the built-in Loki API.
+
+### Backing up etcd
+
+An etcd snapshot allows you to preserve the current state of the cluster at the key-value storage level. This is a full dump that can be used for recovery.
+
+To create a snapshot, run the following command:
+
+```console
+d8 backup etcd <path-to-snapshot> [flags]
+```
+
+Flags:
+
+- `-p`, `--etcd-pod string` — name of the etcd pod to snapshot;
+- `-h`, `--help` — show help for the etcd command;
+- `--verbose` — enable verbose output for detailed logging.
+
+Example:
+
+```console
+d8 backup etcd mybackup.snapshot
+```
+
+Example output:
+
+```console
+2025/04/22 08:38:58 Trying to snapshot etcd-sandbox-master-0
+2025/04/22 08:39:01 Snapshot successfully taken from etcd-sandbox-master-0
+```
+
+#### Automatic etcd backup
+
+Deckhouse automatically performs a daily etcd backup using a CronJob that runs inside the `d8-etcd-backup` pod in the `kube-system` namespace. The job creates a snapshot of the database, compresses it, and saves the archive locally on the node at `/var/lib/etcd/`:
+
+```console
+etcdctl snapshot save etcd-backup.snapshot
+tar -czvf etcd-backup.tar.gz etcd-backup.snapshot
+mv etcd-backup.tar.gz /var/lib/etcd/etcd-backup.tar.gz
+```
+
+To configure automatic etcd backups, use the `control-plane-manager` module. The required parameters are specified in its configuration:
+
+| Parameter                  | Description                                                                 |
+|---------------------------|-----------------------------------------------------------------------------|
+| `etcd.backup.enabled`     | Enables daily etcd backup.                                                  |
+| `etcd.backup.cronSchedule`| Cron-formatted schedule for running the backup. Local time of `kube-controller-manager` is used. |
+| `etcd.backup.hostPath`    | Path on master nodes where etcd backup archives will be stored.             |
+
+Example configuration fragment:
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+spec:
+  etcd:
+    backup:
+      enabled: true
+      cronSchedule: "0 1 * * *"
+      hostPath: "/var/lib/etcd"
+```
+
+### Cluster configuration backup
+
+The `d8 backup cluster-config` command creates an archive containing a set of key resources related to the cluster configuration. This is not a full backup of all objects, but a specific whitelist.
+
+To create the backup, run the following command:
+
+```console
+d8 backup cluster-config <path-to-backup-file>
+```
+
+Example:
+
+```console
+d8 backup cluster-config /backup/cluster-config-2025-04-21.tar
+```
+
+The archive includes only those objects that meet the following criteria:
+
+- CustomResource objects whose CRDs are annotated with:
+
+  ```console
+  backup.deckhouse.io/cluster-config=true
+  ```
+
+- StorageClasses with the label:
+
+  ```console
+  heritage=deckhouse
+  ```
+
+- Secrets and ConfigMaps from namespaces starting with `d8-` or `kube-`, if they are explicitly listed in the whitelist file.
+
+- Cluster-level Roles and Bindings (ClusterRole and ClusterRoleBinding), if they are not labeled with:
+
+  ```console
+  heritage=deckhouse
+  ```
+
+> The backup includes only CR objects, but not the CRD definitions themselves. To fully restore the cluster, the corresponding CRDs must already be present (e.g., installed by Deckhouse modules).
+
+Example whitelist content:
+
+| Namespace           | Object     | Name                                               |
+|---------------------|------------|----------------------------------------------------|
+| `d8-system`         | Secret     | `d8-cluster-terraform-state`                      |
+|                     |            | <span title="The string is interpreted as a regular expression and covers all secrets whose names start with d8-node-terraform-state-."><code style="color:#d63384">$regexp:^d8-node-terraform-state-(.*)$</code></span> |
+|                     |            | `deckhouse-registry`                              |
+|                     | ConfigMap  | `d8-deckhouse-version-info`                       |
+| `kube-system`       | ConfigMap  | `d8-cluster-is-bootstraped`                       |
+|                     |            | `d8-cluster-uuid`                                 |
+|                     |            | `extension-apiserver-authentication`              |
+|                     | Secret     | `d8-cloud-provider-discovery-data`                |
+|                     |            | `d8-cluster-configuration`                        |
+|                     |            | `d8-cni-configuration`                            |
+|                     |            | `d8-control-plane-manager-config`                 |
+|                     |            | `d8-node-manager-cloud-provider`                  |
+|                     |            | `d8-pki`                                          |
+|                     |            | `d8-provider-cluster-configuration`               |
+|                     |            | `d8-static-cluster-configuration`                 |
+|                     |            | `d8-secret-encryption-key`                        |
+| `d8-cert-manager`   | Secret     | `cert-manager-letsencrypt-private-key`            |
+|                     |            | `selfsigned-ca-key-pair`                          |
+
+### Exporting logs from Loki
+
+The `d8 backup loki` command is intended for exporting logs from the built-in Loki. This is not a full backup, but rather a diagnostic export: the resulting data cannot be restored back into Loki.
+
+To perform the export, `d8` accesses the Loki API using the `loki` ServiceAccount in the `d8-monitoring` namespace, authenticated via a token stored in a Kubernetes secret.
+
+The `loki` ServiceAccount is automatically created starting from Deckhouse v1.69.0. However, to use the `d8 backup loki` command, you must manually create the token secret and assign the necessary Role and RoleBinding if they are not already present.
+
+Apply the manifests below before running `d8 backup loki` to ensure the command can properly authenticate and access the Loki API.
+
+Example manifests:
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: loki-api-token
+  namespace: d8-monitoring
+  annotations:
+    kubernetes.io/service-account.name: loki
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: access-to-loki-from-d8
+  namespace: d8-monitoring
+rules:
+  - apiGroups: ["apps"]
+    resources:
+      - "statefulsets/http"
+    resourceNames: ["loki"]
+    verbs: ["create", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: access-to-loki-from-d8
+  namespace: d8-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: access-to-loki-from-d8
+subjects:
+  - kind: ServiceAccount
+    name: loki
+    namespace: d8-monitoring
+```
+
+To create a log backup, run the following command:
+
+```console
+d8 backup loki [flags]
+```
+
+Example:
+
+```console
+d8 backup loki --days 1 > ./loki.log
+```
+
+Flags:
+
+- `--start`, `--end` — time range boundaries in the format "YYYY-MM-DD HH:MM:SS";
+- `--days` — the time window size for log export (default is 5 days);
+- `--limit` — the maximum number of log lines per request (default is 5000).
+
+You can list all available flags using the following command `d8 backup loki --help`.


### PR DESCRIPTION
## Description
Translate new DKP structure — Backup and restore.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Translate new DKP structure — Backup and restore.
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
