### PR TITLE
[dhctl][testing] create resources before deckhouse manifest and mutating webhook for prom rules for e2e tests

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -178,6 +178,7 @@ func CreateDeckhouseManifests(
 	ctx context.Context,
 	kubeCl *client.KubernetesClient,
 	cfg *config.DeckhouseInstaller,
+	beforeDeckhouseTask func() error,
 ) (*ManifestsResult, error) {
 	tasks := []actions.ManifestTask{
 		{
@@ -424,6 +425,11 @@ func CreateDeckhouseManifests(
 				return err
 			},
 		})
+	}
+
+	err := beforeDeckhouseTask()
+	if err != nil {
+		return nil, err
 	}
 
 	lockCmTask, err := LockDeckhouseQueueBeforeCreatingModuleConfigs(ctx, kubeCl)

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
@@ -53,7 +53,9 @@ func TestDeckhouseInstall(t *testing.T) {
 		{
 			"Empty config",
 			func() error {
-				_, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{})
+				_, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{}, func() error {
+					return nil
+				})
 				return err
 			},
 			false,
@@ -61,11 +63,15 @@ func TestDeckhouseInstall(t *testing.T) {
 		{
 			"Double install",
 			func() error {
-				_, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{})
+				_, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{}, func() error {
+					return nil
+				})
 				if err != nil {
 					return err
 				}
-				_, err = CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{})
+				_, err = CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{}, func() error {
+					return nil
+				})
 				return err
 			},
 			false,
@@ -75,6 +81,8 @@ func TestDeckhouseInstall(t *testing.T) {
 			func() error {
 				_, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 					Registry: config.RegistryData{DockerCfg: "YW55dGhpbmc="},
+				}, func() error {
+					return nil
 				})
 				if err != nil {
 					return err
@@ -100,7 +108,9 @@ func TestDeckhouseInstall(t *testing.T) {
 					ProviderClusterConfig: []byte(`test`),
 					InfrastructureState:   []byte(`test`),
 				}
-				_, err := CreateDeckhouseManifests(ctx, fakeClient, &conf)
+				_, err := CreateDeckhouseManifests(ctx, fakeClient, &conf, func() error {
+					return nil
+				})
 				if err != nil {
 					return err
 				}
@@ -139,6 +149,8 @@ func TestDeckhouseInstallWithDevBranch(t *testing.T) {
 
 	_, err = CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 		DevBranch: "pr1111",
+	}, func() error {
+		return nil
 	})
 
 	require.NoError(t, err)
@@ -175,6 +187,8 @@ func TestDeckhouseInstallWithModuleConfig(t *testing.T) {
 	_, err = CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 		DevBranch:     "pr1111",
 		ModuleConfigs: []*config.ModuleConfig{mc1},
+	}, func() error {
+		return nil
 	})
 
 	require.NoError(t, err)
@@ -233,6 +247,8 @@ func TestDeckhouseInstallWithModuleConfigs(t *testing.T) {
 	_, err = CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 		DevBranch:     "pr1111",
 		ModuleConfigs: []*config.ModuleConfig{mc1, mc2},
+	}, func() error {
+		return nil
 	})
 
 	require.NoError(t, err)
@@ -273,6 +289,8 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 			res, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 				DevBranch:     "pr1111",
 				ModuleConfigs: []*config.ModuleConfig{mc},
+			}, func() error {
+				return nil
 			})
 			require.NoError(t, err)
 
@@ -310,6 +328,8 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 			res, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 				DevBranch:     "pr1111",
 				ModuleConfigs: []*config.ModuleConfig{mc},
+			}, func() error {
+				return nil
 			})
 			require.NoError(t, err)
 
@@ -339,6 +359,8 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 			res, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 				DevBranch:     "pr1111",
 				ModuleConfigs: []*config.ModuleConfig{mc},
+			}, func() error {
+				return nil
 			})
 			require.NoError(t, err)
 
@@ -378,6 +400,8 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 			res, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
 				DevBranch:     "pr1111",
 				ModuleConfigs: []*config.ModuleConfig{mcDeckhouse, mcGlobal},
