### PR TITLE
[node-manager][autoscaler] Remove additional cordon node by mcm provider

### DIFF
--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.30/004-delete-mcm-annotations-from-md.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.30/004-delete-mcm-annotations-from-md.patch
@@ -1,37 +1,5 @@
 Subject: [PATCH] ++
 ---
-Index: cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
---- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(revision 36b348865994909216b64e3a12e9c776f1d24732)
-+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1745702750947)
-@@ -1112,7 +1112,7 @@
- 	alreadyMarkedSet := sets.New(getMachineNamesTriggeredForDeletion(md)...)
-
- 	uniqueForDeletionSet := forDeletionSet.Difference(alreadyMarkedSet)
--	toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
-+	//toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
-
- 	data.RevisedToBeDeletedMachineNames = uniqueForDeletionSet
- 	data.RevisedScaledownAmount = uniqueForDeletionSet.Len()
-@@ -1128,10 +1128,10 @@
- 		if mdCopy.Annotations == nil {
- 			mdCopy.Annotations = make(map[string]string)
- 		}
--		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
--		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
--			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
--		}
-+		//triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
-+		//if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
-+		//	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
-+		//}
- 		mdCopy.Spec.Replicas = expectedReplicas
- 		data.RevisedMachineDeployment = mdCopy
- 	}
 Index: cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
 IDEA additional info:
 Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
@@ -39,7 +7,7 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
 --- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(revision 36b348865994909216b64e3a12e9c776f1d24732)
-+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1745702810634)
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1746780734524)
 @@ -25,7 +25,6 @@
  	"context"
  	"fmt"
@@ -136,3 +104,67 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluste
  }
 
  // TODO: Move to using MCM annotations.CreateMachinesTriggeredForDeletionAnnotValue after MCM release
+Index: cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(revision 36b348865994909216b64e3a12e9c776f1d24732)
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1746780796303)
+@@ -535,18 +535,19 @@
+ 	}
+ 	klog.V(2).Infof("MachineDeployment %q size decreased from %d to %d, TriggerDeletionByMCM Annotation Value: %q", md.Name, md.Spec.Replicas, updatedMd.Spec.Replicas, updatedMd.Annotations[machineutils.TriggerDeletionByMCM])
+
+-	toBeCordonedNodeNames := make([]string, 0, len(data.RevisedToBeDeletedMachineNames))
+-	for _, mInfo := range toBeDeletedMachineInfos {
+-		if data.RevisedToBeDeletedMachineNames.Has(mInfo.Key.Name) {
+-			toBeCordonedNodeNames = append(toBeCordonedNodeNames, mInfo.NodeName)
+-			klog.V(2).Infof("For MachineDeployment %q, will cordon node: %q corresponding to machine %q", md.Name, mInfo.NodeName, mInfo.Key.Name)
+-		}
+-	}
+-	err = m.cordonNodes(toBeCordonedNodeNames)
+-	if err != nil {
+-		// Do not return error as cordoning is best-effort
+-		klog.Warningf("NodeGroup.deleteMachines() of %q ran into error cordoning nodes: %v", md.Name, err)
+-	}
++	//toBeCordonedNodeNames := make([]string, 0, len(data.RevisedToBeDeletedMachineNames))
++	//for _, mInfo := range toBeDeletedMachineInfos {
++	//	if data.RevisedToBeDeletedMachineNames.Has(mInfo.Key.Name) {
++	//		toBeCordonedNodeNames = append(toBeCordonedNodeNames, mInfo.NodeName)
++	//		klog.V(2).Infof("For MachineDeployment %q, will cordon node: %q corresponding to machine %q", md.Name, mInfo.NodeName, mInfo.Key.Name)
++	//	}
++	//}
++	//err = m.cordonNodes(toBeCordonedNodeNames)
++	//if err != nil {
++	//	// Do not return error as cordoning is best-effort
++	//	klog.Warningf("NodeGroup.deleteMachines() of %q ran into error cordoning nodes: %v", md.Name, err)
++	//}
++
+ 	return false, nil
+ }
+
+@@ -1112,7 +1113,7 @@
+ 	alreadyMarkedSet := sets.New(getMachineNamesTriggeredForDeletion(md)...)
+
+ 	uniqueForDeletionSet := forDeletionSet.Difference(alreadyMarkedSet)
+-	toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
++	//toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
+
+ 	data.RevisedToBeDeletedMachineNames = uniqueForDeletionSet
+ 	data.RevisedScaledownAmount = uniqueForDeletionSet.Len()
+@@ -1128,10 +1129,10 @@
+ 		if mdCopy.Annotations == nil {
+ 			mdCopy.Annotations = make(map[string]string)
+ 		}
+-		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
+-		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
+-			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
+-		}
++		//triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
++		//if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
++		//	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
++		//}
+ 		mdCopy.Spec.Replicas = expectedReplicas
+ 		data.RevisedMachineDeployment = mdCopy
+ 	}

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.31/004-delete-mcm-annotations-from-md.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.31/004-delete-mcm-annotations-from-md.patch
@@ -1,45 +1,13 @@
 Subject: [PATCH] ++
 ---
