### PR TITLE
[metallb] fix CRD addresspools.metallb.io deletion

### DIFF
--- a/ee/se/modules/380-metallb/hooks/delete-deprecated-crd.go
+++ b/ee/se/modules/380-metallb/hooks/delete-deprecated-crd.go
@@ -1,17 +1,7 @@
 /*
 Copyright 2025 Flant JSC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license.
+See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package hooks

--- a/ee/se/modules/380-metallb/hooks/delete-deprecated-crd_test.go
+++ b/ee/se/modules/380-metallb/hooks/delete-deprecated-crd_test.go
@@ -1,17 +1,7 @@
 /*
 Copyright 2025 Flant JSC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license.
+See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package hooks


### PR DESCRIPTION
## Description

Move the global hook to remove CRD `addresspools.metallb.io` to the `d8-metallb` module.

## Why do we need it, and what problem does it solve?

PR #12453 implements the removal of the `addresspools.metallb.io` CRD. But if the customer uses its own `metallb` module, the hook removes its CRD too. Now hook removes CRD only when `d8-metallb` module is enabled.

## Why do we need it in the patch release (if we do)?

The problem affects CE edition users after upgrading to version 1.69.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: fix
summary: Fixed deprecated CRD addresspools.metallb.io deletion.
```
