### PR TITLE
[docs] Add logs for modules processing

### DIFF
--- a/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scanner/process.go
+++ b/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scanner/process.go
@@ -69,6 +69,8 @@ func (s *registryscanner) processModules(ctx context.Context, registry Client, m
 	versions := make([]internal.VersionData, 0, len(modules))
 
 	for _, module := range modules {
+		s.logger.Info("processing module", slog.String("module", module))
+
 		tags, err := registry.ListTags(ctx, module)
 		if err != nil {
 			s.logger.Error("failed to list tags",
@@ -90,6 +92,8 @@ func (s *registryscanner) processReleaseChannels(ctx context.Context, registry, 
 	versions := make([]internal.VersionData, 0, len(releaseChannels))
 
 	for _, releaseChannel := range releaseChannels {
+		s.logger.Info("processing channel", slog.String("module", module), slog.String("channel", releaseChannel))
+
 		versionData, err := s.processReleaseChannel(ctx, registry, module, releaseChannel)
 		if err != nil {
 			s.logger.Error("failed to process release channel",


### PR DESCRIPTION
## Description
Improved Logging for Module Processing
We've added info-level logging to module processing functions to improve visibility. Previously, there was no way to track which modules were being processed in real-time, making debugging difficult. 
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
The new logs now provide:
- Real-time visibility into currently processing modules
- Clear tracking of module execution flow
- Immediate feedback during operations

Problems Solved:
- Eliminated blind spots in module processing
- Enabled real-time monitoring of operations
- Improved debugging capabilities

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: feature
summary: Added info level logs
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
