### PR TITLE
[deckhouse] restore only ready mpo

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -122,6 +122,11 @@ func (l *Loader) restoreAbsentModulesFromOverrides(ctx context.Context) error {
 			continue
 		}
 
+		// skip unready mpo
+		if mpo.Status.Message != v1alpha1.ModulePullOverrideMessageReady {
+			continue
+		}
+
 		module := new(v1alpha1.Module)
 		if err := l.client.Get(ctx, client.ObjectKey{Name: mpo.Name}, module); err != nil {
 			if !apierrors.IsNotFound(err) {

--- a/deckhouse-controller/pkg/controller/moduleloader/testdata/overrides/mpo-with-old-deployed-on.yaml
+++ b/deckhouse-controller/pkg/controller/moduleloader/testdata/overrides/mpo-with-old-deployed-on.yaml
@@ -84,6 +84,6 @@ spec:
   source: losev-test
 status:
   imageDigest: sha256:379b341598e85104ffe01643af6eeff5e1022ca60b4cc90be639b8ec59c61a47
-  message: ""
+  message: "Ready"
   updatedAt: "2024-05-22T10:05:45Z"
   weight: 900

--- a/deckhouse-controller/pkg/controller/moduleloader/testdata/overrides/mpo-without-weight.yaml
+++ b/deckhouse-controller/pkg/controller/moduleloader/testdata/overrides/mpo-without-weight.yaml
@@ -84,5 +84,5 @@ spec:
   source: losev-test
 status:
   imageDigest: sha256:379b341598e85104ffe01643af6eeff5e1022ca60b4cc90be639b8ec59c61a47
-  message: ""
+  message: "Ready"
   updatedAt: "2024-05-22T10:05:45Z"

--- a/deckhouse-controller/pkg/controller/moduleloader/testdata/overrides/mpo.yaml
+++ b/deckhouse-controller/pkg/controller/moduleloader/testdata/overrides/mpo.yaml
@@ -84,6 +84,6 @@ spec:
   source: losev-test
 status:
   imageDigest: sha256:379b341598e85104ffe01643af6eeff5e1022ca60b4cc90be639b8ec59c61a47
-  message: ""
+  message: "Ready"
   updatedAt: "2024-05-22T10:05:45Z"
   weight: 900


### PR DESCRIPTION
## Description
It restore only ready mpo.

## Why do we need it, and what problem does it solve?
Useless to restore unready mpo.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Restore only ready mpo.
impact_level: low
```
