### PR TITLE
[ci] Add define for getting base image for terraform-manager image depends of terraform_versions.yaml file

### DIFF
--- a/.werf/defines/infrastructure-manager.tmpl
+++ b/.werf/defines/infrastructure-manager.tmpl
@@ -1,4 +1,4 @@
-# calculate base image for terraform-auto-exporter и terraform-state-exporteer
+# calculate base image for terraform-auto-exporter and terraform-state-exporteer
 # . is dict with keys:
 #   TF - TF from werf.yaml
 #   providerName - from terraform_versions.yaml key in root like azure or decort for example

--- a/.werf/defines/terradform-manager.tmpl
+++ b/.werf/defines/terradform-manager.tmpl
@@ -1,0 +1,18 @@
+# calculate base image for terraform-auto-exporter и terraform-state-exporteer
+# . is dict with keys:
+#   TF - TF from werf.yaml
+#   providerName - from terraform_versions.yaml key in root like azure or decort for example
+
+{{- define "infrastructure_manager_base_image" }}
+{{- $context := . -}}
+{{- if hasKey $context.TF $context.providerName -}}
+  {{- $provider := get $context.TF $context.providerName -}}
+  {{- if $provider.useOpentofu -}}
+terraform-manager/base-terraform-manager-opentofu
+  {{- else -}}
+terraform-manager/base-terraform-manager
+  {{- end -}}
+{{- else }}
+    {{- fail (printf "provider %s not found" $context.providerName) -}}
+{{- end }}
+{{- end }}

--- a/candi/terraform_versions.yml
+++ b/candi/terraform_versions.yml
@@ -16,6 +16,7 @@ aws:
   artifactBinary: terraform-provider-aws
   # provider binary name with destination image
   destinationBinary: terraform-provider-aws
+  useOpentofu: false
 
 azure:
   namespace: hashicorp
@@ -25,6 +26,7 @@ azure:
   artifact: terraform-provider-azure
   artifactBinary: terraform-provider-azurerm
   destinationBinary: terraform-provider-azurerm
+  useOpentofu: false
 
 gcp:
   namespace: hashicorp
@@ -34,6 +36,7 @@ gcp:
   artifact: terraform-provider-gcp
   artifactBinary: terraform-provider-gcp
   destinationBinary: terraform-provider-google
+  useOpentofu: false
 
 openstack:
   namespace: terraform-provider-openstack
@@ -43,6 +46,7 @@ openstack:
   artifact: terraform-provider-openstack
   artifactBinary: terraform-provider-openstack
   destinationBinary: terraform-provider-openstack
+  useOpentofu: false
 
 ovirt:
   namespace: terraform-provider-ovirt
@@ -52,6 +56,7 @@ ovirt:
   artifact: terraform-provider-ovirt
   artifactBinary: terraform-provider-ovirt
   destinationBinary: terraform-provider-ovirt
+  useOpentofu: false
 
 vsphere:
   namespace: hashicorp
@@ -61,6 +66,7 @@ vsphere:
   artifact: terraform-provider-vsphere
   artifactBinary: terraform-provider-vsphere
   destinationBinary: terraform-provider-vsphere
+  useOpentofu: false
 
 vcd:
   namespace: vmware
@@ -70,6 +76,7 @@ vcd:
   artifact: terraform-provider-vcd-artifact
   artifactBinary: terraform-provider-vcd
   destinationBinary: terraform-provider-vcd
+  useOpentofu: false
 
 yandex:
   namespace: yandex-cloud
@@ -89,6 +96,7 @@ decort:
   artifact: terraform-provider-decort
   artifactBinary: terraform-provider-decort
   destinationBinary: terraform-provider-decort
+  useOpentofu: false
 
 huaweicloud:
   namespace: terraform-provider-huaweicloud
@@ -98,3 +106,4 @@ huaweicloud:
   artifact: terraform-provider-huaweicloud
   artifactBinary: terraform-provider-huaweicloud
   destinationBinary: terraform-provider-huaweicloud
+  useOpentofu: false

--- a/ee/modules/040-terraform-manager/images/terraform-manager-dynamix/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-dynamix/werf.inc.yaml
@@ -1,5 +1,5 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: {{ .ModuleName }}/base-terraform-manager
+fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "decort") -}}'
 git:
   - add: /{{ .ModulePath }}candi/cloud-providers/dynamix
     to: /deckhouse/candi/cloud-providers/dynamix

--- a/ee/modules/040-terraform-manager/images/terraform-manager-huaweicloud/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-huaweicloud/werf.inc.yaml
@@ -1,5 +1,5 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: {{ .ModuleName }}/base-terraform-manager
+fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "huaweicloud") }}'
 git:
   - add: /{{ .ModulePath }}candi/cloud-providers/huaweicloud
     to: /deckhouse/candi/cloud-providers/huaweicloud

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
@@ -1,5 +1,5 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: {{ .ModuleName }}/base-terraform-manager
+fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "openstack") }}'
 git:
 - add: /{{ .ModulePath }}candi/cloud-providers/openstack
   to: /deckhouse/candi/cloud-providers/openstack

--- a/ee/modules/040-terraform-manager/images/terraform-manager-vcd/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-vcd/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: {{ .ModuleName }}/base-terraform-manager
+fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "vcd") }}'
 git:
 - add: /{{ .ModulePath }}candi/cloud-providers/vcd
   to: /deckhouse/candi/cloud-providers/vcd

--- a/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
+++ b/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: {{ .ModuleName }}/base-terraform-manager
+fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "vsphere") }}'
 git:
 - add: /{{ .ModulePath }}candi/cloud-providers/vsphere
   to: /deckhouse/candi/cloud-providers/vsphere

--- a/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-zvirt/werf.inc.yaml
+++ b/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-zvirt/werf.inc.yaml
@@ -1,5 +1,5 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: {{ .ModuleName }}/base-terraform-manager
+fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "ovirt") }}'
 git:
   - add: /{{ .ModulePath }}candi/cloud-providers/zvirt
     to: /deckhouse/candi/cloud-providers/zvirt

--- a/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
@@ -1,5 +1,5 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: {{ .ModuleName }}/base-terraform-manager
+fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "aws") }}'
 git:
 - add: /{{ .ModulePath }}candi/cloud-providers/aws
   to: /deckhouse/candi/cloud-providers/aws

--- a/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
@@ -1,5 +1,5 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: {{ .ModuleName }}/base-terraform-manager
+fromImage: '{{ include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "azure") }}'
 git:
 - add: /{{ .ModulePath }}candi/cloud-providers/azure
   to: /deckhouse/candi/cloud-providers/azure

--- a/modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: {{ .ModuleName }}/base-terraform-manager
+fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "gcp") }}'
 git:
 - add: /{{ .ModulePath }}candi/cloud-providers/gcp
   to: /deckhouse/candi/cloud-providers/gcp

--- a/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
@@ -1,5 +1,5 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: {{ .ModuleName }}/base-terraform-manager-opentofu
+fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "yandex") }}'
 git:
 - add: /{{ .ModulePath }}candi/cloud-providers/yandex
   to: /deckhouse/candi/cloud-providers/yandex


### PR DESCRIPTION
## Description
Add define for getting base image for terraform-manager image depends of terraform_versions.yaml file

## Why do we need it, and what problem does it solve?
Manage base image in terraform_versions.yaml file without remembering about changing base image in terraform-manager module when migrate module to opentofu

![image](https://github.com/user-attachments/assets/c3ebc8c9-fa72-4752-9d31-4b50666e668c)


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Add define for getting base image for terraform-manager image depends of terraform_versions.yaml file.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
