### PR TITLE
[dashboard] Fix display workload metrics on ui kubernetes-dashboard

### DIFF
--- a/modules/500-dashboard/templates/api/deployment.yaml
+++ b/modules/500-dashboard/templates/api/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         image: {{ include "helm_lib_module_image" (list . "api") }}
         args:
         - --namespace=d8-{{ .Chart.Name }}
-        - --metrics-scraper-service-name=metrics-scraper
+        - --metrics-scraper-service-name=metrics-scraper:http
         - --insecure-bind-address=127.0.0.1
         - --v=3
         env:

--- a/modules/500-dashboard/templates/api/rbac-for-us.yaml
+++ b/modules/500-dashboard/templates/api/rbac-for-us.yaml
@@ -32,7 +32,7 @@ rules:
 # Allow Dashboard API to get metrics from metrics-scraper.
 - apiGroups: [""]
   resources: ["services/proxy"]
-  resourceNames: ["metrics-scraper", "http:metrics-scraper"]
+  resourceNames: ["metrics-scraper", "metrics-scraper:http"]
   verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/500-dashboard/templates/metrics-scraper/service.yaml
+++ b/modules/500-dashboard/templates/metrics-scraper/service.yaml
@@ -7,8 +7,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "metrics-scraper")) | nindent 2 }}
 spec:
   ports:
-    - name: http
-      port: 8000
-      targetPort: http
+    - port: 8000
+      targetPort: 8000
   selector:
     app: metrics-scraper

--- a/modules/500-dashboard/templates/metrics-scraper/service.yaml
+++ b/modules/500-dashboard/templates/metrics-scraper/service.yaml
@@ -7,7 +7,8 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "metrics-scraper")) | nindent 2 }}
 spec:
   ports:
-    - port: 8000
-      targetPort: 8000
+    - name: http
+      port: 8000
+      targetPort: http
   selector:
     app: metrics-scraper


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
After refactor for DMT Lint https://github.com/deckhouse/deckhouse/commit/c5777e4980e77029a78801ac45325b68ff0429e6#diff-67adf522866f2751b19b320f5a73171647f713b54b22faacd3345f44a6082729 add named port to svc metrics-scraper

Named port in metrics-scraper svc generate error in api-dashboard and metrics not display
![2025-05-23 в 15 41 53](https://github.com/user-attachments/assets/b56a665e-2605-4c59-b8d6-cabe3dfea4d1)
```
E0509 17:09:48.742991       1 manager.go:96] Metric client health check failed: the server is currently unable to handle the request (get services metrics-scraper). Retrying in 30 seconds.
E0509 17:10:18.751070       1 manager.go:96] Metric client health check failed: the server is currently unable to handle the request (get services metrics-scraper). Retrying in 30 seconds.
E0509 17:10:48.756521       1 manager.go:96] Metric client health check failed: the server is currently unable to handle the request (get services metrics-scraper). Retrying in 30 seconds.
...
```
In official helm chart kubernetes [dashboard](https://github.com/kubernetes/dashboard/blob/b0c1c0fa27602c5dfc496fbad4896bc6079ffd04/charts/kubernetes-dashboard/templates/services/metrics-scraper.yaml#L38)
```
  ports:
    {{- range $port := .Values.metricsScraper.containers.ports }}
    # Name is intentionally not used here as it breaks the connection between API <-> Scraper
    # Named ports have an issue when trying to connect through in-cluster service proxy.
```
For satisfy dmt lint we may
https://github.com/deckhouse/deckhouse/blob/a2d1e8ff12d4ce5443400ecb8a5ea71b1d6c54c7/modules/500-dashboard/templates/api/deployment.yaml#L63 change to `--metrics-scraper-service-name=metrics-scraper:http`
and https://github.com/deckhouse/deckhouse/blob/a2d1e8ff12d4ce5443400ecb8a5ea71b1d6c54c7/modules/500-dashboard/templates/api/rbac-for-us.yaml#L35 change to resourceNames: `["metrics-scraper", "metrics-scraper:http"]`
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix display metrics
![2025-05-23 в 14 51 25](https://github.com/user-attachments/assets/a5f5a68b-7d4c-4eac-a38e-dfb23d553d17)

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dashboard
type: fix
summary: fix display workload metrics on dashboard
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
