### PR TITLE
[user-authz] role-binding problem

### DIFF
--- a/modules/140-user-authz/hooks/handle_dict_bindings.go
+++ b/modules/140-user-authz/hooks/handle_dict_bindings.go
@@ -93,6 +93,7 @@ func ensureDictBindings(input *go_hook.HookInput) error {
 		}
 
 		for _, subject := range parsed.Subjects {
+			subject.Namespace = "default"
 			subjects[stringBySubject(subject)] = subject
 		}
 	}


### PR DESCRIPTION
## Description
Fixes an issue where the user-authz module fails to process RoleBindings/ClusterRoleBindings when ServiceAccount subjects don't have an explicitly specified namespace. The hook handle_dict_bindings.go attempts to create these bindings but crashes with the error:
subjects[0].namespace: Required value.

Automatic fallback to the "default" namespace when not specified

## Why do we need it, and what problem does it solve?

Currently, if a RoleBinding contains a ServiceAccount subject without a namespace, the entire hook fails and enters a crash loop (visible in logs as sleep after fail messages). This affects:

Cluster stability: The module keeps retrying failed operations.
User experience: Admins see RBAC errors without clear context.
Security: Some legitimate bindings might not be applied.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->



<!---
## Why do we need it in the patch release (if we do)?
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authz
type: fix
summary: fix role-binding problem
impact: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
