### PR TITLE
Revert [docs] Change version for ClusterLoggingConfig in the documentation

### DIFF
--- a/docs/documentation/pages/security/KUMA.md
+++ b/docs/documentation/pages/security/KUMA.md
@@ -44,7 +44,7 @@ spec:
     encoding:
       codec: "JSON"
 ---
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubelet-audit-logs
@@ -75,7 +75,7 @@ spec:
     encoding:
       codec: "JSON"
 ---
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubelet-audit-logs
@@ -109,7 +109,7 @@ spec:
     encoding:
       codec: "CEF"
 ---
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubelet-audit-logs
@@ -144,7 +144,7 @@ spec:
     encoding:
       codec: "Syslog"
 ---
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubelet-audit-logs
@@ -179,7 +179,7 @@ spec:
       - kafka-address:9092 # Replace with the current value during the setup
     topic: k8s-logs
 ---
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubelet-audit-logs

--- a/docs/documentation/pages/security/KUMA_RU.md
+++ b/docs/documentation/pages/security/KUMA_RU.md
@@ -40,7 +40,7 @@ spec:
     encoding:
       codec: "JSON"
 ---
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubelet-audit-logs
@@ -71,7 +71,7 @@ spec:
     encoding:
       codec: "JSON"
 ---
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubelet-audit-logs
@@ -105,7 +105,7 @@ spec:
     encoding:
       codec: "CEF"
 ---
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubelet-audit-logs
@@ -140,7 +140,7 @@ spec:
     encoding:
       codec: "Syslog"
 ---
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubelet-audit-logs
@@ -175,7 +175,7 @@ spec:
       - kafka-address:9092 # Заменить при настройке на актуальное значение
     topic: k8s-logs
 ---
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubelet-audit-logs

--- a/ee/modules/650-runtime-audit-engine/docs/FAQ.md
+++ b/ee/modules/650-runtime-audit-engine/docs/FAQ.md
@@ -12,7 +12,7 @@ Those events can then be collected by [log-shipper-agents](../log-shipper/) and 
 Below is an example [ClusterLoggingConfig](../log-shipper/cr.html#clusterloggingconfig) configuration for the `log-shipper` module:
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: falco-events

--- a/ee/modules/650-runtime-audit-engine/docs/FAQ_RU.md
+++ b/ee/modules/650-runtime-audit-engine/docs/FAQ_RU.md
@@ -12,7 +12,7 @@ title: "Модуль runtime-audit-engine: FAQ"
 Пример конфигурации [ClusterLoggingConfig](../log-shipper/cr.html#clusterloggingconfig) для модуля `log-shipper`:
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: falco-events

--- a/modules/460-log-shipper/docs/EXAMPLES.md
+++ b/modules/460-log-shipper/docs/EXAMPLES.md
@@ -8,7 +8,7 @@ description: Examples of using the log-shipper Deckhouse module. Examples of mod
 ## Getting logs from all cluster Pods and sending them to Loki
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: all-logs
@@ -32,7 +32,7 @@ spec:
 Reading logs from `namespace=whispers` with label `app=booking` and storing them into Loki and Elasticsearch:
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: whispers-booking-logs
@@ -400,7 +400,7 @@ spec:
 Apply the following `ClusterLoggingConfig` to collect logs from the `events-exporter` Pod:
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubernetes-events
@@ -427,7 +427,7 @@ Users can filter logs by applying two filters:
 ### Collect only logs of the `nginx` container
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: nginx-logs
@@ -444,7 +444,7 @@ spec:
 ### Collect logs without strings `GET /status" 200`
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: all-logs
@@ -462,7 +462,7 @@ spec:
 ### Audit of kubelet actions
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubelet-audit-logs
@@ -482,7 +482,7 @@ spec:
 ### Deckhouse system logs
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: system-logs
@@ -512,7 +512,7 @@ If you need logs from only one or from a small group of a Pods, try to use the k
 ## Collect logs from production namespaces using the namespace label selector option
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: production-logs

--- a/modules/460-log-shipper/docs/EXAMPLES_RU.md
+++ b/modules/460-log-shipper/docs/EXAMPLES_RU.md
@@ -8,7 +8,7 @@ description: Примеры использования модуля log-shipper 
 ## Чтение логов из всех подов кластера и направление их в Loki
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: all-logs
@@ -32,7 +32,7 @@ spec:
 Чтение логов подов из namespace `whispers` только с label `app=booking` и перенаправление одновременно в Loki и Elasticsearch:
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: whispers-booking-logs
@@ -400,7 +400,7 @@ spec:
 Выложите в кластер следующий `ClusterLoggingConfig`, чтобы собирать сообщения с пода `events-exporter`:
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubernetes-events
@@ -427,7 +427,7 @@ spec:
 ### Сборка логов только для контейнера `nginx`
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: nginx-logs
@@ -444,7 +444,7 @@ spec:
 ### Сборка логов без строки, содержащей `GET /status" 200`
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: all-logs
@@ -462,7 +462,7 @@ spec:
 ### Аудит событий kubelet'а
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: kubelet-audit-logs
@@ -482,7 +482,7 @@ spec:
 ### Системные логи Deckhouse
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: system-logs
@@ -512,7 +512,7 @@ spec:
 ## Настройка сборки логов с продуктовых пространств имен, используя опцию namespace label selector
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: production-logs

--- a/modules/462-loki/docs/EXAMPLES.md
+++ b/modules/462-loki/docs/EXAMPLES.md
@@ -20,7 +20,7 @@ spec:
   enabled: true
   version: 1
 ---
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: development-logs

--- a/modules/462-loki/docs/EXAMPLES_RU.md
+++ b/modules/462-loki/docs/EXAMPLES_RU.md
@@ -19,7 +19,7 @@ spec:
   enabled: true
   version: 1
 ---
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLoggingConfig
 metadata:
   name: development-logs


### PR DESCRIPTION
## Description
This reverts commit cf9d7590da7c4b23c7eab10da37abc16397faf87.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix 
summary: This reverts commit cf9d7590da7c4b23c7eab10da37abc16397faf87.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
