### PR TITLE
[node-manager][autoscaler] Patch autoscaler 1.30-1.32 to support our MCM

### DIFF
--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.30/004-set-priorities-for-to-de-deleted-machines-and-clean-annotation.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.30/004-set-priorities-for-to-de-deleted-machines-and-clean-annotation.patch
@@ -7,16 +7,18 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
 --- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(revision 36b348865994909216b64e3a12e9c776f1d24732)
-+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1746780734524)
-@@ -25,7 +25,6 @@
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1747480094495)
+@@ -25,7 +25,8 @@
  	"context"
  	"fmt"
  	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 -	"k8s.io/apimachinery/pkg/util/sets"
++	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
  	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
  	"slices"
  	"strconv"
-@@ -33,7 +32,6 @@
+@@ -33,7 +34,6 @@
  	"sync"
  	"time"
 
@@ -24,23 +26,23 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluste
  	apiv1 "k8s.io/api/core/v1"
  	"k8s.io/apimachinery/pkg/api/resource"
  	"k8s.io/apimachinery/pkg/types"
-@@ -332,34 +330,34 @@
-
- // Refresh cordons the Nodes corresponding to the machines that have been marked for deletion in the TriggerDeletionByMCM annotation on the MachineDeployment
- func (ngImpl *nodeGroup) Refresh() error {
--	mcd, err := ngImpl.mcmManager.GetMachineDeploymentObject(ngImpl.Name)
--	if err != nil {
--		return err
--	}
--	toBeDeletedMachineNames := getMachineNamesTriggeredForDeletion(mcd)
--	if len(toBeDeletedMachineNames) == 0 {
--		return nil
--	}
+@@ -340,26 +340,63 @@
+ 	if len(toBeDeletedMachineNames) == 0 {
+ 		return nil
+ 	}
 -	machinesOfNodeGroup, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
--	if err != nil {
++
++	machines, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
+ 	if err != nil {
 -		klog.Warningf("NodeGroup.Refresh() of %q failed to get machines for MachineDeployment due to: %v", ngImpl.Name, err)
 -		return nil
--	}
++		return err
++	}
++
++	machinesSet := make(map[string]*v1alpha1.Machine)
++	for _, machine := range machines {
++		machinesSet[machine.Name] = machine
+ 	}
 -	toBeDeletedMachines := filterMachinesMatchingNames(machinesOfNodeGroup, sets.New(toBeDeletedMachineNames...))
 -	if len(toBeDeletedMachines) == 0 {
 -		klog.Warningf("NodeGroup.Refresh() of %q could not find Machine objects for toBeDeletedMachineNames %q", ngImpl.Name, toBeDeletedMachineNames)
@@ -50,20 +52,36 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluste
 -	if len(toBeDeletedNodeNames) == 0 {
 -		klog.Warningf("NodeGroup.Refresh() of %q could not find toBeDeletedNodeNames for toBeDeletedMachineNames %q of MachineDeployment", ngImpl.Name, toBeDeletedMachineNames)
 -		return nil
--	}
++
++	savedInAnnotation := make([]string, 0, len(toBeDeletedMachineNames))
++	for _, deleted := range toBeDeletedMachineNames {
++		if machine, ok := machinesSet[deleted]; ok {
++			if isMachineFailedOrTerminating(machine) {
++				klog.V(4).Infof("Machine %s is marked as failed or terminating. Will be removed from annotation", deleted)
++				continue
++			}
++
++			klog.V(4).Infof("Machine %s was found. Will keep in annotation", deleted)
++			savedInAnnotation = append(savedInAnnotation, deleted)
++		}
++
++		klog.V(4).Infof("Not found machine %s in machineset. Will be removed from annotation", deleted)
+ 	}
 -	err = ngImpl.mcmManager.cordonNodes(toBeDeletedNodeNames)
--	if err != nil {
++
++	klog.V(2).Infof("Next machines will be saved to annotation %v", savedInAnnotation)
++
++	annotationVal := createMachinesTriggeredForDeletionAnnotValue(savedInAnnotation)
++	mdCopy := mcd.DeepCopy()
++	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = annotationVal
++	updatedMd, err := ngImpl.mcmManager.machineClient.MachineDeployments(mcd.Namespace).Update(context.TODO(), mdCopy, metav1.UpdateOptions{})
+ 	if err != nil {
 -		// we do not return error since we don't want this to block CA operation. This is best-effort.
 -		klog.Warningf("NodeGroup.Refresh() of %q ran into error cordoning nodes: %v", ngImpl.Name, err)
--	}
-+	//mcd, err := ngImpl.mcmManager.GetMachineDeploymentObject(ngImpl.Name)
-+	//if err != nil {
-+	//	return err
-+	//}
-+	//toBeDeletedMachineNames := getMachineNamesTriggeredForDeletion(mcd)
-+	//if len(toBeDeletedMachineNames) == 0 {
-+	//	return nil
-+	//}
++		return err
+ 	}
++	klog.V(2).Infof("MachineDeployment %q triggered by mcm annotation cleaned to %q", mcd.Name, updatedMd.Annotations[machineutils.TriggerDeletionByMCM])
++
 +	//machinesOfNodeGroup, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
 +	//if err != nil {
 +	//	klog.Warningf("NodeGroup.Refresh() of %q failed to get machines for MachineDeployment due to: %v", ngImpl.Name, err)
@@ -87,23 +105,27 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluste
  	return nil
  }
 
-@@ -567,10 +565,12 @@
- // getMachineNamesTriggeredForDeletion returns the set of machine names contained within the machineutils.TriggerDeletionByMCM annotation on the given MachineDeployment
- // TODO: Move to using MCM annotations.GetMachineNamesTriggeredForDeletion after MCM release.
- func getMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []string {
--	if mcd.Annotations == nil || mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
--		return nil
--	}
--	return strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
-+	//if mcd.Annotations == nil || mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
-+	//	return nil
-+	//}
-+	//return strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
-+
-+	return nil
- }
+@@ -434,6 +471,20 @@
+ 		return fmt.Errorf("MachineDeployment %s is under rolling update , cannot reduce replica count", ngImpl.Name)
+ 	}
 
