### PR TITLE
Fix git.stageDependencies for modules werf files

### DIFF
--- a/docs/site/werf-docs-builder.inc.yaml
+++ b/docs/site/werf-docs-builder.inc.yaml
@@ -17,11 +17,17 @@ imageSpec:
 git:
   - add: /{{ .ModulePath }}docs/site/backends/docs-builder-template
     to: /app/hugo
+    stageDependencies:
+      install:
+      - '**/*'
 {{ if ne .ModuleName "docs" }}
     excludePaths:
     - config/production/
   - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/modules-docs/hugo.yaml
     to: /app/hugo/config/production/hugo.yaml
+    stageDependencies:
+      install:
+      - '**/*'
 {{ end }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact

--- a/modules/040-control-plane-manager/images/kube-apiserver-healthcheck/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/kube-apiserver-healthcheck/werf.inc.yaml
@@ -44,3 +44,6 @@ git:
   - go.mod
   - go.sum
   - main.go
+  stageDependencies:
+    install:
+    - '**/*'

--- a/modules/040-node-manager/images/early-oom/werf.inc.yaml
+++ b/modules/040-node-manager/images/early-oom/werf.inc.yaml
@@ -5,6 +5,9 @@ final: false
 git:
 - add: /{{ $.ModulePath }}modules/040-node-manager/images/early-oom/src
   to: /src
+  stageDependencies:
+    install:
+    - '**/*'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 fromImage: builder/golang-alpine

--- a/modules/040-node-manager/images/fencing-agent/werf.inc.yaml
+++ b/modules/040-node-manager/images/fencing-agent/werf.inc.yaml
@@ -5,6 +5,9 @@ final: false
 git:
 - add: /{{ $.ModulePath }}modules/040-node-manager/images/fencing-agent/src
   to: /src
+  stageDependencies:
+    install:
+    - '**/*'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 fromImage: builder/golang-alpine

--- a/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
@@ -21,6 +21,9 @@ git:
   includePaths:
     - "candi/openapi"
     - "candi/terraform_versions.yml"
+  stageDependencies:
+    install:
+    - '**/*'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-opentofu
 final: false
@@ -48,6 +51,9 @@ git:
   includePaths:
     - "candi/openapi"
     - "candi/terraform_versions.yml"
+  stageDependencies:
+    install:
+    - '**/*'
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-terraform-src-artifact
 final: false

--- a/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
@@ -3,6 +3,9 @@ fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "prov
 git:
 - add: /{{ .ModulePath }}candi/cloud-providers/aws
   to: /deckhouse/candi/cloud-providers/aws
+  stageDependencies:
+    install:
+    - '**/*'
 import:
 - image: terraform-provider-aws
   add: /terraform-provider-aws

--- a/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
@@ -3,6 +3,9 @@ fromImage: '{{ include "infrastructure_manager_base_image" (dict "TF" .TF "provi
 git:
 - add: /{{ .ModulePath }}candi/cloud-providers/azure
   to: /deckhouse/candi/cloud-providers/azure
+  stageDependencies:
+    install:
+    - '**/*'
 import:
 - image: terraform-provider-azure
   add: /terraform-provider-azurerm

--- a/modules/040-terraform-manager/images/terraform-manager-dvp/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-dvp/werf.inc.yaml
@@ -3,6 +3,9 @@ fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "prov
 git:
 - add: /{{ .ModulePath }}candi/cloud-providers/dvp
   to: /deckhouse/candi/cloud-providers/dvp
+  stageDependencies:
+    install:
+    - '**/*'
 import:
 - image: terraform-provider-kubernetes
   add: /terraform-provider-kubernetes

--- a/modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
@@ -4,6 +4,9 @@ fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "prov
 git:
 - add: /{{ .ModulePath }}candi/cloud-providers/gcp
   to: /deckhouse/candi/cloud-providers/gcp
+  stageDependencies:
+    install:
+    - '**/*'
 import:
 - image: terraform-provider-gcp
   add: /terraform-provider-gcp

--- a/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
@@ -3,6 +3,9 @@ fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "prov
 git:
 - add: /{{ .ModulePath }}candi/cloud-providers/yandex
   to: /deckhouse/candi/cloud-providers/yandex
+  stageDependencies:
+    install:
+    - '**/*'
 import:
 - image: terraform-provider-yandex
   add: /terraform-provider-yandex

--- a/modules/150-user-authn/images/self-signed-generator/werf.inc.yaml
+++ b/modules/150-user-authn/images/self-signed-generator/werf.inc.yaml
@@ -16,6 +16,9 @@ final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
     to: /src
+    stageDependencies:
+      install:
+      - '**/*'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-self-signed-generator-artifact
 fromImage: builder/golang-alpine

--- a/modules/300-prometheus/images/grafana-dashboard-provisioner/werf.inc.yaml
+++ b/modules/300-prometheus/images/grafana-dashboard-provisioner/werf.inc.yaml
@@ -13,6 +13,9 @@ import:
 git:
 - add: /{{ $.ModulePath }}modules/300-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/hooks
   to: /hooks
+  stageDependencies:
+    install:
+    - '**/*'
 ---
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/werf.inc.yaml
@@ -4,6 +4,9 @@ fromImage: common/distroless
 git:
 - add: /{{ $.ModulePath }}modules/340-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/extended-monitoring.py
   to: /app/extended-monitoring.py
+  stageDependencies:
+    install:
+    - '**/*'
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
   add: /


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Not all 'git' directives in the werf.inc.yaml modules of Deckhouse have a 'stageDependencies' directive, which leads to a lack of image reassembly when changes are made to the specified files.
Also this change aligned werf files with new DMT Linter feature

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Image of Deck house module now will be reassembled when changes are made to the specified files as expected
New DMT Linter feature now does not show errors

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
