### PR TITLE
[monitoring-ping] added init container for cleanup deprecated exporter

### DIFF
--- a/modules/340-monitoring-ping/images/monitoring-ping/src/main.go
+++ b/modules/340-monitoring-ping/images/monitoring-ping/src/main.go
@@ -38,7 +38,7 @@ func main() {
 	flag.BoolVar(&cleanupNodeExporterMetrics, "cleanup-node-exporter-metrics", false, "Clean up node exporter metrics")
 	flag.Parse()
 	if cleanupNodeExporterMetrics {
-		// TODO remove volumes in future, need for clean staled medtrics
+		// TODO remove volumes in future, need for clean staled metrics
 		log.Info("cleanup mode enabled, running CleanUpDeprecatedExporterFile")
 		CleanUpDeprecatedExporterFile()
 		return

--- a/modules/340-monitoring-ping/images/monitoring-ping/src/main.go
+++ b/modules/340-monitoring-ping/images/monitoring-ping/src/main.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"flag"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -29,12 +30,19 @@ import (
 
 var (
 	countPings int = 30 // Count pings on every cycle
+	cleanupNodeExporterMetrics bool
 )
 
 func main() {
 
-	// TODO remove volumes in future, need for clean staled medtrics
-	CleanUpDeprecatedExporterFile()
+	flag.BoolVar(&cleanupNodeExporterMetrics, "cleanup-node-exporter-metrics", false, "Clean up node exporter metrics")
+	flag.Parse()
+	if cleanupNodeExporterMetrics {
+		// TODO remove volumes in future, need for clean staled medtrics
+		log.Info("cleanup mode enabled, running CleanUpDeprecatedExporterFile")
+		CleanUpDeprecatedExporterFile()
+		return
+	}
 
 	reg := prometheus.NewRegistry()
 	metrics := RegisterMetrics(reg)

--- a/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
+++ b/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
@@ -8,8 +8,8 @@ import:
     add: /src/monitoring-ping
     to: /monitoring-ping
     before: setup
-  - image: tools/setcap
-    add: /usr/bin/setcap
+  - image: tools/libcap
+    add: /usr/sbin/setcap
     to: /tools/setcap
     before: setup
 shell:

--- a/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
+++ b/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
@@ -45,7 +45,7 @@ shell:
   - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
   setup:
   - cd /src
-  - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ .GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+  - export GO_VERSION=${GOLANG_VERSION} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
   - go build -ldflags="-s -w" -o /src/monitoring-ping
   - chmod 0755 /src/monitoring-ping # change to 0500 after removed init container
   - chown 64535:64535 /src/monitoring-ping

--- a/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
+++ b/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
@@ -1,17 +1,30 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+fromImage: base/distroless
+final: true
+fromCacheVersion: "2025-05-26"
 import:
   - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
     add: /src/monitoring-ping
     to: /monitoring-ping
-    after: setup
+    before: setup
+  - image: tools/setcap
+    add: /usr/bin/setcap
+    to: /tools/setcap
+    before: setup
+shell:
+  setup:
+  - /tools/setcap cap_net_raw=+eip /monitoring-ping # Need for run icmp ping from non root user
 imageSpec:
   config:
+    workingDir: /tools
+    clearWorkingDir: true
     entrypoint: ["/monitoring-ping"]
+    
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 fromImage: builder/golang-alpine-1.23
+fromCacheVersion: "2025-05-26"
 final: false
 import:
   - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
@@ -28,16 +41,18 @@ shell:
   {{- include "alpine packages proxy" . | nindent 2 }}
   - apk add --no-cache bash git binutils
   install:
-    - cd /src
-    - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
+  - cd /src
+  - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
   setup:
-    - cd /src
-    - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ .GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
-    - go build -ldflags="-s -w" -o /src/monitoring-ping
-    - chmod 0700 /src/monitoring-ping # it is necessary to make a launch from user deckhouse after allocation of the file /var/run/node-exporter-textfile/monitoring-ping_*.prom
+  - cd /src
+  - export GO_VERSION=${GOLANG_VERSION} GOPROXY={{ .GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+  - go build -ldflags="-s -w" -o /src/monitoring-ping
+  - chmod 0755 /src/monitoring-ping # change to 0500 after removed init container
+  - chown 64535:64535 /src/monitoring-ping
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 fromImage: common/src-artifact
+fromCacheVersion: "2025-05-26"
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src

--- a/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
+++ b/modules/340-monitoring-ping/images/monitoring-ping/werf.inc.yaml
@@ -18,7 +18,7 @@ shell:
 imageSpec:
   config:
     workingDir: /tools
-    clearWorkingDir: true
+    clearWorkingDir: true # a hack to delete the setcap binary from final image
     entrypoint: ["/monitoring-ping"]
     
 ---

--- a/modules/340-monitoring-ping/templates/daemonset.yaml
+++ b/modules/340-monitoring-ping/templates/daemonset.yaml
@@ -56,13 +56,25 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       automountServiceAccountToken: true
       serviceAccountName: monitoring-ping
+      initContainers:
+      - name: monitoring-ping-clean-node-exporter-stale # TODO remove container in future, need for clean staled metrics
+        image: {{ include "helm_lib_module_image" (list . "monitoringPing") }}
+        args:
+          - "--cleanup-node-exporter-metrics=true"
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsGroup: 0
+          runAsNonRoot: false
+          runAsUser: 0
+        volumeMounts: # TODO remove volumes in future, need for clean staled metrics
+          - name: textfile
+            mountPath: /node-exporter-textfile
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
       containers:
       - image: {{ include "helm_lib_module_image" (list . "monitoringPing") }}
         name: monitoring-ping
-        {{- /*
-          UID: 0 GID:0 using for privilege access for fping because using hostNetwork
-          it is necessary to make a launch from user deckhouse after allocation of the file /var/run/node-exporter-textfile/monitoring-ping_*.prom
-        */}}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -71,17 +83,11 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
         env:
           - name: MY_NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-        volumeMounts: # TODO remove volumes in future, need for clean staled metrics
-          - name: textfile
-            mountPath: /node-exporter-textfile
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

 * Added init container for clearing obsolete mertrics passed through the file. The cleanup logic was migrated from agent to init-container.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In the previous implementation of monitoring-ping (python version) a file was created to transfer metrics to node-exporter in the directory /var/run/node-exporter-textfile named in the following pattern “monitoring-ping*.prom, after switching to exporting metrics using http server, the file remains, and as a consequence the hung metrics are displayed in monitoring prometheus and grafana. The cleanup function is already implemented, but the best solution would be to run it in a separate init container, since deleting files requires root privileges, it is reasonable to perform the deletion in the init container, and leave the execution of the application itself to a non-privileged user.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-ping
type: chore
summary: Garbage collecting legacy metrics from node-exporter was moved to init-container.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
