### PR TITLE
[dhctl] Disable caching metaconfig during converge and disable converge deckhouse manifests

### DIFF
--- a/dhctl/pkg/operations/converge/context/context.go
+++ b/dhctl/pkg/operations/converge/context/context.go
@@ -38,7 +38,6 @@ type Context struct {
 	// but it is not recommended https://go.dev/wiki/CodeReviewComments#contexts
 	ctx              context.Context
 	phaseContext     phases.DefaultPhasedExecutionContext
-	metaConfig       *config.MetaConfig
 	terraformContext *terraform.TerraformContext
 	commanderParams  *commander.CommanderModeParams
 	changeParams     terraform.ChangeActionSettings
@@ -121,17 +120,11 @@ func (c *Context) CompleteExecutionPhase(data any) error {
 }
 
 func (c *Context) MetaConfig() (*config.MetaConfig, error) {
-	if c.metaConfig != nil {
-		return c.metaConfig, nil
-	}
-
 	if c.CommanderMode() {
 		metaConfig, err := commander.ParseMetaConfig(c.stateCache, c.commanderParams)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse meta configuration: %w", err)
 		}
-
-		c.metaConfig = metaConfig
 
 		return metaConfig, nil
 	}
@@ -140,8 +133,6 @@ func (c *Context) MetaConfig() (*config.MetaConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	c.metaConfig = metaConfig
 
 	return metaConfig, nil
 }

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -211,8 +211,14 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 
 	kubectlSwitcher := convergectx.NewKubeClientSwitcher(convergeCtx, inLockRunner)
 
+	phasesToSkip := make([]phases.OperationPhase, 0)
+	if !c.CommanderMode {
+		phasesToSkip = []phases.OperationPhase{phases.DeckhouseConfigurationPhase}
+	}
+
 	r := newRunner(inLockRunner, kubectlSwitcher).
-		WithCommanderUUID(c.CommanderUUID)
+		WithCommanderUUID(c.CommanderUUID).
+		WithSkipPhases(phasesToSkip)
 
 	err = r.RunConverge(convergeCtx)
 	if err != nil {
@@ -273,7 +279,7 @@ func (c *Converger) AutoConverge() error {
 	r := newRunner(inLockRunner, convergectx.NewKubeClientSwitcher(convergeCtx, inLockRunner)).
 		WithCommanderUUID(c.CommanderUUID).
 		WithExcludedNodes([]string{app.RunningNodeName}).
-		WithSkipPhases([]phases.OperationPhase{phases.AllNodesPhase})
+		WithSkipPhases([]phases.OperationPhase{phases.AllNodesPhase, phases.DeckhouseConfigurationPhase})
 
 	converger := NewAutoConverger(r, app.AutoConvergeListenAddress, app.ApplyInterval)
 	return converger.Start(convergeCtx)

--- a/dhctl/pkg/operations/converge/runner.go
+++ b/dhctl/pkg/operations/converge/runner.go
@@ -291,9 +291,13 @@ func (r *runner) converge(ctx *context.Context) error {
 		log.InfoLn("Skip converge nodes")
 	}
 
-	err = r.convergeDeckhouseConfiguration(ctx, r.commanderUUID)
-	if err != nil {
-		return err
+	if !r.isSkip(phases.DeckhouseConfigurationPhase) {
+		err = r.convergeDeckhouseConfiguration(ctx, r.commanderUUID)
+		if err != nil {
+			return err
+		}
+	} else {
+		log.InfoLn("Skip converge deckhouse configuration")
 	}
 
 	if kubeClientSwitched {

--- a/dhctl/pkg/operations/phases/phases.go
+++ b/dhctl/pkg/operations/phases/phases.go
@@ -36,9 +36,10 @@ const (
 	DeleteResourcesPhase                   OperationPhase = "DeleteResources"
 	ExecPostBootstrapPhase                 OperationPhase = "ExecPostBootstrap"
 	// converge only
-	AllNodesPhase            OperationPhase = "AllNodes"
-	ScaleToMultiMasterPhase  OperationPhase = "ScaleToMultiMaster"
-	ScaleToSingleMasterPhase OperationPhase = "ScaleToSingleMaster"
+	AllNodesPhase               OperationPhase = "AllNodes"
+	ScaleToMultiMasterPhase     OperationPhase = "ScaleToMultiMaster"
+	ScaleToSingleMasterPhase    OperationPhase = "ScaleToSingleMaster"
+	DeckhouseConfigurationPhase OperationPhase = "DeckhouseConfiguration"
 	// all
 	FinalizationPhase OperationPhase = "Finalization"
 )


### PR DESCRIPTION
## Description
Disable caching metaconfig during converge and disable converge deckhouse manifests.

## Why do we need it, and what problem does it solve?
Caching metaconfig during converge break autoconverger logic. Because we load metaconfig once autoconverge does not getting actual config during attempts.

Together with converge deckhouse manifests it can revert changes in provider and cluster configuration.
Also, converge deckhouse manifest should enabled only for commander.  

## Why do we need it in the patch release (if we do)?
Autoconverger and converge operation can revert changes in cluster and provider cluster configuration. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: <Disable caching metaconfig during converge and disable converge deckhouse manifests.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
