### PR TITLE
add webhook for remotewrite ca

### DIFF
--- a/modules/300-prometheus/webhooks/validating/prometheusremotewrite.py
+++ b/modules/300-prometheus/webhooks/validating/prometheusremotewrite.py
@@ -1,0 +1,107 @@
+#!/usr/bin/python3
+from typing import Optional
+
+import cryptography.hazmat
+import cryptography.hazmat.backends
+
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from deckhouse import hook
+from dotmap import DotMap
+import cryptography
+from cryptography.hazmat.backends import default_backend
+
+config = """
+configVersion: v1
+kubernetesValidating:
+- name: prometheusremotewrite-policy.deckhouse.io
+  group: main
+  rules:
+  - apiGroups:   ["deckhouse.io"]
+    apiVersions: ["v1alpha1", "v1"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["prometheusremotewrites"]
+    scope:       "Cluster"
+kubernetes:
+- name: prometheusremotewrites
+  group: main
+  executeHookOnEvent: []
+  executeHookOnSynchronization: false
+  keepFullObjectsInMemory: false
+  apiVersion: deckhouse.io/v1
+  kind: PrometheusRemoteWrite
+  jqFilter: |
+    {
+      "name": .metadata.name,
+      "url": .spec.url,
+    }
+"""
+
+
+def main(ctx: hook.Context):
+    try:
+        # DotMap is a dict with dot notation
+        binding_context = DotMap(ctx.binding_context)
+        validate(binding_context, ctx.output.validations)
+    except Exception as e:
+        ctx.output.validations.error(str(e))
+
+
+def validate(ctx: DotMap, output: hook.ValidationsCollector):
+    operation = ctx.review.request.operation
+    if operation == "CREATE" or operation == "UPDATE":
+        validate_creation_or_update(ctx, output)
+    else:
+        raise Exception(f"Unknown operation {ctx.operation}")
+
+
+def validate_creation_or_update(ctx: DotMap, output: hook.ValidationsCollector):
+    error = check_verify_url_signatures(ctx)
+    if error is not None:
+        output.deny(error)
+        return
+    error = check_verify_ca_signatures(ctx)
+    if error is not None:
+        output.deny(error)
+        return
+    output.allow()
+
+
+# check that all image references don't have intersection, it's required by ratify
+# https://ratify.dev/docs/plugins/verifier/cosign/#scopes
+def check_verify_url_signatures(ctx: DotMap) -> Optional[str]:
+    url = ctx.review.request.object.spec.url
+    filtered_name = ""
+    if len(url) == 0:
+        return "Url has empty string"
+    if ctx.review.request.operation == "UPDATE":
+        filtered_name = ctx.review.request.name
+    # search in all prometheusremote write if url alredy used
+    if len([rw for rw in ctx.snapshots.prmetheusremotewrites if rw.spec.url == url and rw.name != filtered_name]) > 0:
+        return f"Remote write URL {url} is already in use"
+    return None
+    
+def check_verify_ca_signatures(ctx: DotMap) -> Optional[str]:
+    ca = ctx.review.request.object.spec.tlsConfig.ca
+    if len(ca) == 0:
+        return None
+    try:
+        cryptography.x509.load_pem_x509_certificate(ca.encode(), cryptography.hazmat.backends())
+        return None
+    except (ValueError, cryptography.exceptions.InvalidKey) as e:
+        return f"Certificate verification failed: {e}"
+    
+if __name__ == "__main__":
+    hook.run(main, config=config)

