### PR TITLE
[candi]  Use node name from kubelet certificate

### DIFF
--- a/candi/bashible/bb_node_name.sh.tpl
+++ b/candi/bashible/bb_node_name.sh.tpl
@@ -33,7 +33,7 @@ bb-discover-node-name() {
     if [[ -s "$kubelet_crt" ]]; then
       openssl x509 -in "$kubelet_crt" \
         -noout -subject -nameopt multiline |
-      awk '/^ *commonName/{print $NF}' > "$discovered_name_file"
+      awk '/^ *commonName/{print $NF}' | cut -d':' -f3- > "$discovered_name_file"
     else
     {{- if and (ne .nodeGroup.nodeType "Static") (ne .nodeGroup.nodeType "CloudStatic") }}
       if [[ "$(hostname)" != "$(hostname -s)" ]]; then

--- a/candi/bashible/bb_node_name.sh.tpl
+++ b/candi/bashible/bb_node_name.sh.tpl
@@ -27,14 +27,13 @@ bb-d8-node-ip() {
 {{- define "bb-discover-node-name" -}}
 bb-discover-node-name() {
   local discovered_name_file="/var/lib/bashible/discovered-node-name"
-  local discovered_ip_file="/var/lib/bashible/discovered-node-ip"
+  local kubelet_crt="/var/lib/kubelet/pki/kubelet-server-current.pem"
 
   if [ ! -s "$discovered_name_file" ]; then
-    if [[ -s "$discovered_ip_file" && -s /etc/kubernetes/kubelet.conf ]]; then
-      kubectl get node --kubeconfig /etc/kubernetes/kubelet.conf -o wide \
-        | awk '{print $1, $6}' \
-        | grep "$(cat "$discovered_ip_file")" \
-        | awk '{print $1}' > "$discovered_name_file"
+    if [[ -s "$kubelet_crt" ]]; then
+      openssl x509 -in "$kubelet_crt" \
+        -noout -subject -nameopt multiline |
+      awk '/^ *commonName/{print $NF}' > "$discovered_name_file"
     else
     {{- if and (ne .nodeGroup.nodeType "Static") (ne .nodeGroup.nodeType "CloudStatic") }}
       if [[ "$(hostname)" != "$(hostname -s)" ]]; then


### PR DESCRIPTION
## Description
 
fix [12996](https://github.com/deckhouse/deckhouse/pull/12996)
Use node name from kubelet certificate, if the node is bootstrapped and there is a certificate.

## Why do we need it, and what problem does it solve?

previous method was more complicated and did not work in kubernetes 1.32+

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: bashible bb-discover-node-name use node name from kubelet certificate
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
