### PR TITLE
[prometheus] Alert if D8 PVC uses deleted SC

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3698,6 +3698,15 @@ alerts:
         Deckhouse module {{ $labels.module_name }} is using emptyDir for storage.
       severity: "9"
       markupFormat: markdown
+    - name: DeckhouseModuleUsesDeletedStorageClass
+      sourceFile: modules/300-prometheus/monitoring/prometheus-rules/deletedsc.yaml
+      moduleUrl: 300-prometheus
+      module: prometheus
+      edition: ce
+      description: ""
+      summary: ""
+      severity: "4"
+      markupFormat: markdown
     - name: DeckhouseReleaseDisruptionApprovalRequired
       sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
       moduleUrl: 340-monitoring-deckhouse

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3703,8 +3703,18 @@ alerts:
       moduleUrl: 300-prometheus
       module: prometheus
       edition: ce
-      description: ""
-      summary: ""
+      description: |
+        PVC `{{ $labels.persistentvolumeclaim }}` in namespace `{{ $labels.namespace }}` uses StorageClass `{{ $labels.storageclass }}`, which is not found in the cluster.
+
+        This could lead to missing data.
+
+        To investigate the issue, inspect the PVC using the following command:
+
+        ```bash
+        kubectl -n {{ $labels.namespace }} get pvc {{ $labels.persistentvolumeclaim }}
+        ```
+      summary: |
+        StorageClass used by PVC {{ $labels.persistentvolumeclaim }} is not found.
       severity: "4"
       markupFormat: markdown
     - name: DeckhouseReleaseDisruptionApprovalRequired

--- a/modules/300-prometheus/monitoring/prometheus-rules/deletedsc.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/deletedsc.yaml
@@ -1,0 +1,23 @@
+- name: d8.deletedsc
+  rules:
+    - alert: DeckhouseModuleUsesDeletedStorageClass
+      expr: |
+        kube_persistentvolumeclaim_info{namespace=~"d8-.*"} unless(kube_persistentvolumeclaim_info{namespace=~"d8-.*"} * on(storageclass) group_left() kube_storageclass_info)
+      for: 10m
+      labels:
+        tier: cluster
+        severity_level: "4"
+      annotations:
+        plk_markup_format: markdown
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__deckhouse_module_use_empty_dir: DeckhouseModuleUsesDeletedStorageClassGroup,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_group_for__deckhouse_module_use_empty_dir: DeckhouseModuleUsesDeletedStorageClassGroup,prometheus=deckhouse,kubernetes=~kubernetes
+      summary: StorageClass used by PVC {{ $labels.persistentvolumeclaim }}` is not found.
+      description: |
+        PVC `{{ $labels.persistentvolumeclaim }}` in namespace `{{ $labels.namespace }}` uses storageclass `{{ $labels.storageclass }}` which is not found in the cluster.
+
+        This could lead to missing data.
+
+        ```bash
+        kubectl -n {{ $labels.namespace }} get pvc {{ $labels.persistentvolumeclaim }}
+        ```

--- a/modules/300-prometheus/monitoring/prometheus-rules/deletedsc.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/deletedsc.yaml
@@ -1,22 +1,24 @@
 - name: d8.deletedsc
   rules:
-    - alert: DeckhouseModuleUsesDeletedStorageClass
-      expr: |
-        kube_persistentvolumeclaim_info{namespace=~"d8-.*"} unless(kube_persistentvolumeclaim_info{namespace=~"d8-.*"} * on(storageclass) group_left() kube_storageclass_info)
-      for: 10m
-      labels:
-        tier: cluster
-        severity_level: "4"
-      annotations:
-        plk_markup_format: markdown
-        plk_protocol_version: "1"
-        plk_create_group_if_not_exists__deckhouse_module_use_empty_dir: DeckhouseModuleUsesDeletedStorageClassGroup,prometheus=deckhouse,kubernetes=~kubernetes
-        plk_group_for__deckhouse_module_use_empty_dir: DeckhouseModuleUsesDeletedStorageClassGroup,prometheus=deckhouse,kubernetes=~kubernetes
-      summary: StorageClass used by PVC {{ $labels.persistentvolumeclaim }}` is not found.
+  - alert: DeckhouseModuleUsesDeletedStorageClass
+    expr: |
+      kube_persistentvolumeclaim_info{namespace=~"d8-.*"} unless(kube_persistentvolumeclaim_info{namespace=~"d8-.*"} * on(storageclass) group_left() kube_storageclass_info)
+    for: 10m
+    labels:
+      tier: cluster
+      severity_level: "4"
+    annotations:
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      plk_create_group_if_not_exists__deckhouse_module_use_empty_dir: DeckhouseModuleUsesDeletedStorageClassGroup,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_group_for__deckhouse_module_use_empty_dir: DeckhouseModuleUsesDeletedStorageClassGroup,prometheus=deckhouse,kubernetes=~kubernetes
+      summary: StorageClass used by PVC {{ $labels.persistentvolumeclaim }} is not found.
       description: |
-        PVC `{{ $labels.persistentvolumeclaim }}` in namespace `{{ $labels.namespace }}` uses storageclass `{{ $labels.storageclass }}` which is not found in the cluster.
+        PVC `{{ $labels.persistentvolumeclaim }}` in namespace `{{ $labels.namespace }}` uses StorageClass `{{ $labels.storageclass }}`, which is not found in the cluster.
 
         This could lead to missing data.
+
+        To investigate the issue, inspect the PVC using the following command:
 
         ```bash
         kubectl -n {{ $labels.namespace }} get pvc {{ $labels.persistentvolumeclaim }}

--- a/modules/300-prometheus/monitoring/prometheus-rules/deletedsc.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/deletedsc.yaml
@@ -2,7 +2,7 @@
   rules:
   - alert: DeckhouseModuleUsesDeletedStorageClass
     expr: |
-      kube_persistentvolumeclaim_info{namespace=~"d8-.*"} unless(kube_persistentvolumeclaim_info{namespace=~"d8-.*"} * on(storageclass) group_left() kube_storageclass_info)
+      sum(kube_persistentvolumeclaim_info{namespace=~"d8-.*"}) by (namespace, persistentvolumeclaim, storageclass) unless on(storageclass) kube_storageclass_info
     for: 10m
     labels:
       tier: cluster

--- a/modules/300-prometheus/monitoring/prometheus-rules/deletedsc.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/deletedsc.yaml
@@ -2,7 +2,7 @@
   rules:
     - alert: DeckhouseModuleUsesDeletedStorageClass
       expr: |
-        kube_persistentvolumeclaim_info{namespace=~"d8-.*"} unless(kube_persistentvolumeclaim_info{namespace=~"d8-.*"} * on(storageclass) group_left() kube_storageclass_info)
+        sum(kube_persistentvolumeclaim_info{namespace=~"d8-.*"}) by (namespace, persistentvolumeclaim, storageclass) unless on(storageclass) kube_storageclass_info
       for: 10m
       labels:
         tier: cluster


### PR DESCRIPTION
## Description
Add alert if storageclass is used in a PVC but actually missing.
Only for `d8-*` namespaces for the time being. Unfortunately, could not be tied to any metric could export list of D8 owned PVCs or PVs, we don't have any.

`
kube_persistentvolumeclaim_info{namespace=~"d8-.*"} unless(kube_persistentvolumeclaim_info{namespace=~"d8-.*"} * on(storageclass) group_left() kube_storageclass_info)
`

## Why do we need it, and what problem does it solve?
Feature request https://github.com/deckhouse/deckhouse/issues/8418

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: feature
summary: Add DeckhouseModuleUsesDeletedStorageClass alert
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
