### PR TITLE
[prometheus] Fix CVEs vulnerabilities alertmanager

### DIFF
--- a/modules/300-prometheus/images/alertmanager/patches/001-go-mod.patch
+++ b/modules/300-prometheus/images/alertmanager/patches/001-go-mod.patch
@@ -1,18 +1,16 @@
 diff --git a/go.mod b/go.mod
-index 76aa4a2f..f6d90783 100644
+index 76aa4a2f..a24b4250 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -1,6 +1,8 @@
+@@ -1,6 +1,6 @@
  module github.com/prometheus/alertmanager
 
 -go 1.21
 +go 1.23.0
-+
-+toolchain go1.24.3
 
  require (
  	github.com/alecthomas/kingpin/v2 v2.4.0
-@@ -33,16 +35,16 @@ require (
+@@ -33,16 +33,16 @@ require (
  	github.com/prometheus/common/assets v0.2.0
  	github.com/prometheus/common/sigv4 v0.1.0
  	github.com/prometheus/exporter-toolkit v0.11.0
@@ -34,7 +32,7 @@ index 76aa4a2f..f6d90783 100644
  	gopkg.in/telebot.v3 v3.2.1
  	gopkg.in/yaml.v2 v2.4.0
  )
-@@ -85,11 +87,11 @@ require (
+@@ -85,11 +85,11 @@ require (
  	go.opentelemetry.io/otel v1.17.0 // indirect
  	go.opentelemetry.io/otel/metric v1.17.0 // indirect
  	go.opentelemetry.io/otel/trace v1.17.0 // indirect


### PR DESCRIPTION
## Description
Fix of image vulnerabilities

## Why do we need it, and what problem does it solve?
To improve security of deckhouse

## What is the expected result?
Fixed CVEs

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fixed CVEs vulnerabilities alertmanager.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
