### PR TITLE
[cloud-provider-zvirt] Enable migrator from terraform state to opentofu

### DIFF
--- a/candi/terraform_versions.yml
+++ b/candi/terraform_versions.yml
@@ -16,6 +16,16 @@ aws:
   artifactBinary: terraform-provider-aws
   # provider binary name with destination image
   destinationBinary: terraform-provider-aws
+  # Attention! For migrate to opentofu we need some manual actions.
+  # Unfortunately useOpentofu variable available only in werf and discovered inside dhctl
+  # But we need enable automigrator and terraform state metrics hook. We can add global hook
+  # for autodiscovery terraform versions file, but we think that this attention will be enough.
+  # So, for switch to opentofu existing provider with terraform we need to do two additional actions:
+  # 1. in the cloud provider module you should add hook go_lib/hooks/to_tofu_migrate_metric, see example
+  #    modules/030-cloud-provider-yandex/hooks/to_tofu_migrate_metric.go
+  # 2. Enable state migrator here https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml#L61
+  #    to enable migrator please add provider name from this list https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/candi/openapi/cluster_configuration.yaml#L63
+  # after migration, please remove this comment
   useOpentofu: false
 
 azure:
@@ -26,6 +36,16 @@ azure:
   artifact: terraform-provider-azure
   artifactBinary: terraform-provider-azurerm
   destinationBinary: terraform-provider-azurerm
+  # Attention! For migrate to opentofu we need some manual actions.
+  # Unfortunately useOpentofu variable available only in werf and discovered inside dhctl
+  # But we need enable automigrator and terraform state metrics hook. We can add global hook
+  # for autodiscovery terraform versions file, but we think that this attention will be enough.
+  # So, for switch to opentofu existing provider with terraform we need to do two additional actions:
+  # 1. in the cloud provider module you should add hook go_lib/hooks/to_tofu_migrate_metric, see example
+  #    modules/030-cloud-provider-yandex/hooks/to_tofu_migrate_metric.go
+  # 2. Enable state migrator here https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml#L61
+  #    to enable migrator please add provider name from this list https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/candi/openapi/cluster_configuration.yaml#L63
+  # after migration, please remove this comment
   useOpentofu: false
 
 gcp:
@@ -36,6 +56,16 @@ gcp:
   artifact: terraform-provider-gcp
   artifactBinary: terraform-provider-gcp
   destinationBinary: terraform-provider-google
+  # Attention! For migrate to opentofu we need some manual actions.
+  # Unfortunately useOpentofu variable available only in werf and discovered inside dhctl
+  # But we need enable automigrator and terraform state metrics hook. We can add global hook
+  # for autodiscovery terraform versions file, but we think that this attention will be enough.
+  # So, for switch to opentofu existing provider with terraform we need to do two additional actions:
+  # 1. in the cloud provider module you should add hook go_lib/hooks/to_tofu_migrate_metric, see example
+  #    modules/030-cloud-provider-yandex/hooks/to_tofu_migrate_metric.go
+  # 2. Enable state migrator here https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml#L61
+  #    to enable migrator please add provider name from this list https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/candi/openapi/cluster_configuration.yaml#L63
+  # after migration, please remove this comment
   useOpentofu: false
 
 openstack:
@@ -46,6 +76,16 @@ openstack:
   artifact: terraform-provider-openstack
   artifactBinary: terraform-provider-openstack
   destinationBinary: terraform-provider-openstack
+  # Attention! For migrate to opentofu we need some manual actions.
+  # Unfortunately useOpentofu variable available only in werf and discovered inside dhctl
+  # But we need enable automigrator and terraform state metrics hook. We can add global hook
+  # for autodiscovery terraform versions file, but we think that this attention will be enough.
+  # So, for switch to opentofu existing provider with terraform we need to do two additional actions:
+  # 1. in the cloud provider module you should add hook go_lib/hooks/to_tofu_migrate_metric, see example
+  #    modules/030-cloud-provider-yandex/hooks/to_tofu_migrate_metric.go
+  # 2. Enable state migrator here https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml#L61
+  #    to enable migrator please add provider name from this list https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/candi/openapi/cluster_configuration.yaml#L63
+  # after migration, please remove this comment
   useOpentofu: false
 
 ovirt:
@@ -66,6 +106,16 @@ vsphere:
   artifact: terraform-provider-vsphere
   artifactBinary: terraform-provider-vsphere
   destinationBinary: terraform-provider-vsphere
