### PR TITLE
[operator-trivy] support anon registry creds for bdu updater

### DIFF
--- a/ee/modules/500-operator-trivy/images/report-updater/src/internal/web/server.go
+++ b/ee/modules/500-operator-trivy/images/report-updater/src/internal/web/server.go
@@ -66,7 +66,7 @@ type ServerConfig struct {
 }
 
 func NewServer(config *ServerConfig) (*Server, error) {
-	c, err := cache.NewVulnerabilityCache(context.Background(), config.Logger)
+	c, err := cache.New(context.Background(), config.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -123,6 +123,7 @@ func (s *Server) Run(ctx context.Context) error {
 	s.logger.Printf("server is starting to listen on '%s' ...\n", listenAddr)
 
 	go s.handler.StartRenewCacheLoop(ctx)
+
 	if err = httpServer.ListenAndServeTLS(sslListenCert, sslListenKey); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("could not listen on %s: %w", listenAddr, err)
 	}


### PR DESCRIPTION
## Description
It adds support anon registry creds for bdu updater.

## Why do we need it, and what problem does it solve?
Fixes #13852

```
root@usmanovddd-master-0:~# kubectl logs -n d8-operator-trivy report-updater-6474b9bbf9-2lqw8
2025/06/06 15:22:21 auth config for the '158.160.34.44' registry is empty; using anonymous access
2025/06/06 15:22:21 initialize BDU dictionary
2025/06/06 15:22:21 download BDU image
2025/06/06 15:22:21 BDU dictionary dated 2025-06-06 12:26:19.686831909 +0000 UTC has been applied
2025/06/06 15:22:21 server is starting to listen on '0.0.0.0:40443' ...
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: operator-trivy
type: fix
summary: Add support anon registry creds for bdu updater.
```