-Index: cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
---- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(revision 36b348865994909216b64e3a12e9c776f1d24732)
-+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1745702750947)
-@@ -1112,7 +1112,7 @@
- 	alreadyMarkedSet := sets.New(getMachineNamesTriggeredForDeletion(md)...)
-
- 	uniqueForDeletionSet := forDeletionSet.Difference(alreadyMarkedSet)
--	toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
-+	//toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
-
- 	data.RevisedToBeDeletedMachineNames = uniqueForDeletionSet
- 	data.RevisedScaledownAmount = uniqueForDeletionSet.Len()
-@@ -1128,10 +1128,10 @@
- 		if mdCopy.Annotations == nil {
- 			mdCopy.Annotations = make(map[string]string)
- 		}
--		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
--		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
--			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
--		}
-+		//triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
-+		//if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
-+		//	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
-+		//}
- 		mdCopy.Spec.Replicas = expectedReplicas
- 		data.RevisedMachineDeployment = mdCopy
- 	}
 Index: cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
 IDEA additional info:
 Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 <+>UTF-8
 ===================================================================
 diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
---- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(revision 36b348865994909216b64e3a12e9c776f1d24732)
-+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1745702810634)
+--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(revision 2818e0cffbc180b42fc486630ab36d43ecf56649)
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1746780978295)
 @@ -25,7 +25,6 @@
  	"context"
  	"fmt"
@@ -136,3 +104,66 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluste
  }
 
  // TODO: Move to using MCM annotations.CreateMachinesTriggeredForDeletionAnnotValue after MCM release
+Index: cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(revision 2818e0cffbc180b42fc486630ab36d43ecf56649)
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1746781131049)
+@@ -537,18 +537,18 @@
+ 	}
+ 	klog.V(2).Infof("MachineDeployment %q size decreased from %d to %d, TriggerDeletionByMCM Annotation Value: %q", md.Name, md.Spec.Replicas, updatedMd.Spec.Replicas, updatedMd.Annotations[machineutils.TriggerDeletionByMCM])
+
+-	toBeCordonedNodeNames := make([]string, 0, len(data.RevisedToBeDeletedMachineNames))
+-	for _, mInfo := range toBeDeletedMachineInfos {
+-		if data.RevisedToBeDeletedMachineNames.Has(mInfo.Key.Name) {
+-			toBeCordonedNodeNames = append(toBeCordonedNodeNames, mInfo.NodeName)
+-			klog.V(2).Infof("For MachineDeployment %q, will cordon node: %q corresponding to machine %q", md.Name, mInfo.NodeName, mInfo.Key.Name)
+-		}
+-	}
+-	err = m.cordonNodes(toBeCordonedNodeNames)
+-	if err != nil {
+-		// Do not return error as cordoning is best-effort
+-		klog.Warningf("NodeGroup.deleteMachines() of %q ran into error cordoning nodes: %v", md.Name, err)
+-	}
++	//toBeCordonedNodeNames := make([]string, 0, len(data.RevisedToBeDeletedMachineNames))
++	//for _, mInfo := range toBeDeletedMachineInfos {
++	//	if data.RevisedToBeDeletedMachineNames.Has(mInfo.Key.Name) {
++	//		toBeCordonedNodeNames = append(toBeCordonedNodeNames, mInfo.NodeName)
++	//		klog.V(2).Infof("For MachineDeployment %q, will cordon node: %q corresponding to machine %q", md.Name, mInfo.NodeName, mInfo.Key.Name)
++	//	}
++	//}
++	//err = m.cordonNodes(toBeCordonedNodeNames)
++	//if err != nil {
++	//	// Do not return error as cordoning is best-effort
++	//	klog.Warningf("NodeGroup.deleteMachines() of %q ran into error cordoning nodes: %v", md.Name, err)
++	//}
+ 	return false, nil
+ }
+
+@@ -1119,7 +1119,7 @@
+ 	alreadyMarkedSet := sets.New(getMachineNamesTriggeredForDeletion(md)...)
+
+ 	uniqueForDeletionSet := forDeletionSet.Difference(alreadyMarkedSet)
+-	toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
++	//toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
+
+ 	data.RevisedToBeDeletedMachineNames = uniqueForDeletionSet
+ 	data.RevisedScaledownAmount = uniqueForDeletionSet.Len()
+@@ -1135,10 +1135,10 @@
+ 		if mdCopy.Annotations == nil {
+ 			mdCopy.Annotations = make(map[string]string)
+ 		}
+-		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
+-		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
+-			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
+-		}
++		//triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
++		//if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
++		//	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
++		//}
+ 		mdCopy.Spec.Replicas = expectedReplicas
+ 		data.RevisedMachineDeployment = mdCopy
+ 	}

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/004-delete-mcm-annotations-from-md.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/004-delete-mcm-annotations-from-md.patch
@@ -1,37 +1,5 @@
 Subject: [PATCH] ++
 ---
