### PR TITLE
[core] Describe module stage

### DIFF
--- a/modules/039-registry-packages-proxy/module.yaml
+++ b/modules/039-registry-packages-proxy/module.yaml
@@ -1,10 +1,10 @@
-name: node-manager
-weight: 40
+name: registry-packages-proxy
+weight: 39
 subsystems:
   - infrastructure
 namespace: d8-cloud-instance-manager
 description: |
-  Managing nodes
+  Internal registry packages proxy
 descriptions:
-  en: Managing nodes
+  en: Internal registry packages proxy
 stage: General Availability

--- a/modules/040-control-plane-manager/module.yaml
+++ b/modules/040-control-plane-manager/module.yaml
@@ -3,3 +3,4 @@ weight: 40
 subsystems:
   - kubernetes
 namespace: kube-system
+stage: General Availability

--- a/modules/040-terraform-manager/module.yaml
+++ b/modules/040-terraform-manager/module.yaml
@@ -3,3 +3,4 @@ weight: 40
 subsystems:
   - infrastructure
 namespace: d8-system
+stage: General Availability

--- a/modules/302-vertical-pod-autoscaler/module.yaml
+++ b/modules/302-vertical-pod-autoscaler/module.yaml
@@ -3,9 +3,9 @@ weight: 302
 subsystems:
   - infrastructure
 namespace: kube-system
-
 requirements:
   bootstrapped: true
   modules:
     prometheus: ">= 0.0.0"
     prometheus-metrics-adapter: ">= 0.0.0"
+stage: General Availability

--- a/modules/400-descheduler/module.yaml
+++ b/modules/400-descheduler/module.yaml
@@ -7,6 +7,6 @@ description: |
   The module runs a descheduler with strategies defined in a `Descheduler` custom resource.
 descriptions:
   en: The module runs a descheduler with strategies defined in a `Descheduler` custom resource.
-
 requirements:
   bootstrapped: true
+stage: General Availability

--- a/modules/470-chrony/module.yaml
+++ b/modules/470-chrony/module.yaml
@@ -3,3 +3,4 @@ weight: 470
 subsystems:
   - infrastructure
 namespace: d8-chrony
+stage: General Availability

--- a/modules/800-deckhouse-tools/module.yaml
+++ b/modules/800-deckhouse-tools/module.yaml
@@ -1,6 +1,6 @@
 name: deckhouse-tools
 weight: 800
 namespace: d8-system
-
 requirements:
   bootstrapped: true
+stage: General Availability


### PR DESCRIPTION
## Description

Describe module stage

## Why do we need it, and what problem does it solve?

Declaring explicit stage for core modules

## Why do we need it in the patch release (if we do)?

Adds module stage visibility for users

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: chrony, control-plane-manager, deckhouse-tools, descheduler, node-manager, registry-packages-proxy, terraform-manager, vertical-pod-autoscaler
type: fix 
summary: Added module stage in module manifest
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
