### PR TITLE
[network] Enabled liveness-probe and readiness-probe probe for network modules.

### DIFF
--- a/ee/be/modules/350-node-local-dns/.dmtlint.yaml
+++ b/ee/be/modules/350-node-local-dns/.dmtlint.yaml
@@ -22,14 +22,8 @@ linters-settings:
       liveness-probe:
         - kind: DaemonSet
           name: node-local-dns
-          container: kube-rbac-proxy
-        - kind: DaemonSet
-          name: node-local-dns
           container: iptables-loop
       readiness-probe:
-        - kind: DaemonSet
-          name: node-local-dns
-          container: kube-rbac-proxy
         - kind: DaemonSet
           name: node-local-dns
           container: iptables-loop

--- a/ee/be/modules/350-node-local-dns/templates/daemonset.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/daemonset.yaml
@@ -177,6 +177,7 @@ spec:
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
+        - "--livez-path=/livez"
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
           valueFrom:
@@ -198,6 +199,16 @@ spec:
         ports:
         - containerPort: 4224
           name: https-metrics
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 4224
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 4224
+            scheme: HTTPS
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}

--- a/ee/modules/610-service-with-healthchecks/.dmtlint.yaml
+++ b/ee/modules/610-service-with-healthchecks/.dmtlint.yaml
@@ -2,19 +2,3 @@ linters-settings:
   module:
     oss:
       disable: true
-  container:
-    exclude-rules:
-      readiness-probe:
-        - kind: Deployment
-          name: controller
-          container: kube-rbac-proxy
-        - kind: DaemonSet
-          name: agent
-          container: kube-rbac-proxy
-      liveness-probe:
-        - kind: Deployment
-          name: controller
-          container: kube-rbac-proxy
-        - kind: DaemonSet
-          name: agent
-          container: kube-rbac-proxy

--- a/ee/modules/610-service-with-healthchecks/template_tests/module_test.go
+++ b/ee/modules/610-service-with-healthchecks/template_tests/module_test.go
@@ -77,6 +77,7 @@ debug: true
   - --v=2
   - --logtostderr=true
   - --stale-cache-interval=1h30m
+  - --livez-path=/livez
   env:
   - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
     valueFrom:
@@ -100,6 +101,16 @@ debug: true
   ports:
   - containerPort: 8383
     name: https-metrics
+  livenessProbe:
+    httpGet:
+      path: /livez
+      port: 8383
+      scheme: HTTPS
+  readinessProbe:
+    httpGet:
+      path: /livez
+      port: 8383
+      scheme: HTTPS
   resources:
     requests:
       ephemeral-storage: 50Mi

--- a/ee/modules/610-service-with-healthchecks/templates/agent/daemonset.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/agent/daemonset.yaml
@@ -98,9 +98,20 @@ spec:
             - "--v=2"
             - "--logtostderr=true"
             - "--stale-cache-interval=1h30m"
+            - "--livez-path=/livez"
           ports:
             - containerPort: 8383
               name: https-metrics
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8383
+              scheme: HTTPS
+          readinessProbe:
+            httpGet:
+              path: /livez
+              port: 8383
+              scheme: HTTPS
           env:
             - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
               valueFrom:

--- a/ee/modules/610-service-with-healthchecks/templates/controller/deployment.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/controller/deployment.yaml
@@ -112,9 +112,20 @@ spec:
             - "--v=2"
             - "--logtostderr=true"
             - "--stale-cache-interval=1h30m"
+            - "--livez-path=/livez"
           ports:
             - containerPort: 7475
               name: https-metrics
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 7475
+              scheme: HTTPS
+          readinessProbe:
+            httpGet:
+              path: /livez
+              port: 7475
+              scheme: HTTPS
           env:
             - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
               valueFrom:

--- a/modules/021-cni-cilium/.dmtlint.yaml
+++ b/modules/021-cni-cilium/.dmtlint.yaml
@@ -28,9 +28,6 @@ linters-settings:
           container: mount-cgroup
       liveness-probe:
         - kind: DaemonSet
-          name: agent
-          container: kube-rbac-proxy
-        - kind: DaemonSet
           name: safe-agent-updater
           container: pause-check-linux-kernel
         - kind: DaemonSet
