### PR TITLE
[docs] Add breadcrumb generator from sidebars

### DIFF
--- a/docs/site/_data/i18n.yaml
+++ b/docs/site/_data/i18n.yaml
@@ -236,6 +236,8 @@ common:
   guides_description:
     en: Helping you achieve a goal or solve a problem with Deckhouse.
     ru: Помогут решить задачу или достичь нужной цели с помощью Deckhouse.
+  virtualization-platform: Virtualization Platform
+  stronghold: Stronghold
 comparison:
   except_parameters:
     en: "Except for the following parameters:<br />"

--- a/docs/site/_includes/nav-breadcrumbs-pagepath.html
+++ b/docs/site/_includes/nav-breadcrumbs-pagepath.html
@@ -7,7 +7,11 @@
   {% else %}
     {%- capture current_breadcrumb_url %}{{ next_prepender }}/{{ page_url_parts[i] }}{% endcapture -%}
     {%- capture next_prepender %}{{ next_prepender }}/{{ page_url_parts[i] }}{% endcapture -%}
-    {%- assign breadcrumb = site.data[page.product_code]['breadcrumbs'][current_breadcrumb_url] %}
+    {% if page.product_code == "virtualization-platform" %}
+      {%- assign breadcrumb = site.data.dvp.['breadcrumbs'][current_breadcrumb_url] %}
+    {% else %}
+      {%- assign breadcrumb = site.data[page.product_code]['breadcrumbs'][current_breadcrumb_url] %}
+    {% endif %}
     {%- if breadcrumb %}
         <li class="breadcrumbs__item">
             {%- if breadcrumb.url %}<a href="{{ breadcrumb.url | true_relative_url }}">{% endif %}

--- a/docs/site/_includes/nav-breadcrumbs.html
+++ b/docs/site/_includes/nav-breadcrumbs.html
@@ -1,13 +1,15 @@
 <div class="breadcrumbs-container">
   <div class="breadcrumbs__left">
     <ol class="breadcrumbs">
-      <li class="breadcrumbs__item">{{ site.data.i18n.common.documentation[page.lang] }}</li>
+      <li class="breadcrumbs__item">{{ site.data.i18n.common.documentation_title[page.lang] }}</li>
     </ol>
   </div>
   <div class="breadcrumbs__right">
     <ol class="breadcrumbs">
       {% if site.data.i18n.common.platform[page.lang] %}
         <li class="breadcrumbs__item">{{ site.data.i18n.common.platform[page.lang] }}</li>
+      {% else %}
+        <li class="breadcrumbs__item">{{ site.data.i18n.common[page.product_code] }}</li>
       {% endif %}
       <!--#include virtual="/includes/group-menu.html" -->
       {% include nav-breadcrumbs-pagepath.html %}