--- a/modules/300-prometheus/webhooks/validating/prometheusremotewrites_test.py
+++ b/modules/300-prometheus/webhooks/validating/prometheusremotewrites_test.py
@@ -1,0 +1,194 @@
+#!/usr/bin/python3
+import json
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from instance_class import main
+from deckhouse import hook, tests
+from dotmap import DotMap
+import json  # Ensure json is imported for loading binding context
+
+def _prepare_validation_binding_context(binding_context_json, new_spec: dict) -> DotMap:
+    ctx_dict = json.loads(binding_context_json)
+    ctx = DotMap(ctx_dict)
+    ctx.review.request.object.spec = new_spec
+    return ctx
+
+def _prepare_prometheusremotewrites_class_binding_context(new_spec: dict) -> DotMap:
+    binding_context_json = f"""
+    {{
+      "binding": "prometheusremotewrites.deckhouse.io",
+      "review": {{
+        "request": {{
+          "uid": "d47e6935-8e58-4270-b193-c4a8e2626ba1",
+          "kind": {{
+            "group": "deckhouse.io",
+            "version": "v1",
+            "kind": "Prometheusremotewrites"
+          }},
+          "resource": {{
+            "group": "deckhouse.io",
+            "version": "v",
+            resources: "prometheusremotewrites"
+          }},
+          "requestKind": {{
+            "group": "deckhouse.io",
+            "version": "v1",
+            "kind": "Prometheusremotewrites"
+          }},
+          "requestResource": {{
+            "group": "deckhouse.io",
+            "version": "v1",
+            "resource": "prometheusremotewrites"
+          }},
+          "name": "worker-test",
+          "operation": "UPDATE",
+          "userInfo": {{
+            "username": "kubernetes-admin",
+            "groups": [
+              "system:masters",
+              "system:authenticated"
+            ]
+          }},
+          "object": {{
+            "apiVersion": "deckhouse.io/v1alpha1",
+            "kind": "Prometheusremotewrites"
+            "metadata": {{
+              "creationTimestamp": "2024-11-22T08:00:33Z",
+              "generation": 1,
+              "managedFields": [
+                {{
+                  "apiVersion": "deckhouse.io/v1",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {{
+                    "f:spec": {{
+                      ".": {{}},
+                      "f:url": "test",
+                      "f:tlsConfig": {{
+                         f:ca": {{}}
+                      }}
+                    }}
+                  }},
+                  "manager": "deckhouse-controller",
+                  "operation": "Update",
+                  "time": "2025-02-17T16:01:42Z"
+                }}
+              ],
+              "name": "{name}",
+              "resourceVersion": "7511300",
+              "uid": "92ce2620-847d-4e45-aaa0-c0e314b33142"
+            }},
+            "spec": {{}},
+          }},
+          "oldObject": {{
+            "apiVersion": "deckhouse.io/v1alpha1",
+            "kind": "Prometheusremotewrites"
+            "metadata": {{
+              "creationTimestamp": "2024-11-22T08:00:33Z",
+              "generation": 1,
+              "managedFields": [
+                {{
+                  "apiVersion": "deckhouse.io/v1",
+                  "fieldsType": "FieldsV1",
+                  "fieldsV1": {{
+                    "f:spec": {{
+                      ".": {{}},
+                      "f:url": "test",
+                      "f:tlsConfig": {{
+                         f:ca": {{}}
+                      }}
+                    }}
+                  }},
+                  "manager": "kubectl-client-side-apply",
+                  "operation": "Update",
+                  "time": "2025-02-17T16:01:42Z"
+                }}
+              ],
+              "name": "old",
+              "resourceVersion": "7511300",
+              "uid": "92ce2620-847d-4e45-aaa0-c0e314b33142"
+            }},
+            "spec": {{
+              "url": "https://old.local"
+              "tlsConfig": {{
+                  "ca": "111"
+              }}
+            }},
+          }},
+          "dryRun": false,
+          "options": {{
+            "kind": "UpdateOptions",
+            "apiVersion": "meta.k8s.io/v1",
+            "propagationPolicy": "Background"
+          }}
+        }}
+      }},
+    "snapshots": {{
+        "prometheusremotewrite": [
+            {{
+                "filterResult": {{
+                    "name": "test_double",
+                    "url": "https://test.local"
+                }}
+            }}
+        ],
+      "type": "Validating"
+    }}
+    """
+    return _prepare_validation_binding_context(binding_context_json, new_spec)
+
+class TestInstanceClassValidationWebhook(unittest.TestCase):
+    def test_should_allow_update_url(self):
+        ctx = _prepare_prometheusremotewrites_class_binding_context({
+            "url": "https://new.local",
+            "name": "new"
+        })
+        out = hook.testrun(main, [ctx])
+        tests.assert_validation_allowed(self, out, None)
+
+    def test_should_deny_double_url(self):
+        ctx = _prepare_prometheusremotewrites_class_binding_context({
+            "url": "https://test.local",
+            "name": "new"
+        })
+        out = hook.testrun(main, [ctx])
+        expected_error = "Remote write URL https://test.local is already in use"
+        tests.assert_validation_deny(self, out, expected_error)
+
+    def test_should_allow_update_valide_ca(self):
+        ctx = _prepare_prometheusremotewrites_class_binding_context({
+            "url": "https://new.local",
+            "tlsConfig": {
+                "ca": "-----BEGIN CERTIFICATE-----\nMIICCTCCAY6gAwIBAgINAgPluILrIPglJ209ZjAKBggqhkjOPQQDAzBHMQswCQYD\nVQQGEwJVUzEiMCAGA1UEChMZR29vZ2xlIFRydXN0IFNlcnZpY2VzIExMQzEUMBIG\nA1UEAxMLR1RTIFJvb3QgUjMwHhcNMTYwNjIyMDAwMDAwWhcNMzYwNjIyMDAwMDAw\nWjBHMQswCQYDVQQGEwJVUzEiMCAGA1UEChMZR29vZ2xlIFRydXN0IFNlcnZpY2Vz\nIExMQzEUMBIGA1UEAxMLR1RTIFJvb3QgUjMwdjAQBgcqhkjOPQIBBgUrgQQAIgNi\nAAQfTzOHMymKoYTey8chWEGJ6ladK0uFxh1MJ7x/JlFyb+Kf1qPKzEUURout736G\njOyxfi//qXGdGIRFBEFVbivqJn+7kAHjSxm65FSWRQmx1WyRRK2EE46ajA2ADDL2\n4CejQjBAMA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQW\nBBTB8Sa6oC2uhYHP0/EqEr24Cmf9vDAKBggqhkjOPQQDAwNpADBmAjEA9uEglRR7\nVKOQFhG/hMjqb2sXnh5GmCCbn9MN2azTL818+FsuVbu/3ZL3pAzcMeGiAjEA/Jdm\nZuVDFhOD3cffL74UOO0BzrEXGhF16b0DjyZ+hOXJYKaV11RZt+cRLInUue4X\n-----END CERTIFICATE-----"
+            },
+            "name": "new"
+        })
+        out = hook.testrun(main, [ctx])
+        tests.assert_validation_allowed(self, out, None)
+
+    def test_should_deny_invalid_ca(self):
+        ctx = _prepare_prometheusremotewrites_class_binding_context({
+            "url": "https://test.local",
+            "tlsConfig": {
+                "ca": "1111"
+            },
+            "name": "new"
+        })
+        out = hook.testrun(main, [ctx])
+        expected_error = "Certificate verification failed"
+        tests.assert_validation_deny(self, out, expected_error)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Webhook for validation prometheus remotewrite ca

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

If ca not valide it broke prometheus operator

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: feature 
summary: Validation prometheus remotewrite ca webhook
impact: prometheus
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
