### PR TITLE
[candi] add support opentofu to the zvirt

### DIFF
--- a/candi/terraform_versions.yml
+++ b/candi/terraform_versions.yml
@@ -56,7 +56,7 @@ ovirt:
   artifact: terraform-provider-ovirt
   artifactBinary: terraform-provider-ovirt
   destinationBinary: terraform-provider-ovirt
-  useOpentofu: false
+  useOpentofu: true
 
 vsphere:
   namespace: hashicorp

--- a/dhctl/pkg/infrastructureprovider/get_test.go
+++ b/dhctl/pkg/infrastructureprovider/get_test.go
@@ -26,9 +26,10 @@ func TestGetCloudsUseOpentofu(t *testing.T) {
 	m, err := getCloudNameToUseOpentofuMap(config.InfrastructureVersions)
 	require.NoError(t, err)
 
-	require.Len(t, m, 2)
+	require.Len(t, m, 3)
 	require.Contains(t, m, "yandex")
 	require.Contains(t, m, "dynamix")
+	require.Contains(t, m, "zvirt")
 }
 
 func TestNeedToUseOpentofu(t *testing.T) {
@@ -44,7 +45,6 @@ func TestNeedToUseOpentofu(t *testing.T) {
 		"vSphere",
 		"Azure",
 		"VCD",
-		"Zvirt",
 		"Huaweicloud",
 	}
 

--- a/go_lib/cloud-data/apis/v1/zvirt_cloud_provider_discovery_data.go
+++ b/go_lib/cloud-data/apis/v1/zvirt_cloud_provider_discovery_data.go
@@ -23,5 +23,5 @@ type ZvirtCloudProviderDiscoveryData struct {
 type ZvirtStorageDomain struct {
 	Name      string `json:"name"`
 	IsEnabled bool   `json:"isEnabled,omitempty"`
-	IsDefault bool   `json:"IsDefault,omitempty"`
+	IsDefault bool   `json:"isDefault,omitempty"`
 }


### PR DESCRIPTION
## Description

Replacing Terraform with OpenTofu for Zvirt
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

An old version of Terraform is used, which has CVE vulnerabilities that cannot be fixed.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Replacing Terraform with OpenTofu for Zvirt
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
