### PR TITLE
[operator-trivy] Add startupProbe

### DIFF
--- a/ee/modules/500-operator-trivy/templates/trivy-server.yaml
+++ b/ee/modules/500-operator-trivy/templates/trivy-server.yaml
@@ -112,6 +112,15 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+          startupProbe:
+            httpGet:
+              scheme: HTTP
+              path: /healthz
+              port: trivy-http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 60
           volumeMounts:
             - mountPath: /tmp
               name: tmp-data


### PR DESCRIPTION
## Description
Fix #13697
Added a startupProbe to extend the initialization window and allow sufficient time for database downloads:
```yaml
startupProbe:
  httpGet:
    scheme: HTTP
    path: /healthz
    port: trivy-http
  initialDelaySeconds: 5     # Wait 5s before first check
  periodSeconds: 10          # Check every 10s
  successThreshold: 1        # 1 successful check = ready
  failureThreshold: 60       # Allow up to 10 minutes (60 attempts × 10s)
```

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
When Trivy downloads security databases over a slow connection (taking more than 105 seconds), the container would repeatedly fail and restart, creating a crash loop. This prevented the pod from ever successfully initializing.

Why This Works:
- Extended Grace Period: The probe now allows 600 seconds (10 minutes) for downloads to complete before failing.
- Health-Checked Readiness: Only marks the pod "ready" after /healthz confirms successful initialization.
- Prevents Crash Loops: Eliminates infinite restarts by giving slow connections enough time to finish.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: fix
summary: added startup probe to trivy-server
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
