### PR TITLE
[docs] Added cell coloring to the module stability table

### DIFF
--- a/docs/documentation/pages/module-development/VERSIONING.md
+++ b/docs/documentation/pages/module-development/VERSIONING.md
@@ -35,53 +35,53 @@ During its life cycle, a module may be at any of the following stages:
 Depending on the stage of the module lifecycle and the release channel from which the specific module version was installed, the overall stability can be determined according to the following table:
 
 <table class="versioning-table">
-    <thead>
-        <tr class="header-row">
-            <th rowspan="2">Lifecycle Stage</th>
-            <th colspan="5">Update Channels</th>
-        </tr>
-        <tr class="sub-header">
-            <th>Alpha</th>
-            <th>Beta</th>
-            <th class="middle">Early Access</th>
-            <th>Stable</th>
-            <th>Rock Solid</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><strong>Experimental</strong></td>
-            <td>Experiments</td>
-            <td>Experiments</td>
-            <td>Experiments</td>
-            <td>Beta testing</td>
-            <td>Beta testing</td>
-        </tr>
-        <tr>
-            <td><strong>Preview</strong></td>
-            <td>Experiments</td>
-            <td>Limited use</td>
-            <td>Limited use</td>
-            <td>Production use</td>
-            <td>Production use</td>
-        </tr>
-        <tr>
-            <td><strong>General Availability</strong></td>
-            <td>Experiments</td>
-            <td>Limited use</td>
-            <td>Limited use</td>
-            <td>Production use</td>
-            <td>Production use in critical systems</td>
-        </tr>
-        <tr>
-            <td><strong>Deprecated</strong></td>
-            <td>Deprecated</td>
-            <td>Deprecated</td>
-            <td>Deprecated</td>
-            <td>Deprecated</td>
-            <td>Deprecated</td>
-        </tr>
-    </tbody>
+  <thead>
+    <tr class="header-row">
+      <th rowspan="2">Lifecycle Stage</th>
+      <th colspan="5">Update Channels</th>
+    </tr>
+    <tr class="sub-header">
+      <th>Alpha</th>
+      <th>Beta</th>
+      <th class="middle">Early Access</th>
+      <th>Stable</th>
+      <th>Rock Solid</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Experimental</strong></td>
+      <td style="background-color:#d68787">Experiments</td>
+      <td style="background-color:#d68787">Experiments</td>
+      <td style="background-color:#d68787">Experiments</td>
+      <td style="background-color:#F8C989">Beta testing</td>
+      <td style="background-color:#F8C989">Beta testing</td>
+    </tr>
+    <tr>
+      <td><strong>Preview</strong></td>
+      <td style="background-color:#d68787">Experiments</td>
+      <td style="background-color:#f0b4b8">Limited use</td>
+      <td style="background-color:#f0b4b8">Limited use</td>
+      <td style="background-color:#a4deb5">Production use</td>
+      <td style="background-color:#a4deb5">Production use</td>
+    </tr>
+    <tr>
+      <td><strong>General Availability</strong></td>
+      <td style="background-color:#d68787">Experiments</td>
+      <td style="background-color:#f0b4b8">Limited use</td>
+      <td style="background-color:#f0b4b8">Limited use</td>
+      <td style="background-color:#a4deb5">Production use</td>
+      <td style="background-color:#68b374">Production use in critical systems</td>
+    </tr>
+    <tr>
+      <td><strong>Deprecated</strong></td>
+      <td style="background-color:#D3D3D3">Deprecated</td>
+      <td style="background-color:#D3D3D3">Deprecated</td>
+      <td style="background-color:#D3D3D3">Deprecated</td>
+      <td style="background-color:#D3D3D3">Deprecated</td>
+      <td style="background-color:#D3D3D3">Deprecated</td>
+    </tr>
+  </tbody>
 </table>
 
 - **Experiments** — Functionality checks, experiments, and testing;

--- a/docs/documentation/pages/module-development/VERSIONING_RU.md
+++ b/docs/documentation/pages/module-development/VERSIONING_RU.md
@@ -36,53 +36,53 @@ lang: ru
 В зависимости от стадии жизненного цикла модуля и канала обновлений, из которого была установлена версия модуля, общая стабильность может быть определена в соответствии со следующей таблицей:
 
 <table class="versioning-table">