- // TODO: Move to using MCM annotations.CreateMachinesTriggeredForDeletionAnnotValue after MCM release
++	klog.V(2).Infof("Start set priorities for machines %v", toBeDeletedMachineInfos)
++
++	for _, info := range toBeDeletedMachineInfos {
++		err = ngImpl.mcmManager.retry(func(ctx context.Context) (bool, error) {
++
++			klog.V(2).Infof("Set priority for machine %s/%s", info.Key.Namespace, info.Key.Name)
++			return ngImpl.mcmManager.updateAnnotationOnMachine(ctx, info.Key.Name, MachinePriorityMachineAnnotation, priorityValueForDeletionCandidateMachines)
++		}, "Machine", "update", info.Key.Name)
++
++		if err != nil {
++			return err
++		}
++	}
++
+ 	// Trying to update the machineDeployment till the deadline
+ 	err = ngImpl.mcmManager.retry(func(ctx context.Context) (bool, error) {
+ 		return ngImpl.mcmManager.scaleDownMachineDeployment(ctx, ngImpl.Name, toBeDeletedMachineInfos)
 Index: cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
 IDEA additional info:
 Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
@@ -111,8 +133,16 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
 --- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(revision 36b348865994909216b64e3a12e9c776f1d24732)
-+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1746780796303)
-@@ -535,18 +535,19 @@
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1747478774501)
+@@ -87,6 +87,7 @@
+ 	defaultPriorityValue = "3"
+ 	// priorityValueForDeletionCandidateMachines is the priority annotation value set on machines that the CA wants to be deleted. Its value is set to 1.
+ 	priorityValueForDeletionCandidateMachines = "1"
++	MachinePriorityMachineAnnotation          = "machinepriority.machine.sapcloud.io"
+ 	minResyncPeriodDefault                    = 1 * time.Hour
+ 	// kindMachineClass is the kind for generic machine class used by the OOT providers
+ 	kindMachineClass = "MachineClass"
+@@ -535,18 +536,19 @@
  	}
  	klog.V(2).Infof("MachineDeployment %q size decreased from %d to %d, TriggerDeletionByMCM Annotation Value: %q", md.Name, md.Spec.Replicas, updatedMd.Spec.Replicas, updatedMd.Annotations[machineutils.TriggerDeletionByMCM])
 
@@ -144,27 +174,3 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autos
  	return false, nil
  }
 
