### PR TITLE
feat: delete cluster on pr closed

### DIFF
--- a/.github/scripts/python/e2e-commander-clean/main.py
+++ b/.github/scripts/python/e2e-commander-clean/main.py
@@ -136,7 +136,7 @@ def remove_old_clusters(clusters: List[Dict]) -> None:
     delete_clusters_by_list(clusters_to_delete)
 
 
-def remove_clusters_by_pr(clusters: List[Dict], pr_number: int) -> None:
+def remove_clusters_by_pr(clusters: List[Dict], pr_number: str) -> None:
     """Remove clusters created from a specific pull request."""
     print(f"Removing all clusters created in PR: {pr_number}")
     clusters_to_delete = []

--- a/.github/scripts/python/e2e-commander-clean/main.py
+++ b/.github/scripts/python/e2e-commander-clean/main.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="E2E Cluster Autocleaner")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--auto", action="store_true", help=f"Delete clusters older than {HOURS_TO_REMOVE} hours")
-    group.add_argument("--pr", type=int, help="Delete clusters created by the specified pull request")
+    group.add_argument("--pr", type=str, help="Delete clusters created by the specified pull request")
     args = parser.parse_args()
 
     clusters_data = get_clusters()

--- a/.github/workflow_templates/e2e-autoclean.yml
+++ b/.github/workflow_templates/e2e-autoclean.yml
@@ -17,14 +17,19 @@ on:
   schedule:
   - cron: '0 7 * * *'
   workflow_dispatch:
+  pull_request:
+    types: [ closed ]
+
+env:
+  SCRIPT_DIR: ".github/scripts/python/e2e-commander-clean"
+  E2E_COMMANDER_HOST: ${{secrets.E2E_COMMANDER_HOST}}
+  E2E_COMMANDER_TOKEN: ${{secrets.E2E_COMMANDER_TOKEN}}
+  PYTHON_VERSION: '3.13'
 
 jobs:
   {!{ tmpl.Exec "skip_tests_repos" . | strings.Indent 2 }!}
   e2e-autoclean:
-    env:
-      SCRIPT_DIR: ".github/scripts/python/e2e-commander-clean"
-      E2E_COMMANDER_HOST: ${{secrets.E2E_COMMANDER_HOST}}
-      E2E_COMMANDER_TOKEN: ${{secrets.E2E_COMMANDER_TOKEN}}
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Run
     needs:
     - skip_tests_repos
