### PR TITLE
[testing] use current release version for cloud testing

### DIFF
--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -557,7 +557,10 @@ import yaml, sys
 data = yaml.safe_load(sys.stdin)
 with open('/tmp/releaseFile.yaml') as f:
   d1 = yaml.safe_load(f)
-data['spec']['requirements'] = d1.get('requirements', {})
+r = d1.get('requirements', {})
+r.pop('k8s', None)  # remove the 'k8s' key
+r.pop('autoK8sVersion', None)  # remove the 'autoK8sVersion' key
+data['spec']['requirements'] = r
 print(yaml.dump(data))
 " | kubectl apply -f -
 


### PR DESCRIPTION
## Description

Update script for e2e testing

## Why do we need it, and what problem does it solve?

Taking the current release version to check the cluster's operation correctly

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: testing
type: fix
summary: use current release version for cloud testing
impact_level: low
```
