### PR TITLE
[ci] fix kubernetes version info in the release file

### DIFF
--- a/.werf/werf-release-channel.yaml
+++ b/.werf/werf-release-channel.yaml
@@ -16,7 +16,11 @@ shell:
   install:
   - |
     export version="{{ env "CI_COMMIT_REF_NAME" }}"
-    yq eval '.version = env(version)' /deckhouse/release.yaml | yq eval -j > version.json
+    # update kubernetes auto version in the release file
+    yq eval '.requirements.autoK8sVersion = "{{ .defaultKubernetesVersion }}"' -i /deckhouse/release.yaml
+    yq eval '.requirements.k8s = "{{ .kubernetesVersions | first }}"' -i /deckhouse/release.yaml
+    yq eval '.version = env(version)' -i /deckhouse/release.yaml
+    yq eval -j /deckhouse/release.yaml > version.json
     # changelog exists only for tags, we have to skip it for branches
     {{- $changelog := index (.Files.Glob "CHANGELOG/CHANGELOG-*") (printf "CHANGELOG/CHANGELOG-%s.yml" (env "CI_COMMIT_REF_NAME")) }}
     {{ if $changelog }}
@@ -24,9 +28,6 @@ shell:
     {{ $changelog | nindent 6 }}
     EOF
     {{ end }}
-    # update kubernetes auto version in the release file
-    yq eval '.requirements.autoK8sVersion = "{{ .defaultKubernetesVersion }}"' -i /deckhouse/release.yaml
-    yq eval '.requirements.k8s = "{{.kubernetesVersions | first }}"' -i /deckhouse/release.yaml
 git:
 - add: /
   to: /deckhouse


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix kubernetes version info in the release file.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Now version.json in the release-channel image cannot have proper info about k8s versions (current and auto). That leads to problems with deckhouse update. This PR fixes it.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: fix kubernetes version info in the release file
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
