### PR TITLE
[docs] Update conversions message

### DIFF
--- a/docs/documentation/_data/i18n.yml
+++ b/docs/documentation/_data/i18n.yml
@@ -111,7 +111,10 @@ common:
     en: Documents found
     ru: Найдено документов
   conversion_action_message:
-    en: "Perform the following actions if you need to convert data from one version of the module parameter schema to another"
+    en: |
+      The module is configured using the ModuleConfig resource created by the user.
+      When changing the version of the module settings, transformations are automatically performed to maintain the functionality of the new version.
+      If you want to update the version in the ModuleConfig manually, then you need to do the following:
     ru: |
       Модуль настраивается с помощью ресурса ModuleConfig, создаваемого пользователем.
       При изменении версии настроек модуля автоматически выполняются преобразования для сохранения работоспособности новой версии.

--- a/docs/documentation/_data/i18n.yml
+++ b/docs/documentation/_data/i18n.yml
@@ -112,16 +112,14 @@ common:
     ru: Найдено документов
   conversion_action_message:
     en: |
-      The module is configured using the ModuleConfig resource created by the user.
-      When changing the version of the module settings, transformations are automatically performed to maintain the functionality of the new version.
-      If you want to update the version in the ModuleConfig manually, then you need to do the following:
+      The module is configured using the ModuleConfig resource, the schema of which contains a version number.
+      When you apply an *old* version of the ModuleConfig schema in a cluster, automatic transformations are performed. To manually update the ModuleConfig schema version, the following steps must be completed **sequentially** for each version
     ru: |
-      Модуль настраивается с помощью ресурса ModuleConfig, создаваемого пользователем.
-      При изменении версии настроек модуля автоматически выполняются преобразования для сохранения работоспособности новой версии.
-      Если вы хотите обновить версию в ModuleConfig вручную, то необходимо выполнить следующие действия:
+      Модуль настраивается с помощью ресурса ModuleConfig, схема которого содержит номер версии.
+      При применении в кластере *старой* версии схемы ModuleConfig выполняются автоматические преобразования. Чтобы обновить версию схемы ModuleConfig вручную, необходимо **последовательно** для каждой версии выполнить следующие действия
   conversion_from_version:
-    en: "from version"
-    ru: "из версии"
+    en: "updates from version"
+    ru: "обновление из версии"
   conversion_to_version:
     en: "to version"
     ru: "в версию"

--- a/docs/documentation/_data/i18n.yml
+++ b/docs/documentation/_data/i18n.yml
@@ -112,7 +112,10 @@ common:
     ru: Найдено документов
   conversion_action_message:
     en: "Perform the following actions if you need to convert data from one version of the module parameter schema to another"
-    ru: "При необходимости преобразования данных из одной версии схемы параметров модуля в другую, выполните следующие действия"
+    ru: |
+      Модуль настраивается с помощью ресурса ModuleConfig, создаваемого пользователем.
+      При изменении версии настроек модуля автоматически выполняются преобразования для сохранения работоспособности новой версии.
+      Если вы хотите обновить версию в ModuleConfig вручную, то необходимо выполнить следующие действия:
   conversion_from_version:
     en: "from version"
     ru: "из версии"

--- a/docs/site/backends/docs-builder-template/i18n/en.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/en.yaml
@@ -7,8 +7,8 @@ documentation: documentation
 modules_documentation: Modules documentation
 core: core
 conversions_title: Conversions
-conversion_action_message: Perform the following actions if you need to convert data from one version of the module parameter schema to another
-conversion_from_version: From version
+conversion_action_message: The module is configured using the ModuleConfig resource, the schema of which contains a version number. When you apply an *old* version of the ModuleConfig schema in a cluster, automatic transformations are performed. To manually update the ModuleConfig schema version, the following steps must be completed **sequentially** for each version
+conversion_from_version: Updates from version
 conversion_to: to
 conversion_expressions: Actions performed by the conversion (jq syntax)
 conversion_missing_description: Conversion description is missing

--- a/docs/site/backends/docs-builder-template/i18n/ru.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/ru.yaml
@@ -7,8 +7,8 @@ documentation: документация
 modules_documentation: Документация модулей
 core: ядро
 conversions_title: Конверсии
-conversion_action_message: При необходимости преобразования данных из одной версии схемы параметров модуля в другую, выполните следующие действия
-conversion_from_version: Из версии
+conversion_action_message: Модуль настраивается с помощью ресурса ModuleConfig, схема которого содержит номер версии. При применении в кластере *старой* версии схемы ModuleConfig выполняются автоматические преобразования. Чтобы обновить версию схемы ModuleConfig вручную, необходимо **последовательно** для каждой версии выполнить следующие действия
+conversion_from_version: Обновление из версии
 conversion_to: в
 conversion_expressions: Преобразования, выполняемые конверсией (синтаксис jq)
 conversion_missing_description: Описание конверсии отсутствует


### PR DESCRIPTION
## Description

This pull request updates the `conversion_action_message` in the `i18n.yml` file to provide a more detailed explanation of how module configuration versioning and transformations are handled. The new message clarifies the automatic and manual processes for updating the module configuration.

### Updated documentation:
* [`docs/documentation/_data/i18n.yml`](diffhunk://#diff-26a2d3ec2aad6effdacc644931a6b5c9e7c3f7d1643f295f1731946c8193ca3fL114-R121): Enhanced the `conversion_action_message` for both English (`en`) and Russian (`ru`) to include details about automatic transformations during version changes and instructions for manual updates to the `ModuleConfig` resource.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Updated conversions message.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
