### PR TITLE
[docs] Correct numbers and padding

### DIFF
--- a/docs/site/_assets/css/docs.scss
+++ b/docs/site/_assets/css/docs.scss
@@ -942,10 +942,6 @@ a.comparison-table__module-proprietaryOkmeter::after {
     margin-left: 24px;
 }
 
-.docs .resources pre.highlight {
-  padding-left: 16px;
-}
-
 .docs ol {
     list-style-type: decimal;
 }

--- a/docs/site/_assets/js/customscripts.js
+++ b/docs/site/_assets/js/customscripts.js
@@ -469,13 +469,15 @@ document.addEventListener("DOMContentLoaded", function() {
 
     let newHTML = '';
 
-    lines.forEach((line, index) => {
+    let lineIndex = 1;
+    lines.forEach(line => {
       const trimLine = line.trim();
 
       if(trimLine.length === 0 || /^<\/span\s*>$/.test(trimLine)) {
         return;
       }
-      newHTML += `<span data-copy="ignore" class="line-number">${index + 1}</span>${line}\n`;
+      newHTML += `<span data-copy="ignore" class="line-number">${lineIndex}</span>${line}\n`;
+      lineIndex++;
     });
 
     code.innerHTML = newHTML;


### PR DESCRIPTION
## Description

Correct numbers and padding.
Fix https://github.com/deckhouse/deckhouse/pull/13161

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Correct numbers and padding. Fix #13161.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
