### PR TITLE
[ci] Fix vSphere E2E config

### DIFF
--- a/testing/cloud_layouts/vSphere/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/vSphere/Standard/configuration.tpl.yaml
@@ -29,7 +29,7 @@ region: spb5-region
 zones:
 - spb5-zone
 internalNetworkNames:
-- DPortGroup-lab-vms
+- "DPortGroup-lab-vms-SPB-5-192.168.240.0[24]"
 internalNetworkCIDR: 192.168.240.0/24
 baseResourcePool: cloud-layout-tests
 masterNodeGroup:
@@ -38,7 +38,7 @@ masterNodeGroup:
     numCPUs: 4
     memory: 8192
     template: vm-teamplates/redos8-cloudinit-2cfg
-    mainNetwork: DPortGroup-lab-vms
+    mainNetwork: "DPortGroup-lab-vms-SPB-5-192.168.240.0[24]"
     datastore: vsan-spb-5-datastore
     rootDiskSize: 50
     runtimeOptions:

--- a/testing/cloud_layouts/vSphere/Standard/resources.yaml
+++ b/testing/cloud_layouts/vSphere/Standard/resources.yaml
@@ -7,7 +7,7 @@ spec:
   numCPUs: 4
   memory: 8192
   rootDiskSize: 40
-  mainNetwork: DPortGroup-lab-vms
+  mainNetwork: "DPortGroup-lab-vms-SPB-5-192.168.240.0[24]"
   datastore: SPB-5/vsan-spb-5-datastore
 ---
 apiVersion: deckhouse.io/v1


### PR DESCRIPTION
## Description
Fix E2E test config for vSphere.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix E2E test config for vSphere.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
