### PR TITLE
[descheduler] Add global parameters to Descheduler CRD

### DIFF
--- a/modules/400-descheduler/crds/deschedulers.yaml
+++ b/modules/400-descheduler/crds/deschedulers.yaml
@@ -483,6 +483,13 @@ spec:
                   oneOf:
                     - required: ["name"]
                     - required: ["value"]
+                evictLocalStoragePods:
+                  type: object
+                  description: Allows Pods using local storage to be evicted.
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Make the option is active.
                 strategies:
                   type: object
                   description: Settings of strategies for the Descheduler instances.

--- a/modules/400-descheduler/crds/deschedulers.yaml
+++ b/modules/400-descheduler/crds/deschedulers.yaml
@@ -484,7 +484,7 @@ spec:
                     - required: ["name"]
                     - required: ["value"]
                 evictLocalStoragePods:
-                  type: object
+                  type: boolean
                   description: Allows Pods using local storage to be evicted.
                   properties:
                     enabled:

--- a/modules/400-descheduler/crds/deschedulers.yaml
+++ b/modules/400-descheduler/crds/deschedulers.yaml
@@ -486,10 +486,6 @@ spec:
                 evictLocalStoragePods:
                   type: boolean
                   description: Allows Pods using local storage to be evicted.
-                  properties:
-                    enabled:
-                      type: boolean
-                      description: Make the option is active.
                 strategies:
                   type: object
                   description: Settings of strategies for the Descheduler instances.

--- a/modules/400-descheduler/crds/deschedulers.yaml
+++ b/modules/400-descheduler/crds/deschedulers.yaml
@@ -485,6 +485,7 @@ spec:
                     - required: ["value"]
                 evictLocalStoragePods:
                   type: boolean
+                  default: false
                   description: Allows Pods using local storage to be evicted.
                 strategies:
                   type: object

--- a/modules/400-descheduler/crds/doc-ru-deschedulers.yaml
+++ b/modules/400-descheduler/crds/doc-ru-deschedulers.yaml
@@ -251,6 +251,11 @@ spec:
                       description: Имя класса приоритета.
                     value:
                       description: Значение класса приоритета.
+                evictLocalStoragePods:
+                  description: Позволяет вытеснять поды, использующие локальное хранилище.
+                  properties:
+                    enabled:
+                      description: Делает стратегию активной.
                 strategies:
                   description:
                     Настройки стратегий данного экземпляра ресурса Descheduler.

--- a/modules/400-descheduler/crds/doc-ru-deschedulers.yaml
+++ b/modules/400-descheduler/crds/doc-ru-deschedulers.yaml
@@ -253,9 +253,6 @@ spec:
                       description: Значение класса приоритета.
                 evictLocalStoragePods:
                   description: Позволяет вытеснять поды, использующие локальное хранилище.
-                  properties:
-                    enabled:
-                      description: Делает стратегию активной.
                 strategies:
                   description:
                     Настройки стратегий данного экземпляра ресурса Descheduler.

--- a/modules/400-descheduler/hooks/get_crds.go
+++ b/modules/400-descheduler/hooks/get_crds.go
@@ -67,6 +67,7 @@ type InternalValuesDeschedulerSpec struct {
 	PodLabelSelector       *metav1.LabelSelector              `json:"podLabelSelector,omitempty" yaml:"podLabelSelector,omitempty"`
 	NamespaceLabelSelector *metav1.LabelSelector              `json:"namespaceLabelSelector,omitempty" yaml:"namespaceLabelSelector,omitempty"`
 	PriorityClassThreshold *dsv1alpha2.PriorityClassThreshold `json:"priorityClassThreshold,omitempty" yaml:"priorityClassThreshold,omitempty"`
+	EvictLocalStoragePods  *dsv1alpha2.EvictLocalStoragePods  `json:"evictLocalStoragePods,omitempty" yaml:"evictLocalStoragePods,omitempty"`
 	Strategies             dsv1alpha2.Strategies              `json:"strategies" yaml:"strategies"`
 }
 
@@ -92,6 +93,9 @@ func getCRDsHandler(input *go_hook.HookInput) error {
 		}
 		if item.Spec.PriorityClassThreshold != nil {
 			ds.PriorityClassThreshold = item.Spec.PriorityClassThreshold
+		}
+		if item.Spec.EvictLocalStoragePods != nil {
+			ds.EvictLocalStoragePods = item.Spec.EvictLocalStoragePods
 		}
 
 		internalValues = append(internalValues, *ds)

