### PR TITLE
[cni-cilium] Fix the examples in the `Egressgateway` documentation.

### DIFF
--- a/docs/site/pages/stronghold/documentation/admin/platform-management/network/EGRESS.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/network/EGRESS.md
@@ -18,7 +18,7 @@ The EgressGateway resource describes a node group that functions as an Egress ga
 To add a node to this group, assign a corresponding label to it:
 
 ```shell
-d8 k label node <node name> node-role.deckhouse.io/egress=
+d8 k label node <node name> dedicated/egress=
 ```
 
 ### PrimaryIPFromEgressGatewayNodeInterface mode
@@ -36,7 +36,7 @@ metadata:
   name: egress-gw
 spec:
   nodeSelector:
-    node-role.deckhouse.io/egress: ""
+    dedicated/egress: ""
   sourceIP:
     # The primary IP address bound to the public network interface of the node will be used as the IP address
     mode: PrimaryIPFromEgressGatewayNodeInterface
@@ -66,7 +66,7 @@ metadata:
   name: egress-gw
 spec:
   nodeSelector:
-    node-role.deckhouse.io/egress: ""
+    dedicated/egress: ""
   sourceIP:
     # The primary IP address bound to the public network interface of the node will be used as the IP address
     mode: VirtualIPAddress
@@ -90,7 +90,7 @@ To check whether a node is suitable for inclusion to the Egress gateway group, r
 
 ```shell
 # Display nodes specified by spec.nodeSelector:
-d8 k get nodes -l node-role.deckhouse.io/egress="" -ojson | jq -r '.items[].metadata.name'
+d8 k get nodes -l dedicated/egress="" -ojson | jq -r '.items[].metadata.name'
 
 # Display nodes in the Ready status:
 d8 k get nodes -ojson | jq -r '.items[] | select(.status.conditions[] | select(.type == "Ready" and .status == "True")) | .metadata.name'

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/network/EGRESS_RU.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/network/EGRESS_RU.md
@@ -19,7 +19,7 @@ lang: ru
 Для включения узла в эту группу нужно назначить ему соответствующую метку:
 
 ```shell
-d8 k label node <имя узла> node-role.deckhouse.io/egress=
+d8 k label node <имя узла> dedicated/egress=
 ```
 
 ### Режим PrimaryIPFromEgressGatewayNodeInterface
@@ -37,7 +37,7 @@ metadata:
   name: egress-gw
 spec:
   nodeSelector:
-    node-role.deckhouse.io/egress: ""
+    dedicated/egress: ""
   sourceIP:
     # В качестве IP-адреса будет использоваться primary IP-адрес на публичном сетевом интерфейсе узла.
     mode: PrimaryIPFromEgressGatewayNodeInterface
@@ -65,7 +65,7 @@ metadata:
   name: egress-gw
 spec:
   nodeSelector:
-    node-role.deckhouse.io/egress: ""
+    dedicated/egress: ""
   sourceIP:
     # В качестве IP-адреса будет использоваться primary IP-адрес на публичном сетевом интерфейсе узла.
     mode: VirtualIPAddress
@@ -89,7 +89,7 @@ EOF
 
 ```shell
 # Вывести узлы, подпадающие под spec.nodeSelector:
-d8 k get nodes -l node-role.deckhouse.io/egress="" -ojson | jq -r '.items[].metadata.name'
+d8 k get nodes -l dedicated/egress="" -ojson | jq -r '.items[].metadata.name'
 
 # Вывести узлы в состоянии Ready:
 d8 k get nodes -ojson | jq -r '.items[] | select(.status.conditions[] | select(.type == "Ready" and .status == "True")) | .metadata.name'

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/network/EGRESS.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/network/EGRESS.md
@@ -18,7 +18,7 @@ The EgressGateway resource describes a node group that functions as an Egress ga
 To add a node to this group, assign a corresponding label to it:
 
 ```shell
-d8 k label node <node name> node-role.deckhouse.io/egress=
+d8 k label node <node name> dedicated/egress=
 ```
 
 ### PrimaryIPFromEgressGatewayNodeInterface mode
@@ -36,7 +36,7 @@ metadata:
   name: egress-gw
 spec:
   nodeSelector:
-    node-role.deckhouse.io/egress: ""
+    dedicated/egress: ""
   sourceIP:
     # The primary IP address bound to the public network interface of the node will be used as the IP address
     mode: PrimaryIPFromEgressGatewayNodeInterface
@@ -66,7 +66,7 @@ metadata:
   name: egress-gw
 spec:
   nodeSelector:
-    node-role.deckhouse.io/egress: ""
+    dedicated/egress: ""
   sourceIP:
     # The primary IP address bound to the public network interface of the node will be used as the IP address
     mode: VirtualIPAddress
