### PR TITLE
Fix Trivy DB update and scan target after push to main

### DIFF
--- a/.github/ci_templates/cve_tests.yaml
+++ b/.github/ci_templates/cve_tests.yaml
@@ -1,5 +1,14 @@
-{!{ define "cve_scan_deckhouse_images_regular" }!}
-# <template: cve_scan_deckhouse_images_regular>
+{!{ define "cve_scan_deckhouse_images" }!}
+# <template: cve_scan_deckhouse_images>
+- name: Set scan target type
+  run: |
+    if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref_name }}" == "main" ]; then
+      echo "SCAN_TARGET=only_main" >> $GITHUB_ENV
+    elif [ "${{ github.event_name }}" == "pull_request" ]; then
+      echo "SCAN_TARGET=pr" >> $GITHUB_ENV
+    elif [ "${{ github.event_name }}" != "schedule" ] || [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+      echo "SCAN_TARGET=regular" >> $GITHUB_ENV
+    fi
 - name: Run Deckhouse images CVE tests on ${{env.TAG}}
   env:
     DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
@@ -20,29 +29,7 @@
   run: |
     echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
     ./.github/scripts/cve_scan.sh -r
-# </template: cve_scan_deckhouse_images_regular>
-{!{- end -}!}
-
-{!{ define "cve_scan_deckhouse_images_pr" }!}
-# <template: cve_scan_deckhouse_images_pr>
-- name: Run Deckhouse images CVE tests on ${{env.TAG}}
-  env:
-    DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
-    DEFECTDOJO_HOST: ${{secrets.DEFECTDOJO_HOST}}
-    DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
-    DEV_REGISTRY: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
-    DEV_REGISTRY_USER: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
-    DEV_REGISTRY_PASSWORD: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
-    TRIVY_BIN_VERSION: "v0.60.0"
-    TRIVY_PROJECT_ID: "2181"
-    TRIVY_DB_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-db:2
-    TRIVY_JAVA_DB_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-java-db:1
-    TRIVY_POLICY_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-bdu:1
-    SEVERITY: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
-  run: |
-    echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
-    ./.github/scripts/cve_scan.sh -p
-# </template: cve_scan_deckhouse_images_pr>
+# </template: cve_scan_deckhouse_images>
 {!{- end -}!}
 
 {!{ define "cve_tests_upload_reports_artifacts" }!}

--- a/.github/scripts/cve_scan.sh
+++ b/.github/scripts/cve_scan.sh
@@ -72,6 +72,9 @@ chmod u+x ${WORKDIR}/bin/trivy-${TRIVY_BIN_VERSION}/trivy
 rm -rf ${WORKDIR}/bin/trivy
 ln -s ${PWD}/${WORKDIR}/bin/trivy-${TRIVY_BIN_VERSION}/trivy ${WORKDIR}/bin/trivy
 
+echo "Updating Trivy Data Bases"
+mkdir -p "${WORKDIR}/bin/trivy_cache"
+${WORKDIR}/bin/trivy --download-db-only --download-java-db-only --db-repository "${TRIVY_DB_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "${WORKDIR}/bin/trivy_cache"
 
 echo "----------------------------------------------"
 echo ""
@@ -204,9 +207,9 @@ for d8_tag in "${d8_tags[@]}"; do
       echo "👾 Scaning Deckhouse image \"${IMAGE_NAME}\" of module \"${MODULE_NAME}\" for tag \"${d8_tag}\""
       echo ""
       if [ "${additional_image_detected}" == true ]; then
-        ${WORKDIR}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${d8_image}:${d8_tag}" --username "${trivy_registry_user}" --password "${trivy_registry_pass}" --image-src remote 
+        ${WORKDIR}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${WORKDIR}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${d8_image}:${d8_tag}" --username "${trivy_registry_user}" --password "${trivy_registry_pass}" --image-src remote 
       else
-        ${WORKDIR}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${d8_image}@${IMAGE_HASH}" --username "${trivy_registry_user}" --password "${trivy_registry_pass}" --image-src remote 
+        ${WORKDIR}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${WORKDIR}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${d8_image}@${IMAGE_HASH}" --username "${trivy_registry_user}" --password "${trivy_registry_pass}" --image-src remote 
       fi
 
       echo ""

--- a/.github/scripts/cve_scan.sh
+++ b/.github/scripts/cve_scan.sh
@@ -74,7 +74,8 @@ ln -s ${PWD}/${WORKDIR}/bin/trivy-${TRIVY_BIN_VERSION}/trivy ${WORKDIR}/bin/triv
 
 echo "Updating Trivy Data Bases"
 mkdir -p "${WORKDIR}/bin/trivy_cache"
-${WORKDIR}/bin/trivy image --download-db-only --download-java-db-only --db-repository "${TRIVY_DB_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "${WORKDIR}/bin/trivy_cache"
+${WORKDIR}/bin/trivy image --download-db-only --db-repository "${TRIVY_DB_URL}" --cache-dir "${WORKDIR}/bin/trivy_cache"
+${WORKDIR}/bin/trivy image --download-java-db-only --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "${WORKDIR}/bin/trivy_cache"
 
 echo "----------------------------------------------"
 echo ""

--- a/.github/scripts/cve_scan.sh
+++ b/.github/scripts/cve_scan.sh
@@ -91,12 +91,15 @@ if [ "${SCAN_TARGET}" == "regular" ]; then
       exit 1
     fi
   else
-    # Get release tags by regexp, sort by sevmer desc, cut to get minor version, uniq and get 3 latest
-    releases=($(crane ls "${PROD_REGISTRY_DECKHOUSE_IMAGE}" | grep "^v[0-9]*\.[0-9]*\.[0-9]*$" | sort -V -r))
-    latest_minor_releases=($(printf '%s\n' "${releases[@]}"| cut -d "." -f -2 | uniq | head -n 3))
-    for r in "${latest_minor_releases[@]}"; do
-      d8_tags+=($(printf '%s\n' "${releases[@]}" | grep "${r}" | sort -V -r|head -n 1))
-    done
+    if [ "${{ github.event_name }}" != "push" ]; then
+      # Get release tags by regexp, sort by sevmer desc, cut to get minor version, uniq and get 3 latest
+      releases=($(crane ls "${PROD_REGISTRY_DECKHOUSE_IMAGE}" | grep "^v[0-9]*\.[0-9]*\.[0-9]*$" | sort -V -r))
+      latest_minor_releases=($(printf '%s\n' "${releases[@]}"| cut -d "." -f -2 | uniq | head -n 3))
+      for r in "${latest_minor_releases[@]}"; do
+        d8_tags+=($(printf '%s\n' "${releases[@]}" | grep "${r}" | sort -V -r|head -n 1))
+      done
+    # else - this was push to main so scan only main branch
+    fi
   fi
 fi
 echo "CVE Scan will be applied to the following tags of Deckhouse"

--- a/.github/scripts/cve_scan.sh
+++ b/.github/scripts/cve_scan.sh
@@ -74,7 +74,7 @@ ln -s ${PWD}/${WORKDIR}/bin/trivy-${TRIVY_BIN_VERSION}/trivy ${WORKDIR}/bin/triv
 
 echo "Updating Trivy Data Bases"
 mkdir -p "${WORKDIR}/bin/trivy_cache"
-${WORKDIR}/bin/trivy --download-db-only --download-java-db-only --db-repository "${TRIVY_DB_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "${WORKDIR}/bin/trivy_cache"
+${WORKDIR}/bin/trivy image --download-db-only --download-java-db-only --db-repository "${TRIVY_DB_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "${WORKDIR}/bin/trivy_cache"
 
 echo "----------------------------------------------"
 echo ""

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -41,6 +41,6 @@ jobs:
     steps:
 {!{ tmpl.Exec "checkout_full_step"           $ctx | strings.Indent 6 }!}
 {!{ tmpl.Exec "link_bin_step"                     | strings.Indent 6 }!}
-{!{ tmpl.Exec "cve_scan_deckhouse_images_pr"      | strings.Indent 6 }!}
+{!{ tmpl.Exec "cve_scan_deckhouse_images"         | strings.Indent 6 }!}
 {!{ tmpl.Exec "cve_tests_upload_reports_artifacts"| strings.Indent 6 }!}
 {!{ tmpl.Exec "unlink_bin_step"                   | strings.Indent 6 }!}

--- a/.github/workflow_templates/cve-weekly.yml
+++ b/.github/workflow_templates/cve-weekly.yml
@@ -47,7 +47,9 @@ jobs:
     steps:
 {!{ tmpl.Exec "checkout_full_step"           $ctx | strings.Indent 6 }!}
 {!{ tmpl.Exec "link_bin_step"                     | strings.Indent 6 }!}
-{!{ tmpl.Exec "cve_scan_deckhouse_images_regular" | strings.Indent 6 }!}
+{!{ tmpl.Exec "cve_scan_deckhouse_images"         | strings.Indent 6 }!}
 {!{ tmpl.Exec "cve_tests_upload_reports_artifacts"| strings.Indent 6 }!}
 {!{ tmpl.Exec "unlink_bin_step"                   | strings.Indent 6 }!}
+{!{/*
 {!{ tmpl.Exec "send_fail_report"                  | strings.Indent 6 }!}
+*/}!}

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -52,7 +52,16 @@ jobs:
           ln -s ~/deckhouse-bin-cache bin
       # </template: link_bin_step>
 
-      # <template: cve_scan_deckhouse_images_pr>
+      # <template: cve_scan_deckhouse_images>
+      - name: Set scan target type
+        run: |
+          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref_name }}" == "main" ]; then
+            echo "SCAN_TARGET=only_main" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "SCAN_TARGET=pr" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" != "schedule" ] || [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            echo "SCAN_TARGET=regular" >> $GITHUB_ENV
+          fi
       - name: Run Deckhouse images CVE tests on ${{env.TAG}}
         env:
           DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