-@@ -1112,7 +1113,7 @@
- 	alreadyMarkedSet := sets.New(getMachineNamesTriggeredForDeletion(md)...)
-
- 	uniqueForDeletionSet := forDeletionSet.Difference(alreadyMarkedSet)
--	toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
-+	//toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
-
- 	data.RevisedToBeDeletedMachineNames = uniqueForDeletionSet
- 	data.RevisedScaledownAmount = uniqueForDeletionSet.Len()
-@@ -1128,10 +1129,10 @@
- 		if mdCopy.Annotations == nil {
- 			mdCopy.Annotations = make(map[string]string)
- 		}
--		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
--		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
--			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
--		}
-+		//triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
-+		//if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
-+		//	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
-+		//}
- 		mdCopy.Spec.Replicas = expectedReplicas
- 		data.RevisedMachineDeployment = mdCopy
- 	}

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.30/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.30/README.md
@@ -31,7 +31,12 @@ TODO: add description
 
 TODO: add description
 
-### 004-delete-mcm-annotations-from-md.patch
+### 004-set-priorities-for-to-de-deleted-machines-and-clean-annotation.patch
 
 Remove additional cordoning nodes from mcm cloud provider.
-Remove adding "node.machine.sapcloud.io/trigger-deletion-by-mcm" annotation to machine deployment to avoid autoscaler warnings.
+
+New autoscaler works with new version MCM witch select nodes for deleting from annotation `node.machine.sapcloud.io/trigger-deletion-by-mcm`
+This annotation does not support by our MCM, and we should set deleting priority with annotation `machinepriority.machine.sapcloud.io`.
+We set priority for machines and keep `node.machine.sapcloud.io/trigger-deletion-by-mcm` annotation for calculation replicas,
+but we need to clean deleted machines from annotation in refresh function for keeping up to date annotation value to avoid
+drizzling replicas count in machine deployment.

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.31/004-set-priorities-for-to-de-deleted-machines-and-clean-annotation.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.31/004-set-priorities-for-to-de-deleted-machines-and-clean-annotation.patch
@@ -6,36 +6,43 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 <+>UTF-8
 ===================================================================
 diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
---- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
-+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1746781221962)
-@@ -31,10 +31,8 @@
- 	"time"
-
+--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(revision 2818e0cffbc180b42fc486630ab36d43ecf56649)
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1747480923187)
+@@ -25,7 +25,8 @@
+ 	"context"
+ 	"fmt"
  	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 -	"k8s.io/apimachinery/pkg/util/sets"
++	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
  	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
+ 	"slices"
+ 	"strconv"
+@@ -33,7 +34,6 @@
+ 	"sync"
+ 	"time"
 
 -	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
  	apiv1 "k8s.io/api/core/v1"
  	"k8s.io/apimachinery/pkg/api/resource"
  	"k8s.io/apimachinery/pkg/types"
