### PR TITLE
[docs] Fix broken links in the Storage overview.

### DIFF
--- a/docs/documentation/pages/storage/README.md
+++ b/docs/documentation/pages/storage/README.md
@@ -17,18 +17,18 @@ Deckhouse Kubernetes Platform offers a wide range of solutions, which can be div
 
 ### Software-Defined Storage
 
-- [Local storage based on LVM (Logical Volume Manager)](../storage/admin/sds/lvm-local.html);
-- [Replicated storage based on DRBD (Distributed Replicated Block Device)](../storage/admin/sds/lvm-replicated.html).
+- [Local storage based on LVM (Logical Volume Manager)](../admin/sds/lvm-local.html);
+- [Replicated storage based on DRBD (Distributed Replicated Block Device)](../admin/sds/lvm-replicated.html).
 
 ### External Storage
 
-- [Distributed Ceph storage](../storage/admin/external/ceph.html);
-- [HPE data storage](../storage/admin/external/hpe.html);
-- [Huawei data storage](../storage/admin/external/huawei.html);
-- [NFS data storage](../storage/admin/external/nfs.html);
-- [S3-based object storage](../storage/admin/external/s3.html);
-- [SCSI-based data storage](../storage/admin/external/scsi.html);
-- [TATLIN.UNIFIED (Yadro) unified storage](../storage/admin/external/yadro.html).
+- [Distributed Ceph storage](../admin/external/ceph.html);
+- [HPE data storage](../admin/external/hpe.html);
+- [Huawei data storage](../admin/external/huawei.html);
+- [NFS data storage](../admin/external/nfs.html);
+- [S3-based object storage](../admin/external/s3.html);
+- [SCSI-based data storage](../admin/external/scsi.html);
+- [TATLIN.UNIFIED (Yadro) unified storage](../admin/external/yadro.html).
 
 ## Key Features
 


### PR DESCRIPTION
## Description
Fix broken links in the Storage overview (English version).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Fix broken links in the Storage overview.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