@@ -61,6 +70,9 @@ jobs:
           DEV_REGISTRY: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           DEV_REGISTRY_USER: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           DEV_REGISTRY_PASSWORD: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          PROD_REGISTRY: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
+          PROD_REGISTRY_USER: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
+          PROD_REGISTRY_PASSWORD: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           TRIVY_BIN_VERSION: "v0.60.0"
           TRIVY_PROJECT_ID: "2181"
           TRIVY_DB_URL: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-db:2
@@ -69,8 +81,8 @@ jobs:
           SEVERITY: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
         run: |
           echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
-          ./.github/scripts/cve_scan.sh -p
-      # </template: cve_scan_deckhouse_images_pr>
+          ./.github/scripts/cve_scan.sh -r
+      # </template: cve_scan_deckhouse_images>
 
       # <template: cve_tests_upload_reports_artifacts>
       - name: Archive report artifacts

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -67,7 +67,16 @@ jobs:
           ln -s ~/deckhouse-bin-cache bin
       # </template: link_bin_step>
 
-      # <template: cve_scan_deckhouse_images_regular>
+      # <template: cve_scan_deckhouse_images>
+      - name: Set scan target type
+        run: |
+          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref_name }}" == "main" ]; then
+            echo "SCAN_TARGET=only_main" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "SCAN_TARGET=pr" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" != "schedule" ] || [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            echo "SCAN_TARGET=regular" >> $GITHUB_ENV
+          fi
       - name: Run Deckhouse images CVE tests on ${{env.TAG}}
         env:
           DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
