### PR TITLE
[service-with-healthchecks] change port kube-rbac-proxy

### DIFF
--- a/ee/modules/610-service-with-healthchecks/template_tests/module_test.go
+++ b/ee/modules/610-service-with-healthchecks/template_tests/module_test.go
@@ -73,7 +73,7 @@ debug: true
       - ALL
     readOnlyRootFilesystem: true
 - args:
-  - --secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4229
+  - --secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8383
   - --v=2
   - --logtostderr=true
   - --stale-cache-interval=1h30m
@@ -98,7 +98,7 @@ debug: true
   image: registry.example.com@imageHash-common-kubeRbacProxy
   name: kube-rbac-proxy
   ports:
-  - containerPort: 4229
+  - containerPort: 8383
     name: https-metrics
   resources:
     requests:

--- a/ee/modules/610-service-with-healthchecks/templates/agent/daemonset.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/agent/daemonset.yaml
@@ -94,12 +94,12 @@ spec:
           {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 10 }}
           image: {{ include "helm_lib_module_common_image" (list $ "kubeRbacProxy") }}
           args:
-            - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4229"
+            - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8383"
             - "--v=2"
             - "--logtostderr=true"
             - "--stale-cache-interval=1h30m"
           ports:
-            - containerPort: 4229
+            - containerPort: 8383
               name: https-metrics
           env:
             - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Changed port for kube-rbac-proxy  container in agent DaemonSet.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Conflict with the cni-nfs module needs to be resolved.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

There is already a conflict in active clusters with the cni-nfs module.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: service-with-healthchecks
type: fix
summary: change port kube-rbac-proxy in agent DaemonSet
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