@@ -39,14 +36,8 @@ linters-settings:
         - kind: DaemonSet
           name: safe-agent-updater
           container: pause-kube-rbac-proxy
-        - kind: Deployment
-          name: operator
-          container: kube-rbac-proxy
       readiness-probe:
         - kind: DaemonSet
-          name: agent
-          container: kube-rbac-proxy
-        - kind: DaemonSet
           name: safe-agent-updater
           container: pause-check-linux-kernel
         - kind: DaemonSet
@@ -55,9 +46,6 @@ linters-settings:
         - kind: DaemonSet
           name: safe-agent-updater
           container: pause-kube-rbac-proxy
-        - kind: Deployment
-          name: operator
-          container: kube-rbac-proxy
         - kind: Deployment
           name: operator
           container: operator

--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -194,6 +194,7 @@ spec:
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
+        - "--livez-path=/livez"
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
           valueFrom:
@@ -215,6 +216,16 @@ spec:
         ports:
         - containerPort: 4241
           name: https-metrics
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 4241
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 4241
+            scheme: HTTPS
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" $context | nindent 12 }}

--- a/modules/021-cni-cilium/templates/operator/deployment.yaml
+++ b/modules/021-cni-cilium/templates/operator/deployment.yaml
@@ -108,6 +108,7 @@ spec:
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
+        - "--livez-path=/livez"
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
           valueFrom:
@@ -129,6 +130,16 @@ spec:
         ports:
         - containerPort: 4242
           name: https-metrics
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 4242
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 4242
+            scheme: HTTPS
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}

--- a/modules/036-kube-proxy/.dmtlint.yaml
+++ b/modules/036-kube-proxy/.dmtlint.yaml
@@ -15,16 +15,10 @@ linters-settings:
         - kind: DaemonSet
           name: d8-kube-proxy
           container: kube-proxy
-        - kind: DaemonSet
-          name: d8-kube-proxy
-          container: kube-rbac-proxy
       readiness-probe:
         - kind: DaemonSet
           name: d8-kube-proxy
           container: kube-proxy
-        - kind: DaemonSet
-          name: d8-kube-proxy
-          container: kube-rbac-proxy
   templates:
     exclude-rules:
       pdb:

--- a/modules/036-kube-proxy/templates/daemonset.yaml
+++ b/modules/036-kube-proxy/templates/daemonset.yaml
@@ -111,6 +111,7 @@ spec:
           - "--v=2"
           - "--logtostderr=true"
           - "--stale-cache-interval=1h30m"
+          - "--livez-path=/livez"
         env:
           - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
             valueFrom:
@@ -132,6 +133,16 @@ spec:
         ports:
           - containerPort: 4210
             name: https-metrics
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 4210
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 4210
+            scheme: HTTPS
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}

--- a/modules/042-kube-dns/.dmtlint.yaml
+++ b/modules/042-kube-dns/.dmtlint.yaml
@@ -10,14 +10,6 @@ linters-settings:
       security-context:
         - kind: Deployment
           name: d8-kube-dns-sts-pods-hosts-appender-webhook
-      liveness-probe:
-        - kind: Deployment
-          name: d8-kube-dns
-          container: kube-rbac-proxy
-      readiness-probe:
-        - kind: Deployment
-          name: d8-kube-dns
-          container: kube-rbac-proxy
   templates:
     exclude-rules:
       service-port:

--- a/modules/042-kube-dns/templates/deployment.yaml
+++ b/modules/042-kube-dns/templates/deployment.yaml
@@ -125,9 +125,20 @@ spec:
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
+        - "--livez-path=/livez"
         ports:
         - containerPort: 9154
           name: https-metrics
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 9154
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 9154
+            scheme: HTTPS
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
           valueFrom:

--- a/modules/110-istio/.dmtlint.yaml
+++ b/modules/110-istio/.dmtlint.yaml
@@ -20,12 +20,6 @@ linters-settings:
         - kind: Deployment
           name: kiali
       readiness-probe:
-        - kind: DaemonSet
-          name: istio-cni-node
-          container: kube-rbac-proxy
-        - kind: Deployment
-          name: kiali
-          container: kube-rbac-proxy
         - kind: Deployment
           name: operator-1x21
           container: operator
