### PR TITLE
[testing] Fix openstack e2e tests with cloud permanent ng

### DIFF
--- a/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
@@ -109,7 +109,7 @@ resource "openstack_compute_instance_v2" "node" {
     update = var.resourceManagementTimeout
   }
 
-  metadata = length(local.metadata_tags) > 0 ? local.metadata_tags : null
+  metadata = length(local.metadata_tags) > 0 ? local.metadata_tags : {}
 }
 
 resource "openstack_compute_floatingip_v2" "floating_ip" {

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/patches/003-empty-metadata-fix.patch
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/patches/003-empty-metadata-fix.patch
@@ -7,13 +7,13 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/openstack/resource_openstack_compute_instance_v2.go b/openstack/resource_openstack_compute_instance_v2.go
 --- a/openstack/resource_openstack_compute_instance_v2.go	(revision a6cf040ae7c8118ff9c3a37b9045b364f9a50ae8)
-+++ b/openstack/resource_openstack_compute_instance_v2.go	(date 1747161978214)
++++ b/openstack/resource_openstack_compute_instance_v2.go	(date 1747175166320)
 @@ -684,6 +684,10 @@
 
  	log.Printf("[DEBUG] Retrieved Server %s: %+v", d.Id(), server)
 
-+	if server.Metadata == nil {
-+		d.Set("metadata", make(map[string]string))
++	if len(server.Metadata) == 0 {
++		d.Set("metadata", nil)
 +	}
 +
  	d.Set("name", server.Name)

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/patches/003-empty-metadata-fix.patch
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/patches/003-empty-metadata-fix.patch
@@ -1,0 +1,21 @@
+Subject: [PATCH] ++
+---
+Index: openstack/resource_openstack_compute_instance_v2.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/openstack/resource_openstack_compute_instance_v2.go b/openstack/resource_openstack_compute_instance_v2.go
+--- a/openstack/resource_openstack_compute_instance_v2.go	(revision a6cf040ae7c8118ff9c3a37b9045b364f9a50ae8)
++++ b/openstack/resource_openstack_compute_instance_v2.go	(date 1747161978214)
+@@ -684,6 +684,10 @@
+
+ 	log.Printf("[DEBUG] Retrieved Server %s: %+v", d.Id(), server)
+
++	if server.Metadata == nil {
++		d.Set("metadata", make(map[string]string))
++	}
++
+ 	d.Set("name", server.Name)
+ 	d.Set("created", server.Created.String())
+ 	d.Set("updated", server.Updated.String())

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/patches/README.md
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/patches/README.md
@@ -3,3 +3,6 @@ add data source for openstack_compute_servergroup_v2
 
 ## 002-go-mod.patch
 update_gomod.patch - update gomod for fix cve
+
+## 003-empty-metadata-fix.patch
+Empty metadata always create diff. Set empty map instead nil for metadata when read resource. 

--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -46,7 +46,7 @@ masterNodeGroup:
   volumeTypeMap:
     ru-3a: "fast.ru-3a"
 nodeGroups:
-- name: cloud-permanent
+- name: cp
   nodeTemplate:
     labels:
       node-role.kubernetes.io/worker: ''


### PR DESCRIPTION
## Description
Decrease cloud permanent in openstack e2e because prefix + ng name lenght > 42 symbols (44)
Fix `D8TerraformStateExporterNodeStateChanged` alert for cloud permanent nodes, create empty object for metadata field instead of null.
Patch terraform-provider-openstack for prevent get diff when metadata of compute instance is empty.

Tested converge with adding, removing tags, and checked that after creating and deleting tags terraform check did not have plan changes.

```
{"level":"info","msg":"cp: node template status is ok\n","time":"2025-05-13T23:41:05Z"}
{"level":"info","msg":"cp: node template clean status changed\n","time":"2025-05-13T23:41:05Z"}
{"level":"info","msg":"cp: node template clean status absent\n","time":"2025-05-13T23:41:05Z"}
```

## Why do we need it, and what problem does it solve?
```
│ │ │ ️⛱️️ Attempt #41 of 45 |
│ │ │ 	Create NodeGroup "cloud-permanent" failed, next attempt will be in 15s"
│ │ │ 	Error: admission webhook "nodegroup-policy.deckhouse.io" denied the request: it is forbidden for this cluster to set (cluster       ↵
│ │ │ prefix + node group name) longer then 42 symbols
```

```
{"level":"info","msg":"[  # openstack_compute_instance_v2.node will be updated in-place]","time":"2025-05-13T17:09:15Z"}
{"level":"info","msg":"[  ~ resource \"openstack_compute_instance_v2\" \"node\" {]","time":"2025-05-13T17:09:15Z"}
{"level":"info","msg":"[        id                  = \"77a44fb7-0f5d-42f8-bb2c-6bc52b00713b\"]","time":"2025-05-13T17:09:15Z"}
{"level":"info","msg":"[      + metadata            = {}]","time":"2025-05-13T17:09:15Z"}
{"level":"info","msg":"[        name                = \"candi-15002198174-1-con-1-30-cp-0\"]","time":"2025-05-13T17:09:15Z"}
{"level":"info","msg":"[        tags                = []]","time":"2025-05-13T17:09:15Z"}
{"level":"info","msg":"[        # (18 unchanged attributes hidden)]","time":"2025-05-13T17:09:15Z"}
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: testing
type: fix
summary: Fix openstack e2e tests with cloud permanent ng.
impact_level: low
---
section: cloud-provider-openstack
type: fix
summary: Patch terraform-provider-openstack for prevent get diff when metadata of compute instance is empty.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
