### PR TITLE
[control-plane-manager] fix audit policy for virtualization

### DIFF
--- a/modules/040-control-plane-manager/hooks/audit_policy.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy.go
@@ -416,7 +416,7 @@ func appendVirtualizationPolicyRules(policy *audit.Policy) {
 			Level: audit.LevelMetadata,
 			Verbs: []string{"update", "patch"},
 			Resources: []audit.GroupResources{{
-				Group:     "subresources.virtualization.deckhouse.io",
+				Group:     "internal.virtualization.deckhouse.io",
 				Resources: []string{"internalvirtualizationvirtualmachineinstances"},
 			}},
 		}


### PR DESCRIPTION
## Description
Fix incorrect group in audit rules for virtualization.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: fix audit policy rules for virtualization
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
