### PR TITLE
[candi] Update step bashible 003_disable_swap

### DIFF
--- a/candi/bashible/common-steps/all/003_disable_swap.sh.tpl
+++ b/candi/bashible/common-steps/all/003_disable_swap.sh.tpl
@@ -17,8 +17,8 @@ for swapunit in $(systemctl list-units --no-legend --plain --no-pager --type swa
   systemctl mask "$swapunit"
 done
 
-# systemd-gpt-auto-generator automatically detects swap partition in GPT and activates it     
-if [ -f /lib/systemd/system-generators/systemd-gpt-auto-generator ]; then 
+# systemd-gpt-auto-generator automatically detects swap partition in GPT and activates it
+if [ -f /lib/systemd/system-generators/systemd-gpt-auto-generator ] && ( [ ! -L /etc/systemd/system-generators/systemd-gpt-auto-generator ] || [ "$(readlink -f /etc/systemd/system-generators/systemd-gpt-auto-generator)" != "/dev/null" ] ); then
   mkdir -p /etc/systemd/system-generators
   ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 fi


### PR DESCRIPTION
## Description

I added a check to the bashible step for the presence of a previously created symlink and where it leads to.

## Why do we need it, and what problem does it solve?

Recreating this symlink every time it is present is unnecessary.

There are clients who have integrity control enabled by inode and the constant re-creation of this symlink triggers the integrity control mechanism.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Added a check to the bashible step for the presence of a previously created symlink and where it leads to
impact_level: low
```

