### PR TITLE
[docs] Rephrased the information about publicDomainTemplate at documentation

### DIFF
--- a/docs/documentation/pages/DECKHOUSE_CONFIGURE_GLOBAL.md
+++ b/docs/documentation/pages/DECKHOUSE_CONFIGURE_GLOBAL.md
@@ -7,11 +7,12 @@ description: "Deckhouse Kubernetes Platform global settings."
 The global Deckhouse settings are stored in the `ModuleConfig/global` resource (see [Deckhouse configuration](./#deckhouse-configuration)).
 
 {% alert %}
-The [publicDomainTemplate](#parameters-modules-publicdomaintemplate) parameter defines the DNS names template some Deckhouse modules use to create Ingress resources.
+The [publicDomainTemplate](#parameters-modules-publicdomaintemplate) parameter specifies a DNS name template used by some Deckhouse modules to create Ingress resources.
 
-You can use the [sslip.io](https://sslip.io/) service (or similar) for testing if wildcard DNS records are unavailable to you for some reason.
+If you don't have access to wildcard DNS records, you can use [sslip.io](https://sslip.io) or similar services for testing purposes.
 
-Domain used in the template must not match the domain specified in the [clusterDomain](installing/configuration.html#clusterconfiguration-clusterdomain) parameter. For example, if `clusterDomain` is set to `cluster.local` (the default value), `publicDomainTemplate` cannot be set to `%s.cluster.local`.
+The domain specified in the template must not match the domain set in the [clusterDomain](installing/configuration.html#clusterconfiguration-clusterdomain) parameter, nor the domain of the internal service network zone.  
+For example, if `clusterDomain` is set to `cluster.local` and the internal zone is `ru-central1.internal`, then publicDomainTemplate must not be `%s.cluster.local` or `%s.ru-central1.internal`.
 {% endalert %}
 
 Example of the `ModuleConfig/global`:

--- a/docs/documentation/pages/DECKHOUSE_CONFIGURE_GLOBAL_RU.md
+++ b/docs/documentation/pages/DECKHOUSE_CONFIGURE_GLOBAL_RU.md
@@ -8,11 +8,12 @@ lang: ru
 Глобальные настройки Deckhouse хранятся в ресурсе `ModuleConfig/global` (см. [конфигурация Deckhouse](./#конфигурация-deckhouse)).
 
 {% alert %}
-В параметре [publicDomainTemplate](#parameters-modules-publicdomaintemplate) указывается шаблон DNS-имен, с учетом которого некоторые модули Deckhouse создают Ingress-ресурсы.
+В параметре [publicDomainTemplate](#parameters-modules-publicdomaintemplate) указывается шаблон DNS-имен, с учётом которого некоторые модули Deckhouse создают Ingress-ресурсы.
 
 Если у вас нет возможности заводить wildcard-записи DNS, для тестирования можно воспользоваться сервисом [sslip.io](https://sslip.io) или его аналогами.
 
-Домен, используемый в шаблоне, не должен совпадать с доменом, указанным в параметре [clusterDomain](installing/configuration.html#clusterconfiguration-clusterdomain). Например, если `clusterDomain` установлен в `cluster.local` (значение по умолчанию), то `publicDomainTemplate` не может быть `%s.cluster.local`.
+Домен, указанный в шаблоне, не должен совпадать с доменом, заданным в параметре [clusterDomain](installing/configuration.html#clusterconfiguration-clusterdomain), а также с доменом внутренней сервисной зоны сети.  
+Например, если `clusterDomain` установлен в `cluster.local`, а внутренняя зона — `ru-central1.internal`, то publicDomainTemplate не может быть ни `%s.cluster.local`, ни `%s.ru-central1.internal`.
 {% endalert %}
 
 Пример ресурса `ModuleConfig/global`:

--- a/global-hooks/openapi/config-values.yaml
+++ b/global-hooks/openapi/config-values.yaml
@@ -67,8 +67,9 @@ properties:
 
           **Pay attention to the following:**
           - Domain must be different from [clusterDomain](https://deckhouse.io/products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration-clusterdomain)!**
-          - Domain used in the template must not match the domain specified in the [clusterDomain](https://deckhouse.io/products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration-clusterdomain) parameter. For example, if `clusterDomain` is set to `cluster.local` (the default value), `publicDomainTemplate` cannot be set to `%s.cluster.local`.
-          - Domain used in the template should not match the domain specified in the [clusterDomain](https://deckhouse.io/products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration-clusterdomain) parameter and the internal service network zone. For example, if clusterDomain is set to cluster.local (default value) and the service network zone is ru-central1.internal, then publicDomainTemplate cannot be %s.cluster.local or %s.ru-central1.internal.
+          - The domain specified in the template must not match the domain defined in the [clusterDomain](https://deckhouse.io/products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration-clusterdomain) parameter.
+          - The domain used in the template must also not match the domain of the internal service network zone.  
+          For example, if the internal zone is `ru-central1.internal`, then publicDomainTemplate must not be `%s.ru-central1.internal`.
           - If this parameter is omitted, no Ingress resources will be created.
         x-doc-examples: [ "%s.kube.company.my", "kube-%s.company.my" ]
         x-examples: [ "%s.kube.company.my" ]

--- a/global-hooks/openapi/doc-ru-config-values.yaml
+++ b/global-hooks/openapi/doc-ru-config-values.yaml
@@ -45,8 +45,9 @@ properties:
 
           **Обратите внимание:**
           - Нельзя использовать в кластере DNS-имена (создавать соответствующие Ingress-ресурсы), подпадающие под указанный шаблон. Это может вызвать пересечения с создаваемыми Deckhouse Ingress-ресурсами.
-          - Домен, используемый в шаблоне, не должен совпадать с доменом, указанным в параметре [clusterDomain](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration-clusterdomain). Например, если `clusterDomain` установлен в `cluster.local` (значение по умолчанию), то `publicDomainTemplate` не может быть `%s.cluster.local`.
-          - Домен, используемый в шаблоне, не должен совпадать с доменом, указанным в параметре [clusterDomain](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration-clusterdomain) и внутренней сервисной зоне сети. Например, если clusterDomain установлен в cluster.local (по умолчанию), а сервисная зона сети — ru-central1.internal, то publicDomainTemplate не может быть %s.cluster.local или %s.ru-central1.internal.
+          - Домен, указанный в шаблоне, не должен совпадать с доменом, заданным в параметре [clusterDomain](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration-clusterdomain).
+          - Домен, используемый в шаблоне, также не должен совпадать с доменом внутренней сервисной зоны сети.  
+          Например, если внутренняя зона — `ru-central1.internal`, то publicDomainTemplate не может быть `%s.ru-central1.internal`.
           - Если параметр не указан, Ingress-ресурсы создаваться не будут.
       placement:
         description: |


### PR DESCRIPTION
## Description
Rephrased the information about publicDomainTemplate at documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix 
summary: Rephrased the information about publicDomainTemplate at documentation.
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
