### PR TITLE
Feat/add wait build image before cve run

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -402,7 +402,7 @@ check_e2e_labels:
 {!{- end }!}
     - git_info
 {!{- if ne $ctx.workflowName "Daily e2e tests" }!}
-    - block-e2e-until-image-is-not-ready
+    - block-until-image-is-not-ready
 {!{- end -}!}
 {!{- if coll.Has $ctx "manualRun" }!}
   if: needs.check_e2e_labels.outputs.run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!} == 'true'

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -114,19 +114,18 @@ block-until-image-is-not-ready:
           const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
           const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
 
-          let branchName = context.payload.inputs.ci_commit_ref_name;
-          if (!branchName) {
-            branchName = githubAction.GetBranchNameFromContext(context);
+          let branchName;
+          let prNum;
+
+          if (context.eventName === 'pull_request') {
+            branchName = context.payload.pull_request.head.ref;
+            prNum = context.payload.pull_request.number;
+          } else if (context.eventName === 'workflow_dispatch') {
+            branchName = context.payload.inputs.ci_commit_ref_name;
+            prNum = context.payload.inputs.issue_number;
           }
 
           if (branchName) {
-            let prNum = context.payload.inputs.issue_number;
-            // if the pull request id is not found, search it by the branch name
-            if (!prNum && branchName !== 'main') {
-              const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
-              prNum = prInfo.number;
-            }
-
             let infoText = `Check build workflow is completed for branch: ${branchName}`;
             if (prNum) {
               infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
@@ -147,6 +146,8 @@ block-until-image-is-not-ready:
             } catch(error) {
               core.setFailed(error);
             }
+          } else {
+            core.setFailed("Branch name not found.");
           }
 
 # </template: block-until-image-is-not-ready>

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -98,16 +98,16 @@ git_info:
 # </template: git_info_job>
 {!{- end -}!}
 
-{!{ define "block-e2e-until-image-is-not-ready" }!}
-# </template: block-e2e-until-image-is-not-ready>
+{!{ define "block-until-image-is-not-ready" }!}
+# </template: block-until-image-is-not-ready>
 {!{- $ctx := . }!}
-block-e2e-until-image-is-not-ready:
-  name: Block e2e until the docker image is not ready
+block-until-image-is-not-ready:
+  name: Block until the docker image is not ready
   runs-on: ubuntu-latest
   steps:
     - uses: {!{ index (ds "actions") "actions/checkout" }!}
-    - name: Block e2e until the docker image is not ready
-      id: block-e2e
+    - name: Block until the docker image is not ready
+      id: block-image-dont-ready
       uses: {!{ index (ds "actions") "actions/github-script" }!}
       with:
         script: |
@@ -149,7 +149,7 @@ block-e2e-until-image-is-not-ready:
             }
           }
 
