### PR TITLE
[monitoring-kubernetes] disable dns target down alert if module kube-dns is not used

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4321,7 +4321,7 @@ alerts:
       severity: "6"
       markupFormat: markdown
     - name: KubernetesDnsTargetDown
-      sourceFile: modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/kube-dns.yaml
+      sourceFile: modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/kube-dns.tpl
       moduleUrl: 340-monitoring-kubernetes
       module: monitoring-kubernetes
       edition: ce

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/kube-dns.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/kube-dns.tpl
@@ -1,3 +1,4 @@
+{{- if ( .Values.global.enabledModules | has "kube-dns") }}
 - name: kubernetes.dns
   rules:
   - alert: KubernetesDnsTargetDown
@@ -26,3 +27,4 @@
            ```bash
            kubectl -n kube-system describe pod -l k8s-app=kube-dns
            ```
+{{- end }}

--- a/tools/helm_generate/runners/alert_templates/template_values/340-monitoring-kubernetes.yaml
+++ b/tools/helm_generate/runners/alert_templates/template_values/340-monitoring-kubernetes.yaml
@@ -1,4 +1,6 @@
 global:
+  enabledModules:
+    - "kube-dns"
   modules:
     publicDomainTemplate: ""
     https:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Disable `KubernetesDnsTargetDown` alert if module `kube-dns` is not used.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This alert use metrics from the `kube-dns` module, which is not included in the `Managed` bundle by default.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: chore
summary: Disable KubernetesDnsTargetDown alert if module `kube-dns` is not used.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
