### PR TITLE
[docs] Fixed installations manifests at Deckhouse Code documentation

### DIFF
--- a/docs/site/pages/code/documentation/admin/install/PLATFORM_INSTALLATION_RU.md
+++ b/docs/site/pages/code/documentation/admin/install/PLATFORM_INSTALLATION_RU.md
@@ -12,8 +12,7 @@ lang: ru
    apiVersion: deckhouse.io/v1alpha1
    kind: ModuleSource
    metadata:
-     annotations:
-       name: code
+     name: code
    spec:
      registry:
        ca: ""
@@ -30,8 +29,7 @@ lang: ru
    apiVersion: deckhouse.io/v1alpha2
    kind: ModuleUpdatePolicy
    metadata:
-     annotations:
-       name: code-policy
+     name: code-policy
    spec:
      releaseChannel: EarlyAccess
      update:


### PR DESCRIPTION
## Description
Fixed installations manifests at Deckhouse Code documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix 
summary: Fixed installations manifests at Deckhouse Code documentation.
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
