### PR TITLE
[control-plane-manager] etcd alert last_over_time

### DIFF
--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
@@ -1,7 +1,7 @@
 - name: d8.etcd-maintenance.quota-backend-bytes
   rules:
     - alert: D8KubeEtcdDatabaseSizeCloseToTheLimit
-      expr: max by (node) (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"}) >= scalar(max(d8_etcd_quota_backend_total) * 0.95)
+      expr: max by (node) (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"}) >= scalar(max(last_over_time(d8_etcd_quota_backend_total[6h])) * 0.95)
       labels:
         severity_level: "3"
         tier: cluster
@@ -44,7 +44,7 @@
             | 72 GB       | 8589934592 (8 GB)   |
             | ...         | ...                 |
     - alert: D8NeedDecreaseEtcdQuotaBackendBytes
-      expr: max(d8_etcd_quota_backend_should_decrease) > 0
+      expr: max(last_over_time(d8_etcd_quota_backend_total[6h])) > 0
       labels:
         tier: cluster
         d8_component: control-plane-manager
@@ -91,7 +91,7 @@
             | 72 GB       | 8589934592 (8 GB)   |
             | ...         | ...                 |
     - alert: D8EtcdExcessiveDatabaseGrowth
-      expr: predict_linear(etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"}[6h], 24*3600) >= scalar(max(d8_etcd_quota_backend_total) * 0.95)
+      expr: predict_linear(etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"}[6h], 24*3600) >= scalar(max(last_over_time(d8_etcd_quota_backend_total[6h])) * 0.95)
       for: "30m"
       labels:
         severity_level: "4"
@@ -107,7 +107,7 @@
 
           To prevent disruptions, investigate the cause and take necessary action.
     - alert: D8EtcdDatabaseHighFragmentationRatio
-      expr: max by (node) (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and max by (node) (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"}) > scalar(max(d8_etcd_quota_backend_total) * 0.75)
+      expr: max by (node) (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and max by (node) (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"}) > scalar(max(last_over_time(d8_etcd_quota_backend_total[6h])) * 0.75)
       for: "10m"
       labels:
         severity_level: "7"


### PR DESCRIPTION
## Description

Use last_over_time to fetch the last available etcd DB size metric if it's missing.

## Why do we need it, and what problem does it solve?

If deckhouse is down due to etcd issues, metrics for etcd DB size become unavailable, breaking our alerts. With last_over_time, we use the latest value from the past 6 hours, so alerts still work even if the metric temporarily disappears.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Use last_over_time to fetch the last available etcd DB size metric if it's missing.
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
