### PR TITLE
[log-shipper] Add CEF device info to CRD

### DIFF
--- a/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
+++ b/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
@@ -126,8 +126,15 @@ const (
 	EncodingCodecGELF   EncodingCodec = "GELF"
 )
 
+type CEFEncoding struct {
+	DeviceVendor  string `json:"device_vendor,omitempty"`
+	DeviceProduct string `json:"device_product,omitempty"`
+	DeviceVersion string `json:"device_version,omitempty"`
+}
+
 type CommonEncoding struct {
 	Codec EncodingCodec `json:"codec"`
+	CEF   CEFEncoding   `json:"cef,omitempty"`
 }
 
 type LokiSpec struct {

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -432,6 +432,26 @@ spec:
                           type: string
                           enum: ["JSON", "CEF"]
                           default: "JSON"
+                        cef:
+                          type: object
+                          description: |
+                            CEF-specific configuration fields. Only applicable when codec is set to "CEF".
+                          properties:
+                            deviceVendor:
+                              minLength: 1
+                              type: string
+                              description: The device vendor field in CEF format
+                              x-doc-examples: ["MyCompany"]
+                            deviceProduct:
+                              minLength: 1
+                              type: string
+                              description: The device product field in CEF format
+                              x-doc-examples: ["MyProduct"]
+                            deviceVersion:
+                              minLength: 1
+                              type: string
+                              description: The device version field in CEF format
+                              x-doc-examples: ["v0.0.1"]
                     keyField:
                       type: string
                       description: |

--- a/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
@@ -83,12 +83,26 @@ func NewKafka(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Kafka {
 		TimestampFormat: "rfc3339",
 	}
 	if spec.Encoding.Codec == v1alpha1.EncodingCodecCEF {
+		deviceVendor := "Deckhouse"
+		if spec.Encoding.CEF.DeviceVendor != "" {
+			deviceVendor = spec.Encoding.CEF.DeviceVendor
+		}
+
+		deviceProduct := "log-shipper-agent"
+		if spec.Encoding.CEF.DeviceProduct != "" {
+			deviceProduct = spec.Encoding.CEF.DeviceProduct
+		}
+
+		deviceVersion := "1"
+		if spec.Encoding.CEF.DeviceVersion != "" {
+			deviceVersion = spec.Encoding.CEF.DeviceVersion
+		}
 		encoding.Codec = "cef"
 		encoding.CEF = CEFEncoding{
 			Version:            "V1",
-			DeviceVendor:       "Deckhouse",
-			DeviceProduct:      "log-shipper-agent",
-			DeviceVersion:      "1",
+			DeviceVendor:       deviceVendor,
+			DeviceProduct:      deviceProduct,
+			DeviceVersion:      deviceVersion,
 			DeviceEventClassID: "Log event",
 			Name:               "cef.name",
 			Severity:           "cef.severity",


### PR DESCRIPTION
## Description
Fix of image vulnerabilities

## Why do we need it, and what problem does it solve?
To improve security of deckhouse

## What is the expected result?
Fixed CVEs

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus-metrics-adapter
type: fix
summary: Fixed security vulnerabilities in `k8s-prometheus-adapter`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