@@ -33,11 +38,30 @@ jobs:
     {!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
     - uses: {!{ index (ds "actions") "actions/setup-python" }!}
       with:
-        python-version: '3.13'
+        python-version: ${PYTHON_VERSION}
     - name: Install deps
       run: |
         pip install -r ${SCRIPT_DIR}/requirements.txt
     - name: Run clean
       run: |
-        python ${SCRIPT_DIR}/main.py
+        python ${SCRIPT_DIR}/main.py --auto
     {!{ tmpl.Exec "send_fail_report" . | strings.Indent 4 }!}
+  e2e-pr-clean:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    env:
+      PULL_REQUEST_NEMBER: ${{ github.event.pull_request.number }}
+    name: Run
+    needs:
+    - skip_tests_repos
+    runs-on: [ self-hosted, regular ]
+    steps:
+    {!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
+    - uses: {!{ index (ds "actions") "actions/setup-python" }!}
+      with:
+        python-version: ${PYTHON_VERSION}
+    - name: Install deps
+      run: |
+        pip install -r ${SCRIPT_DIR}/requirements.txt
+    - name: Run clean
+      run: |
+        python ${SCRIPT_DIR}/main.py --pr ${PULL_REQUEST_NEMBER}

--- a/.github/workflow_templates/e2e-autoclean.yml
+++ b/.github/workflow_templates/e2e-autoclean.yml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{!{- $enableWorkflowOnTestRepos := true }!}
+
 name: E2E Autoclean
 on:
   schedule:
@@ -27,7 +29,13 @@ env:
   PYTHON_VERSION: '3.13'
 
 jobs:
-  {!{ tmpl.Exec "skip_tests_repos" . | strings.Indent 2 }!}
+  skip_tests_repos:
+    name: Skip tests repos
+    runs-on: ubuntu-latest
+    if: ${{ {!{ $enableWorkflowOnTestRepos }!} || github.repository == 'deckhouse/deckhouse' }}
+    steps:
+    - name: Do nothing
+      run: echo "Empty action to fulfil Github requirements."
   e2e-autoclean:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Run

--- a/.github/workflow_templates/e2e-autoclean.yml
+++ b/.github/workflow_templates/e2e-autoclean.yml
@@ -46,7 +46,7 @@ jobs:
     {!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
     - uses: {!{ index (ds "actions") "actions/setup-python" }!}
       with:
-        python-version: ${PYTHON_VERSION}
+        python-version: ${{ env.PYTHON_VERSION }}
     - name: Install deps
       run: |
         pip install -r ${SCRIPT_DIR}/requirements.txt

--- a/.github/workflow_templates/e2e-autoclean.yml
+++ b/.github/workflow_templates/e2e-autoclean.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{!{- $enableWorkflowOnTestRepos := true }!}
+{!{- $enableWorkflowOnTestRepos := false }!}
 
 name: E2E Autoclean
 on:

--- a/.github/workflow_templates/e2e-autoclean.yml
+++ b/.github/workflow_templates/e2e-autoclean.yml
@@ -57,7 +57,7 @@ jobs:
   e2e-pr-clean:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     env:
-      PULL_REQUEST_NEMBER: ${{ github.event.pull_request.number }}
+      PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
     name: Run
     needs:
     - skip_tests_repos
@@ -72,4 +72,9 @@ jobs:
         pip install -r ${SCRIPT_DIR}/requirements.txt
     - name: Run clean
       run: |
-        python ${SCRIPT_DIR}/main.py --pr ${PULL_REQUEST_NEMBER}
+        REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+        if [[ deckhouse/deckhouse == $GITHUB_REPOSITORY ]] ; then
+          # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+          REPO_SUFFIX=
+        fi
+        python ${SCRIPT_DIR}/main.py --pr ${PULL_REQUEST_NUMBER}${REPO_SUFFIX:+-${REPO_SUFFIX}}

--- a/.github/workflow_templates/e2e-autoclean.yml
+++ b/.github/workflow_templates/e2e-autoclean.yml
@@ -66,7 +66,7 @@ jobs:
     {!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
     - uses: {!{ index (ds "actions") "actions/setup-python" }!}
       with:
-        python-version: ${PYTHON_VERSION}
+        python-version: ${{ env.PYTHON_VERSION }}
     - name: Install deps
       run: |
         pip install -r ${SCRIPT_DIR}/requirements.txt

--- a/.github/workflows/e2e-autoclean.yml
+++ b/.github/workflows/e2e-autoclean.yml
@@ -75,7 +75,7 @@ jobs:
   e2e-pr-clean:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     env:
-      PULL_REQUEST_NEMBER: ${{ github.event.pull_request.number }}
+      PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
     name: Run
     needs:
     - skip_tests_repos
@@ -95,4 +95,9 @@ jobs:
         pip install -r ${SCRIPT_DIR}/requirements.txt
     - name: Run clean
       run: |
-        python ${SCRIPT_DIR}/main.py --pr ${PULL_REQUEST_NEMBER}
+        REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+        if [[ deckhouse/deckhouse == $GITHUB_REPOSITORY ]] ; then
+          # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+          REPO_SUFFIX=
+        fi
+        python ${SCRIPT_DIR}/main.py --pr ${PULL_REQUEST_NUMBER}${REPO_SUFFIX:+-${REPO_SUFFIX}}

--- a/.github/workflows/e2e-autoclean.yml
+++ b/.github/workflows/e2e-autoclean.yml
@@ -31,16 +31,13 @@ env:
   PYTHON_VERSION: '3.13'
 
 jobs:
-
-  # <template: skip_tests_repos>
   skip_tests_repos:
     name: Skip tests repos
     runs-on: ubuntu-latest
-    if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
+    if: ${{ true || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing
       run: echo "Empty action to fulfil Github requirements."
-  # </template: skip_tests_repos>
   e2e-autoclean:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Run

--- a/.github/workflows/e2e-autoclean.yml
+++ b/.github/workflows/e2e-autoclean.yml
@@ -89,7 +89,7 @@ jobs:
     # </template: checkout_step>
     - uses: actions/setup-python@v5.6.0
       with:
-        python-version: ${PYTHON_VERSION}
+        python-version: ${{ env.PYTHON_VERSION }}
     - name: Install deps
       run: |
         pip install -r ${SCRIPT_DIR}/requirements.txt

--- a/.github/workflows/e2e-autoclean.yml
+++ b/.github/workflows/e2e-autoclean.yml
@@ -34,7 +34,7 @@ jobs:
   skip_tests_repos:
     name: Skip tests repos
     runs-on: ubuntu-latest
-    if: ${{ true || github.repository == 'deckhouse/deckhouse' }}
+    if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing
       run: echo "Empty action to fulfil Github requirements."

--- a/.github/workflows/e2e-autoclean.yml
+++ b/.github/workflows/e2e-autoclean.yml
@@ -21,6 +21,14 @@ on:
   schedule:
   - cron: '0 7 * * *'
   workflow_dispatch:
+  pull_request:
+    types: [ closed ]
+
+env:
+  SCRIPT_DIR: ".github/scripts/python/e2e-commander-clean"
+  E2E_COMMANDER_HOST: ${{secrets.E2E_COMMANDER_HOST}}
+  E2E_COMMANDER_TOKEN: ${{secrets.E2E_COMMANDER_TOKEN}}
+  PYTHON_VERSION: '3.13'
 
 jobs:
 
@@ -34,10 +42,7 @@ jobs:
       run: echo "Empty action to fulfil Github requirements."
   # </template: skip_tests_repos>
   e2e-autoclean:
-    env:
-      SCRIPT_DIR: ".github/scripts/python/e2e-commander-clean"
-      E2E_COMMANDER_HOST: ${{secrets.E2E_COMMANDER_HOST}}
-      E2E_COMMANDER_TOKEN: ${{secrets.E2E_COMMANDER_TOKEN}}
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: Run
     needs:
     - skip_tests_repos
@@ -51,13 +56,13 @@ jobs:
     # </template: checkout_step>
     - uses: actions/setup-python@v5.6.0
       with:
-        python-version: '3.13'
+        python-version: ${PYTHON_VERSION}
     - name: Install deps
       run: |
         pip install -r ${SCRIPT_DIR}/requirements.txt
     - name: Run clean
       run: |
-        python ${SCRIPT_DIR}/main.py
+        python ${SCRIPT_DIR}/main.py --auto
 
     # <template: send_fail_report>
     - name: Send fail report
@@ -70,3 +75,27 @@ jobs:
       run: |
         bash ./.github/scripts/send-report.sh
     # </template: send_fail_report>
+  e2e-pr-clean:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    env:
+      PULL_REQUEST_NEMBER: ${{ github.event.pull_request.number }}
+    name: Run
+    needs:
+    - skip_tests_repos
+    runs-on: [ self-hosted, regular ]
+    steps:
+
+    # <template: checkout_step>
+    - name: Checkout sources
+      uses: actions/checkout@v3.5.2
+
+    # </template: checkout_step>
+    - uses: actions/setup-python@v5.6.0
+      with:
+        python-version: ${PYTHON_VERSION}
+    - name: Install deps
+      run: |
+        pip install -r ${SCRIPT_DIR}/requirements.txt
+    - name: Run clean
+      run: |
+        python ${SCRIPT_DIR}/main.py --pr ${PULL_REQUEST_NEMBER}

--- a/.github/workflows/e2e-autoclean.yml
+++ b/.github/workflows/e2e-autoclean.yml
@@ -53,7 +53,7 @@ jobs:
     # </template: checkout_step>
     - uses: actions/setup-python@v5.6.0
       with:
-        python-version: ${PYTHON_VERSION}
+        python-version: ${{ env.PYTHON_VERSION }}
     - name: Install deps
       run: |
         pip install -r ${SCRIPT_DIR}/requirements.txt


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Now when closing or merging a pull request, running clusters remain
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Make E2E clusters delete when closing or merging a pull request
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not related to release
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: feature
summary: Make E2E clusters delete when closing or merging a pull request.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
