### PR TITLE
add transformation for destination

### DIFF
--- a/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
+++ b/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
@@ -68,7 +68,16 @@ type ClusterLogDestinationSpec struct {
 	// Add rateLimit for sink
 	RateLimit RateLimitSpec `json:"rateLimit,omitempty"`
 
-	Buffer *Buffer `json:"buffer,omitempty"`
+	Buffer         *Buffer     `json:"buffer,omitempty"`
+	Transformation []Transform `json:"transformation,omitempty"`
+}
+
+// Modules labeles transformation that users can use
+type Transform struct {
+	// Name module
+	Action      string   `json:"action"`
+	TargetField string   `json:"targetField,omitempty"`
+	Labels      []string `json:"labels,omitempty"`
 }
 
 type ClusterLogDestinationStatus struct {

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -834,6 +834,46 @@ spec:
                     anyOf:
                       - pattern: '^[a-zA-Z0-9_\-]+$'
                       - pattern: '^\{\{\ [a-zA-Z0-9\\\-][a-zA-Z0-9\[\]_\\\-\.]+\ \}\}$'
+                transformation:
+                  type: array
+                  description: >
+                    List of transformation steps. Each step defines a specific action and parameters for it
+                  items:
+                    oneOf:
+                      - description: "Normalizes names with a dot, replacing dots with underscores"
+                        type: object
+                        required:
+                          - action
+                        properties:
+                          action:
+                            type: string
+                            enum: ["normalizeLabelKeys"]
+                      - description: "Ensures that the message field contains a Json object"
+                        type: object
+                        required:
+                          - action
+                          - targetField
+                        properties:
+                          action:
+                            type: string
+                            enum: ["ensureStructuredMessage"]
+                          targetField:
+                            type: string
+                            description: "The target field into which wrapped string is placed"
+                      - description: "Removes the specified labels"
+                        type: object
+                        required:
+                          - action
+                          - labels
+                        properties:
+                          action:
+                            type: string
+                            enum: ["dropLabels"]
+                          labels:
+                            type: array
+                            description: "List of labels to remove"
+                            items:
+                              type: string
                 buffer:
                   type: object
                   oneOf:

--- a/modules/460-log-shipper/crds/doc-ru-cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/doc-ru-cluster-log-destination.yaml
@@ -415,6 +415,46 @@ spec:
                     - pod_owner.
 
                     [Подробнее о путях к полям...](https://vector.dev/docs/reference/configuration/field-path-notation/)
+                transformation:
+                  type: array
+                  description: >
+                    Список шагов трансформации. Каждый шаг определяет определенное действие и параметры к нему.
+                  items:
+                    oneOf:
+                      - description: "Нормализует имена меток, заменяя точки на подчеркивания"
+                        type: object
+                        required:
+                          - action
+                        properties:
+                          action:
+                            type: string
+                            enum: ["normalizeLabelKeys"]
+                      - description: "Гарантирует, что поле message содержит JSON-объект"
+                        type: object
+                        required:
+                          - action
+                          - targetField
+                        properties:
+                          action:
+                            type: string
+                            enum: ["ensureStructuredMessage"]
+                          targetField:
+                            type: string
+                            description: "Целевое поле, в которое помещается обертка сообщения"
+                      - description: "Удаляет указанные метки"
+                        type: object
+                        required:
+                          - action
+                          - labels
+                        properties:
+                          action:
+                            type: string
+                            enum: ["dropLabels"]
+                          labels:
+                            type: array
+                            description: "Список меток, которые необходимо удалить"
+                            items:
+                              type: string
                 buffer:
                   description: Параметры буфера.
                   properties:

--- a/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
@@ -24,8 +24,13 @@ import (
 )
 
 func CreateLogDestinationTransforms(name string, dest v1alpha1.ClusterLogDestination) ([]apis.LogTransform, error) {
+	var err error
 	transforms := make([]apis.LogTransform, 0)
-
+	if len(dest.Spec.Transformation) > 0 {
+		if transforms, err = BuildModes(dest.Spec.Transformation); err != nil {
+			return nil, err
+		}
+	}
 	switch dest.Spec.Type {
 	case v1alpha1.DestElasticsearch, v1alpha1.DestLogstash:
 		transforms = append(transforms, DeDotTransform())

--- a/modules/460-log-shipper/hooks/internal/vector/transform/transformation.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/transformation.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transform
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/deckhouse/deckhouse/go_lib/set"
+	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis"
+	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
+)
+
+type module interface {
+	getTransform() apis.LogTransform
+}
+
+func BuildModes(tms []v1alpha1.Transform) ([]apis.LogTransform, error) {
+	transforms := make([]apis.LogTransform, 0)
+	var module module
+	for _, tm := range tms {
+		switch tm.Action {
+		case "normalizeLabelKeys":
+			module = normalizeLabelKeys{}
+		case "ensureStructuredMessage":
+			module = ensureStructuredMessage{targetField: tm.TargetField}
+		case "dropLabels":
+			if len(tm.Labels) > 0 {
+				module = dropLabels{labels: tm.Labels}
+			}
+		default:
+			return nil, fmt.Errorf("TransformMod: action %s not found", tm.Action)
+		}
+		lofTransform := module.getTransform()
+		transforms = append(transforms, lofTransform)
+	}
+	return transforms, nil
+}
+
+type normalizeLabelKeys struct{}
+
+func (nlk normalizeLabelKeys) getTransform() apis.LogTransform {
+	var vrl string
+	name := "tf_normolazeLabelKeys"
+	vrl = "if exists(.pod_labels) {\n.pod_labels = map_keys(object!(.pod_labels), recursive: true) -> |key| { replace(key, \".\", \"_\")}\n}"
+	return NewTransformation(name, vrl)
+}
+
+type ensureStructuredMessage struct {
+	targetField string
+}
+
+func (esm ensureStructuredMessage) getTransform() apis.LogTransform {
+	var vrl string
+	name := "tf_ensureStructuredMessage"
+	vrl = fmt.Sprintf(".message = parse_json(.message) ?? { \"%s\": .message }\n", esm.targetField)
+	return NewTransformation(name, vrl)
+}
+
+type dropLabels struct {
+	labels []string
+}
+
+func (d dropLabels) getTransform() apis.LogTransform {
+	var vrl string
+	name := fmt.Sprintf("tf_delete_%s", splitAndremoveDot(d.labels))
+	labels := checkFixDotPrefix(d.labels)
+	for _, l := range labels {
+		vrl = fmt.Sprintf("%sif exists(%s) {\n del(%s)\n}\n", vrl, l, l)
+	}
+	return NewTransformation(name, vrl)
+}
+
+func NewTransformation(name, vrl string) *DynamicTransform {
+	return &DynamicTransform{
+		CommonTransform: CommonTransform{
+			Name:   name,
+			Type:   "remap",
+			Inputs: set.New(),
+		},
+		DynamicArgsMap: map[string]any{
+			"source":        vrl,
+			"drop_on_abort": false,
+		},
+	}
+}
+
+// name transform couldn't have dot
+func splitAndremoveDot(labels []string) string {
+	var s string
+	for _, l := range labels {
+		l = strings.Replace(l, ".", "", -1)
+		s = fmt.Sprintf("%s_%s", s, l)
+	}
+	return s
+}
+
+// dot in label prefix need for vector
+func checkFixDotPrefix(lbs []string) []string {
+	labels := []string{}
+	for _, l := range lbs {
+		if !strings.HasPrefix(l, ".") {
+			labels = append(labels, fmt.Sprintf(".%s", l))
+			continue
+		}
+		labels = append(labels, l)
+	}
+	return labels
+}

--- a/modules/460-log-shipper/hooks/internal/vector/transform/transformation_test.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/transformation_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transform
+
+import (
+	"testing"
+
+	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+var testCases = []struct {
+	name string
+	in   v1alpha1.Transform
+	out  string
+}{
+	{"fixNestedJson lable message", v1alpha1.Transform{Action: "ensureStructuredMessage", TargetField: "text"},
+		".message = parse_json(.message) ?? { \"text\": .message }\n"},
+	// {"del_Not_labels", v1alpha1.Transform{Action: "dropLabels", Labels: []string{}},
+	// "if exists(.first) {\n del(.first)\n}\nif exists(.second) {\n del(.second)\n}\n"},
+	{"del", v1alpha1.Transform{Action: "dropLabels", Labels: []string{"first", "second"}},
+		"if exists(.first) {\n del(.first)\n}\nif exists(.second) {\n del(.second)\n}\n"},
+	{"replaceDot", v1alpha1.Transform{Action: "normalizeLabelKeys"},
+		"if exists(.pod_labels) {\n.pod_labels = map_keys(object!(.pod_labels), recursive: true) -> |key| { replace(key, \".\", \"_\")}\n}"},
+}
+
+func TestReplaceDot(t *testing.T) {
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			tr, err := BuildModes([]v1alpha1.Transform{test.in})
+			if err != nil {
+				t.Error(err)
+			}
+			assert.Len(t, tr, 1)
+			transform := tr[0].(*DynamicTransform)
+			assert.Equal(t, test.out, transform.DynamicArgsMap["source"].(string))
+		})
+	}
+}

--- a/modules/460-log-shipper/hooks/testdata/transform-mods/manifests.yaml
+++ b/modules/460-log-shipper/hooks/testdata/transform-mods/manifests.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLoggingConfig
+metadata:
+  name: test-source
+spec:
+  type: File
+  file:
+    include: ["/var/log/kube-audit/audit.log"]
+  destinationRefs:
+    - test-kafka-dest
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: test-kafka-dest
+spec:
+  type: Kafka
+  kafka:
+    bootstrapServers:
+    - "192.168.1.1:9200"
+    topic: "logs"
+    keyField: host
+    sasl:
+      mechanism: PLAIN
+      username: test
+      password: test
+  transformation:
+  - action: normalizeLabelKeys
+  - action: ensureStructuredMessage
+    targetField: text
+  - action: dropLabels
+    labels: 
+    - first
+    - .second

--- a/modules/460-log-shipper/hooks/testdata/transform-mods/result.json
+++ b/modules/460-log-shipper/hooks/testdata/transform-mods/result.json
@@ -1,0 +1,89 @@
+{
+  "sources": {
+    "cluster_logging_config/test-source": {
+      "type": "file",
+      "include": [
+        "/var/log/kube-audit/audit.log"
+      ]
+    }
+  },
+  "transforms": {
+    "transform/destination/test-kafka-dest/00_tf_normolazeLabelKeys": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-source/01_clean_up"
+      ],
+      "source": "if exists(.pod_labels) {\n.pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\")}\n}",
+      "type": "remap"
+    },
+    "transform/destination/test-kafka-dest/01_tf_ensureStructuredMessage": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/destination/test-kafka-dest/00_tf_normolazeLabelKeys"
+      ],
+      "source": ".message = parse_json(.message) ?? { \"text\": .message }\n",
+      "type": "remap"
+    },
+    "transform/destination/test-kafka-dest/02_tf_delete__first_second": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/destination/test-kafka-dest/01_tf_ensureStructuredMessage"
+      ],
+      "source": "if exists(.first) {\n del(.first)\n}\nif exists(.second) {\n del(.second)\n}\n",
+      "type": "remap"
+    },
+    "transform/destination/test-kafka-dest/03_del_parsed_data": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/destination/test-kafka-dest/02_tf_delete__first_second"
+      ],
+      "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
+      "type": "remap"
+    },
+    "transform/source/test-source/00_local_timezone": {
+      "drop_on_abort": false,
+      "inputs": [
+        "cluster_logging_config/test-source"
+      ],
+      "source": "if exists(.\"timestamp\") {\n    ts = parse_timestamp!(.\"timestamp\", format: \"%+\")\n    .\"timestamp\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}\n\nif exists(.\"timestamp_end\") {\n    ts = parse_timestamp!(.\"timestamp_end\", format: \"%+\")\n    .\"timestamp_end\" = format_timestamp!(ts, format: \"%+\", timezone: \"local\")\n}",
+      "type": "remap"
+    },
+    "transform/source/test-source/01_clean_up": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-source/00_local_timezone"
+      ],
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}\nif exists(.node_labels.\"node.deckhouse.io/group\") {\n\t.node_group = (.node_labels.\"node.deckhouse.io/group\")\n}\ndel(.node_labels)",
+      "type": "remap"
+    }
+  },
+  "sinks": {
+    "destination/cluster/test-kafka-dest": {
+      "type": "kafka",
+      "inputs": [
+        "transform/destination/test-kafka-dest/03_del_parsed_data"
+      ],
+      "healthcheck": {
+        "enabled": false
+      },
+      "bootstrap_servers": "192.168.1.1:9200",
+      "encoding": {
+        "codec": "json",
+        "timestamp_format": "rfc3339"
+      },
+      "topic": "logs",
+      "key_field": "host",
+      "compression": "gzip",
+      "tls": {
+        "verify_hostname": true,
+        "verify_certificate": true
+      },
+      "sasl": {
+        "username": "test",
+        "password": "test",
+        "mechanism": "PLAIN",
+        "enabled": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added the ability to specify additional log transformations before sending to the destination

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Needed to provide users with processing of log changes for non standard sending methods

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: feature
summary: Added the additional log transformations
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