-@@ -333,34 +331,34 @@
-
- // Refresh cordons the Nodes corresponding to the machines that have been marked for deletion in the TriggerDeletionByMCM annotation on the MachineDeployment
- func (ngImpl *nodeGroup) Refresh() error {
--	mcd, err := ngImpl.mcmManager.GetMachineDeploymentObject(ngImpl.Name)
--	if err != nil {
--		return err
--	}
--	toBeDeletedMachineNames := getMachineNamesTriggeredForDeletion(mcd)
--	if len(toBeDeletedMachineNames) == 0 {
--		return nil
--	}
+@@ -340,26 +340,63 @@
+ 	if len(toBeDeletedMachineNames) == 0 {
+ 		return nil
+ 	}
 -	machinesOfNodeGroup, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
--	if err != nil {
++
++	machines, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
+ 	if err != nil {
 -		klog.Warningf("NodeGroup.Refresh() of %q failed to get machines for MachineDeployment due to: %v", ngImpl.Name, err)
 -		return nil
--	}
++		return err
++	}
++
++	machinesSet := make(map[string]*v1alpha1.Machine)
++	for _, machine := range machines {
++		machinesSet[machine.Name] = machine
+ 	}
 -	toBeDeletedMachines := filterMachinesMatchingNames(machinesOfNodeGroup, sets.New(toBeDeletedMachineNames...))
 -	if len(toBeDeletedMachines) == 0 {
 -		klog.Warningf("NodeGroup.Refresh() of %q could not find Machine objects for toBeDeletedMachineNames %q", ngImpl.Name, toBeDeletedMachineNames)
@@ -45,20 +52,36 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluste
 -	if len(toBeDeletedNodeNames) == 0 {
 -		klog.Warningf("NodeGroup.Refresh() of %q could not find toBeDeletedNodeNames for toBeDeletedMachineNames %q of MachineDeployment", ngImpl.Name, toBeDeletedMachineNames)
 -		return nil
--	}
++
++	savedInAnnotation := make([]string, 0, len(toBeDeletedMachineNames))
++	for _, deleted := range toBeDeletedMachineNames {
++		if machine, ok := machinesSet[deleted]; ok {
++			if isMachineFailedOrTerminating(machine) {
++				klog.V(4).Infof("Machine %s is marked as failed or terminating. Will be removed from annotation", deleted)
++				continue
++			}
++
++			klog.V(4).Infof("Machine %s was found. Will keep in annotation", deleted)
++			savedInAnnotation = append(savedInAnnotation, deleted)
++		}
++
++		klog.V(4).Infof("Not found machine %s in machineset. Will be removed from annotation", deleted)
+ 	}
 -	err = ngImpl.mcmManager.cordonNodes(toBeDeletedNodeNames)
--	if err != nil {
++
++	klog.V(2).Infof("Next machines will be saved to annotation %v", savedInAnnotation)
++
++	annotationVal := createMachinesTriggeredForDeletionAnnotValue(savedInAnnotation)
++	mdCopy := mcd.DeepCopy()
++	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = annotationVal
++	updatedMd, err := ngImpl.mcmManager.machineClient.MachineDeployments(mcd.Namespace).Update(context.TODO(), mdCopy, metav1.UpdateOptions{})
+ 	if err != nil {
 -		// we do not return error since we don't want this to block CA operation. This is best-effort.
 -		klog.Warningf("NodeGroup.Refresh() of %q ran into error cordoning nodes: %v", ngImpl.Name, err)
--	}
-+	//mcd, err := ngImpl.mcmManager.GetMachineDeploymentObject(ngImpl.Name)
-+	//if err != nil {
-+	//	return err
-+	//}
-+	//toBeDeletedMachineNames := getMachineNamesTriggeredForDeletion(mcd)
-+	//if len(toBeDeletedMachineNames) == 0 {
-+	//	return nil
-+	//}
++		return err
+ 	}
++	klog.V(2).Infof("MachineDeployment %q triggered by mcm annotation cleaned to %q", mcd.Name, updatedMd.Annotations[machineutils.TriggerDeletionByMCM])
++
 +	//machinesOfNodeGroup, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
 +	//if err != nil {
 +	//	klog.Warningf("NodeGroup.Refresh() of %q failed to get machines for MachineDeployment due to: %v", ngImpl.Name, err)
@@ -82,32 +105,44 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluste
  	return nil
  }
 
-@@ -577,10 +575,12 @@
- // getMachineNamesTriggeredForDeletion returns the set of machine names contained within the machineutils.TriggerDeletionByMCM annotation on the given MachineDeployment
- // TODO: Move to using MCM annotations.GetMachineNamesTriggeredForDeletion after MCM release.
- func getMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []string {
--	if mcd.Annotations == nil || mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
--		return nil
--	}
--	return strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
-+	//if mcd.Annotations == nil || mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
-+	//	return nil
-+	//}
-+	//return strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
-+
-+	return nil
- }
+@@ -434,6 +471,20 @@
+ 		return fmt.Errorf("MachineDeployment %s is under rolling update , cannot reduce replica count", ngImpl.Name)
+ 	}
 
