### PR TITLE
[fix] static e2e tests for fe/upgrade (#13667)

### DIFF
--- a/testing/cloud_layouts/Static/infra.tpl.tf
+++ b/testing/cloud_layouts/Static/infra.tpl.tf
@@ -182,7 +182,7 @@ resource "openstack_compute_instance_v2" "master" {
 
 resource "openstack_blockstorage_volume_v3" "bastion" {
   name                 = "candi-${PREFIX}-bastion-0"
-  size                 = "60"
+  size                 = "90"
   image_id             = data.openstack_images_image_v2.astra_image.id
   volume_type          = var.volume_type
   availability_zone    = var.az_zone

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -739,6 +739,38 @@ d8 mirror pull d8 --source-login ${D8_MIRROR_USER} --source-password ${D8_MIRROR
   --source "dev-registry.deckhouse.io/sys/deckhouse-oss" --deckhouse-tag "${DEV_BRANCH}"
 # push
 d8 mirror push d8 "${IMAGES_REPO}" --registry-login mirror --registry-password $LOCAL_REGISTRY_MIRROR_PASSWORD
+
+# Checking that it's FE-UPGRADE
+# Extracting major and minor versions from DECKHOUSE_IMAGE_TAG
+dh_version="${DECKHOUSE_IMAGE_TAG#release-}"
+dh_major="\${dh_version%%.*}"
+
+# Handle both 'release-x.y' and 'release-x.y-test-z'
+dh_minor_version_part="\${dh_version#*.}"
+dh_minor_number="\${dh_minor_version_part%%-*}"
+dh_minor="\${dh_minor_number%.*}"
+
+# Extracting the major and minor versions from INITIAL_IMAGE_TAG
+initial_version="${INITIAL_IMAGE_TAG#release-}"
+initial_major="\${initial_version%%.*}"
+
+initial_minor_version_part="\${initial_version#*.}"
+initial_minor_number="\${initial_minor_version_part%%-*}"
+initial_minor="\${initial_minor_number%.*}"
+
+echo "Initial Minor Version: \$initial_minor"
+echo "Deckhouse Minor Version: \$dh_minor"
+
+# Check that the major versions match and the minor differs by +1
+if [ "\$dh_major" = "\$initial_major" ] && [ "\$dh_minor" -eq "\$((initial_minor + 1))" ]; then
+    >&2 echo "Pull both versions of fe-upgrade"
+    # pull
+    d8 mirror pull d8-upgrade --source-login ${D8_MIRROR_USER} --source-password ${D8_MIRROR_PASSWORD} \
+    --source "dev-registry.deckhouse.io/sys/deckhouse-oss" --deckhouse-tag "${DECKHOUSE_IMAGE_TAG}"
+    # push
+    d8 mirror push d8-upgrade "${IMAGES_REPO}" --registry-login mirror --registry-password ${LOCAL_REGISTRY_MIRROR_PASSWORD}
+fi
+
 set +x
 EOF
        chmod +x /tmp/install-d8-and-pull-push-images.sh
@@ -747,7 +779,8 @@ EOF
        # cleanup
        rm -f /tmp/install-d8-and-pull-push-images.sh
        rm -rf d8
-           
+       rm -rf d8-upgrade
+
        docker run -d --name='tinyproxy' --restart=always -p 8888:8888 -e ALLOWED_NETWORKS="127.0.0.1/8 10.0.0.0/8 192.168.0.1/8" mirror.gcr.io/kalaksi/tinyproxy:latest@sha256:561ef49fa0f0a9747db12abdfed9ab3d7de17e95c811126f11e026b3b1754e54
 ENDSSH
 


### PR DESCRIPTION
## Description
fix static e2e tests for fe/upgrade

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: fix static e2e tests for fe/upgrade
impact: fix static e2e tests for fe/upgrade
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
