### PR TITLE
[docs] Add empty-state message to external module configuration pages

### DIFF
--- a/docs/site/backends/docs-builder-template/i18n/en.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/en.yaml
@@ -66,4 +66,4 @@ version_of_module: "### module version"
 version_of_schema: Schema version
 required_value_sentence: Required value
 parameters: parameters
-
+no_custom_configuration: No additional parameters are available for this module.

--- a/docs/site/backends/docs-builder-template/i18n/en.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/en.yaml
@@ -66,4 +66,4 @@ version_of_module: "### module version"
 version_of_schema: Schema version
 required_value_sentence: Required value
 parameters: parameters
-no_custom_configuration: No additional parameters are available for this module.
+no_custom_configuration: The module has no configuration parameters.

--- a/docs/site/backends/docs-builder-template/i18n/ru.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/ru.yaml
@@ -66,4 +66,4 @@ version_of_module: "Версия модуля ###"
 version_of_schema: Версия схемы
 required_value_sentence: Обязательный параметр
 parameters: параметры
-no_custom_configuration: Дополнительные параметры для этого модуля не предусмотрены.
+no_custom_configuration: У модуля нет параметров для настройки.

--- a/docs/site/backends/docs-builder-template/i18n/ru.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/ru.yaml
@@ -66,3 +66,4 @@ version_of_module: "Версия модуля ###"
 version_of_schema: Версия схемы
 required_value_sentence: Обязательный параметр
 parameters: параметры
+no_custom_configuration: Дополнительные параметры для этого модуля не предусмотрены.

--- a/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-configuration.html
+++ b/docs/site/backends/docs-builder-template/layouts/partials/openapi/format-configuration.html
@@ -80,7 +80,7 @@ Context:
 {{- end }}
 {{/* END Conversions rendering */}}
 
-{{- if $data.properties }}
+{{- if gt (len $data.properties) 0 }}
 <p><font size="-1">{{ T "version_of_schema" }}: {{ $configVersion }}</font></p>
 
 <ul class="resources">
@@ -92,4 +92,7 @@ Context:
   {{- end }}
 
 </ul>
+
+{{- else }}
+<p>{{ T "no_custom_configuration" }}</p>
 {{- end }}


### PR DESCRIPTION
## Description
Display “No additional parameters are available for this module” on configuration pages for external modules with no defined parameters.

## Why do we need it, and what problem does it solve?
When a docs/CONFIGURATION.md file exists but openapi/config-values.yaml properties list is empty, the configuration page would render completely blank, leaving users confused. This change adds a clear message so that empty-state pages give meaningful feedback.

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: feature
summary: Display “No additional parameters are available for this module” on configuration pages for external modules with no defined parameters.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
