### PR TITLE
[cloud-provider-vcd] terraform layout StandardWithNetwork

### DIFF
--- a/ee/candi/cloud-providers/vcd/layouts/standard-with-network/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/vcd/layouts/standard-with-network/base-infrastructure/main.tf
@@ -1,0 +1,21 @@
+# Copyright 2023 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+module "network" {
+  source                       = "../../../terraform-modules/network"
+  providerClusterConfiguration = var.providerClusterConfiguration
+  prefix                       = var.clusterConfiguration.prefix
+}
+
+module "vapp" {
+  source                       = "../../../terraform-modules/vapp"
+  prefix                       = var.clusterConfiguration.prefix
+  providerClusterConfiguration = var.providerClusterConfiguration
+}
+
+resource "vcd_vapp_org_network" "vapp_network" {
+  org              = var.providerClusterConfiguration.organization
+  vdc              = var.providerClusterConfiguration.virtualDataCenter
+  vapp_name        = var.clusterConfiguration.prefix
+  org_network_name = var.clusterConfiguration.prefix
+}

--- a/ee/candi/cloud-providers/vcd/layouts/standard-with-network/base-infrastructure/providers.tf
+++ b/ee/candi/cloud-providers/vcd/layouts/standard-with-network/base-infrastructure/providers.tf
@@ -1,0 +1,1 @@
+../../../terraform-modules/providers.tf

--- a/ee/candi/cloud-providers/vcd/layouts/standard-with-network/base-infrastructure/variables.tf
+++ b/ee/candi/cloud-providers/vcd/layouts/standard-with-network/base-infrastructure/variables.tf
@@ -1,0 +1,23 @@
+# Copyright 2021 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+variable "clusterConfiguration" {
+  type = any
+}
+
+variable "providerClusterConfiguration" {
+  type = any
+}
+
+variable "nodeIndex" {
+  type    = number
+  default = 0
+}
+
+variable "clusterUUID" {
+  type = string
+}
+
+locals {
+  prefix = var.clusterConfiguration.cloud.prefix
+}

--- a/ee/candi/cloud-providers/vcd/layouts/standard-with-network/base-infrastructure/versions.tf
+++ b/ee/candi/cloud-providers/vcd/layouts/standard-with-network/base-infrastructure/versions.tf
@@ -1,0 +1,1 @@
+../../../terraform-modules/versions.tf

--- a/ee/candi/cloud-providers/vcd/layouts/standard-with-network/master-node
+++ b/ee/candi/cloud-providers/vcd/layouts/standard-with-network/master-node
@@ -1,0 +1,1 @@
+../../terraform-modules/master-node

--- a/ee/candi/cloud-providers/vcd/layouts/standard-with-network/static-node
+++ b/ee/candi/cloud-providers/vcd/layouts/standard-with-network/static-node
@@ -1,0 +1,1 @@
+../../terraform-modules/static-node

--- a/ee/candi/cloud-providers/vcd/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/cluster_configuration.yaml
@@ -273,6 +273,10 @@ apiVersions:
           pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
           description: |
             VMware Cloud Director Virtual Application name (belongs to Virtual Data Center).
+        edgeGatewayName:
+          type: string
+          description: |
+            VMware Cloud Director Edge Gateway name (belongs to Virtual Data Center).
         mainNetwork:
           description: |
             Path to the network that VirtualMachines' primary NICs will connect to (default gateway).
@@ -292,6 +296,7 @@ apiVersions:
             The way resources are located in the cloud.
 
             Read [more](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/cloud-provider-vcd/layouts.html) about possible provider layouts.
+          enum: [Standard, StandardWithNetwork]
         provider:
           type: object
           additionalProperties: false

--- a/ee/candi/cloud-providers/vcd/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vcd/openapi/doc-ru-cluster_configuration.yaml
@@ -139,6 +139,9 @@ apiVersions:
         virtualApplicationName:
           description: |
             Имя VMware Cloud Director Virtual Application (принадлежащее Virtual Data Center).
+        edgeGatewayName:
+          description: |
+            Имя VMware Cloud Director Edge Gateway (принадлежащее Virtual Data Center).
         mainNetwork:
           description: |
             Путь до сети, которая будет подключена к виртуальной машине как основная (шлюз по умолчанию).

--- a/ee/candi/cloud-providers/vcd/terraform-modules/network/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/network/main.tf
@@ -1,0 +1,20 @@
+# Copyright 2023 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+data "vcd_nsxt_edgegateway" "gateway" {
+  org  = var.providerClusterConfiguration.organization
+  name = var.providerClusterConfiguration.edgeGatewayName
+}
+
+resource "vcd_network_routed_v2" "network" {
+  org  = var.providerClusterConfiguration.virtualApplicationName
+  name = var.prefix
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.edge.id
+
+  gateway            = cidrhost(var.providerClusterConfiguration.internalNetworkCIDR, 1)
+  prefix_length      = 24
+  guest_vlan_allowed = false
+  dns1               = "8.8.8.8"
+  dns2               = "1.1.1.1"
+}

--- a/ee/candi/cloud-providers/vcd/terraform-modules/network/providers.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/network/providers.tf
@@ -1,0 +1,1 @@
+../providers.tf

