### PR TITLE
[docs] Added instructions for integrating DKP with Zabbix

### DIFF
--- a/docs/documentation/pages/admin/configuration/monitoring/ALERTS_RU.md
+++ b/docs/documentation/pages/admin/configuration/monitoring/ALERTS_RU.md
@@ -8,7 +8,7 @@ lang: ru
 
 ## Перенаправление алертов в Zabbix
 
-Deckhouse поддерживает интеграцию с системой мониторинга Zabbix. Для этого используется внешний скрипт, который получает алерты из Deckhouse через `kubectl` и передаёт их в Zabbix с помощью Zabbix-агента.
+Deckhouse Kubernetes Platform поддерживает интеграцию с системой мониторинга Zabbix. Для этого используется внешний скрипт, который получает алерты из Deckhouse через `kubectl` и передаёт их в Zabbix с помощью Zabbix-агента.
 
 Для работы скрипта потребуются:
 
@@ -20,12 +20,156 @@ Deckhouse поддерживает интеграцию с системой мо
 
 1. Импортируйте шаблон в Zabbix:
    - В веб-интерфейсе Zabbix перейдите в раздел «Data collection → Templates»
-   - Нажмите «Import» и загрузите файл `zbx_export_templates.yaml`
+   - Нажмите «Import» и загрузите файл `zbx_export_templates.yaml`:
+
+     ```yaml
+     zabbix_export:
+       version: '6.4'
+       template_groups:
+         - uuid: 7df96b18c230490a9a0a9e2307226338
+           name: Templates
+       templates:
+         - uuid: 91d9cf9d023749a3997bc6429ef45fe1
+           template: 'Module d8alerts'
+           name: 'Deckhouse Alerts'
+           groups:
+             - name: Templates
+           discovery_rules:
+             - uuid: e9be18e9305e48e887c43e1ad9ea9c31
+               name: 'Deckhouse Alert Discovery'
+               key: d8alerts.discovery
+               lifetime: 3d
+               item_prototypes:
+                 - uuid: c4152d379d7a46cab23f7437cdb632c1
+                   name: 'Deckhouse alert: {#ALERTNAME} severity'
+                   key: 'd8alerts.severity[{#ALERTID}]'
+                   history: 1d
+                   trends: '0'
+                   description: |
+                     Summary: {#SUMMARY}
+                
+                     {#DESCRIPTION}
+                
+                     Labels: {#LABELS}
+                     To get more information: `kubectl describe clusteralert {#ALERTID}`
+                   preprocessing:
+                     - type: REGEX
+                       parameters:
+                         - (\d+)
+                         - \1
+                   tags:
+                     - tag: Application
+                       value: deckhouse
+                   trigger_prototypes:
+                     - uuid: b27f8d03dc4c4d33bab4193a6ce57ae7
+                       expression: 'last(/Module d8alerts/d8alerts.severity[{#ALERTID}]) <= 2 and last(/Module d8alerts/d8alerts.severity[{#ALERTID}]) > 0'
+                       name: '{#ALERTNAME} is firing'
+                       priority: DISASTER
+                       description: |
+                         Summary: {#SUMMARY}
+                    
+                         {#DESCRIPTION}
+                    
+                         Labels: {#LABELS}
+                         To get more information: `kubectl describe clusteralert {#ALERTID}`
+                     - uuid: d1935044cf3f49df8bc53f738e36b683
+                       expression: 'last(/Module d8alerts/d8alerts.severity[{#ALERTID}]) >= 3 and last(/Module d8alerts/d8alerts.severity[{#ALERTID}]) <= 4'
+                       name: '{#ALERTNAME} is firing'
+                       priority: HIGH
+                       description: |
+                         Summary: {#SUMMARY}
+                    
+                         {#DESCRIPTION}
+                    
+                         Labels: {#LABELS}
+                         To get more information: `kubectl describe clusteralert {#ALERTID}`
+                     - uuid: 0b134c599d9d4de79f906fbd8e749ec2
+                       expression: 'last(/Module d8alerts/d8alerts.severity[{#ALERTID}]) >= 5 and last(/Module d8alerts/d8alerts.severity[{#ALERTID}]) <= 6'
+                       name: '{#ALERTNAME} is firing'
+                       priority: AVERAGE
+                       description: |
+                         Summary: {#SUMMARY}
+                    
+                         {#DESCRIPTION}
+                    
+                         Labels: {#LABELS}
+                         To get more information: `kubectl describe clusteralert {#ALERTID}`
+                     - uuid: 6967dc80d6414239b2d597447815048a
+                       expression: 'last(/Module d8alerts/d8alerts.severity[{#ALERTID}]) >= 7 and last(/Module d8alerts/d8alerts.severity[{#ALERTID}]) <= 8'
+                       name: '{#ALERTNAME} is firing'
+                       priority: WARNING
+                       description: |
+                         Summary: {#SUMMARY}
+                    
+                         {#DESCRIPTION}
+                    
+                         Labels: {#LABELS}
+                         To get more information: `kubectl describe clusteralert {#ALERTID}`
+                     - uuid: 8e531a2e6a0f47849c1dffea9a1733e1
+                       expression: 'last(/Module d8alerts/d8alerts.severity[{#ALERTID}]) >= 9 and last(/Module d8alerts/d8alerts.severity[{#ALERTID}]) <= 10'
+                       name: '{#ALERTNAME} is firing'
+                       priority: INFO
+                       description: |
+                         Summary: {#SUMMARY}
+                    
+                         {#DESCRIPTION}
+                    
+                         Labels: {#LABELS}
+                         To get more information: `kubectl describe clusteralert {#ALERTID}`
+      ```
+
    - После установки шаблона укажите ему группу, соответствующую агентам, с которых будет происходить сбор метрик.
 
 1. Настройте Zabbix-агент:
-   - Скопируйте файл `d8alerts.conf` в директорию, указанную в параметре `Include` основного конфига Zabbix-агента (обычно расположен по пути `/etc/zabbix/zabbix_agentd.d/`)
-   - Скопируйте скрипт `clusteralerts.sh` в директорию `/etc/zabbix/scripts/` и убедитесь, что он имеет права на выполнение:
+   - Скопируйте файл `d8alerts.conf` в директорию, указанную в параметре `Include` основного конфига Zabbix-агента (обычно расположен по пути `/etc/zabbix/zabbix_agentd.d/`):
+
+     ```console
+     # LLD of deckhouse cluster alerts
+     UserParameter=d8alerts.discovery,/etc/zabbix/scripts/clusteralerts.sh discovery
+
+     # Severity of a specific alert by its ID
+     UserParameter=d8alerts.severity[*],/etc/zabbix/scripts/clusteralerts.sh severity "$1"
+     ```
+
+   - Скопируйте скрипт `clusteralerts.sh` в директорию `/etc/zabbix/scripts/`:
+
+     ```console
+     #!/bin/bash
+
+     MODE="$1"
+     ALERT_ID="$2"
+
+     get_alerts_json() {
+       kubectl get clusteralerts -o json
+     }
+
+     get_alert_by_id() {
+       local id="$1"
+       kubectl get clusteralerts "$id" -o json
+     }
+
+     if [[ "$MODE" == "discovery" ]]; then
+       get_alerts_json | jq -c '{
+           data: [.items[] | {
+             "{#ALERTID}": .metadata.name,
+             "{#ALERTNAME}": .alert.name,
+             "{#SEVERITY}": (.alert.severityLevel | tonumber),
+             "{#DESCRIPTION}": .alert.description,
+             "{#SUMMARY}": .alert.summary,
+             "{#LABELS}": (.alert.labels | to_entries | map("\(.key)=\(.value)") | join(","))
+           }]
+         }'
+
+     elif [[ "$MODE" == "severity" && -n "$ALERT_ID" ]]; then
+       get_alert_by_id "$ALERT_ID" | jq -r '.alert.severityLevel'
+
+     else
+       echo "Invalid usage"
+       exit 1
+     fi
+     ```
+
+   - Убедитесь, что скрипт имеет права на выполнение:
 
      ```console
      chmod +x /etc/zabbix/scripts/clusteralerts.sh


### PR DESCRIPTION
## Description
Added instructions for integrating DKP with Zabbix.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Added instructions for integrating DKP with Zabbix.
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
