### PR TITLE
[node-local-dns] fix stale-dns-connections-cleaner

### DIFF
--- a/ee/be/modules/350-node-local-dns/templates/stale-dns-connections-cleaner/daemonset.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/stale-dns-connections-cleaner/daemonset.yaml
@@ -46,7 +46,8 @@ spec:
     spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      # could be run as not root, but, in the first place, a way of setting file capabilities for binaries in distroless images must be developed
+      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
## Description

Restoring the launch of the `stale-dns-connections-cleaner` container under the `root` user, which was previously replaced by the `deckhouse` user in [PR11962](https://github.com/deckhouse/deckhouse/pull/11962).

## Why do we need it, and what problem does it solve?

`stale-dns-connections-cleaner` cannot work without root permissions.

## Why do we need it in the patch release (if we do)?

The `stale-dns-connections-cleaner` pods cannot start and do not perform their function.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-local-dns
type: fix
summary: Fixing of the stale-dns-connections-cleaner pods
impact_level: default
```

