### PR TITLE
[node-manager] Make NodeUser passwordHash parameter optional

### DIFF
--- a/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
@@ -184,7 +184,7 @@ function add_sudoer_group() {
     fi
 
     local sudoers_file="${sudoersd_path}/${sudoers_filename}"
-    
+
     if ! getent group $groupname >/dev/null
       then
         groupadd $groupname
@@ -282,7 +282,11 @@ function main() {
       continue
     else
       # Adding user
-      error_message=$(useradd -b "$home_base_path" -g "$main_group" -G "$extra_groups" -p "$password_hash" -s "$default_shell" -u "$uid" -c "$comment" -m "$user_name" 2>&1)
+      useradd_cmd=(useradd -b "$home_base_path" -g "$main_group" -G "$extra_groups" -s "$default_shell" -u "$uid" -c "$comment" -m "$user_name")
+      if [[ -n "$password_hash" ]]; then
+        useradd_cmd+=(-p "$password_hash")
+      fi
+      error_message=$("${useradd_cmd[@]}" 2>&1)
       if bb-error?
       then
         bb-log-error "Error adding user '$user_name': ${error_message}"

--- a/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
@@ -184,7 +184,6 @@ function add_sudoer_group() {
     fi
 
     local sudoers_file="${sudoersd_path}/${sudoers_filename}"
-
     if ! getent group $groupname >/dev/null
       then
         groupadd $groupname

--- a/modules/040-node-manager/crds/nodeuser.yaml
+++ b/modules/040-node-manager/crds/nodeuser.yaml
@@ -37,7 +37,6 @@ spec:
                 - sshPublicKeys
               required:
                 - uid
-                - passwordHash
               properties:
                 uid:
                   type: number
@@ -143,7 +142,6 @@ spec:
                 - sshPublicKeys
               required:
                 - uid
-                - passwordHash
               properties:
                 uid:
                   type: number

--- a/modules/040-node-manager/hooks/internal/v1/node_user.go
+++ b/modules/040-node-manager/hooks/internal/v1/node_user.go
@@ -39,7 +39,7 @@ type NodeUserSpec struct {
 	UID           int      `json:"uid"`
 	SSHPublicKey  string   `json:"sshPublicKey,omitempty"`
 	SSHPublicKeys []string `json:"sshPublicKeys,omitempty"`
-	PasswordHash  string   `json:"passwordHash"`
+	PasswordHash  string   `json:"passwordHash,omitempty"`
 	IsSudoer      bool     `json:"isSudoer"`
 	NodeGroups    []string `json:"nodeGroups"`
 	ExtraGroups   []string `json:"extraGroups,omitempty"`

--- a/modules/040-node-manager/webhooks/validating/node_user
+++ b/modules/040-node-manager/webhooks/validating/node_user
@@ -52,7 +52,6 @@ function __main__() {
   nodeGroups=$(context::jq -r '.review.request.object.spec.nodeGroups[]')
   operation=$(context::jq -r '.review.request.operation')
   passwordHash=$(context::jq -r '.review.request.object.spec.passwordHash')
-  warnings=()
 
   snapshots=$(context::jq -cr '[.snapshots.nodeUsers[].filterResult]')
   if [ "$operation" = "UPDATE" ]; then
@@ -83,12 +82,8 @@ EOF
   done
 
   if [ -z "$passwordHash" ] || [ "$passwordHash" = "null" ]; then
-    warnings+=("\"Password hash is empty. The user might not be able to log in.\"")
-  fi
-
-  if [ ${#warnings[@]} -gt 0 ]; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed": true, "warnings": [${warnings[*]}] }
+{"allowed": true, "warnings": ["Password hash is empty. The user might not be able to log in."] }
 EOF
   fi
 

--- a/modules/040-node-manager/webhooks/validating/node_user
+++ b/modules/040-node-manager/webhooks/validating/node_user
@@ -52,7 +52,6 @@ function __main__() {
   uid=$(context::jq -r '.review.request.object.spec.uid')
   nodeGroups=$(context::jq -r '.review.request.object.spec.nodeGroups[]')
   operation=$(context::jq -r '.review.request.operation')
-  passwordHash=$(context::jq -r '.review.request.object.spec.passwordHash')
 
   snapshots=$(context::jq -cr '[.snapshots.nodeUsers[].filterResult]')
   if [ "$operation" = "UPDATE" ]; then
@@ -82,10 +81,11 @@ EOF
     fi
   done
 
-  if [ -z "$passwordHash" ] || [ "$passwordHash" = "null" ]; then
+if [ $(jq -cr '[.[] | select(.passwordHash == null or .passwordHash == "")] | length' <<< "$snapshots") -gt 0 ]; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed": true, "warnings": ["Password hash is empty. The user might not be able to log in."] }
 EOF
+      return 0
   fi
 
   cat <<EOF > "$VALIDATING_RESPONSE_PATH"

--- a/modules/040-node-manager/webhooks/validating/node_user
+++ b/modules/040-node-manager/webhooks/validating/node_user
@@ -83,7 +83,7 @@ EOF
 
 if [ -z "$passwordHash" ] || [ "$passwordHash" = "null" ]; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed": true, "warnings": ["Password hash is empty. The user might not be able to log in."] }
+{"allowed": true, "warnings": ["Password hash is empty. This may not be secure and it may be prohibited by PAM settings."] }
 EOF
       return 0
   fi

--- a/modules/040-node-manager/webhooks/validating/node_user
+++ b/modules/040-node-manager/webhooks/validating/node_user
@@ -51,6 +51,8 @@ function __main__() {
   uid=$(context::jq -r '.review.request.object.spec.uid')
   nodeGroups=$(context::jq -r '.review.request.object.spec.nodeGroups[]')
   operation=$(context::jq -r '.review.request.operation')
+  passwordHash=$(context::jq -r '.review.request.object.spec.passwordHash')
+  warnings=()
 
   snapshots=$(context::jq -cr '[.snapshots.nodeUsers[].filterResult]')
   if [ "$operation" = "UPDATE" ]; then
@@ -79,6 +81,16 @@ EOF
       return 0
     fi
   done
+
+  if [ -z "$passwordHash" ] || [ "$passwordHash" = "null" ]; then
+    warnings+=("\"Password hash is empty. The user might not be able to log in.\"")
+  fi
+
+  if [ ${#warnings[@]} -gt 0 ]; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed": true, "warnings": [${warnings[*]}] }
+EOF
+  fi
 
   cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":true}

--- a/modules/040-node-manager/webhooks/validating/node_user
+++ b/modules/040-node-manager/webhooks/validating/node_user
@@ -32,7 +32,8 @@ kubernetes:
       {
         "name": .metadata.name,
         "uid": .spec.uid,
-        "nodeGroups": .spec.nodeGroups
+        "nodeGroups": .spec.nodeGroups,
+        "passwordHash": .spec.passwordHash
       }
 kubernetesValidating:
 - name: nodeuser-unique.deckhouse.io

--- a/modules/040-node-manager/webhooks/validating/node_user
+++ b/modules/040-node-manager/webhooks/validating/node_user
@@ -33,7 +33,6 @@ kubernetes:
         "name": .metadata.name,
         "uid": .spec.uid,
         "nodeGroups": .spec.nodeGroups,
-        "passwordHash": .spec.passwordHash
       }
 kubernetesValidating:
 - name: nodeuser-unique.deckhouse.io
@@ -52,6 +51,7 @@ function __main__() {
   uid=$(context::jq -r '.review.request.object.spec.uid')
   nodeGroups=$(context::jq -r '.review.request.object.spec.nodeGroups[]')
   operation=$(context::jq -r '.review.request.operation')
+  passwordHash=$(context::jq -r '.review.request.object.spec.passwordHash')
 
   snapshots=$(context::jq -cr '[.snapshots.nodeUsers[].filterResult]')
   if [ "$operation" = "UPDATE" ]; then
@@ -81,7 +81,7 @@ EOF
     fi
   done
 
-if [ $(jq -cr '[.[] | select(.passwordHash == null or .passwordHash == "")] | length' <<< "$snapshots") -gt 0 ]; then
+if [ -z "$passwordHash" ] || [ "$passwordHash" = "null" ]; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed": true, "warnings": ["Password hash is empty. The user might not be able to log in."] }
 EOF

--- a/modules/040-node-manager/webhooks/validating/node_user
+++ b/modules/040-node-manager/webhooks/validating/node_user
@@ -32,7 +32,7 @@ kubernetes:
       {
         "name": .metadata.name,
         "uid": .spec.uid,
-        "nodeGroups": .spec.nodeGroups,
+        "nodeGroups": .spec.nodeGroups
       }
 kubernetesValidating:
 - name: nodeuser-unique.deckhouse.io


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
The PR allows creating NodeUser CR without passwordHash field.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this allow to create node user without password to avoid auth issues from pam, ldap, etc.
ex.
```
---
apiVersion: deckhouse.io/v1
kind: NodeUser
metadata:
  name: user
spec:
  uid: 20029
  sshPublicKey: "ssh-rsa  ..."
  isSudoer: true
  nodeGroups:
  - master

kubectl apply -f nodeuser.yaml
Warning: Password hash is empty. The user might not be able to log in.
nodeuser.deckhouse.io/user created

cat /etc/shadow | grep user
...
user:!:20235:0:99999:7:::
```
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type:  chore
summary: passwordHash in nodeuser cr is not required
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
