### PR TITLE
[testing] Improve autoscaler e2e tests

### DIFF
--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_autoscaler.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_autoscaler.sh
@@ -212,7 +212,7 @@ function check_cordon_events() {
 
     if [[ "$cordon_events_count" == "1" ]]; then
       echo "Node $n cordoned before deleting!"
-      ((captured_events++))
+      ((captured_events+=1))
     else
       echo "Cordon events for node $n not found"
       break
@@ -280,7 +280,7 @@ function verify_that_nodes_were_drained() {
 
       if [[ "$drain_events_count" == "1" ]]; then
         echo "Node $n drained before deleting!"
-        ((captured_events++))
+        ((captured_events+=1))
       else
         echo "Drain events for node $n not found"
         break


### PR DESCRIPTION
## Description
Improve autoscaler e2e tests.

Now we save nodes names and nodes count of autoscaler in variables. We grep cordon and draining events for each node in nodes list and grep events by node name instead of nodegroup prefix. This allows you to more accurately collect events this allows restarting testing without side effects (when we have separate events for each nodes by test attempt and we wait 1 one event for test). Also, during testing, we found that k8s not always set cordon event, but autoscaler always. We begin to check k8s events and if we did not find them check autoscaler events as fallback.  

## Why do we need it, and what problem does it solve?
Restarting e2e tests not working correctly and we summarized tests for adding additional nodes in tests.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: fix
summary: Improve autoscaler e2e tests.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
