### PR TITLE
[kube-dns] The d8-kube-dns-redirect service has been restored

### DIFF
--- a/modules/042-kube-dns/templates/service.yaml
+++ b/modules/042-kube-dns/templates/service.yaml
@@ -23,6 +23,26 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: d8-kube-dns-redirect
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "coredns-redirect")) | nindent 2 }}
+spec:
+  type: ClusterIP
+  selector:
+    k8s-app: kube-dns
+  ports:
+  - name: dns
+    port: 53
+    targetPort: dns
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    targetPort: dns-tcp
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: kube-dns
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list . (dict "k8s-app" "kube-dns")) | nindent 2 }}

--- a/modules/042-kube-dns/templates/service.yaml
+++ b/modules/042-kube-dns/templates/service.yaml
@@ -20,6 +20,7 @@ spec:
     targetPort: dns-tcp
     protocol: TCP
 ---
+#TODO: remove the service in future releases
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The d8-kube-dns-redirect service has been reverted.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The d8-kube-dns-redirect service was used as a forwarding server for node-local-dns. During an upgrade, this service is removed and old instances of local-dns continue to access the non-existent forward server. However, because the service was not responding, and due to the behavior of the cache plugin, specifically the serve_stale 1h verify setting, it waited up to 5 seconds for a response from the forwarding server. This delay can be critical for latency-sensitive applications such as web frontends.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

On large clusters, updating node-local-dns pods can take 10-15 minutes, at which point local dns is left without forwarding servers, which can be undesirable.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: kube-dns
type: fix
summary: Fixed release upgrade issue with removed d8-kube-dns-redirect service.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
