### PR TITLE
[docs] Added alert about latest version at Deckhouse CLI documentation

### DIFF
--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -55,11 +55,13 @@
 
 {% if page.lang == 'ru' %}
 {% alert level="warning" %}
-Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя сборка доступна на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Команды ниже актуальны для Deckhouse CLI версии {{ site.data.supported_versions.d8.d8CliVersion }}, поставляемой с Deckhouse Kubernetes Platform. Последняя версия Deckhouse CLI доступна на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Узнать используемую версию Deckhouse CLI можно при помощи команды `d8 --version`. 
 {% endalert %}
 {% else %}
 {% alert level="warning" %}
-Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest available release is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+The commands below apply to Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }}, which is bundled with the Deckhouse Kubernetes Platform. The latest version of Deckhouse CLI is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+You can check your current Deckhouse CLI version using the `d8 --version` command.
 {% endalert %}
 {% endif %}
 

--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -1,3 +1,15 @@
+{% if page.lang == 'ru' %}
+{% alert level="warning" %}
+Команды ниже актуальны для Deckhouse CLI версии {{ site.data.supported_versions.d8.d8CliVersion }}, поставляемой с Deckhouse Kubernetes Platform. Последняя версия Deckhouse CLI доступна на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Узнать используемую версию Deckhouse CLI можно при помощи команды `d8 --version`. 
+{% endalert %}
+{% else %}
+{% alert level="warning" %}
+The commands below apply to Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }}, which is bundled with the Deckhouse Kubernetes Platform. The latest version of Deckhouse CLI is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+You can check your current Deckhouse CLI version using the `d8 --version` command.
+{% endalert %}
+{% endif %}
+
 {% if include.os == "Windows" %}
 1. {% if page.lang == 'ru' %}Скачайте [архив для {{ include.os }} {{ include.arch }}]{% else %}Download the [archive for {{ include.os }} {{ include.arch }}]{% endif -%}
 ({%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/{{ site.data.supported_versions.d8.d8CliVersion }}/d8-{{ site.data.supported_versions.d8.d8CliVersion }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz) {% if page.lang == 'ru' %}
@@ -51,18 +63,6 @@
    ```shell
    curl -LO {{ site.urls[page.lang] }}/downloads/deckhouse-cli/{{ site.data.supported_versions.d8.d8CliVersion }}/d8-{{ site.data.supported_versions.d8.d8CliVersion }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz
    ```
-{% endif %}
-
-{% if page.lang == 'ru' %}
-{% alert level="warning" %}
-Команды ниже актуальны для Deckhouse CLI версии {{ site.data.supported_versions.d8.d8CliVersion }}, поставляемой с Deckhouse Kubernetes Platform. Последняя версия Deckhouse CLI доступна на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
-Узнать используемую версию Deckhouse CLI можно при помощи команды `d8 --version`. 
-{% endalert %}
-{% else %}
-{% alert level="warning" %}
-The commands below apply to Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }}, which is bundled with the Deckhouse Kubernetes Platform. The latest version of Deckhouse CLI is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
-You can check your current Deckhouse CLI version using the `d8 --version` command.
-{% endalert %}
 {% endif %}
 
 {% if include.os == "Windows" %}

--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -55,11 +55,11 @@
 
 {% if page.lang == 'ru' %}
 {% alert level="warning" %}
-Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя доступная версия опубликована на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя доступная версия утилиты опубликована на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% else %}
 {% alert level="warning" %}
-Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest version is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest available version of the CLI is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% endif %}
 

--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -55,11 +55,11 @@
 
 {% if page.lang == 'ru' %}
 {% alert level="warning" %}
-Версия Deckhouse CLI `{{ site.data.supported_versions.d8.d8CliVersion }}` входит в состав текущей версии Deckhouse. Если вы используете другую версию платформы, убедитесь, что загружаете совместимую версию утилиты. Последняя доступная версия опубликована на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя доступная версия опубликована на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% else %}
 {% alert level="warning" %}
-Deckhouse CLI version `{{ site.data.supported_versions.d8.d8CliVersion }}` is bundled with this version of Deckhouse. If you're using a different version of the platform, make sure to download a compatible CLI version. The latest version is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest version is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% endif %}
 

--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -55,11 +55,11 @@
 
 {% if page.lang == 'ru' %}
 {% alert level="warning" %}
-Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя доступная версия утилиты опубликована на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя доступная сборка доступна на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% else %}
 {% alert level="warning" %}
-Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest available version of the CLI is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest available release is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% endif %}
 

--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -55,7 +55,7 @@
 
 {% if page.lang == 'ru' %}
 {% alert level="warning" %}
-Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя доступная сборка доступна на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя сборка доступна на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% else %}
 {% alert level="warning" %}

--- a/docs/documentation/_includes/d8-cli-install/content.liquid
+++ b/docs/documentation/_includes/d8-cli-install/content.liquid
@@ -53,6 +53,16 @@
    ```
 {% endif %}
 
+{% if page.lang == 'ru' %}
+{% alert level="warning" %}
+Версия Deckhouse CLI `{{ site.data.supported_versions.d8.d8CliVersion }}` входит в состав текущей версии Deckhouse. Если вы используете другую версию платформы, убедитесь, что загружаете совместимую версию утилиты. Последняя доступная версия опубликована на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+{% endalert %}
+{% else %}
+{% alert level="warning" %}
+Deckhouse CLI version `{{ site.data.supported_versions.d8.d8CliVersion }}` is bundled with this version of Deckhouse. If you're using a different version of the platform, make sure to download a compatible CLI version. The latest version is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+{% endalert %}
+{% endif %}
+
 {% if include.os == "Windows" %}
 {%    if page.lang == 'ru' -%}
 1. Распакуйте архив, переместите файл `d8.exe` в выбранный вами каталог и добавьте каталог в переменную `PATH` операционной системы.

--- a/docs/site/_includes/d8-cli-install/content.liquid
+++ b/docs/site/_includes/d8-cli-install/content.liquid
@@ -55,11 +55,13 @@
 
 {% if page.lang == 'ru' %}
 {% alert level="warning" %}
-Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя доступная сборка доступна на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Команды ниже актуальны для Deckhouse CLI версии {{ site.data.supported_versions.d8.d8CliVersion }}, поставляемой с Deckhouse Kubernetes Platform. Последняя версия Deckhouse CLI доступна на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Узнать используемую версию Deckhouse CLI можно при помощи команды `d8 --version`. 
 {% endalert %}
 {% else %}
 {% alert level="warning" %}
-Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest release is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+The commands below apply to Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }}, which is bundled with the Deckhouse Kubernetes Platform. The latest version of Deckhouse CLI is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+You can check your current Deckhouse CLI version using the `d8 --version` command.
 {% endalert %}
 {% endif %}
 

--- a/docs/site/_includes/d8-cli-install/content.liquid
+++ b/docs/site/_includes/d8-cli-install/content.liquid
@@ -1,3 +1,15 @@
+{% if page.lang == 'ru' %}
+{% alert level="warning" %}
+Команды ниже актуальны для Deckhouse CLI версии {{ site.data.supported_versions.d8.d8CliVersion }}, поставляемой с Deckhouse Kubernetes Platform. Последняя версия Deckhouse CLI доступна на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Узнать используемую версию Deckhouse CLI можно при помощи команды `d8 --version`. 
+{% endalert %}
+{% else %}
+{% alert level="warning" %}
+The commands below apply to Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }}, which is bundled with the Deckhouse Kubernetes Platform. The latest version of Deckhouse CLI is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+You can check your current Deckhouse CLI version using the `d8 --version` command.
+{% endalert %}
+{% endif %}
+
 {% if include.os == "Windows" %}
 1. {% if page.lang == 'ru' %}Скачайте [архив для {{ include.os }} {{ include.arch }}]{% else %}Download the [archive for {{ include.os }} {{ include.arch }}]{% endif -%}
 ({%- if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/downloads/deckhouse-cli/{{ site.data.supported_versions.d8.d8CliVersion }}/d8-{{ site.data.supported_versions.d8.d8CliVersion }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz) {% if page.lang == 'ru' %}
@@ -51,18 +63,6 @@
    ```shell
    curl -LO {{ site.urls[page.lang] }}/downloads/deckhouse-cli/{{ site.data.supported_versions.d8.d8CliVersion }}/d8-{{ site.data.supported_versions.d8.d8CliVersion }}-{{ include.os | downcase | replace: "macos", "darwin"  }}-{{ include.arch | downcase | replace: "x86-64", "amd64" }}.tar.gz
    ```
-{% endif %}
-
-{% if page.lang == 'ru' %}
-{% alert level="warning" %}
-Команды ниже актуальны для Deckhouse CLI версии {{ site.data.supported_versions.d8.d8CliVersion }}, поставляемой с Deckhouse Kubernetes Platform. Последняя версия Deckhouse CLI доступна на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
-Узнать используемую версию Deckhouse CLI можно при помощи команды `d8 --version`. 
-{% endalert %}
-{% else %}
-{% alert level="warning" %}
-The commands below apply to Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }}, which is bundled with the Deckhouse Kubernetes Platform. The latest version of Deckhouse CLI is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
-You can check your current Deckhouse CLI version using the `d8 --version` command.
-{% endalert %}
 {% endif %}
 
 {% if include.os == "Windows" %}

--- a/docs/site/_includes/d8-cli-install/content.liquid
+++ b/docs/site/_includes/d8-cli-install/content.liquid
@@ -55,11 +55,11 @@
 
 {% if page.lang == 'ru' %}
 {% alert level="warning" %}
-Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя доступная версия опубликована на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя доступная версия утилиты опубликована на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% else %}
 {% alert level="warning" %}
-Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest version is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest available version of the CLI is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% endif %}
 

--- a/docs/site/_includes/d8-cli-install/content.liquid
+++ b/docs/site/_includes/d8-cli-install/content.liquid
@@ -55,11 +55,11 @@
 
 {% if page.lang == 'ru' %}
 {% alert level="warning" %}
-Версия Deckhouse CLI `{{ site.data.supported_versions.d8.d8CliVersion }}` входит в состав текущей версии Deckhouse. Если вы используете другую версию платформы, убедитесь, что загружаете совместимую версию утилиты. Последняя доступная версия опубликована на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя доступная версия опубликована на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% else %}
 {% alert level="warning" %}
-Deckhouse CLI version `{{ site.data.supported_versions.d8.d8CliVersion }}` is bundled with this version of Deckhouse. If you're using a different version of the platform, make sure to download a compatible CLI version. The latest version is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest version is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% endif %}
 

--- a/docs/site/_includes/d8-cli-install/content.liquid
+++ b/docs/site/_includes/d8-cli-install/content.liquid
@@ -59,7 +59,7 @@
 {% endalert %}
 {% else %}
 {% alert level="warning" %}
-Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest available release is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest release is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% endif %}
 

--- a/docs/site/_includes/d8-cli-install/content.liquid
+++ b/docs/site/_includes/d8-cli-install/content.liquid
@@ -55,11 +55,11 @@
 
 {% if page.lang == 'ru' %}
 {% alert level="warning" %}
-Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя доступная версия утилиты опубликована на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Версия Deckhouse CLI {{ site.data.supported_versions.d8.d8CliVersion }} соответствует версии утилиты, поставляемой с Deckhouse в рамках этой версии документации. Последняя доступная сборка доступна на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% else %}
 {% alert level="warning" %}
-Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest available version of the CLI is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+Deckhouse CLI version {{ site.data.supported_versions.d8.d8CliVersion }} matches the version bundled with Deckhouse for this version of the documentation. The latest available release is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
 {% endalert %}
 {% endif %}
 

--- a/docs/site/_includes/d8-cli-install/content.liquid
+++ b/docs/site/_includes/d8-cli-install/content.liquid
@@ -53,6 +53,16 @@
    ```
 {% endif %}
 
+{% if page.lang == 'ru' %}
+{% alert level="warning" %}
+Версия Deckhouse CLI `{{ site.data.supported_versions.d8.d8CliVersion }}` входит в состав текущей версии Deckhouse. Если вы используете другую версию платформы, убедитесь, что загружаете совместимую версию утилиты. Последняя доступная версия опубликована на [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+{% endalert %}
+{% else %}
+{% alert level="warning" %}
+Deckhouse CLI version `{{ site.data.supported_versions.d8.d8CliVersion }}` is bundled with this version of Deckhouse. If you're using a different version of the platform, make sure to download a compatible CLI version. The latest version is available on [GitHub](https://github.com/deckhouse/deckhouse-cli/releases).
+{% endalert %}
+{% endif %}
+
 {% if include.os == "Windows" %}
 {%    if page.lang == 'ru' -%}
 1. Распакуйте архив, переместите файл `d8.exe` в выбранный вами каталог и добавьте каталог в переменную `PATH` операционной системы.


### PR DESCRIPTION
## Description
Added alert about latest version at Deckhouse CLI documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Added alert about latest version at Deckhouse CLI documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
