### PR TITLE
[deckhouse-controller] Backport: Clean DeckhouseRelease message when release deployed

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -1011,12 +1011,14 @@ func (r *deckhouseReleaseReconciler) reconcileDeployedRelease(ctx context.Contex
 		return res, nil
 	}
 
-	err := ctrlutils.UpdateStatusWithRetry(ctx, r.client, dr, func() error {
-		dr.Status.Message = ""
-		return nil
-	})
-	if err != nil {
-		return res, err
+	if dr.Status.Message != "" {
+		err := ctrlutils.UpdateStatusWithRetry(ctx, r.client, dr, func() error {
+			dr.Status.Message = ""
+			return nil
+		})
+		if err != nil {
+			return res, err
+		}
 	}
 
 	if dr.GetIsUpdating() {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
@@ -1007,6 +1007,21 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 			_, err := suite.ctr.createOrUpdateReconcile(ctx, dr)
 			require.NoError(suite.T(), err)
 		})
+		suite.Run("clear data after deploy", func() {
+			mup := embeddedMUP.DeepCopy()
+			mup.Update.Mode = v1alpha1.UpdateModeManual.String()
+
+			dependency.TestDC.HTTPClient.DoMock.
+				Expect(&http.Request{}).
+				Return(&http.Response{
+					StatusCode: http.StatusNotFound,
+				}, nil)
+			suite.setupController("clear-data-after-deploy.yaml", initValues, mup)
+			dr := suite.getDeckhouseRelease("v1.26.2")
+			_, err := suite.ctr.createOrUpdateReconcile(ctx, dr)
+			require.NoError(suite.T(), err)
+			require.Empty(suite.T(), dr.Status.Message)
+		})
 	})
 }
 

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/clear-data-after-deploy.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/clear-data-after-deploy.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  name: v1.26.2
+spec:
+  version: v1.26.2
+status:
+  approved: true
+  message: "This message must be cleaned"
+  phase: Deployed

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/clear-data-after-deploy.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/clear-data-after-deploy.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.26.2
+  resourceVersion: "1000"
+spec:
+  version: v1.26.2
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: null


### PR DESCRIPTION
## Description

Backport of this [PR](https://github.com/deckhouse/deckhouse/pull/13761)

This change ensures that the `Message` field in `DeckhouseReleaseStatus` is cleared when a Deckhouse release transitions to the `Deployed` phase. This prevents outdated or misleading status messages from persisting in the `DeckhouseRelease` resource.

The issue arises because:
- The `Message` field is not automatically reset when the release moves to the `Deployed` phase.
- In cases where multiple reconciliation processes run concurrently, an outdated message might remain in the status, even after the release is successfully deployed.

**Changes**
- Clear the `Message` field in `DeckhouseReleaseStatus` when the release reaches the `Deployed` phase and `Message` is empty.
- Ensure the status reflects the actual deployment state consistently.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

- Prevents user confusion caused by outdated status messages in logs or UI.
- Maintains consistency between the actual deployment state and the displayed status, even during concurrent reconciliation processes.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->



<!---
## Why do we need it in the patch release (if we do)?
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section:  deckhouse-controller
type: chore
summary: clean deckhouse release message when release deployed
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