-# </template: block-e2e-until-image-is-not-ready>
+# </template: block-until-image-is-not-ready>
 {!{- end -}!}
 
 # Check pull request state on push or pull_request_target events:

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -29,6 +29,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  {!{ tmpl.Exec "block-until-image-is-not-ready" . | strings.Indent 2 }!}
+
   test_cve_report_main:
     name: Trivy scan dev images
     if: |

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -29,6 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+{!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
 {!{ tmpl.Exec "block-until-image-is-not-ready" . | strings.Indent 2 }!}
 
   test_cve_report_main:

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -29,11 +29,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-{!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
 {!{ tmpl.Exec "block-until-image-is-not-ready" . | strings.Indent 2 }!}
 
   test_cve_report_main:
     name: Trivy scan dev images
+    needs:
+    - block-until-image-is-not-ready
     if: |
       github.event.label.name == 'security/cve' ||
       (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -29,7 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  {!{ tmpl.Exec "block-until-image-is-not-ready" . | strings.Indent 2 }!}
+{!{ tmpl.Exec "block-until-image-is-not-ready" . | strings.Indent 2 }!}
 
   test_cve_report_main:
     name: Trivy scan dev images

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -119,7 +119,7 @@ jobs:
 
 {!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
 
-{!{ tmpl.Exec "block-e2e-until-image-is-not-ready" . | strings.Indent 2 }!}
+{!{ tmpl.Exec "block-until-image-is-not-ready" . | strings.Indent 2 }!}
 
 {!{ tmpl.Exec "check_e2e_labels_job" $ctx | strings.Indent 2 }!}
 

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -28,84 +28,6 @@ concurrency:
 
 jobs:
 
-  # <template: git_info_job>
-
-  git_info:
-    name: Get git info
-    runs-on: ubuntu-latest
-    outputs:
-      ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
-      ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
-      ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
-      ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ref_full: ${{ steps.git_info.outputs.ref_full }}
-      github_sha: ${{ steps.git_info.outputs.github_sha }}
-      pr_number: ${{ steps.git_info.outputs.pr_number }}
-    # Skip the CI for automation PRs, e.g. changelog, don't skip if Pull Request title contains "[run ci]".
-    if: ${{ contains(github.event.pull_request.title, '[run ci]') || github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
-    steps:
-      - id: git_info
-        name: Get tag name and SHA
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
-
-            let refSlug = ''
-            let refName = ''
-            let refFull = ''
-            let githubBranch = ''
-            let githubTag = ''
-            let githubSHA = ''
-            let prNumber = ''
-            if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // Trigger: workflow_dispatch with pull_request_ref.
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              prNumber = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
-
-              refSlug       = `pr${prNumber}`
-              refName       = context.payload.inputs.ci_commit_ref_name
-              refFull       = context.payload.inputs.pull_request_ref
-              githubBranch  = refName
-              githubSHA     = context.payload.inputs.pull_request_sha
-              core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
-            } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
-              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
-              const targetRepo = context.payload.repository.full_name;
-              const prRepo = context.payload.pull_request.head.repo.full_name
-              const prRef = context.payload.pull_request.head.ref
-
-              refSlug = `pr${context.issue.number}`;
-              refName = (prRepo === targetRepo) ? prRef : refSlug;
-              refFull = `refs/pull/${context.issue.number}/head`
-              githubBranch = refName
-              githubSHA = context.payload.pull_request.head.sha
-              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
-              prNumber = context.issue.number
-            } else {
-              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = GITHUB_REF_NAME
-              refName       = GITHUB_REF_NAME
-              refFull       = GITHUB_REF
-              githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
-              githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
-              githubSHA     = context.sha
-              core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
-            }
-
-            core.setCommandEcho(true)
-            core.setOutput('ci_commit_ref_slug', refSlug)
-            core.setOutput('ci_commit_ref_name', refName)
-            core.setOutput(`ci_commit_tag`, githubTag)
-            core.setOutput(`ci_commit_branch`, githubBranch)
-            core.setOutput(`ref_full`, refFull)
-            core.setOutput('github_sha', githubSHA)
-            core.setOutput('pr_number', prNumber)
-            core.setCommandEcho(false)
-
-  # </template: git_info_job>
-
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
@@ -160,6 +82,8 @@ jobs:
 
   test_cve_report_main:
     name: Trivy scan dev images
+    needs:
+    - block-until-image-is-not-ready
     if: |
       github.event.label.name == 'security/cve' ||
       (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -28,6 +28,84 @@ concurrency:
 
 jobs:
 
+  # <template: git_info_job>
+
+  git_info:
+    name: Get git info
+    runs-on: ubuntu-latest
+    outputs:
+      ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
+      ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
+      ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
+      ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
+      github_sha: ${{ steps.git_info.outputs.github_sha }}
+      pr_number: ${{ steps.git_info.outputs.pr_number }}
+    # Skip the CI for automation PRs, e.g. changelog, don't skip if Pull Request title contains "[run ci]".
+    if: ${{ contains(github.event.pull_request.title, '[run ci]') || github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
+    steps:
+      - id: git_info
+        name: Get tag name and SHA
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
+
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
+            let prNumber = ''
+            if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              prNumber = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNumber}`
+              refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
+              githubBranch  = refName
+              githubSHA     = context.payload.inputs.pull_request_sha
+              core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+            } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
+
+              refSlug = `pr${context.issue.number}`;
+              refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+              prNumber = context.issue.number
+            } else {
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
+              refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
+              githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+              githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+              githubSHA     = context.sha
+              core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+            }
+
+            core.setCommandEcho(true)
+            core.setOutput('ci_commit_ref_slug', refSlug)
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
+            core.setOutput('github_sha', githubSHA)
+            core.setOutput('pr_number', prNumber)
+            core.setCommandEcho(false)
+
+  # </template: git_info_job>
+
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -120,19 +120,18 @@ jobs:
             const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
             const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
 
-            let branchName = context.payload.inputs.ci_commit_ref_name;
-            if (!branchName) {
-              branchName = githubAction.GetBranchNameFromContext(context);
+            let branchName;
+            let prNum;
+
+            if (context.eventName === 'pull_request') {
+              branchName = context.payload.pull_request.head.ref;
+              prNum = context.payload.pull_request.number;
+            } else if (context.eventName === 'workflow_dispatch') {
+              branchName = context.payload.inputs.ci_commit_ref_name;
+              prNum = context.payload.inputs.issue_number;
             }
 
             if (branchName) {
-              let prNum = context.payload.inputs.issue_number;
-              // if the pull request id is not found, search it by the branch name
-              if (!prNum && branchName !== 'main') {
-                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
-                prNum = prInfo.number;
-              }
-
               let infoText = `Check build workflow is completed for branch: ${branchName}`;
               if (prNum) {
                 infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
@@ -153,6 +152,8 @@ jobs:
               } catch(error) {
                 core.setFailed(error);
               }
+            } else {
+              core.setFailed("Branch name not found.");
             }
 
   # </template: block-until-image-is-not-ready>

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -27,6 +27,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # </template: block-until-image-is-not-ready>
+  block-until-image-is-not-ready:
+    name: Block until the docker image is not ready
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - name: Block until the docker image is not ready
+        id: block-image-dont-ready
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
+            const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
+
+            let branchName = context.payload.inputs.ci_commit_ref_name;
+            if (!branchName) {
+              branchName = githubAction.GetBranchNameFromContext(context);
+            }
+
+            if (branchName) {
+              let prNum = context.payload.inputs.issue_number;
+              // if the pull request id is not found, search it by the branch name
+              if (!prNum && branchName !== 'main') {
+                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
+                prNum = prInfo.number;
+              }
+
+              let infoText = `Check build workflow is completed for branch: ${branchName}`;
+              if (prNum) {
+                infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
+              }
+              core.info(infoText);
+
+              const { waitForJobInWorkflowIsCompletedWithSuccess } = require('./.github/scripts/js/validators/validate-job-in-workflow-is-ready')({ github, context, core });
+              try {
+                let workflowName = 'Build and test for dev branches';
+                let jobName = 'Build FE';
+                if (isReleaseBranch(branchName)) {
+                  workflowName = 'Build and test for release branches';
+                }
+                if (branchName === 'main') {
+                  return true;
+                }
+                await waitForJobInWorkflowIsCompletedWithSuccess(branchName, workflowName, jobName);
+              } catch(error) {
+                core.setFailed(error);
+              }
+            }
+
+  # </template: block-until-image-is-not-ready>
+
   test_cve_report_main:
     name: Trivy scan dev images
     if: |

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -168,14 +168,14 @@ jobs:
   # </template: git_info_job>
 
 
-  # </template: block-e2e-until-image-is-not-ready>
-  block-e2e-until-image-is-not-ready:
-    name: Block e2e until the docker image is not ready
+  # </template: block-until-image-is-not-ready>
+  block-until-image-is-not-ready:
+    name: Block until the docker image is not ready
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-      - name: Block e2e until the docker image is not ready
-        id: block-e2e
+      - name: Block until the docker image is not ready
+        id: block-image-dont-ready
         uses: actions/github-script@v6.4.1
         with:
           script: |
@@ -217,7 +217,7 @@ jobs:
               }
             }
 
-  # </template: block-e2e-until-image-is-not-ready>
+  # </template: block-until-image-is-not-ready>
 
   # <template: check_e2e_labels_job>
   check_e2e_labels:
@@ -261,7 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -638,7 +638,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1015,7 +1015,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1392,7 +1392,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1769,7 +1769,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2146,7 +2146,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_33 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2523,7 +2523,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -182,19 +182,18 @@ jobs:
             const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
             const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
 
-            let branchName = context.payload.inputs.ci_commit_ref_name;
-            if (!branchName) {
-              branchName = githubAction.GetBranchNameFromContext(context);
+            let branchName;
+            let prNum;
+
+            if (context.eventName === 'pull_request') {
+              branchName = context.payload.pull_request.head.ref;
+              prNum = context.payload.pull_request.number;
+            } else if (context.eventName === 'workflow_dispatch') {
+              branchName = context.payload.inputs.ci_commit_ref_name;
+              prNum = context.payload.inputs.issue_number;
             }
 
             if (branchName) {
-              let prNum = context.payload.inputs.issue_number;
-              // if the pull request id is not found, search it by the branch name
-              if (!prNum && branchName !== 'main') {
-                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
-                prNum = prInfo.number;
-              }
-
               let infoText = `Check build workflow is completed for branch: ${branchName}`;
               if (prNum) {
                 infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
@@ -215,6 +214,8 @@ jobs:
               } catch(error) {
                 core.setFailed(error);
               }
+            } else {
+              core.setFailed("Branch name not found.");
             }
 
   # </template: block-until-image-is-not-ready>

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -168,14 +168,14 @@ jobs:
   # </template: git_info_job>
 
 
-  # </template: block-e2e-until-image-is-not-ready>
-  block-e2e-until-image-is-not-ready:
-    name: Block e2e until the docker image is not ready
+  # </template: block-until-image-is-not-ready>
+  block-until-image-is-not-ready:
+    name: Block until the docker image is not ready
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-      - name: Block e2e until the docker image is not ready
-        id: block-e2e
+      - name: Block until the docker image is not ready
+        id: block-image-dont-ready
         uses: actions/github-script@v6.4.1
         with:
           script: |
@@ -217,7 +217,7 @@ jobs:
               }
             }
 
-  # </template: block-e2e-until-image-is-not-ready>
+  # </template: block-until-image-is-not-ready>
 
   # <template: check_e2e_labels_job>
   check_e2e_labels:
@@ -261,7 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -646,7 +646,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1031,7 +1031,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1416,7 +1416,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1801,7 +1801,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2186,7 +2186,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_33 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2571,7 +2571,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -182,19 +182,18 @@ jobs:
             const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
             const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
 
-            let branchName = context.payload.inputs.ci_commit_ref_name;
-            if (!branchName) {
-              branchName = githubAction.GetBranchNameFromContext(context);
+            let branchName;
+            let prNum;
+
+            if (context.eventName === 'pull_request') {
+              branchName = context.payload.pull_request.head.ref;
+              prNum = context.payload.pull_request.number;
+            } else if (context.eventName === 'workflow_dispatch') {
+              branchName = context.payload.inputs.ci_commit_ref_name;
+              prNum = context.payload.inputs.issue_number;
             }
 
             if (branchName) {
-              let prNum = context.payload.inputs.issue_number;
-              // if the pull request id is not found, search it by the branch name
-              if (!prNum && branchName !== 'main') {
-                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
-                prNum = prInfo.number;
-              }
-
               let infoText = `Check build workflow is completed for branch: ${branchName}`;
               if (prNum) {
                 infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
@@ -215,6 +214,8 @@ jobs:
               } catch(error) {
                 core.setFailed(error);
               }
+            } else {
+              core.setFailed("Branch name not found.");
             }
 
   # </template: block-until-image-is-not-ready>

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -182,19 +182,18 @@ jobs:
             const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
             const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
 
-            let branchName = context.payload.inputs.ci_commit_ref_name;
-            if (!branchName) {
-              branchName = githubAction.GetBranchNameFromContext(context);
+            let branchName;
+            let prNum;
+
+            if (context.eventName === 'pull_request') {
+              branchName = context.payload.pull_request.head.ref;
+              prNum = context.payload.pull_request.number;
+            } else if (context.eventName === 'workflow_dispatch') {
+              branchName = context.payload.inputs.ci_commit_ref_name;
+              prNum = context.payload.inputs.issue_number;
             }
 
             if (branchName) {
-              let prNum = context.payload.inputs.issue_number;
-              // if the pull request id is not found, search it by the branch name
-              if (!prNum && branchName !== 'main') {
-                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
-                prNum = prInfo.number;
-              }
-
               let infoText = `Check build workflow is completed for branch: ${branchName}`;
               if (prNum) {
                 infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
@@ -215,6 +214,8 @@ jobs:
               } catch(error) {
                 core.setFailed(error);
               }
+            } else {
+              core.setFailed("Branch name not found.");
             }
 
   # </template: block-until-image-is-not-ready>

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -168,14 +168,14 @@ jobs:
   # </template: git_info_job>
 
 
-  # </template: block-e2e-until-image-is-not-ready>
-  block-e2e-until-image-is-not-ready:
-    name: Block e2e until the docker image is not ready
+  # </template: block-until-image-is-not-ready>
+  block-until-image-is-not-ready:
+    name: Block until the docker image is not ready
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-      - name: Block e2e until the docker image is not ready
-        id: block-e2e
+      - name: Block until the docker image is not ready
+        id: block-image-dont-ready
         uses: actions/github-script@v6.4.1
         with:
           script: |
@@ -217,7 +217,7 @@ jobs:
               }
             }
 
-  # </template: block-e2e-until-image-is-not-ready>
+  # </template: block-until-image-is-not-ready>
 
   # <template: check_e2e_labels_job>
   check_e2e_labels:
@@ -261,7 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -828,7 +828,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1395,7 +1395,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1962,7 +1962,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2529,7 +2529,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3096,7 +3096,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_33 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3663,7 +3663,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -168,14 +168,14 @@ jobs:
   # </template: git_info_job>
 
 
-  # </template: block-e2e-until-image-is-not-ready>
-  block-e2e-until-image-is-not-ready:
-    name: Block e2e until the docker image is not ready
+  # </template: block-until-image-is-not-ready>
+  block-until-image-is-not-ready:
+    name: Block until the docker image is not ready
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-      - name: Block e2e until the docker image is not ready
-        id: block-e2e
+      - name: Block until the docker image is not ready
+        id: block-image-dont-ready
         uses: actions/github-script@v6.4.1
         with:
           script: |
@@ -217,7 +217,7 @@ jobs:
               }
             }
 
-  # </template: block-e2e-until-image-is-not-ready>
+  # </template: block-until-image-is-not-ready>
 
   # <template: check_e2e_labels_job>
   check_e2e_labels:
@@ -261,7 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -638,7 +638,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1015,7 +1015,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1392,7 +1392,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1769,7 +1769,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2146,7 +2146,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_33 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2523,7 +2523,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -182,19 +182,18 @@ jobs:
             const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
             const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
 
-            let branchName = context.payload.inputs.ci_commit_ref_name;
-            if (!branchName) {
-              branchName = githubAction.GetBranchNameFromContext(context);
+            let branchName;
+            let prNum;
+
+            if (context.eventName === 'pull_request') {
+              branchName = context.payload.pull_request.head.ref;
+              prNum = context.payload.pull_request.number;
+            } else if (context.eventName === 'workflow_dispatch') {
+              branchName = context.payload.inputs.ci_commit_ref_name;
+              prNum = context.payload.inputs.issue_number;
             }
 
             if (branchName) {
-              let prNum = context.payload.inputs.issue_number;
-              // if the pull request id is not found, search it by the branch name
-              if (!prNum && branchName !== 'main') {
-                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
-                prNum = prInfo.number;
-              }
-
               let infoText = `Check build workflow is completed for branch: ${branchName}`;
               if (prNum) {
                 infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
@@ -215,6 +214,8 @@ jobs:
               } catch(error) {
                 core.setFailed(error);
               }
+            } else {
+              core.setFailed("Branch name not found.");
             }
 
   # </template: block-until-image-is-not-ready>

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -168,14 +168,14 @@ jobs:
   # </template: git_info_job>
 
 
-  # </template: block-e2e-until-image-is-not-ready>
-  block-e2e-until-image-is-not-ready:
-    name: Block e2e until the docker image is not ready
+  # </template: block-until-image-is-not-ready>
+  block-until-image-is-not-ready:
+    name: Block until the docker image is not ready
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-      - name: Block e2e until the docker image is not ready
-        id: block-e2e
+      - name: Block until the docker image is not ready
+        id: block-image-dont-ready
         uses: actions/github-script@v6.4.1
         with:
           script: |
@@ -217,7 +217,7 @@ jobs:
               }
             }
 
-  # </template: block-e2e-until-image-is-not-ready>
+  # </template: block-until-image-is-not-ready>
 
   # <template: check_e2e_labels_job>
   check_e2e_labels:
@@ -261,7 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -776,7 +776,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1291,7 +1291,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1806,7 +1806,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2321,7 +2321,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2836,7 +2836,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_33 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3351,7 +3351,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -182,19 +182,18 @@ jobs:
             const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
             const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
 
-            let branchName = context.payload.inputs.ci_commit_ref_name;
-            if (!branchName) {
-              branchName = githubAction.GetBranchNameFromContext(context);
+            let branchName;
+            let prNum;
+
+            if (context.eventName === 'pull_request') {
+              branchName = context.payload.pull_request.head.ref;
+              prNum = context.payload.pull_request.number;
+            } else if (context.eventName === 'workflow_dispatch') {
+              branchName = context.payload.inputs.ci_commit_ref_name;
+              prNum = context.payload.inputs.issue_number;
             }
 
             if (branchName) {
-              let prNum = context.payload.inputs.issue_number;
-              // if the pull request id is not found, search it by the branch name
-              if (!prNum && branchName !== 'main') {
-                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
-                prNum = prInfo.number;
-              }
-
               let infoText = `Check build workflow is completed for branch: ${branchName}`;
               if (prNum) {
                 infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
@@ -215,6 +214,8 @@ jobs:
               } catch(error) {
                 core.setFailed(error);
               }
+            } else {
+              core.setFailed("Branch name not found.");
             }
 
   # </template: block-until-image-is-not-ready>

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -168,14 +168,14 @@ jobs:
   # </template: git_info_job>
 
 
-  # </template: block-e2e-until-image-is-not-ready>
-  block-e2e-until-image-is-not-ready:
-    name: Block e2e until the docker image is not ready
+  # </template: block-until-image-is-not-ready>
+  block-until-image-is-not-ready:
+    name: Block until the docker image is not ready
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-      - name: Block e2e until the docker image is not ready
-        id: block-e2e
+      - name: Block until the docker image is not ready
+        id: block-image-dont-ready
         uses: actions/github-script@v6.4.1
         with:
           script: |
@@ -217,7 +217,7 @@ jobs:
               }
             }
 
-  # </template: block-e2e-until-image-is-not-ready>
+  # </template: block-until-image-is-not-ready>
 
   # <template: check_e2e_labels_job>
   check_e2e_labels:
@@ -261,7 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -776,7 +776,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1291,7 +1291,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1806,7 +1806,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2321,7 +2321,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2836,7 +2836,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_33 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3351,7 +3351,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -182,19 +182,18 @@ jobs:
             const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
             const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
 
-            let branchName = context.payload.inputs.ci_commit_ref_name;
-            if (!branchName) {
-              branchName = githubAction.GetBranchNameFromContext(context);
+            let branchName;
+            let prNum;
+
+            if (context.eventName === 'pull_request') {
+              branchName = context.payload.pull_request.head.ref;
+              prNum = context.payload.pull_request.number;
+            } else if (context.eventName === 'workflow_dispatch') {
+              branchName = context.payload.inputs.ci_commit_ref_name;
+              prNum = context.payload.inputs.issue_number;
             }
 
             if (branchName) {
-              let prNum = context.payload.inputs.issue_number;
-              // if the pull request id is not found, search it by the branch name
-              if (!prNum && branchName !== 'main') {
-                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
-                prNum = prInfo.number;
-              }
-
               let infoText = `Check build workflow is completed for branch: ${branchName}`;
               if (prNum) {
                 infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
@@ -215,6 +214,8 @@ jobs:
               } catch(error) {
                 core.setFailed(error);
               }
+            } else {
+              core.setFailed("Branch name not found.");
             }
 
   # </template: block-until-image-is-not-ready>

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -182,19 +182,18 @@ jobs:
             const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
             const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
 
-            let branchName = context.payload.inputs.ci_commit_ref_name;
-            if (!branchName) {
-              branchName = githubAction.GetBranchNameFromContext(context);
+            let branchName;
+            let prNum;
+
+            if (context.eventName === 'pull_request') {
+              branchName = context.payload.pull_request.head.ref;
+              prNum = context.payload.pull_request.number;
+            } else if (context.eventName === 'workflow_dispatch') {
+              branchName = context.payload.inputs.ci_commit_ref_name;
+              prNum = context.payload.inputs.issue_number;
             }
 
             if (branchName) {
-              let prNum = context.payload.inputs.issue_number;
-              // if the pull request id is not found, search it by the branch name
-              if (!prNum && branchName !== 'main') {
-                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
-                prNum = prInfo.number;
-              }
-
               let infoText = `Check build workflow is completed for branch: ${branchName}`;
               if (prNum) {
                 infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
@@ -215,6 +214,8 @@ jobs:
               } catch(error) {
                 core.setFailed(error);
               }
+            } else {
+              core.setFailed("Branch name not found.");
             }
 
   # </template: block-until-image-is-not-ready>

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -168,14 +168,14 @@ jobs:
   # </template: git_info_job>
 
 
-  # </template: block-e2e-until-image-is-not-ready>
-  block-e2e-until-image-is-not-ready:
-    name: Block e2e until the docker image is not ready
+  # </template: block-until-image-is-not-ready>
+  block-until-image-is-not-ready:
+    name: Block until the docker image is not ready
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-      - name: Block e2e until the docker image is not ready
-        id: block-e2e
+      - name: Block until the docker image is not ready
+        id: block-image-dont-ready
         uses: actions/github-script@v6.4.1
         with:
           script: |
@@ -217,7 +217,7 @@ jobs:
               }
             }
 
-  # </template: block-e2e-until-image-is-not-ready>
+  # </template: block-until-image-is-not-ready>
 
   # <template: check_e2e_labels_job>
   check_e2e_labels:
@@ -261,7 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -792,7 +792,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1323,7 +1323,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1854,7 +1854,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2385,7 +2385,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2916,7 +2916,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_33 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3447,7 +3447,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -168,14 +168,14 @@ jobs:
   # </template: git_info_job>
 
 
-  # </template: block-e2e-until-image-is-not-ready>
-  block-e2e-until-image-is-not-ready:
-    name: Block e2e until the docker image is not ready
+  # </template: block-until-image-is-not-ready>
+  block-until-image-is-not-ready:
+    name: Block until the docker image is not ready
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-      - name: Block e2e until the docker image is not ready
-        id: block-e2e
+      - name: Block until the docker image is not ready
+        id: block-image-dont-ready
         uses: actions/github-script@v6.4.1
         with:
           script: |
@@ -217,7 +217,7 @@ jobs:
               }
             }
 
-  # </template: block-e2e-until-image-is-not-ready>
+  # </template: block-until-image-is-not-ready>
 
   # <template: check_e2e_labels_job>
   check_e2e_labels:
@@ -261,7 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -780,7 +780,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1299,7 +1299,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1818,7 +1818,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2337,7 +2337,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2856,7 +2856,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_33 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -3375,7 +3375,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -182,19 +182,18 @@ jobs:
             const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
             const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
 
-            let branchName = context.payload.inputs.ci_commit_ref_name;
-            if (!branchName) {
-              branchName = githubAction.GetBranchNameFromContext(context);
+            let branchName;
+            let prNum;
+
+            if (context.eventName === 'pull_request') {
+              branchName = context.payload.pull_request.head.ref;
+              prNum = context.payload.pull_request.number;
+            } else if (context.eventName === 'workflow_dispatch') {
+              branchName = context.payload.inputs.ci_commit_ref_name;
+              prNum = context.payload.inputs.issue_number;
             }
 
             if (branchName) {
-              let prNum = context.payload.inputs.issue_number;
-              // if the pull request id is not found, search it by the branch name
-              if (!prNum && branchName !== 'main') {
-                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
-                prNum = prInfo.number;
-              }
-
               let infoText = `Check build workflow is completed for branch: ${branchName}`;
               if (prNum) {
                 infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
@@ -215,6 +214,8 @@ jobs:
               } catch(error) {
                 core.setFailed(error);
               }
+            } else {
+              core.setFailed("Branch name not found.");
             }
 
   # </template: block-until-image-is-not-ready>

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -182,19 +182,18 @@ jobs:
             const githubAction = require('./.github/scripts/js/helpers/github-actions')({github, context, core});
             const { isReleaseBranch } = require('./.github/scripts/js/helpers/utils');
 
-            let branchName = context.payload.inputs.ci_commit_ref_name;
-            if (!branchName) {
-              branchName = githubAction.GetBranchNameFromContext(context);
+            let branchName;
+            let prNum;
+
+            if (context.eventName === 'pull_request') {
+              branchName = context.payload.pull_request.head.ref;
+              prNum = context.payload.pull_request.number;
+            } else if (context.eventName === 'workflow_dispatch') {
+              branchName = context.payload.inputs.ci_commit_ref_name;
+              prNum = context.payload.inputs.issue_number;
             }
 
             if (branchName) {
-              let prNum = context.payload.inputs.issue_number;
-              // if the pull request id is not found, search it by the branch name
-              if (!prNum && branchName !== 'main') {
-                const prInfo = await githubAction.GetPullRequestByBranchName(branchName);
-                prNum = prInfo.number;
-              }
-
               let infoText = `Check build workflow is completed for branch: ${branchName}`;
               if (prNum) {
                 infoText +=  ` PR: ${context.payload.repository.html_url}/pull/${prNum}`;
@@ -215,6 +214,8 @@ jobs:
               } catch(error) {
                 core.setFailed(error);
               }
+            } else {
+              core.setFailed("Branch name not found.");
             }
 
   # </template: block-until-image-is-not-ready>

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -168,14 +168,14 @@ jobs:
   # </template: git_info_job>
 
 
-  # </template: block-e2e-until-image-is-not-ready>
-  block-e2e-until-image-is-not-ready:
-    name: Block e2e until the docker image is not ready
+  # </template: block-until-image-is-not-ready>
+  block-until-image-is-not-ready:
+    name: Block until the docker image is not ready
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-      - name: Block e2e until the docker image is not ready
-        id: block-e2e
+      - name: Block until the docker image is not ready
+        id: block-image-dont-ready
         uses: actions/github-script@v6.4.1
         with:
           script: |
@@ -217,7 +217,7 @@ jobs:
               }
             }
 
-  # </template: block-e2e-until-image-is-not-ready>
+  # </template: block-until-image-is-not-ready>
 
   # <template: check_e2e_labels_job>
   check_e2e_labels:
@@ -261,7 +261,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_28 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -642,7 +642,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_29 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1023,7 +1023,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_30 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1404,7 +1404,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_31 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -1785,7 +1785,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_32 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2166,7 +2166,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_1_33 == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}
@@ -2547,7 +2547,7 @@ jobs:
     needs:
       - check_e2e_labels
       - git_info
-      - block-e2e-until-image-is-not-ready
+      - block-until-image-is-not-ready
     if: needs.check_e2e_labels.outputs.run_containerd_Automatic == 'true'
     outputs:
       ssh_master_connection_string: ${{ steps.check_stay_failed_cluster.outputs.ssh_master_connection_string }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Now the cve check workflow in the pull request does not wait for the image build
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Add wait for image build in CVE scans
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not related to release
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: feature
summary: Add wait for image build in CVE scans.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