+  # Attention! For migrate to opentofu we need some manual actions.
+  # Unfortunately useOpentofu variable available only in werf and discovered inside dhctl
+  # But we need enable automigrator and terraform state metrics hook. We can add global hook
+  # for autodiscovery terraform versions file, but we think that this attention will be enough.
+  # So, for switch to opentofu existing provider with terraform we need to do two additional actions:
+  # 1. in the cloud provider module you should add hook go_lib/hooks/to_tofu_migrate_metric, see example
+  #    modules/030-cloud-provider-yandex/hooks/to_tofu_migrate_metric.go
+  # 2. Enable state migrator here https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml#L61
+  #    to enable migrator please add provider name from this list https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/candi/openapi/cluster_configuration.yaml#L63
+  # after migration, please remove this comment
   useOpentofu: false
 
 vcd:
@@ -76,6 +126,16 @@ vcd:
   artifact: terraform-provider-vcd-artifact
   artifactBinary: terraform-provider-vcd
   destinationBinary: terraform-provider-vcd
+  # Attention! For migrate to opentofu we need some manual actions.
+  # Unfortunately useOpentofu variable available only in werf and discovered inside dhctl
+  # But we need enable automigrator and terraform state metrics hook. We can add global hook
+  # for autodiscovery terraform versions file, but we think that this attention will be enough.
+  # So, for switch to opentofu existing provider with terraform we need to do two additional actions:
+  # 1. in the cloud provider module you should add hook go_lib/hooks/to_tofu_migrate_metric, see example
+  #    modules/030-cloud-provider-yandex/hooks/to_tofu_migrate_metric.go
+  # 2. Enable state migrator here https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml#L61
+  #    to enable migrator please add provider name from this list https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/candi/openapi/cluster_configuration.yaml#L63
+  # after migration, please remove this comment
   useOpentofu: false
 
 yandex:
@@ -106,6 +166,15 @@ huaweicloud:
   artifact: terraform-provider-huaweicloud
   artifactBinary: terraform-provider-huaweicloud
   destinationBinary: terraform-provider-huaweicloud
+  # Attention! For migrate to opentofu we need some manual actions.
+  # Unfortunately useOpentofu variable available only in werf and discovered inside dhctl
+  # But we need enable automigrator and terraform state metrics hook. We can add global hook
+  # for autodiscovery terraform versions file, but we think that this attention will be enough.
+  # So, for switch to opentofu existing provider with terraform we need to do two additional actions:
+  # 1. in the cloud provider module you should add hook go_lib/hooks/to_tofu_migrate_metric, see example
+  #    modules/030-cloud-provider-yandex/hooks/to_tofu_migrate_metric.go
+  # 2. Enable state migrator here https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml#L61
+  #    to enable migrator please add provider name from this list https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/candi/openapi/cluster_configuration.yaml#L63
   useOpentofu: false
 
 kubernetes:

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/to_tofu_migrate_metric.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/to_tofu_migrate_metric.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	metric "github.com/deckhouse/deckhouse/go_lib/hooks/to_tofu_migrate_metric"
+)
+
+var _ = metric.RegisterHook()

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/to_tofu_migrate_metric.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/to_tofu_migrate_metric.go
@@ -1,17 +1,6 @@
 /*
 Copyright 2025 Flant JSC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package hooks

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
@@ -58,7 +58,7 @@ spec:
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: terraform-auto-converger
-      {{- if has .Values.global.clusterConfiguration.cloud.provider (list "Yandex") }}
+      {{- if has .Values.global.clusterConfiguration.cloud.provider (list "Yandex" "Zvirt") }}
       initContainers:
       - name: to-tofu-migrator
         {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 8 }}


### PR DESCRIPTION
## Description
In the previous pr https://github.com/deckhouse/deckhouse/pull/13386/files we forget to enable migrator to opentofu states from terraform and did not add hook for fire alert when cluster has terraform state.

Alse we added comment in `terraform_versions.yaml` for providers that using terraform with instruction to migrate to opentofu.

For cloud-provider-dynamics we did not add migrator because we do not have working installation with this provider.

## Why do we need it, and what problem does it solve?
We have Zvirt installation on terraform. We need to enable migrator for smooth migration from terraform to opentofu.

Also we added comment in `terraform_versions.yaml` to prevent forgetting enable migrator and metrics hook when we migrate from terraform to opentofu

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-zvirt
type: chore
summary: Enable migrator from terraform state to opentofu.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
