### PR TITLE
[monitoring-kubernetes-control-plane] Add API server latency alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3777,6 +3777,16 @@ alerts:
         API servers can't be reached.
       severity: "3"
       markupFormat: default
+    - name: K8SApiserverHighLatency
+      sourceFile: modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kubernetes.tpl
+      moduleUrl: 340-monitoring-kubernetes-control-plane
+      module: monitoring-kubernetes-control-plane
+      edition: ce
+      description: The API server is experiencing high latency, which may lead to additional issues in the cluster. Verify whether there are sufficient resources on the master nodes.
+      summary: |
+        High latency of the API server  {{$labels.instance}}.
+      severity: "5"
+      markupFormat: default
     - name: K8sCertificateExpiration
       sourceFile: modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kubernetes.tpl
       moduleUrl: 340-monitoring-kubernetes-control-plane

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3782,9 +3782,12 @@ alerts:
       moduleUrl: 340-monitoring-kubernetes-control-plane
       module: monitoring-kubernetes-control-plane
       edition: ce
-      description: The API server is experiencing high latency, which may lead to additional issues in the cluster. Verify whether there are sufficient resources on the master nodes.
+      description: |
+        The API server is experiencing high latency, which may lead to degraded performance and additional issues in the cluster.
+
+        To resolve the issue, verify whether the master nodes have sufficient CPU, memory, and disk resources.
       summary: |
-        High latency of the API server  {{$labels.instance}}.
+        High latency of the API server {{$labels.instance}}.
       severity: "5"
       markupFormat: default
     - name: K8sCertificateExpiration

--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kubernetes.tpl
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kubernetes.tpl
@@ -102,8 +102,11 @@ Consider enabling the `control-plane-manager` module for advanced debugging.
       severity_level: "5"
     annotations:
       plk_protocol_version: "1"
-      summary: High latency of the API server  `{{`{{$labels.instance}}`}}`.
-      description: The API server is experiencing high latency, which may lead to additional issues in the cluster. Verify whether there are sufficient resources on the master nodes.
+      summary: High latency of the API server `{{`{{$labels.instance}}`}}`.
+      description: |
+        The API server is experiencing high latency, which may lead to degraded performance and additional issues in the cluster.
+        
+        To resolve the issue, verify whether the master nodes have sufficient CPU, memory, and disk resources.
   - alert: K8sCertificateExpiration
     expr: sum(label_replace(rate(apiserver_client_certificate_expiration_seconds_bucket{le="604800", job=~"kubelet|kube-apiserver"}[1m]) > 0, "component", "$1", "job", "(.*)")) by (component, node)
     labels:

--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kubernetes.tpl
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kubernetes.tpl
@@ -95,6 +95,15 @@ Consider enabling the `control-plane-manager` module for advanced debugging.
       plk_protocol_version: "1"
       summary: API servers can't be reached.
       description: No API servers are reachable, or they have all disappeared from service discovery.
+  - alert: K8SApiserverHighLatency
+    expr: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!~"CONNECT|WATCH", job="kube-apiserver", instance=~".*:6443", verb=~".*"}[20m])) by (instance, le)) > 1
+    for: 1h
+    labels:
+      severity_level: "5"
+    annotations:
+      plk_protocol_version: "1"
+      summary: High latency of the API server  `{{`{{$labels.instance}}`}}`.
+      description: The API server is experiencing high latency, which may lead to additional issues in the cluster. Verify whether there are sufficient resources on the master nodes.
   - alert: K8sCertificateExpiration
     expr: sum(label_replace(rate(apiserver_client_certificate_expiration_seconds_bucket{le="604800", job=~"kubelet|kube-apiserver"}[1m]) > 0, "component", "$1", "job", "(.*)")) by (component, node)
     labels:

--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kubernetes.tpl
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kubernetes.tpl
@@ -96,7 +96,7 @@ Consider enabling the `control-plane-manager` module for advanced debugging.
       summary: API servers can't be reached.
       description: No API servers are reachable, or they have all disappeared from service discovery.
   - alert: K8SApiserverHighLatency
-    expr: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!~"CONNECT|WATCH", job="kube-apiserver", instance=~".*:6443", verb=~".*"}[20m])) by (instance, le)) > 1
+    expr: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!~"CONNECT|WATCH", job="kube-apiserver", instance=~".*:6443", verb=~".*"}[5m])) by (instance, le)) > 1
     for: 1h
     labels:
       severity_level: "5"


### PR DESCRIPTION
## Description

Add alert for high latency from kube-apiserver

## Why do we need it, and what problem does it solve?
Respond promptly to API high latency.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes-control-plane
type: chore
summary: Add the new alert for high latency from kube-apiserver.
```