- // TODO: Move to using MCM annotations.CreateMachinesTriggeredForDeletionAnnotValue after MCM release
++	klog.V(2).Infof("Start set priorities for machines %v", toBeDeletedMachineInfos)
++
++	for _, info := range toBeDeletedMachineInfos {
++		err = ngImpl.mcmManager.retry(func(ctx context.Context) (bool, error) {
++
++			klog.V(2).Infof("Set priority for machine %s/%s", info.Key.Namespace, info.Key.Name)
++			return ngImpl.mcmManager.updateAnnotationOnMachine(ctx, info.Key.Name, MachinePriorityMachineAnnotation, priorityValueForDeletionCandidateMachines)
++		}, "Machine", "update", info.Key.Name)
++
++		if err != nil {
++			return err
++		}
++	}
++
+ 	// Trying to update the machineDeployment till the deadline
+ 	err = ngImpl.mcmManager.retry(func(ctx context.Context) (bool, error) {
+ 		return ngImpl.mcmManager.scaleDownMachineDeployment(ctx, ngImpl.Name, toBeDeletedMachineInfos)
 Index: cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
 IDEA additional info:
 Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 <+>UTF-8
 ===================================================================
 diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
---- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
-+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1746781249737)
-@@ -538,18 +538,18 @@
+--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(revision 2818e0cffbc180b42fc486630ab36d43ecf56649)
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1747480923237)
+@@ -89,6 +89,7 @@
+ 	defaultPriorityValue = "3"
+ 	// priorityValueForDeletionCandidateMachines is the priority annotation value set on machines that the CA wants to be deleted. Its value is set to 1.
+ 	priorityValueForDeletionCandidateMachines = "1"
++	MachinePriorityMachineAnnotation          = "machinepriority.machine.sapcloud.io"
+ 	minResyncPeriodDefault                    = 1 * time.Hour
+ 	// kindMachineClass is the kind for generic machine class used by the OOT providers
+ 	kindMachineClass = "MachineClass"
+@@ -537,18 +538,19 @@
  	}
  	klog.V(2).Infof("MachineDeployment %q size decreased from %d to %d, TriggerDeletionByMCM Annotation Value: %q", md.Name, md.Spec.Replicas, updatedMd.Spec.Replicas, updatedMd.Annotations[machineutils.TriggerDeletionByMCM])
 
@@ -135,30 +170,7 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autos
 +	//	// Do not return error as cordoning is best-effort
 +	//	klog.Warningf("NodeGroup.deleteMachines() of %q ran into error cordoning nodes: %v", md.Name, err)
 +	//}
++
  	return false, nil
  }
 
-@@ -1120,7 +1120,7 @@
- 	alreadyMarkedSet := sets.New(getMachineNamesTriggeredForDeletion(md)...)
-
- 	uniqueForDeletionSet := forDeletionSet.Difference(alreadyMarkedSet)
--	toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
-+	//toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
-
- 	data.RevisedToBeDeletedMachineNames = uniqueForDeletionSet
- 	data.RevisedScaledownAmount = uniqueForDeletionSet.Len()
-@@ -1136,10 +1136,10 @@
- 		if mdCopy.Annotations == nil {
- 			mdCopy.Annotations = make(map[string]string)
- 		}
--		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
--		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
--			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
--		}
-+		//triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
-+		//if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
-+		//	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
-+		//}
- 		mdCopy.Spec.Replicas = expectedReplicas
- 		data.RevisedMachineDeployment = mdCopy
- 	}

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.31/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.31/README.md
@@ -31,7 +31,12 @@ TODO: add description
 
 TODO: add description
 
-### 004-delete-mcm-annotations-from-md.patch
+### 004-set-priorities-for-to-de-deleted-machines-and-clean-annotation.patch
 
 Remove additional cordoning nodes from mcm cloud provider.
-Remove adding "node.machine.sapcloud.io/trigger-deletion-by-mcm" annotation to machine deployment to avoid autoscaler warnings.
+
+New autoscaler works with new version MCM witch select nodes for deleting from annotation `node.machine.sapcloud.io/trigger-deletion-by-mcm`
+This annotation does not support by our MCM, and we should set deleting priority with annotation `machinepriority.machine.sapcloud.io`.
+We set priority for machines and keep `node.machine.sapcloud.io/trigger-deletion-by-mcm` annotation for calculation replicas,
+but we need to clean deleted machines from annotation in refresh function for keeping up to date annotation value to avoid
+drizzling replicas count in machine deployment.

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/004-set-priorities-for-to-de-deleted-machines-and-clean-annotation.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/004-set-priorities-for-to-de-deleted-machines-and-clean-annotation.patch
@@ -6,41 +6,39 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 <+>UTF-8
 ===================================================================
 diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
---- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(revision 2818e0cffbc180b42fc486630ab36d43ecf56649)
-+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1746780978295)
-@@ -25,7 +25,6 @@
- 	"context"
- 	"fmt"
- 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
--	"k8s.io/apimachinery/pkg/util/sets"
- 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
- 	"slices"
- 	"strconv"
-@@ -33,7 +32,6 @@
- 	"sync"
+--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1747481033457)
+@@ -31,10 +31,10 @@
  	"time"
 