--- a/modules/400-descheduler/hooks/get_crds_test.go
+++ b/modules/400-descheduler/hooks/get_crds_test.go
@@ -161,6 +161,7 @@ var _ = Describe("Modules :: descheduler :: hooks :: get_crds ::", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("descheduler.internal.deschedulers").String()).To(MatchYAML(`
 - name: test
+  evictLocalStoragePods: false
   strategies:
     lowNodeUtilization:
       enabled: true
@@ -188,6 +189,7 @@ var _ = Describe("Modules :: descheduler :: hooks :: get_crds ::", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("descheduler.internal.deschedulers").String()).To(MatchYAML(`
 - name: test
+  evictLocalStoragePods: false
   strategies:
     lowNodeUtilization:
       enabled: true
@@ -234,6 +236,7 @@ var _ = Describe("Modules :: descheduler :: hooks :: get_crds ::", func() {
 			Expect(f.ValuesGet("descheduler.internal.deschedulers").String()).To(MatchYAML(`
 - nodeLabelSelector: node.deckhouse.io/group in (test1,test2)
   name: test3
+  evictLocalStoragePods: false
   strategies:
     highNodeUtilization:
       enabled: true
@@ -257,6 +260,7 @@ var _ = Describe("Modules :: descheduler :: hooks :: get_crds ::", func() {
 			Expect(f.ValuesGet("descheduler.internal.deschedulers").String()).To(MatchYAML(`
 - nodeLabelSelector: node.deckhouse.io/group=test3
   name: test4
+  evictLocalStoragePods: false
   strategies:
     highNodeUtilization:
       enabled: false
@@ -280,6 +284,7 @@ var _ = Describe("Modules :: descheduler :: hooks :: get_crds ::", func() {
 			Expect(f.ValuesGet("descheduler.internal.deschedulers").String()).To(MatchYAML(`
 - nodeLabelSelector: node.deckhouse.io/group in (test1,test2)
   name: test5
+  evictLocalStoragePods: false
   podLabelSelector:
     matchExpressions:
       - key: dbType

--- a/modules/400-descheduler/hooks/get_crds_test.go
+++ b/modules/400-descheduler/hooks/get_crds_test.go
@@ -203,6 +203,7 @@ var _ = Describe("Modules :: descheduler :: hooks :: get_crds ::", func() {
         memory: 20
         pods: 30
 - name: test2
+  evictLocalStoragePods: false
   strategies:
     highNodeUtilization:
       enabled: false

--- a/modules/400-descheduler/hooks/internal/v1alpha2/descheduler.go
+++ b/modules/400-descheduler/hooks/internal/v1alpha2/descheduler.go
@@ -42,12 +42,17 @@ type DeschedulerSpec struct {
 	PodLabelSelector       *metav1.LabelSelector   `json:"podLabelSelector,omitempty" yaml:"podLabelSelector,omitempty"`
 	NamespaceLabelSelector *metav1.LabelSelector   `json:"namespaceLabelSelector,omitempty" yaml:"namespaceLabelSelector,omitempty"`
 	PriorityClassThreshold *PriorityClassThreshold `json:"priorityClassThreshold,omitempty" yaml:"priorityClassThreshold,omitempty"`
+	EvictLocalStoragePods  *EvictLocalStoragePods  `json:"evictLocalStoragePods,omitempty" yaml:"evictLocalStoragePods,omitempty"`
 	Strategies             Strategies              `json:"strategies" yaml:"strategies"`
 }
 
 type PriorityClassThreshold struct {
 	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
 	Value int    `json:"value,omitempty" yaml:"value,omitempty"`
+}
+
+type EvictLocalStoragePods struct {
+	Enabled bool `json:"enabled" yaml:"enabled"`
 }
 
 type Strategies struct {

--- a/modules/400-descheduler/hooks/internal/v1alpha2/descheduler.go
+++ b/modules/400-descheduler/hooks/internal/v1alpha2/descheduler.go
@@ -51,9 +51,7 @@ type PriorityClassThreshold struct {
 	Value int    `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
-type EvictLocalStoragePods struct {
-	Enabled bool `json:"enabled" yaml:"enabled"`
-}
+type EvictLocalStoragePods bool
 
 type Strategies struct {
 	LowNodeUtilization                      *LowNodeUtilization                      `json:"lowNodeUtilization,omitempty" yaml:"lowNodeUtilization,omitempty"`

--- a/modules/400-descheduler/openapi/openapi-case-tests.yaml
+++ b/modules/400-descheduler/openapi/openapi-case-tests.yaml
@@ -40,3 +40,18 @@ positive:
                   memory: 50
                   pods: 50
                   gpu: "gpuNode"
+          - name: test3
+            evictLocalStoragePods:
+              enabled: false
+            strategies:
+              lowNodeUtilization:
+                enabled: true
+                thresholds:
+                  cpu: 10
+                  memory: 20
+                  pods: 30
+                targetThresholds:
+                  cpu: 40
+                  memory: 50
+                  pods: 50
+                  gpu: "gpuNode"

--- a/modules/400-descheduler/openapi/openapi-case-tests.yaml
+++ b/modules/400-descheduler/openapi/openapi-case-tests.yaml
@@ -41,8 +41,7 @@ positive:
                   pods: 50
                   gpu: "gpuNode"
           - name: test3
-            evictLocalStoragePods:
-              enabled: false
+            evictLocalStoragePods: false
             strategies:
               lowNodeUtilization:
                 enabled: true

--- a/modules/400-descheduler/openapi/values.yaml
+++ b/modules/400-descheduler/openapi/values.yaml
@@ -139,6 +139,11 @@ properties:
               oneOf:
                 - required: ["name"]
                 - required: ["value"]
+            evictLocalStoragePods:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
             strategies:
               type: object
               default: {}

--- a/modules/400-descheduler/openapi/values.yaml
+++ b/modules/400-descheduler/openapi/values.yaml
@@ -140,10 +140,7 @@ properties:
                 - required: ["name"]
                 - required: ["value"]
             evictLocalStoragePods:
-              type: object
-              properties:
-                enabled:
-                  type: boolean
+              type: boolean
             strategies:
               type: object
               default: {}

--- a/modules/400-descheduler/template_tests/module_test.go
+++ b/modules/400-descheduler/template_tests/module_test.go
@@ -110,8 +110,7 @@ internal:
           memory: 23
           pods: 3
   - name: test4
-    evictLocalStoragePods:
-      enabled: true
+    evictLocalStoragePods: true
     strategies:
       lowNodeUtilization:
         enabled: true

--- a/modules/400-descheduler/template_tests/module_test.go
+++ b/modules/400-descheduler/template_tests/module_test.go
@@ -109,6 +109,21 @@ internal:
           cpu: 14
           memory: 23
           pods: 3
+  - name: test4
+    evictLocalStoragePods:
+      enabled: true
+    strategies:
+      lowNodeUtilization:
+        enabled: true
+        thresholds:
+          cpu: 10
+          memory: 20
+          pods: 30
+        targetThresholds:
+          cpu: 40
+          memory: 50
+          pods: 50
+          gpu: "gpuNode"
 `
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
@@ -230,6 +245,36 @@ profiles:
     balance:
       enabled:
       - HighNodeUtilization
+    filter:
+      enabled:
+      - DefaultEvictor
+    preEvictionFilter:
+      enabled:
+      - DefaultEvictor
+- name: test4
+  pluginConfig:
+  - args:
+      evictFailedBarePods: true
+      evictLocalStoragePods: true
+      evictSystemCriticalPods: false
+      ignorePvcPods: false
+      nodeFit: true
+    name: DefaultEvictor
+  - args:
+      targetThresholds:
+        cpu: 40
+        gpu: gpuNode
+        memory: 50
+        pods: 50
+      thresholds:
+        cpu: 10
+        memory: 20
+        pods: 30
+    name: LowNodeUtilization
+  plugins:
+    balance:
+      enabled:
+      - LowNodeUtilization
     filter:
       enabled:
       - DefaultEvictor

--- a/modules/400-descheduler/templates/configmap.yaml
+++ b/modules/400-descheduler/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
           {{- if $d.nodeLabelSelector }}
           nodeSelector: {{ $d.nodeLabelSelector }}
           {{- end }}
-          evictLocalStoragePods: {{ if $d.evictLocalStoragePods }}{{ $d.evictLocalStoragePods.enabled }}{{- else }}false{{- end }}
+          evictLocalStoragePods: {{ if $d.evictLocalStoragePods }}{{ $d.evictLocalStoragePods }}{{- else }}false{{- end }}
           evictSystemCriticalPods: false
           ignorePvcPods: false
           evictFailedBarePods: true

--- a/modules/400-descheduler/templates/configmap.yaml
+++ b/modules/400-descheduler/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
           {{- if $d.nodeLabelSelector }}
           nodeSelector: {{ $d.nodeLabelSelector }}
           {{- end }}
-          evictLocalStoragePods: false
+          evictLocalStoragePods: {{ if $d.evictLocalStoragePods }}{{ $d.evictLocalStoragePods.enabled }}{{- else }}false{{- end }}
           evictSystemCriticalPods: false
           ignorePvcPods: false
           evictFailedBarePods: true


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Closes #13172

This pr allow to add evictLocalStoragePods option as boolean parameters in descheduler cr, ex.
```
---
apiVersion: deckhouse.io/v1alpha2
kind: Descheduler
metadata:
  name: low-node-utilization
spec:
  evictLocalStoragePods: true
  strategies:
    lowNodeUtilization:
      enabled: true
```
```
kubectl -nd8-descheduler get cm descheduler-policy -oyaml
apiVersion: v1
data:
  policy.yaml: |
    apiVersion: "descheduler/v1alpha2"
    kind: "DeschedulerPolicy"
    profiles:
    - name: low-node-utilization
      pluginConfig:
      - name: "DefaultEvictor"
        args:
          evictLocalStoragePods: true
...
```
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this pr allow edit global parameters in used strategies in descheduler cr
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: descheduler
type: feature
summary: add crd descheduler global parameters
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