+			}, func() error {
+				return nil
 			})
 			require.NoError(t, err)
 

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
@@ -70,6 +70,8 @@ func (b *ClusterBootstrapper) InstallDeckhouse(ctx context.Context) error {
 		return err
 	}
 
-	_, err = InstallDeckhouse(ctx, kubeCl, installConfig)
+	_, err = InstallDeckhouse(ctx, kubeCl, installConfig, func() error {
+		return nil
+	})
 	return err
 }

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
 	"reflect"
 	"time"
 
@@ -27,7 +26,9 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/entity"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/resources"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
@@ -102,8 +103,7 @@ type Params struct {
 type ClusterBootstrapper struct {
 	*Params
 	PhasedExecutionContext phases.DefaultPhasedExecutionContext
-
-	initializeNewAgent bool
+	initializeNewAgent     bool
 	// TODO(dhctl-for-commander): pass stateCache externally using params as in Destroyer, this variable will be unneeded then
 	lastState phases.DhctlState
 }
@@ -374,14 +374,18 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 	// next parse and check resources
 	// do it after bootstrap cloud because resources can be template
 	// and we want to fail immediately if template has errors
-	var resourcesToCreate template.Resources
+	var resourcesToCreateBeforeDeckhouseBootstrap template.Resources
+	var resourcesToCreateAfterDeckhouseBootstrap template.Resources
 	if metaConfig.ResourcesYAML != "" {
 		parsedResources, err := template.ParseResourcesContent(metaConfig.ResourcesYAML, resourcesTemplateData)
 		if err != nil {
 			return err
 		}
 
-		resourcesToCreate = parsedResources
+		before, after := splitResourcesOnPreAndPostDeckhouseInstall(parsedResources)
+
+		resourcesToCreateBeforeDeckhouseBootstrap = before
+		resourcesToCreateAfterDeckhouseBootstrap = after
 	}
 
 	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.RegistryPackagesProxyPhase, false, stateCache, nil); err != nil {
@@ -420,6 +424,11 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 	}
 
 	kubeCl, err := kubernetes.ConnectToKubernetesAPI(ctx, b.NodeInterface)
+	if err != nil {
+		return err
+	}
+
+	err = createResources(ctx, kubeCl, resourcesToCreateBeforeDeckhouseBootstrap, metaConfig, nil)
 	if err != nil {
 		return err
 	}
@@ -467,7 +476,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		return err
 	}
 
-	err = createResources(ctx, kubeCl, resourcesToCreate, metaConfig, installDeckhouseResult)
+	err = createResources(ctx, kubeCl, resourcesToCreateAfterDeckhouseBootstrap, metaConfig, installDeckhouseResult)
 	if err != nil {
 		return err
 	}
@@ -606,19 +615,41 @@ func bootstrapAdditionalNodesForCloudCluster(ctx context.Context, kubeCl *client
 		return nil
 	})
 }