--- a/docs/site/_tools/breadcrumbs-builder/go.mod
+++ b/docs/site/_tools/breadcrumbs-builder/go.mod
@@ -1,0 +1,7 @@
+module main
+
+go 1.23.6
+
+require (
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/docs/site/_tools/breadcrumbs-builder/go.sum
+++ b/docs/site/_tools/breadcrumbs-builder/go.sum
@@ -1,0 +1,6 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/docs/site/_tools/breadcrumbs-builder/main.go
+++ b/docs/site/_tools/breadcrumbs-builder/main.go
@@ -1,0 +1,141 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+const pathToSidebars = "/app/sidebars"
+const pathToResult = "/app/results"
+const breadcrumbsFileName = "breadcrumbs.yml"
+
+const templateString = `{{ .Url }}:
+  title:
+    en: {{ .En }}
+    ru: {{ .Ru }}
+`
+
+type data struct {
+	Url string
+	En  string
+	Ru  string
+}
+
+type Sidebar struct {
+	Entries []Entry `yaml:"entries"`
+}
+
+type Entry struct {
+	Title struct {
+		En string `yaml:"en"`
+		Ru string `yaml:"ru"`
+	} `yaml:"title"`
+	URL     string  `yaml:"url,omitempty"`
+	Folders []Entry `yaml:"folders,omitempty"`
+}
+
+func main() {
+	if err := os.Mkdir(pathToResult, os.ModePerm); err != nil {
+		log.Fatal(err)
+	}
+	files, err := os.ReadDir(pathToSidebars)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, f := range files {
+		var sidebar Sidebar
+
+		file, err := os.ReadFile(filepath.Join(pathToSidebars, f.Name()))
+		if err != nil {
+			log.Fatal(err)
+		}
+		err = yaml.Unmarshal(file, &sidebar)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		pathToBreadcrumbsFile := filepath.Join(pathToResult, strings.TrimSuffix(f.Name(), filepath.Ext(f.Name())))
+		err = os.MkdirAll(pathToBreadcrumbsFile, os.ModePerm)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pathToFile := filepath.Join(pathToBreadcrumbsFile, breadcrumbsFileName)
+		breadcrumbsFile, err := os.Create(pathToFile)
+		if err != nil {
+			fmt.Println(err)
+		}
+		defer breadcrumbsFile.Close()
+
+		for _, entry := range sidebar.Entries {
+			if entry.Folders != nil {
+				readFolders(entry.Title.En, entry.Title.Ru, entry.Folders, *breadcrumbsFile)
+			}
+		}
+	}
+}
+
+func getLevelUrl(folders []Entry) string {
+	index := strings.LastIndex(folders[0].URL, "/")
+	if index != -1 {
+		return folders[0].URL[:index]
+	}
+	return ""
+}
+
+func readFolders(titleEn string, titleRu string, folders []Entry, breadcrumbsFile os.File) {
+	for _, entry := range folders {
+		if entry.Folders != nil {
+			readFolders(entry.Title.En, entry.Title.Ru, entry.Folders, breadcrumbsFile)
+		}
+	}
+	if checkURLs(folders) {
+		url := getLevelUrl(folders)
+		if url != "" {
+			var dt data
+			dt.Url = url
+			dt.En = titleEn
+			dt.Ru = titleRu
+
+			tmpl, err := template.New("struct").Parse(templateString)
+			if err != nil {
+				panic(err)
+			}
+
+			err = tmpl.Execute(&breadcrumbsFile, dt)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+
+func checkURLs(folders []Entry) bool {
+	result := false
+	for _, entity := range folders {
+		if entity.URL != "" {
+			result = true
+		}
+	}
+	return result
+}

--- a/docs/site/werf.yaml
+++ b/docs/site/werf.yaml
@@ -295,8 +295,20 @@ git:
   group: jekyll
   stageDependencies:
     setup: ['**/*']
-{{- if and (ne $.Env "development") (ne $.Env "module") (ne $.Env "local") }}
 import:
+  - image: sidebars-builder
+    add: /app/results/virtualization-platform/breadcrumbs.yml
+    to: /srv/jekyll-data/site/_data/dvp/breadcrumbs.yml
+    before: setup
+  - image: sidebars-builder
+    add: /app/results/stronghold/breadcrumbs.yml
+    to: /srv/jekyll-data/site/_data/stronghold/breadcrumbs.yml
+    before: setup
+  - image: sidebars-builder
+    add: /app/results/code/breadcrumbs.yml
+    to: /srv/jekyll-data/site/_data/code/breadcrumbs.yml
+    before: setup
+{{- if and (ne $.Env "development") (ne $.Env "module") (ne $.Env "local") }}
   - image: site-external-artifacts
     add: /data/topnav.json
     to: /srv/jekyll-data/site/_data/topnav.json
@@ -413,3 +425,26 @@ import:
     add: /go/src/app/registry-modules-watcher
     to: /app/registry-modules-watcher
     before: setup
+---
+image: sidebars-builder
+from: {{ .Images.BASE_GOLANG_23_ALPINE }}
+final: false
+shell:
+  setup:
+  - |
+        echo "Generate sidebars..."
+        cd /app
+        go run main.go
+git:
+  - add: /docs/site/_tools/breadcrumbs-builder
+    to: /app
+    stageDependencies:
+      setup:
+        - "**/*.go"
+        - "**/*.mod"
+        - "**/*.sum"
+  - add: /docs/site/_data/sidebars
+    to: /app/sidebars
+    stageDependencies:
+      setup:
+        - "**/*.yml"


### PR DESCRIPTION
## Description

Added breadcrumb generator from sidebars.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Added breadcrumb generator from sidebars.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
