### PR TITLE
[deckhouse] Liveness and Readiness probes for kube-rbac-proxy

### DIFF
--- a/ee/modules/500-operator-trivy/templates/deployment.yaml
+++ b/ee/modules/500-operator-trivy/templates/deployment.yaml
@@ -207,12 +207,12 @@ spec:
         livenessProbe:
           httpGet:
             path: /livez
-            port: 8080
+            port: 8081
             scheme: HTTPS
         readinessProbe:
           httpGet:
             path: /livez
-            port: 8080
+            port: 8081
             scheme: HTTPS
         ports:
         - containerPort: 8081

--- a/modules/015-admission-policy-engine/templates/audit-deployment.yaml
+++ b/modules/015-admission-policy-engine/templates/audit-deployment.yaml
@@ -183,12 +183,12 @@ spec:
         livenessProbe:
           httpGet:
             path: /livez
-            port: 8080
+            port: 10354
             scheme: HTTPS
         readinessProbe:
           httpGet:
             path: /livez
-            port: 8080
+            port: 10354
             scheme: HTTPS
         ports:
           - containerPort: 10354

--- a/modules/015-admission-policy-engine/templates/gatekeeper-deployment.yaml
+++ b/modules/015-admission-policy-engine/templates/gatekeeper-deployment.yaml
@@ -155,12 +155,12 @@ spec:
         livenessProbe:
           httpGet:
             path: /livez
-            port: 8080
+            port: 10354
             scheme: HTTPS
         readinessProbe:
           httpGet:
             path: /livez
-            port: 8080
+            port: 10354
             scheme: HTTPS
         ports:
           - containerPort: 10354

--- a/modules/101-cert-manager/templates/cert-manager/deployment.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/deployment.yaml
@@ -136,12 +136,12 @@ spec:
           livenessProbe:
             httpGet:
               path: /livez
-              port: 8080
+              port: 9404
               scheme: HTTPS
           readinessProbe:
             httpGet:
               path: /livez
-              port: 8080
+              port: 9404
               scheme: HTTPS
           ports:
           - containerPort: 9404


### PR DESCRIPTION
## Description

Changing the ports used in Kube-RBAC-Proxy for Liveness and Readness probes.

## Why do we need it, and what problem does it solve?

Change is necessary for the correct monitoring of the work of the pods

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Liveness and Readiness probes for kube-rbac-proxy
impact_level: default
```