--	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
+ 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+-	"k8s.io/apimachinery/pkg/util/sets"
+-	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
+-
+ 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
++
  	apiv1 "k8s.io/api/core/v1"
  	"k8s.io/apimachinery/pkg/api/resource"
  	"k8s.io/apimachinery/pkg/types"
-@@ -332,34 +330,34 @@
-
- // Refresh cordons the Nodes corresponding to the machines that have been marked for deletion in the TriggerDeletionByMCM annotation on the MachineDeployment
- func (ngImpl *nodeGroup) Refresh() error {
--	mcd, err := ngImpl.mcmManager.GetMachineDeploymentObject(ngImpl.Name)
--	if err != nil {
--		return err
--	}
--	toBeDeletedMachineNames := getMachineNamesTriggeredForDeletion(mcd)
--	if len(toBeDeletedMachineNames) == 0 {
--		return nil
--	}
+@@ -341,26 +341,63 @@
+ 	if len(toBeDeletedMachineNames) == 0 {
+ 		return nil
+ 	}
 -	machinesOfNodeGroup, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
--	if err != nil {
++
++	machines, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
+ 	if err != nil {
 -		klog.Warningf("NodeGroup.Refresh() of %q failed to get machines for MachineDeployment due to: %v", ngImpl.Name, err)
 -		return nil
--	}
++		return err
++	}
++
++	machinesSet := make(map[string]*v1alpha1.Machine)
++	for _, machine := range machines {
++		machinesSet[machine.Name] = machine
+ 	}
 -	toBeDeletedMachines := filterMachinesMatchingNames(machinesOfNodeGroup, sets.New(toBeDeletedMachineNames...))
 -	if len(toBeDeletedMachines) == 0 {
 -		klog.Warningf("NodeGroup.Refresh() of %q could not find Machine objects for toBeDeletedMachineNames %q", ngImpl.Name, toBeDeletedMachineNames)
@@ -50,20 +48,36 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluste
 -	if len(toBeDeletedNodeNames) == 0 {
 -		klog.Warningf("NodeGroup.Refresh() of %q could not find toBeDeletedNodeNames for toBeDeletedMachineNames %q of MachineDeployment", ngImpl.Name, toBeDeletedMachineNames)
 -		return nil
--	}
++
++	savedInAnnotation := make([]string, 0, len(toBeDeletedMachineNames))
++	for _, deleted := range toBeDeletedMachineNames {
++		if machine, ok := machinesSet[deleted]; ok {
++			if isMachineFailedOrTerminating(machine) {
++				klog.V(4).Infof("Machine %s is marked as failed or terminating. Will be removed from annotation", deleted)
++				continue
++			}
++
++			klog.V(4).Infof("Machine %s was found. Will keep in annotation", deleted)
++			savedInAnnotation = append(savedInAnnotation, deleted)
++		}
++
++		klog.V(4).Infof("Not found machine %s in machineset. Will be removed from annotation", deleted)
+ 	}
 -	err = ngImpl.mcmManager.cordonNodes(toBeDeletedNodeNames)
--	if err != nil {
++
++	klog.V(2).Infof("Next machines will be saved to annotation %v", savedInAnnotation)
++
++	annotationVal := createMachinesTriggeredForDeletionAnnotValue(savedInAnnotation)
++	mdCopy := mcd.DeepCopy()
++	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = annotationVal
++	updatedMd, err := ngImpl.mcmManager.machineClient.MachineDeployments(mcd.Namespace).Update(context.TODO(), mdCopy, metav1.UpdateOptions{})
+ 	if err != nil {
 -		// we do not return error since we don't want this to block CA operation. This is best-effort.
 -		klog.Warningf("NodeGroup.Refresh() of %q ran into error cordoning nodes: %v", ngImpl.Name, err)
--	}
-+	//mcd, err := ngImpl.mcmManager.GetMachineDeploymentObject(ngImpl.Name)
-+	//if err != nil {
-+	//	return err
-+	//}
-+	//toBeDeletedMachineNames := getMachineNamesTriggeredForDeletion(mcd)
-+	//if len(toBeDeletedMachineNames) == 0 {
-+	//	return nil
-+	//}
++		return err
+ 	}
++	klog.V(2).Infof("MachineDeployment %q triggered by mcm annotation cleaned to %q", mcd.Name, updatedMd.Annotations[machineutils.TriggerDeletionByMCM])
++
 +	//machinesOfNodeGroup, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
 +	//if err != nil {
 +	//	klog.Warningf("NodeGroup.Refresh() of %q failed to get machines for MachineDeployment due to: %v", ngImpl.Name, err)
@@ -87,32 +101,44 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluste
  	return nil
  }
 
-@@ -567,10 +565,12 @@
- // getMachineNamesTriggeredForDeletion returns the set of machine names contained within the machineutils.TriggerDeletionByMCM annotation on the given MachineDeployment
- // TODO: Move to using MCM annotations.GetMachineNamesTriggeredForDeletion after MCM release.
- func getMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []string {
--	if mcd.Annotations == nil || mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
--		return nil
--	}
--	return strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
-+	//if mcd.Annotations == nil || mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
-+	//	return nil
-+	//}
-+	//return strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
-+
-+	return nil
- }
+@@ -441,6 +478,20 @@
+ 		return fmt.Errorf("MachineDeployment %s is under rolling update , cannot reduce replica count", ngImpl.Name)
+ 	}
 