@@ -88,7 +97,7 @@ jobs:
         run: |
           echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
           ./.github/scripts/cve_scan.sh -r
-      # </template: cve_scan_deckhouse_images_regular>
+      # </template: cve_scan_deckhouse_images>
 
       # <template: cve_tests_upload_reports_artifacts>
       - name: Archive report artifacts
@@ -127,15 +136,3 @@ jobs:
         run: |
           rm bin
       # </template: unlink_bin_step>
-
-      # <template: send_fail_report>
-      - name: Send fail report
-        if: failure()
-        env:
-          LOOP_SERVICE_NOTIFICATIONS: ${{ secrets.LOOP_SERVICE_NOTIFICATIONS }}
-          JOB_NAME: ${{ github.job }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-          WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
-        run: |
-          bash ./.github/scripts/send-report.sh
-      # </template: send_fail_report>


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- Fixed scan targets on push to main
- Trivy DBs update moved to separate step before trivy scan

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
- On push to main branch this CI started to scan main and 3 releases, but should scan only main branch
- As each image scan trivy compares cached DB with remote DB - sometimes strange issue came from trivy
```
FATAL    Fatal error    init error: DB error: error in vulnerability DB initialize: db corrupted: runtime error: invalid memory address or nil pointer dereference
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix Trivy DB update and scan target after push to main
impact: none
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
