### PR TITLE
[docs] Remove unnecessary blocks with commands on the installation page of GS.

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
+++ b/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
@@ -110,7 +110,7 @@
 
 <div id='block_other_{{ revision }}' class="tabs__content tabs__content_other
 {% if revision == 'ce' %} active{% endif %}
-{% if page.ee_only == true and page.se_support != true %} active{% endif %}
+{% if revision == 'ee' and page.ee_only == true and page.se_support != true %} active{% endif %}
 {% if revision == 'se' and page.se_support == true %} active{% endif %}
 {% if revision == 'se-plus' and page.se_support == true %} active{% endif %}
 " markdown="1">


### PR DESCRIPTION
## Description

This pull request includes a minor update to the `select_revision.html.liquid` file to refine the conditions for setting the `active` class.

* [`docs/site/_includes/getting_started/global/partials/select_revision.html.liquid`](diffhunk://#diff-357ad82a89b0d4877517cc8bed968343739b23ad3b33c8337bb83147bca30aacL113-R113): Updated the conditional logic to ensure that the `active` class is applied only when the revision is `ee` and both `page.ee_only` is `true` and `page.se_support` is not `true`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Removed unnecessary blocks with commands on the installation page of GS.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
