### PR TITLE
[deckhouse-tools] fix render deployment

### DIFF
--- a/modules/800-deckhouse-tools/templates/deployment.yaml
+++ b/modules/800-deckhouse-tools/templates/deployment.yaml
@@ -23,6 +23,8 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
+      serviceAccountName: ""
+      serviceAccount: ""
       containers:
       - name: web
         image: {{ include "helm_lib_module_image" (list $ "web") }}

--- a/modules/800-deckhouse-tools/templates/deployment.yaml
+++ b/modules/800-deckhouse-tools/templates/deployment.yaml
@@ -23,8 +23,8 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
-      serviceAccountName: ""
-      serviceAccount: ""
+      serviceAccountName: null
+      serviceAccount: null
       containers:
       - name: web
         image: {{ include "helm_lib_module_image" (list $ "web") }}


### PR DESCRIPTION
## Description

as described [here](https://github.com/kubernetes/kubernetes/issues/72519) there are some issues with removing `serviceAccountName` field from the deployment.
So I add an empty value, it will be removed in the next release

## Why do we need it, and what problem does it solve?

After updating release, the field did not disappear from the deployment

```
 Warning  FailedCreate  42s (x16 over 3m17s)  replicaset-controller  Error creating: pods "deckhouse-tools-55c9768cfc-" is forbidden: error looking up service account d8-system/deckhouse-tools: serviceaccount "deckhouse-tools" not found
```
problem occurred after this [change](https://github.com/deckhouse/deckhouse/pull/11962/files#diff-91ff6ae8e9c32539ebbbbf177dc33d7b8972404d60c63133173b4c7e44b06f55):

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-tools
type: fix
summary: deckhouse-tools fix deployment render
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
