### PR TITLE
[dhctl] chore(dhctl-for-commander): make dhctl server state extractor more reliable

### DIFF
--- a/dhctl/pkg/server/rpc/dhctl/abort.go
+++ b/dhctl/pkg/server/rpc/dhctl/abort.go
@@ -136,7 +136,8 @@ connectionProcessor:
 func (s *Service) abortSafe(ctx context.Context, request *pb.AbortStart, switchPhase phases.DefaultOnPhaseFunc, options logger.Options) (result *pb.AbortResult) {
 	defer func() {
 		if r := recover(); r != nil {
-			result = &pb.AbortResult{Err: panicMessage(ctx, r)}
+			lastState, err := panicResult(ctx, r)
+			result = &pb.AbortResult{State: string(lastState), Err: err.Error()}
 		}
 	}()
 
@@ -259,11 +260,10 @@ func (s *Service) abort(ctx context.Context, request *pb.AbortStart, switchPhase
 	})
 
 	abortErr := bootstrapper.Abort(ctx, false)
-	state := bootstrapper.GetLastState()
-	stateData, marshalErr := json.Marshal(state)
-	err = errors.Join(abortErr, marshalErr)
+	state, stateErr := extractLastState()
+	err = errors.Join(abortErr, stateErr)
 
-	return &pb.AbortResult{State: string(stateData), Err: util.ErrToString(err)}
+	return &pb.AbortResult{State: string(state), Err: util.ErrToString(err)}
 }
 
 func (s *Service) abortServerTransitions() []fsm.Transition {

--- a/dhctl/pkg/server/rpc/dhctl/service.go
+++ b/dhctl/pkg/server/rpc/dhctl/service.go
@@ -34,6 +34,7 @@ import (
 	pb "github.com/deckhouse/deckhouse/dhctl/pkg/server/pb/dhctl"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/fsm"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/logger"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
@@ -220,12 +221,36 @@ func onCheckResult(checkRes *check.CheckResult) error {
 	return nil
 }
 
-func panicMessage(ctx context.Context, p any) string {
+func extractLastState() ([]byte, error) {
+	state, err := phases.ExtractDhctlState(cache.Global())
+	if err != nil {
+		return nil, fmt.Errorf("extracting last state: %w", err)
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling last state: %w", err)
+	}
+
+	return data, nil
+}
+
+func panicResult(ctx context.Context, p any) ([]byte, error) {
 	stack := string(debug.Stack())
 
 	logger.L(ctx).Error("recovered from panic",
 		slog.Any("panic", p),
 		slog.String("stack", stack),
 	)
-	return fmt.Sprintf("panic: %v, %s", p, stack)
+
+	errs := []error{
+		fmt.Errorf("panic: %v, %s", p, stack),
+	}
+
+	lastState, err := extractLastState()
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	return lastState, errors.Join(errs...)
 }


### PR DESCRIPTION
## Description
When encountering panic or errors, always read the last state directly from the cache (currently implemented on disk). Do not rely on phasedExecutionContext and its internal state. This is particularly important with the introduction of cancellations when a task can be interrupted between phases.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: read dchtl server state from disk on errors
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
