### PR TITLE
[go_lib] Handle hybrid clusters case in the to_tofu_migrate_metric hook

### DIFF
--- a/go_lib/hooks/to_tofu_migrate_metric/hook.go
+++ b/go_lib/hooks/to_tofu_migrate_metric/hook.go
@@ -172,6 +172,9 @@ func nodeStateSecretFilter(unstructured *unstructured.Unstructured) (go_hook.Fil
 
 func fireNeedMigrateToOpenTofuMetric(input *go_hook.HookInput) error {
 	clusterStates, err := sdkobjectpatch.UnmarshalToStruct[StateClusterResult](input.NewSnapshots, "cluster_state")
+	if err != nil {
+		return err
+	}
 
 	input.MetricsCollector.Expire(metricGroup)
 

--- a/go_lib/hooks/to_tofu_migrate_metric/hook.go
+++ b/go_lib/hooks/to_tofu_migrate_metric/hook.go
@@ -172,30 +172,28 @@ func nodeStateSecretFilter(unstructured *unstructured.Unstructured) (go_hook.Fil
 
 func fireNeedMigrateToOpenTofuMetric(input *go_hook.HookInput) error {
 	clusterStates, err := sdkobjectpatch.UnmarshalToStruct[StateClusterResult](input.NewSnapshots, "cluster_state")
-	if err != nil {
-		return fmt.Errorf("cannot unmarshal cluster_state snapshot: %w", err)
-	}
-	if len(clusterStates) == 0 {
-		return fmt.Errorf("no cluster state snapshot found")
-	}
 
 	input.MetricsCollector.Expire(metricGroup)
 
 	needMigrate := false
 
-	for _, clusterState := range clusterStates {
-		if !clusterState.ClusterState {
-			input.Logger.Warn("Secret is not terraform state. Probably you located in test env", slog.String("secret_name", clusterState.SecretName))
-			continue
-		}
+	if len(clusterStates) != 0 {
+		for _, clusterState := range clusterStates {
+			if !clusterState.ClusterState {
+				input.Logger.Warn("Secret is not terraform state. Probably you located in test env", slog.String("secret_name", clusterState.SecretName))
+				continue
+			}
 
-		if clusterState.TerraformVersion == terraformVersion {
-			needMigrate = true
-			input.Logger.Info("Cluster state has terraform state. Needing to migrate to tofu")
-		}
+			if clusterState.TerraformVersion == terraformVersion {
+				needMigrate = true
+				input.Logger.Info("Cluster state has terraform state. Needing to migrate to tofu")
+			}
 
-		// cluster secret always one. hack for test envs see above
-		break
+			// cluster secret always one. hack for test envs see above
+			break
+		}
+	} else {
+		input.Logger.Info("Cluster state not found. Probably you have hybrid cluster")
 	}
 
 	nodeStates, err := sdkobjectpatch.UnmarshalToStruct[StateNodeResult](input.NewSnapshots, "nodes_state")

--- a/modules/000-common/hooks/to_tofu_migrate_metric_test.go
+++ b/modules/000-common/hooks/to_tofu_migrate_metric_test.go
@@ -155,8 +155,8 @@ common: {}
 			f.RunHook()
 		})
 
-		It("Hook should fail with not found cluster state error", func() {
-			Expect(f).ToNot(ExecuteSuccessfully())
+		It("Hook should execute successfully (hybrid cluster case)", func() {
+			Expect(f).To(ExecuteSuccessfully())
 		})
 	})
 


### PR DESCRIPTION
## Description

to_tofu_migrate_metric hook does not respect hybrid clusters.

## Why do we need it, and what problem does it solve?

Deckhouse stuck in error in hybrid clusters.

## Why do we need it in the patch release (if we do)?

Deckhouse stuck in error in hybrid clusters.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Handle hybrid clusters case in the to_tofu_migrate_metric hook
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