+func splitResourcesOnPreAndPostDeckhouseInstall(resourcesToCreate template.Resources) (before template.Resources, after template.Resources) {
+	before = make(template.Resources, 0, len(resourcesToCreate))
+	after = make(template.Resources, 0, len(resourcesToCreate))
 
-func createResources(ctx context.Context, kubeCl *client.KubernetesClient, resourcesToCreate template.Resources, metaConfig *config.MetaConfig, result *InstallDeckhouseResult) error {
-	log.WarnLn("Some resources require at least one non-master node to be added to the cluster.")
-
-	tasks := result.ManifestResult.WithResourcesMCTasks
-
-	if resourcesToCreate == nil {
-		for _, task := range tasks {
-			return retry.NewLoop(task.Title, 60, 5*time.Second).RunContext(ctx, func() error {
-				return task.Do(kubeCl)
-			})
+	for _, resource := range resourcesToCreate {
+		annotations := resource.Object.GetAnnotations()
+		if annotations == nil || annotations["dhctl.deckhouse.io/bootstrap-resource-place"] != "before-deckhouse" {
+			after = append(after, resource)
 		}
 
+		before = append(before, resource)
+	}
+
+	return before, after
+}
+
+func createResources(ctx context.Context, kubeCl *client.KubernetesClient, resourcesToCreate template.Resources, metaConfig *config.MetaConfig, result *InstallDeckhouseResult) error {
+	tasks := make([]actions.ModuleConfigTask, 0)
+	if result != nil {
+		log.WarnLn("Some resources require at least one non-master node to be added to the cluster.")
+
+		tasks = result.ManifestResult.WithResourcesMCTasks
+
+		if len(resourcesToCreate) == 0 {
+			for _, task := range tasks {
+				return retry.NewLoop(task.Title, 60, 5*time.Second).RunContext(ctx, func() error {
+					return task.Do(kubeCl)
+				})
+			}
+
+			return nil
+		}
+	}
+
+	if len(resourcesToCreate) == 0 {
 		return nil
 	}
 

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -677,7 +677,7 @@ type InstallDeckhouseResult struct {
 	ManifestResult *deckhouse.ManifestsResult
 }
 
-func InstallDeckhouse(ctx context.Context, kubeCl *client.KubernetesClient, config *config.DeckhouseInstaller) (*InstallDeckhouseResult, error) {
+func InstallDeckhouse(ctx context.Context, kubeCl *client.KubernetesClient, config *config.DeckhouseInstaller, beforeDeckhouseTask func() error) (*InstallDeckhouseResult, error) {
 	res := &InstallDeckhouseResult{}
 	err := log.Process("bootstrap", "Install Deckhouse", func() error {
 		err := CheckPreventBreakAnotherBootstrappedCluster(ctx, kubeCl, config)
@@ -685,7 +685,7 @@ func InstallDeckhouse(ctx context.Context, kubeCl *client.KubernetesClient, conf
 			return err
 		}
 
-		resManifests, err := deckhouse.CreateDeckhouseManifests(ctx, kubeCl, config)
+		resManifests, err := deckhouse.CreateDeckhouseManifests(ctx, kubeCl, config, beforeDeckhouseTask)
 		if err != nil {
 			return fmt.Errorf("deckhouse create manifests: %v", err)
 		}

--- a/dhctl/pkg/operations/bootstrap/steps_test.go
+++ b/dhctl/pkg/operations/bootstrap/steps_test.go
@@ -211,7 +211,9 @@ func TestInstallDeckhouse(t *testing.T) {
 			fakeClient := client.NewFakeKubernetesClient()
 			createReadyDeckhousePod(fakeClient)
 
-			_, err := InstallDeckhouse(ctx, fakeClient, conf)
+			_, err := InstallDeckhouse(ctx, fakeClient, conf, func() error {
+				return nil
+			})
 
 			require.NoError(t, err, "Should install Deckhouse")
 
@@ -228,7 +230,9 @@ func TestInstallDeckhouse(t *testing.T) {
 				createReadyDeckhousePod(fakeClient)
 				createUUIDConfigMap(fakeClient, curUUID)
 
-				_, err := InstallDeckhouse(ctx, fakeClient, conf)
+				_, err := InstallDeckhouse(ctx, fakeClient, conf, func() error {
+					return nil
+				})
 
 				require.Error(t, err, "Should not install Deckhouse")
 
@@ -245,7 +249,9 @@ func TestInstallDeckhouse(t *testing.T) {
 				createReadyDeckhousePod(fakeClient)
 				createUUIDConfigMap(fakeClient, curUUID)
 
-				_, err := InstallDeckhouse(ctx, fakeClient, conf)
+				_, err := InstallDeckhouse(ctx, fakeClient, conf, func() error {
+					return nil
+				})
 
 				require.Error(t, err, "Should not install Deckhouse")
 
@@ -259,7 +265,9 @@ func TestInstallDeckhouse(t *testing.T) {
 				createReadyDeckhousePod(fakeClient)
 				createUUIDConfigMap(fakeClient, clusterUUID)
 
-				_, err := InstallDeckhouse(ctx, fakeClient, conf)
+				_, err := InstallDeckhouse(ctx, fakeClient, conf, func() error {
+					return nil
+				})
 
 				require.NoError(t, err, "Should install Deckhouse")
 

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -187,7 +187,7 @@ spec:
   ports:
     - name: webhook
       port: 443
-      targetPort: 11112
+      targetPort: 11114
       protocol: TCP
   selector:
     app: prom-rules-mutating

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -141,9 +141,11 @@ spec:
         node.deckhouse.io/group: master
       containers:
         - name: shell-operator
-          image: dev-registry.deckhouse.io/base_images@sha256:724dbdea3d542b51fda82d9909cc90dcd93bf4bc25bf3638ce72a86e688e5498
+          image: dev-registry.deckhouse.io/base_images@sha256:07cf494de0cc3f644562b9edf20ac2f2395ff6d9586cc909498dc71176e7fa10
           imagePullPolicy: Always
           env:
+            - name: VALIDATING_WEBHOOK_LISTEN_PORT
+              value: "11114"
             - name: SHELL_OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -156,7 +158,7 @@ spec:
               value: "prom-rules-mutating"
           livenessProbe:
             httpGet:
-              port: 9680
+              port: 11114
               path: /healthz
               scheme: HTTPS
           volumeMounts:

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -101,3 +101,121 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: argocd-application-controller-sa
 type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prom-rules-mutating
+  annotations:
+    dhctl.deckhouse.io/bootstrap-resource-place: before-deckhouse
+type: kubernetes.io/tls
+data:
+  tls.crt: |
+    LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQyVENDQXNHZ0F3SUJBZ0lVWXRJR09mSW1Tam1vczlvVkNvUWpEVGl5VEQwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1BqRThNRG9HQTFVRUF4TXpVMmhsYkd3dGIzQmxjbUYwYjNJZ1pYaGhiWEJzWlNBeU1EWXRiWFYwWVhScApibWN0ZDJWaWFHOXZheUJTYjI5MElFTkJNQjRYRFRJMU1EVXdNekU1TlRJd01Gb1hEVEkyTURVd016RTVOVEl3Ck1Gb3dKekVsTUNNR0ExVUVBeE1jYlhWMFlYUnBibWN0YzJWeWRtbGpaUzVrWldaaGRXeDBMbk4yWXpDQ0FTSXcKRFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU53eHhQTzNwSHhKRG9JM0dEUW13S2Y0L0JTYwp3d09YNk9vWm9kb0hpakNMZ3cvR3V1ci94emRZZkFSMWJ4TmZVTVdmUEdqcjBZZEZseG9qVzcwOXBzUXVuamJOCjFZaEV5NVF6RmdLQ2lQL2UxbU05cFp3TnRaZzFSSmk1eTU2U0tESnh3Vm1abElBaGtMMUdlU2lPTWpZR0RHbFEKelRFS0xjckUza1FuaEhwNTA0cTczblRzQWZNNU5QKzVhQi8yOVg3ODljUk4xMFBpUzBwTUJPMkFEb2dxeUdBTQpGWnkvWlJqQlo2WEJ5dWY0YmhKdGZXWkhZSkJrc0tmWVdUdEkrNy83eG5PUkF4NGYydDU2a0dFejl0cmIxTFlvCjgrN1BCZ3h6UnlUTCt5TVZJWWNQaGEwaWVySWNKbUlTbE04K0ZQV2RUQUlid0VjT0xTbmgyalBrZlRjQ0F3RUEKQWFPQjVUQ0I0akFPQmdOVkhROEJBZjhFQkFNQ0JhQXdFd1lEVlIwbEJBd3dDZ1lJS3dZQkJRVUhBd0V3REFZRApWUjBUQVFIL0JBSXdBREFkQmdOVkhRNEVGZ1FVTlUwNDhTK1lVaWxoakRkaTFrcVEydHM4UDA0d0h3WURWUjBqCkJCZ3dGb0FVZHpxMzE1cVRHY1Z4akFSRTM2cldnQmNzWUVrd2JRWURWUjBSQkdZd1pJSVliWFYwWVhScGJtY3QKYzJWeWRtbGpaUzVrWldaaGRXeDBnaHh0ZFhSaGRHbHVaeTF6WlhKMmFXTmxMbVJsWm1GMWJIUXVjM1pqZ2lwdApkWFJoZEdsdVp5MXpaWEoyYVdObExtUmxabUYxYkhRdWMzWmpMbU5zZFhOMFpYSXViRzlqWVd3d0RRWUpLb1pJCmh2Y05BUUVMQlFBRGdnRUJBSlpra1BQeDJwVWpBS1VxZWdjbW9XOWN3ejZGdlpOdUlRYXNRU3k0UXVkMzFMeUoKNGJKbWx1OFV5dWx5WktOMWFtdDVyVGIzbG1DajNOa20vcUo2akZvMUp2WHYrVEg4R3F3UGxMbm1rMDc1NERQUAo3bWZCckZEZWg1VzVkb21LbmI4SDdCMEpyZ1JIOGFCbnMvUkhJWnVLN1NKOVVoNDcvQ2kxa21KWnpYbXU0THFvCjh0RTRaYjg3dDNFVEw3NVIvT2NXaERaYWJWYzhqTGdaS0g4N2FCL0JZZ3VOckZMc1dEUW5aM3lEOTFuYWM0QUwKcEJpRURHVnR1MWcxaElFRWMrV2R5RmNYNFdvcm1qNEsrc3kzSE40YUlxMlJVL1gzNVNoWUdWNTVscHdvMjJscgp6bE5XTnkwS3lrc1JLS0pHYlRvSjZwNlc4czhKUC9zbnVmVWpJc2c9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  tls.key: |
+    LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcFFJQkFBS0NBUUVBM0RIRTg3ZWtmRWtPZ2pjWU5DYkFwL2o4Rkp6REE1Zm82aG1oMmdlS01JdUREOGE2CjZ2L0hOMWg4QkhWdkUxOVF4Wjg4YU92UmgwV1hHaU5idlQybXhDNmVOczNWaUVUTGxETVdBb0tJLzk3V1l6MmwKbkEyMW1EVkVtTG5MbnBJb01uSEJXWm1VZ0NHUXZVWjVLSTR5TmdZTWFWRE5NUW90eXNUZVJDZUVlbm5UaXJ2ZQpkT3dCOHprMC83bG9IL2IxZnZ6MXhFM1hRK0pMU2t3RTdZQU9pQ3JJWUF3Vm5MOWxHTUZucGNISzUvaHVFbTE5ClprZGdrR1N3cDloWk8wajd2L3ZHYzVFREhoL2EzbnFRWVRQMjJ0dlV0aWp6N3M4R0RITkhKTXY3SXhVaGh3K0YKclNKNnNod21ZaEtVeno0VTlaMU1BaHZBUnc0dEtlSGFNK1I5TndJREFRQUJBb0lCQUNNN08xNGJoZy8weUlPQgpPVGd1OHlodEtEaE1GTS9nWUg0RWQrY2d5YldXdlBPclFvRVRSOWJOSzVxekI0QzhBWHA5VGZjanREVEdwN1NnCjc2N0p6SU1iU21sT2Fkb1IxOWp3aTViL045aG8yVGlyeG5HL3A4eWd5VWIrZzF2dDJzeW5jdDVaT205OTcyQzUKZyswL1F6MXRubExEZ1BGVnhabnFBZjQ1ckhMRCswSjUvU1ZTOThiT2JodnRhbmp1dGtJRzh3OWpyeFZxWUhydQpKbXE2ZGhPL0JPb25mbWNrb2hMZDc0cUNPeW84amd0M2oyMXJYVmZuNHRyTzRFd2Z2NXNvRWlvSlNrcGpnNU9NCkhPYUFXUTF2ZHh6NEtZcFgvZXUrbWVCUitDQTNJSnhiRWpnNTJ3SnoreU9QczNOSDFUcjdBVGJVUzRzbHc5dUYKaU9oaXlWRUNnWUVBK3crbmNITmpYbHFDSTVFbmV4SC8rZ2hWcWQrV2Q5Yi9YYnNocDJIT2VNUGFyQmlPdStWdQoyb3FmTGlPMUowWGM4L0Y3RnBvc0FmcjZ6S3lMamxOYkJsbFU3bjhSam5LMUptVERmRCs2d1pNZldDeS9tNE5oCkp1c3IzYnB4bFQ5cHdSRkttTHhXY3ozc3NtVFpBSWg5Si96VzVLMENRdVpZUjhoV0xGa0VFUU1DZ1lFQTRJYXIKanZzaWQxRGlzblJrWEZLaXJZUjlxMWVLREx2LzFncWlNK3h5aDVvWmdYZ1FBMS9YRkNsendYcjVtc2k4Z0cxRgo3RGV6eWV4WU1sVUFjdkd4blhFQ3pTbGtEa21HQUFpanJ2STZMdkFndzRWSFplNndCcGF4OWlsRlBybSt5aTdoClZDMlZ0QXkrM2pMMmc5aTNETllCSTBXSkplUzA4WnJ1cEJkdCtyMENnWUVBdnJMaFNEVWRZV24yTi9YbHUwR3MKNGNxNjV0R0NoWHkxZEFqVVEwT3poVitmRmVHQmFZK1lhRCtyTVd6R0NSSzBCa2VDYTJTbjBNbEcvM2lBZUpjdwpLTjVwK001a0U0Tmx2Y2dFQkxpVHJyMkZyWUF2K253TXEzY3VWcmxyMVNYWnVtRGIvSy95S283NjMzWmlybGorCldBVmhaVWxVMG1RTTRsbDF1ekhTT09rQ2dZRUF4Qm5iVFk1YWxBdTVkRlBrTkI2WXB5VEkvaFgvSlJBdWF5dnUKYjV0Y2pNTXk4N21CZ3ZENlVVbkRLSUhYOEREVE12ZzkwZ3IwcExBZ2VCVjF4dThDU3BpaDhiN3MvTzJLZEEwWApxWDAzQkRnRzViNUtsZVRiS1dZRkdSTUN2NzVMdlJzbEF2aXRnQXlCeUdDS25xMXhjMnlXb2MvaDhZN0gyeDJPCndSTVZvNkVDZ1lFQTRhR3paenlWWmdzU1JuMkRQYjFpRlNOZ252UVFUL2VrZ3hadGdHZEdyNndnNjFacDhicVMKMzU1YUJZNi9VNDNvdk10bC9PcytrTjVLTDBzaDVLY2M0ajYwQWx5QUZLakMxOGtFQ29TSzBQT0ZOSXRVdzVqZApBcWNyRzBiVHlTWE1jcmNQU1Bpbm8xMzQxcDM3WEtyMitFTU1Pa3lDZmJvNTlabXRZM1kwVFc4PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
+  ca.crt: |
+    LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURURENDQWpTZ0F3SUJBZ0lVU2c3a2toblI3YXVEUzlpVmV5VlIzQk1ZVFVJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1BqRThNRG9HQTFVRUF4TXpVMmhsYkd3dGIzQmxjbUYwYjNJZ1pYaGhiWEJzWlNBeU1EWXRiWFYwWVhScApibWN0ZDJWaWFHOXZheUJTYjI5MElFTkJNQjRYRFRJMU1EVXdNekU1TlRJd01Gb1hEVE13TURVd01qRTVOVEl3Ck1Gb3dQakU4TURvR0ExVUVBeE16VTJobGJHd3RiM0JsY21GMGIzSWdaWGhoYlhCc1pTQXlNRFl0YlhWMFlYUnAKYm1jdGQyVmlhRzl2YXlCU2IyOTBJRU5CTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQwpBUUVBbzk2bDkreGpjRGJXbFExM3VJaWtFc1M5WlFFb1doMkZ1WDZGVWFxenNjS08vR1lob24wKzlLSDRveUNnCi9FUDJkTG90T0Z5V1NxeWkvWmMvMm9paWlNdmFCQjV6UlB0eFo4ZUUwdFJEMEJJVVBpY2o0WGZvd2hsYzlzanEKcVZ3am5zdHIxR0UwaUU3ajlvOFRGaFh6QWd2NDNNU1MrVC9qZktaSWxTZ2tHMzQwczhVbTNUWDZUOWdNVWRUOQphSitRdGMwY2oyT3ZvVHZ4VDEvb2pFMndyNEZPUGVpZVVsb2tRVHA1aDczenBJdk9HSXUzN0w0STNNYk1ZbjZMCk5nL2dSRnMwV3JuZGFCeStFdyswVnJiRDhwVFByMWFNMEdxdjBOcEJsaXR1MXIrY1QvR2hpdG92SzlkV1d4b1UKS0JpR0tIaUNHQzlENVdVdkJEOUlBODFtWlFJREFRQUJvMEl3UURBT0JnTlZIUThCQWY4RUJBTUNBUVl3RHdZRApWUjBUQVFIL0JBVXdBd0VCL3pBZEJnTlZIUTRFRmdRVWR6cTMxNXFUR2NWeGpBUkUzNnJXZ0Jjc1lFa3dEUVlKCktvWklodmNOQVFFTEJRQURnZ0VCQUNKeW9xbStVdUJlYnByTDVyWTd4djZoSlI2bFNWMlJ4cjQwdkQ2RFF6MDkKdEFzVnhFQkJmV09mbFNabFVZelVPVDh1RFdwei9XaUdzUllJNDZtb0pKK1hNbUk0bXdYelJ6eWg4UFhndUw1LwpnTGovVVVlOHVTUi9USitkVWlnaHcvY3lkeGRVdU11SlpqbnF5NW5hRHRGNHhrSU9tTzlEWTJaem03NXFGREdVCmpQZFJWV3FJT1NUSlFMZGNrdmsxWWdQakR4dlhnWlR6aGkydWJFVVduR0lYWS8vcDJxU2tTZlQzZWxYajB0dVUKZzZwajR6SUE3RVMrQ01wTDJlbW9xckwzeWlQT3I0YUFjZXBMY1ZNUHdKUk5WRld6OUFiOGdvSEtmWlVON3g2egpoQlJHWVBoNHdROFhqaFY1MGRYM2k0QjZMOGZES0VLNytXbGxlZFU3aGJjPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prom-rules-mutating
+  labels:
+    app: prom-rules-mutating
+  annotations:
+    dhctl.deckhouse.io/bootstrap-resource-place: before-deckhouse
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prom-rules-mutating
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: prom-rules-mutating
+    spec:
+      containers:
+        - name: shell-operator
+          image: dev-registry.deckhouse.io/sys/deckhouse-oss:9fba94be60f958a73782b103e33b6e9d75f5408946ab10cb404d752b-1746310113490
+          imagePullPolicy: Always
+          env:
+            - name: SHELL_OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LOG_LEVEL
+              value: Debug
+            - name: VALIDATING_WEBHOOK_SERVICE_NAME
+              value: mutating-service
+            - name: VALIDATING_WEBHOOK_CONFIGURATION_NAME
+              value: "prom-rules-mutating"
+          livenessProbe:
+            httpGet:
+              port: 9680
+              path: /healthz
+              scheme: HTTPS
+          volumeMounts:
+            - name: validating-certs
+              mountPath: /validating-certs/
+              readOnly: true
+      serviceAccountName: prom-rules-mutating
+      tolerations:
+        - operator: "Exists"
+      volumes:
+        - name: validating-certs
+          secret:
+            secretName: prom-rules-mutating
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mutating-service
+  annotations:
+    dhctl.deckhouse.io/bootstrap-resource-place: before-deckhouse
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      targetPort: 9680
+      protocol: TCP
+  selector:
+    app: prom-rules-mutating
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prom-rules-mutating
+  annotations:
+    dhctl.deckhouse.io/bootstrap-resource-place: before-deckhouse
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prom-rules-mutating
+  annotations:
+    dhctl.deckhouse.io/bootstrap-resource-place: before-deckhouse
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    verbs: ["create", "list", "update"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["create", "list", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prom-rules-mutating
+  annotations:
+    dhctl.deckhouse.io/bootstrap-resource-place: before-deckhouse
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prom-rules-mutating
+subjects:
+  - kind: ServiceAccount
+    name: prom-rules-mutating
+    namespace: default

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -137,6 +137,8 @@ spec:
       labels:
         app: prom-rules-mutating
     spec:
+      nodeSelector:
+        node.deckhouse.io/group: master
       containers:
         - name: shell-operator
           image: dev-registry.deckhouse.io/base_images@sha256:724dbdea3d542b51fda82d9909cc90dcd93bf4bc25bf3638ce72a86e688e5498
@@ -146,8 +148,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: VALIDATING_WEBHOOK_LISTEN_PORT
-              value: "11112"
             - name: LOG_LEVEL
               value: Debug
             - name: VALIDATING_WEBHOOK_SERVICE_NAME
@@ -156,7 +156,7 @@ spec:
               value: "prom-rules-mutating"
           livenessProbe:
             httpGet:
-              port: 11112
+              port: 9680
               path: /healthz
               scheme: HTTPS
           volumeMounts:

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -146,6 +146,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: VALIDATING_WEBHOOK_LISTEN_PORT
+              value: "11112"
             - name: LOG_LEVEL
               value: Debug
             - name: VALIDATING_WEBHOOK_SERVICE_NAME

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -154,7 +154,7 @@ spec:
               value: "prom-rules-mutating"
           livenessProbe:
             httpGet:
-              port: 9680
+              port: 11112
               path: /healthz
               scheme: HTTPS
           volumeMounts:
@@ -162,6 +162,7 @@ spec:
               mountPath: /validating-certs/
               readOnly: true
       serviceAccountName: prom-rules-mutating
+      hostNetwork: true
       tolerations:
         - operator: "Exists"
       volumes:
@@ -179,7 +180,7 @@ spec:
   ports:
     - name: webhook
       port: 443
-      targetPort: 9680
+      targetPort: 11112
       protocol: TCP
   selector:
     app: prom-rules-mutating

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -169,6 +169,7 @@ spec:
               readOnly: true
       serviceAccountName: prom-rules-mutating
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       tolerations:
         - operator: "Exists"
       volumes:

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -139,7 +139,7 @@ spec:
     spec:
       containers:
         - name: shell-operator
-          image: dev-registry.deckhouse.io/sys/deckhouse-oss:9fba94be60f958a73782b103e33b6e9d75f5408946ab10cb404d752b-1746310113490
+          image: dev-registry.deckhouse.io/base_images@sha256:724dbdea3d542b51fda82d9909cc90dcd93bf4bc25bf3638ce72a86e688e5498
           imagePullPolicy: Always
           env:
             - name: SHELL_OPERATOR_NAMESPACE

--- a/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
+++ b/testing/cloud_layouts/AWS/WithoutNAT/resources.yaml
@@ -144,6 +144,8 @@ spec:
           image: dev-registry.deckhouse.io/base_images@sha256:07cf494de0cc3f644562b9edf20ac2f2395ff6d9586cc909498dc71176e7fa10
           imagePullPolicy: Always
           env:
+            - name: SHELL_OPERATOR_LISTEN_PORT
+              value: "11115"
             - name: VALIDATING_WEBHOOK_LISTEN_PORT
               value: "11114"
             - name: SHELL_OPERATOR_NAMESPACE


### PR DESCRIPTION
## Description
Create resources before deckhouse manifests resources will be selected by special secret (for only our use) annotation.
Add manifests for creation prometheus rules mutating webhook which replace 'for' for rules to 1m. (only aws in this pr)

![image](https://github.com/user-attachments/assets/98664196-6add-4951-9843-e073a7c1ea0f)

This pr does not fix alerts in aws. We have problems with tags in static instances. For fix it we need additional discussion.

Show results here https://github.com/deckhouse/deckhouse/actions/runs/14824592925

## Why do we need it, and what problem does it solve?
We have many alerts that begin firing after some delay. We want get all events in he cluster during e2e tests without delay and additional sleep in the tests

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Create resources before deckhouse manifests resources will be selected by special secret (for only our use) annotation.
impact_level: low
---
section: testing
type: feature
summary: Add manifests for creation prometheus rules mutating webhook which replace 'for' for rules to 1m. 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
