### PR TITLE
[istio] garbage collecting CRs when module is disabled

### DIFF
--- a/modules/110-istio/hooks/purge_orphan_resources.go
+++ b/modules/110-istio/hooks/purge_orphan_resources.go
@@ -25,6 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 )
@@ -45,6 +47,12 @@ var (
 		Version:  "v1alpha1",
 		Resource: "istiooperators",
 	}
+	istioClusterCRDs = []schema.GroupVersionResource{
+		{Group: "networking.istio.io", Version: "v1alpha3", Resource: "envoyfilters"},
+		{Group: "networking.istio.io", Version: "v1alpha3", Resource: "gateways"},
+		{Group: "security.istio.io", Version: "v1beta1", Resource: "peerauthentications"},
+		{Group: "security.istio.io", Version: "v1beta1", Resource: "requestauthentications"},
+	}
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -57,6 +65,17 @@ func purgeOrphanResources(input *go_hook.HookInput, dc dependency.Container) err
 		return err
 	}
 	k8sClient, err := dc.GetK8sClient()
+	if err != nil {
+		return err
+	}
+	// Create a rest.Config object
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return err
+	}
+
+	// Create the dynamic client
+	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return err
 	}
@@ -144,6 +163,23 @@ func purgeOrphanResources(input *go_hook.HookInput, dc dependency.Container) err
 			return err
 		}
 		input.Logger.Infof("ValidatingWebhookConfiguration/%s deleted", ivwc.GetName())
+	}
+
+	// delete cluster-wide Custom Resources
+	for _, icwr := range istioClusterCRDs {
+		crList, err := dynamicClient.Resource(icwr).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			input.Logger.Warnf("Failed to list %s: %v", icwr.Resource, err)
+			continue
+		}
+		for _, cr := range crList.Items {
+			err := dynamicClient.Resource(icwr).Namespace(cr.GetNamespace()).Delete(context.TODO(), cr.GetName(), metav1.DeleteOptions{})
+			if err != nil {
+				input.Logger.Warnf("Failed to delete %s/%s: %v", icwr.Resource, cr.GetName(), err)
+			} else {
+				input.Logger.Infof("%s/%s deleted", icwr.Resource, cr.GetName())
+			}
+		}
 	}
 
 	return nil

--- a/modules/110-istio/hooks/purge_orphan_resources.go
+++ b/modules/110-istio/hooks/purge_orphan_resources.go
@@ -174,14 +174,6 @@ func purgeOrphanResources(input *go_hook.HookInput, dc dependency.Container) err
 					input.Logger.Infof("ConfigMap/%s deleted from namespace %s", istioRootCertConfigMapName, namespace.Name)
 				}
 			}
-
-			// Delete the istio-ca-root-cert ConfigMap in d8-istio namespace
-			err = k8sClient.CoreV1().ConfigMaps(istioSystemNs).Delete(context.TODO(), istioRootCertConfigMapName, metav1.DeleteOptions{})
-			if err != nil {
-				input.Logger.Warnf("Failed to delete ConfigMap/%s in namespace %s: %v", istioRootCertConfigMapName, istioSystemNs, err)
-			} else {
-				input.Logger.Infof("ConfigMap/%s deleted from namespace %s", istioRootCertConfigMapName, istioSystemNs)
-			}
 		}
 
 		// delete NS

--- a/modules/110-istio/hooks/purge_orphan_resources.go
+++ b/modules/110-istio/hooks/purge_orphan_resources.go
@@ -173,7 +173,7 @@ func purgeOrphanResources(input *go_hook.HookInput, dc dependency.Container) err
 			continue
 		}
 		for _, cr := range crList.Items {
-			err := dynamicClient.Resource(icwr).Namespace(cr.GetNamespace()).Delete(context.TODO(), cr.GetName(), metav1.DeleteOptions{})
+			err := dynamicClient.Resource(icwr).Delete(context.TODO(), cr.GetName(), metav1.DeleteOptions{})
 			if err != nil {
 				input.Logger.Warnf("Failed to delete %s/%s: %v", icwr.Resource, cr.GetName(), err)
 			} else {

--- a/modules/110-istio/hooks/purge_orphan_resources_test.go
+++ b/modules/110-istio/hooks/purge_orphan_resources_test.go
@@ -17,6 +17,7 @@ package hooks
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -290,8 +291,6 @@ metadata:
 			Expect(f.KubernetesGlobalResource("ValidatingWebhookConfiguration", "istio-validator-v1x16-d8-istio").Exists()).To(BeFalse())
 
 			// Verify ConfigMaps are deleted
-			_, err = f.KubeClient().CoreV1().ConfigMaps(istioSystemNs).Get(context.TODO(), "istio-ca-root-cert", metav1.GetOptions{})
-			Expect(err).To(HaveOccurred())
 			_, err = f.KubeClient().CoreV1().ConfigMaps(otherNs1.Name).Get(context.TODO(), "istio-ca-root-cert", metav1.GetOptions{})
 			Expect(err).To(HaveOccurred())
 		})

