### PR TITLE
[dhctl] Add Local Registry Configuration Check to Installation Process

### DIFF
--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -104,7 +104,9 @@ func (m *MetaConfig) Prepare() (*MetaConfig, error) {
 		m.Registry.DockerCfg = m.DeckhouseConfig.RegistryDockerCfg
 		m.Registry.Scheme = strings.ToLower(m.DeckhouseConfig.RegistryScheme)
 		m.Registry.CA = m.DeckhouseConfig.RegistryCA
-
+		if err := validateHTTPRegistryScheme(m.Registry.Scheme, m.Registry.CA); err != nil {
+			return nil, err
+		}
 	}
 
 	if m.ClusterType != CloudClusterType || len(m.ProviderClusterConfig) == 0 {
@@ -261,6 +263,13 @@ func validateRegistryDockerCfg(cfg string, repo string) error {
 		}
 	}
 	return fmt.Errorf("incorrect registryDockerCfg. It must contain auths host {\"auths\": { \"%s\": {}}}", repo)
+}
+
+func validateHTTPRegistryScheme(scheme string, CA string) error {
+	if strings.ToLower(scheme) == "http" && len(CA) > 0 {
+		return fmt.Errorf("registry CA is not allowed for HTTP scheme")
+	}
+	return nil
 }
 
 func (m *MetaConfig) GetTerraNodeGroups() []TerraNodeGroupSpec {

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -252,6 +252,14 @@ func TestPrepareRegistry(t *testing.T) {
 		})
 	})
 
+	t.Run("Validate HTTP imagesRepo with CA", func(t *testing.T) {
+		cfg := generateMetaConfigForMetaConfigTest(t, make(map[string]interface{}))
+		cfg.Registry.Scheme = "http"
+		cfg.Registry.CA = "==exampleCA=="
+		err := validateHTTPRegistryScheme(cfg.Registry.Scheme, cfg.Registry.CA)
+		require.EqualError(t, err, "registry CA is not allowed for HTTP scheme")
+	})
+
 	t.Run("Has not imagesRepo and dockerCfg", func(t *testing.T) {
 		cfg := generateMetaConfigForMetaConfigTest(t, make(map[string]interface{}))
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Alert the user with an error about the CA certificate when the local registry is configured with the HTTP scheme on `dhctl bootstrap` phase
Fix [issue](https://github.com/deckhouse/deckhouse/issues/10834) 
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When run `dhctl bootstrap` with the HTTP scheme and CA on InitConfiguration, an unobvious behavior occurs (containerd have different [configuration](https://github.com/deckhouse/deckhouse/blob/e38ab2ee95f102629f0c93145f4f74fbd05c7b83/candi/bashible/common-steps/node-group/032_configure_containerd.sh.tpl#L148-L155) for both params)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Add Local Registry Configuration Check to Installation Process
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