--- a/ee/candi/cloud-providers/vcd/terraform-modules/network/variables.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/network/variables.tf
@@ -1,0 +1,20 @@
+# Copyright 2023 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+variable "providerClusterConfiguration" {
+  type = any
+
+  validation {
+    condition     = cidrsubnet(var.providerClusterConfiguration.internalNetworkCIDR, 0, 0) == var.providerClusterConfiguration.internalNetworkCIDR
+    error_message = "Invalid internalNetworkCIDR in VCDClusterConfiguration."
+  }
+
+  validation {
+    condition     = length(flatten([for ng in var.providerClusterConfiguration.nodeGroups : ng.instanceClass.mainNetworkIPAddresses if contains(keys(ng.instanceClass), "mainNetworkIPAddresses")])) == length(flatten([for ng in var.providerClusterConfiguration.nodeGroups : [for s in ng.instanceClass.mainNetworkIPAddresses : s if cidrsubnet(format("%s/%s", s, split("/", var.providerClusterConfiguration.internalNetworkCIDR)[1]), 0, 0) == var.providerClusterConfiguration.internalNetworkCIDR] if contains(keys(ng.instanceClass), "mainNetworkIPAddresses")]))
+    error_message = "Address in mainNetworkIPAddresses not in internalNetworkCIDR."
+  }
+}
+
+variable "prefix" {
+  type = string
+}

--- a/ee/candi/cloud-providers/vcd/terraform-modules/network/versions.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/network/versions.tf
@@ -1,0 +1,1 @@
+../versions.tf

--- a/ee/candi/cloud-providers/vcd/terraform-modules/providers.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/providers.tf
@@ -2,13 +2,13 @@
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 
 provider "vcd" {
-  url = join("/", [trimsuffix(trimsuffix(var.providerClusterConfiguration.provider.server, "/"), "/api"), "api"])
-  org = var.providerClusterConfiguration.organization
-  vdc = var.providerClusterConfiguration.virtualDataCenter
-  user = lookup(var.providerClusterConfiguration.provider, "username", "none")
-  password = lookup(var.providerClusterConfiguration.provider, "password", "none")
-  api_token = lookup(var.providerClusterConfiguration.provider, "apiToken", "")
-  auth_type = lookup(var.providerClusterConfiguration.provider, "apiToken", null) != null ? "api_token" : "integrated"
+  url                  = join("/", [trimsuffix(trimsuffix(var.providerClusterConfiguration.provider.server, "/"), "/api"), "api"])
+  org                  = var.providerClusterConfiguration.organization
+  vdc                  = var.providerClusterConfiguration.virtualDataCenter
+  user                 = lookup(var.providerClusterConfiguration.provider, "username", "none")
+  password             = lookup(var.providerClusterConfiguration.provider, "password", "none")
+  api_token            = lookup(var.providerClusterConfiguration.provider, "apiToken", "")
+  auth_type            = lookup(var.providerClusterConfiguration.provider, "apiToken", null) != null ? "api_token" : "integrated"
   allow_unverified_ssl = lookup(var.providerClusterConfiguration.provider, "insecure", false)
-  max_retry_timeout = 60
+  max_retry_timeout    = 60
 }

--- a/ee/candi/cloud-providers/vcd/terraform-modules/vapp/main.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/vapp/main.tf
@@ -1,12 +1,7 @@
 # Copyright 2023 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 
-terraform {
-  required_providers {
-    vcd = {
-      source  = "vmware/vcd"
-      version = "3.14.1"
-    }
-  }
-  required_version = ">= 0.13"
+resource "vcd_vapp" "vapp" {
+  name = var.prefix
+  org  = var.providerClusterConfiguration.organization
 }

--- a/ee/candi/cloud-providers/vcd/terraform-modules/vapp/providers.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/vapp/providers.tf
@@ -1,0 +1,1 @@
+../providers.tf

--- a/ee/candi/cloud-providers/vcd/terraform-modules/vapp/variables.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/vapp/variables.tf
@@ -1,0 +1,20 @@
+# Copyright 2023 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+variable "providerClusterConfiguration" {
+  type = any
+
+  validation {
+    condition     = cidrsubnet(var.providerClusterConfiguration.internalNetworkCIDR, 0, 0) == var.providerClusterConfiguration.internalNetworkCIDR
+    error_message = "Invalid internalNetworkCIDR in VCDClusterConfiguration."
+  }
+
+  validation {
+    condition     = length(flatten([for ng in var.providerClusterConfiguration.nodeGroups : ng.instanceClass.mainNetworkIPAddresses if contains(keys(ng.instanceClass), "mainNetworkIPAddresses")])) == length(flatten([for ng in var.providerClusterConfiguration.nodeGroups : [for s in ng.instanceClass.mainNetworkIPAddresses : s if cidrsubnet(format("%s/%s", s, split("/", var.providerClusterConfiguration.internalNetworkCIDR)[1]), 0, 0) == var.providerClusterConfiguration.internalNetworkCIDR] if contains(keys(ng.instanceClass), "mainNetworkIPAddresses")]))
+    error_message = "Address in mainNetworkIPAddresses not in internalNetworkCIDR."
+  }
+}
+
+variable "prefix" {
+  type = string  
+}

--- a/ee/candi/cloud-providers/vcd/terraform-modules/vapp/versions.tf
+++ b/ee/candi/cloud-providers/vcd/terraform-modules/vapp/versions.tf
@@ -1,0 +1,1 @@
+../versions.tf


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add new `StandardWithNetwork` layout for the cloud-provider-vcd module. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

`Standard` layout does not include any `network` or `vapp` resources.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: feature
summary: Add `StandardWithNetwork` layout
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