--- a/modules/110-istio/hooks/purge_orphan_resources_test.go
+++ b/modules/110-istio/hooks/purge_orphan_resources_test.go
@@ -17,7 +17,6 @@ package hooks
 
 import (
 	"context"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -51,6 +50,24 @@ metadata:
   - istio-finalizer.install.istio.io
   name: v1x16
   namespace: d8-istio
+`
+		federationYAML = `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioFederation
+metadata:
+  finalizers:
+  - istio-finalizer.deckhouse.io
+  name: federation-1
+`
+		multiclusterYAML = `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioMulticluster
+metadata:
+  finalizers:
+  - istio-finalizer.deckhouse.io
+  name: multicluster-1
 `
 		cr1YAML = `
 ---
@@ -106,6 +123,31 @@ metadata:
   labels:
     install.operator.istio.io/owning-resource-namespace: d8-istio
 `
+		rootCertYAML = `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-ca-root-cert
+  namespace: d8-istio
+  creationTimestamp: "2023-01-01T00:00:00Z"
+`
+		otherNs1YAML = `
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns1
+`
+		otherNs1RootCertYAML = `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-ca-root-cert
+  namespace: ns1
+  creationTimestamp: "2023-01-01T00:00:00Z"
+`
 	)
 
 	var (
@@ -119,17 +161,34 @@ metadata:
 			Version: "v1alpha1",
 			Kind:    "IstioOperator",
 		}
-		ns   *corev1.Namespace
-		cr1  *rbacv1.ClusterRole
-		cr2  *rbacv1.ClusterRole
-		crb1 *rbacv1.ClusterRoleBinding
-		crb2 *rbacv1.ClusterRoleBinding
-		mwc  *admissionregistrationv1.MutatingWebhookConfiguration
-		vwc  *admissionregistrationv1.ValidatingWebhookConfiguration
-		iop  *unstructured.Unstructured
+		federationGVR = schema.GroupVersionResource{
+			Group:    "deckhouse.io",
+			Version:  "v1alpha1",
+			Resource: "istiofederations",
+		}
+		multiclusterGVR = schema.GroupVersionResource{
+			Group:    "deckhouse.io",
+			Version:  "v1alpha1",
+			Resource: "istiomulticlusters",
+		}
+		ns               *corev1.Namespace
+		cr1              *rbacv1.ClusterRole
+		cr2              *rbacv1.ClusterRole
+		crb1             *rbacv1.ClusterRoleBinding
+		crb2             *rbacv1.ClusterRoleBinding
+		mwc              *admissionregistrationv1.MutatingWebhookConfiguration
+		vwc              *admissionregistrationv1.ValidatingWebhookConfiguration
+		iop              *unstructured.Unstructured
+		federation       *unstructured.Unstructured
+		multicluster     *unstructured.Unstructured
+		rootCert         *corev1.ConfigMap
+		otherNs1         *corev1.Namespace
+		otherNs1RootCert *corev1.ConfigMap
 	)
 	BeforeEach(func() {
 		_ = yaml.Unmarshal([]byte(iopYAML), &iop)
+		_ = yaml.Unmarshal([]byte(federationYAML), &federation)
+		_ = yaml.Unmarshal([]byte(multiclusterYAML), &multicluster)
 		_ = yaml.Unmarshal([]byte(nsYAML), &ns)
 		_ = yaml.Unmarshal([]byte(cr1YAML), &cr1)
 		_ = yaml.Unmarshal([]byte(cr2YAML), &cr2)
@@ -137,10 +196,15 @@ metadata:
 		_ = yaml.Unmarshal([]byte(crb2YAML), &crb2)
 		_ = yaml.Unmarshal([]byte(mwcYAML), &mwc)
 		_ = yaml.Unmarshal([]byte(vwcYAML), &vwc)
+		_ = yaml.Unmarshal([]byte(rootCertYAML), &rootCert)
+		_ = yaml.Unmarshal([]byte(otherNs1YAML), &otherNs1)
+		_ = yaml.Unmarshal([]byte(otherNs1RootCertYAML), &otherNs1RootCert)
 	})
 
 	f := HookExecutionConfigInit(`{}`, `{}`)
 	f.RegisterCRD(iopGVK.Group, iopGVK.Version, iopGVK.Kind, true)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "IstioFederation", false)   // cluster-scoped
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "IstioMulticluster", false) // cluster-scoped
 
 	Context("Empty cluster and minimal settings", func() {
 		BeforeEach(func() {
@@ -155,122 +219,81 @@ metadata:
 		})
 	})
 
-	Context("Cluster with minimal settings and orphan iop", func() {
+	Context("Cluster with IstioFederation and IstioMulticluster resources", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.GenerateAfterDeleteHelmContext())
 			f.KubeStateSet("")
 
-			_, _ = f.KubeClient().CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
-			_, _ = f.KubeClient().Dynamic().Resource(iopGVR).Namespace(istioSystemNs).Create(context.TODO(), iop, metav1.CreateOptions{})
+			// Create cluster-wide resources
+			_, _ = f.KubeClient().Dynamic().Resource(federationGVR).Create(context.TODO(), federation, metav1.CreateOptions{})
+			_, _ = f.KubeClient().Dynamic().Resource(multiclusterGVR).Create(context.TODO(), multicluster, metav1.CreateOptions{})
 
 			f.RunHook()
 		})
 
-		It("Hook must execute successfully", func() {
+		It("Should delete cluster-wide Istio resources", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(string(f.LoggerOutput.Contents())).ToNot(HaveLen(0))
-			Expect(f.KubernetesGlobalResource("Namespace", "d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("Namespace d8-istio deleted"))
-			Expect(f.KubernetesResource("IstioOperator", "d8-istio", "v1x16").Exists()).To(BeFalse())
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("Finalizers from IstioOperator/v1x16 in namespace d8-istio removed"))
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("IstioOperator/v1x16 deleted from namespace d8-istio"))
+
+			// Verify IstioFederation is deleted
+			_, err := f.KubeClient().Dynamic().Resource(federationGVR).Get(context.TODO(), "federation-1", metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
+			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("Finalizers from IstioFederation/federation-1 removed"))
+			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("IstioFederation/federation-1 deleted"))
+
+			// Verify IstioMulticluster is deleted
+			_, err = f.KubeClient().Dynamic().Resource(multiclusterGVR).Get(context.TODO(), "multicluster-1", metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
+			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("Finalizers from IstioMulticluster/multicluster-1 removed"))
+			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("IstioMulticluster/multicluster-1 deleted"))
 		})
 	})
 
-	Context("Cluster with minimal settings and orphan istio resources", func() {
+	Context("Cluster with all types of Istio resources", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.GenerateAfterDeleteHelmContext())
 			f.KubeStateSet("")
 
+			// Create all test resources
 			_, _ = f.KubeClient().CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+			_, _ = f.KubeClient().CoreV1().Namespaces().Create(context.TODO(), otherNs1, metav1.CreateOptions{})
 			_, _ = f.KubeClient().Dynamic().Resource(iopGVR).Namespace(istioSystemNs).Create(context.TODO(), iop, metav1.CreateOptions{})
+			_, _ = f.KubeClient().Dynamic().Resource(federationGVR).Create(context.TODO(), federation, metav1.CreateOptions{})
+			_, _ = f.KubeClient().Dynamic().Resource(multiclusterGVR).Create(context.TODO(), multicluster, metav1.CreateOptions{})
 			_, _ = f.KubeClient().RbacV1().ClusterRoles().Create(context.TODO(), cr1, metav1.CreateOptions{})
-			_, _ = f.KubeClient().RbacV1().ClusterRoles().Create(context.TODO(), cr2, metav1.CreateOptions{})
 			_, _ = f.KubeClient().RbacV1().ClusterRoleBindings().Create(context.TODO(), crb1, metav1.CreateOptions{})
-			_, _ = f.KubeClient().RbacV1().ClusterRoleBindings().Create(context.TODO(), crb2, metav1.CreateOptions{})
 			_, _ = f.KubeClient().AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.TODO(), mwc, metav1.CreateOptions{})
 			_, _ = f.KubeClient().AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(context.TODO(), vwc, metav1.CreateOptions{})
+			_, _ = f.KubeClient().CoreV1().ConfigMaps(istioSystemNs).Create(context.TODO(), rootCert, metav1.CreateOptions{})
+			_, _ = f.KubeClient().CoreV1().ConfigMaps(otherNs1.Name).Create(context.TODO(), otherNs1RootCert, metav1.CreateOptions{})
 
 			f.RunHook()
 		})
 
-		It("Hook must execute successfully", func() {
+		It("Should delete all Istio resources", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(string(f.LoggerOutput.Contents())).ToNot(HaveLen(0))
-			Expect(f.KubernetesGlobalResource("Namespace", "d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("Namespace d8-istio deleted"))
 
+			// Verify cluster-wide resources are deleted
+			_, err := f.KubeClient().Dynamic().Resource(federationGVR).Get(context.TODO(), "federation-1", metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
+			_, err = f.KubeClient().Dynamic().Resource(multiclusterGVR).Get(context.TODO(), "multicluster-1", metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
+
+			// Verify namespace-scoped resources are deleted
 			Expect(f.KubernetesResource("IstioOperator", "d8-istio", "v1x16").Exists()).To(BeFalse())
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("Finalizers from IstioOperator/v1x16 in namespace d8-istio removed"))
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("IstioOperator/v1x16 deleted from namespace d8-istio"))
+			Expect(f.KubernetesGlobalResource("Namespace", "d8-istio").Exists()).To(BeFalse())
 
+			// Verify other resources are deleted
 			Expect(f.KubernetesGlobalResource("ClusterRole", "istio-reader-d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("ClusterRole/istio-reader-d8-istio deleted"))
-			Expect(f.KubernetesGlobalResource("ClusterRole", "istio-reader-clusterrole-v1x16-d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("ClusterRole/istio-reader-clusterrole-v1x16-d8-istio deleted"))
 			Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "istio-reader-d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("ClusterRoleBinding/istio-reader-d8-istio deleted"))
-			Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "istio-reader-clusterrole-v1x16-d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("ClusterRoleBinding/istio-reader-clusterrole-v1x16-d8-istio deleted"))
 			Expect(f.KubernetesGlobalResource("MutatingWebhookConfiguration", "istio-sidecar-injector-v1x16-d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("MutatingWebhookConfiguration/istio-sidecar-injector-v1x16-d8-istio deleted"))
 			Expect(f.KubernetesGlobalResource("ValidatingWebhookConfiguration", "istio-validator-v1x16-d8-istio").Exists()).To(BeFalse())
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("ValidatingWebhookConfiguration/istio-validator-v1x16-d8-istio deleted"))
-		})
-	})
 
-	Context("Cluster with minimal settings and orphan istio resources including multicluster and federation", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.GenerateAfterDeleteHelmContext())
-			f.KubeStateSet("")
-			f := HookExecutionConfigInit(`{}`, `{}`)
-			f.RegisterCRD("deckhouse.io", "v1alpha1", "IstioMulticluster", true)
-			f.RegisterCRD("deckhouse.io", "v1alpha1", "IstioFederation", true)
-
-			// Create test resources
-			imc := &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "deckhouse.io/v1alpha1",
-					"kind":       "IstioMulticluster",
-					"metadata": map[string]interface{}{
-						"name": "test-multicluster",
-					},
-				},
-			}
-
-			ifed := &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "deckhouse.io/v1alpha1",
-					"kind":       "IstioFederation",
-					"metadata": map[string]interface{}{
-						"name": "test-federation",
-					},
-				},
-			}
-
-			imcGVR := schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1alpha1", Resource: "istiomulticlusters"}
-			ifedGVR := schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1alpha1", Resource: "istiofederations"}
-
-			_, _ = f.KubeClient().Dynamic().Resource(imcGVR).Namespace("").Create(context.TODO(), imc, metav1.CreateOptions{})
-			_, _ = f.KubeClient().Dynamic().Resource(ifedGVR).Namespace("").Create(context.TODO(), ifed, metav1.CreateOptions{})
-
-			f.RunHook()
-		})
-
-		It("Should delete Deckhouse Istio resources", func() {
-			Expect(f).To(ExecuteSuccessfully())
-
-			// Verify deletions
-			imcGVR := schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1alpha1", Resource: "istiomulticlusters"}
-			ifedGVR := schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1alpha1", Resource: "istiofederations"}
-
-			imcList, err := f.KubeClient().Dynamic().Resource(imcGVR).Namespace("").List(context.TODO(), metav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(imcList.Items).To(HaveLen(0))
-
-			ifedList, err := f.KubeClient().Dynamic().Resource(ifedGVR).Namespace("").List(context.TODO(), metav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(ifedList.Items).To(HaveLen(0))
+			// Verify ConfigMaps are deleted
+			_, err = f.KubeClient().CoreV1().ConfigMaps(istioSystemNs).Get(context.TODO(), "istio-ca-root-cert", metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
+			_, err = f.KubeClient().CoreV1().ConfigMaps(otherNs1.Name).Get(context.TODO(), "istio-ca-root-cert", metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
## Description
Changes to the resource deletion hook when disabling the module for deleting resources `configmap.istio-ca-root-cert`, `IstioMulticluster`, `IstioFederation`

## Why do we need it, and what problem does it solve?
When the `Istio` module was turned off, `configmap.istio-ca-root-cert` remained in the user namespace, which carried outdated certificates, which could lead to the failure of mtls if the certificates were not updated. There are also outdated cluster-wide resources `IstioMulticluster`, `IstioFederation`.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: feature
summary: Added garbage collection of istio-ca-root-cert and IstioMulticluster/IstioFederation resources after module disabling.
impact_level: default
```
