### PR TITLE
[descheduler] Descheduler hotfix go mod tidy

### DIFF
--- a/modules/400-descheduler/images/descheduler/patches/001-go-mod.patch
+++ b/modules/400-descheduler/images/descheduler/patches/001-go-mod.patch
@@ -1,18 +1,16 @@
 diff --git a/go.mod b/go.mod
-index 54ba2a602..cf216134c 100644
+index 54ba2a602..b9e1909f1 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -1,6 +1,8 @@
+@@ -1,6 +1,6 @@
  module sigs.k8s.io/descheduler
  
 -go 1.22.5
 +go 1.24.2
-+
-+toolchain go1.24.2
  
  require (
  	github.com/client9/misspell v0.3.4
-@@ -52,7 +54,7 @@ require (
+@@ -52,7 +52,7 @@ require (
  	github.com/gogo/protobuf v1.3.2 // indirect
  	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
  	github.com/golang/protobuf v1.5.4 // indirect
@@ -21,7 +19,7 @@ index 54ba2a602..cf216134c 100644
  	github.com/google/cel-go v0.20.1 // indirect
  	github.com/google/gnostic-models v0.6.8 // indirect
  	github.com/google/gofuzz v1.2.0 // indirect
-@@ -85,15 +87,15 @@ require (
+@@ -85,15 +85,15 @@ require (
  	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
  	go.uber.org/multierr v1.11.0 // indirect
  	go.uber.org/zap v1.26.0 // indirect


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
fix bug go mod tidy

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: descheduler
type: fix
summary: descheduler fix go mod tidy
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