@@ -33,9 +27,6 @@ linters-settings:
           name: metadata-exporter
           container: metadata-discovery
       liveness-probe:
-        - kind: DaemonSet
-          name: istio-cni-node
-          container: kube-rbac-proxy
         - kind: Deployment
           name: operator-1x21
           container: operator

--- a/modules/110-istio/templates/cni/daemonset.yaml
+++ b/modules/110-istio/templates/cni/daemonset.yaml
@@ -146,6 +146,7 @@ spec:
           - "--v=2"
           - "--logtostderr=true"
           - "--stale-cache-interval=1h30m"
+          - "--livez-path=/livez"
           env:
           - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
             valueFrom:
@@ -167,6 +168,16 @@ spec:
           ports:
             - containerPort: 9734
               name: https-metrics
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 9734
+              scheme: HTTPS
+          readinessProbe:
+            httpGet:
+              path: /livez
+              port: 9734
+              scheme: HTTPS
           resources:
             requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}

--- a/modules/110-istio/templates/kiali/deployment.yaml
+++ b/modules/110-istio/templates/kiali/deployment.yaml
@@ -142,6 +142,11 @@ spec:
             path: /livez
             port: 8443
             scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 8443
+            scheme: HTTPS
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}

--- a/modules/500-cilium-hubble/.dmtlint.yaml
+++ b/modules/500-cilium-hubble/.dmtlint.yaml
@@ -22,9 +22,6 @@ linters-settings:
         - kind: Deployment
           name: hubble-ui
           container: frontend
-        - kind: Deployment
-          name: hubble-ui
-          container: kube-rbac-proxy
   module:
     conversions:
       disable: true

--- a/modules/500-cilium-hubble/templates/ui/deployment.yaml
+++ b/modules/500-cilium-hubble/templates/ui/deployment.yaml
@@ -182,6 +182,11 @@ spec:
             path: /livez
             port: 8443
             scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 8443
+            scheme: HTTPS
         resources:
           requests:
           {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}

--- a/modules/500-openvpn/.dmtlint.yaml
+++ b/modules/500-openvpn/.dmtlint.yaml
@@ -8,17 +8,11 @@ linters-settings:
       liveness-probe:
         - kind: StatefulSet
           name: openvpn
-          container: kube-rbac-proxy
-        - kind: StatefulSet
-          name: openvpn
           container: openvpn-tcp
         - kind: StatefulSet
           name: openvpn
           container: ovpn-admin
       readiness-probe:
-        - kind: StatefulSet
-          name: openvpn
-          container: kube-rbac-proxy
         - kind: StatefulSet
           name: openvpn
           container: openvpn-tcp

--- a/modules/500-openvpn/templates/openvpn/statefulset.yaml
+++ b/modules/500-openvpn/templates/openvpn/statefulset.yaml
@@ -329,9 +329,20 @@ spec:
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
+        - "--livez-path=/livez"
         ports:
         - containerPort: 8443
           name: https
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8443
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 8443
+            scheme: HTTPS
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
           valueFrom:


### PR DESCRIPTION
## Description

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added missing probes for kube-rbac-proxy in all network modules.
* node-local-dns
* kube-dns
* istio
* openvpn
* cilium-hubble
* kube-proxy
* cni-cilium
* service-with-healthchecks

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This PR is part of solution for https://github.com/deckhouse/deckhouse/issues/11295.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-local-dns
type: fix
summary: Added probes for `kube-rbac-proxy`.
impact_level: default
---
section: kube-dns
type: fix
summary: Added probes for `kube-rbac-proxy`.
---
section: istio
type: fix
summary: Added probes for `kube-rbac-proxy`.
---
section: openvpn
type: fix
summary: Added probes for `kube-rbac-proxy`.
---
section: cilium-hubble
type: fix
summary: Added probes for `kube-rbac-proxy`.
---
section: kube-proxy
type: fix
summary: Added probes for `kube-rbac-proxy`.
---
section: cni-cilium
type: fix
summary: Added probes for `kube-rbac-proxy`.
---
section: service-with-healthchecks
type: fix
summary: Added probes for `kube-rbac-proxy`.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
