### PR TITLE
[cilium] fixed race condition when deleting element from map

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-managment.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-managment.patch
@@ -326,7 +326,7 @@ index bf47c44de9..ece7d4a286 100644
  		m.RemoveCEPFromCache(GetCEPNameFromCCEP(cep2, "kube-system"), DefaultCESSyncTime)
  		remCEPs := m.getRemovedCEPs(cesName)
 diff --git a/operator/watchers/cilium_endpoint.go b/operator/watchers/cilium_endpoint.go
-index 7c1b240f77..30b1a2780f 100644
+index 7c1b240f77..5836519f09 100644
 --- a/operator/watchers/cilium_endpoint.go
 +++ b/operator/watchers/cilium_endpoint.go
 @@ -7,8 +7,11 @@ import (
@@ -692,7 +692,7 @@ index 4a2b401797..64b4012b74 100644
  	"github.com/cilium/cilium/pkg/metrics"
  	"github.com/cilium/cilium/pkg/monitor/notifications"
 diff --git a/pkg/ipcache/ipcache.go b/pkg/ipcache/ipcache.go
-index 59f89704c1..bb61ec3ed9 100644
+index 59f89704c1..999df50441 100644
 --- a/pkg/ipcache/ipcache.go
 +++ b/pkg/ipcache/ipcache.go
 @@ -12,6 +12,10 @@ import (
@@ -706,7 +706,7 @@ index 59f89704c1..bb61ec3ed9 100644
  	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
  	"github.com/cilium/cilium/pkg/controller"
  	"github.com/cilium/cilium/pkg/identity"
-@@ -22,12 +26,340 @@ import (
+@@ -22,12 +26,344 @@ import (
  	"github.com/cilium/cilium/pkg/labels/cidr"
  	"github.com/cilium/cilium/pkg/lock"
  	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -1005,6 +1005,8 @@ index 59f89704c1..bb61ec3ed9 100644
 +
 +// DeleteEntry deletes a single map entry
 +func DeleteEntry(ip net.IP) error {
++	globalIPCache.Lock()
++	defer globalIPCache.Unlock()
 +	delete(globalIPCache.ipToEndpointInfo, ip.To4().String())
 +	return LXCMap().Delete(NewEndpointKey(ip))
 +}
@@ -1015,7 +1017,9 @@ index 59f89704c1..bb61ec3ed9 100644
 +	var errors []error
 +	for _, k := range GetBPFKeys(f) {
 +		ip := getEndpointAddress(k)
++		globalIPCache.Lock()
 +		delete(globalIPCache.ipToEndpointInfo, ip)
++		globalIPCache.Unlock()
 +		if err := LXCMap().Delete(k); err != nil {
 +			errors = append(errors, fmt.Errorf("Unable to delete key %v from %s: %w", k, bpf.MapPath(MapName), err))
 +		}
@@ -1047,7 +1051,7 @@ index 59f89704c1..bb61ec3ed9 100644
  // Identity is the identity representation of an IP<->Identity cache.
  type Identity struct {
  	// ID is the numeric identity
-@@ -99,6 +431,7 @@ type IPCache struct {
+@@ -99,6 +435,7 @@ type IPCache struct {
  	identityToIPCache map[identity.NumericIdentity]map[string]struct{}
  	ipToHostIPCache   map[string]IPKeyPair
  	ipToK8sMetadata   map[string]K8sMetadata
@@ -1055,7 +1059,7 @@ index 59f89704c1..bb61ec3ed9 100644
  
  	listeners []IPIdentityMappingListener
  
-@@ -140,6 +473,7 @@ func NewIPCache(c *Configuration) *IPCache {
+@@ -140,6 +477,7 @@ func NewIPCache(c *Configuration) *IPCache {
  		identityToIPCache: map[identity.NumericIdentity]map[string]struct{}{},
  		ipToHostIPCache:   map[string]IPKeyPair{},
  		ipToK8sMetadata:   map[string]K8sMetadata{},
@@ -1063,7 +1067,7 @@ index 59f89704c1..bb61ec3ed9 100644
  		controllers:       controller.NewManager(),
  		namedPorts:        types.NewNamedPortMultiMap(),
  		metadata:          newMetadata(),
-@@ -389,6 +723,8 @@ func (ipc *IPCache) upsertLocked(
+@@ -389,6 +727,8 @@ func (ipc *IPCache) upsertLocked(
  
  	scopedLog.Debug("Upserting IP into ipcache layer")
  
@@ -1072,7 +1076,7 @@ index 59f89704c1..bb61ec3ed9 100644
  	// Update both maps.
  	ipc.ipToIdentityCache[ip] = newIdentity
  	// Delete the old identity, if any.
-@@ -686,6 +1022,13 @@ func (ipc *IPCache) DeleteOnMetadataMatch(IP string, source source.Source, names
+@@ -686,6 +1026,13 @@ func (ipc *IPCache) DeleteOnMetadataMatch(IP string, source source.Source, names
  	return false
  }
  


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed race condition when deleting element from ipcache agent map during VM migration.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This bug causes cilium agent crashes.

Fixes https://github.com/deckhouse/deckhouse/issues/13249.

## Why do we need it in the patch release (if we do)?

There are customers who faced the issue.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: Fixed race condition when deleting element from ipcache map during VM migration.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
