### PR TITLE
[network gateway] Fix python path

### DIFF
--- a/ee/modules/450-network-gateway/images/dnsmasq/prepare-config.py
+++ b/ee/modules/450-network-gateway/images/dnsmasq/prepare-config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 # Copyright 2021 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE

--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -39,14 +39,14 @@ import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /etc/dnsmasq.conf.d
     before: install
-  - image: common/python-static
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /opt/python-static/bin
     to: /usr/bin
     before: install
     includePaths:
     - python3*
     - python3
-  - image: common/python-static
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /opt/python-static/lib
     to: /usr/lib
     before: install

--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -1,27 +1,14 @@
-{{- $binaries := "/usr/lib64/libsqlite3.so* /usr/sbin/dnsmasq /lib64/libnss_*" }}
+{{- $binaries := "/usr/bin/python3 /lib64/libz.so* /lib64/libexpat.so* /usr/lib64/libffi.so* /lib64/libcrypto.so* /lib64/libssl.so* /usr/lib64/libsqlite3.so* /usr/sbin/dnsmasq /lib64/libnss_*" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-fromImage: common/relocate-artifact
 final: false
-git:
-- add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/requirements.txt
-  to: /requirements.txt
-  stageDependencies:
-    install:
-    - '**/*'
-import:
-- image: common/python-static
-  add: /opt/python-static
-  to: /opt/python-static
-  before: install
+from: {{ .Images.BASE_ALT_DEV }}
 shell:
-  beforeInstall:
-  - apt-get install -y git dnsmasq libsqlite3
   install:
-  - git clone --depth 1 {{ $.SOURCE_REPO }}/python-modules/wheels /wheels
-  - /opt/python-static/bin/pip3 install -f file:///wheels --no-index -r requirements.txt
-  - rm -rf /wheels
-  - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+    - apt-get update
+    - apt-get install -y python3 python3-modules-sqlite3 pip dnsmasq
+    - /usr/bin/pip3 install pyroute2 six ipcalc
+    - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
@@ -34,21 +21,20 @@ import:
     to: /
     before: install
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib64/python3
+    before: install
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib64/python3.9
+    before: install
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/lib/python3/site-packages
+    before: install
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+    add: /usr/local/lib/python3/site-packages
+    before: install
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /etc/dnsmasq.conf
     before: install
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
     add: /etc/dnsmasq.conf.d
     before: install
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-    add: /opt/python-static/bin
-    to: /usr/bin
-    before: install
-    includePaths:
-    - python3*
-    - python3
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-    add: /opt/python-static/lib
-    to: /usr/lib
-    before: install
-    includePaths:
-    - python3*

--- a/ee/modules/450-network-gateway/images/snat/iptables-loop.py
+++ b/ee/modules/450-network-gateway/images/snat/iptables-loop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 # Copyright 2021 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix python path in the network-gateway components.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
dhcp server from network-gateway cannot start.
```
"reason": "StartError",
    "message": "failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: \"/usr/bin/python3\": permission denied: unknown",
    "labels": {
      "io.kubernetes.container.name": "init",
      "io.kubernetes.pod.name": "dhcp-0",
      "io.kubernetes.pod.namespace": "d8-network-gateway",
      "io.kubernetes.pod.uid": "0ad6859e-edc7-4a76-bab8-b7c5cb9d605c"
    },
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: network-gateway
type: fix
summary: Fix python path
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