- // TODO: Move to using MCM annotations.CreateMachinesTriggeredForDeletionAnnotValue after MCM release
++	klog.V(2).Infof("Start set priorities for machines %v", toBeDeletedMachineInfos)
++
++	for _, info := range toBeDeletedMachineInfos {
++		err = ngImpl.mcmManager.retry(func(ctx context.Context) (bool, error) {
++
++			klog.V(2).Infof("Set priority for machine %s/%s", info.Key.Namespace, info.Key.Name)
++			return ngImpl.mcmManager.updateAnnotationOnMachine(ctx, info.Key.Name, MachinePriorityMachineAnnotation, priorityValueForDeletionCandidateMachines)
++		}, "Machine", "update", info.Key.Name)
++
++		if err != nil {
++			return err
++		}
++	}
++
+ 	// Trying to update the machineDeployment till the deadline
+ 	err = ngImpl.mcmManager.retry(func(ctx context.Context) (bool, error) {
+ 		return ngImpl.mcmManager.scaleDownMachineDeployment(ctx, ngImpl.Name, toBeDeletedMachineInfos)
 Index: cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
 IDEA additional info:
 Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 <+>UTF-8
 ===================================================================
 diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
---- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(revision 2818e0cffbc180b42fc486630ab36d43ecf56649)
-+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1746781131049)
-@@ -537,18 +537,18 @@
+--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1747481033495)
+@@ -90,6 +90,7 @@
+ 	defaultPriorityValue = "3"
+ 	// priorityValueForDeletionCandidateMachines is the priority annotation value set on machines that the CA wants to be deleted. Its value is set to 1.
+ 	priorityValueForDeletionCandidateMachines = "1"
++	MachinePriorityMachineAnnotation          = "machinepriority.machine.sapcloud.io"
+ 	minResyncPeriodDefault                    = 1 * time.Hour
+ 	// kindMachineClass is the kind for generic machine class used by the OOT providers
+ 	kindMachineClass = "MachineClass"
+@@ -538,18 +539,19 @@
  	}
  	klog.V(2).Infof("MachineDeployment %q size decreased from %d to %d, TriggerDeletionByMCM Annotation Value: %q", md.Name, md.Spec.Replicas, updatedMd.Spec.Replicas, updatedMd.Annotations[machineutils.TriggerDeletionByMCM])
 
@@ -140,30 +166,7 @@ diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autos
 +	//	// Do not return error as cordoning is best-effort
 +	//	klog.Warningf("NodeGroup.deleteMachines() of %q ran into error cordoning nodes: %v", md.Name, err)
 +	//}
++
  	return false, nil
  }
 
