### PR TITLE
[user-authn] fix: add onBeforeHelm for applyDexAuthenticatorSecretFilter

### DIFF
--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
@@ -102,7 +102,8 @@ func applyDexAuthenticatorSecretFilter(obj *unstructured.Unstructured) (go_hook.
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	Queue: "/modules/user-authn",
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Queue:        "/modules/user-authn",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "authenticators",


### PR DESCRIPTION
## Description

You need to update k8s Values before launching helm. To do this, specify OnBeforeHelm in the hooks.

## Why do we need it, and what problem does it solve?

There is a situation when we start the installation, we have a change in the environment, but at the same time we change Values. The hook is restarted, and we are no longer trying to work with resources that are not available. As a result, the queue gets up.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: add onBeforeHalm for applyDexAuthenticatorSecretFilter
impact_level: default
```
