### PR TITLE
[candi] bootstrap 401 retry

### DIFF
--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -68,8 +68,8 @@ function get_phase2() {
   token="$(<${BOOTSTRAP_DIR}/bootstrap-token)"
   check_python
 
-  local 401_err_count=0
-  local max_401_err_count=6
+  local http_401_count=0
+  local max_http_401_count=6
 
   while true; do
     for server in {{ $context.Values.nodeManager.internal.clusterMasterAddresses | join " " }}; do
@@ -78,8 +78,8 @@ function get_phase2() {
         return 0
       fi
       if [ $? -eq 2 ]; then
-        ((401_err_count++))
-        if [ $401_err_count -ge $max_401_err_count ]; then
+        ((http_401_count++))
+        if [ $http_401_count -ge $max_http_401_count ]; then
           return 1
         fi
       else

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -77,7 +77,8 @@ function get_phase2() {
       if eval "${python_binary}" - "${url}" "${token}" <<< "$(load_phase2_script)"; then
         return 0
       fi
-      if [ $? -eq 2 ]; then
+      local rc=$?
+      if [ $rc -eq 2 ]; then
         ((http_401_count++))
         if [ $http_401_count -ge $max_http_401_count ]; then
           return 1


### PR DESCRIPTION
## Description

n PR [#10845](https://github.com/deckhouse/deckhouse/pull/10845), we changed the bootstrap.sh behavior to exit immediately with a human-readable exception when receiving a 401 error from the master node during bootstrapping.

Now we've added a retry mechanism for 401 errors, since they can occur not only due to an expired token.

## Why do we need it, and what problem does it solve?

In some rare cases, the bootstrap script fails even when the token is valid

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: retry logic for 401 in bootstrap script
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
