### PR TITLE
[docs] Fix apiVersion for s3 storageclass

### DIFF
--- a/docs/documentation/pages/storage/external/S3.md
+++ b/docs/documentation/pages/storage/external/S3.md
@@ -57,7 +57,7 @@ d8 k get module csi-s3 -w
 The module is configured via the [S3StorageClass](../../../reference/cr/s3storageclass/) manifest. Below is an example configuration:
 
 ```yaml
-apiVersion: csi.s3.storage.k8s.io/v1
+apiVersion: storage.deckhouse.io/v1alpha1
 kind: S3StorageClass
 metadata:
   name: example-s3
@@ -68,6 +68,7 @@ spec:
   accessKey: <your-access-key>
   secretKey: <your-secret-key>
   maxCacheSize: 500
+  insecure: false
 ```
 
 If `bucketName` is empty then bucket in S3 will be created for each PV. If `bucketName` is not empty then folder inside the bucket will be created for each PV. If the specifies bucket does not exist it will be created.

--- a/docs/documentation/pages/storage/external/S3_RU.md
+++ b/docs/documentation/pages/storage/external/S3_RU.md
@@ -59,7 +59,7 @@ d8 k get module csi-s3 -w
 Модуль настраивается с помощью манифеста [S3StorageClass](../../../reference/cr/s3storageclass/). Пример конфигурации:
 
 ```yaml
-apiVersion: csi.s3.storage.k8s.io/v1
+apiVersion: storage.deckhouse.io/v1alpha1
 kind: S3StorageClass
 metadata:
   name: example-s3
@@ -70,6 +70,7 @@ spec:
   accessKey: <your-access-key>
   secretKey: <your-secret-key>
   maxCacheSize: 500
+  insecure: false
 ```
 
 Если `bucketName` не указан, для каждого PersistentVolume будет создан отдельный bucket. Если `bucketName` задан, в нем будут создаваться папки под каждый PersistentVolume. Если такого bucket нет, он создастся автоматически.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->
Fix apiVersion [here](https://deckhouse.io/products/kubernetes-platform/documentation/v1.69/storage/admin/external/s3.html#creating-storageclass) for [actual](https://deckhouse.io/products/kubernetes-platform/modules/csi-s3/alpha/#creating-storageclass) info
```changes
section: docs
type: fix
summary: Fix apiVersion for s3 storageclass
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