-Index: cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
---- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
-+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1745846227339)
-@@ -1120,7 +1120,7 @@
- 	alreadyMarkedSet := sets.New(getMachineNamesTriggeredForDeletion(md)...)
-
- 	uniqueForDeletionSet := forDeletionSet.Difference(alreadyMarkedSet)
--	toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
-+	//toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
-
- 	data.RevisedToBeDeletedMachineNames = uniqueForDeletionSet
- 	data.RevisedScaledownAmount = uniqueForDeletionSet.Len()
-@@ -1136,10 +1136,10 @@
- 		if mdCopy.Annotations == nil {
- 			mdCopy.Annotations = make(map[string]string)
- 		}
--		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
--		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
--			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
--		}
-+		//triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
-+		//if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
-+		//	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
-+		//}
- 		mdCopy.Spec.Replicas = expectedReplicas
- 		data.RevisedMachineDeployment = mdCopy
- 	}
 Index: cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
 IDEA additional info:
 Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
@@ -39,7 +7,7 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
 --- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
-+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1745846330291)
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1746781221962)
 @@ -31,10 +31,8 @@
  	"time"
 
@@ -131,3 +99,66 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluste
  }
 
  // TODO: Move to using MCM annotations.CreateMachinesTriggeredForDeletionAnnotValue after MCM release
+Index: cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1746781249737)
+@@ -538,18 +538,18 @@
+ 	}
+ 	klog.V(2).Infof("MachineDeployment %q size decreased from %d to %d, TriggerDeletionByMCM Annotation Value: %q", md.Name, md.Spec.Replicas, updatedMd.Spec.Replicas, updatedMd.Annotations[machineutils.TriggerDeletionByMCM])
+
+-	toBeCordonedNodeNames := make([]string, 0, len(data.RevisedToBeDeletedMachineNames))
+-	for _, mInfo := range toBeDeletedMachineInfos {
+-		if data.RevisedToBeDeletedMachineNames.Has(mInfo.Key.Name) {
+-			toBeCordonedNodeNames = append(toBeCordonedNodeNames, mInfo.NodeName)
+-			klog.V(2).Infof("For MachineDeployment %q, will cordon node: %q corresponding to machine %q", md.Name, mInfo.NodeName, mInfo.Key.Name)
+-		}
+-	}
+-	err = m.cordonNodes(toBeCordonedNodeNames)
+-	if err != nil {
+-		// Do not return error as cordoning is best-effort
+-		klog.Warningf("NodeGroup.deleteMachines() of %q ran into error cordoning nodes: %v", md.Name, err)
+-	}
++	//toBeCordonedNodeNames := make([]string, 0, len(data.RevisedToBeDeletedMachineNames))
++	//for _, mInfo := range toBeDeletedMachineInfos {
++	//	if data.RevisedToBeDeletedMachineNames.Has(mInfo.Key.Name) {
++	//		toBeCordonedNodeNames = append(toBeCordonedNodeNames, mInfo.NodeName)
++	//		klog.V(2).Infof("For MachineDeployment %q, will cordon node: %q corresponding to machine %q", md.Name, mInfo.NodeName, mInfo.Key.Name)
++	//	}
++	//}
++	//err = m.cordonNodes(toBeCordonedNodeNames)
++	//if err != nil {
++	//	// Do not return error as cordoning is best-effort
++	//	klog.Warningf("NodeGroup.deleteMachines() of %q ran into error cordoning nodes: %v", md.Name, err)
++	//}
+ 	return false, nil
+ }
+
+@@ -1120,7 +1120,7 @@
+ 	alreadyMarkedSet := sets.New(getMachineNamesTriggeredForDeletion(md)...)
+
+ 	uniqueForDeletionSet := forDeletionSet.Difference(alreadyMarkedSet)
+-	toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
++	//toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
+
+ 	data.RevisedToBeDeletedMachineNames = uniqueForDeletionSet
+ 	data.RevisedScaledownAmount = uniqueForDeletionSet.Len()
+@@ -1136,10 +1136,10 @@
+ 		if mdCopy.Annotations == nil {
+ 			mdCopy.Annotations = make(map[string]string)
+ 		}
+-		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
+-		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
+-			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
+-		}
++		//triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
++		//if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
++		//	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
++		//}
+ 		mdCopy.Spec.Replicas = expectedReplicas
+ 		data.RevisedMachineDeployment = mdCopy
+ 	}

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/README.md
@@ -11,3 +11,7 @@ It makes sense only for calculation node-group capacity from zero, when we have 
 Cluster autoscaler can't tell the difference between pods created by apps/v1 and apps.kruise.io/v1alpha1 
 daemonsets when simulating if a node can be terminated. This patch makes cluster autoscaler check PDB 
 instead of checking if an apps/v1 daemonset exists, when it bumps into a pod created by an advanced daemonset.
+
+# Remove additional cordon by mcm cloud provider
+Gardner cluster autoscaler cordon node of main flow of autoscaler.
+It can be keep nodes in cordon status without deleting them.


### PR DESCRIPTION
## Description
Remove additional cordon node by mcm provider.

Continue of https://github.com/deckhouse/deckhouse/pull/13180

## Why do we need it, and what problem does it solve?
MCM provider of cluster autoscaler can cordon nodes out of autoscaler flow.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Autoscaler - remove additional cordon node by mcm provider.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
