### PR TITLE
[docs] Updated VCD Getting Started documentation

### DIFF
--- a/docs/site/_includes/getting_started/vcd/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/vcd/partials/config.ru.yml.standard.other.inc
@@ -116,6 +116,11 @@ kind: ModuleConfig
 metadata:
   name: metallb
 spec:
+  enabled: true
+  settings:
+    speaker:
+      nodeSelector:
+        node-role.deckhouse.io/frontend: ""
   version: 2
   enabled: true
   settings:
@@ -141,6 +146,28 @@ spec:
         operator: Equal
         value: frontend
 ---
+# [<en>] Load balancer class for Ingress resources.
+# [<en>] https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/metallb/cr.html#metalloadbalancerclass
+# [<ru>] Класс балансировщика нагрузки для ресурсов Ingress.
+# [<ru>] https://deckhouse.ru/products/kubernetes-platform/documentation/v1/modules/metallb/cr.html#metalloadbalancerclass
+apiVersion: network.deckhouse.io/v1alpha1
+kind: MetalLoadBalancerClass
+metadata:
+  name: ingress
+spec:
+  # [<en>] IP range from the address pool.
+  # [<ru>] Диапазон IP-адресов из пула.
+  addressPool:
+    - 192.168.207.100-192.168.207.101  # <- замените на свои свободные IP в сети frontend-нод
+  # [<en>] Set false to apply this class only when explicitly requested.
+  # [<ru>] False — класс используется только при явном указании.
+  isDefault: false
+  # [<en>] Limit allocation to nodes with the frontend role.
+  # [<ru>] Ограничить выдачу IP-адресов только нодам с ролью frontend.
+  nodeSelector:
+    node-role.deckhouse.io/frontend: ""
+  type: L2
+---
 # [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/cloud-provider-vsphere/cluster_configuration.html
 # [<ru>] Настройки облачного провайдера.
@@ -164,7 +191,7 @@ masterNodeGroup:
     # [<en>] The name of the image, taking into account the vCloudDirector catalog path.
     # [<en>] Example: "catalog/ubuntu-jammy-22.04".
     # [<ru>] Имя образа, созданного с учетом каталога размещения образа в vCloudDirector.
-    # [<ru>] Пример: "catatlog/ubuntu-jammy-22.04".
+    # [<ru>] Пример: "catalog/ubuntu-jammy-22.04".
     template: *!CHANGE_TEMPLATE_NAME*
   replicas: 1
 nodeGroups:
@@ -177,7 +204,7 @@ nodeGroups:
     # [<en>] The name of the image, taking into account the vCloudDirector catalog path.
     # [<en>] Example: "catalog/ubuntu-jammy-22.04".
     # [<ru>] Имя образа, созданного с учетом каталога размещения образа в vCloudDirector.
-    # [<ru>] Пример: "catatlog/ubuntu-jammy-22.04".
+    # [<ru>] Пример: "catalog/ubuntu-jammy-22.04".
     template: *!CHANGE_TEMPLATE_NAME*
   name: frontend
   replicas: 1
@@ -260,15 +287,15 @@ spec:
   ingressClass: nginx
   # [<en>] The way traffic goes to cluster from the outer network.
   # [<ru>] Способ поступления трафика из внешнего мира.
-  inlet: HostPort
-  hostPort:
-    httpPort: 80
-    httpsPort: 443
-    realIPHeader: X-Forwarded-For
+  inlet: LoadBalancer
+  loadBalancer:
+    loadBalancerClass: ingress
   nodeSelector:
-    node-role.kubernetes.io/control-plane: ""
+    node-role.deckhouse.io/frontend: ""
   tolerations:
-  - operator: Exists
+    - key: dedicated.deckhouse.io
+      operator: Equal
+      value: frontend
 ---
 # [<en>] RBAC and authorization settings.
 # [<en>] https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/user-authz/cr.html#clusterauthorizationrule

--- a/docs/site/_includes/getting_started/vcd/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/vcd/partials/config.yml.standard.other.inc
@@ -116,6 +116,11 @@ kind: ModuleConfig
 metadata:
   name: metallb
 spec:
+  enabled: true
+  settings:
+    speaker:
+      nodeSelector:
+        node-role.deckhouse.io/frontend: ""
   version: 2
   enabled: true
   settings:
@@ -140,6 +145,28 @@ spec:
         key: dedicated.deckhouse.io
         operator: Equal
         value: frontend
+---
+# [<en>] Load balancer class for Ingress resources.
+# [<en>] https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/metallb/cr.html#metalloadbalancerclass
+# [<ru>] Класс балансировщика нагрузки для ресурсов Ingress.
+# [<ru>] https://deckhouse.ru/products/kubernetes-platform/documentation/v1/modules/metallb/cr.html#metalloadbalancerclass
+apiVersion: network.deckhouse.io/v1alpha1
+kind: MetalLoadBalancerClass
+metadata:
+  name: ingress
+spec:
+  # [<en>] IP range from the address pool.
+  # [<ru>] Диапазон IP-адресов из пула.
+  addressPool:
+    - 192.168.207.100-192.168.207.101  # <- замените на свои свободные IP в сети frontend-нод
+  # [<en>] Set false to apply this class only when explicitly requested.
+  # [<ru>] False — класс используется только при явном указании.
+  isDefault: false
+  # [<en>] Limit allocation to nodes with the frontend role.
+  # [<ru>] Ограничить выдачу IP-адресов только нодам с ролью frontend.
+  nodeSelector:
+    node-role.deckhouse.io/frontend: ""
+  type: L2
 ---
 # [<en>] Cloud provider settings.
 # [<en>] https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/cloud-provider-vsphere/cluster_configuration.html
@@ -260,15 +287,15 @@ spec:
   ingressClass: nginx
   # [<en>] The way traffic goes to cluster from the outer network.
   # [<ru>] Способ поступления трафика из внешнего мира.
-  inlet: HostPort
-  hostPort:
-    httpPort: 80
-    httpsPort: 443
-    realIPHeader: X-Forwarded-For
+  inlet: LoadBalancer
+  loadBalancer:
+    loadBalancerClass: ingress
   nodeSelector:
-    node-role.kubernetes.io/control-plane: ""
+    node-role.deckhouse.io/frontend: ""
   tolerations:
-  - operator: Exists
+    - key: dedicated.deckhouse.io
+      operator: Equal
+      value: frontend
 ---
 # [<en>] RBAC and authorization settings.
 # [<en>] https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/user-authz/cr.html#clusterauthorizationrule


### PR DESCRIPTION
## Description
Updated VCD Getting Started documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Updated VCD Getting Started documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
