### PR TITLE
[cloud-provider-zvirt] fix cloud data discoverer logger

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/src/discoverer.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/src/discoverer.go
@@ -17,7 +17,6 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1alpha1"
 	"github.com/deckhouse/deckhouse/pkg/log"
 
-	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
 	ovirtclient "github.com/ovirt/go-ovirt-client/v3"
 )
 
@@ -69,8 +68,8 @@ func newCloudConfig() (*CloudConfig, error) {
 }
 
 // Client Creates a zvirt client
-func (c *CloudConfig) client() (ovirtclient.ClientWithLegacySupport, error) {
-	logger := ovirtclientlog.NewGoLogger()
+func (c *CloudConfig) client(logger *log.Logger) (ovirtclient.ClientWithLegacySupport, error) {
+	oVirtLog := NewOvirtLogger(logger)
 
 	tls := ovirtclient.TLS()
 
@@ -86,7 +85,7 @@ func (c *CloudConfig) client() (ovirtclient.ClientWithLegacySupport, error) {
 		c.Username,
 		c.Password,
 		tls,
-		logger,
+		oVirtLog,
 		nil,
 	)
 	if err != nil {
@@ -123,7 +122,7 @@ func (d *Discoverer) DiscoveryData(
 		}
 	}
 
-	zvirtClient, err := d.config.client()
+	zvirtClient, err := d.config.client(d.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create zvirt client: %v", err)
 	}

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/src/ovirt_logger.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/src/ovirt_logger.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
+)
+
+func NewOvirtLogger(logger *log.Logger) ovirtclientlog.Logger {
+	return &oVirtLogger{
+		logger: logger,
+	}
+}
+
+type oVirtLogger struct {
+	logger *log.Logger
+}
+
+func (o *oVirtLogger) WithContext(_ context.Context) ovirtclientlog.Logger {
+	return o
+}
+
+func (o *oVirtLogger) Debugf(format string, args ...interface{}) {
+	o.logger.Debugf(format, args...)
+}
+
+func (o *oVirtLogger) Infof(format string, args ...interface{}) {
+	o.logger.Infof(format, args...)
+}
+
+func (o *oVirtLogger) Warningf(format string, args ...interface{}) {
+	o.logger.Warnf(format, args...)
+}
+
+func (o *oVirtLogger) Errorf(format string, args ...interface{}) {
+	o.logger.Errorf(format, args...)
+}

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/src/ovirt_logger.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/src/ovirt_logger.go
@@ -1,3 +1,8 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
 package main
 
 import (


### PR DESCRIPTION
## Description
oVirt have own wrapper for `log` logger and in its constructor `log` is mentioned as optional, however wrapper's constructor panics if it is not provided here: https://github.com/oVirt/go-ovirt-client-log/blob/main/go_logger.go#L17

## Why do we need it, and what problem does it solve?
This PR adds our own oVirt logger wrapper and fixes panic. 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-zvirt
type: fix
summary: fix zvirt cloud-discoverer panic
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
