### PR TITLE
[docs] Added global module conversions at documentation

### DIFF
--- a/docs/documentation/_tools/modules_generate_configuration.sh
+++ b/docs/documentation/_tools/modules_generate_configuration.sh
@@ -56,6 +56,8 @@ done
 
 if [ -d /src/global ]; then
   mkdir -p /srv/jekyll-data/documentation/_data/schemas/global/crds
+  # Conversions
+  cp -fr /src/global/conversions _data/schemas/global/
   # OpenAPI spec for Deckhouse global config
   cp -f /src/global/config-values.yaml _data/schemas/global/
   echo -e "\ni18n:\n  ru:" >>_data/schemas/global/config-values.yaml

--- a/docs/documentation/pages/DECKHOUSE_CONFIGURE_GLOBAL.md
+++ b/docs/documentation/pages/DECKHOUSE_CONFIGURE_GLOBAL.md
@@ -2,6 +2,7 @@
 title: "Global configuration"
 permalink: en/deckhouse-configure-global.html
 description: "Deckhouse Kubernetes Platform global settings."
+module-kebab-name: "global"
 ---
 
 The global Deckhouse settings are stored in the `ModuleConfig/global` resource (see [Deckhouse configuration](./#deckhouse-configuration)).
@@ -36,6 +37,8 @@ spec:
         - dedicated.example.com
       storageClass: 'default-fast'
 ```
+
+{% include module-conversion.liquid %}
 
 ## Parameters
 

--- a/docs/documentation/pages/DECKHOUSE_CONFIGURE_GLOBAL_RU.md
+++ b/docs/documentation/pages/DECKHOUSE_CONFIGURE_GLOBAL_RU.md
@@ -2,6 +2,7 @@
 title: "Глобальные настройки"
 permalink: ru/deckhouse-configure-global.html
 description: "Описание глобальных настроек Deckhouse Kubernetes Platform"
+module-kebab-name: "global"
 lang: ru
 ---
 
@@ -37,6 +38,8 @@ spec:
         - dedicated.example.com
       storageClass: 'default-fast'
 ```
+
+{% include module-conversion.liquid %}
 
 ## Параметры
 

--- a/docs/documentation/werf-git-section.inc.yaml
+++ b/docs/documentation/werf-git-section.inc.yaml
@@ -32,7 +32,7 @@
   group: jekyll
   stageDependencies:
     setup: ['**/*']
-  includePaths: ['*config-values.yaml','doc-ru-config-values.yaml']
+  includePaths: ['*config-values.yaml','doc-ru-config-values.yaml','conversions/v*.yml','conversions/v*.yaml']
 - add: /candi/openapi
   to: /src/global
   owner: jekyll


### PR DESCRIPTION
## Description
Added global module conversions at documentation.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Added global module conversions at documentation.↓
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
