### PR TITLE
[istio] fix RBAC rules for HuaweiCloud CCM

### DIFF
--- a/modules/110-istio/templates/rbac-to-us.yaml
+++ b/modules/110-istio/templates/rbac-to-us.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.clusterConfiguration.cloud.provider "Huaweicloud" }}
+{{- if (.Values.global.enabledModules | has "cloud-provider-huaweicloud") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

If the `cloud-provider-huaweicloud` module is enabled, define `RBAC` permissions granting the `cloud-controller-manager` access to list pods in the `d8-istio` namespace.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

An error occurred in the prior implementation:
```
{
    "level": "error",
    "logger": "addon-operator",
    "msg": "ModuleRun failed. Requeue task to retry after delay.",
    "binding": "ConvergeModules",
    "count": 24,
    "error": "run helm install: template: istio/templates/rbac-to-us.yaml:1:17: executing \"istio/templates/rbac-to-us.yaml\" at <.Values.global.clusterConfiguration.cloud.provider>: nil pointer evaluating interface {}.provider\n\nUse --debug flag to render out invalid YAML",
    "event.type": "OperatorStartup",
    "module": "istio",
    "phase": "RunHelm",
    "queue": "main",
    "task.id": "e9d7d735-5f3e-452a-b462-e1f9fe52c569",
    "stacktrace": [
        {
            "ID": 585,
            "State": "running",
            "Wait": 0,
            "LockedToThread": false,
            "Stack": [
                {
                    "Func": "runtime/debug.Stack",
                    "File": "/usr/lib/golang/src/runtime/debug/stack.go",
                    "Line": 26
                },
                {
                    "Func": "github.com/deckhouse/deckhouse/pkg/log.getStack",
                    "File": "/deckhouse/pkg/log/logger.go",
                    "Line": 258
                },
                {
                    "Func": "github.com/deckhouse/deckhouse/pkg/log.(*Logger).Error",
                    "File": "/deckhouse/pkg/log/logger.go",
                    "Line": 225
                },
                {
                    "Func": "github.com/flant/addon-operator/pkg/addon-operator.(*AddonOperator).HandleModuleRun",
                    "File": "/root/go/pkg/mod/github.com/flant/addon-operator@v1.6.2/pkg/addon-operator/operator.go",
                    "Line": 2090
                },
                {
                    "Func": "github.com/flant/addon-operator/pkg/addon-operator.(*AddonOperator).TaskHandler",
                    "File": "/root/go/pkg/mod/github.com/flant/addon-operator@v1.6.2/pkg/addon-operator/operator.go",
                    "Line": 1418
                },
                {
                    "Func": "github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start.func1",
                    "File": "/root/go/pkg/mod/github.com/flant/shell-operator@v1.6.1/pkg/task/queue/task_queue.go",
                    "Line": 441
                }
            ],
            "FramesElided": false,
            "CreatedBy": {
                "Func": "github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start",
                "File": "/root/go/pkg/mod/github.com/flant/shell-operator@v1.6.1/pkg/task/queue/task_queue.go",
                "Line": 422
            }
        }
    ],
    "time": "2025-04-29T07:19:36Z"
}
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: If the `cloud-provider-huaweicloud` module is enabled, define `RBAC` permissions granting the `cloud-controller-manager` access to list pods in the `d8-istio` namespace.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
