### PR TITLE
[multitenancy-manager] fix incorrect labels.module value

### DIFF
--- a/modules/160-multitenancy-manager/crds/projects.yaml
+++ b/modules/160-multitenancy-manager/crds/projects.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     heritage: deckhouse
-    module: deckhouse
+    module: multitenancy-manager
     backup.deckhouse.io/cluster-config: "true"
   name: projects.deckhouse.io
 spec:

--- a/modules/160-multitenancy-manager/crds/projecttemplate.yaml
+++ b/modules/160-multitenancy-manager/crds/projecttemplate.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     heritage: deckhouse
-    module: deckhouse
+    module: multitenancy-manager
     backup.deckhouse.io/cluster-config: "true"
   name: projecttemplates.deckhouse.io
 spec:


### PR DESCRIPTION
## Description
Fixed labels for Custom Resource Definitions (CRDs) in the `multitenancy-manager` module:

- `projects.deckhouse.io`
- `projecttemplates.deckhouse.io`

Previously, these resources were incorrectly labeled as belonging to the deckhouse module, although they are actually part of the `multitenancy-manager`.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Incorrect labels in CRDs can lead to:

- Maintenance confusion - it is more difficult to filter resources related to `multitenancy-manager`.
- Errors in automated processes - if scripts or monitoring tools rely on tags, they may not work correctly.
- Inconsistency with documentation - the documentation lists these CRDs as part of the `multitenancy-manager`, but they are labeled differently in the cluster.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

<!---

## Why do we need it in the patch release (if we do)?

Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: multitenancy-manager
type: fix
summary: fix incorrect labels.module value
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
