### PR TITLE
[chore] deckhouse version generating in CI

### DIFF
--- a/.werf/werf-deckhouse-controller.yaml
+++ b/.werf/werf-deckhouse-controller.yaml
@@ -45,17 +45,24 @@ shell:
   - |
     CI_COMMIT_TAG="{{- env "CI_COMMIT_TAG" "" }}"
     if [ -z "$CI_COMMIT_TAG" ]; then
-        latest_tag=$(git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags https://github.com/deckhouse/deckhouse.git 'v*.*.*' | tail --lines=1 | cut --delimiter='/' --fields=3)
-        IFS='.' read -r -a version_parts <<< "$latest_tag"
-
-        major=${version_parts[0]}
-        minor=${version_parts[1]}
-        new_minor=$((minor + 1))
-        new_patch=0
-        prerelease={{- env "CI_COMMIT_REF_SLUG" "main" }}
-
-        new_version="${major}.${new_minor}.${new_patch}-${prerelease}+${WERF_COMMIT_HASH::7}"
-        export CI_COMMIT_TAG=${new_version}
+      if [[ "$CI_COMMIT_REF_SLUG" =~ ^release-([0-9]+\.[0-9]+)$ ]]; then
+          # CI_COMMIT_REF_SLUG for release branch `release-X.Y`. Need for e2e testing
+          version="${BASH_REMATCH[1]}"
+          # `release-1.69` branch will become `v1.69.0`
+          CI_COMMIT_TAG="v${version}.0"
+      else
+          # for dev branches - create release as next prerelease version. Get the latest branch and increment the minor version
+          latest_tag=$(git -c 'versionsort.suffix=-' ls-remote --exit-code --sort='version:refname' --refs --heads https://github.com/deckhouse/deckhouse.git 'refs/heads/release-[0-9]\.[0-9]?' | tail --lines=1 | cut --delimiter='/' --fields=3 | sed 's/release-/v/').0
+          IFS='.' read -r -a version_parts <<< "$latest_tag"
+          major=${version_parts[0]}
+          minor=${version_parts[1]}
+          new_minor=$((minor + 1))
+          new_patch=0
+          prerelease={{- env "CI_COMMIT_REF_SLUG" "main" }}
+          new_version="${major}.${new_minor}.${new_patch}-${prerelease}+${WERF_COMMIT_HASH::7}"
+          CI_COMMIT_TAG=${new_version}
+      fi
+      export CI_COMMIT_TAG
     fi
   - cd /deckhouse
   # Generate hooks imports for particular edition

--- a/.werf/werf-deckhouse-controller.yaml
+++ b/.werf/werf-deckhouse-controller.yaml
@@ -44,6 +44,7 @@ shell:
   setup:
   - |
     CI_COMMIT_TAG="{{- env "CI_COMMIT_TAG" "" }}"
+    CI_COMMIT_REF_SLUG="{{- env "CI_COMMIT_REF_SLUG" "" }}"
     if [ -z "$CI_COMMIT_TAG" ]; then
       if [[ "$CI_COMMIT_REF_SLUG" =~ ^release-([0-9]+\.[0-9]+)$ ]]; then
           # CI_COMMIT_REF_SLUG for release branch `release-X.Y`. Need for e2e testing


### PR DESCRIPTION
## Description
Change deckhouse version generation during the build phase

## Why do we need it, and what problem does it solve?
At now we are calculating the deckhouse version for the latest tag. It has 2 cases:
1. Next tag is not created yet but the release branch exists
2. `release-X.Y` branches generates `v1.<tag>.0-release-X.Y.` release version


We can change the logic:
1. Use latest branch, not tag for calculating the next prerelease version
2. Change logic for `release` branches to generate the desired deckhouse version `release-1.69` generate `v1.69.0`

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Change deckhouse version variable generation
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
