### PR TITLE
[node-manager] Add support scaling from zero to CAPI node groups

### DIFF
--- a/modules/040-node-manager/openapi/values.yaml
+++ b/modules/040-node-manager/openapi/values.yaml
@@ -261,6 +261,18 @@ properties:
               type: string
               description: |
                 Value of NodeGroup's annotation "manual-rollout-id".
+            serializedLabels:
+              type: string
+              description: |
+                Labels from node template in the format: key1=value1,key2=value2. If labels does not persist it will set
+                to empty string. Now it needs for correct work scaling from zero for CAPI nodegroups.
+                https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/autoscaling#pre-defined-labels-and-taints-on-nodes-scaled-from-zero
+            serializedTaints:
+              type: string
+              description: |
+                Taints from node template in the format: key1=value1:NoSchedule,key2=value2:NoExecute. If taints does not persist it will set
+                to empty string. Now it needs for correct work scaling from zero for CAPI nodegroups.
+                https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/autoscaling#pre-defined-labels-and-taints-on-nodes-scaled-from-zero
             static:
               type: object
               description: |

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -1750,6 +1750,185 @@ ccc: ddd
 			Expect(capiDeploy.Exists()).To(BeTrue())
 		}
 
+		Context("Scale from zero annotations", func() {
+			const nodeManager = `
+internal:
+  capiControllerManagerEnabled: true
+  bootstrapTokens:
+    worker: mytoken
+  capiControllerManagerWebhookCert:
+    ca: string
+    key: string
+    crt: string
+  capsControllerManagerWebhookCert:
+    ca: string
+    key: string
+    crt: string
+  machineDeployments: {}
+  instancePrefix: myprefix
+  clusterMasterAddresses: ["10.0.0.1:6443", "10.0.0.2:6443", "10.0.0.3:6443"]
+  kubernetesCA: myclusterca
+  cloudProvider:
+    type: vcd
+    machineClassKind: ""
+    capiClusterKind: "VCDCluster"
+    capiClusterAPIVersion: "infrastructure.cluster.x-k8s.io/v1beta2"
+    capiClusterName: "app"
+    capiMachineTemplateKind: "VCDMachineTemplate"
+    capiMachineTemplateAPIVersion: "infrastructure.cluster.x-k8s.io/v1beta2"
+    vcd:
+      sshPublicKey: cert-authority,principals="test" ssh-rsa AAAAB...==
+      organization: org
+      virtualDataCenter: dc
+      virtualApplicationName: app
+      server: https://localhost:5000
+      username: user
+      password: pass
+      insecure: true
+  nodeGroups:
+  - name: without-labels-and-taints
+    serializedLabels: ""
+    serializedTaints: ""
+    nodeCapacity:
+      cpu: "2"
+      memory: "2Gi"
+    instanceClass:
+      rootDiskSizeGb: 20
+      sizingPolicy: s-c572-MSK1-S1-vDC1
+      storageProfile: vHDD
+      template: Ubuntu
+      placementPolicy: policy
+    nodeType: CloudEphemeral
+    kubernetesVersion: "1.24"
+    cri:
+      type: "Containerd"
+    cloudInstances:
+      classReference:
+        kind: VcdInstanceClass
+        name: worker
+      maxPerZone: 5
+      minPerZone: 4
+      zones:
+      - zonea
+      - zoneb
+  - name: with-labels-only
+    serializedLabels: "app=warp-drive-ai,environment=production"
+    serializedTaints: ""
+    nodeCapacity:
+      cpu: "2"
+      memory: "2Gi"
+    instanceClass:
+      rootDiskSizeGb: 20
+      sizingPolicy: s-c572-MSK1-S1-vDC1
+      storageProfile: vHDD
+      template: catalog/Ubuntu
+      placementPolicy: policy
+    nodeType: CloudEphemeral
+    kubernetesVersion: "1.24"
+    cri:
+      type: "Containerd"
+    cloudInstances:
+      classReference:
+        kind: VcdInstanceClass
+        name: worker
+      maxPerZone: 5
+      minPerZone: 4
+      zones:
+      - zonea
+  - name: with-taints-only
+    serializedLabels: ""
+    serializedTaints: "b=v:NoExecute,a,d:NoExecute,c=v1:"
+    nodeCapacity:
+      cpu: "2"
+      memory: "2Gi"
+    instanceClass:
+      rootDiskSizeGb: 20
+      sizingPolicy: s-c572-MSK1-S1-vDC1
+      storageProfile: vHDD
+      template: catalog/Ubuntu
+      placementPolicy: policy
+    nodeType: CloudEphemeral
+    kubernetesVersion: "1.24"
+    cri:
+      type: "Containerd"
+    cloudInstances:
+      classReference:
+        kind: VcdInstanceClass
+        name: worker
+      maxPerZone: 5
+      minPerZone: 4
+      zones:
+      - zonea
+  - name: with-labels-and-taints
+    serializedLabels: "app=warp-drive-ai,environment=production"
+    serializedTaints: "b=v:NoExecute,a,d:NoExecute,c=v1:"
+    nodeCapacity:
+      cpu: "2"
+      memory: "2Gi"
+    instanceClass:
+      rootDiskSizeGb: 20
+      sizingPolicy: s-c572-MSK1-S1-vDC1
+      storageProfile: vHDD
+      template: catalog/Ubuntu
+      placementPolicy: policy
+    nodeType: CloudEphemeral
+    kubernetesVersion: "1.24"
+    cri:
+      type: "Containerd"
+    cloudInstances:
+      classReference:
+        kind: VcdInstanceClass
+        name: worker
+      maxPerZone: 5
+      minPerZone: 4
+      zones:
+      - zonea
+  machineControllerManagerEnabled: false
+`
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("global", globalValues)
+				f.ValuesSet("global.modulesImages", GetModulesImages())
+				f.ValuesSetFromYaml("nodeManager", nodeManagerConfigValues+nodeManager)
+				setBashibleAPIServerTLSValues(f)
+				f.HelmRender()
+			})
+
+			It("Everything must render properly", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				assertAutoscalingAnnotations := func(md object_store.KubeObject, labels, taints string) {
+					Expect(md.Exists()).To(BeTrue())
+
+					annotations := md.Field("metadata.annotations").Map()
+
+					if labels != "" {
+						Expect(annotations["capacity.cluster-autoscaler.kubernetes.io/labels"].String()).To(Equal(labels))
+					} else {
+						Expect(annotations).ToNot(HaveKey("capacity.cluster-autoscaler.kubernetes.io/labels"))
+					}
+
+					if taints != "" {
+						Expect(annotations["capacity.cluster-autoscaler.kubernetes.io/taints"].String()).To(Equal(taints))
+					} else {
+						Expect(annotations).ToNot(HaveKey("capacity.cluster-autoscaler.kubernetes.io/taints"))
+					}
+
+				}
+
+				md1 := f.KubernetesResource("MachineDeployment", "d8-cloud-instance-manager", "myprefix-without-labels-and-taints-02320933")
+				assertAutoscalingAnnotations(md1, "", "")
+
+				md2 := f.KubernetesResource("MachineDeployment", "d8-cloud-instance-manager", "myprefix-with-labels-only-02320933")
+				assertAutoscalingAnnotations(md2, "app=warp-drive-ai,environment=production", "")
+
+				md3 := f.KubernetesResource("MachineDeployment", "d8-cloud-instance-manager", "myprefix-with-taints-only-02320933")
+				assertAutoscalingAnnotations(md3, "", "b=v:NoExecute,a,d:NoExecute,c=v1:")
+
+				md4 := f.KubernetesResource("MachineDeployment", "d8-cloud-instance-manager", "myprefix-with-labels-and-taints-02320933")
+				assertAutoscalingAnnotations(md4, "app=warp-drive-ai,environment=production", "b=v:NoExecute,a,d:NoExecute,c=v1:")
+			})
+		})
+
 		Context("VCD", func() {
 			const nodeManagerVCD = `
 internal:

--- a/modules/040-node-manager/templates/node-group/_capi_machine_deployment.tpl
+++ b/modules/040-node-manager/templates/node-group/_capi_machine_deployment.tpl
@@ -27,6 +27,12 @@ metadata:
     capacity.cluster-autoscaler.kubernetes.io/cpu: {{ $ng.nodeCapacity.cpu | quote }}
     capacity.cluster-autoscaler.kubernetes.io/memory: {{ $ng.nodeCapacity.memory | quote }}
   {{- end }}
+  {{- if $ng.serializedLabels }}
+    capacity.cluster-autoscaler.kubernetes.io/labels: {{ $ng.serializedLabels | quote }}
+  {{- end }}
+  {{- if $ng.serializedTaints }}
+    capacity.cluster-autoscaler.kubernetes.io/taints: {{ $ng.serializedTaints | quote }}
+  {{- end }}
 spec:
   clusterName: {{ $context.Values.nodeManager.internal.cloudProvider.capiClusterName | quote }}
   template:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
