### PR TITLE
[ci] Add listing of changed modules for release branch changes

### DIFF
--- a/.github/scripts/python/compare_version_modules.py
+++ b/.github/scripts/python/compare_version_modules.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import subprocess
+
+
+def regctl(command_list):
+    completed_process = subprocess.run(["regctl"] + command_list, text=True, capture_output=True)
+    print(completed_process.stderr)
+    completed_process.check_returncode()
+    return completed_process.stdout
+
+
+image_from = os.getenv("IMAGE_FROM")
+image_to = os.getenv("IMAGE_TO")
+
+print(f"Lookup image_digests from {image_from}")
+
+digests_from = json.loads(regctl([
+    "image",
+    "get-file",
+    image_from,
+    "/deckhouse/modules/images_digests.json"
+]))
+
+print(f"Lookup image_digests from {image_to}")
+
+digests_to = json.loads(regctl([
+    "image",
+    "get-file",
+    image_to,
+    "/deckhouse/modules/images_digests.json"
+]))
+
+digests_unique = {}
+
+for module, images in digests_from.items():
+    if module not in digests_unique:
+        digests_unique[module] = {}
+    for image, digest in images.items():
+        if image not in digests_unique[module]:
+            digests_unique[module][image] = set()
+        digests_unique[module][image].add(digest)
+
+for module, images in digests_to.items():
+    if module not in digests_unique:
+        digests_unique[module] = {}
+    for image, digest in images.items():
+        if image not in digests_unique[module]:
+            digests_unique[module][image] = set()
+        digests_unique[module][image].add(digest)
+
+results = []
+
+for module, images in digests_unique.items():
+    for image, digests_set in images.items():
+        if len(digests_set) > 1:
+            results.append(f"{module}.{image}")
+
+results.sort()
+
+if len(results) != 0:
+    print("Found changes in following module images:")
+    print(*results, sep="\n")
+else:
+    print("No changed module images found.")

--- a/.github/scripts/python/compare_version_modules.py
+++ b/.github/scripts/python/compare_version_modules.py
@@ -78,10 +78,6 @@ results.sort()
 
 dangerous_results = [i for i in results if any(m in i for m in dangerous_modules)]
 
-if len(dangerous_results != 0):
-    print("Found possibly dangerous changes in following module images:")
-    print(*dangerous_results, sep="\n")
-
 if len(results) != 0:
     print("Found changes in following module images:")
     print(*results, sep="\n")
@@ -89,4 +85,6 @@ else:
     print("No changed module images found.")
 
 if len(dangerous_results != 0):
+    print("Found possibly dangerous changes in following module images:")
+    print(*dangerous_results, sep="\n")
     exit(1)

--- a/.github/scripts/python/compare_version_modules.py
+++ b/.github/scripts/python/compare_version_modules.py
@@ -26,6 +26,8 @@ def regctl(command_list):
     return completed_process.stdout
 
 
+dangerous_modules = ["controlPlaneManager", "ingressNginx.controller"]
+
 image_from = os.getenv("IMAGE_FROM")
 image_to = os.getenv("IMAGE_TO")
 
@@ -74,8 +76,17 @@ for module, images in digests_unique.items():
 
 results.sort()
 
+dangerous_results = [i for i in results if any(m in i for m in dangerous_modules)]
+
+if len(dangerous_results != 0):
+    print("Found possibly dangerous changes in following module images:")
+    print(*dangerous_results, sep="\n")
+
 if len(results) != 0:
     print("Found changes in following module images:")
     print(*results, sep="\n")
 else:
     print("No changed module images found.")
+
+if len(dangerous_results != 0):
+    exit(1)

