### PR TITLE
[prometheus] Improve prometheus response caching

### DIFF
--- a/modules/300-prometheus/templates/aggregating-proxy/configmap.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/configmap.yaml
@@ -18,7 +18,7 @@ data:
       grpc_listen_address: 127.0.0.1
       grpc_listen_port: 9095
     limits:
-      align_queries_with_step: false
+      align_queries_with_step: true
     frontend:
       cache_results: true
       log_queries_longer_than: 0


### PR DESCRIPTION
## Description
When a user requests a large metrics range, the query frontend splits the request into subrequests of a configured duration (24h by default), executes them in parallel, and caches the result. The cache, however, is useless because almost every query starts with the current timestamp; hence, splitting the entire time range into 24h has no positive outcome, as the subrequests always have different caching keys.

This can be fixed by enabling this option:
```
# Mutate incoming queries to align their start and end with their step to
# improve result caching.
# CLI flag: -query-frontend.align-queries-with-step
[align_queries_with_step: <boolean> | default = false]
```
making subrequests have a predictable range, thus reusable while caching.
## Why do we need it, and what problem does it solve?
This change drastically improves caching of the wide range requests.
The option, described above, was disabled explicitly for an unknown reason.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: fix
summary: improve caching of the long-range requests.
impact: aggregating-proxy will be rollout restarted with no disruption
impact_level: default
```
