### PR TITLE
[admission-policy-engine] remove namespace from RoleBinding

### DIFF
--- a/ee/modules/015-admission-policy-engine/templates/ratify/rbac-for-us.yaml
+++ b/ee/modules/015-admission-policy-engine/templates/ratify/rbac-for-us.yaml
@@ -317,5 +317,4 @@ roleRef:
   kind: Role
   name: ratify-manager
   apiGroup: rbac.authorization.k8s.io
-  namespace: d8-{{ .Chart.Name }}
 {{- end }}


### PR DESCRIPTION
## Description

The namespace field in RoleBinding for admission-policy-engine is superfluous

## Why do we need it, and what problem does it solve?

Bringing application templates to a working state

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix
summary: remove redundant namespace from RoleBinding
impact_level: low
```
