### PR TITLE
[docs] Add missing permission in aws policy to docs

### DIFF
--- a/candi/cloud-providers/aws/docs/ENVIRONMENT.md
+++ b/candi/cloud-providers/aws/docs/ENVIRONMENT.md
@@ -55,6 +55,7 @@ First, prepare a JSON file with the configuration of the necessary privileges:
                 "ec2:DeleteVpc",
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAddresses",
+                "ec2:DescribeAddressesAttribute",
                 "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstanceAttribute",

--- a/candi/cloud-providers/aws/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/aws/docs/ENVIRONMENT_RU.md
@@ -56,6 +56,7 @@ description: "Настройка AWS для работы облачного пр
                 "ec2:DeleteVpc",
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAddresses",
+                "ec2:DescribeAddressesAttribute",
                 "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstanceAttribute",

--- a/docs/site/_includes/getting_started/aws/STEP_ENV.md
+++ b/docs/site/_includes/getting_started/aws/STEP_ENV.md
@@ -46,6 +46,7 @@ cat > policy.json << EOF
                 "ec2:DeleteVpc",
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAddresses",
+                "ec2:DescribeAddressesAttribute",
                 "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstanceAttribute",

--- a/docs/site/_includes/getting_started/aws/STEP_ENV_RU.md
+++ b/docs/site/_includes/getting_started/aws/STEP_ENV_RU.md
@@ -46,6 +46,7 @@ cat > policy.json << EOF
                 "ec2:DeleteVpc",
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAddresses",
+                "ec2:DescribeAddressesAttribute",
                 "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstanceAttribute",


### PR DESCRIPTION
## Description
Added an additional permission to the AWS policy required when setting up a cluster

## Why do we need it, and what problem does it solve?
Now an alert appears in the cluster about a missing permission.
```bash
{"level":"info","msg":"Condition (INSUFFICIENT_AWS_SA_PERMISSIONS) message: DescribeAddressesAttribute is not allowed, ok: false\n","time":"2025-05-14T15:41:00Z"}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```
section: docs
type: chore
summary: Added an additional permission to the AWS policy
impact_level: low
```