### PR TITLE
[cloud-provider-zvirt] fix UUID validation regex

### DIFF
--- a/ee/se-plus/candi/cloud-providers/zvirt/openapi/cluster_configuration.yaml
+++ b/ee/se-plus/candi/cloud-providers/zvirt/openapi/cluster_configuration.yaml
@@ -60,7 +60,7 @@ apiVersions:
         type: string
         description: |
           Cluster ID with shared storage domains and CPUs of the same type to create virtual machines.
-        pattern: ^[\da-fA-F]{8}\-[\da-fA-F]{4}\-4[\da-fA-F]{3}\-[\da-fA-F]{4}\-[\da-fA-F]{12}$
+        pattern: ^[\da-fA-F]{8}\-[\da-fA-F]{4}\-[\da-fA-F]{4}\-[\da-fA-F]{4}\-[\da-fA-F]{12}$
         example: "49bb4594-0cd4-4eb7-8288-8594eafd5a86"
       masterNodeGroup:
         type: object
@@ -116,13 +116,13 @@ apiVersions:
                 type: string
                 description: |
                   Virtual NIC profile ID on the basis of which the virtual NIC will be created.
-                pattern: ^[\da-fA-F]{8}\-[\da-fA-F]{4}\-4[\da-fA-F]{3}\-[\da-fA-F]{4}\-[\da-fA-F]{12}$
+                pattern: ^[\da-fA-F]{8}\-[\da-fA-F]{4}\-[\da-fA-F]{4}\-[\da-fA-F]{4}\-[\da-fA-F]{12}$
                 example: "49bb4594-0cd4-4eb7-8288-8594eafd5a86"
               storageDomainID:
                 type: string
                 description: |
                   Storage domain id which contains the shared resources that must be available to all datacenter hosts.
-                pattern: ^[\da-fA-F]{8}\-[\da-fA-F]{4}\-4[\da-fA-F]{3}\-[\da-fA-F]{4}\-[\da-fA-F]{12}$
+                pattern: ^[\da-fA-F]{8}\-[\da-fA-F]{4}\-[\da-fA-F]{4}\-[\da-fA-F]{4}\-[\da-fA-F]{12}$
                 example: "49bb4594-0cd4-4eb7-8288-8594eafd5a86"
       nodeGroups:
         type: array

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/openapi/values.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/openapi/values.yaml
@@ -118,13 +118,13 @@ properties:
                     type: string
                     description: |
                       Virtual NIC profile ID on the basis of which the virtual NIC will be created.
-                    pattern: ^[\da-fA-F]{8}\-[\da-fA-F]{4}\-4[\da-fA-F]{3}\-[\da-fA-F]{4}\-[\da-fA-F]{12}$
+                    pattern: ^[\da-fA-F]{8}\-[\da-fA-F]{4}\-[\da-fA-F]{4}\-[\da-fA-F]{4}\-[\da-fA-F]{12}$
                     example: "49bb4594-0cd4-4eb7-8288-8594eafd5a86"
                   storageDomainID:
                     type: string
                     description: |
                       Storage domain id which contains the shared resources that must be available to all datacenter hosts.
-                    pattern: ^[\da-fA-F]{8}\-[\da-fA-F]{4}\-4[\da-fA-F]{3}\-[\da-fA-F]{4}\-[\da-fA-F]{12}$
+                    pattern: ^[\da-fA-F]{8}\-[\da-fA-F]{4}\-[\da-fA-F]{4}\-[\da-fA-F]{4}\-[\da-fA-F]{12}$
                     example: "49bb4594-0cd4-4eb7-8288-8594eafd5a86"
           nodeGroups:
             type: array


### PR DESCRIPTION
## Description
This PR relaxes UUID validation. In current implementation it allows only UUID v4.  

## Why do we need it, and what problem does it solve?
zVirt 4.3 uses UUID v1, which are not compatible with our UUID validation regex. 
![image](https://github.com/user-attachments/assets/c11024dd-b470-4468-a6d5-5837190f48d8)


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-zvirt
type: fix
summary: fix UUID validation regex
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
