### PR TITLE
[openvpn] Override LoadBalancer with externalHost value

### DIFF
--- a/modules/500-openvpn/templates/openvpn/statefulset.yaml
+++ b/modules/500-openvpn/templates/openvpn/statefulset.yaml
@@ -254,14 +254,16 @@ spec:
         - "{{ include "get_network_with_bitmask" (list . .Values.openvpn.tunnelNetwork) }}"
         {{- if hasKey .Values.openvpn "inlet" }}
           {{- if eq .Values.openvpn.inlet "LoadBalancer" }}
+            {{- if not (hasKey .Values.openvpn "externalHost") }}
         - --ovpn.server.behindLB
-            {{- if .Values.openvpn.udpEnabled }}
+              {{- if .Values.openvpn.udpEnabled }}
         - --ovpn.service
         - openvpn-external-udp
-            {{- end }}
-            {{- if .Values.openvpn.tcpEnabled }}
+              {{- end }}
+              {{- if .Values.openvpn.tcpEnabled }}
         - --ovpn.service
         - openvpn-external
+              {{- end }}
             {{- end }}
           {{- end }}
         {{- end }}


### PR DESCRIPTION
## Description
Add condition to the statefulset template that doesn't render `ovpn.server.behindLB` and `ovpn.service` flags if `externalHost` is set. This allows `ovpn.server` flag to take effect.

## Why do we need it, and what problem does it solve?
Fixes https://github.com/deckhouse/deckhouse/issues/7358
Issue was that `externalHost` didn't take any effect if inlet was using `LoadBalancer` service.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: openvpn
type: fix
summary: OpenVPN setting externalHost will actually override LB address when generating user config.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