--- a/.github/workflow_templates/build-and-test_pre-release.yml
+++ b/.github/workflow_templates/build-and-test_pre-release.yml
@@ -274,3 +274,29 @@ jobs:
 {!{ tmpl.Exec "doc_version_template" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_doc_template" "production" | strings.Indent 6 }!}
 
+  list_changed_modules:
+    name: List changed modules
+    needs:
+      - git_info
+      - build_fe
+    if: ${{ startsWith(github.ref, 'refs/heads/release') && github.repository == 'deckhouse/deckhouse' }}
+    runs-on: [self-hosted, regular]
+    steps:
+      - uses: {!{ index (ds "actions") "actions/setup-python" }!}
+        with:
+          python-version: '3.12.3'
+      {!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
+      {!{ tmpl.Exec "login_dev_registry_step" $ctx | strings.Indent 6 }!}
+      {!{ tmpl.Exec "login_readonly_registry_step" $ctx | strings.Indent 6 }!}
+      - name: List changed modules from latest released version
+        id: list_changed_modules
+        env:
+          IMAGE_TO: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss:${{ github.ref_name }}"
+        run: |
+          TAG_FROM="$(git ls-remote --tags origin | grep -F tags/v${GITHUB_REF_NAME#release-} | awk -F '/' '{print $3}' | sort -V | tail -n 1)"
+          if [[ -n "${TAG_FROM}" ]]; then
+            export IMAGE_FROM="${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}/deckhouse/fe:${TAG_FROM}"
+            python .github/scripts/python/compare_version_modules.py
+          else
+            echo "No released versions exist. Skipping."
+          fi

--- a/.github/workflow_templates/build-and-test_pre-release.yml
+++ b/.github/workflow_templates/build-and-test_pre-release.yml
@@ -300,3 +300,4 @@ jobs:
           else
             echo "No released versions exist. Skipping."
           fi
+      {!{ tmpl.Exec "send_fail_report" . | strings.Indent 6 }!}

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3394,3 +3394,15 @@ jobs:
           else
             echo "No released versions exist. Skipping."
           fi
+
+      # <template: send_fail_report>
+      - name: Send fail report
+        if: ${{ failure() && github.repository == 'deckhouse/deckhouse' }}
+        env:
+          LOOP_SERVICE_NOTIFICATIONS: ${{ secrets.LOOP_SERVICE_NOTIFICATIONS }}
+          JOB_NAME: ${{ github.job }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
+        run: |
+          bash ./.github/scripts/send-report.sh
+      # </template: send_fail_report>

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3325,3 +3325,72 @@ jobs:
           WERF_SET_DCNAME: "web.dc_name=prod-25"
       # </template: deploy_doc_template>
 
+  list_changed_modules:
+    name: List changed modules
+    needs:
+      - git_info
+      - build_fe
+    if: ${{ startsWith(github.ref, 'refs/heads/release') && github.repository == 'deckhouse/deckhouse' }}
+    runs-on: [self-hosted, regular]
+    steps:
+      - uses: actions/setup-python@v5.6.0
+        with:
+          python-version: '3.12.3'
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+
+      # </template: checkout_step>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "has_credentials=true" >> $GITHUB_OUTPUT
+            echo "web_registry_path=${{secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/deckhouse/site" >> $GITHUB_OUTPUT
+          fi
+      - name: Login to dev registry
+        uses: docker/login-action@v2.1.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "has_credentials=true" >> $GITHUB_OUTPUT
+            echo "web_registry_path=${{secrets.DECKHOUSE_REGISTRY_READ_HOST }}/deckhouse/site" >> $GITHUB_OUTPUT
+          fi
+      - name: Login to readonly registry
+        uses: docker/login-action@v2.1.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          logout: false
+      # </template: login_readonly_registry_step>
+      - name: List changed modules from latest released version
+        id: list_changed_modules
+        env:
+          IMAGE_TO: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss:${{ github.ref_name }}"
+        run: |
+          TAG_FROM="$(git ls-remote --tags origin | grep -F tags/v${GITHUB_REF_NAME#release-} | awk -F '/' '{print $3}' | sort -V | tail -n 1)"
+          if [[ -n "${TAG_FROM}" ]]; then
+            export IMAGE_FROM="${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}/deckhouse/fe:${TAG_FROM}"
+            python .github/scripts/python/compare_version_modules.py
+          else
+            echo "No released versions exist. Skipping."
+          fi


### PR DESCRIPTION
## Description
Add listing of changed modules for release branch changes.

Example:
![2025-05-30-194131_485x609_scrot](https://github.com/user-attachments/assets/031d44bf-359f-4f06-bf40-1ed9e8e8b112)

## Why do we need it, and what problem does it solve?
This change allows to detect potentially destructive image changes for minor release.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: feature
summary: Add listing of changed modules for release branch changes.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
