### PR TITLE
[docs] Fix label about default Kubernetes version in the table with supported versions

### DIFF
--- a/docs/documentation/_includes/SUPPORTED_VERSIONS.liquid
+++ b/docs/documentation/_includes/SUPPORTED_VERSIONS.liquid
@@ -230,7 +230,7 @@
   </td>
   <td style="text-align: center; font-weight:bold">{{ k8sItem[0] }}</td>
   <td style="text-align: left">
-    <p>{%- if k8sItem[0] == site.data.version_kubernetes.default %}<strong>{{ site.data.i18n.common['default_version'][page.lang] | capitalize }}.</strong> {% endif %}
+    <p>{%- if k8sItem[1].default %}<strong>{{ site.data.i18n.common['default_version'][page.lang] | capitalize }}.</strong> {% endif %}
     {{ site.data.supported_versions.k8s_statuses[k8sStatus][page.lang] }}</p>
   </td>
 </tr>


### PR DESCRIPTION
## Description

This pull request updates the logic in the `SUPPORTED_VERSIONS.liquid` file to correctly identify the default Kubernetes version. The change replaces the comparison of the first element (`k8sItem[0]`) with the default version, using a more explicit check on the `default` property of the second element (`k8sItem[1]`).

* [`docs/documentation/_includes/SUPPORTED_VERSIONS.liquid`](diffhunk://#diff-e44f23e14a0796fdb27cc05a99f779755bfdfeaaab2ef1d82ba21e9512253405L233-R233): Updated the conditional logic to check the `default` property of `k8sItem[1]` instead of comparing `k8sItem[0]` with the default version, improving clarity and accuracy.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fixed generation of label about default Kubernetes version in the table with supported versions.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
