### PR TITLE
[dhctl] Do not create a local-converger lock for commanderMode

### DIFF
--- a/dhctl/pkg/kubernetes/actions/converge/master_node_group_controller.go
+++ b/dhctl/pkg/kubernetes/actions/converge/master_node_group_controller.go
@@ -121,6 +121,10 @@ func (c *MasterNodeGroupController) Run() error {
 		if err := c.lockRunner.Run(c.run); err != nil {
 			return fmt.Errorf("failed to run lock runner: %w", err)
 		}
+	} else {
+		if err := c.run(); err != nil {
+			return fmt.Errorf("failed to run runner: %w", err)
+		}
 	}
 
 	return nil

--- a/dhctl/pkg/kubernetes/actions/converge/master_node_group_controller.go
+++ b/dhctl/pkg/kubernetes/actions/converge/master_node_group_controller.go
@@ -116,11 +116,11 @@ func (c *MasterNodeGroupController) Run() error {
 		if err := c.replaceKubeClient(c.state.State); err != nil {
 			return fmt.Errorf("failed to replace kube client: %w", err)
 		}
-	}
 
-	c.lockRunner = NewInLockLocalRunner(c.client, "local-converger")
-	if err := c.lockRunner.Run(c.run); err != nil {
-		return fmt.Errorf("failed to run lock runner: %w", err)
+		c.lockRunner = NewInLockLocalRunner(c.client, "local-converger")
+		if err := c.lockRunner.Run(c.run); err != nil {
+			return fmt.Errorf("failed to run lock runner: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Do not create a local-converger lock for commanderMode

## Why do we need it, and what problem does it solve?

When using commander dhctl should not create a local-converger lock it is intended for manual converge only

## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Do not create a local-converger lock for commanderMode
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
