### PR TITLE
[metallb] Add a description of the conversions

### DIFF
--- a/docs/documentation/_data/conversions.yml
+++ b/docs/documentation/_data/conversions.yml
@@ -22,6 +22,9 @@ istio:
     - version: 2
 metallb:
     - version: 2
+      description:
+        en: Remove all `addressPool` elements with the `layer2` protocol.
+        ru: Удалите все элементы `addressPool` с протоколом `layer2`.
 node-manager:
     - version: 2
       description:

--- a/ee/se/modules/380-metallb/openapi/conversions/v2.yaml
+++ b/ee/se/modules/380-metallb/openapi/conversions/v2.yaml
@@ -1,3 +1,6 @@
 version: 2
 conversions:
   - . # We will force users to get rid of extra unwanted elements in MC through alert
+description:
+  ru: "Удалите все элементы `addressPool` с протоколом `layer2`."
+  en: "Remove all `addressPool` elements with the `layer2` protocol."


### PR DESCRIPTION
## Description
Added conversion rule to guide users in removing `addressPool` elements with `layer2` protocol for the new version upgrade.

<img width="719" alt="image" src="https://github.com/user-attachments/assets/3098f7f8-e411-4ee4-8d99-f6479ca7c844" />


## Why do we need it, and what problem does it solve?
Informs users via documentation about the need to remove deprecated `layer2` `addressPool` elements, ensuring a smooth transition to the new version and preventing configuration issues.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: chore
summary: Added a description of the conversions.
impact_level: low
```