@@ -90,7 +90,7 @@ To check whether a node is suitable for inclusion to the Egress gateway group, r
 
 ```shell
 # Display nodes specified by spec.nodeSelector:
-d8 k get nodes -l node-role.deckhouse.io/egress="" -ojson | jq -r '.items[].metadata.name'
+d8 k get nodes -l dedicated/egress="" -ojson | jq -r '.items[].metadata.name'
 
 # Display nodes in the Ready status:
 d8 k get nodes -ojson | jq -r '.items[] | select(.status.conditions[] | select(.type == "Ready" and .status == "True")) | .metadata.name'

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/network/EGRESS_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/network/EGRESS_RU.md
@@ -19,7 +19,7 @@ lang: ru
 Для включения узла в эту группу нужно назначить ему соответствующую метку:
 
 ```shell
-d8 k label node <имя узла> node-role.deckhouse.io/egress=
+d8 k label node <имя узла> dedicated/egress=
 ```
 
 ### Режим PrimaryIPFromEgressGatewayNodeInterface
@@ -37,7 +37,7 @@ metadata:
   name: egress-gw
 spec:
   nodeSelector:
-    node-role.deckhouse.io/egress: ""
+    dedicated/egress: ""
   sourceIP:
     # В качестве IP-адреса будет использоваться primary IP-адрес на публичном сетевом интерфейсе узла.
     mode: PrimaryIPFromEgressGatewayNodeInterface
@@ -65,7 +65,7 @@ metadata:
   name: egress-gw
 spec:
   nodeSelector:
-    node-role.deckhouse.io/egress: ""
+    dedicated/egress: ""
   sourceIP:
     # В качестве IP-адреса будет использоваться primary IP-адрес на публичном сетевом интерфейсе узла.
     mode: VirtualIPAddress
@@ -89,7 +89,7 @@ EOF
 
 ```shell
 # Вывести узлы, подпадающие под spec.nodeSelector:
-d8 k get nodes -l node-role.deckhouse.io/egress="" -ojson | jq -r '.items[].metadata.name'
+d8 k get nodes -l dedicated/egress="" -ojson | jq -r '.items[].metadata.name'
 
 # Вывести узлы в состоянии Ready:
 d8 k get nodes -ojson | jq -r '.items[] | select(.status.conditions[] | select(.type == "Ready" and .status == "True")) | .metadata.name'

--- a/modules/021-cni-cilium/docs/EXAMPLES.md
+++ b/modules/021-cni-cilium/docs/EXAMPLES.md
@@ -34,14 +34,14 @@ metadata:
   name: my-egressgw
 spec:
   nodeSelector:
-    node-role.deckhouse.io/egress: ""
+    dedicated/egress: ""
   sourceIP:
     mode: PrimaryIPFromEgressGatewayNodeInterface
     primaryIPFromEgressGatewayNodeInterface:
       # The "public" interface must have the same name on all nodes that matching the nodeSelector.
       # If the active node fails, traffic will be redirected through the backup node and
       # the source IP address of the network packets will change.
-      interfaceName: eth1 
+      interfaceName: eth1
 ```
 
 #### EgressGateway in VirtualIPAddress mode (Virtual IP mode)
@@ -53,7 +53,7 @@ metadata:
   name: my-egressgw
 spec:
   nodeSelector:
-    node-role.deckhouse.io/egress: ""
+    dedicated/egress: ""
   sourceIP:
     mode: VirtualIPAddress
     virtualIPAddress:

--- a/modules/021-cni-cilium/docs/EXAMPLES_RU.md
+++ b/modules/021-cni-cilium/docs/EXAMPLES_RU.md
@@ -34,7 +34,7 @@ metadata:
   name: myegressgw
 spec:
   nodeSelector:
-    node-role.deckhouse.io/egress: ""
+    dedicated/egress: ""
   sourceIP:
     mode: PrimaryIPFromEgressGatewayNodeInterface
     primaryIPFromEgressGatewayNodeInterface:
@@ -53,7 +53,7 @@ metadata:
   name: myeg
 spec:
   nodeSelector:
-    node-role.deckhouse.io/egress: ""
+    dedicated/egress: ""
   sourceIP:
     mode: VirtualIPAddress
     virtualIPAddress:


### PR DESCRIPTION
## Description

In the examples from the `EgressGateway` documentation, the label that specifies which nodes should run `EgressGateway` components has been changed from `node-role.deckhouse.io/egress: ""` to `dedicated/egress: ""`. 

## Why do we need it, and what problem does it solve?

Labels `node-role.deckhouse.io` are reserved and keys can only contain `master`, `system` or `frontend`, or the names of specific D8 modules. As egress is part of the cni-cilium (and not an independent module), an alert is triggered when this label is used. This can lead to confusion. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Fixed the examples in the `Egressgateway` documentation.
impact_level: low
```
