### PR TITLE
[ingress-nginx] Added TLS proxy-pass to documentation.d8-system pod

### DIFF
--- a/modules/810-documentation/templates/configmap.yaml
+++ b/modules/810-documentation/templates/configmap.yaml
@@ -57,7 +57,7 @@ data:
       }
 
       server {
-        listen   8080;
+        listen   127.0.0.1:8080;
         server_name _;
 
         root   /app;

--- a/modules/810-documentation/templates/deployment.yaml
+++ b/modules/810-documentation/templates/deployment.yaml
@@ -103,6 +103,56 @@ spec:
             name: modules-docs-en
           - mountPath: "/mount/public/ru/modules"
             name: modules-docs-ru
+      - name: kube-rbac-proxy
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
+        args:
+          - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8443"
+          - "--client-ca-file=/etc/kube-rbac-proxy/ca.crt"
+          - "--v=2"
+          - "--logtostderr=true"
+          - "--stale-cache-interval=1h30m"
+          - "--livez-path=/livez"
+        env:
+          - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: KUBE_RBAC_PROXY_CONFIG
+            value: |
+              upstreams:
+              - upstream: http://127.0.0.1:8080/
+                path: /
+                authorization:
+                  resourceAttributes:
+                    namespace: d8-system
+                    apiGroup: apps
+                    apiVersion: v1
+                    resource: deployments
+                    subresource: http
+                    name: documentation
+        ports:
+          - containerPort: 8443
+            name: https
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8443
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 8443
+            scheme: HTTPS
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+{{- end }}
+        volumeMounts:
+          - name: kube-rbac-proxy-ca
+            mountPath: /etc/kube-rbac-proxy
       volumes:
         - name: config
           configMap:
@@ -116,4 +166,8 @@ spec:
           emptyDir: {}
         - name: modules-docs-ru
           emptyDir: {}
+        - name: kube-rbac-proxy-ca
+          configMap:
+            defaultMode: 420
+            name: kube-rbac-proxy-ca.crt
 {{- end }}

--- a/modules/810-documentation/templates/ingress.yaml
+++ b/modules/810-documentation/templates/ingress.yaml
@@ -7,7 +7,12 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "documentation")) | nindent 2 }}
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/configuration-snippet: |-
+      proxy_ssl_certificate /etc/nginx/ssl/client.crt;
+      proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
+      proxy_ssl_protocols TLSv1.2;
+      proxy_ssl_session_reuse on;
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
@@ -21,14 +26,14 @@ spec:
           service:
             name: documentation
             port:
-              name: http
+              name: https
       - path: /(site.webmanifest|browserconfig.xml)
         pathType: ImplementationSpecific
         backend:
           service:
             name: documentation
             port:
-              name: http
+              name: https
   {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
   tls:
     - hosts:
@@ -48,17 +53,17 @@ metadata:
   {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.documentation.auth.externalAuthentication }}
     nginx.ingress.kubernetes.io/auth-signin: {{ .Values.documentation.auth.externalAuthentication.authSignInURL | quote }}
     nginx.ingress.kubernetes.io/auth-url: {{ .Values.documentation.auth.externalAuthentication.authURL | quote }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
   {{- else }}
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: documentation-basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
-    nginx.ingress.kubernetes.io/configuration-snippet: |-
+  {{- end }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_ssl_certificate /etc/nginx/ssl/client.crt;
       proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
       proxy_ssl_protocols TLSv1.2;
       proxy_ssl_session_reuse on;
-  {{- end }}
       rewrite ^/(en|ru)/?$ /$1/platform/ redirect;
       rewrite ^/modules/(.+) /en/modules/$1 redirect;
       rewrite ^/(ru|en)/modules$ /$1/modules/ permanent;
@@ -78,14 +83,14 @@ spec:
           service:
             name: documentation
             port:
-              name: http
+              name: https
         path: /
         pathType: ImplementationSpecific
       - backend:
           service:
             name: documentation
             port:
-              name: http
+              name: https
         path: /modules
         pathType: Prefix
   {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}

--- a/modules/810-documentation/templates/rbac-to-us.yaml
+++ b/modules/810-documentation/templates/rbac-to-us.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.global.modules.publicDomainTemplate }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kube-rbac-proxy:documentation
+  namespace: d8-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "documentation")) | nindent 2 }}
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments/http"]
+  resourceNames: ["documentation"]
+  verbs: ["get", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-rbac-proxy:documentation
+  namespace: d8-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "documentation")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-rbac-proxy:documentation
+subjects:
+- kind: Group
+  name: ingress-nginx:auth
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:system:documentation:rbac-proxy
+  namespace: d8-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "documentation")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:rbac-proxy
+subjects:
+  - kind: ServiceAccount
+    name: documentation
+    namespace: d8-system

--- a/modules/810-documentation/templates/service.yaml
+++ b/modules/810-documentation/templates/service.yaml
@@ -8,25 +8,10 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "documentation")) | nindent 2 }}
 spec:
   ports:
-  - name: http
-    port: 80
-    targetPort: http
+  - name: https
+    port: 443
+    targetPort: https
     protocol: TCP
   selector:
     app: documentation
 {{- end }}
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: documentation-builder
-  namespace: d8-system
-  {{- include "helm_lib_module_labels" (list . (dict "app" "documentation")) | nindent 2 }}
-spec:
-  ports:
-    - name: builder-http
-      port: 8081
-      targetPort: builder-http
-      protocol: TCP
-  selector:
-    app: documentation

--- a/modules/810-documentation/templates/vertical-pod-autoscaler.yaml
+++ b/modules/810-documentation/templates/vertical-pod-autoscaler.yaml
@@ -38,4 +38,5 @@ spec:
       maxAllowed:
         cpu: 200m
         memory: 500Mi
+    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
## Description
Added TLS encryption via kube-rbac-proxy between ingress-nginx and documentation pod

To implement it, the following changes are made:
- Nginx in the documentation container listens only to 127.0.0.1:8080, external communication is done via kube-rbac-proxy on port :8443
- The service (clusterIP) "documentation-builder" has been deleted because it is not in use

## Why do we need it, and what problem does it solve?
Some customers may have had problems with security scanners due to the lack of TLS encryption at the pod with documentation

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: chore
summary: Added TLS between ingress-nginx controller and documentation.d8-system pod.
```