### PR TITLE
[ci] moved filter from cse edition when rendering parse_version_map

### DIFF
--- a/.werf/defines/version-map.tmpl
+++ b/.werf/defines/version-map.tmpl
@@ -7,13 +7,22 @@
   {{- $versionMap := dict }}
   {{- range $_, $edition := $.Editions }}
    {{- if $edition.versionMapFile }}
-     {{- $versionMap = (merge $versionMap ($.Files.Get $edition.versionMapFile | fromYaml) )}}
+     {{- $versionMap = (mergeOverwrite $versionMap ($.Files.Get $edition.versionMapFile | fromYaml) )}}
    {{- end }}
    {{- if eq $.Env $edition.name }}
      {{- break -}}
    {{- end }}
   {{- end }}
 
+  # Filtering only non-empty values in k8s
+  {{- $filteredK8s := dict }}
+  {{- range $ver, $val := $versionMap.k8s }}
+    {{- if $val }}
+      {{- $_ := set $filteredK8s $ver $val }}
+    {{- end }}
+  {{- end }}
+
+  {{- $_ := set $versionMap "k8s" $filteredK8s }}
   {{- $_ := set $context "CandiVersionMap" $versionMap }}
   # kubernetes versions list
   {{- $kubernetesVersions := list }}

--- a/.werf/werf-version-map.yaml
+++ b/.werf/werf-version-map.yaml
@@ -33,9 +33,8 @@ shell:
      {{- if $previousEditionFile }}
   - cp {{ $edition.versionMapFile }} {{ $tmpEditionFile }}
   - |
-    yq eval-all \
-      'select(fileIndex == 0) * select(fileIndex == 1) | with(.k8s; del(.[] | select(. == null or tag == "!!map" and length == 0)))' \
-      {{ $previousEditionFile }} {{ $tmpEditionFile }} > {{ $curEditionFile }}
+    yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' {{ $previousEditionFile }} {{ $tmpEditionFile }} | \
+    yq eval-all 'with(.k8s; del(.[] | select(. == null or tag == "!!map" and length == 0)))' > {{ $curEditionFile }}
       {{- else }}
   - cp {{ $edition.versionMapFile }} {{ $curEditionFile }}
       {{- end }}

--- a/.werf/werf-version-map.yaml
+++ b/.werf/werf-version-map.yaml
@@ -30,23 +30,18 @@ shell:
   {{- $curEditionFile := printf "/version_map_%s.yml" $edition.name }}
   {{- if $edition.versionMapFile }}
     {{- $tmpEditionFile := printf "%s.tmp" $curEditionFile }}
-
      {{- if $previousEditionFile }}
   - cp {{ $edition.versionMapFile }} {{ $tmpEditionFile }}
-  - yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' {{ $previousEditionFile }} {{ $tmpEditionFile }} > {{ $curEditionFile }}
-
+  - |
+    yq eval-all \
+      'select(fileIndex == 0) * select(fileIndex == 1) | with(.k8s; del(.[] | select(. == null or tag == "!!map" and length == 0)))' \
+      {{ $previousEditionFile }} {{ $tmpEditionFile }} > {{ $curEditionFile }}
       {{- else }}
-
   - cp {{ $edition.versionMapFile }} {{ $curEditionFile }}
-
       {{- end }}
-
   {{- else }}
-
   - cp {{ $previousEditionFile }} {{ $curEditionFile }}
-
   {{- end }}
-
   {{- $previousEditionFile = $curEditionFile }}
 {{- end }}
 ---

--- a/.werf/werf-version-map.yaml
+++ b/.werf/werf-version-map.yaml
@@ -33,8 +33,10 @@ shell:
      {{- if $previousEditionFile }}
   - cp {{ $edition.versionMapFile }} {{ $tmpEditionFile }}
   - |
-    yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' {{ $previousEditionFile }} {{ $tmpEditionFile }} | \
-    yq eval-all 'with(.k8s; del(.[] | select(. == null or tag == "!!map" and length == 0)))' > {{ $curEditionFile }}
+    yq eval-all '
+      select(fileIndex == 0) * select(fileIndex == 1) |
+      with(.k8s; del(.[] | select(. == null or tag == "!!map" and length == 0)))
+      ' {{ $previousEditionFile }} {{ $tmpEditionFile }} > {{ $curEditionFile }}
       {{- else }}
   - cp {{ $edition.versionMapFile }} {{ $curEditionFile }}
       {{- end }}


### PR DESCRIPTION
## Description
Added additional logic to handle empty versions. This allows inheritance of CE settings but leaves the possibility to reduce the number of supported kube versions.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
This will reduce the number of modified files in cse.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: moved filter from cse edition when rendering parse_version_map
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
