### PR TITLE
[ingress-nginx] Add a WAF description to the documentation.

### DIFF
--- a/modules/402-ingress-nginx/docs/FAQ.md
+++ b/modules/402-ingress-nginx/docs/FAQ.md
@@ -288,7 +288,7 @@ kubectl drain <node_name> --delete-emptydir-data --ignore-daemonsets --force
 ## Web Application Firewall (WAF)
 
 Software known as a Web Application Firewall (WAF) is used to protect web applications from Layer 7 attacks.
-Ingress-nginx controller has a built-in WAF called `ModSecurity' (OpenSource Web Application Firewall project).
+Ingress-nginx controller has a built-in WAF called `ModSecurity' (The Open Worldwide Application Security Project).
 
 ModSecurity is disabled by default.
 

--- a/modules/402-ingress-nginx/docs/FAQ.md
+++ b/modules/402-ingress-nginx/docs/FAQ.md
@@ -286,15 +286,17 @@ kubectl drain <node_name> --delete-emptydir-data --ignore-daemonsets --force
 ```
 
 ## Web Application Firewall (WAF)
+
 Software known as a Web Application Firewall (WAF) is used to protect web applications from Layer 7 attacks.
 Ingress-nginx controller has a built-in WAF called `ModSecurity' (OpenSource Web Application Firewall project).
 
 ModSecurity is disabled by default.
 
-### Enabling ModSecurity.
+### Enabling ModSecurity
+
 To enable ModSecurity, you must specify the following parameters in the `config` section of the CR IngressNginxController:
 
-```
+```yaml
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController
 metadata:
@@ -309,7 +311,8 @@ spec:
 After that, ModSecurity will start working for all traffic passing through this ingress-nginx controller.
 This uses the audit mode (`DetectionOnly`) and [basic recommended configuration](https://github.com/owasp-modsecurity/ModSecurity/blob/v3/master/modsecurity.conf-recommended)
 
-### Setting up ModSecurity.
+### Setting up ModSecurity
+
 You can configure ModSecurity in two ways:
 - For the entire ingress-nginx controller
   - the necessary directives are described in the section `config.modsecurity-snippet` in CR IngressNginxController, as in the example above.
@@ -319,11 +322,12 @@ You can configure ModSecurity in two ways:
 In order to start performing actions, not just logging, you need to add the `SecRuleEngine On` directive.
 
 For example like this:
-```
+
+```yaml
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController
 metadata:
-  name: <имя_контролера>
+  name: <name_of_the_controller>
 spec:
   config:
     enable-modsecurity: "true"

--- a/modules/402-ingress-nginx/docs/FAQ.md
+++ b/modules/402-ingress-nginx/docs/FAQ.md
@@ -284,3 +284,54 @@ are backed by Advanced DaemonSets):
 ```shell
 kubectl drain <node_name> --delete-emptydir-data --ignore-daemonsets --force
 ```
