### PR TITLE
[monitoring-ping] changed metrics port monitoring-ping 

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -212,7 +212,7 @@ groups:
     description:
       en: chrony-exporter metrics port
       ru: Метрики chrony-exporter
-  - ports: "4288, 4229"
+  - ports: "4288, 4289"
     protocol: TCP
     description:
       en: "monitoring-ping metrics"

--- a/modules/340-monitoring-ping/templates/daemonset.yaml
+++ b/modules/340-monitoring-ping/templates/daemonset.yaml
@@ -110,7 +110,7 @@ spec:
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         args:
-          - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4229"
+          - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4289"
           - "--v=2"
           - "--logtostderr=true"
           - "--stale-cache-interval=1h30m"
@@ -134,17 +134,17 @@ spec:
                     subresource: prometheus-metrics
                     name: monitoring-ping
         ports:
-          - containerPort: 4229
+          - containerPort: 4289
             name: https-metrics
         livenessProbe:
           httpGet:
             path: /livez
-            port: 4229
+            port: 4289
             scheme: HTTPS
         readinessProbe:
           httpGet:
             path: /livez
-            port: 4229
+            port: 4289
             scheme: HTTPS
         resources:
           requests:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Changed the container port kube-rbac-proxy of DaemonSet monitoring-ping from 4229 to 4289

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The port overlaps with the health check probe of the csi-nfs module.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

The port overlaps with the health check probe of the csi-nfs module

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-ping
type: fix
summary: Changed the container port kube-rbac-proxy of DaemonSet monitoring-ping from 4229 to 4289
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
