### PR TITLE
[node-manager] Rename lease name for caps-controller-manager

### DIFF
--- a/modules/040-node-manager/hooks/migration/migrate_remove_old_caps_lease.go
+++ b/modules/040-node-manager/hooks/migration/migrate_remove_old_caps_lease.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+)
+
+const (
+	d8CapsNs           = "d8-cloud-instance-manager"
+	d8CapsLeaseNameOld = "faf94607.cluster.x-k8s.io"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 10},
+}, dependency.WithExternalDependencies(removeOldCapsLease))
+
+func removeOldCapsLease(_ *go_hook.HookInput, dc dependency.Container) error {
+	kubeClient := dc.MustGetK8sClient()
+
+	err := kubeClient.CoordinationV1().Leases(d8CapsNs).Delete(context.Background(), d8CapsLeaseNameOld, metav1.DeleteOptions{})
+
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}

--- a/modules/040-node-manager/hooks/migration/migrate_remove_old_caps_lease_test.go
+++ b/modules/040-node-manager/hooks/migration/migrate_remove_old_caps_lease_test.go
@@ -22,14 +22,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	coordination "k8s.io/api/coordination/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
@@ -42,7 +41,7 @@ metadata:
   name: d8-cloud-instance-manager
 `
 
-	leaseYaml = `
+	lsYaml = `
 ---
 apiVersion: coordination.k8s.io/v1
 kind: Lease
@@ -72,7 +71,7 @@ var _ = Describe("node-manager :: hooks :: remove_old_caps_lease_migration ::", 
 			f.BindingContexts.Set(f.GenerateOnStartupContext())
 
 			createNs(f.KubeClient(), nsYaml)
-			createLease(f.KubeClient(), leaseYaml)
+			createLease(f.KubeClient(), lsYaml)
 
 			f.RunGoHook()
 		})
@@ -96,7 +95,7 @@ func createNs(kubeClient client.KubeClient, spec string) {
 }
 
 func createLease(kubeClient client.KubeClient, spec string) {
-	ls := new(coordination.Lease)
+	ls := new(coordinationv1.Lease)
 	if err := yaml.Unmarshal([]byte(spec), ls); err != nil {
 		panic(err)
 	}

--- a/modules/040-node-manager/hooks/migration/migrate_remove_old_caps_lease_test.go
+++ b/modules/040-node-manager/hooks/migration/migrate_remove_old_caps_lease_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/modules/040-node-manager/hooks/migration/migrate_remove_old_caps_lease_test.go
+++ b/modules/040-node-manager/hooks/migration/migrate_remove_old_caps_lease_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	coordination "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/yaml"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	nsYaml = `
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d8-cloud-instance-manager
+`
+
+	leaseYaml = `
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: faf94607.cluster.x-k8s.io
+  namespace: d8-cloud-instance-manager
+`
+)
+
+var _ = Describe("node-manager :: hooks :: remove_old_caps_lease_migration ::", func() {
+	f := HookExecutionConfigInit("", "")
+
+	Context("An empty cluster", func() {
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.RunGoHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("Cluster with old caps lease installed", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+
+			createNs(f.KubeClient(), nsYaml)
+			createLease(f.KubeClient(), leaseYaml)
+
+			f.RunGoHook()
+		})
+
+		It("Lease must be deleted", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			_, err := f.KubeClient().CoreV1().Namespaces().Get(context.TODO(), d8CapsNs, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			_, err = f.KubeClient().CoordinationV1().Leases(d8CapsNs).Get(context.TODO(), d8CapsLeaseNameOld, metav1.GetOptions{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+})
+
+func createNs(kubeClient client.KubeClient, spec string) {
+	ns := new(corev1.Namespace)
+	if err := yaml.Unmarshal([]byte(spec), ns); err != nil {
+		panic(err)
+	}
+	_, _ = kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+}
+
+func createLease(kubeClient client.KubeClient, spec string) {
+	ls := new(coordination.Lease)
+	if err := yaml.Unmarshal([]byte(spec), ls); err != nil {
+		panic(err)
+	}
+	_, _ = kubeClient.CoordinationV1().Leases(d8CapsNs).Create(context.TODO(), ls, metav1.CreateOptions{})
+}

--- a/modules/040-node-manager/images/caps-controller-manager/src/cmd/main.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/cmd/main.go
@@ -89,7 +89,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "faf94607.cluster.x-k8s.io",
+		LeaderElectionID:       "controller-leader-election-capi",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/modules/040-node-manager/images/caps-controller-manager/src/cmd/main.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/cmd/main.go
@@ -89,7 +89,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "controller-leader-election-capi",
+		LeaderElectionID:       "controller-leader-election-caps",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly


### PR DESCRIPTION
## Description
Rename caps-controller-manager lease from `faf94607.cluster.x-k8s.io` to `controller-leader-election-caps`

## Why do we need it, and what problem does it solve?
Fix https://github.com/deckhouse/deckhouse/issues/8952

Before:
```
~ $ kubectl -n d8-cloud-instance-manager get leases
NAME                              HOLDER                                                                          AGE
controller-leader-election-capi   kovalkov-master-2_737cd5cb-0b2d-4ed8-8965-b30219bec756                          4m15s
faf94607.cluster.x-k8s.io         caps-controller-manager-76d5586866-555l8_7fab1154-54c9-4946-be69-d3623e523c53   4m10s
```

After:
```
~ $ kubectl -n d8-cloud-instance-manager get leases.coordination.k8s.io
NAME                              HOLDER                                                                          AGE
controller-leader-election-capi   kovalkov-master-2_7e6b2e7a-d64b-4aa7-b0cd-241866ed21aa                          3h19m
controller-leader-election-caps   caps-controller-manager-66bd799967-swp65_6fd4d741-1193-4bd9-b23c-2043e981f2a6   79m
```

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Rename caps-controller-manager lease.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
