### PR TITLE
[cloud-provider-vsphere] add datastore name RFC 1123 normalization

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores_test.go
@@ -123,7 +123,7 @@ cloudProviderVsphere:
 
 	dependency.TestDC.VsphereClient = vsphere.NewClientMock(GinkgoT())
 	var output vsphere.Output
-	_ = json.Unmarshal([]byte(`{"datacenter":"DCTEST","datastores":[{"datastoreType":"DatastoreCluster","name":"test-1-k8s-3cf5ce84","path":"/DCTEST/datastore/test_1_k8s","zones":["ZONE-TEST"]},{"datastoreType":"Datastore","datastoreURL":"ds:///vmfs/volumes/503a9af1-291d17b0-52e0-1d01842f428c/","name":"test-1-lun101-b39d82fa","path":"/DCTEST/datastore/test_1_Lun101","zones":["ZONE-TEST"]},{"datastoreType":"Datastore","datastoreURL":"ds:///vmfs/volumes/55832249-30a68048-496f-33f77fed3c5c/","name":"test-1-lun102-0403073a","path":"/DCTEST/datastore/test_1_Lun102","zones":["ZONE-TEST"]}],"zones":["ZONE-TEST"]}`), &output)
+	_ = json.Unmarshal([]byte(`{"datacenter":"DCTEST","datastores":[{"datastoreType":"DatastoreCluster","name":"test-1-k8s-3cf5ce84","path":"/DCTEST/datastore/test_1_k8s","zones":["ZONE-TEST"]},{"datastoreType":"Datastore","datastoreURL":"ds:///vmfs/volumes/503a9af1-291d17b0-52e0-1d01842f428c/","name":"test-1-LUN101-b39d82fa","path":"/DCTEST/datastore/test_1_Lun101","zones":["ZONE-TEST"]},{"datastoreType":"Datastore","datastoreURL":"ds:///vmfs/volumes/55832249-30a68048-496f-33f77fed3c5c/","name":"test-1-LUN102-0403073a","path":"/DCTEST/datastore/test_1_Lun102","zones":["ZONE-TEST"]}],"zones":["ZONE-TEST"]}`), &output)
 	dependency.TestDC.VsphereClient.GetZonesDatastoresMock.Return(&output, nil)
 
 	Context("Empty cluster", func() {


### PR DESCRIPTION
## Description
This PR adds name normalization to datastores discovered from vSphere.

## Why do we need it, and what problem does it solve?
Currently, if some datastores names do not match `RFC 1123` requiements, `storageClass.storage.k8s.io` resource cannot be created. 

## Why do we need it in the patch release (if we do)?
Client impact

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary:  Add datastore name RFC 1123 normalization.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
