### PR TITLE
[registrypackages] return shim-runc-v1

### DIFF
--- a/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/ADVANCED_RU.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/ADVANCED_RU.md
@@ -169,7 +169,7 @@ spec:
                 privileged_without_host_devices = false
                 runtime_engine = ""
                 runtime_root = ""
-                runtime_type = "io.containerd.runc.v1"
+                runtime_type = "io.containerd.runc.v2"
                 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
                   BinaryName = "/usr/bin/nvidia-container-runtime"
                   SystemdCgroup = false

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/ADVANCED.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/ADVANCED.md
@@ -182,7 +182,7 @@ When you change the CRI in the cluster, complete several additional steps for th
                    privileged_without_host_devices = false
                    runtime_engine = ""
                    runtime_root = ""
-                   runtime_type = "io.containerd.runc.v1"
+                   runtime_type = "io.containerd.runc.v2"
                    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
                      BinaryName = "/usr/bin/nvidia-container-runtime"
                      SystemdCgroup = false

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/ADVANCED_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/ADVANCED_RU.md
@@ -178,7 +178,7 @@ spec:
                    privileged_without_host_devices = false
                    runtime_engine = ""
                    runtime_root = ""
-                   runtime_type = "io.containerd.runc.v1"
+                   runtime_type = "io.containerd.runc.v2"
                    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
                      BinaryName = "/usr/bin/nvidia-container-runtime"
                      SystemdCgroup = false

--- a/modules/007-registrypackages/images/containerd/scripts/install
+++ b/modules/007-registrypackages/images/containerd/scripts/install
@@ -31,7 +31,7 @@ version = 2
     enable_selinux = ${enable_selinux}
 EOF
 
-cp -f containerd containerd-shim-runc-v2 ctr runc /opt/deckhouse/bin
+cp -f containerd containerd-shim-runc-v1 containerd-shim-runc-v2 ctr runc /opt/deckhouse/bin
 
 mkdir -p /lib/systemd/system/
 cp -f containerd.service /lib/systemd/system/containerd-deckhouse.service

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -10,6 +10,7 @@ import:
   to: /
   includePaths:
   - containerd
+  - containerd-shim-runc-v1
   - containerd-shim-runc-v2
   - ctr
   - runc

--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -688,7 +688,7 @@ spec:
                 privileged_without_host_devices = false
                 runtime_engine = ""
                 runtime_root = ""
-                runtime_type = "io.containerd.runc.v1"
+                runtime_type = "io.containerd.runc.v2"
                 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
                   BinaryName = "/usr/bin/nvidia-container-runtime"
                   SystemdCgroup = false

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -698,7 +698,7 @@ spec:
                 privileged_without_host_devices = false
                 runtime_engine = ""
                 runtime_root = ""
-                runtime_type = "io.containerd.runc.v1"
+                runtime_type = "io.containerd.runc.v2"
                 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
                   BinaryName = "/usr/bin/nvidia-container-runtime"
                   SystemdCgroup = false


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Return `shim-runc-v1` for backward compatibility. 
Update docs for using `shim-runc-v2` in ngc for GPU.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Related to #13205 .
`shim-runc-v1` was specified in the NGC example for GPU nodes in our [documentation](https://github.com/deckhouse/deckhouse/blob/4ceec52c4f37b5e214cc726fe1c4ae417be138a2/docs/site/pages/virtualization-platform/documentation/admin/platform-management/node-management/ADVANCED.md?plain=1#L185).
Need to return `shim-runc-v1` to registrypackages for backward compatibility.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi, docs
type: fix
summary: Return `shim-runc-v1` for backward compatibility. 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
