### PR TITLE
[cloud-provider-aws] Fix ListRoutes implementation in CCM

### DIFF
--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.28/005-fix-list-routes-method.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.28/005-fix-list-routes-method.patch
@@ -1,0 +1,20 @@
+Subject: [PATCH] fix ListRoutes implementation
+---
+Index: pkg/providers/v1/aws_routes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/providers/v1/aws_routes.go b/pkg/providers/v1/aws_routes.go
+--- a/pkg/providers/v1/aws_routes.go	(revision 8ed070cd7501f6032ac056a4e79b9afc70fe522c)
++++ b/pkg/providers/v1/aws_routes.go	(date 1746511538247)
+@@ -116,7 +116,8 @@
+ 			if found {
+ 				node, err := c.instanceIDToNodeName(InstanceID(instanceID))
+ 				if err != nil {
+-					return nil, err
++					klog.Errorf("error converting instance ID '%s' to node name: %w", instanceID, err)
++					continue
+ 				}
+ 				route.TargetNode = node
+ 				routes = append(routes, route)

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.28/README.md
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.28/README.md
@@ -16,3 +16,7 @@ We shouldn't delete Ingress SG rule, if it allows access from configured "ElbSec
 ## 004-bump-deps.patch
 
 Update dependencies
+
+## 005-fix-list-routes-method.patch
+
+Modify `ListRoutes` method to handle errors gracefully without blocking reconcile loop.

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.29/005-fix-list-routes-method.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.29/005-fix-list-routes-method.patch
@@ -1,0 +1,20 @@
+Subject: [PATCH] fix ListRoutes implementation
+---
+Index: pkg/providers/v1/aws_routes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/providers/v1/aws_routes.go b/pkg/providers/v1/aws_routes.go
+--- a/pkg/providers/v1/aws_routes.go	(revision 933cfdef070d214e85550b1d516457faf338a1e4)
++++ b/pkg/providers/v1/aws_routes.go	(date 1746511538247)
+@@ -116,7 +116,8 @@
+ 			if found {
+ 				node, err := c.instanceIDToNodeName(InstanceID(instanceID))
+ 				if err != nil {
+-					return nil, err
++					klog.Errorf("error converting instance ID '%s' to node name: %w", instanceID, err)
++					continue
+ 				}
+ 				route.TargetNode = node
+ 				routes = append(routes, route)

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.29/README.md
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.29/README.md
@@ -16,3 +16,7 @@ We shouldn't delete Ingress SG rule, if it allows access from configured "ElbSec
 ## 004-bump-deps.patch
 
 Update dependencies
+
+## 005-fix-list-routes-method.patch
+
+Modify `ListRoutes` method to handle errors gracefully without blocking reconcile loop.

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.30/005-fix-list-routes-method.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.30/005-fix-list-routes-method.patch
@@ -1,0 +1,20 @@
+Subject: [PATCH] fix ListRoutes implementation
+---
+Index: pkg/providers/v1/aws_routes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/providers/v1/aws_routes.go b/pkg/providers/v1/aws_routes.go
+--- a/pkg/providers/v1/aws_routes.go	(revision a5c80a4686394a1971d117d39eb0460694877636)
++++ b/pkg/providers/v1/aws_routes.go	(date 1746511538247)
+@@ -116,7 +116,8 @@
+ 			if found {
+ 				node, err := c.instanceIDToNodeName(InstanceID(instanceID))
+ 				if err != nil {
+-					return nil, err
++					klog.Errorf("error converting instance ID '%s' to node name: %w", instanceID, err)
++					continue
+ 				}
+ 				route.TargetNode = node
+ 				routes = append(routes, route)

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.30/README.md
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.30/README.md
@@ -16,3 +16,7 @@ We shouldn't delete Ingress SG rule, if it allows access from configured "ElbSec
 ## 004-bump-deps.patch
 
 Update dependencies
+
+## 005-fix-list-routes-method.patch
+
+Modify `ListRoutes` method to handle errors gracefully without blocking reconcile loop.

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.31/005-fix-list-routes-method.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.31/005-fix-list-routes-method.patch
@@ -1,0 +1,20 @@
+Subject: [PATCH] fix ListRoutes implementation
+---
+Index: pkg/providers/v1/aws_routes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/providers/v1/aws_routes.go b/pkg/providers/v1/aws_routes.go
+--- a/pkg/providers/v1/aws_routes.go	(revision 8af8a5b7b47af667fd2ee1df080ab39cbdc09f50)
++++ b/pkg/providers/v1/aws_routes.go	(date 1746511538247)
+@@ -116,7 +116,8 @@
+ 			if found {
+ 				node, err := c.instanceIDToNodeName(InstanceID(instanceID))
+ 				if err != nil {
+-					return nil, err
++					klog.Errorf("error converting instance ID '%s' to node name: %w", instanceID, err)
++					continue
+ 				}
+ 				route.TargetNode = node
+ 				routes = append(routes, route)

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.31/README.md
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.31/README.md
@@ -16,3 +16,7 @@ We shouldn't delete Ingress SG rule, if it allows access from configured "ElbSec
 ## 004-bump-deps.patch
 
 Update dependencies
+
+## 005-fix-list-routes-method.patch
+
+Modify `ListRoutes` method to handle errors gracefully without blocking reconcile loop.

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.32/005-fix-list-routes-method.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.32/005-fix-list-routes-method.patch
@@ -1,0 +1,20 @@
+Subject: [PATCH] fix ListRoutes implementation
+---
+Index: pkg/providers/v1/aws_routes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/providers/v1/aws_routes.go b/pkg/providers/v1/aws_routes.go
+--- a/pkg/providers/v1/aws_routes.go	(revision a92f96d8e7b8bcab09252ca62815d01db30db6c1)
++++ b/pkg/providers/v1/aws_routes.go	(date 1746511538247)
+@@ -116,7 +116,8 @@
+ 			if found {
+ 				node, err := c.instanceIDToNodeName(InstanceID(instanceID))
+ 				if err != nil {
+-					return nil, err
++					klog.Errorf("error converting instance ID '%s' to node name: %w", instanceID, err)
++					continue
+ 				}
+ 				route.TargetNode = node
+ 				routes = append(routes, route)

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.32/README.md
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.32/README.md
@@ -16,3 +16,7 @@ We shouldn't delete Ingress SG rule, if it allows access from configured "ElbSec
 ## 004-bump-deps.patch
 
 Update dependencies
+
+## 005-fix-list-routes-method.patch
+
+Modify `ListRoutes` method to handle errors gracefully without blocking reconcile loop.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Modify `ListRoutes` method to handle errors gracefully without blocking reconcile loop.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

`cloud-controller-manager` can get stuck in an infinite loop and stop creating new routes in AWS if, for any reason, it fails to find a Node with the specified ID:
```
E0429 06:44:40.239875       1 route_controller.go:120] Couldn't reconcile node routes: error listing routes: node with instanceID "i-0c1d9d783896b27c2" not found
```
When a new Deckhouse release is applied to the cluster and system pods are restarted, the Kubernetes API server starts responding with delays. As a result, the `fencing-agent` on some nodes fails to renew the lease in time, and those nodes are removed from the cluster ([see source](https://github.com/deckhouse/deckhouse/blob/070629cd3265a2eafe10ee7e56c24b8198155de9/modules/040-node-manager/hooks/fencing_controller.go#L162)).
At the same time, the `machine-controller-manager` (MCM) does not immediately delete such nodes — and during mass restarts, its behavior becomes unpredictable, potentially causing significant delays.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: fix
summary: cloud-controller-manager continues processing routes creation without blocking, even when errors occur.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
