### PR TITLE
[openvpn] Fix e2e-tests

### DIFF
--- a/modules/500-openvpn/templates/openvpn/configmap.yaml
+++ b/modules/500-openvpn/templates/openvpn/configmap.yaml
@@ -19,7 +19,7 @@ data:
     client-config-dir /etc/openvpn/ccd
     key-direction 0
     data-ciphers AES-256-GCM:AES-128-GCM:AES-128-CBC
-    data-ciphers-fallback AES-128-CBC # for getting rid of "Note: --cipher is not set. OpenVPN versions before 2.5 defaulted to BF-CBC as fallback when cipher negotiation failed in this case." error message in logs 
+    data-ciphers-fallback AES-128-CBC:BF-CBC # for getting rid of "Note: --cipher is not set. OpenVPN versions before 2.5 defaulted to BF-CBC as fallback when cipher negotiation failed in this case." error message in logs
     keepalive 10 60
     persist-key
     persist-tun


### PR DESCRIPTION
## Description

Adding the `BF-CBC` cipher to the `data-ciphers-fallback` parameter.

## Why do we need it, and what problem does it solve?

Without this fix, the e2e test failed with an error: `OpenVPN versions before 2.5 defaulted to BF-CBC as fallback when cipher negotiation failed in this case. If you need this fallback please add '--data-ciphers-fallback BF-CBC' to your configuration and/or add BF-CBC to --data-ciphers.`

## Why do we need it in the patch release (if we do)?

Broken e2e-tests can interfere with the development process.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: openvpn
type: fix
summary: Ciphers `BF-CBC` has been added to the options `data-ciphers-fallback`.
impact_level: default
```

