### PR TITLE
[network] Added stage field to module.yaml in all network-related mod…

### DIFF
--- a/ee/be/modules/350-node-local-dns/module.yaml
+++ b/ee/be/modules/350-node-local-dns/module.yaml
@@ -1,4 +1,5 @@
 name: node-local-dns
+stage: "General Availability"
 weight: 350
 subsystems:
   - networking

--- a/ee/modules/450-keepalived/module.yaml
+++ b/ee/modules/450-keepalived/module.yaml
@@ -1,4 +1,5 @@
 name: keepalived
+stage: "General Availability"
 weight: 450
 subsystems:
   - infrastructure

--- a/ee/modules/450-network-gateway/module.yaml
+++ b/ee/modules/450-network-gateway/module.yaml
@@ -1,4 +1,5 @@
 name: network-gateway
+stage: "General Availability"
 weight: 450
 subsystems:
   - networking

--- a/ee/modules/610-service-with-healthchecks/module.yaml
+++ b/ee/modules/610-service-with-healthchecks/module.yaml
@@ -1,4 +1,5 @@
 name: service-with-healthchecks
+stage: "General Availability"
 weight: 610
 namespace: d8-service-with-healthchecks
 description: |

--- a/ee/se/modules/380-metallb/module.yaml
+++ b/ee/se/modules/380-metallb/module.yaml
@@ -1,4 +1,5 @@
 name: metallb
+stage: "General Availability"
 weight: 380
 subsystems:
   - networking

--- a/modules/021-cni-cilium/module.yaml
+++ b/modules/021-cni-cilium/module.yaml
@@ -1,4 +1,5 @@
 name: cni-cilium
+stage: "General Availability"
 weight: 21
 subsystems:
   - networking

--- a/modules/035-cni-flannel/module.yaml
+++ b/modules/035-cni-flannel/module.yaml
@@ -1,4 +1,5 @@
 name: cni-flannel
+stage: "General Availability"
 weight: 35
 subsystems:
   - networking

--- a/modules/035-cni-simple-bridge/module.yaml
+++ b/modules/035-cni-simple-bridge/module.yaml
@@ -1,4 +1,5 @@
 name: cni-simple-bridge
+stage: "General Availability"
 weight: 35
 subsystems:
   - networking

--- a/modules/036-kube-proxy/module.yaml
+++ b/modules/036-kube-proxy/module.yaml
@@ -1,4 +1,5 @@
 name: kube-proxy
+stage: "General Availability"
 weight: 36
 subsystems:
   - kubernetes

--- a/modules/042-kube-dns/module.yaml
+++ b/modules/042-kube-dns/module.yaml
@@ -1,4 +1,5 @@
 name: kube-dns
+stage: "General Availability"
 weight: 42
 subsystems:
   - kubernetes

--- a/modules/050-network-policy-engine/module.yaml
+++ b/modules/050-network-policy-engine/module.yaml
@@ -1,4 +1,5 @@
 name: network-policy-engine
+stage: "General Availability"
 weight: 50
 subsystems:
   - networking

--- a/modules/110-istio/module.yaml
+++ b/modules/110-istio/module.yaml
@@ -1,4 +1,5 @@
 name: istio
+stage: "General Availability"
 weight: 110
 subsystems:
   - infrastructure

--- a/modules/402-ingress-nginx/module.yaml
+++ b/modules/402-ingress-nginx/module.yaml
@@ -1,4 +1,5 @@
 name: ingress-nginx
+stage: "General Availability"
 weight: 402
 subsystems:
   - networking

--- a/modules/500-openvpn/module.yaml
+++ b/modules/500-openvpn/module.yaml
@@ -1,4 +1,5 @@
 name: openvpn
+stage: "General Availability"
 weight: 500
 subsystems:
   - networking


### PR DESCRIPTION
## Description
Added the `stage` field to the `module.yaml` of all network-related modules.

This metadata field explicitly declares the [lifecycle stage](https://deckhouse.io/products/kubernetes-platform/documentation/v1/module-development/versioning/#how-do-i-figure-out-how-stable-a-module-is) of each network module. It improves clarity and helps consumers of the module (both internal tools and users) make informed decisions regarding stability, risk, and expected support level.


## Why do we need it, and what problem does it solve?
Currently, there is no consistent way to determine the maturity or readiness level of a module from its metadata. This creates ambiguity for both users and automated tooling when evaluating which modules are safe to use in production environments.

✅ This change introduces no runtime behavior modifications and is fully backward compatible.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Added the `stage` field to the `module.yaml` of all network-related modules
impact_level: low
```