-@@ -1119,7 +1119,7 @@
- 	alreadyMarkedSet := sets.New(getMachineNamesTriggeredForDeletion(md)...)
-
- 	uniqueForDeletionSet := forDeletionSet.Difference(alreadyMarkedSet)
--	toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
-+	//toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
-
- 	data.RevisedToBeDeletedMachineNames = uniqueForDeletionSet
- 	data.RevisedScaledownAmount = uniqueForDeletionSet.Len()
-@@ -1135,10 +1135,10 @@
- 		if mdCopy.Annotations == nil {
- 			mdCopy.Annotations = make(map[string]string)
- 		}
--		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
--		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
--			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
--		}
-+		//triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
-+		//if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
-+		//	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
-+		//}
- 		mdCopy.Spec.Replicas = expectedReplicas
- 		data.RevisedMachineDeployment = mdCopy
- 	}

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/README.md
@@ -31,7 +31,12 @@ TODO: add description
 
 TODO: add description
 
-### 004-delete-mcm-annotations-from-md.patch
+### 004-set-priorities-for-to-de-deleted-machines-and-clean-annotation.patch
 
 Remove additional cordoning nodes from mcm cloud provider.
-Remove adding "node.machine.sapcloud.io/trigger-deletion-by-mcm" annotation to machine deployment to avoid autoscaler warnings.
+
+New autoscaler works with new version MCM witch select nodes for deleting from annotation `node.machine.sapcloud.io/trigger-deletion-by-mcm`
+This annotation does not support by our MCM, and we should set deleting priority with annotation `machinepriority.machine.sapcloud.io`.
+We set priority for machines and keep `node.machine.sapcloud.io/trigger-deletion-by-mcm` annotation for calculation replicas,
+but we need to clean deleted machines from annotation in refresh function for keeping up to date annotation value to avoid
+drizzling replicas count in machine deployment.

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/README.md
@@ -12,6 +12,11 @@ Cluster autoscaler can't tell the difference between pods created by apps/v1 and
 daemonsets when simulating if a node can be terminated. This patch makes cluster autoscaler check PDB 
 instead of checking if an apps/v1 daemonset exists, when it bumps into a pod created by an advanced daemonset.
 
-# Remove additional cordon by mcm cloud provider
-Gardner cluster autoscaler cordon node of main flow of autoscaler.
-It can be keep nodes in cordon status without deleting them.
+# Set priorities for to de deleted machines and clean annotation node.machine.sapcloud.io/trigger-deletion-by-mcm
+Remove additional cordoning nodes from mcm cloud provider.
+
+New autoscaler works with new version MCM witch select nodes for deleting from annotation `node.machine.sapcloud.io/trigger-deletion-by-mcm`
+This annotation does not support by our MCM, and we should set deleting priority with annotation `machinepriority.machine.sapcloud.io`.
+We set priority for machines and keep `node.machine.sapcloud.io/trigger-deletion-by-mcm` annotation for calculation replicas,
+but we need to clean deleted machines from annotation in refresh function for keeping up to date annotation value to avoid
+drizzling replicas count in machine deployment.

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_autoscaler.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_autoscaler.sh
@@ -71,6 +71,13 @@ spec:
             cpu: "1"
       nodeSelector:
         node-role/autoscaler: ""
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: $deployment_name
+            topologyKey: kubernetes.io/hostname
       tolerations:
       - key: node
         operator: Equal


### PR DESCRIPTION
## Description
Patch autoscaler 1.30-1.32 to support our MCM.

New autoscaler works with new version MCM which select nodes for deleting from annotation `node.machine.sapcloud.io/trigger-deletion-by-mcm` This annotation does not support by our MCM, and we should set deleting priority with annotation `machinepriority.machine.sapcloud.io` for right deletion order.
We set priority for machines and keep `node.machine.sapcloud.io/trigger-deletion-by-mcm` annotation for calculation replicas, but we need to clean deleted machines from annotation in refresh function for keeping up to date annotation value to avoid drizzling replicas count in machine deployment.

## Why do we need it, and what problem does it solve?

After our previous patch https://github.com/deckhouse/deckhouse/pull/13391 cluster autoscaler periodically scale up and scale down machine deployments, because after our patch CA cannot right calculated replicas, because we deleted `node.machine.sapcloud.io/trigger-deletion-by-mcm` annotation.

Because new CA is oriented on `node.machine.sapcloud.io/trigger-deletion-by-mcm` annotation for deleting nodes, but our mcm is oriented on `machinepriority.machine.sapcloud.io` annotation for calculate nodes for delete. we can have situation when nodes for deleting calculated by CA do not delete, but delete another nodes and some nodes stuck in Scheduling Disable status.  

Also   

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Patch autoscaler 1.30-1.32 to support our MCM
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
