### PR TITLE
[docs] Add notice about RED virtualization in GS

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
+++ b/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
@@ -4,6 +4,11 @@
 Доступно начиная с версии 1.65 Deckhouse Kubernetes Platform.
 {% endalert %}
 {%- endif %}
+{%- if page.platform_code == "red" %}
+{%- alert level="info" %}
+Перед установкой Deckhouse Kubernetes Platform в среде РЕД виртуализации необходимо предварительно создать нужное количество виртуальных машин с требуемыми параметрами.
+{% endalert %}
+{%- endif %}
 {%- if page.platform_code == "dynamix" %}
 {%- alert level="warning" %}
 Доступно начиная с версии 1.66 Deckhouse Kubernetes Platform.


### PR DESCRIPTION
## Description

This pull request updates the `NOTICES.liquid` file to include a new informational alert specific to the "red" platform code. 

Documentation update:

* [`docs/site/_includes/getting_started/global/partials/NOTICES.liquid`](diffhunk://#diff-6c16be6010fc68740657eca2822d958961d1a89811301dcccdcbf12248d33051R7-R11): Added an informational alert advising users to pre-create virtual machines with required parameters before installing Deckhouse Kubernetes Platform in the "red" virtualization environment.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Added notice about creating VMs in the RED virtualization.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
