### PR TITLE
[docs] Add read-only mode comments for the console module editions

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -90,7 +90,7 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "The system part of the platform in UI is available in read-only mode",
+        "en": "The system part of the platform in UI&nbsp;is available in read-only mode",
         "ru": "Системная часть платформы в UI&nbsp;доступна только на чтение"
       }
     },

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -88,6 +88,12 @@
       "ce",
       "be"
     ],
+    "editionsWithRestrictionsComments": {
+      "all": {
+        "en": "The system part of the platform in UI is available in read-only mode",
+        "ru": "Системная часть платформы в UI&nbsp;доступна только на чтение"
+      }
+    },
     "external": "true",
     "path": "/products/kubernetes-platform/modules/console/stable/"
   },

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -90,8 +90,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "The system part of the platform in UI&nbsp;is available in read-only mode",
-        "ru": "Системная часть платформы в UI&nbsp;доступна только на чтение"
+        "en": "The system part of the platform in UI is available in read-only mode",
+        "ru": "Системная часть платформы в UI доступна только на чтение"
       }
     },
     "external": "true",

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -90,8 +90,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "The system part of the platform in UI is available in read-only mode",
-        "ru": "Системная часть платформы в UI доступна только на чтение"
+        "en": "The system part of Deckhouse is read-only in the web UI",
+        "ru": "Системная часть Deckhouse доступна в веб-интерфейсе только для чтения"
       }
     },
     "external": "true",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -50,7 +50,7 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "The system part of the platform in UI is available in read-only mode",
+        "en": "The system part of the platform in UI&nbsp;is available in read-only mode",
         "ru": "Системная часть платформы в UI&nbsp;доступна только на чтение"
       }
     },

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -50,8 +50,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "The system part of the platform in UI&nbsp;is available in read-only mode",
-        "ru": "Системная часть платформы в UI&nbsp;доступна только на чтение"
+        "en": "The system part of the platform in UI is available in read-only mode",
+        "ru": "Системная часть платформы в UI доступна только на чтение"
       }
     },
     "external": "true",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -48,6 +48,12 @@
       "ce",
       "be"
     ],
+    "editionsWithRestrictionsComments": {
+      "all": {
+        "en": "The system part of the platform in UI is available in read-only mode",
+        "ru": "Системная часть платформы в UI&nbsp;доступна только на чтение"
+      }
+    },
     "external": "true",
     "path": "/products/kubernetes-platform/modules/console/stable/"
   },

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -50,8 +50,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "The system part of the platform in UI is available in read-only mode",
-        "ru": "Системная часть платформы в UI доступна только на чтение"
+        "en": "The system part of Deckhouse is read-only in the web UI",
+        "ru": "Системная часть Deckhouse доступна в веб-интерфейсе только для чтения"
       }
     },
     "external": "true",


### PR DESCRIPTION
## Description
Add read-only mode comments for the console module editions.

## Changelog entries
```changes
section: docs
type: chore
summary: Add read-only mode comments for the console module editions
impact_level: low
```
