### PR TITLE
[deckhouse] Liveness and Readiness probes for kube-rbac-proxy

### DIFF
--- a/ee/modules/500-operator-trivy/.dmtlint.yaml
+++ b/ee/modules/500-operator-trivy/.dmtlint.yaml
@@ -8,14 +8,7 @@ linters-settings:
         - kind: StatefulSet
           name: trivy-server
           container: chown-volume-data
-      liveness-probe:
-        - kind: Deployment
-          name: operator
-          container: kube-rbac-proxy
       readiness-probe:
-        - kind: Deployment
-          name: operator
-          container: kube-rbac-proxy
         - kind: Deployment
           name: report-updater
           container: report-updater

--- a/ee/modules/500-operator-trivy/templates/deployment.yaml
+++ b/ee/modules/500-operator-trivy/templates/deployment.yaml
@@ -203,6 +203,17 @@ spec:
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
+        - "--livez-path=/livez"
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
         ports:
         - containerPort: 8081
           name: https-metrics

--- a/modules/015-admission-policy-engine/.dmtlint.yaml
+++ b/modules/015-admission-policy-engine/.dmtlint.yaml
@@ -18,21 +18,9 @@ linters-settings:
     exclude-rules:
       liveness-probe:
         - kind: Deployment
-          name: gatekeeper-controller-manager
-          container: kube-rbac-proxy
-        - kind: Deployment
           name: gatekeeper-audit
           container: constraint-exporter
-        - kind: Deployment
-          name: gatekeeper-audit
-          container: kube-rbac-proxy
       readiness-probe:
         - kind: Deployment
-          name: gatekeeper-controller-manager
-          container: kube-rbac-proxy
-        - kind: Deployment
           name: gatekeeper-audit
           container: constraint-exporter
-        - kind: Deployment
-          name: gatekeeper-audit
-          container: kube-rbac-proxy

--- a/modules/015-admission-policy-engine/templates/audit-deployment.yaml
+++ b/modules/015-admission-policy-engine/templates/audit-deployment.yaml
@@ -151,6 +151,7 @@ spec:
           - "--v=2"
           - "--logtostderr=true"
           - "--stale-cache-interval=1h30m"
+          - "--livez-path=/livez"
         env:
           - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
             valueFrom:
@@ -179,6 +180,16 @@ spec:
                     resource: deployments
                     subresource: prometheus-metrics
                     name: gatekeeper-audit
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
         ports:
           - containerPort: 10354
             name: https-metrics

--- a/modules/015-admission-policy-engine/templates/gatekeeper-deployment.yaml
+++ b/modules/015-admission-policy-engine/templates/gatekeeper-deployment.yaml
@@ -133,6 +133,7 @@ spec:
           - "--v=2"
           - "--logtostderr=true"
           - "--stale-cache-interval=1h30m"
+          - "--livez-path=/livez"
         env:
           - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
             valueFrom:
@@ -151,6 +152,16 @@ spec:
                     resource: deployments
                     subresource: prometheus-metrics
                     name: gatekeeper-controller-manager
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
         ports:
           - containerPort: 10354
             name: https-metrics

--- a/modules/101-cert-manager/.dmtlint.yaml
+++ b/modules/101-cert-manager/.dmtlint.yaml
@@ -8,13 +8,7 @@ linters-settings:
         - kind: Deployment
           name: cert-manager
           container: cert-manager
-        - kind: Deployment
-          name: cert-manager
-          container: kube-rbac-proxy
       liveness-probe:
         - kind: Deployment
           name: cainjector
           container: cainjector
-        - kind: Deployment
-          name: cert-manager
-          container: kube-rbac-proxy

--- a/modules/101-cert-manager/templates/cert-manager/deployment.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/deployment.yaml
@@ -114,6 +114,7 @@ spec:
           - "--v=2"
           - "--logtostderr=true"
           - "--stale-cache-interval=1h30m"
+          - "--livez-path=/livez"
           env:
           - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
             valueFrom:
@@ -132,6 +133,16 @@ spec:
                     resource: deployments
                     subresource: prometheus-metrics
                     name: cert-manager
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+              scheme: HTTPS
+          readinessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+              scheme: HTTPS
           ports:
           - containerPort: 9404
             name: https-metrics


### PR DESCRIPTION
## Description

Addendum Liveness and Readiness probes for kube-rbac-proxy

## Why do we need it, and what problem does it solve?

Bringing containers to a single standard of operation

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Liveness and Readiness probes for kube-rbac-proxy
impact_level: default
```