+
+## Web Application Firewall (WAF)
+Software known as a Web Application Firewall (WAF) is used to protect web applications from Layer 7 attacks.
+Ingress-nginx controller has a built-in WAF called `ModSecurity' (OpenSource Web Application Firewall project).
+
+ModSecurity is disabled by default.
+
+### Enabling ModSecurity.
+To enable ModSecurity, you must specify the following parameters in the `config` section of the CR IngressNginxController:
+
+```
+apiVersion: deckhouse.io/v1
+kind: IngressNginxController
+metadata:
+  name: <name_of_the_controller>
+spec:
+  config:
+    enable-modsecurity: "true"
+    modsecurity-snippet: |
+      Include /etc/nginx/modsecurity/modsecurity.conf
+```
+
+After that, ModSecurity will start working for all traffic passing through this ingress-nginx controller.
+This uses the audit mode (`DetectionOnly`) and [basic recommended configuration](https://github.com/owasp-modsecurity/ModSecurity/blob/v3/master/modsecurity.conf-recommended)
+
+### Setting up ModSecurity.
+You can configure ModSecurity in two ways:
+- For the entire ingress-nginx controller
+  - the necessary directives are described in the section `config.modsecurity-snippet` in CR IngressNginxController, as in the example above.
+- For each CR Ingress separately
+  - the necessary directives are described in the annotation `nginx.ingress.kubernetes.io/modsecurity-snippet : |` directly in Ingress manifests.
+
+In order to start performing actions, not just logging, you need to add the `SecRuleEngine On` directive.
+
+For example like this:
+```
+apiVersion: deckhouse.io/v1
+kind: IngressNginxController
+metadata:
+  name: <имя_контролера>
+spec:
+  config:
+    enable-modsecurity: "true"
+    modsecurity-snippet: |
+      Include /etc/nginx/modsecurity/modsecurity.conf
+      SecRuleEngine On
+```
+
+A full list and description of the directives can be found in the [official documentation](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v3.x%29 ).
+
+Currently, the OWASP Core Rule Set (CRS) is not available.

--- a/modules/402-ingress-nginx/docs/FAQ_RU.md
+++ b/modules/402-ingress-nginx/docs/FAQ_RU.md
@@ -288,15 +288,17 @@ kubectl drain <node_name> --delete-emptydir-data --ignore-daemonsets --force
 ```
 
 ## Web Application Firewall (WAF)
+
 Для защиты веб-приложений от L7-атак используется программное обеспечение известное как Web Application Firewall (WAF).
 В ingress-nginx контроллер встроен WAF под названием `ModSecurity` (проект OpenSource Web Application Firewall).
 
 По умолчанию ModSecurity выключен.
 
-### Включение ModSecurity.
+### Включение ModSecurity
+
 Для включения ModSecurity необходимо в CR IngressNginxController прописать следующие параметры в секции `config`:
 
-```
+```yaml
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController
 metadata:
@@ -311,7 +313,8 @@ spec:
 После этого ModSecurity начнет работать для всего трафика, проходящего через данный ingress-nginx контроллер.
 При этом используется режиме аудита (`DetectionOnly`) и [базовая рекомендуемая конфигурация](https://github.com/owasp-modsecurity/ModSecurity/blob/v3/master/modsecurity.conf-recommended)
 
-### Настройка ModSecurity.
+### Настройка ModSecurity
+
 Вы можете настраивать ModSecurity двумя способами:
 - Для всего ingress-nginx контроллера
   - необходимые директивы описываются в секции `config.modsecurity-snippet` в CR IngressNginxController, как в примере выше.
@@ -320,7 +323,8 @@ spec:
 
 Для того чтобы начали выполняться действия, а не только логирование, необходимо добавить директиву `SecRuleEngine On`.
 Например так
-```
+
+```yaml
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController
 metadata:

--- a/modules/402-ingress-nginx/docs/FAQ_RU.md
+++ b/modules/402-ingress-nginx/docs/FAQ_RU.md
@@ -290,7 +290,7 @@ kubectl drain <node_name> --delete-emptydir-data --ignore-daemonsets --force
 ## Web Application Firewall (WAF)
 
 Для защиты веб-приложений от L7-атак используется программное обеспечение известное как Web Application Firewall (WAF).
-В ingress-nginx контроллер встроен WAF под названием `ModSecurity` (проект OpenSource Web Application Firewall).
+В ingress-nginx контроллер встроен WAF под названием `ModSecurity` (проект Open Worldwide Application Security).
 
 По умолчанию ModSecurity выключен.
 


### PR DESCRIPTION
## Description

A description of the Web Application Firewall (WAF) has been added to the documentation for the ingress-nginx module. This includes information on how to enable and configure the WAF.

## Why do we need it, and what problem does it solve?

Our users often ask about the presence of a WAF (Web Application Firewall) in the Deckhouse and, if so, how it can be configured.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: chore
summary: Adding a WAF description to the documentation.
impact_level: low
```

