### PR TITLE
[docs] Change Using CiliumClusterwideNetworkPolicies section

### DIFF
--- a/modules/021-cni-cilium/docs/README.md
+++ b/modules/021-cni-cilium/docs/README.md
@@ -49,11 +49,15 @@ Network equipment must be ready for asymmetric traffic flow: IP address anti-spo
 
 ## Using CiliumClusterwideNetworkPolicies
 
-To use CiliumClusterwideNetworkPolicies, apply:
+Follow these steps to use CiliumClusterwideNetworkPolicies:
 
-1. The primary set of `CiliumClusterwideNetworkPolicy` objects with the configuration option `policyAuditMode` set to `true`.
-   The absence of this option may lead to incorrect operation of the control plane or loss of SSH access to all cluster nodes . The option can be removed after applying all `CiliumClusterwideNetworkPolicy` objects and verifying their functionality in Hubble UI.
-2. Network security policy rule:
+1. Apply the primary set of `CiliumClusterwideNetworkPolicy` objects. To do this, in the settings of the cni-cilium module add the configuration option [`policyAuditMode`](../cni-cilium/configuration.html#parameters-policyauditmode) with the value `true`.
+
+    > Using CiliumClusterwideNetworkPolicies if the `policyAuditMode` option is absent in the cni-cilium module settings may lead to incorrect operation of Control plane or loss of SSH access to all cluster nodes.
+
+    The option can be removed after applying all `CiliumClusterwideNetworkPolicy` objects and verifying their functionality in Hubble UI.
+
+2. Apply network security policy rule:
 
    ```yaml
    apiVersion: "cilium.io/v2"

--- a/modules/021-cni-cilium/docs/README.md
+++ b/modules/021-cni-cilium/docs/README.md
@@ -49,15 +49,16 @@ Network equipment must be ready for asymmetric traffic flow: IP address anti-spo
 
 ## Using CiliumClusterwideNetworkPolicies
 
+{% alert level="danger" %}
+Using CiliumClusterwideNetworkPolicies if the `policyAuditMode` option is absent in the cni-cilium module settings may lead to incorrect operation of Control plane or loss of SSH access to all cluster nodes.
+{% endalert %}
+
 Follow these steps to use CiliumClusterwideNetworkPolicies:
 
 1. Apply the primary set of `CiliumClusterwideNetworkPolicy` objects. To do this, in the settings of the cni-cilium module add the configuration option [`policyAuditMode`](../cni-cilium/configuration.html#parameters-policyauditmode) with the value `true`.
+The option can be removed after applying all `CiliumClusterwideNetworkPolicy` objects and verifying their functionality in Hubble UI.
 
-    > Using CiliumClusterwideNetworkPolicies if the `policyAuditMode` option is absent in the cni-cilium module settings may lead to incorrect operation of Control plane or loss of SSH access to all cluster nodes.
-
-    The option can be removed after applying all `CiliumClusterwideNetworkPolicy` objects and verifying their functionality in Hubble UI.
-
-2. Apply network security policy rule:
+1. Apply network security policy rule:
 
    ```yaml
    apiVersion: "cilium.io/v2"

--- a/modules/021-cni-cilium/docs/README_RU.md
+++ b/modules/021-cni-cilium/docs/README_RU.md
@@ -51,13 +51,14 @@ description: Модуль cni-cilium Deckhouse обеспечивает рабо
 
 ## Использование CiliumClusterwideNetworkPolicies
 
+{% alert level="danger" %}
+Использование CiliumClusterwideNetworkPolicies при отсутствии опции `policyAuditMode` в настройках модуля cni-cilium может привести к некорректной работе Control plane или потере доступа ко всем узлам кластера по SSH.
+{% endalert %}
+
 Для использования CiliumClusterwideNetworkPolicies выполните следующие шаги:
 
 1. Примените первичный набор объектов `CiliumClusterwideNetworkPolicy`. Для этого в настройки модуля cni-cilium добавьте конфигурационную опцию [`policyAuditMode`](../cni-cilium/configuration.html#parameters-policyauditmode) со значением `true`.
-
-      > Использование CiliumClusterwideNetworkPolicies при отсутствии опции `policyAuditMode` в настройках модуля cni-cilium может привести к некорректной работе Control plane или потере доступа ко всем узлам кластера по SSH.
-
-      Опция `policyAuditMode` может быть удалена после применения всех `CniliumClusterwideNetworkPolicy`-объектов и проверки корректности их работы в Hubble UI.
+Опция `policyAuditMode` может быть удалена после применения всех `CniliumClusterwideNetworkPolicy`-объектов и проверки корректности их работы в Hubble UI.
 
 1. Примените правило политики сетевой безопасности:
 

--- a/modules/021-cni-cilium/docs/README_RU.md
+++ b/modules/021-cni-cilium/docs/README_RU.md
@@ -51,10 +51,15 @@ description: Модуль cni-cilium Deckhouse обеспечивает рабо
 
 ## Использование CiliumClusterwideNetworkPolicies
 
-Для использования CiliumClusterwideNetworkPolicies следует применить:
+Для использования CiliumClusterwideNetworkPolicies выполните следующие шаги:
 
-1. Первичный набор объектов `CiliumClusterwideNetworkPolicy`, поставив конфигурационную опцию `policyAuditMode` в `true`. Отсутствие опции может привести к некорректной работе Control plane или потере доступа ко всем узлам кластера по SSH. Опция может быть удалена после применения всех `CniliumClusterwideNetworkPolicy`-объектов и проверки корректности их работы в Hubble UI.
-2. Правило политики сетевой безопасности:
+1. Примените первичный набор объектов `CiliumClusterwideNetworkPolicy`. Для этого в настройки модуля cni-cilium добавьте конфигурационную опцию [`policyAuditMode`](../cni-cilium/configuration.html#parameters-policyauditmode) со значением `true`.
+
+      > Использование CiliumClusterwideNetworkPolicies при отсутствии опции `policyAuditMode` в настройках модуля cni-cilium может привести к некорректной работе Control plane или потере доступа ко всем узлам кластера по SSH.
+
+      Опция `policyAuditMode` может быть удалена после применения всех `CniliumClusterwideNetworkPolicy`-объектов и проверки корректности их работы в Hubble UI.
+
+1. Примените правило политики сетевой безопасности:
 
    ```yaml
    apiVersion: "cilium.io/v2"
@@ -70,7 +75,7 @@ description: Модуль cni-cilium Deckhouse обеспечивает рабо
          node-role.kubernetes.io/control-plane: ""
    ```
 
-В случае, если CiliumClusterwideNetworkPolicies не будут использованы, Control plane может некорректно работать до одной минуты во время перезагрузки `cilium-agent`-подов. Это происходит из-за [сброса Conntrack-таблицы](https://github.com/cilium/cilium/issues/19367). Привязка к entity `kube-apiserver` позволяет обойти баг.
+В случае, если CiliumClusterwideNetworkPolicies не будут использованы, Control plane может некорректно работать до одной минуты во время перезагрузки `cilium-agent`-подов. Это происходит из-за [сброса Conntrack-таблицы](https://github.com/cilium/cilium/issues/19367). Привязка к entity `kube-apiserver` позволяет избежать проблемы.
 
 ## Смена режима работы Cilium
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Change Using CiliumClusterwideNetworkPolicies section (cni-cilium).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Change Using CiliumClusterwideNetworkPolicies section (cni-cilium).
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
