### PR TITLE
[cilium] fix bug in cilium operator priority filter

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,5 +1,176 @@
+From 1d0a465d291beec75bc2bf2220c85fca19e57dfb Mon Sep 17 00:00:00 2001
+From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
+Date: Mon, 2 Jun 2025 14:44:31 +0300
+Subject: [PATCH] add: priority patch
+
+Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
+---
+ cilium-dbg/cmd/bpf_endpoint_delete.go         |   2 +-
+ cilium-dbg/cmd/bpf_endpoint_list.go           |   2 +-
+ daemon/cmd/daemon.go                          |  13 +-
+ daemon/cmd/datapath.go                        |   2 +-
+ daemon/cmd/hostips-sync.go                    |   2 +-
+ daemon/cmd/state.go                           |   2 +-
+ daemon/cmd/status.go                          |   2 +-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 250 +++++++++++-
+ operator/watchers/cilium_endpoint.go          |   1 +
+ pkg/datapath/alignchecker/alignchecker.go     |   2 +-
+ pkg/datapath/linux/config/config.go           |   2 +-
+ pkg/endpoint/bpf.go                           |   2 +-
+ pkg/ipcache/ipcache.go                        | 356 ++++++++++++++++++
+ pkg/k8s/watchers/cilium_endpoint.go           |  15 +
+ .../cilium_endpoint_slice_subscriber.go       |   9 +-
+ pkg/k8s/watchers/watcher.go                   |   1 +
+ pkg/labels/labels.go                          |   4 +
+ pkg/maps/bwmap/bwmap.go                       |   2 +-
+ pkg/maps/lxcmap/doc.go                        |   9 -
+ pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
+ 20 files changed, 642 insertions(+), 288 deletions(-)
+ delete mode 100644 pkg/maps/lxcmap/doc.go
+ delete mode 100644 pkg/maps/lxcmap/lxcmap.go
+
+diff --git a/cilium-dbg/cmd/bpf_endpoint_delete.go b/cilium-dbg/cmd/bpf_endpoint_delete.go
+index fb2e5f7682..434d78f164 100644
+--- a/cilium-dbg/cmd/bpf_endpoint_delete.go
++++ b/cilium-dbg/cmd/bpf_endpoint_delete.go
+@@ -9,7 +9,7 @@ import (
+ 	"github.com/spf13/cobra"
+ 
+ 	"github.com/cilium/cilium/pkg/common"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ )
+ 
+ var bpfEndpointDeleteCmd = &cobra.Command{
+diff --git a/cilium-dbg/cmd/bpf_endpoint_list.go b/cilium-dbg/cmd/bpf_endpoint_list.go
+index ce72120d24..0249739c44 100644
+--- a/cilium-dbg/cmd/bpf_endpoint_list.go
++++ b/cilium-dbg/cmd/bpf_endpoint_list.go
+@@ -10,7 +10,7 @@ import (
+ 
+ 	"github.com/cilium/cilium/pkg/command"
+ 	"github.com/cilium/cilium/pkg/common"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ )
+ 
+ const (
+diff --git a/daemon/cmd/daemon.go b/daemon/cmd/daemon.go
+index 8161060573..7c672f9dea 100644
+--- a/daemon/cmd/daemon.go
++++ b/daemon/cmd/daemon.go
+@@ -13,12 +13,6 @@ import (
+ 	"runtime"
+ 	"sync"
+ 
+-	"github.com/cilium/hive/job"
+-	"github.com/cilium/statedb"
+-	"github.com/sirupsen/logrus"
+-	"github.com/vishvananda/netlink"
+-	"golang.org/x/sync/semaphore"
+-
+ 	"github.com/cilium/cilium/api/v1/models"
+ 	health "github.com/cilium/cilium/cilium-health/launch"
+ 	"github.com/cilium/cilium/daemon/cmd/cni"
+@@ -80,6 +74,11 @@ import (
+ 	"github.com/cilium/cilium/pkg/status"
+ 	"github.com/cilium/cilium/pkg/time"
+ 	wireguard "github.com/cilium/cilium/pkg/wireguard/agent"
++	"github.com/cilium/hive/job"
++	"github.com/cilium/statedb"
++	"github.com/sirupsen/logrus"
++	"github.com/vishvananda/netlink"
++	"golang.org/x/sync/semaphore"
+ )
+ 
+ const (
+@@ -411,6 +410,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
+ 		maglevConfig:      params.MaglevConfig,
+ 	}
+ 
++	ipcache.SetGlobalIPCache(d.ipcache)
++
+ 	// initialize endpointRestoreComplete channel as soon as possible so that subsystems
+ 	// can wait on it to get closed and not block forever if they happen so start
+ 	// waiting when it is not yet initialized (which causes them to block forever).
+diff --git a/daemon/cmd/datapath.go b/daemon/cmd/datapath.go
+index a8680acbac..f6e8efcd0d 100644
+--- a/daemon/cmd/datapath.go
++++ b/daemon/cmd/datapath.go
+@@ -21,6 +21,7 @@ import (
+ 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+ 	"github.com/cilium/cilium/pkg/defaults"
+ 	"github.com/cilium/cilium/pkg/endpointmanager"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	"github.com/cilium/cilium/pkg/logging/logfields"
+ 	"github.com/cilium/cilium/pkg/maps/ctmap"
+ 	"github.com/cilium/cilium/pkg/maps/encrypt"
+@@ -28,7 +29,6 @@ import (
+ 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
+ 	"github.com/cilium/cilium/pkg/maps/ipmasq"
+ 	"github.com/cilium/cilium/pkg/maps/lbmap"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
+ 	"github.com/cilium/cilium/pkg/maps/metricsmap"
+ 	"github.com/cilium/cilium/pkg/maps/nat"
+ 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
+diff --git a/daemon/cmd/hostips-sync.go b/daemon/cmd/hostips-sync.go
+index 175158b92e..ca51ac71eb 100644
+--- a/daemon/cmd/hostips-sync.go
++++ b/daemon/cmd/hostips-sync.go
+@@ -19,10 +19,10 @@ import (
+ 	"github.com/cilium/cilium/pkg/identity"
+ 	ippkg "github.com/cilium/cilium/pkg/ip"
+ 	"github.com/cilium/cilium/pkg/ipcache"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
+ 	"github.com/cilium/cilium/pkg/labels"
+ 	"github.com/cilium/cilium/pkg/logging/logfields"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
+ 	"github.com/cilium/cilium/pkg/metrics"
+ 	"github.com/cilium/cilium/pkg/option"
+ 	"github.com/cilium/cilium/pkg/source"
+diff --git a/daemon/cmd/state.go b/daemon/cmd/state.go
+index 342c7c49dc..7728eb165c 100644
+--- a/daemon/cmd/state.go
++++ b/daemon/cmd/state.go
+@@ -19,6 +19,7 @@ import (
+ 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+ 	"github.com/cilium/cilium/pkg/endpoint"
+ 	"github.com/cilium/cilium/pkg/ipam"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	"github.com/cilium/cilium/pkg/k8s"
+ 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+ 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
+@@ -26,7 +27,6 @@ import (
+ 	"github.com/cilium/cilium/pkg/lock"
+ 	"github.com/cilium/cilium/pkg/logging/logfields"
+ 	"github.com/cilium/cilium/pkg/maps/ctmap"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
+ 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+ 	"github.com/cilium/cilium/pkg/option"
+ )
+diff --git a/daemon/cmd/status.go b/daemon/cmd/status.go
+index b678668ac0..d42dae075b 100644
+--- a/daemon/cmd/status.go
++++ b/daemon/cmd/status.go
+@@ -24,6 +24,7 @@ import (
+ 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
+ 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+ 	"github.com/cilium/cilium/pkg/identity"
++	lxcmap "github.com/cilium/cilium/pkg/ipcache"
+ 	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
+ 	"github.com/cilium/cilium/pkg/kvstore"
+ 	"github.com/cilium/cilium/pkg/lock"
+@@ -31,7 +32,6 @@ import (
+ 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
+ 	ipmasqmap "github.com/cilium/cilium/pkg/maps/ipmasq"
+ 	"github.com/cilium/cilium/pkg/maps/lbmap"
+-	"github.com/cilium/cilium/pkg/maps/lxcmap"
+ 	"github.com/cilium/cilium/pkg/maps/metricsmap"
+ 	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
+ 	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..66159bcaa5 100644
+index 3b3ffc13ef..ced1f484b8 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,6 +6,9 @@ package ciliumendpointslice
@@ -10,7 +181,7 @@ index 3b3ffc13ef..66159bcaa5 100644
 +	"strconv"
 +	"strings"
  	"time"
-
+ 
  	"github.com/cilium/hive/cell"
 @@ -18,6 +21,7 @@ import (
  	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -19,18 +190,18 @@ index 3b3ffc13ef..66159bcaa5 100644
 +	"github.com/cilium/cilium/pkg/labels"
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
-
-@@ -49,10 +53,209 @@ const (
+ 
+@@ -49,10 +53,216 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
-
+ 
 +	// Force CES update
 +	ForceCESSyncTime = 5 * time.Millisecond
 +
  	CESWriteQPSLimitMax = 50
  	CESWriteQPSBurstMax = 100
  )
-
+ 
 +type cepPriority uint32
 +
 +const (
@@ -118,6 +289,10 @@ index 3b3ffc13ef..66159bcaa5 100644
 +		isInserted := false
 +		// new cep will have higher priority than old ceps with same priority
 +		highest := &info
++		if len(cepList) > 1 {
++			fmt.Printf("DEBUG len(cepList) > 1: %v\n", cepList)
++		}
++
 +		currentOwner := cepList[0].cep
 +		for i := range cepList {
 +			if len(cepList[i].cep.Status.Networking.Addressing) != 0 {
@@ -161,11 +336,14 @@ index 3b3ffc13ef..66159bcaa5 100644
 +			highest.cep.Status.Networking.Addressing = append(emptyAddrList, addr)
 +			oldOwner = cep
 +			newOwner = highest.cep
++			fmt.Printf("DEBUG isOwner && !isHighest old, new: %v %v\n", oldOwner, newOwner)
 +		} else if !isOwner && isHighest {
 +			currentOwner.Status.Networking.Addressing = emptyAddrList
 +			oldOwner = currentOwner
++			fmt.Printf("DEBUG !isOwner && isHighest old, new: %v %v\n", oldOwner, newOwner)
 +		} else { // !isOwner && !isHighest
 +			cep.Status.Networking.Addressing = emptyAddrList
++			fmt.Printf("DEBUG !isOwner && !isHighest old, new: %v %v\n", oldOwner, newOwner)
 +		}
 +	} else {
 +		c.ipToCepList[shared.IPV4] = []coreCiliumEndpointInfo{info}
@@ -230,35 +408,80 @@ index 3b3ffc13ef..66159bcaa5 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,11 +276,26 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +283,46 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
 -	touchedCESs := c.manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
+-	c.enqueueCESReconciliation(touchedCESs)
 +
-+	// TODO use delay
-+	oldOwner, _, newOwner := filter.filterAddressByPriority(cep)
++	oldOwner, delay, newOwner := filter.filterAddressByPriority(cep)
 +	if oldOwner != nil {
 +		touchedCESs := c.manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(oldOwner), oldOwner.Namespace)
-+		c.enqueueCESReconciliation(touchedCESs)
++		c.enqueueCESReconciliation(touchedCESs, delay)
 +	}
 +
 +	touchedCESs := c.manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(newOwner), newOwner.Namespace)
- 	c.enqueueCESReconciliation(touchedCESs)
++	c.enqueueCESReconciliation(touchedCESs, delay)
  }
-
+ 
  func (c *Controller) onEndpointDelete(cep *cilium_api_v2.CiliumEndpoint) {
 +	hiddenCep := filter.removeCEPFromFilter(cep)
 +
 +	if hiddenCep != nil {
++		fmt.Printf("DEBUG onEndpointDelete: %v\n", hiddenCep)
 +		touchedCESs := c.manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(hiddenCep), hiddenCep.Namespace)
-+		c.enqueueCESReconciliation(touchedCESs)
++		c.enqueueCESReconciliation(touchedCESs, DefaultCESSyncTime)
 +	}
 +
  	touchedCES := c.manager.RemoveCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
- 	c.enqueueCESReconciliation([]CESKey{touchedCES})
+-	c.enqueueCESReconciliation([]CESKey{touchedCES})
++	c.enqueueCESReconciliation([]CESKey{touchedCES}, DefaultCESSyncTime)
  }
-@@ -186,6 +404,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+ 
+ func (c *Controller) onSliceUpdate(ces *capi_v2a1.CiliumEndpointSlice) {
+-	c.enqueueCESReconciliation([]CESKey{NewCESKey(ces.Name, ces.Namespace)})
++	c.enqueueCESReconciliation([]CESKey{NewCESKey(ces.Name, ces.Namespace)}, DefaultCESSyncTime)
+ }
+ 
+ func (c *Controller) onSliceDelete(ces *capi_v2a1.CiliumEndpointSlice) {
+-	c.enqueueCESReconciliation([]CESKey{NewCESKey(ces.Name, ces.Namespace)})
++	c.enqueueCESReconciliation([]CESKey{NewCESKey(ces.Name, ces.Namespace)}, DefaultCESSyncTime)
+ }
+ 
+-func (c *Controller) addToQueue(ces CESKey) {
++func (c *Controller) addToQueue(ces CESKey, delay time.Duration) {
+ 	c.priorityNamespacesLock.RLock()
+ 	_, exists := c.priorityNamespaces[ces.Namespace]
+ 	c.priorityNamespacesLock.RUnlock()
+-	time.AfterFunc(c.syncDelay, func() {
++	time.AfterFunc(delay, func() {
+ 		c.cond.L.Lock()
+ 		defer c.cond.L.Unlock()
+-		if exists {
++		if exists || delay == ForceCESSyncTime {
+ 			c.fastQueue.Add(ces)
+ 		} else {
+ 			c.standardQueue.Add(ces)
+@@ -108,7 +333,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+ 
+ }
+ 
+-func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
++func (c *Controller) enqueueCESReconciliation(cess []CESKey, delay time.Duration) {
+ 	for _, ces := range cess {
+ 		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
+ 		if ces.Name != "" {
+@@ -117,7 +342,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+ 				c.enqueuedAt[ces] = time.Now()
+ 			}
+ 			c.enqueuedAtLock.Unlock()
+-			c.addToQueue(ces)
++			c.addToQueue(ces, delay)
+ 		}
+ 	}
+ }
+@@ -186,6 +411,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)
@@ -282,151 +505,6 @@ index 40bf20429a..765ceb9614 100644
  			},
  			Status: cilium_api_v2.EndpointStatus{
  				Identity:   concreteObj.Status.Identity,
-diff --git a/pkg/labels/labels.go b/pkg/labels/labels.go
-index 40c714ee0f..9541281c22 100644
---- a/pkg/labels/labels.go
-+++ b/pkg/labels/labels.go
-@@ -80,6 +80,10 @@ const (
- 	// IDNameUnknown is the label used to to identify an endpoint with an
- 	// unknown identity.
- 	IDNameUnknown = "unknown"
-+
-+	// IDNamePriority is the label used to set pod priority on shared ip4-address
-+	// network access
-+	IDNamePriority = "network.deckhouse.io/pod-common-ip-priority"
- )
-
- var (
---
-2.34.1
-
-
-From b1e78ba176092400a918de2eb77982389e3a13be Mon Sep 17 00:00:00 2001
-From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
-Date: Fri, 25 Apr 2025 12:21:17 +0300
-Subject: [PATCH 2/4] move lxcmap module to ipcache
-
-Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
----
- cilium-dbg/cmd/bpf_endpoint_delete.go     |   2 +-
- cilium-dbg/cmd/bpf_endpoint_list.go       |   2 +-
- daemon/cmd/datapath.go                    |   2 +-
- daemon/cmd/hostips-sync.go                |   2 +-
- daemon/cmd/state.go                       |   2 +-
- daemon/cmd/status.go                      |   2 +-
- pkg/datapath/alignchecker/alignchecker.go |   2 +-
- pkg/datapath/linux/config/config.go       |   2 +-
- pkg/endpoint/bpf.go                       |   2 +-
- pkg/ipcache/ipcache.go                    | 243 +++++++++++++++++++++
- pkg/maps/bwmap/bwmap.go                   |   2 +-
- pkg/maps/lxcmap/doc.go                    |   9 -
- pkg/maps/lxcmap/lxcmap.go                 | 252 ----------------------
- 13 files changed, 253 insertions(+), 271 deletions(-)
- delete mode 100644 pkg/maps/lxcmap/doc.go
- delete mode 100644 pkg/maps/lxcmap/lxcmap.go
-
-diff --git a/cilium-dbg/cmd/bpf_endpoint_delete.go b/cilium-dbg/cmd/bpf_endpoint_delete.go
-index fb2e5f7682..434d78f164 100644
---- a/cilium-dbg/cmd/bpf_endpoint_delete.go
-+++ b/cilium-dbg/cmd/bpf_endpoint_delete.go
-@@ -9,7 +9,7 @@ import (
- 	"github.com/spf13/cobra"
-
- 	"github.com/cilium/cilium/pkg/common"
--	"github.com/cilium/cilium/pkg/maps/lxcmap"
-+	lxcmap "github.com/cilium/cilium/pkg/ipcache"
- )
-
- var bpfEndpointDeleteCmd = &cobra.Command{
-diff --git a/cilium-dbg/cmd/bpf_endpoint_list.go b/cilium-dbg/cmd/bpf_endpoint_list.go
-index ce72120d24..0249739c44 100644
---- a/cilium-dbg/cmd/bpf_endpoint_list.go
-+++ b/cilium-dbg/cmd/bpf_endpoint_list.go
-@@ -10,7 +10,7 @@ import (
-
- 	"github.com/cilium/cilium/pkg/command"
- 	"github.com/cilium/cilium/pkg/common"
--	"github.com/cilium/cilium/pkg/maps/lxcmap"
-+	lxcmap "github.com/cilium/cilium/pkg/ipcache"
- )
-
- const (
-diff --git a/daemon/cmd/datapath.go b/daemon/cmd/datapath.go
-index a8680acbac..f6e8efcd0d 100644
---- a/daemon/cmd/datapath.go
-+++ b/daemon/cmd/datapath.go
-@@ -21,6 +21,7 @@ import (
- 	datapath "github.com/cilium/cilium/pkg/datapath/types"
- 	"github.com/cilium/cilium/pkg/defaults"
- 	"github.com/cilium/cilium/pkg/endpointmanager"
-+	lxcmap "github.com/cilium/cilium/pkg/ipcache"
- 	"github.com/cilium/cilium/pkg/logging/logfields"
- 	"github.com/cilium/cilium/pkg/maps/ctmap"
- 	"github.com/cilium/cilium/pkg/maps/encrypt"
-@@ -28,7 +29,6 @@ import (
- 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
- 	"github.com/cilium/cilium/pkg/maps/ipmasq"
- 	"github.com/cilium/cilium/pkg/maps/lbmap"
--	"github.com/cilium/cilium/pkg/maps/lxcmap"
- 	"github.com/cilium/cilium/pkg/maps/metricsmap"
- 	"github.com/cilium/cilium/pkg/maps/nat"
- 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
-diff --git a/daemon/cmd/hostips-sync.go b/daemon/cmd/hostips-sync.go
-index 175158b92e..ca51ac71eb 100644
---- a/daemon/cmd/hostips-sync.go
-+++ b/daemon/cmd/hostips-sync.go
-@@ -19,10 +19,10 @@ import (
- 	"github.com/cilium/cilium/pkg/identity"
- 	ippkg "github.com/cilium/cilium/pkg/ip"
- 	"github.com/cilium/cilium/pkg/ipcache"
-+	lxcmap "github.com/cilium/cilium/pkg/ipcache"
- 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
- 	"github.com/cilium/cilium/pkg/labels"
- 	"github.com/cilium/cilium/pkg/logging/logfields"
--	"github.com/cilium/cilium/pkg/maps/lxcmap"
- 	"github.com/cilium/cilium/pkg/metrics"
- 	"github.com/cilium/cilium/pkg/option"
- 	"github.com/cilium/cilium/pkg/source"
-diff --git a/daemon/cmd/state.go b/daemon/cmd/state.go
-index 74ee125ca8..7effe86fbf 100644
---- a/daemon/cmd/state.go
-+++ b/daemon/cmd/state.go
-@@ -19,6 +19,7 @@ import (
- 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
- 	"github.com/cilium/cilium/pkg/endpoint"
- 	"github.com/cilium/cilium/pkg/ipam"
-+	lxcmap "github.com/cilium/cilium/pkg/ipcache"
- 	"github.com/cilium/cilium/pkg/k8s"
- 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
- 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
-@@ -26,7 +27,6 @@ import (
- 	"github.com/cilium/cilium/pkg/lock"
- 	"github.com/cilium/cilium/pkg/logging/logfields"
- 	"github.com/cilium/cilium/pkg/maps/ctmap"
--	"github.com/cilium/cilium/pkg/maps/lxcmap"
- 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
- 	"github.com/cilium/cilium/pkg/option"
- )
-diff --git a/daemon/cmd/status.go b/daemon/cmd/status.go
-index 84970920aa..59be900c03 100644
---- a/daemon/cmd/status.go
-+++ b/daemon/cmd/status.go
-@@ -24,6 +24,7 @@ import (
- 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
- 	datapath "github.com/cilium/cilium/pkg/datapath/types"
- 	"github.com/cilium/cilium/pkg/identity"
-+	lxcmap "github.com/cilium/cilium/pkg/ipcache"
- 	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
- 	"github.com/cilium/cilium/pkg/kvstore"
- 	"github.com/cilium/cilium/pkg/lock"
-@@ -31,7 +32,6 @@ import (
- 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
- 	ipmasqmap "github.com/cilium/cilium/pkg/maps/ipmasq"
- 	"github.com/cilium/cilium/pkg/maps/lbmap"
--	"github.com/cilium/cilium/pkg/maps/lxcmap"
- 	"github.com/cilium/cilium/pkg/maps/metricsmap"
- 	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
- 	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/pkg/datapath/alignchecker/alignchecker.go b/pkg/datapath/alignchecker/alignchecker.go
 index 56e7ee2b93..6ed225938c 100644
 --- a/pkg/datapath/alignchecker/alignchecker.go
@@ -468,7 +546,7 @@ index a3243d93e3..5b146026fc 100644
  	"github.com/cilium/cilium/pkg/maps/nat"
  	"github.com/cilium/cilium/pkg/maps/neighborsmap"
 diff --git a/pkg/endpoint/bpf.go b/pkg/endpoint/bpf.go
-index 06763bb552..697b014ee7 100644
+index 59e81f5bd1..37b0e54781 100644
 --- a/pkg/endpoint/bpf.go
 +++ b/pkg/endpoint/bpf.go
 @@ -30,11 +30,11 @@ import (
@@ -485,25 +563,26 @@ index 06763bb552..697b014ee7 100644
  	"github.com/cilium/cilium/pkg/option"
  	"github.com/cilium/cilium/pkg/policy"
 diff --git a/pkg/ipcache/ipcache.go b/pkg/ipcache/ipcache.go
-index 34e46fba68..4325fbc6b3 100644
+index 34e46fba68..4a29583038 100644
 --- a/pkg/ipcache/ipcache.go
 +++ b/pkg/ipcache/ipcache.go
 @@ -12,6 +12,9 @@ import (
-
+ 
  	"github.com/sirupsen/logrus"
-
+ 
 +	"fmt"
 +
 +	"github.com/cilium/cilium/pkg/bpf"
  	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
  	"github.com/cilium/cilium/pkg/controller"
  	"github.com/cilium/cilium/pkg/counter"
-@@ -22,12 +25,252 @@ import (
+@@ -22,12 +25,355 @@ import (
  	"github.com/cilium/cilium/pkg/labels"
  	"github.com/cilium/cilium/pkg/lock"
  	"github.com/cilium/cilium/pkg/logging/logfields"
 +	"github.com/cilium/cilium/pkg/mac"
  	"github.com/cilium/cilium/pkg/metrics"
++	"github.com/cilium/cilium/pkg/node"
  	"github.com/cilium/cilium/pkg/option"
  	"github.com/cilium/cilium/pkg/source"
  	"github.com/cilium/cilium/pkg/types"
@@ -528,6 +607,74 @@ index 34e46fba68..4325fbc6b3 100644
 +	lxcMapOnce sync.Once
 +)
 +
++type LxcEndpointInfo struct {
++	key    *EndpointKey
++	info   *EndpointInfo
++	active bool
++}
++
++var globalIPCache *IPCache
++
++func SetGlobalIPCache(ipcache *IPCache) {
++	globalIPCache = ipcache
++}
++
++func (ipc *IPCache) isIPCacheHostLocal(epAddr string, nodeIPv4 net.IP) bool {
++	ipKeyPair := ipc.ipToHostIPCache[epAddr]
++	host := ipKeyPair.IP
++	if host == nil {
++		// cilium_health ep always have nil host - force default behavior
++		return true
++	}
++	return host.Equal(nodeIPv4)
++}
++
++func (ipc *IPCache) checkLxcMapRelation(ip string, hostIP, oldHostIP net.IP) {
++	if hostIP.Equal(oldHostIP) {
++		return
++	}
++
++	hostIP4 := hostIP.To4()
++	if hostIP4 == nil {
++		return
++	}
++
++	lxc, exist := ipc.ipToEndpointInfo[ip]
++	if !exist {
++		return
++	}
++
++	nodeIPv4 := node.GetIPv4()
++	isLocal := nodeIPv4.Equal(hostIP4)
++	if isLocal && !lxc.active {
++		LXCMap().Update(lxc.key, lxc.info)
++		lxc.active = true
++		log.WithFields(logrus.Fields{
++			logfields.IPAddr: ip,
++		}).Debug("restore record in in cilium_lxc map")
++	} else if !isLocal && lxc.active {
++		LXCMap().Delete(lxc.key)
++		lxc.active = false
++		log.WithFields(logrus.Fields{
++			logfields.IPAddr: ip,
++		}).Debug("hiding record in in cilium_lxc map")
++	}
++}
++
++func getEndpointAddress(v *EndpointKey) string {
++	ip := v.ToIP()
++	if ip == nil {
++		return ""
++	}
++
++	ip4 := ip.To4()
++	if ip4 == nil {
++		return ""
++	}
++
++	return ip4.String()
++}
++
 +func LXCMap() *bpf.Map {
 +	lxcMapOnce.Do(func() {
 +		lxcMap = bpf.NewMap(MapName,
@@ -550,7 +697,7 @@ index 34e46fba68..4325fbc6b3 100644
 +	// namespace
 +	EndpointFlagAtHostNS = 2
  )
-
+ 
 +// EndpointFrontend is the interface to implement for an object to synchronize
 +// with the endpoint BPF map.
 +type EndpointFrontend interface {
@@ -680,9 +827,36 @@ index 34e46fba68..4325fbc6b3 100644
 +	}
 +
 +	// FIXME: Revert on failure
++	nodeIPv4 := node.GetIPv4()
++	// for prevent race conditions between ipcache upsert method used common mutex
++	globalIPCache.Lock()
++	defer globalIPCache.Unlock()
 +	for _, v := range GetBPFKeys(f) {
-+		if err := LXCMap().Update(v, info); err != nil {
-+			return err
++
++		epAddr := getEndpointAddress(v)
++		if epAddr == "" {
++			continue
++		}
++
++		if globalIPCache.isIPCacheHostLocal(epAddr, nodeIPv4) {
++			if err := LXCMap().Update(v, info); err != nil {
++				return err
++			}
++			globalIPCache.ipToEndpointInfo[epAddr] = &LxcEndpointInfo{
++				key:    v,
++				info:   info,
++				active: true,
++			}
++		} else {
++			LXCMap().Delete(v)
++			globalIPCache.ipToEndpointInfo[epAddr] = &LxcEndpointInfo{
++				key:    v,
++				info:   info,
++				active: false,
++			}
++			log.WithFields(logrus.Fields{
++				logfields.IPAddr: epAddr,
++			}).Debug("hiding pod address in cilium_lxc map")
 +		}
 +	}
 +
@@ -712,6 +886,9 @@ index 34e46fba68..4325fbc6b3 100644
 +
 +// DeleteEntry deletes a single map entry
 +func DeleteEntry(ip net.IP) error {
++	globalIPCache.Lock()
++	defer globalIPCache.Unlock()
++	delete(globalIPCache.ipToEndpointInfo, ip.To4().String())
 +	return LXCMap().Delete(NewEndpointKey(ip))
 +}
 +
@@ -720,6 +897,10 @@ index 34e46fba68..4325fbc6b3 100644
 +func DeleteElement(f EndpointFrontend) []error {
 +	var errors []error
 +	for _, k := range GetBPFKeys(f) {
++		ip := getEndpointAddress(k)
++		globalIPCache.Lock()
++		delete(globalIPCache.ipToEndpointInfo, ip)
++		globalIPCache.Unlock()
 +		if err := LXCMap().Delete(k); err != nil {
 +			errors = append(errors, fmt.Errorf("Unable to delete key %v from %s: %w", k, bpf.MapPath(MapName), err))
 +		}
@@ -751,6 +932,127 @@ index 34e46fba68..4325fbc6b3 100644
  // Identity is the identity representation of an IP<->Identity cache.
  type Identity struct {
  	// Note: The ordering of these fields is optimized to reduce padding
+@@ -121,6 +467,7 @@ type IPCache struct {
+ 	identityToIPCache map[identity.NumericIdentity]map[string]struct{}
+ 	ipToHostIPCache   map[string]IPKeyPair
+ 	ipToK8sMetadata   map[string]K8sMetadata
++	ipToEndpointInfo  map[string]*LxcEndpointInfo
+ 
+ 	listeners []IPIdentityMappingListener
+ 
+@@ -165,6 +512,7 @@ func NewIPCache(c *Configuration) *IPCache {
+ 		identityToIPCache: map[identity.NumericIdentity]map[string]struct{}{},
+ 		ipToHostIPCache:   map[string]IPKeyPair{},
+ 		ipToK8sMetadata:   map[string]K8sMetadata{},
++		ipToEndpointInfo:  map[string]*LxcEndpointInfo{},
+ 		controllers:       controller.NewManager(),
+ 		namedPorts:        types.NewNamedPortMultiMap(),
+ 		metadata:          newMetadata(),
+@@ -444,6 +792,7 @@ func (ipc *IPCache) upsertLocked(
+ 
+ 	scopedLog.Debug("Upserting IP into ipcache layer")
+ 
++	ipc.checkLxcMapRelation(ip, hostIP, oldHostIP)
+ 	// Update both maps.
+ 	ipc.ipToIdentityCache[ip] = newIdentity
+ 	// Delete the old identity, if any.
+@@ -489,6 +838,13 @@ func (ipc *IPCache) upsertLocked(
+ 	return namedPortsChanged, nil
+ }
+ 
++func (ipc *IPCache) IsIPcacheOwner(IP string, source source.Source, namespace, name string) (isOwner bool) {
++	ipc.mutex.Lock()
++	defer ipc.mutex.Unlock()
++	k8sMeta := ipc.getK8sMetadata(IP)
++	return k8sMeta != nil && k8sMeta.Namespace == namespace && k8sMeta.PodName == name
++}
++
+ // DumpToListener dumps the entire contents of the IPCache by triggering
+ // the listener's "OnIPIdentityCacheChange" method for each entry in the cache.
+ func (ipc *IPCache) DumpToListener(listener IPIdentityMappingListener) {
+diff --git a/pkg/k8s/watchers/cilium_endpoint.go b/pkg/k8s/watchers/cilium_endpoint.go
+index 79a64a2543..126ee2d547 100644
+--- a/pkg/k8s/watchers/cilium_endpoint.go
++++ b/pkg/k8s/watchers/cilium_endpoint.go
+@@ -287,3 +287,18 @@ func (k *K8sCiliumEndpointsWatcher) endpointDeleted(endpoint *types.CiliumEndpoi
+ 	}
+ 	hubblemetrics.ProcessCiliumEndpointDeletion(endpoint)
+ }
++
++func (k *K8sCiliumEndpointsWatcher) endpointIsIPcacheOwner(c *types.CiliumEndpoint) bool {
++	isOwner := true
++	if c.Networking != nil {
++		for _, pair := range c.Networking.Addressing {
++			if pair.IPV4 != "" {
++				isOwner = k.ipcache.IsIPcacheOwner(pair.IPV4, source.CustomResource, c.Namespace, c.Name)
++				if !isOwner {
++					break
++				}
++			}
++		}
++	}
++	return isOwner
++}
+diff --git a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+index 8467720fb4..b2c02a7112 100644
+--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
++++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+@@ -19,6 +19,7 @@ import (
+ type endpointWatcher interface {
+ 	endpointUpdated(oldC, newC *types.CiliumEndpoint)
+ 	endpointDeleted(c *types.CiliumEndpoint)
++	endpointIsIPcacheOwner(c *types.CiliumEndpoint) bool
+ }
+ 
+ type localEndpointCache interface {
+@@ -154,13 +155,19 @@ func (cs *cesSubscriber) deleteCEPfromCES(CEPName, CESName string, c *types.Cili
+ 			"CEPName": CEPName,
+ 		}).Debug("CEP deleted, calling endpointDeleted")
+ 		cs.epWatcher.endpointDeleted(c)
+-	} else {
++	} else if cs.epWatcher.endpointIsIPcacheOwner(c) {
+ 		log.WithFields(logrus.Fields{
+ 			"CESName": CESName,
+ 			"CEPName": CEPName,
+ 		}).Debug("CEP deleted, other CEP exists, calling endpointUpdated")
+ 		cs.epWatcher.endpointUpdated(c, cep)
++	} else {
++		log.WithFields(logrus.Fields{
++			"CESName": CESName,
++			"CEPName": CEPName,
++		}).Debug("not last CEP deleted and CEP don't own ipcache, skip ipcache changes")
+ 	}
++
+ }
+ 
+ // addCEPwithCES insert CEP with CES to the map and triggers endpointUpdated.
+diff --git a/pkg/k8s/watchers/watcher.go b/pkg/k8s/watchers/watcher.go
+index 0f4947864e..1f306ba4aa 100644
+--- a/pkg/k8s/watchers/watcher.go
++++ b/pkg/k8s/watchers/watcher.go
+@@ -115,6 +115,7 @@ type ipcacheManager interface {
+ 	UpsertLabels(prefix netip.Prefix, lbls labels.Labels, src source.Source, resource ipcacheTypes.ResourceID)
+ 	RemoveLabelsExcluded(lbls labels.Labels, toExclude map[netip.Prefix]struct{}, resource ipcacheTypes.ResourceID)
+ 	DeleteOnMetadataMatch(IP string, source source.Source, namespace, name string) (namedPortsChanged bool)
++	IsIPcacheOwner(IP string, source source.Source, namespace, name string) (isOwner bool)
+ }
+ 
+ type K8sWatcher struct {
+diff --git a/pkg/labels/labels.go b/pkg/labels/labels.go
+index 92e91dd31a..172aa62aa1 100644
+--- a/pkg/labels/labels.go
++++ b/pkg/labels/labels.go
+@@ -81,6 +81,10 @@ const (
+ 	// IDNameUnknown is the label used to to identify an endpoint with an
+ 	// unknown identity.
+ 	IDNameUnknown = "unknown"
++
++	// IDNamePriority is the label used to set pod priority on shared ip4-address
++	// network access
++	IDNamePriority = "network.deckhouse.io/pod-common-ip-priority"
+ )
+ 
+ var (
 diff --git a/pkg/maps/bwmap/bwmap.go b/pkg/maps/bwmap/bwmap.go
 index 301d7c2c35..5d4049abe7 100644
 --- a/pkg/maps/bwmap/bwmap.go
@@ -763,7 +1065,7 @@ index 301d7c2c35..5d4049abe7 100644
 +	lxcmap "github.com/cilium/cilium/pkg/ipcache"
  	"github.com/cilium/cilium/pkg/time"
  )
-
+ 
 diff --git a/pkg/maps/lxcmap/doc.go b/pkg/maps/lxcmap/doc.go
 deleted file mode 100644
 index 01af96c4ad..0000000000
@@ -1037,407 +1339,6 @@ index deb81c9af0..0000000000
 -
 -	return m, nil
 -}
---
-2.34.1
-
-
-From e83477d0398e2970c39e96fbd9cbcd524560e4c1 Mon Sep 17 00:00:00 2001
-From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
-Date: Mon, 28 Apr 2025 19:11:08 +0300
-Subject: [PATCH 3/4] patch lxcmap|ipcache logic for shared ip4 between pods
-
-Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
----
- daemon/cmd/daemon.go                          |  13 +-
- pkg/ipcache/ipcache.go                        | 117 +++++++++++++++++-
- pkg/k8s/watchers/cilium_endpoint.go           |  15 +++
- .../cilium_endpoint_slice_subscriber.go       |   9 +-
- pkg/k8s/watchers/watcher.go                   |   1 +
- 5 files changed, 146 insertions(+), 9 deletions(-)
-
-diff --git a/daemon/cmd/daemon.go b/daemon/cmd/daemon.go
-index 8161060573..7c672f9dea 100644
---- a/daemon/cmd/daemon.go
-+++ b/daemon/cmd/daemon.go
-@@ -13,12 +13,6 @@ import (
- 	"runtime"
- 	"sync"
-
--	"github.com/cilium/hive/job"
--	"github.com/cilium/statedb"
--	"github.com/sirupsen/logrus"
--	"github.com/vishvananda/netlink"
--	"golang.org/x/sync/semaphore"
--
- 	"github.com/cilium/cilium/api/v1/models"
- 	health "github.com/cilium/cilium/cilium-health/launch"
- 	"github.com/cilium/cilium/daemon/cmd/cni"
-@@ -80,6 +74,11 @@ import (
- 	"github.com/cilium/cilium/pkg/status"
- 	"github.com/cilium/cilium/pkg/time"
- 	wireguard "github.com/cilium/cilium/pkg/wireguard/agent"
-+	"github.com/cilium/hive/job"
-+	"github.com/cilium/statedb"
-+	"github.com/sirupsen/logrus"
-+	"github.com/vishvananda/netlink"
-+	"golang.org/x/sync/semaphore"
- )
-
- const (
-@@ -411,6 +410,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
- 		maglevConfig:      params.MaglevConfig,
- 	}
-
-+	ipcache.SetGlobalIPCache(d.ipcache)
-+
- 	// initialize endpointRestoreComplete channel as soon as possible so that subsystems
- 	// can wait on it to get closed and not block forever if they happen so start
- 	// waiting when it is not yet initialized (which causes them to block forever).
-diff --git a/pkg/ipcache/ipcache.go b/pkg/ipcache/ipcache.go
-index 4325fbc6b3..4a29583038 100644
---- a/pkg/ipcache/ipcache.go
-+++ b/pkg/ipcache/ipcache.go
-@@ -27,6 +27,7 @@ import (
- 	"github.com/cilium/cilium/pkg/logging/logfields"
- 	"github.com/cilium/cilium/pkg/mac"
- 	"github.com/cilium/cilium/pkg/metrics"
-+	"github.com/cilium/cilium/pkg/node"
- 	"github.com/cilium/cilium/pkg/option"
- 	"github.com/cilium/cilium/pkg/source"
- 	"github.com/cilium/cilium/pkg/types"
-@@ -51,6 +52,74 @@ var (
- 	lxcMapOnce sync.Once
- )
-
-+type LxcEndpointInfo struct {
-+	key    *EndpointKey
-+	info   *EndpointInfo
-+	active bool
-+}
-+
-+var globalIPCache *IPCache
-+
-+func SetGlobalIPCache(ipcache *IPCache) {
-+	globalIPCache = ipcache
-+}
-+
-+func (ipc *IPCache) isIPCacheHostLocal(epAddr string, nodeIPv4 net.IP) bool {
-+	ipKeyPair := ipc.ipToHostIPCache[epAddr]
-+	host := ipKeyPair.IP
-+	if host == nil {
-+		// cilium_health ep always have nil host - force default behavior
-+		return true
-+	}
-+	return host.Equal(nodeIPv4)
-+}
-+
-+func (ipc *IPCache) checkLxcMapRelation(ip string, hostIP, oldHostIP net.IP) {
-+	if hostIP.Equal(oldHostIP) {
-+		return
-+	}
-+
-+	hostIP4 := hostIP.To4()
-+	if hostIP4 == nil {
-+		return
-+	}
-+
-+	lxc, exist := ipc.ipToEndpointInfo[ip]
-+	if !exist {
-+		return
-+	}
-+
-+	nodeIPv4 := node.GetIPv4()
-+	isLocal := nodeIPv4.Equal(hostIP4)
-+	if isLocal && !lxc.active {
-+		LXCMap().Update(lxc.key, lxc.info)
-+		lxc.active = true
-+		log.WithFields(logrus.Fields{
-+			logfields.IPAddr: ip,
-+		}).Debug("restore record in in cilium_lxc map")
-+	} else if !isLocal && lxc.active {
-+		LXCMap().Delete(lxc.key)
-+		lxc.active = false
-+		log.WithFields(logrus.Fields{
-+			logfields.IPAddr: ip,
-+		}).Debug("hiding record in in cilium_lxc map")
-+	}
-+}
-+
-+func getEndpointAddress(v *EndpointKey) string {
-+	ip := v.ToIP()
-+	if ip == nil {
-+		return ""
-+	}
-+
-+	ip4 := ip.To4()
-+	if ip4 == nil {
-+		return ""
-+	}
-+
-+	return ip4.String()
-+}
-+
- func LXCMap() *bpf.Map {
- 	lxcMapOnce.Do(func() {
- 		lxcMap = bpf.NewMap(MapName,
-@@ -203,9 +272,36 @@ func WriteEndpoint(f EndpointFrontend) error {
- 	}
-
- 	// FIXME: Revert on failure
-+	nodeIPv4 := node.GetIPv4()
-+	// for prevent race conditions between ipcache upsert method used common mutex
-+	globalIPCache.Lock()
-+	defer globalIPCache.Unlock()
- 	for _, v := range GetBPFKeys(f) {
--		if err := LXCMap().Update(v, info); err != nil {
--			return err
-+
-+		epAddr := getEndpointAddress(v)
-+		if epAddr == "" {
-+			continue
-+		}
-+
-+		if globalIPCache.isIPCacheHostLocal(epAddr, nodeIPv4) {
-+			if err := LXCMap().Update(v, info); err != nil {
-+				return err
-+			}
-+			globalIPCache.ipToEndpointInfo[epAddr] = &LxcEndpointInfo{
-+				key:    v,
-+				info:   info,
-+				active: true,
-+			}
-+		} else {
-+			LXCMap().Delete(v)
-+			globalIPCache.ipToEndpointInfo[epAddr] = &LxcEndpointInfo{
-+				key:    v,
-+				info:   info,
-+				active: false,
-+			}
-+			log.WithFields(logrus.Fields{
-+				logfields.IPAddr: epAddr,
-+			}).Debug("hiding pod address in cilium_lxc map")
- 		}
- 	}
-
-@@ -235,6 +331,9 @@ func SyncHostEntry(ip net.IP) (bool, error) {
-
- // DeleteEntry deletes a single map entry
- func DeleteEntry(ip net.IP) error {
-+	globalIPCache.Lock()
-+	defer globalIPCache.Unlock()
-+	delete(globalIPCache.ipToEndpointInfo, ip.To4().String())
- 	return LXCMap().Delete(NewEndpointKey(ip))
- }
-
-@@ -243,6 +342,10 @@ func DeleteEntry(ip net.IP) error {
- func DeleteElement(f EndpointFrontend) []error {
- 	var errors []error
- 	for _, k := range GetBPFKeys(f) {
-+		ip := getEndpointAddress(k)
-+		globalIPCache.Lock()
-+		delete(globalIPCache.ipToEndpointInfo, ip)
-+		globalIPCache.Unlock()
- 		if err := LXCMap().Delete(k); err != nil {
- 			errors = append(errors, fmt.Errorf("Unable to delete key %v from %s: %w", k, bpf.MapPath(MapName), err))
- 		}
-@@ -364,6 +467,7 @@ type IPCache struct {
- 	identityToIPCache map[identity.NumericIdentity]map[string]struct{}
- 	ipToHostIPCache   map[string]IPKeyPair
- 	ipToK8sMetadata   map[string]K8sMetadata
-+	ipToEndpointInfo  map[string]*LxcEndpointInfo
-
- 	listeners []IPIdentityMappingListener
-
-@@ -408,6 +512,7 @@ func NewIPCache(c *Configuration) *IPCache {
- 		identityToIPCache: map[identity.NumericIdentity]map[string]struct{}{},
- 		ipToHostIPCache:   map[string]IPKeyPair{},
- 		ipToK8sMetadata:   map[string]K8sMetadata{},
-+		ipToEndpointInfo:  map[string]*LxcEndpointInfo{},
- 		controllers:       controller.NewManager(),
- 		namedPorts:        types.NewNamedPortMultiMap(),
- 		metadata:          newMetadata(),
-@@ -687,6 +792,7 @@ func (ipc *IPCache) upsertLocked(
-
- 	scopedLog.Debug("Upserting IP into ipcache layer")
-
-+	ipc.checkLxcMapRelation(ip, hostIP, oldHostIP)
- 	// Update both maps.
- 	ipc.ipToIdentityCache[ip] = newIdentity
- 	// Delete the old identity, if any.
-@@ -732,6 +838,13 @@ func (ipc *IPCache) upsertLocked(
- 	return namedPortsChanged, nil
- }
-
-+func (ipc *IPCache) IsIPcacheOwner(IP string, source source.Source, namespace, name string) (isOwner bool) {
-+	ipc.mutex.Lock()
-+	defer ipc.mutex.Unlock()
-+	k8sMeta := ipc.getK8sMetadata(IP)
-+	return k8sMeta != nil && k8sMeta.Namespace == namespace && k8sMeta.PodName == name
-+}
-+
- // DumpToListener dumps the entire contents of the IPCache by triggering
- // the listener's "OnIPIdentityCacheChange" method for each entry in the cache.
- func (ipc *IPCache) DumpToListener(listener IPIdentityMappingListener) {
-diff --git a/pkg/k8s/watchers/cilium_endpoint.go b/pkg/k8s/watchers/cilium_endpoint.go
-index 79a64a2543..126ee2d547 100644
---- a/pkg/k8s/watchers/cilium_endpoint.go
-+++ b/pkg/k8s/watchers/cilium_endpoint.go
-@@ -287,3 +287,18 @@ func (k *K8sCiliumEndpointsWatcher) endpointDeleted(endpoint *types.CiliumEndpoi
- 	}
- 	hubblemetrics.ProcessCiliumEndpointDeletion(endpoint)
- }
-+
-+func (k *K8sCiliumEndpointsWatcher) endpointIsIPcacheOwner(c *types.CiliumEndpoint) bool {
-+	isOwner := true
-+	if c.Networking != nil {
-+		for _, pair := range c.Networking.Addressing {
-+			if pair.IPV4 != "" {
-+				isOwner = k.ipcache.IsIPcacheOwner(pair.IPV4, source.CustomResource, c.Namespace, c.Name)
-+				if !isOwner {
-+					break
-+				}
-+			}
-+		}
-+	}
-+	return isOwner
-+}
-diff --git a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
-index 8467720fb4..b2c02a7112 100644
---- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
-+++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
-@@ -19,6 +19,7 @@ import (
- type endpointWatcher interface {
- 	endpointUpdated(oldC, newC *types.CiliumEndpoint)
- 	endpointDeleted(c *types.CiliumEndpoint)
-+	endpointIsIPcacheOwner(c *types.CiliumEndpoint) bool
- }
-
- type localEndpointCache interface {
-@@ -154,13 +155,19 @@ func (cs *cesSubscriber) deleteCEPfromCES(CEPName, CESName string, c *types.Cili
- 			"CEPName": CEPName,
- 		}).Debug("CEP deleted, calling endpointDeleted")
- 		cs.epWatcher.endpointDeleted(c)
--	} else {
-+	} else if cs.epWatcher.endpointIsIPcacheOwner(c) {
- 		log.WithFields(logrus.Fields{
- 			"CESName": CESName,
- 			"CEPName": CEPName,
- 		}).Debug("CEP deleted, other CEP exists, calling endpointUpdated")
- 		cs.epWatcher.endpointUpdated(c, cep)
-+	} else {
-+		log.WithFields(logrus.Fields{
-+			"CESName": CESName,
-+			"CEPName": CEPName,
-+		}).Debug("not last CEP deleted and CEP don't own ipcache, skip ipcache changes")
- 	}
-+
- }
-
- // addCEPwithCES insert CEP with CES to the map and triggers endpointUpdated.
-diff --git a/pkg/k8s/watchers/watcher.go b/pkg/k8s/watchers/watcher.go
-index 0f4947864e..1f306ba4aa 100644
---- a/pkg/k8s/watchers/watcher.go
-+++ b/pkg/k8s/watchers/watcher.go
-@@ -115,6 +115,7 @@ type ipcacheManager interface {
- 	UpsertLabels(prefix netip.Prefix, lbls labels.Labels, src source.Source, resource ipcacheTypes.ResourceID)
- 	RemoveLabelsExcluded(lbls labels.Labels, toExclude map[netip.Prefix]struct{}, resource ipcacheTypes.ResourceID)
- 	DeleteOnMetadataMatch(IP string, source source.Source, namespace, name string) (namedPortsChanged bool)
-+	IsIPcacheOwner(IP string, source source.Source, namespace, name string) (isOwner bool)
- }
-
- type K8sWatcher struct {
---
-2.34.1
-
-
-From 43e08b3d64aeacd3fa104337668e06412ae70d97 Mon Sep 17 00:00:00 2001
-From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
-Date: Mon, 5 May 2025 14:20:37 +0300
-Subject: [PATCH 4/4] force slice update when new VM ready
-
-Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
----
- .../pkg/ciliumendpointslice/endpointslice.go  | 25 +++++++++----------
- 1 file changed, 12 insertions(+), 13 deletions(-)
-
-diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 66159bcaa5..8e11d9d7ff 100644
---- a/operator/pkg/ciliumendpointslice/endpointslice.go
-+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
-@@ -277,15 +277,14 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
- 		return
- 	}
-
--	// TODO use delay
--	oldOwner, _, newOwner := filter.filterAddressByPriority(cep)
-+	oldOwner, delay, newOwner := filter.filterAddressByPriority(cep)
- 	if oldOwner != nil {
- 		touchedCESs := c.manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(oldOwner), oldOwner.Namespace)
--		c.enqueueCESReconciliation(touchedCESs)
-+		c.enqueueCESReconciliation(touchedCESs, delay)
- 	}
-
- 	touchedCESs := c.manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(newOwner), newOwner.Namespace)
--	c.enqueueCESReconciliation(touchedCESs)
-+	c.enqueueCESReconciliation(touchedCESs, delay)
- }
-
- func (c *Controller) onEndpointDelete(cep *cilium_api_v2.CiliumEndpoint) {
-@@ -293,29 +292,29 @@ func (c *Controller) onEndpointDelete(cep *cilium_api_v2.CiliumEndpoint) {
-
- 	if hiddenCep != nil {
- 		touchedCESs := c.manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(hiddenCep), hiddenCep.Namespace)
--		c.enqueueCESReconciliation(touchedCESs)
-+		c.enqueueCESReconciliation(touchedCESs, DefaultCESSyncTime)
- 	}
-
- 	touchedCES := c.manager.RemoveCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
--	c.enqueueCESReconciliation([]CESKey{touchedCES})
-+	c.enqueueCESReconciliation([]CESKey{touchedCES}, DefaultCESSyncTime)
- }
-
- func (c *Controller) onSliceUpdate(ces *capi_v2a1.CiliumEndpointSlice) {
--	c.enqueueCESReconciliation([]CESKey{NewCESKey(ces.Name, ces.Namespace)})
-+	c.enqueueCESReconciliation([]CESKey{NewCESKey(ces.Name, ces.Namespace)}, DefaultCESSyncTime)
- }
-
- func (c *Controller) onSliceDelete(ces *capi_v2a1.CiliumEndpointSlice) {
--	c.enqueueCESReconciliation([]CESKey{NewCESKey(ces.Name, ces.Namespace)})
-+	c.enqueueCESReconciliation([]CESKey{NewCESKey(ces.Name, ces.Namespace)}, DefaultCESSyncTime)
- }
-
--func (c *Controller) addToQueue(ces CESKey) {
-+func (c *Controller) addToQueue(ces CESKey, delay time.Duration) {
- 	c.priorityNamespacesLock.RLock()
- 	_, exists := c.priorityNamespaces[ces.Namespace]
- 	c.priorityNamespacesLock.RUnlock()
--	time.AfterFunc(c.syncDelay, func() {
-+	time.AfterFunc(delay, func() {
- 		c.cond.L.Lock()
- 		defer c.cond.L.Unlock()
--		if exists {
-+		if exists || delay == ForceCESSyncTime {
- 			c.fastQueue.Add(ces)
- 		} else {
- 			c.standardQueue.Add(ces)
-@@ -326,7 +325,7 @@ func (c *Controller) addToQueue(ces CESKey) {
-
- }
-
--func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
-+func (c *Controller) enqueueCESReconciliation(cess []CESKey, delay time.Duration) {
- 	for _, ces := range cess {
- 		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
- 		if ces.Name != "" {
-@@ -335,7 +334,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
- 				c.enqueuedAt[ces] = time.Now()
- 			}
- 			c.enqueuedAtLock.Unlock()
--			c.addToQueue(ces)
-+			c.addToQueue(ces, delay)
- 		}
- 	}
- }
---
+-- 
 2.34.1
 

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From b8ae25a0562040df25d3661f593fb15c3bd0545b Mon Sep 17 00:00:00 2001
+From 87c5164e03ec598e758f13c9aca0f106bbb94019 Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -170,7 +170,7 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..6a75bf3bc7 100644
+index 3b3ffc13ef..8f65a5b003 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,8 +6,12 @@ package ciliumendpointslice
@@ -351,7 +351,7 @@ index 3b3ffc13ef..6a75bf3bc7 100644
 +			oldOwner = currentOwner
 +			fmt.Printf("DEBUG !isOwner && isHighest old, new: %v %v\n", oldOwner, newOwner)
 +		} else { // !isOwner && !isHighest
-+			cep.Status.Networking.Addressing = emptyAddrList
++			ccep.ccep.Networking.Addressing = emptyAddrList
 +			fmt.Printf("DEBUG !isOwner && !isHighest old, new: %v %v\n", oldOwner, newOwner)
 +		}
 +	} else {
@@ -444,7 +444,7 @@ index 3b3ffc13ef..6a75bf3bc7 100644
 +
 +	touchedCESs := c.manager.UpdateCEPMapping(newOwner.ccep, newOwner.ns)
 +	c.enqueueCESReconciliation(touchedCESs, delay)
-+	fmt.Printf("DEBUG onEndpointDelete %v, %p, %v\n", cep.Name, cep, cep.Status.Networking.Addressing)
++	fmt.Printf("DEBUG onEndpointUpdate %v, %p, %v\n", cep.Name, cep, cep.Status.Networking.Addressing)
  }
  
  func (c *Controller) onEndpointDelete(cep *cilium_api_v2.CiliumEndpoint) {

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From 9260204adc447af1313f960aac30d3230d215ce0 Mon Sep 17 00:00:00 2001
+From 33a0e3e138ac8581a1eb9c29694f6b9ec7189423 Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -12,7 +12,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  daemon/cmd/hostips-sync.go                    |   2 +-
  daemon/cmd/state.go                           |   2 +-
  daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  | 264 ++++++++++++-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 266 ++++++++++++-
  operator/watchers/cilium_endpoint.go          |   1 +
  pkg/datapath/alignchecker/alignchecker.go     |   2 +-
  pkg/datapath/linux/config/config.go           |   2 +-
@@ -25,7 +25,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  pkg/maps/bwmap/bwmap.go                       |   2 +-
  pkg/maps/lxcmap/doc.go                        |   9 -
  pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
- 20 files changed, 656 insertions(+), 288 deletions(-)
+ 20 files changed, 658 insertions(+), 288 deletions(-)
  delete mode 100644 pkg/maps/lxcmap/doc.go
  delete mode 100644 pkg/maps/lxcmap/lxcmap.go
 
@@ -170,7 +170,7 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..3ea4482de1 100644
+index 3b3ffc13ef..b59350c817 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,6 +6,9 @@ package ciliumendpointslice
@@ -191,7 +191,7 @@ index 3b3ffc13ef..3ea4482de1 100644
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
  
-@@ -49,10 +53,230 @@ const (
+@@ -49,10 +53,232 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
  
@@ -256,6 +256,8 @@ index 3b3ffc13ef..3ea4482de1 100644
 +
 +func getCepAddressPair(cep *cilium_api_v2.CiliumEndpoint) cilium_api_v2.AddressPair {
 +	var shared cilium_api_v2.AddressPair
++	fmt.Printf("DEBUG getCepAddressPair addr: %p", cep)
++	fmt.Printf("DEBUG getCepAddressPair cep name: %v", cep.Name)
 +	fmt.Printf("DEBUG getCepAddressPair: %v", cep.Status.Networking.Addressing)
 +	for _, pair := range cep.Status.Networking.Addressing {
 +		if pair.IPV4 == "" {
@@ -422,7 +424,7 @@ index 3b3ffc13ef..3ea4482de1 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,31 +297,46 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +299,46 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
@@ -477,7 +479,7 @@ index 3b3ffc13ef..3ea4482de1 100644
  			c.fastQueue.Add(ces)
  		} else {
  			c.standardQueue.Add(ces)
-@@ -108,7 +347,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+@@ -108,7 +349,7 @@ func (c *Controller) addToQueue(ces CESKey) {
  
  }
  
@@ -486,7 +488,7 @@ index 3b3ffc13ef..3ea4482de1 100644
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {
-@@ -117,7 +356,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+@@ -117,7 +358,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
  				c.enqueuedAt[ces] = time.Now()
  			}
  			c.enqueuedAtLock.Unlock()
@@ -495,7 +497,7 @@ index 3b3ffc13ef..3ea4482de1 100644
  		}
  	}
  }
-@@ -186,6 +425,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+@@ -186,6 +427,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From 1d0a465d291beec75bc2bf2220c85fca19e57dfb Mon Sep 17 00:00:00 2001
+From c91c123a894c302611f07057ffe373d29fea0dbf Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -12,7 +12,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  daemon/cmd/hostips-sync.go                    |   2 +-
  daemon/cmd/state.go                           |   2 +-
  daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  | 250 +++++++++++-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 253 ++++++++++++-
  operator/watchers/cilium_endpoint.go          |   1 +
  pkg/datapath/alignchecker/alignchecker.go     |   2 +-
  pkg/datapath/linux/config/config.go           |   2 +-
@@ -25,7 +25,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  pkg/maps/bwmap/bwmap.go                       |   2 +-
  pkg/maps/lxcmap/doc.go                        |   9 -
  pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
- 20 files changed, 642 insertions(+), 288 deletions(-)
+ 20 files changed, 645 insertions(+), 288 deletions(-)
  delete mode 100644 pkg/maps/lxcmap/doc.go
  delete mode 100644 pkg/maps/lxcmap/lxcmap.go
 
@@ -170,7 +170,7 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..ced1f484b8 100644
+index 3b3ffc13ef..a198b423b8 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,6 +6,9 @@ package ciliumendpointslice
@@ -191,7 +191,7 @@ index 3b3ffc13ef..ced1f484b8 100644
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
  
-@@ -49,10 +53,216 @@ const (
+@@ -49,10 +53,219 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
  
@@ -291,6 +291,9 @@ index 3b3ffc13ef..ced1f484b8 100644
 +		highest := &info
 +		if len(cepList) > 1 {
 +			fmt.Printf("DEBUG len(cepList) > 1: %v\n", cepList)
++			for i := range cepList {
++				fmt.Printf("DEBUG ELEMS index, cep: %v %v\n", i, cepList[i].cep)
++			}
 +		}
 +
 +		currentOwner := cepList[0].cep
@@ -408,7 +411,7 @@ index 3b3ffc13ef..ced1f484b8 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,31 +283,46 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +286,46 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
@@ -463,7 +466,7 @@ index 3b3ffc13ef..ced1f484b8 100644
  			c.fastQueue.Add(ces)
  		} else {
  			c.standardQueue.Add(ces)
-@@ -108,7 +333,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+@@ -108,7 +336,7 @@ func (c *Controller) addToQueue(ces CESKey) {
  
  }
  
@@ -472,7 +475,7 @@ index 3b3ffc13ef..ced1f484b8 100644
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {
-@@ -117,7 +342,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+@@ -117,7 +345,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
  				c.enqueuedAt[ces] = time.Now()
  			}
  			c.enqueuedAtLock.Unlock()
@@ -481,7 +484,7 @@ index 3b3ffc13ef..ced1f484b8 100644
  		}
  	}
  }
-@@ -186,6 +411,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+@@ -186,6 +414,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From 14dd565d43b65b41a5aa7c9f020712359da878b7 Mon Sep 17 00:00:00 2001
+From b8ae25a0562040df25d3661f593fb15c3bd0545b Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -12,7 +12,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  daemon/cmd/hostips-sync.go                    |   2 +-
  daemon/cmd/state.go                           |   2 +-
  daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  | 270 ++++++++++++-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 271 ++++++++++++-
  operator/watchers/cilium_endpoint.go          |   1 +
  pkg/datapath/alignchecker/alignchecker.go     |   2 +-
  pkg/datapath/linux/config/config.go           |   2 +-
@@ -25,7 +25,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  pkg/maps/bwmap/bwmap.go                       |   2 +-
  pkg/maps/lxcmap/doc.go                        |   9 -
  pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
- 20 files changed, 662 insertions(+), 288 deletions(-)
+ 20 files changed, 663 insertions(+), 288 deletions(-)
  delete mode 100644 pkg/maps/lxcmap/doc.go
  delete mode 100644 pkg/maps/lxcmap/lxcmap.go
 
@@ -170,7 +170,7 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..c9a799cc38 100644
+index 3b3ffc13ef..6a75bf3bc7 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,8 +6,12 @@ package ciliumendpointslice
@@ -194,7 +194,7 @@ index 3b3ffc13ef..c9a799cc38 100644
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
  
-@@ -49,10 +54,233 @@ const (
+@@ -49,10 +54,234 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
  
@@ -264,7 +264,7 @@ index 3b3ffc13ef..c9a799cc38 100644
 +
 +func getCepAddressPair(cep *cilium_api_v2.CiliumEndpoint) cilium_api_v2.AddressPair {
 +	var shared cilium_api_v2.AddressPair
-+	fmt.Printf("DEBUG getCepAddressPair %v, %p, %v", cep.Name, cep, cep.Status.Networking.Addressing)
++	fmt.Printf("DEBUG getCepAddressPair %v, %p, %v\n", cep.Name, cep, cep.Status.Networking.Addressing)
 +	for _, pair := range cep.Status.Networking.Addressing {
 +		if pair.IPV4 == "" {
 +			continue
@@ -335,6 +335,7 @@ index 3b3ffc13ef..c9a799cc38 100644
 +		isHighest := equalCeps(ccep, highest.cep)
 +		if isOwner && isHighest {
 +			// just skip
++			fmt.Printf("DEBUG isOwner && isHighest new: %v\n", newOwner)
 +		} else if isOwner && !isHighest {
 +			ccep.ccep.Networking.Addressing = emptyAddrList
 +			addr := &cilium_api_v2.AddressPair{
@@ -428,7 +429,7 @@ index 3b3ffc13ef..c9a799cc38 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,31 +301,48 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +302,48 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
@@ -443,7 +444,7 @@ index 3b3ffc13ef..c9a799cc38 100644
 +
 +	touchedCESs := c.manager.UpdateCEPMapping(newOwner.ccep, newOwner.ns)
 +	c.enqueueCESReconciliation(touchedCESs, delay)
-+	fmt.Printf("DEBUG onEndpointDelete %v, %p, %v", cep.Name, cep, cep.Status.Networking.Addressing)
++	fmt.Printf("DEBUG onEndpointDelete %v, %p, %v\n", cep.Name, cep, cep.Status.Networking.Addressing)
  }
  
  func (c *Controller) onEndpointDelete(cep *cilium_api_v2.CiliumEndpoint) {
@@ -458,7 +459,7 @@ index 3b3ffc13ef..c9a799cc38 100644
  	touchedCES := c.manager.RemoveCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
 -	c.enqueueCESReconciliation([]CESKey{touchedCES})
 +	c.enqueueCESReconciliation([]CESKey{touchedCES}, DefaultCESSyncTime)
-+	fmt.Printf("DEBUG onEndpointDelete %v, %p, %v", cep.Name, cep, cep.Status.Networking.Addressing)
++	fmt.Printf("DEBUG onEndpointDelete %v, %p, %v\n", cep.Name, cep, cep.Status.Networking.Addressing)
  }
  
  func (c *Controller) onSliceUpdate(ces *capi_v2a1.CiliumEndpointSlice) {
@@ -485,7 +486,7 @@ index 3b3ffc13ef..c9a799cc38 100644
  			c.fastQueue.Add(ces)
  		} else {
  			c.standardQueue.Add(ces)
-@@ -108,7 +353,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+@@ -108,7 +354,7 @@ func (c *Controller) addToQueue(ces CESKey) {
  
  }
  
@@ -494,7 +495,7 @@ index 3b3ffc13ef..c9a799cc38 100644
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {
-@@ -117,7 +362,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+@@ -117,7 +363,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
  				c.enqueuedAt[ces] = time.Now()
  			}
  			c.enqueuedAtLock.Unlock()
@@ -503,7 +504,7 @@ index 3b3ffc13ef..c9a799cc38 100644
  		}
  	}
  }
-@@ -186,6 +431,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+@@ -186,6 +432,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From e47adb672b3d81deca1d78fec9177672deb8e476 Mon Sep 17 00:00:00 2001
+From 14dd565d43b65b41a5aa7c9f020712359da878b7 Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -12,7 +12,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  daemon/cmd/hostips-sync.go                    |   2 +-
  daemon/cmd/state.go                           |   2 +-
  daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  | 267 ++++++++++++-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 270 ++++++++++++-
  operator/watchers/cilium_endpoint.go          |   1 +
  pkg/datapath/alignchecker/alignchecker.go     |   2 +-
  pkg/datapath/linux/config/config.go           |   2 +-
@@ -25,7 +25,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  pkg/maps/bwmap/bwmap.go                       |   2 +-
  pkg/maps/lxcmap/doc.go                        |   9 -
  pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
- 20 files changed, 659 insertions(+), 288 deletions(-)
+ 20 files changed, 662 insertions(+), 288 deletions(-)
  delete mode 100644 pkg/maps/lxcmap/doc.go
  delete mode 100644 pkg/maps/lxcmap/lxcmap.go
 
@@ -170,7 +170,7 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..75037c933e 100644
+index 3b3ffc13ef..c9a799cc38 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,8 +6,12 @@ package ciliumendpointslice
@@ -194,7 +194,7 @@ index 3b3ffc13ef..75037c933e 100644
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
  
-@@ -49,10 +54,232 @@ const (
+@@ -49,10 +54,233 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
  
@@ -264,6 +264,7 @@ index 3b3ffc13ef..75037c933e 100644
 +
 +func getCepAddressPair(cep *cilium_api_v2.CiliumEndpoint) cilium_api_v2.AddressPair {
 +	var shared cilium_api_v2.AddressPair
++	fmt.Printf("DEBUG getCepAddressPair %v, %p, %v", cep.Name, cep, cep.Status.Networking.Addressing)
 +	for _, pair := range cep.Status.Networking.Addressing {
 +		if pair.IPV4 == "" {
 +			continue
@@ -427,7 +428,7 @@ index 3b3ffc13ef..75037c933e 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,31 +300,46 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +301,48 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
@@ -442,6 +443,7 @@ index 3b3ffc13ef..75037c933e 100644
 +
 +	touchedCESs := c.manager.UpdateCEPMapping(newOwner.ccep, newOwner.ns)
 +	c.enqueueCESReconciliation(touchedCESs, delay)
++	fmt.Printf("DEBUG onEndpointDelete %v, %p, %v", cep.Name, cep, cep.Status.Networking.Addressing)
  }
  
  func (c *Controller) onEndpointDelete(cep *cilium_api_v2.CiliumEndpoint) {
@@ -456,6 +458,7 @@ index 3b3ffc13ef..75037c933e 100644
  	touchedCES := c.manager.RemoveCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
 -	c.enqueueCESReconciliation([]CESKey{touchedCES})
 +	c.enqueueCESReconciliation([]CESKey{touchedCES}, DefaultCESSyncTime)
++	fmt.Printf("DEBUG onEndpointDelete %v, %p, %v", cep.Name, cep, cep.Status.Networking.Addressing)
  }
  
  func (c *Controller) onSliceUpdate(ces *capi_v2a1.CiliumEndpointSlice) {
@@ -482,7 +485,7 @@ index 3b3ffc13ef..75037c933e 100644
  			c.fastQueue.Add(ces)
  		} else {
  			c.standardQueue.Add(ces)
-@@ -108,7 +350,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+@@ -108,7 +353,7 @@ func (c *Controller) addToQueue(ces CESKey) {
  
  }
  
@@ -491,7 +494,7 @@ index 3b3ffc13ef..75037c933e 100644
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {
-@@ -117,7 +359,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+@@ -117,7 +362,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
  				c.enqueuedAt[ces] = time.Now()
  			}
  			c.enqueuedAtLock.Unlock()
@@ -500,7 +503,7 @@ index 3b3ffc13ef..75037c933e 100644
  		}
  	}
  }
-@@ -186,6 +428,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+@@ -186,6 +431,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From fbbbf022d02a049325c0544d1a7a3d1cef1af7c8 Mon Sep 17 00:00:00 2001
+From 9260204adc447af1313f960aac30d3230d215ce0 Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -12,7 +12,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  daemon/cmd/hostips-sync.go                    |   2 +-
  daemon/cmd/state.go                           |   2 +-
  daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  | 263 ++++++++++++-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 264 ++++++++++++-
  operator/watchers/cilium_endpoint.go          |   1 +
  pkg/datapath/alignchecker/alignchecker.go     |   2 +-
  pkg/datapath/linux/config/config.go           |   2 +-
@@ -25,7 +25,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  pkg/maps/bwmap/bwmap.go                       |   2 +-
  pkg/maps/lxcmap/doc.go                        |   9 -
  pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
- 20 files changed, 655 insertions(+), 288 deletions(-)
+ 20 files changed, 656 insertions(+), 288 deletions(-)
  delete mode 100644 pkg/maps/lxcmap/doc.go
  delete mode 100644 pkg/maps/lxcmap/lxcmap.go
 
@@ -170,7 +170,7 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..8152e7186c 100644
+index 3b3ffc13ef..3ea4482de1 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,6 +6,9 @@ package ciliumendpointslice
@@ -191,7 +191,7 @@ index 3b3ffc13ef..8152e7186c 100644
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
  
-@@ -49,10 +53,229 @@ const (
+@@ -49,10 +53,230 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
  
@@ -256,6 +256,7 @@ index 3b3ffc13ef..8152e7186c 100644
 +
 +func getCepAddressPair(cep *cilium_api_v2.CiliumEndpoint) cilium_api_v2.AddressPair {
 +	var shared cilium_api_v2.AddressPair
++	fmt.Printf("DEBUG getCepAddressPair: %v", cep.Status.Networking.Addressing)
 +	for _, pair := range cep.Status.Networking.Addressing {
 +		if pair.IPV4 == "" {
 +			continue
@@ -421,7 +422,7 @@ index 3b3ffc13ef..8152e7186c 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,31 +296,46 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +297,46 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
@@ -476,7 +477,7 @@ index 3b3ffc13ef..8152e7186c 100644
  			c.fastQueue.Add(ces)
  		} else {
  			c.standardQueue.Add(ces)
-@@ -108,7 +346,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+@@ -108,7 +347,7 @@ func (c *Controller) addToQueue(ces CESKey) {
  
  }
  
@@ -485,7 +486,7 @@ index 3b3ffc13ef..8152e7186c 100644
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {
-@@ -117,7 +355,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+@@ -117,7 +356,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
  				c.enqueuedAt[ces] = time.Now()
  			}
  			c.enqueuedAtLock.Unlock()
@@ -494,7 +495,7 @@ index 3b3ffc13ef..8152e7186c 100644
  		}
  	}
  }
-@@ -186,6 +424,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+@@ -186,6 +425,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From 85312cb90e9dcc35b80259f86b9f9ddf9f185a43 Mon Sep 17 00:00:00 2001
+From 1df52fd9ad70c3d2a5d5b2fd1c3a8872bf81431e Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -12,7 +12,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  daemon/cmd/hostips-sync.go                    |   2 +-
  daemon/cmd/state.go                           |   2 +-
  daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  | 329 +++++++++++++++-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 310 ++++++++++++++-
  .../pkg/ciliumendpointslice/reconciler.go     |   3 +-
  operator/watchers/cilium_endpoint.go          |   1 +
  pkg/datapath/alignchecker/alignchecker.go     |   2 +-
@@ -26,7 +26,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  pkg/maps/bwmap/bwmap.go                       |   2 +-
  pkg/maps/lxcmap/doc.go                        |   9 -
  pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
- 21 files changed, 722 insertions(+), 290 deletions(-)
+ 21 files changed, 703 insertions(+), 290 deletions(-)
  delete mode 100644 pkg/maps/lxcmap/doc.go
  delete mode 100644 pkg/maps/lxcmap/lxcmap.go
 
@@ -171,10 +171,10 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..6ec472c946 100644
+index 3b3ffc13ef..c039e922ac 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
-@@ -6,8 +6,13 @@ package ciliumendpointslice
+@@ -6,8 +6,14 @@ package ciliumendpointslice
  import (
  	"context"
  	"fmt"
@@ -185,10 +185,11 @@ index 3b3ffc13ef..6ec472c946 100644
  
 +	cilium_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 +	"github.com/cilium/cilium/pkg/lock"
++	"github.com/cilium/cilium/pkg/logging"
  	"github.com/cilium/hive/cell"
  	"github.com/cilium/hive/job"
  	"github.com/cilium/workerpool"
-@@ -18,6 +23,7 @@ import (
+@@ -18,6 +24,7 @@ import (
  	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
  	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
  	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -196,7 +197,7 @@ index 3b3ffc13ef..6ec472c946 100644
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
  
-@@ -49,10 +55,289 @@ const (
+@@ -49,10 +56,274 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
  
@@ -249,6 +250,7 @@ index 3b3ffc13ef..6ec472c946 100644
 +}
 +
 +var filter priorityFilter
++var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "filter")
 +
 +func getCepPriority(cep *cilium_api_v2.CiliumEndpoint) cepPriority {
 +	var priority cepPriority = Default
@@ -275,7 +277,6 @@ index 3b3ffc13ef..6ec472c946 100644
 +
 +func getCepAddressPair(cep *cilium_api_v2.CiliumEndpoint) cilium_api_v2.AddressPair {
 +	var shared cilium_api_v2.AddressPair
-+	fmt.Printf("DEBUG getCepAddressPair %v, %p, %v\n", cep.Name, cep, cep.Status.Networking.Addressing)
 +	for _, pair := range cep.Status.Networking.Addressing {
 +		if pair.IPV4 == "" {
 +			continue
@@ -292,11 +293,13 @@ index 3b3ffc13ef..6ec472c946 100644
 +
 +	shared := getCepAddressPair(cep)
 +	if shared.IPV4 == "" {
++		log.Warn("CEP have not address", logfields.CEPName, cep.Name)
 +		return nil
 +	}
 +
 +	cepList, exist := c.ipToCepList[shared.IPV4]
 +	if !exist {
++		log.Warn("CEP not found in filter map", logfields.CEPName, cep.Name)
 +		return nil
 +	}
 +
@@ -311,11 +314,7 @@ index 3b3ffc13ef..6ec472c946 100644
 +}
 +
 +func FilterGetCoreCiliumEndpoint(cep *cilium_api_v2.CiliumEndpoint) *cilium_v2alpha1.CoreCiliumEndpoint {
-+	ccep := filter.getCoreCiliumEndpoint(cep)
-+	if ccep != nil {
-+		fmt.Printf("DEBUG FilterGetCoreCiliumEndpoint: %v %v\n", ccep.Name, ccep.Networking.Addressing)
-+	}
-+	return ccep
++	return filter.getCoreCiliumEndpoint(cep)
 +}
 +
 +// WARNING this update logic will work only if CEP(new and old) network addresses is not changed !!!
@@ -336,27 +335,22 @@ index 3b3ffc13ef..6ec472c946 100644
 +
 +	shared := getCepAddressPair(cep)
 +	if shared.IPV4 == "" {
++		log.Warn("CEP have not address", logfields.CEPName, cep.Name)
 +		return oldOwner, delay, newOwner
 +	}
 +
 +	priority := getCepPriority(cep)
-+
 +	info := coreCiliumEndpointInfo{
 +		cep:      ccep,
 +		priority: priority,
 +	}
-+
-+	defer fmt.Printf("DEBUG FILTER len(c.ipToCepList[shared.IPV4]) = %v\n", len(c.ipToCepList[shared.IPV4]))
 +
 +	if cepList, exist := c.ipToCepList[shared.IPV4]; exist {
 +		isInserted := false
 +		// new cep will have higher priority than old ceps with same priority
 +		highest := &info
 +		currentOwner := cepList[0].cep
-+		fmt.Printf("DEBUG filterAddressByPriority 111\n")
 +		for i := range cepList {
-+			fmt.Printf("DEBUG range cepList cep: %v,,, %v\n", cepList[i].cep.ccep.Name, cepList[i].cep.ccep.Networking.Addressing)
-+			fmt.Printf("DEBUG filterAddressByPriority 222\n")
 +			if len(cepList[i].cep.ccep.Networking.Addressing) != 0 {
 +				currentOwner = cepList[i].cep
 +			}
@@ -379,7 +373,6 @@ index 3b3ffc13ef..6ec472c946 100644
 +			}
 +			c.ipToCepList[shared.IPV4] = append(cepList, info)
 +		}
-+		fmt.Printf("DEBUG filterAddressByPriority 333\n")
 +		// possibly cases:
 +		// 1) income cep is highest and already ip4 owner(only update income cep)
 +		// 2) income cep is highest and replace other owner cep(hide ip4 address for previous owner and make owner income cep)
@@ -390,7 +383,7 @@ index 3b3ffc13ef..6ec472c946 100644
 +		isHighest := equalCeps(ccep, highest.cep)
 +		if isOwner && isHighest {
 +			// just skip
-+			fmt.Printf("DEBUG isOwner && isHighest new: %v\n", newOwner)
++			log.Debug("CEP is already address owner", logfields.CEPName, newOwner.ccep.Name)
 +		} else if isOwner && !isHighest {
 +			ccep.ccep.Networking.Addressing = emptyAddrList
 +			addr := &cilium_api_v2.AddressPair{
@@ -400,14 +393,14 @@ index 3b3ffc13ef..6ec472c946 100644
 +			highest.cep.ccep.Networking.Addressing = append(emptyAddrList, addr)
 +			oldOwner = ccep
 +			newOwner = highest.cep
-+			fmt.Printf("DEBUG isOwner && !isHighest old, new: %v %v\n", oldOwner.ccep.Name, newOwner.ccep.Name)
++			log.Debug("CEP loses ownership of address", logfields.CEPName, oldOwner.ccep.Name, newOwner.ccep.Name)
 +		} else if !isOwner && isHighest {
 +			currentOwner.ccep.Networking.Addressing = emptyAddrList
 +			oldOwner = currentOwner
-+			fmt.Printf("DEBUG !isOwner && isHighest old, new: %v %v\n", oldOwner.ccep.Name, newOwner.ccep.Name)
++			log.Debug("CEP takes ownership of address", logfields.CEPName, newOwner.ccep.Name, oldOwner.ccep.Name)
 +		} else { // !isOwner && !isHighest
 +			ccep.ccep.Networking.Addressing = emptyAddrList
-+			fmt.Printf("DEBUG !isOwner && !isHighest old, new: %v %v\n", newOwner.ccep.Name)
++			log.Debug("CEP is not address owner", logfields.CEPName, newOwner.ccep.Name)
 +		}
 +	} else {
 +		c.ipToCepList[shared.IPV4] = []coreCiliumEndpointInfo{info}
@@ -423,17 +416,15 @@ index 3b3ffc13ef..6ec472c946 100644
 +		return nil
 +	}
 +
-+	filter.mutex.Lock()
-+	defer filter.mutex.Unlock()
++	c.mutex.Lock()
++	defer c.mutex.Unlock()
 +
 +	// filter support only one ip4 address for pod
 +	shared := getCepAddressPair(cep)
 +	if shared.IPV4 == "" {
-+		fmt.Printf("DEBUG removeCEPFromFilter 222: %v\n", cep.Name)
++		log.Warn("CEP have not address", logfields.CEPName, cep.Name)
 +		return nil
 +	}
-+
-+	defer fmt.Printf("DEBUG DELETE len(c.ipToCepList[shared.IPV4]) = %v\n", len(c.ipToCepList[shared.IPV4]))
 +
 +	ccep := &coreCiliumEndpointNS{
 +		ccep: k8s.ConvertCEPToCoreCEP(cep),
@@ -441,12 +432,9 @@ index 3b3ffc13ef..6ec472c946 100644
 +	}
 +	var hiddenCep *coreCiliumEndpointNS
 +	if cepList, exist := c.ipToCepList[shared.IPV4]; exist {
-+		fmt.Printf("DEBUG removeCEPFromFilter 444: %v\n", cep.Name)
 +		if len(cepList) == 1 {
-+			fmt.Printf("DEBUG removeCEPFromFilter 555: %v\n", cep.Name)
 +			prev := cepList[0]
 +			if equalCeps(prev.cep, ccep) {
-+				fmt.Printf("DEBUG removeCEPFromFilter 666: %v\n", cep.Name)
 +				delete(filter.ipToCepList, shared.IPV4)
 +			}
 +			return nil
@@ -455,19 +443,16 @@ index 3b3ffc13ef..6ec472c946 100644
 +		// remove CEP from slice with several elements
 +		newList := []coreCiliumEndpointInfo{}
 +		for _, prev := range cepList {
-+			fmt.Printf("DEBUG removeCEPFromFilter 777: %v %v\n", cep.Name, prev.cep.ccep.Name)
 +			if !equalCeps(prev.cep, ccep) {
-+				fmt.Printf("DEBUG removeCEPFromFilter 888: %v\n", cep.Name)
 +				newList = append(newList, prev)
 +			} else {
-+				fmt.Printf("DEBUG removeCEPFromFilter 999: %v\n", cep.Name)
++				log.Debug("CEP is removed from filter", logfields.CEPName, cep.Name)
 +				// if removed CEP have address - restoring hidden CEP
 +				needRestoring = len(prev.cep.ccep.Networking.Addressing) != 0
 +			}
 +		}
 +		c.ipToCepList[shared.IPV4] = newList
 +		if !needRestoring {
-+			fmt.Printf("DEBUG removeCEPFromFilter 888: %v\n", cep.Name)
 +			return nil
 +		}
 +		// find most priorioty hidden cep for restoring its network access
@@ -479,6 +464,7 @@ index 3b3ffc13ef..6ec472c946 100644
 +		}
 +		hiddenCep = highest.cep
 +		hiddenCep.ccep.Networking.Addressing = append(hiddenCep.ccep.Networking.Addressing, &shared)
++		log.Debug("Hidden CEP is restored", logfields.CEPName, hiddenCep.ccep.Name)
 +	}
 +	return hiddenCep
 +}
@@ -486,7 +472,7 @@ index 3b3ffc13ef..6ec472c946 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,31 +358,50 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +344,45 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
@@ -495,22 +481,18 @@ index 3b3ffc13ef..6ec472c946 100644
 +
 +	oldOwner, delay, newOwner := filter.filterAddressByPriority(cep)
 +	if oldOwner != nil {
-+		fmt.Printf("DEBUG onEndpointUpdate oldOwner: %v\n", oldOwner.ccep.Networking.Addressing)
 +		touchedCESs := c.manager.UpdateCEPMapping(oldOwner.ccep, oldOwner.ns)
 +		c.enqueueCESReconciliation(touchedCESs, delay)
 +	}
 +
-+	fmt.Printf("DEBUG onEndpointUpdate newOwner: %v\n", newOwner.ccep.Networking.Addressing)
 +	touchedCESs := c.manager.UpdateCEPMapping(newOwner.ccep, newOwner.ns)
 +	c.enqueueCESReconciliation(touchedCESs, delay)
-+	fmt.Printf("DEBUG onEndpointUpdate %v, %p, %v\n", cep.Name, cep, cep.Status.Networking.Addressing)
  }
  
  func (c *Controller) onEndpointDelete(cep *cilium_api_v2.CiliumEndpoint) {
 +	hiddenCep := filter.removeCEPFromFilter(cep)
 +
 +	if hiddenCep != nil {
-+		fmt.Printf("DEBUG onEndpointDelete: %v\n", hiddenCep.ccep.Networking)
 +		touchedCESs := c.manager.UpdateCEPMapping(hiddenCep.ccep, hiddenCep.ns)
 +		c.enqueueCESReconciliation(touchedCESs, DefaultCESSyncTime)
 +	}
@@ -518,7 +500,6 @@ index 3b3ffc13ef..6ec472c946 100644
  	touchedCES := c.manager.RemoveCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
 -	c.enqueueCESReconciliation([]CESKey{touchedCES})
 +	c.enqueueCESReconciliation([]CESKey{touchedCES}, DefaultCESSyncTime)
-+	fmt.Printf("DEBUG onEndpointDelete %v, %p, %v\n", cep.Name, cep, cep.Status.Networking.Addressing)
  }
  
  func (c *Controller) onSliceUpdate(ces *capi_v2a1.CiliumEndpointSlice) {
@@ -545,7 +526,7 @@ index 3b3ffc13ef..6ec472c946 100644
  			c.fastQueue.Add(ces)
  		} else {
  			c.standardQueue.Add(ces)
-@@ -108,7 +412,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+@@ -108,7 +393,7 @@ func (c *Controller) addToQueue(ces CESKey) {
  
  }
  
@@ -554,7 +535,7 @@ index 3b3ffc13ef..6ec472c946 100644
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {
-@@ -117,7 +421,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+@@ -117,7 +402,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
  				c.enqueuedAt[ces] = time.Now()
  			}
  			c.enqueuedAtLock.Unlock()
@@ -563,7 +544,7 @@ index 3b3ffc13ef..6ec472c946 100644
  		}
  	}
  }
-@@ -186,6 +490,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+@@ -186,6 +471,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From 87c5164e03ec598e758f13c9aca0f106bbb94019 Mon Sep 17 00:00:00 2001
+From b9c34558ab4733ab0813a299ae7121889947cb4d Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -12,7 +12,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  daemon/cmd/hostips-sync.go                    |   2 +-
  daemon/cmd/state.go                           |   2 +-
  daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  | 271 ++++++++++++-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 274 +++++++++++++-
  operator/watchers/cilium_endpoint.go          |   1 +
  pkg/datapath/alignchecker/alignchecker.go     |   2 +-
  pkg/datapath/linux/config/config.go           |   2 +-
@@ -25,7 +25,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  pkg/maps/bwmap/bwmap.go                       |   2 +-
  pkg/maps/lxcmap/doc.go                        |   9 -
  pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
- 20 files changed, 663 insertions(+), 288 deletions(-)
+ 20 files changed, 666 insertions(+), 288 deletions(-)
  delete mode 100644 pkg/maps/lxcmap/doc.go
  delete mode 100644 pkg/maps/lxcmap/lxcmap.go
 
@@ -170,7 +170,7 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..8f65a5b003 100644
+index 3b3ffc13ef..f5c0749f53 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,8 +6,12 @@ package ciliumendpointslice
@@ -194,7 +194,7 @@ index 3b3ffc13ef..8f65a5b003 100644
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
  
-@@ -49,10 +54,234 @@ const (
+@@ -49,10 +54,235 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
  
@@ -278,12 +278,12 @@ index 3b3ffc13ef..8f65a5b003 100644
 +// WARNING this update logic will work only if CEP(new and old) network addresses is not changed !!!
 +// If some address was removed in new CEP - it will never removed from map
 +func (c *priorityFilter) filterAddressByPriority(cep *cilium_api_v2.CiliumEndpoint) (*coreCiliumEndpointNS, time.Duration, *coreCiliumEndpointNS) {
-+	var oldOwner *coreCiliumEndpointNS
 +	ccep := &coreCiliumEndpointNS{
 +		ccep: k8s.ConvertCEPToCoreCEP(cep),
 +		ns:   cep.GetNamespace(),
 +	}
 +	newOwner := ccep
++	var oldOwner *coreCiliumEndpointNS
 +	delay := DefaultCESSyncTime
 +	priority := getCepPriority(cep)
 +	// filter support only one ip4 address for pod
@@ -303,6 +303,7 @@ index 3b3ffc13ef..8f65a5b003 100644
 +		highest := &info
 +		currentOwner := cepList[0].cep
 +		for i := range cepList {
++			fmt.Printf("DEBUG range cepList cep: %v,,, %v\n", cepList[i].cep.ccep.Name, cepList[i].cep.ccep.Networking.Addressing)
 +			if len(cepList[i].cep.ccep.Networking.Addressing) != 0 {
 +				currentOwner = cepList[i].cep
 +			}
@@ -345,14 +346,14 @@ index 3b3ffc13ef..8f65a5b003 100644
 +			highest.cep.ccep.Networking.Addressing = append(emptyAddrList, addr)
 +			oldOwner = ccep
 +			newOwner = highest.cep
-+			fmt.Printf("DEBUG isOwner && !isHighest old, new: %v %v\n", oldOwner, newOwner)
++			fmt.Printf("DEBUG isOwner && !isHighest old, new: %v %v\n", oldOwner.ccep.Name, newOwner.ccep.Name)
 +		} else if !isOwner && isHighest {
 +			currentOwner.ccep.Networking.Addressing = emptyAddrList
 +			oldOwner = currentOwner
-+			fmt.Printf("DEBUG !isOwner && isHighest old, new: %v %v\n", oldOwner, newOwner)
++			fmt.Printf("DEBUG !isOwner && isHighest old, new: %v %v\n", oldOwner.ccep.Name, newOwner.ccep.Name)
 +		} else { // !isOwner && !isHighest
 +			ccep.ccep.Networking.Addressing = emptyAddrList
-+			fmt.Printf("DEBUG !isOwner && !isHighest old, new: %v %v\n", oldOwner, newOwner)
++			fmt.Printf("DEBUG !isOwner && !isHighest old, new: %v %v\n", oldOwner.ccep.Name, newOwner.ccep.Name)
 +		}
 +	} else {
 +		c.ipToCepList[shared.IPV4] = []coreCiliumEndpointInfo{info}
@@ -429,7 +430,7 @@ index 3b3ffc13ef..8f65a5b003 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,31 +302,48 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +303,50 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
@@ -438,10 +439,12 @@ index 3b3ffc13ef..8f65a5b003 100644
 +
 +	oldOwner, delay, newOwner := filter.filterAddressByPriority(cep)
 +	if oldOwner != nil {
++		fmt.Printf("DEBUG onEndpointUpdate oldOwner: %v\n", oldOwner.ccep.Networking.Addressing)
 +		touchedCESs := c.manager.UpdateCEPMapping(oldOwner.ccep, oldOwner.ns)
 +		c.enqueueCESReconciliation(touchedCESs, delay)
 +	}
 +
++	fmt.Printf("DEBUG onEndpointUpdate newOwner: %v\n", newOwner.ccep.Networking.Addressing)
 +	touchedCESs := c.manager.UpdateCEPMapping(newOwner.ccep, newOwner.ns)
 +	c.enqueueCESReconciliation(touchedCESs, delay)
 +	fmt.Printf("DEBUG onEndpointUpdate %v, %p, %v\n", cep.Name, cep, cep.Status.Networking.Addressing)
@@ -451,7 +454,7 @@ index 3b3ffc13ef..8f65a5b003 100644
 +	hiddenCep := filter.removeCEPFromFilter(cep)
 +
 +	if hiddenCep != nil {
-+		fmt.Printf("DEBUG onEndpointDelete: %v\n", hiddenCep)
++		fmt.Printf("DEBUG onEndpointDelete: %v\n", hiddenCep.ccep.Networking)
 +		touchedCESs := c.manager.UpdateCEPMapping(hiddenCep.ccep, hiddenCep.ns)
 +		c.enqueueCESReconciliation(touchedCESs, DefaultCESSyncTime)
 +	}
@@ -486,7 +489,7 @@ index 3b3ffc13ef..8f65a5b003 100644
  			c.fastQueue.Add(ces)
  		} else {
  			c.standardQueue.Add(ces)
-@@ -108,7 +354,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+@@ -108,7 +357,7 @@ func (c *Controller) addToQueue(ces CESKey) {
  
  }
  
@@ -495,7 +498,7 @@ index 3b3ffc13ef..8f65a5b003 100644
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {
-@@ -117,7 +363,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+@@ -117,7 +366,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
  				c.enqueuedAt[ces] = time.Now()
  			}
  			c.enqueuedAtLock.Unlock()
@@ -504,7 +507,7 @@ index 3b3ffc13ef..8f65a5b003 100644
  		}
  	}
  }
-@@ -186,6 +432,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+@@ -186,6 +435,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From d5828b535c4e77107af6e7be52ecc01aef5dd816 Mon Sep 17 00:00:00 2001
+From 85312cb90e9dcc35b80259f86b9f9ddf9f185a43 Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -12,7 +12,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  daemon/cmd/hostips-sync.go                    |   2 +-
  daemon/cmd/state.go                           |   2 +-
  daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  | 321 +++++++++++++++-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 329 +++++++++++++++-
  .../pkg/ciliumendpointslice/reconciler.go     |   3 +-
  operator/watchers/cilium_endpoint.go          |   1 +
  pkg/datapath/alignchecker/alignchecker.go     |   2 +-
@@ -26,7 +26,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  pkg/maps/bwmap/bwmap.go                       |   2 +-
  pkg/maps/lxcmap/doc.go                        |   9 -
  pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
- 21 files changed, 714 insertions(+), 290 deletions(-)
+ 21 files changed, 722 insertions(+), 290 deletions(-)
  delete mode 100644 pkg/maps/lxcmap/doc.go
  delete mode 100644 pkg/maps/lxcmap/lxcmap.go
 
@@ -171,7 +171,7 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..10813bfab1 100644
+index 3b3ffc13ef..6ec472c946 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,8 +6,13 @@ package ciliumendpointslice
@@ -196,7 +196,7 @@ index 3b3ffc13ef..10813bfab1 100644
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
  
-@@ -49,10 +55,281 @@ const (
+@@ -49,10 +55,289 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
  
@@ -311,7 +311,11 @@ index 3b3ffc13ef..10813bfab1 100644
 +}
 +
 +func FilterGetCoreCiliumEndpoint(cep *cilium_api_v2.CiliumEndpoint) *cilium_v2alpha1.CoreCiliumEndpoint {
-+	return filter.getCoreCiliumEndpoint(cep)
++	ccep := filter.getCoreCiliumEndpoint(cep)
++	if ccep != nil {
++		fmt.Printf("DEBUG FilterGetCoreCiliumEndpoint: %v %v\n", ccep.Name, ccep.Networking.Addressing)
++	}
++	return ccep
 +}
 +
 +// WARNING this update logic will work only if CEP(new and old) network addresses is not changed !!!
@@ -341,6 +345,8 @@ index 3b3ffc13ef..10813bfab1 100644
 +		cep:      ccep,
 +		priority: priority,
 +	}
++
++	defer fmt.Printf("DEBUG FILTER len(c.ipToCepList[shared.IPV4]) = %v\n", len(c.ipToCepList[shared.IPV4]))
 +
 +	if cepList, exist := c.ipToCepList[shared.IPV4]; exist {
 +		isInserted := false
@@ -401,7 +407,7 @@ index 3b3ffc13ef..10813bfab1 100644
 +			fmt.Printf("DEBUG !isOwner && isHighest old, new: %v %v\n", oldOwner.ccep.Name, newOwner.ccep.Name)
 +		} else { // !isOwner && !isHighest
 +			ccep.ccep.Networking.Addressing = emptyAddrList
-+			fmt.Printf("DEBUG !isOwner && !isHighest old, new: %v %v\n", oldOwner.ccep.Name, newOwner.ccep.Name)
++			fmt.Printf("DEBUG !isOwner && !isHighest old, new: %v %v\n", newOwner.ccep.Name)
 +		}
 +	} else {
 +		c.ipToCepList[shared.IPV4] = []coreCiliumEndpointInfo{info}
@@ -426,6 +432,8 @@ index 3b3ffc13ef..10813bfab1 100644
 +		fmt.Printf("DEBUG removeCEPFromFilter 222: %v\n", cep.Name)
 +		return nil
 +	}
++
++	defer fmt.Printf("DEBUG DELETE len(c.ipToCepList[shared.IPV4]) = %v\n", len(c.ipToCepList[shared.IPV4]))
 +
 +	ccep := &coreCiliumEndpointNS{
 +		ccep: k8s.ConvertCEPToCoreCEP(cep),
@@ -478,7 +486,7 @@ index 3b3ffc13ef..10813bfab1 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,31 +350,50 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +358,50 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
@@ -537,7 +545,7 @@ index 3b3ffc13ef..10813bfab1 100644
  			c.fastQueue.Add(ces)
  		} else {
  			c.standardQueue.Add(ces)
-@@ -108,7 +404,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+@@ -108,7 +412,7 @@ func (c *Controller) addToQueue(ces CESKey) {
  
  }
  
@@ -546,7 +554,7 @@ index 3b3ffc13ef..10813bfab1 100644
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {
-@@ -117,7 +413,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+@@ -117,7 +421,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
  				c.enqueuedAt[ces] = time.Now()
  			}
  			c.enqueuedAtLock.Unlock()
@@ -555,7 +563,7 @@ index 3b3ffc13ef..10813bfab1 100644
  		}
  	}
  }
-@@ -186,6 +482,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+@@ -186,6 +490,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From c924292c9ae35f1fc52227f9e8b030c0a6c7066a Mon Sep 17 00:00:00 2001
+From fbbbf022d02a049325c0544d1a7a3d1cef1af7c8 Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -12,7 +12,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  daemon/cmd/hostips-sync.go                    |   2 +-
  daemon/cmd/state.go                           |   2 +-
  daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  | 253 ++++++++++++-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 263 ++++++++++++-
  operator/watchers/cilium_endpoint.go          |   1 +
  pkg/datapath/alignchecker/alignchecker.go     |   2 +-
  pkg/datapath/linux/config/config.go           |   2 +-
@@ -25,7 +25,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  pkg/maps/bwmap/bwmap.go                       |   2 +-
  pkg/maps/lxcmap/doc.go                        |   9 -
  pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
- 20 files changed, 645 insertions(+), 288 deletions(-)
+ 20 files changed, 655 insertions(+), 288 deletions(-)
  delete mode 100644 pkg/maps/lxcmap/doc.go
  delete mode 100644 pkg/maps/lxcmap/lxcmap.go
 
@@ -170,7 +170,7 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..5272c8dd58 100644
+index 3b3ffc13ef..8152e7186c 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,6 +6,9 @@ package ciliumendpointslice
@@ -191,7 +191,7 @@ index 3b3ffc13ef..5272c8dd58 100644
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
  
-@@ -49,10 +53,219 @@ const (
+@@ -49,10 +53,229 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
  
@@ -363,19 +363,25 @@ index 3b3ffc13ef..5272c8dd58 100644
 +
 +func (c *priorityFilter) removeCEPFromFilter(cep *cilium_api_v2.CiliumEndpoint) *cilium_api_v2.CiliumEndpoint {
 +	if cep.Status.Networking == nil || cep.GetName() == "" || cep.Namespace == "" {
++		fmt.Printf("DEBUG removeCEPFromFilter 111: %v\n", cep.Name)
 +		return nil
 +	}
 +	// filter support only one ip4 address for pod
 +	shared := getCepAddressPair(cep)
 +	if shared.IPV4 == "" {
++		fmt.Printf("DEBUG removeCEPFromFilter 222: %v\n", cep.Name)
 +		return nil
 +	}
 +
++	fmt.Printf("DEBUG removeCEPFromFilter 333: %v\n", cep.Name)
 +	var hiddenCep *cilium_api_v2.CiliumEndpoint
 +	if cepList, exist := c.ipToCepList[shared.IPV4]; exist {
++		fmt.Printf("DEBUG removeCEPFromFilter 444: %v\n", cep.Name)
 +		if len(cepList) == 1 {
++			fmt.Printf("DEBUG removeCEPFromFilter 555: %v\n", cep.Name)
 +			prev := cepList[0]
 +			if equalCeps(prev.cep, cep) {
++				fmt.Printf("DEBUG removeCEPFromFilter 666: %v\n", cep.Name)
 +				delete(filter.ipToCepList, shared.IPV4)
 +			}
 +			return nil
@@ -384,15 +390,19 @@ index 3b3ffc13ef..5272c8dd58 100644
 +		// remove CEP from slice with several elements
 +		newList := []coreCiliumEndpointInfo{}
 +		for _, prev := range cepList {
++			fmt.Printf("DEBUG removeCEPFromFilter 777: %v %v\n", cep.Name, prev.cep.Name)
 +			if !equalCeps(prev.cep, cep) {
++				fmt.Printf("DEBUG removeCEPFromFilter 888: %v\n", cep.Name)
 +				newList = append(newList, prev)
 +			} else {
++				fmt.Printf("DEBUG removeCEPFromFilter 999: %v\n", cep.Name)
 +				// if removed CEP have address - restoring hidden CEP
 +				needRestoring = len(prev.cep.Status.Networking.Addressing) != 0
 +			}
 +		}
 +		c.ipToCepList[shared.IPV4] = newList
 +		if !needRestoring {
++			fmt.Printf("DEBUG removeCEPFromFilter 888: %v\n", cep.Name)
 +			return nil
 +		}
 +		// find most priorioty hidden cep for restoring its network access
@@ -411,7 +421,7 @@ index 3b3ffc13ef..5272c8dd58 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,31 +286,46 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +296,46 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
@@ -466,7 +476,7 @@ index 3b3ffc13ef..5272c8dd58 100644
  			c.fastQueue.Add(ces)
  		} else {
  			c.standardQueue.Add(ces)
-@@ -108,7 +336,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+@@ -108,7 +346,7 @@ func (c *Controller) addToQueue(ces CESKey) {
  
  }
  
@@ -475,7 +485,7 @@ index 3b3ffc13ef..5272c8dd58 100644
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {
-@@ -117,7 +345,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+@@ -117,7 +355,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
  				c.enqueuedAt[ces] = time.Now()
  			}
  			c.enqueuedAtLock.Unlock()
@@ -484,7 +494,7 @@ index 3b3ffc13ef..5272c8dd58 100644
  		}
  	}
  }
-@@ -186,6 +414,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+@@ -186,6 +424,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From b9c34558ab4733ab0813a299ae7121889947cb4d Mon Sep 17 00:00:00 2001
+From de750c726a68dce6fcf9c9515adadc8d2db5ad73 Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -12,7 +12,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  daemon/cmd/hostips-sync.go                    |   2 +-
  daemon/cmd/state.go                           |   2 +-
  daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  | 274 +++++++++++++-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 277 +++++++++++++-
  operator/watchers/cilium_endpoint.go          |   1 +
  pkg/datapath/alignchecker/alignchecker.go     |   2 +-
  pkg/datapath/linux/config/config.go           |   2 +-
@@ -25,7 +25,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  pkg/maps/bwmap/bwmap.go                       |   2 +-
  pkg/maps/lxcmap/doc.go                        |   9 -
  pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
- 20 files changed, 666 insertions(+), 288 deletions(-)
+ 20 files changed, 669 insertions(+), 288 deletions(-)
  delete mode 100644 pkg/maps/lxcmap/doc.go
  delete mode 100644 pkg/maps/lxcmap/lxcmap.go
 
@@ -170,7 +170,7 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..f5c0749f53 100644
+index 3b3ffc13ef..76d757f807 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,8 +6,12 @@ package ciliumendpointslice
@@ -194,7 +194,7 @@ index 3b3ffc13ef..f5c0749f53 100644
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
  
-@@ -49,10 +54,235 @@ const (
+@@ -49,10 +54,238 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
  
@@ -302,8 +302,10 @@ index 3b3ffc13ef..f5c0749f53 100644
 +		// new cep will have higher priority than old ceps with same priority
 +		highest := &info
 +		currentOwner := cepList[0].cep
++		fmt.Printf("DEBUG filterAddressByPriority 111\n")
 +		for i := range cepList {
 +			fmt.Printf("DEBUG range cepList cep: %v,,, %v\n", cepList[i].cep.ccep.Name, cepList[i].cep.ccep.Networking.Addressing)
++			fmt.Printf("DEBUG filterAddressByPriority 222\n")
 +			if len(cepList[i].cep.ccep.Networking.Addressing) != 0 {
 +				currentOwner = cepList[i].cep
 +			}
@@ -326,6 +328,7 @@ index 3b3ffc13ef..f5c0749f53 100644
 +			}
 +			c.ipToCepList[shared.IPV4] = append(cepList, info)
 +		}
++		fmt.Printf("DEBUG filterAddressByPriority 333\n")
 +		// possibly cases:
 +		// 1) income cep is highest and already ip4 owner(only update income cep)
 +		// 2) income cep is highest and replace other owner cep(hide ip4 address for previous owner and make owner income cep)
@@ -430,7 +433,7 @@ index 3b3ffc13ef..f5c0749f53 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,31 +303,50 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +306,50 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
@@ -489,7 +492,7 @@ index 3b3ffc13ef..f5c0749f53 100644
  			c.fastQueue.Add(ces)
  		} else {
  			c.standardQueue.Add(ces)
-@@ -108,7 +357,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+@@ -108,7 +360,7 @@ func (c *Controller) addToQueue(ces CESKey) {
  
  }
  
@@ -498,7 +501,7 @@ index 3b3ffc13ef..f5c0749f53 100644
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {
-@@ -117,7 +366,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+@@ -117,7 +369,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
  				c.enqueuedAt[ces] = time.Now()
  			}
  			c.enqueuedAtLock.Unlock()
@@ -507,7 +510,7 @@ index 3b3ffc13ef..f5c0749f53 100644
  		}
  	}
  }
-@@ -186,6 +435,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+@@ -186,6 +438,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From c91c123a894c302611f07057ffe373d29fea0dbf Mon Sep 17 00:00:00 2001
+From 7363329ab8293ed327754fc6ec739e31338d1be1 Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -170,7 +170,7 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..a198b423b8 100644
+index 3b3ffc13ef..c664a5806b 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,6 +6,9 @@ package ciliumendpointslice
@@ -290,9 +290,9 @@ index 3b3ffc13ef..a198b423b8 100644
 +		// new cep will have higher priority than old ceps with same priority
 +		highest := &info
 +		if len(cepList) > 1 {
-+			fmt.Printf("DEBUG len(cepList) > 1: %v\n", cepList)
++			fmt.Printf("DEBUG len(cepList) > 1: %v\n", len(cepList))
 +			for i := range cepList {
-+				fmt.Printf("DEBUG ELEMS index, cep: %v %v\n", i, cepList[i].cep)
++				fmt.Printf("DEBUG ELEMS index, cep: %v %v %v\n", i, cepList[i].cep.Name, cepList[i].priority)
 +			}
 +		}
 +
@@ -471,7 +471,7 @@ index 3b3ffc13ef..a198b423b8 100644
  }
  
 -func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
-+func (c *Controller) enqueueCESReconciliation(cess []CESKey, delay time.Duration) {
++func (c *Contwroller) enqueueCESReconciliation(cess []CESKey, delay time.Duration) {
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From 33a0e3e138ac8581a1eb9c29694f6b9ec7189423 Mon Sep 17 00:00:00 2001
+From e47adb672b3d81deca1d78fec9177672deb8e476 Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -12,7 +12,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  daemon/cmd/hostips-sync.go                    |   2 +-
  daemon/cmd/state.go                           |   2 +-
  daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  | 266 ++++++++++++-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 267 ++++++++++++-
  operator/watchers/cilium_endpoint.go          |   1 +
  pkg/datapath/alignchecker/alignchecker.go     |   2 +-
  pkg/datapath/linux/config/config.go           |   2 +-
@@ -25,7 +25,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  pkg/maps/bwmap/bwmap.go                       |   2 +-
  pkg/maps/lxcmap/doc.go                        |   9 -
  pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
- 20 files changed, 658 insertions(+), 288 deletions(-)
+ 20 files changed, 659 insertions(+), 288 deletions(-)
  delete mode 100644 pkg/maps/lxcmap/doc.go
  delete mode 100644 pkg/maps/lxcmap/lxcmap.go
 
@@ -170,10 +170,10 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..b59350c817 100644
+index 3b3ffc13ef..75037c933e 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
-@@ -6,6 +6,9 @@ package ciliumendpointslice
+@@ -6,8 +6,12 @@ package ciliumendpointslice
  import (
  	"context"
  	"fmt"
@@ -182,8 +182,11 @@ index 3b3ffc13ef..b59350c817 100644
 +	"strings"
  	"time"
  
++	cilium_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
  	"github.com/cilium/hive/cell"
-@@ -18,6 +21,7 @@ import (
+ 	"github.com/cilium/hive/job"
+ 	"github.com/cilium/workerpool"
+@@ -18,6 +22,7 @@ import (
  	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
  	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
  	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -191,7 +194,7 @@ index 3b3ffc13ef..b59350c817 100644
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
  
-@@ -49,10 +53,232 @@ const (
+@@ -49,10 +54,232 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
  
@@ -220,8 +223,13 @@ index 3b3ffc13ef..b59350c817 100644
 +	return Default
 +}
 +
++type coreCiliumEndpointNS struct {
++	ccep *cilium_v2alpha1.CoreCiliumEndpoint
++	ns   string
++}
++
 +type coreCiliumEndpointInfo struct {
-+	cep      *cilium_api_v2.CiliumEndpoint
++	cep      *coreCiliumEndpointNS
 +	priority cepPriority
 +}
 +
@@ -256,9 +264,6 @@ index 3b3ffc13ef..b59350c817 100644
 +
 +func getCepAddressPair(cep *cilium_api_v2.CiliumEndpoint) cilium_api_v2.AddressPair {
 +	var shared cilium_api_v2.AddressPair
-+	fmt.Printf("DEBUG getCepAddressPair addr: %p", cep)
-+	fmt.Printf("DEBUG getCepAddressPair cep name: %v", cep.Name)
-+	fmt.Printf("DEBUG getCepAddressPair: %v", cep.Status.Networking.Addressing)
 +	for _, pair := range cep.Status.Networking.Addressing {
 +		if pair.IPV4 == "" {
 +			continue
@@ -271,12 +276,15 @@ index 3b3ffc13ef..b59350c817 100644
 +
 +// WARNING this update logic will work only if CEP(new and old) network addresses is not changed !!!
 +// If some address was removed in new CEP - it will never removed from map
-+func (c *priorityFilter) filterAddressByPriority(cep *cilium_api_v2.CiliumEndpoint) (*cilium_api_v2.CiliumEndpoint, time.Duration, *cilium_api_v2.CiliumEndpoint) {
-+	var oldOwner *cilium_api_v2.CiliumEndpoint
-+	newOwner := cep
++func (c *priorityFilter) filterAddressByPriority(cep *cilium_api_v2.CiliumEndpoint) (*coreCiliumEndpointNS, time.Duration, *coreCiliumEndpointNS) {
++	var oldOwner *coreCiliumEndpointNS
++	ccep := &coreCiliumEndpointNS{
++		ccep: k8s.ConvertCEPToCoreCEP(cep),
++		ns:   cep.GetNamespace(),
++	}
++	newOwner := ccep
 +	delay := DefaultCESSyncTime
 +	priority := getCepPriority(cep)
-+
 +	// filter support only one ip4 address for pod
 +	shared := getCepAddressPair(cep)
 +	if shared.IPV4 == "" {
@@ -284,7 +292,7 @@ index 3b3ffc13ef..b59350c817 100644
 +	}
 +
 +	info := coreCiliumEndpointInfo{
-+		cep:      cep,
++		cep:      ccep,
 +		priority: priority,
 +	}
 +
@@ -292,21 +300,14 @@ index 3b3ffc13ef..b59350c817 100644
 +		isInserted := false
 +		// new cep will have higher priority than old ceps with same priority
 +		highest := &info
-+		if len(cepList) > 1 {
-+			fmt.Printf("DEBUG len(cepList) > 1: %v\n", len(cepList))
-+			for i := range cepList {
-+				fmt.Printf("DEBUG ELEMs index, cep: %v %v %v\n", i, cepList[i].cep.Name, cepList[i].priority)
-+			}
-+		}
-+
 +		currentOwner := cepList[0].cep
 +		for i := range cepList {
-+			if len(cepList[i].cep.Status.Networking.Addressing) != 0 {
++			if len(cepList[i].cep.ccep.Networking.Addressing) != 0 {
 +				currentOwner = cepList[i].cep
 +			}
-+			if equalCeps(cep, cepList[i].cep) {
++			if equalCeps(ccep, cepList[i].cep) {
 +				isInserted = true
-+				cepList[i].cep = cep
++				cepList[i].cep = ccep
 +				// forced update only on first appearance
 +				if cepList[i].priority != priority && priority == High {
 +					delay = ForceCESSyncTime
@@ -329,22 +330,22 @@ index 3b3ffc13ef..b59350c817 100644
 +		// 3) income cep is lowest and need to be replaced by other cep
 +		// 4) income cep is lowest and other cep is already owner
 +		emptyAddrList := cilium_api_v2.AddressPairList{}
-+		isOwner := equalCeps(cep, currentOwner)
-+		isHighest := equalCeps(cep, highest.cep)
++		isOwner := equalCeps(ccep, currentOwner)
++		isHighest := equalCeps(ccep, highest.cep)
 +		if isOwner && isHighest {
 +			// just skip
 +		} else if isOwner && !isHighest {
-+			cep.Status.Networking.Addressing = emptyAddrList
++			ccep.ccep.Networking.Addressing = emptyAddrList
 +			addr := &cilium_api_v2.AddressPair{
 +				IPV4: shared.IPV4,
 +				IPV6: shared.IPV6,
 +			}
-+			highest.cep.Status.Networking.Addressing = append(emptyAddrList, addr)
-+			oldOwner = cep
++			highest.cep.ccep.Networking.Addressing = append(emptyAddrList, addr)
++			oldOwner = ccep
 +			newOwner = highest.cep
 +			fmt.Printf("DEBUG isOwner && !isHighest old, new: %v %v\n", oldOwner, newOwner)
 +		} else if !isOwner && isHighest {
-+			currentOwner.Status.Networking.Addressing = emptyAddrList
++			currentOwner.ccep.Networking.Addressing = emptyAddrList
 +			oldOwner = currentOwner
 +			fmt.Printf("DEBUG !isOwner && isHighest old, new: %v %v\n", oldOwner, newOwner)
 +		} else { // !isOwner && !isHighest
@@ -360,13 +361,12 @@ index 3b3ffc13ef..b59350c817 100644
 +	return oldOwner, delay, newOwner
 +}
 +
-+func equalCeps(cep0, cep1 *cilium_api_v2.CiliumEndpoint) bool {
-+	return cep0.Name == cep1.Name && cep0.Namespace == cep1.Namespace
++func equalCeps(cep0, cep1 *coreCiliumEndpointNS) bool {
++	return cep0.ccep.Name == cep1.ccep.Name && cep0.ns == cep1.ns
 +}
 +
-+func (c *priorityFilter) removeCEPFromFilter(cep *cilium_api_v2.CiliumEndpoint) *cilium_api_v2.CiliumEndpoint {
++func (c *priorityFilter) removeCEPFromFilter(cep *cilium_api_v2.CiliumEndpoint) *coreCiliumEndpointNS {
 +	if cep.Status.Networking == nil || cep.GetName() == "" || cep.Namespace == "" {
-+		fmt.Printf("DEBUG removeCEPFromFilter 111: %v\n", cep.Name)
 +		return nil
 +	}
 +	// filter support only one ip4 address for pod
@@ -376,14 +376,17 @@ index 3b3ffc13ef..b59350c817 100644
 +		return nil
 +	}
 +
-+	fmt.Printf("DEBUG removeCEPFromFilter 333: %v\n", cep.Name)
-+	var hiddenCep *cilium_api_v2.CiliumEndpoint
++	ccep := &coreCiliumEndpointNS{
++		ccep: k8s.ConvertCEPToCoreCEP(cep),
++		ns:   cep.GetNamespace(),
++	}
++	var hiddenCep *coreCiliumEndpointNS
 +	if cepList, exist := c.ipToCepList[shared.IPV4]; exist {
 +		fmt.Printf("DEBUG removeCEPFromFilter 444: %v\n", cep.Name)
 +		if len(cepList) == 1 {
 +			fmt.Printf("DEBUG removeCEPFromFilter 555: %v\n", cep.Name)
 +			prev := cepList[0]
-+			if equalCeps(prev.cep, cep) {
++			if equalCeps(prev.cep, ccep) {
 +				fmt.Printf("DEBUG removeCEPFromFilter 666: %v\n", cep.Name)
 +				delete(filter.ipToCepList, shared.IPV4)
 +			}
@@ -393,14 +396,14 @@ index 3b3ffc13ef..b59350c817 100644
 +		// remove CEP from slice with several elements
 +		newList := []coreCiliumEndpointInfo{}
 +		for _, prev := range cepList {
-+			fmt.Printf("DEBUG removeCEPFromFilter 777: %v %v\n", cep.Name, prev.cep.Name)
-+			if !equalCeps(prev.cep, cep) {
++			fmt.Printf("DEBUG removeCEPFromFilter 777: %v %v\n", cep.Name, prev.cep.ccep.Name)
++			if !equalCeps(prev.cep, ccep) {
 +				fmt.Printf("DEBUG removeCEPFromFilter 888: %v\n", cep.Name)
 +				newList = append(newList, prev)
 +			} else {
 +				fmt.Printf("DEBUG removeCEPFromFilter 999: %v\n", cep.Name)
 +				// if removed CEP have address - restoring hidden CEP
-+				needRestoring = len(prev.cep.Status.Networking.Addressing) != 0
++				needRestoring = len(prev.cep.ccep.Networking.Addressing) != 0
 +			}
 +		}
 +		c.ipToCepList[shared.IPV4] = newList
@@ -416,7 +419,7 @@ index 3b3ffc13ef..b59350c817 100644
 +			}
 +		}
 +		hiddenCep = highest.cep
-+		hiddenCep.Status.Networking.Addressing = append(hiddenCep.Status.Networking.Addressing, &shared)
++		hiddenCep.ccep.Networking.Addressing = append(hiddenCep.ccep.Networking.Addressing, &shared)
 +	}
 +	return hiddenCep
 +}
@@ -424,7 +427,7 @@ index 3b3ffc13ef..b59350c817 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,31 +299,46 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +300,46 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
@@ -433,11 +436,11 @@ index 3b3ffc13ef..b59350c817 100644
 +
 +	oldOwner, delay, newOwner := filter.filterAddressByPriority(cep)
 +	if oldOwner != nil {
-+		touchedCESs := c.manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(oldOwner), oldOwner.Namespace)
++		touchedCESs := c.manager.UpdateCEPMapping(oldOwner.ccep, oldOwner.ns)
 +		c.enqueueCESReconciliation(touchedCESs, delay)
 +	}
 +
-+	touchedCESs := c.manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(newOwner), newOwner.Namespace)
++	touchedCESs := c.manager.UpdateCEPMapping(newOwner.ccep, newOwner.ns)
 +	c.enqueueCESReconciliation(touchedCESs, delay)
  }
  
@@ -446,7 +449,7 @@ index 3b3ffc13ef..b59350c817 100644
 +
 +	if hiddenCep != nil {
 +		fmt.Printf("DEBUG onEndpointDelete: %v\n", hiddenCep)
-+		touchedCESs := c.manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(hiddenCep), hiddenCep.Namespace)
++		touchedCESs := c.manager.UpdateCEPMapping(hiddenCep.ccep, hiddenCep.ns)
 +		c.enqueueCESReconciliation(touchedCESs, DefaultCESSyncTime)
 +	}
 +
@@ -479,7 +482,7 @@ index 3b3ffc13ef..b59350c817 100644
  			c.fastQueue.Add(ces)
  		} else {
  			c.standardQueue.Add(ces)
-@@ -108,7 +349,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+@@ -108,7 +350,7 @@ func (c *Controller) addToQueue(ces CESKey) {
  
  }
  
@@ -488,7 +491,7 @@ index 3b3ffc13ef..b59350c817 100644
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {
-@@ -117,7 +358,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+@@ -117,7 +359,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
  				c.enqueuedAt[ces] = time.Now()
  			}
  			c.enqueuedAtLock.Unlock()
@@ -497,7 +500,7 @@ index 3b3ffc13ef..b59350c817 100644
  		}
  	}
  }
-@@ -186,6 +427,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+@@ -186,6 +428,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From de750c726a68dce6fcf9c9515adadc8d2db5ad73 Mon Sep 17 00:00:00 2001
+From d5828b535c4e77107af6e7be52ecc01aef5dd816 Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -12,7 +12,8 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  daemon/cmd/hostips-sync.go                    |   2 +-
  daemon/cmd/state.go                           |   2 +-
  daemon/cmd/status.go                          |   2 +-
- .../pkg/ciliumendpointslice/endpointslice.go  | 277 +++++++++++++-
+ .../pkg/ciliumendpointslice/endpointslice.go  | 321 +++++++++++++++-
+ .../pkg/ciliumendpointslice/reconciler.go     |   3 +-
  operator/watchers/cilium_endpoint.go          |   1 +
  pkg/datapath/alignchecker/alignchecker.go     |   2 +-
  pkg/datapath/linux/config/config.go           |   2 +-
@@ -25,7 +26,7 @@ Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
  pkg/maps/bwmap/bwmap.go                       |   2 +-
  pkg/maps/lxcmap/doc.go                        |   9 -
  pkg/maps/lxcmap/lxcmap.go                     | 252 -------------
- 20 files changed, 669 insertions(+), 288 deletions(-)
+ 21 files changed, 714 insertions(+), 290 deletions(-)
  delete mode 100644 pkg/maps/lxcmap/doc.go
  delete mode 100644 pkg/maps/lxcmap/lxcmap.go
 
@@ -170,10 +171,10 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..76d757f807 100644
+index 3b3ffc13ef..10813bfab1 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
-@@ -6,8 +6,12 @@ package ciliumendpointslice
+@@ -6,8 +6,13 @@ package ciliumendpointslice
  import (
  	"context"
  	"fmt"
@@ -183,10 +184,11 @@ index 3b3ffc13ef..76d757f807 100644
  	"time"
  
 +	cilium_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
++	"github.com/cilium/cilium/pkg/lock"
  	"github.com/cilium/hive/cell"
  	"github.com/cilium/hive/job"
  	"github.com/cilium/workerpool"
-@@ -18,6 +22,7 @@ import (
+@@ -18,6 +23,7 @@ import (
  	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
  	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
  	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -194,7 +196,7 @@ index 3b3ffc13ef..76d757f807 100644
  	"github.com/cilium/cilium/pkg/logging/logfields"
  )
  
-@@ -49,10 +54,238 @@ const (
+@@ -49,10 +55,281 @@ const (
  	// batched and synced together after a short delay.
  	DefaultCESSyncTime = 500 * time.Millisecond
  
@@ -216,6 +218,14 @@ index 3b3ffc13ef..76d757f807 100644
 +	return c > rv
 +}
 +
++func equalCeps2(cep0 *cilium_api_v2.CiliumEndpoint, cep1 *coreCiliumEndpointNS) bool {
++	return cep0.Name == cep1.ccep.Name && cep0.Namespace == cep1.ns
++}
++
++func equalCeps(cep0, cep1 *coreCiliumEndpointNS) bool {
++	return cep0.ccep.Name == cep1.ccep.Name && cep0.ns == cep1.ns
++}
++
 +func getPriority(s string) cepPriority {
 +	if num, err := strconv.ParseUint(s, 10, 32); err == nil {
 +		return cepPriority(num)
@@ -234,6 +244,7 @@ index 3b3ffc13ef..76d757f807 100644
 +}
 +
 +type priorityFilter struct {
++	mutex       lock.RWMutex
 +	ipToCepList map[string][]coreCiliumEndpointInfo
 +}
 +
@@ -275,22 +286,56 @@ index 3b3ffc13ef..76d757f807 100644
 +	return shared
 +}
 +
++func (c *priorityFilter) getCoreCiliumEndpoint(cep *cilium_api_v2.CiliumEndpoint) *cilium_v2alpha1.CoreCiliumEndpoint {
++	c.mutex.RLock()
++	defer c.mutex.RUnlock()
++
++	shared := getCepAddressPair(cep)
++	if shared.IPV4 == "" {
++		return nil
++	}
++
++	cepList, exist := c.ipToCepList[shared.IPV4]
++	if !exist {
++		return nil
++	}
++
++	var ccep *cilium_v2alpha1.CoreCiliumEndpoint
++	for i := range cepList {
++		if equalCeps2(cep, cepList[i].cep) {
++			ccep = cepList[i].cep.ccep
++			break
++		}
++	}
++	return ccep
++}
++
++func FilterGetCoreCiliumEndpoint(cep *cilium_api_v2.CiliumEndpoint) *cilium_v2alpha1.CoreCiliumEndpoint {
++	return filter.getCoreCiliumEndpoint(cep)
++}
++
 +// WARNING this update logic will work only if CEP(new and old) network addresses is not changed !!!
 +// If some address was removed in new CEP - it will never removed from map
++// filter support only one ip4 address for pod
 +func (c *priorityFilter) filterAddressByPriority(cep *cilium_api_v2.CiliumEndpoint) (*coreCiliumEndpointNS, time.Duration, *coreCiliumEndpointNS) {
++	c.mutex.Lock()
++	defer c.mutex.Unlock()
++
 +	ccep := &coreCiliumEndpointNS{
 +		ccep: k8s.ConvertCEPToCoreCEP(cep),
 +		ns:   cep.GetNamespace(),
 +	}
++
 +	newOwner := ccep
 +	var oldOwner *coreCiliumEndpointNS
 +	delay := DefaultCESSyncTime
-+	priority := getCepPriority(cep)
-+	// filter support only one ip4 address for pod
++
 +	shared := getCepAddressPair(cep)
 +	if shared.IPV4 == "" {
 +		return oldOwner, delay, newOwner
 +	}
++
++	priority := getCepPriority(cep)
 +
 +	info := coreCiliumEndpointInfo{
 +		cep:      ccep,
@@ -367,14 +412,14 @@ index 3b3ffc13ef..76d757f807 100644
 +	return oldOwner, delay, newOwner
 +}
 +
-+func equalCeps(cep0, cep1 *coreCiliumEndpointNS) bool {
-+	return cep0.ccep.Name == cep1.ccep.Name && cep0.ns == cep1.ns
-+}
-+
 +func (c *priorityFilter) removeCEPFromFilter(cep *cilium_api_v2.CiliumEndpoint) *coreCiliumEndpointNS {
 +	if cep.Status.Networking == nil || cep.GetName() == "" || cep.Namespace == "" {
 +		return nil
 +	}
++
++	filter.mutex.Lock()
++	defer filter.mutex.Unlock()
++
 +	// filter support only one ip4 address for pod
 +	shared := getCepAddressPair(cep)
 +	if shared.IPV4 == "" {
@@ -433,7 +478,7 @@ index 3b3ffc13ef..76d757f807 100644
  func (c *Controller) initializeQueue() {
  	c.logger.Info("CES controller workqueue configuration",
  		logfields.WorkQueueQPSLimit, c.rateLimit.current.Limit,
-@@ -73,31 +306,50 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+@@ -73,31 +350,50 @@ func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
  	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
  		return
  	}
@@ -492,7 +537,7 @@ index 3b3ffc13ef..76d757f807 100644
  			c.fastQueue.Add(ces)
  		} else {
  			c.standardQueue.Add(ces)
-@@ -108,7 +360,7 @@ func (c *Controller) addToQueue(ces CESKey) {
+@@ -108,7 +404,7 @@ func (c *Controller) addToQueue(ces CESKey) {
  
  }
  
@@ -501,7 +546,7 @@ index 3b3ffc13ef..76d757f807 100644
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {
-@@ -117,7 +369,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
+@@ -117,7 +413,7 @@ func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
  				c.enqueuedAt[ces] = time.Now()
  			}
  			c.enqueuedAtLock.Unlock()
@@ -510,7 +555,7 @@ index 3b3ffc13ef..76d757f807 100644
  		}
  	}
  }
-@@ -186,6 +438,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
+@@ -186,6 +482,11 @@ func (c *Controller) Start(ctx cell.HookContext) error {
  			return c.processNamespaceEvents(ctx)
  		}),
  	)
@@ -522,6 +567,27 @@ index 3b3ffc13ef..76d757f807 100644
  	// Start the work pools processing CEP events only after syncing CES in local cache.
  	c.wp = workerpool.New(3)
  	c.wp.Submit("cilium-endpoints-updater", c.runCiliumEndpointsUpdater)
+diff --git a/operator/pkg/ciliumendpointslice/reconciler.go b/operator/pkg/ciliumendpointslice/reconciler.go
+index 5ec6e5966b..60f9b00e09 100644
+--- a/operator/pkg/ciliumendpointslice/reconciler.go
++++ b/operator/pkg/ciliumendpointslice/reconciler.go
+@@ -11,7 +11,6 @@ import (
+ 
+ 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 
+-	"github.com/cilium/cilium/pkg/k8s"
+ 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+ 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+ 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
+@@ -188,7 +187,7 @@ func (r *reconciler) reconcileCESDelete(ces *cilium_v2a1.CiliumEndpointSlice) (e
+ func (r *reconciler) getCoreEndpointFromStore(cepName CEPName) *cilium_v2a1.CoreCiliumEndpoint {
+ 	cepObj, exists, err := r.cepStore.GetByKey(cepName.key())
+ 	if err == nil && exists {
+-		return k8s.ConvertCEPToCoreCEP(cepObj)
++		return FilterGetCoreCiliumEndpoint(cepObj)
+ 	}
+ 	r.logger.Debug(fmt.Sprintf("Couldn't get CEP from Store (err=%v, exists=%v)", err, exists), logfields.CEPName, cepName.string())
+ 	return nil
 diff --git a/operator/watchers/cilium_endpoint.go b/operator/watchers/cilium_endpoint.go
 index 40bf20429a..765ceb9614 100644
 --- a/operator/watchers/cilium_endpoint.go

--- a/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/006-add-pod-prioroty-management.patch
@@ -1,4 +1,4 @@
-From 7363329ab8293ed327754fc6ec739e31338d1be1 Mon Sep 17 00:00:00 2001
+From c924292c9ae35f1fc52227f9e8b030c0a6c7066a Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Mon, 2 Jun 2025 14:44:31 +0300
 Subject: [PATCH] add: priority patch
@@ -170,7 +170,7 @@ index b678668ac0..d42dae075b 100644
  	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
  	"github.com/cilium/cilium/pkg/maps/timestamp"
 diff --git a/operator/pkg/ciliumendpointslice/endpointslice.go b/operator/pkg/ciliumendpointslice/endpointslice.go
-index 3b3ffc13ef..c664a5806b 100644
+index 3b3ffc13ef..5272c8dd58 100644
 --- a/operator/pkg/ciliumendpointslice/endpointslice.go
 +++ b/operator/pkg/ciliumendpointslice/endpointslice.go
 @@ -6,6 +6,9 @@ package ciliumendpointslice
@@ -292,7 +292,7 @@ index 3b3ffc13ef..c664a5806b 100644
 +		if len(cepList) > 1 {
 +			fmt.Printf("DEBUG len(cepList) > 1: %v\n", len(cepList))
 +			for i := range cepList {
-+				fmt.Printf("DEBUG ELEMS index, cep: %v %v %v\n", i, cepList[i].cep.Name, cepList[i].priority)
++				fmt.Printf("DEBUG ELEMs index, cep: %v %v %v\n", i, cepList[i].cep.Name, cepList[i].priority)
 +			}
 +		}
 +
@@ -471,7 +471,7 @@ index 3b3ffc13ef..c664a5806b 100644
  }
  
 -func (c *Controller) enqueueCESReconciliation(cess []CESKey) {
-+func (c *Contwroller) enqueueCESReconciliation(cess []CESKey, delay time.Duration) {
++func (c *Controller) enqueueCESReconciliation(cess []CESKey, delay time.Duration) {
  	for _, ces := range cess {
  		c.logger.Debug("Enqueueing CES (if not empty name)", logfields.CESName, ces.string())
  		if ces.Name != "" {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed cleanup logic in cilium 1.17 when removing cilium endpoint from an cilium operator priority filter.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Without correct cleanup cilium endpoint from operator priority filter may be situation where new cilium endpoint can't reuse IP4 address from previously removed cilium endpoint.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: fixed bug in cilium 1.17 operator priority filter
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
