### PR TITLE
[metallb] Fix of the logic of dashboard imports

### DIFF
--- a/ee/se/modules/380-metallb/.dmtlint.yaml
+++ b/ee/se/modules/380-metallb/.dmtlint.yaml
@@ -6,3 +6,6 @@ linters-settings:
     exclude-rules:
       enum:
         - properties.addressPools.items.properties.protocol
+  templates:
+    grafana-dashboards:
+      disable: true

--- a/ee/se/modules/380-metallb/templates/monitoring.yaml
+++ b/ee/se/modules/380-metallb/templates/monitoring.yaml
@@ -1,2 +1,23 @@
-{{- include "helm_lib_grafana_dashboard_definitions" . }}
+{{- /* The dashboard will be imported only if the customer enables BGP balancing */ -}}
+{{- if and .Values.metallb.bgpPeers (gt (len .Values.metallb.bgpPeers) 0) }}
+  {{- $resourceName := "d8-metallb-kubernetes-cluster-metallb-bgp" }}
+  {{- $definition := .Files.Get "monitoring/grafana-dashboards/kubernetes-cluster/metallb-bgp.json" }}
+  {{- $folder := "Kubernetes Cluster" }}
+  {{- include "helm_lib_single_dashboard" (list . $resourceName $folder $definition) }}
+{{ end}}
+
+{{- /* The dashboard will be imported only if the customer enables L2 balancing */ -}}
+{{- if and .Values.metallb.internal.l2loadbalancers (gt (len .Values.metallb.internal.l2loadbalancers) 0) }}
+  {{- $resourceName := "d8-metallb-kubernetes-cluster-metallb-l2" }}
+  {{- $definition := .Files.Get "monitoring/grafana-dashboards/kubernetes-cluster/metallb-l2.json" }}
+  {{- $folder := "Kubernetes Cluster" }}
+  {{- include "helm_lib_single_dashboard" (list . $resourceName $folder $definition) }}
+{{- end }}
+
+{{/* Dashboard with a IP pool is always imported */}}
+{{- $resourceName := "d8-metallb-kubernetes-cluster-metallb-pools" }}
+{{- $definition := .Files.Get "monitoring/grafana-dashboards/kubernetes-cluster/metallb-pools.json" }}
+{{- $folder := "Kubernetes Cluster" }}
+{{- include "helm_lib_single_dashboard" (list . $resourceName $folder $definition) }}
+
 {{- include "helm_lib_prometheus_rules" (list . "d8-metallb") }}


### PR DESCRIPTION
## Description
Fixed import logic of MetalLB dashboards
Now BGP dashboard will be added only when BGP balancing is enabled, otherwise L2 dashboard will be added

## Why do we need it in the patch release (if we do)?
When the client does not enable BGP balancing in the MetalLB module, the module still imports the BGP dashboard
But there are no metrics (No Data) from BGP, this can be misleading for the client

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: metallb
type: fix
summary: BGP grafane dashboard is deployed only when BGP balancing is enabled 
```
