### PR TITLE
[dhctl] Disable converge deckhouse configuration for terraform autoconverger and converge from CLI

### DIFF
--- a/dhctl/pkg/operations/converge/context/context.go
+++ b/dhctl/pkg/operations/converge/context/context.go
@@ -40,7 +40,6 @@ type Context struct {
 	// but it is not recommended https://go.dev/wiki/CodeReviewComments#contexts
 	ctx                   context.Context
 	phaseContext          phases.DefaultPhasedExecutionContext
-	metaConfig            *config.MetaConfig
 	infrastructureContext *infrastructure.Context
 	commanderParams       *commander.CommanderModeParams
 	changeParams          infrastructure.ChangeActionSettings
@@ -147,8 +146,6 @@ func (c *Context) MetaConfig() (*config.MetaConfig, error) {
 			return nil, fmt.Errorf("unable to parse meta configuration: %w", err)
 		}
 
-		c.metaConfig = metaConfig
-
 		return metaConfig, nil
 	}
 
@@ -156,8 +153,6 @@ func (c *Context) MetaConfig() (*config.MetaConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	c.metaConfig = metaConfig
 
 	return metaConfig, nil
 }

--- a/dhctl/pkg/operations/converge/runner.go
+++ b/dhctl/pkg/operations/converge/runner.go
@@ -452,9 +452,13 @@ func (r *runner) converge(ctx *context.Context) error {
 		log.InfoLn("Skip converge nodes")
 	}
 
-	err = r.convergeDeckhouseConfiguration(ctx, r.commanderUUID)
-	if err != nil {
-		return err
+	if !r.isSkip(phases.DeckhouseConfigurationPhase) {
+		err = r.convergeDeckhouseConfiguration(ctx, r.commanderUUID)
+		if err != nil {
+			return err
+		}
+	} else {
+		log.InfoLn("Skip converge deckhouse configuration")
 	}
 
 	if kubeClientSwitched {

--- a/dhctl/pkg/operations/phases/phases.go
+++ b/dhctl/pkg/operations/phases/phases.go
@@ -36,9 +36,10 @@ const (
 	DeleteResourcesPhase                   OperationPhase = "DeleteResources"
 	ExecPostBootstrapPhase                 OperationPhase = "ExecPostBootstrap"
 	// converge only
-	AllNodesPhase            OperationPhase = "AllNodes"
-	ScaleToMultiMasterPhase  OperationPhase = "ScaleToMultiMaster"
-	ScaleToSingleMasterPhase OperationPhase = "ScaleToSingleMaster"
+	AllNodesPhase               OperationPhase = "AllNodes"
+	ScaleToMultiMasterPhase     OperationPhase = "ScaleToMultiMaster"
+	ScaleToSingleMasterPhase    OperationPhase = "ScaleToSingleMaster"
+	DeckhouseConfigurationPhase OperationPhase = "DeckhouseConfiguration"
 	// all
 	FinalizationPhase OperationPhase = "Finalization"
 )

--- a/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
@@ -20,6 +20,7 @@ git:
   to: /deckhouse
   includePaths:
     - "candi/openapi"
+    - "candi/terraform_versions.yml"
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-opentofu
 final: false


### PR DESCRIPTION
## Description
Disable converge deckhouse configuration for terraform autoconverger and converge from CLI

Also fix panic with running terraform-auto-converger and terraform state exporter because terraform_versions.yaml did not copied to images

## Why do we need it, and what problem does it solve?
Deckhouse configuration converge should work with commander only.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

![image](https://github.com/user-attachments/assets/cb74facc-9a5d-490b-9508-26bc83f73b6c)
![image](https://github.com/user-attachments/assets/009b1221-6d67-414a-a3d5-a3ac7991d57a)
![image](https://github.com/user-attachments/assets/d76f20dd-db88-4a1b-a2f8-75b2dabf00a2)


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Disable converge deckhouse configuration for terraform autoconverger and converge from CLI
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
