### PR TITLE
[linting] Add usestdlibvars lint and fix errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,7 @@ linters:
     - unconvert
     - unparam
     - whitespace
+    - usestdlibvars
   settings:
     errcheck:
       exclude-functions:

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -184,7 +184,7 @@ func applyServiceAPIServerFilter(obj *unstructured.Unstructured) (go_hook.Filter
 // Therefore, we need to request all api servers, get versions and choice minimal
 func getKubeVersionForServer(endpoint string, cl d8http.Client) (*semver.Version, error) {
 	url := fmt.Sprintf("https://%s/version?timeout=5s", endpoint)
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func getKubeVersionForServer(endpoint string, cl d8http.Client) (*semver.Version
 
 	defer res.Body.Close()
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("k8s version: incorrect response code: %v", res.Status)
 	}
 


### PR DESCRIPTION
## Description
Add `usestdlibvars` linter and fix _magic values_.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
The `usestdlibvars` linter identifies instances where hardcodes literals can be replaced with well-defined constants from Go's standard library (e.g "GET" -> http.MethodGet).
This practice enhances code clarity, reduces the risk of errors, and aligns with Go's idiomatic standards.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


<!---

## Why do we need it in the patch release (if we do)?
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: add usestdlibvars lint and fix errors
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
