### PR TITLE
[docs] Update Ingress paths to use ImplementationSpecific pathType and update apiVersion for DexAuthenticator

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -168,14 +168,14 @@ spec:
             port:
               name: http
       - path: /license_request_expired.html
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: frontend
             port:
               name: http
       - path: /license_request_success.html
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: frontend

--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -321,7 +321,7 @@ spec:
   dnsNames:
   - {{ .URL }}
 ---
-apiVersion: deckhouse.io/v1alpha1
+apiVersion: deckhouse.io/v1
 kind: DexAuthenticator
 metadata:
   name: {{ $.Chart.Name }}-{{ .Lang }}


### PR DESCRIPTION
## Description

Update Ingress paths to use ImplementationSpecific pathType.
Update apiVersion for DexAuthenticator to deckhouse.io/v1

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update Ingress paths to use ImplementationSpecific pathType and update apiVersion for DexAuthenticator
impact_level: low
```
