### PR TITLE
[dhctl] Fix panic in check operations

### DIFF
--- a/.werf/defines/infrastructure-manager.tmpl
+++ b/.werf/defines/infrastructure-manager.tmpl
@@ -16,3 +16,22 @@ terraform-manager/base-terraform-manager
     {{- fail (printf "provider %s not found" $context.providerName) -}}
 {{- end }}
 {{- end }}
+
+# calculate plugins dir for terraform-auto-exporter and terraform-state-exporteer
+# . is dict with keys:
+#   TF - TF from werf.yaml
+#   providerName - from terraform_versions.yaml key in root like azure or decort for example
+
+{{- define "infrastructure_manager_plugin_dir" }}
+{{- $context := . -}}
+{{- if hasKey $context.TF $context.providerName -}}
+  {{- $provider := get $context.TF $context.providerName -}}
+  {{- if $provider.useOpentofu -}}
+registry.opentofu.org
+  {{- else -}}
+registry.terraform.io
+  {{- end -}}
+{{- else }}
+    {{- fail (printf "provider %s not found" $context.providerName) -}}
+{{- end }}
+{{- end }}

--- a/dhctl/pkg/operations/check/check.go
+++ b/dhctl/pkg/operations/check/check.go
@@ -316,11 +316,16 @@ func CheckState(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig
 		statistics.Cluster.Status = DestructiveStatus
 		statistics.Cluster.DestructiveChanges = baseRes.DestructiveChanges
 	}
-	if baseRes.Plan != nil {
-		statistics.InfrastructurePlan = append(statistics.InfrastructurePlan, baseRes.Plan)
-	}
 
-	hasTerraformState := baseRes.IsTerraformState
+	hasTerraformState := false
+
+	if baseRes != nil {
+		if baseRes.Plan != nil {
+			statistics.InfrastructurePlan = append(statistics.InfrastructurePlan, baseRes.Plan)
+		}
+
+		hasTerraformState = baseRes.IsTerraformState
+	}
 
 	log.DebugF("Base infrastructure has terraform state %v\n", hasTerraformState)
 
@@ -472,15 +477,17 @@ func CheckState(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig
 			}
 
 			statistics.Node = append(statistics.Node, checkResult)
-			if nodeRes.Plan != nil {
-				statistics.InfrastructurePlan = append(statistics.InfrastructurePlan, nodeRes.Plan)
-			}
+			if nodeRes != nil {
+				if nodeRes.Plan != nil {
+					statistics.InfrastructurePlan = append(statistics.InfrastructurePlan, nodeRes.Plan)
+				}
 
-			log.DebugF("Node %s has terraform state: %v\n", name, nodeRes.IsTerraformState)
+				log.DebugF("Node %s has terraform state: %v\n", name, nodeRes.IsTerraformState)
 
-			if nodeRes.IsTerraformState && !hasTerraformState {
-				hasTerraformState = nodeRes.IsTerraformState
-				log.DebugF("Has terraform state after node %s: %v\n", name, hasTerraformState)
+				if nodeRes.IsTerraformState && !hasTerraformState {
+					hasTerraformState = nodeRes.IsTerraformState
+					log.DebugF("Has terraform state after node %s: %v\n", name, hasTerraformState)
+				}
 			}
 		}
 	}

--- a/ee/modules/040-terraform-manager/images/terraform-manager-dynamix/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-dynamix/werf.inc.yaml
@@ -6,7 +6,7 @@ git:
 import:
   - image: terraform-provider-decort
     add: /terraform-provider-decort
-    to: /plugins/registry.terraform.io/{{ .TF.decort.namespace }}/{{ .TF.decort.type }}/{{ .TF.decort.version }}/linux_amd64/terraform-provider-decort
+    to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "decort") }}/{{ .TF.decort.namespace }}/{{ .TF.decort.type }}/{{ .TF.decort.version }}/linux_amd64/terraform-provider-decort
     before: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/modules/040-terraform-manager/images/terraform-manager-huaweicloud/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-huaweicloud/werf.inc.yaml
@@ -6,7 +6,7 @@ git:
 import:
   - image: terraform-provider-huaweicloud
     add: /terraform-provider-huaweicloud
-    to: /plugins/registry.terraform.io/{{ .TF.huaweicloud.namespace }}/{{ .TF.huaweicloud.type }}/{{ .TF.huaweicloud.version }}/linux_amd64/terraform-provider-huaweicloud
+    to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "huaweicloud") }}/{{ .TF.huaweicloud.namespace }}/{{ .TF.huaweicloud.type }}/{{ .TF.huaweicloud.version }}/linux_amd64/terraform-provider-huaweicloud
     before: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
@@ -6,7 +6,7 @@ git:
 import:
 - image: terraform-provider-openstack
   add: /terraform-provider-openstack
-  to: /plugins/registry.terraform.io/{{ .TF.openstack.namespace }}/{{ .TF.openstack.type }}/{{ .TF.openstack.version }}/linux_amd64/terraform-provider-openstack
+  to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "openstack") }}/{{ .TF.openstack.namespace }}/{{ .TF.openstack.type }}/{{ .TF.openstack.version }}/linux_amd64/terraform-provider-openstack
   before: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/modules/040-terraform-manager/images/terraform-manager-vcd/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-vcd/werf.inc.yaml
@@ -8,7 +8,7 @@ import:
 {{- range $version := .TF.vcd.versions }}
 - image: terraform-provider-vcd-artifact
   add: /terraform-provider-vcd-v{{ $version }}
