### PR TITLE
[candi] fix step for discovering kubernetes-device in gcp

### DIFF
--- a/candi/cloud-providers/gcp/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
+++ b/candi/cloud-providers/gcp/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
@@ -59,7 +59,7 @@ if [ -f /var/lib/bashible/kubernetes_data_device_path ]; then
     return 0
   fi
 else
-  cloud_disk_name="$(get_data_device_secret | jq -re --arg hostname "$HOSTNAME" '.data[$hostname]' | base64 -d)"
+  cloud_disk_name="$(get_data_device_secret | jq -re --arg hostname "$(bb-d8-node-name)" '.data[$hostname]' | base64 -d)"
 fi
 
 echo "$(discover_device_path "$cloud_disk_name")" > /var/lib/bashible/kubernetes_data_device_path

--- a/testing/cloud_layouts/GCP/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/GCP/WithoutNAT/configuration.tpl.yaml
@@ -58,13 +58,6 @@ spec:
         customTolerationKeys:
           - node
   version: 1
----
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: flant-integration
-spec:
-  enabled: false
 # move ingres from resources yaml for testing dhctl configuration with 3-rd party resources
 ---
 apiVersion: deckhouse.io/v1


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Use `bb-d8-node-name` instead `HOSTNAME` variable for getting current node name in bashible step for gcp. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


`HOSTNAME` env variable doesn't updated value without rerun login scripts or start a new shell. In some cases this will broke step for discovering kubernetes device.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Use bb-d8-node-name instead HOSTNAME variable for getting current node name in bashible step for gcp. 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