-    <thead>
-        <tr class="header-row">
-            <th rowspan="2">Стадия жизненного цикла</th>
-            <th colspan="5">Каналы обновлений</th>
-        </tr>
-        <tr class="sub-header">
-            <th>Alpha</th>
-            <th>Beta</th>
-            <th class="middle">Early Access</th>
-            <th>Stable</th>
-            <th>Rock Solid</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><strong>Experimental</strong></td>
-            <td>Эксперименты</td>
-            <td>Эксперименты</td>
-            <td>Эксперименты</td>
-            <td>Опытная эксплуатация</td>
-            <td>Опытная эксплуатация</td>
-        </tr>
-        <tr>
-            <td><strong>Preview</strong></td>
-            <td>Эксперименты</td>
-            <td>Ограниченная эксплуатация</td>
-            <td>Ограниченная эксплуатация</td>
-            <td>Промышленная эксплуатация</td>
-            <td>Промышленная эксплуатация</td>
-        </tr>
-        <tr>
-            <td><strong>General Availability</strong></td>
-            <td>Эксперименты</td>
-            <td>Ограниченная эксплуатация</td>
-            <td>Ограниченная эксплуатация</td>
-            <td>Промышленная эксплуатация</td>
-            <td>Промышленная эксплуатация в ответственных системах</td>
-        </tr>
-        <tr>
-            <td><strong>Deprecated</strong></td>
-            <td>Отказ от использования</td>
-            <td>Отказ от использования</td>
-            <td>Отказ от использования</td>
-            <td>Отказ от использования</td>
-            <td>Отказ от использования</td>
-        </tr>
-    </tbody>
+  <thead>
+    <tr class="header-row">
+      <th rowspan="2">Стадия жизненного цикла</th>
+      <th colspan="5">Каналы обновлений</th>
+    </tr>
+    <tr class="sub-header">
+      <th>Alpha</th>
+      <th>Beta</th>
+      <th class="middle">Early Access</th>
+      <th>Stable</th>
+      <th>Rock Solid</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Experimental</strong></td>
+      <td style="background-color:#d68787">Эксперименты</td>
+      <td style="background-color:#d68787">Эксперименты</td>
+      <td style="background-color:#d68787">Эксперименты</td>
+      <td style="background-color:#F8C989">Опытная эксплуатация</td>
+      <td style="background-color:#F8C989">Опытная эксплуатация</td>
+    </tr>
+    <tr>
+      <td><strong>Preview</strong></td>
+      <td style="background-color:#d68787">Эксперименты</td>
+      <td style="background-color:#f0b4b8">Ограниченная эксплуатация</td>
+      <td style="background-color:#f0b4b8">Ограниченная эксплуатация</td>
+      <td style="background-color:#a4deb5">Промышленная эксплуатация</td>
+      <td style="background-color:#a4deb5">Промышленная эксплуатация</td>
+    </tr>
+    <tr>
+      <td><strong>General Availability</strong></td>
+      <td style="background-color:#d68787">Эксперименты</td>
+      <td style="background-color:#f0b4b8">Ограниченная эксплуатация</td>
+      <td style="background-color:#f0b4b8">Ограниченная эксплуатация</td>
+      <td style="background-color:#a4deb5">Промышленная эксплуатация</td>
+      <td style="background-color:#68b374">Промышленная эксплуатация в ответственных системах</td>
+    </tr>
+    <tr>
+      <td><strong>Deprecated</strong></td>
+      <td style="background-color:#D3D3D3">Отказ от использования</td>
+      <td style="background-color:#D3D3D3">Отказ от использования</td>
+      <td style="background-color:#D3D3D3">Отказ от использования</td>
+      <td style="background-color:#D3D3D3">Отказ от использования</td>
+      <td style="background-color:#D3D3D3">Отказ от использования</td>
+    </tr>
+  </tbody>
 </table>
 
 - **Эксперименты** — Проверка функциональности, эксперименты и тестирование;


### PR DESCRIPTION
## Description
Added cell coloring to the module stability table.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Added cell coloring to the module stability table.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
