### PR TITLE
[node-local-dns] stale dns cleaner change port

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -222,6 +222,10 @@ groups:
     description:
       en: "monitoring-ping metrics"
       ru: "Метрики monitoring-ping"
+  - ports: "8768"
+    protocol: TCP
+    en: stale-dns-connections-cleaner port for liveness probe
+    ru: Порт для проверки работоспособности stale-dns-connections-cleaner
 
 - group: ExternalToMaster
   description:

--- a/ee/be/modules/350-node-local-dns/images/stale-dns-connections-cleaner/main.go
+++ b/ee/be/modules/350-node-local-dns/images/stale-dns-connections-cleaner/main.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"flag"
 	"github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/vishvananda/netlink"
 )
@@ -34,7 +35,6 @@ const (
 	nldLabelSelector string = "app=node-local-dns"
 	nldDstPort       uint16 = 53
 	scanInterval            = 10 * time.Second
-	listenAddress           = "127.0.0.1:8001"
 	// netlink const
 	familyIPv4          = syscall.AF_INET
 	protoUDP            = unix.IPPROTO_UDP
@@ -56,6 +56,7 @@ type ConnectionsCleaner struct {
 var (
 	native       = nl.NativeEndian()
 	networkOrder = binary.BigEndian
+	listenAddress string
 )
 
 func main() {
@@ -70,6 +71,8 @@ func main() {
 	log.Infof("  - Retrieve the current IP address of the node-local-dns pod.")
 	log.Infof("  - Retrieve all UDP sockets on the node and search for those with dst_port 53 and dsp_ip belonging to PodCidr, but not equal to the current IP address of the node-local-dns pod.")
 	log.Infof("  - If such sockets are found, delete them.")
+	flag.StringVar(&listenAddress, "health-probe-bind-address", "127.0.0.1:8768", "The address the probe endpoint binds to.")
+	flag.Parse()
 
 	// Init kubeClient
 	config, err := rest.InClusterConfig()

--- a/ee/be/modules/350-node-local-dns/templates/stale-dns-connections-cleaner/daemonset.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/stale-dns-connections-cleaner/daemonset.yaml
@@ -59,6 +59,8 @@ spec:
         {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "NET_ADMIN")) | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "staleDnsConnectionsCleaner") }}
         command: ["/stale-dns-connections-cleaner"]
+        args:
+          - "--health-probe-bind-address=127.0.0.1:8768"
         env:
         - name: NODE_NAME
           valueFrom:
@@ -69,7 +71,7 @@ spec:
           httpGet:
             path: /healthz
             host: 127.0.0.1
-            port: 8001
+            port: 8768
             scheme: HTTP
         resources:
           requests:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
