### PR TITLE
[docs] Removed documentation about module lifecycle parameters

### DIFF
--- a/docs/documentation/pages/module-development/DEVELOPMENT.md
+++ b/docs/documentation/pages/module-development/DEVELOPMENT.md
@@ -29,31 +29,6 @@ To force scan you can change the interval or set the `renew=""` annotation on Mo
 
 The `spec.rollback` indicates whether the deployed module release should be rollback after deleting the `ModulePullOverride`.
 
-Deckhouse provides the ability to temporarily change a module's behavior using the `ModulePullOverride` object. This object is created separately from `module.yaml` and can override certain aspects of module management:
-
-- `unmanaged` — *boolean*. Disables Deckhouse's control over the module (no updates or deletions will occur).
-- `disable` — *boolean*. Temporarily disables the module and removes all of its resources.
-- `terminating` — *boolean*. Transitions the module to a deletion state, causing all module resources and the `Module` object itself to be removed.
-- `rollback` — *boolean*. If set to `true`, when the `ModulePullOverride` object is deleted, Deckhouse will:
-  - remove the module's artifacts;
-  - restart itself;
-  - revert to the previous stable version of the module.
-
-Example:
-
-```yaml
-apiVersion: deckhouse.io/v1alpha1
-kind: ModulePullOverride
-metadata:
-  name: example
-spec:
-  version: v1.2.3
-  unmanaged: false
-  disable: false
-  terminating: false
-  rollback: true
-```
-
 You can get the result of applying ModulePullOverride in the message (column `MESSAGE`) when retrieving ModulePullOverride information. The value `Ready` indicates the successful application of ModulePullOverride parameters. Any other value indicates conflict.
 
 Example of absence of conflicts when using ModulePullOverride:

--- a/docs/documentation/pages/module-development/DEVELOPMENT_RU.md
+++ b/docs/documentation/pages/module-development/DEVELOPMENT_RU.md
@@ -29,31 +29,6 @@ spec:
 
 Необязательный параметр `spec.rollback` — если установить этот параметр в `true`, это восстановит развернутый модуль до предыдущего состояния после удаления `ModulePullOverride`.
 
-Deckhouse предоставляет возможность временно изменить поведение модуля с помощью дополнительных параметров объекта `ModulePullOverride`. Эти параметры позволяют управлять жизненным циклом модуля независимо от `module.yaml`:
-
-- `unmanaged` — *boolean*. Отключает управление модулем со стороны Deckhouse (никаких обновлений или удалений).
-- `disable` — *boolean*. Временно отключает модуль и удаляет все его ресурсы.
-- `terminating` — *boolean*. Переводит модуль в состояние удаления, в результате чего удаляются все ресурсы и сам объект Module.
-- `rollback` — *boolean*. Если установлен в `true`, то при удалении объекта `ModulePullOverride`:
-  - будут удалены артефакты модуля;
-  - Deckhouse перезапустится;
-  - будет восстановлена последняя стабильная версия модуля.
-
-Пример:
-
-```yaml
-apiVersion: deckhouse.io/v1alpha1
-kind: ModulePullOverride
-metadata:
-  name: example
-spec:
-  version: v1.2.3
-  unmanaged: false
-  disable: false
-  terminating: false
-  rollback: true
-```
-
 Результат применения ModulePullOverride можно увидеть в сообщении (колонка `MESSAGE`) при получении информации об ModulePullOverride. Значение `Ready` означает применение параметров ModulePullOverride. Любое другое значение означает конфликт.
 
 Пример отсутствия конфликтов при применении ModulePullOverride:


### PR DESCRIPTION
## Description
Removed documentation about module lifecycle parameters.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Removed documentation about module lifecycle parameters.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
