### PR TITLE
[dhctl] Implement native tar

### DIFF
--- a/dhctl/pkg/system/node/ssh/frontend/upload-script.go
+++ b/dhctl/pkg/system/node/ssh/frontend/upload-script.go
@@ -30,6 +30,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh/session"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tar"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
 
@@ -163,8 +164,7 @@ func (u *UploadScript) ExecuteBundle(ctx context.Context, parentDir, bundleDir s
 	bundleLocalFilepath := filepath.Join(app.TmpDirName, bundleName)
 
 	// tar cpf bundle.tar -C /tmp/dhctl.1231qd23/var/lib bashible
-	tarCmd := exec.CommandContext(ctx, "tar", "cpf", bundleLocalFilepath, "-C", parentDir, bundleDir)
-	err = tarCmd.Run()
+	err = tar.CreateTar(bundleLocalFilepath, parentDir, bundleDir)
 	if err != nil {
 		return nil, fmt.Errorf("tar bundle: %v", err)
 	}

--- a/dhctl/pkg/util/tar/tar.go
+++ b/dhctl/pkg/util/tar/tar.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tar
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func CreateTar(tarFilePath, baseDir, targetDir string) error {
+	tarFile, err := os.Create(tarFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to create tar file: %w", err)
+	}
+	defer tarFile.Close()
+
+	tarWriter := tar.NewWriter(tarFile)
+	defer tarWriter.Close()
+
+	err = filepath.Walk(filepath.Join(baseDir, targetDir), func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("failed to walk path: %w", err)
+		}
+
+		relPath, err := filepath.Rel(baseDir, filePath)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path: %w", err)
+		}
+
+		header, err := tar.FileInfoHeader(info, relPath)
+		if err != nil {
+			return fmt.Errorf("failed to create tar header: %w", err)
+		}
+
+		header.Name = relPath
+
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return fmt.Errorf("failed to write header to tar file: %w", err)
+		}
+
+		if info.Mode().IsRegular() {
+			file, err := os.Open(filePath)
+			if err != nil {
+				return fmt.Errorf("failed to open file: %w", err)
+			}
+			defer file.Close()
+
+			if _, err := io.Copy(tarWriter, file); err != nil {
+				return fmt.Errorf("failed to copy file to tar: %w", err)
+			}
+		}
+
+		return nil
+	})
+
+	return err
+}

--- a/dhctl/pkg/util/tar/tar_test.go
+++ b/dhctl/pkg/util/tar/tar_test.go
@@ -1,0 +1,94 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tar
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func createTestDir(baseDir string) error {
+	testDir := filepath.Join(baseDir, "testdir")
+	err := os.MkdirAll(testDir, 0755)
+	if err != nil {
+		return err
+	}
+
+	files := []string{"file1.txt", "file2.txt"}
+	for _, file := range files {
+		err := os.WriteFile(filepath.Join(testDir, file), []byte("This is a test file."), 0644)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func TestCreateTar(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tar_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	err = createTestDir(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+
+	tarFilePath := filepath.Join(tmpDir, "output.tar")
+	err = CreateTar(tarFilePath, tmpDir, "testdir")
+	if err != nil {
+		t.Fatalf("Failed to create tar file: %v", err)
+	}
+
+	tarFile, err := os.Open(tarFilePath)
+	if err != nil {
+		t.Fatalf("Failed to open tar file: %v", err)
+	}
+	defer tarFile.Close()
+
+	tarReader := tar.NewReader(tarFile)
+
+	_, err = tarReader.Next()
+	if err != nil {
+		t.Fatalf("Failed to read from tar file: %v", err)
+	}
+
+	expectedFiles := []string{"testdir/file1.txt", "testdir/file2.txt"}
+	for _, expectedFile := range expectedFiles {
+		header, err := tarReader.Next()
+		if err != nil {
+			t.Fatalf("Failed to read from tar file: %v", err)
+		}
+
+		if header.Name != expectedFile {
+			t.Errorf("Expected %s, got %s", expectedFile, header.Name)
+		}
+
+		content, err := io.ReadAll(tarReader)
+		if err != nil {
+			t.Fatalf("Failed to read file content from tar: %v", err)
+		}
+
+		if string(content) != "This is a test file." {
+			t.Errorf("Content mismatch for %s", expectedFile)
+		}
+	}
+}


### PR DESCRIPTION
## Description

Implement native tar instead of using binary `tar`

## Why do we need it, and what problem does it solve?

Reduce dependencies, needed for `dhctl` run

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Replace call of binary tar to native golang tar implementation in dhctl.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
