### PR TITLE
[deckhouse] change storage for MUP CRD

### DIFF
--- a/deckhouse-controller/crds/doc-ru-module-pull-override.yaml
+++ b/deckhouse-controller/crds/doc-ru-module-pull-override.yaml
@@ -2,7 +2,7 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
       schema:
         openAPIV3Schema:
           type: object
@@ -34,7 +34,7 @@ spec:
                   description: Вес (приоритет) модуля.
     - name: v1alpha2
       served: true
-      storage: false
+      storage: true
       schema:
         openAPIV3Schema:
           type: object

--- a/deckhouse-controller/crds/module-pull-override.yaml
+++ b/deckhouse-controller/crds/module-pull-override.yaml
@@ -19,7 +19,7 @@ spec:
   versions:
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
       deprecated: true
       schema:
         openAPIV3Schema:
@@ -78,7 +78,7 @@ spec:
           description: 'Detailed description.'
     - name: v1alpha2
       served: true
-      storage: false
+      storage: true
       schema:
         openAPIV3Schema:
           type: object


### PR DESCRIPTION
## Description
This action we are gradually getting rid of the deprecated version (`ModulePullOverride - v1alpha1`).

The `v1alpha1` lifecycle is coming to an end, so the validation webhook prohibits these resources from being deployed to the cluster. Since the old resource is deprecated, we must backup the updated `v1alpha2` resource and keep data of actual version.

After successful data migration, we observe in the CRD:
```
storedVersions:
  - v1alpha2
```
 
Also, I attach `d8 backup` logs before and after the change (only related to `ModulePullOverride`):
### Before
```
# d8 logs, old resource in backup
W0527 14:54:16 [warnings.go:70] ModulePullOverride v1alpha1 deprecated (repeated x30)
```

### After
```
# d8 logs, new resource in backup
I0527 15:07:04 [request.go:729] Client throttling: GET v1alpha2/modulepulloverrides (2.78s)
```

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
The problem:
- The cluster uses `ModulePullOverride` version `v1alpha2`.
- But the backup retains `v1alpha1` version, which is deprecated.
- `v1alpha1` deployment by validation webhook is not allowed in cluster.
The problem is that when a backup is created, the deprecated version `v1alpha1` for the `ModulePullOverride` resource is retained, even though the cluster actually uses version `v1alpha2`.

Because of this, problems may occur with:
- Compatibility: The v1alpha1 version is deprecated and may not contain a mandatory field that is required in v1alpha2 and vice versa.
- Recovery: Backups in their current form may be impossible to apply due to a validation error.
- Consistency: The backup must accurately reflect the current state of the cluster, including the correct versions of resources.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: convert MPU CRD v1alpha2 storage.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