-  to: /plugins/registry.terraform.io/{{ $.TF.vcd.namespace }}/{{ $.TF.vcd.type }}/{{ $version }}/linux_amd64/terraform-provider-vcd
+  to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" $.TF "providerName" "vcd") }}/{{ $.TF.vcd.namespace }}/{{ $.TF.vcd.type }}/{{ $version }}/linux_amd64/terraform-provider-vcd
   before: setup
 {{- end }}
 ---

--- a/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
+++ b/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
@@ -7,7 +7,7 @@ git:
 import:
 - image: terraform-provider-vsphere
   add: /terraform-provider-vsphere
-  to: /plugins/registry.terraform.io/{{ .TF.vsphere.namespace }}/{{ .TF.vsphere.type }}/{{ .TF.vsphere.version }}/linux_amd64/terraform-provider-vsphere
+  to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "vsphere") }}/{{ .TF.vsphere.namespace }}/{{ .TF.vsphere.type }}/{{ .TF.vsphere.version }}/linux_amd64/terraform-provider-vsphere
   before: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-zvirt/werf.inc.yaml
+++ b/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-zvirt/werf.inc.yaml
@@ -6,7 +6,7 @@ git:
 import:
   - image: terraform-provider-ovirt
     add: /terraform-provider-ovirt
-    to: /plugins/registry.terraform.io/{{ .TF.ovirt.namespace }}/{{ .TF.ovirt.type }}/{{ .TF.ovirt.version }}/linux_amd64/terraform-provider-ovirt
+    to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "ovirt") }}/{{ .TF.ovirt.namespace }}/{{ .TF.ovirt.type }}/{{ .TF.ovirt.version }}/linux_amd64/terraform-provider-ovirt
     before: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
@@ -6,7 +6,7 @@ git:
 import:
 - image: terraform-provider-aws
   add: /terraform-provider-aws
-  to: /plugins/registry.terraform.io/{{ .TF.aws.namespace }}/{{ .TF.aws.type }}/{{ .TF.aws.version }}/linux_amd64/terraform-provider-aws
+  to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "aws") }}/{{ .TF.aws.namespace }}/{{ .TF.aws.type }}/{{ .TF.aws.version }}/linux_amd64/terraform-provider-aws
   before: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
@@ -6,7 +6,7 @@ git:
 import:
 - image: terraform-provider-azure
   add: /terraform-provider-azurerm
-  to: /plugins/registry.terraform.io/{{ .TF.azure.namespace }}/{{ .TF.azure.type }}/{{ .TF.azure.version }}/linux_amd64/terraform-provider-azurerm
+  to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "azure") }}/{{ .TF.azure.namespace }}/{{ .TF.azure.type }}/{{ .TF.azure.version }}/linux_amd64/terraform-provider-azurerm
   before: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
@@ -7,7 +7,7 @@ git:
 import:
 - image: terraform-provider-gcp
   add: /terraform-provider-gcp
-  to: /plugins/registry.terraform.io/{{ .TF.gcp.namespace }}/{{ .TF.gcp.type }}/{{ .TF.gcp.version }}/linux_amd64/terraform-provider-google
+  to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "gcp") }}/{{ .TF.gcp.namespace }}/{{ .TF.gcp.type }}/{{ .TF.gcp.version }}/linux_amd64/terraform-provider-google
   before: setup
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact

--- a/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
@@ -6,7 +6,7 @@ git:
 import:
 - image: terraform-provider-yandex
   add: /terraform-provider-yandex
-  to: /plugins/registry.opentofu.org/{{ .TF.yandex.namespace }}/{{ .TF.yandex.type }}/{{ .TF.yandex.version }}/linux_amd64/terraform-provider-yandex
+  to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "yandex") }}/{{ .TF.yandex.namespace }}/{{ .TF.yandex.type }}/{{ .TF.yandex.version }}/linux_amd64/terraform-provider-yandex
   before: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact


### PR DESCRIPTION
## Description
Fix panic during dhctl terraform check if terraform returns error.
Also, add additional define for werf.yaml which calculate plugins dir for state-exporter and autoconverger images.

## Why do we need it, and what problem does it solve?
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1aa4ffb]

goroutine 15 [running]:
github.com/deckhouse/deckhouse/dhctl/pkg/operations/check.CheckState({0x24d5750, 0xc000714730}, 0xc000710240, 0xc00080e000, 0xc000713ca0, {0xe0?, {0x0?, 0x0?}})
        /dhctl/pkg/operations/check/check.go:319 +0x27b
github.com/deckhouse/deckhouse/dhctl/pkg/operations.(*ConvergeExporter).getStatistic(0xc00007eea0, {0x24d5750, 0xc000714730})
        /dhctl/pkg/operations/exporter.go:261 +0x285
github.com/deckhouse/deckhouse/dhctl/pkg/operations.(*ConvergeExporter).convergeLoop(0xc00007eea0, {0x24d5750, 0xc000714730})
        /dhctl/pkg/operations/exporter.go:227 +0x46
created by github.com/deckhouse/deckhouse/dhctl/pkg/operations.(*ConvergeExporter).Start in goroutine 7
        /dhctl/pkg/operations/exporter.go:205 +0x2a
```

Implement logic for simply migrate from terraform to opentofu, using terraform_versions.yam file.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix 
summary: Fix panic in check operations.
impact_level: low
---
section: ci
type: chore
summary: Add additional define for werf.yaml which calculate plugins dir for state-exporter and autoconverger images.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
