### PR TITLE
[deckhouse-controller] Add validation according to RFC 1123 for module names added to ModuleSource

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -286,6 +287,10 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 			continue
 		}
 
+		if errs := validation.IsDNS1123Subdomain(moduleName); len(errs) > 0 {
+			r.logger.Warn("the module has invalid name: must coply with RFC 1123 subdomain format, skip it", slog.String("name", moduleName))
+			continue
+		}
 		availableModule := v1alpha1.AvailableModule{Name: moduleName}
 		for _, available := range source.Status.AvailableModules {
 			if available.Name == moduleName {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -485,7 +485,7 @@ spec:
 
 	source := suite.moduleSource("test-source")
 
-	var moduleNames []string
+	moduleNames := make([]string, 0, len(source.Status.AvailableModules))
 	for _, mod := range source.Status.AvailableModules {
 		moduleNames = append(moduleNames, mod.Name)
 	}

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -448,4 +449,46 @@ func (suite *ControllerTestSuite) moduleSource(name string) *v1alpha1.ModuleSour
 	require.NoError(suite.T(), err)
 
 	return source
+}
+
+func (suite *ControllerTestSuite) TestFilterInvalidModuleNames() {
+	suite.T().Setenv("D8_IS_TESTS_ENVIRONMENT", "false")
+
+	sourceYAML := `
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: test-source
+spec:
+  registry:
+    dockerCfg: ""
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+`
+
+	suite.setupTestController(sourceYAML)
+
+	pulledModules := []string{
+		"modules",               // reserved
+		strings.Repeat("a", 65), // too big
+		"invalid_name!",         // invalid RFC1123
+		"Cloud-Provider-AWS",    // invalid RFC1123
+		"-invalid-module",       // invalid RFC1123
+		"invalid_module",        // invalid RFC1123
+		"valid.module",          //	ok
+		"valid-module",          // ok
+		"another-valid-module",  // ok
+	}
+
+	err := suite.r.processModules(context.Background(), suite.moduleSource("test-source"), nil, pulledModules)
+	require.NoError(suite.T(), err)
+
+	source := suite.moduleSource("test-source")
+
+	var moduleNames []string
+	for _, mod := range source.Status.AvailableModules {
+		moduleNames = append(moduleNames, mod.Name)
+	}
+
+	assert.ElementsMatch(suite.T(), []string{"valid-module", "valid.module", "another-valid-module"}, moduleNames)
 }


### PR DESCRIPTION
## Description
It is necessary to add validation according to `RFC 1123` for module names added to `ModuleSource`, as well as to cover with unit tests.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
`RFC 1123` defines the rules for names used in _DNS_, including subdomain names. According to this standard, a name must:

- Consist of lowercase letters (a–z), digits (0–9), hyphens (-), and dots (.).
- Start and end with an alphanumeric character.
- Be no more than 253 characters in length.

If module names do not conform to these requirements, it can lead to errors when creating resources, issues with _DNS_ name resolution, and other unpredictable behaviors in the cluster.

Adding validation of module names according to `RFC 1123` allows:

- Preventing the creation of modules with invalid names.
- Ensuring compatibility with other Kubernetes components that expect names to follow this standard.
- Simplifying debugging and maintenance by eliminating errors related to invalid names.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


<!---

## Why do we need it in the patch release (if we do)?
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: add validation according to RFC 1123 for module names added to ModuleSource
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
