### PR TITLE
[node-manager] Add additional logs to enable_cluster_api_cloud_and_static hook

### DIFF
--- a/modules/040-node-manager/hooks/enable_cluster_api_cloud_and_static.go
+++ b/modules/040-node-manager/hooks/enable_cluster_api_cloud_and_static.go
@@ -98,10 +98,14 @@ func handleClusterAPIDeploymentRequired(input *go_hook.HookInput) error {
 	capiControllerManagerEnabledBeforeExecuting := input.Values.Get("nodeManager.internal.capiControllerManagerEnabled")
 	capsControllerManagerEnabledBeforeExecuting := input.Values.Get("nodeManager.internal.capsControllerManagerEnabled")
 
-	input.Logger.Infof("Flags before executing: capiControllerManagerEnabled (exists: %v; value %v) capsControllerManagerEnabled (exists: %v; value %v)",
+	input.Logger.Info("Flags before executing.",
+		"capiControllerManagerEnabled_exists",
 		capiControllerManagerEnabledBeforeExecuting.Exists(),
+		"capiControllerManagerEnabled",
 		capiControllerManagerEnabledBeforeExecuting.Bool(),
+		"capsControllerManagerEnabled_exists",
 		capsControllerManagerEnabledBeforeExecuting.Exists(),
+		"capsControllerManagerEnabled",
 		capsControllerManagerEnabledBeforeExecuting.Bool(),
 	)
 
@@ -116,12 +120,12 @@ func handleClusterAPIDeploymentRequired(input *go_hook.HookInput) error {
 		}
 	}
 
-	input.Logger.Infof("hasStaticInstancesField value %v", hasStaticInstancesField)
+	input.Logger.Info("hasStaticInstancesField", "value", hasStaticInstancesField)
 
 	capiClusterName := input.Values.Get("nodeManager.internal.cloudProvider.capiClusterName").String()
 	hasCapiProvider := capiClusterName != ""
 
-	input.Logger.Infof("capiClusterName discovered %s: %v", capiClusterName, hasCapiProvider)
+	input.Logger.Info("capiClusterName discovered", "capiClusterName", capiClusterName, "hasCapiProvider", hasCapiProvider)
 
 	var capiEnabled bool
 	var capsEnabled bool
@@ -129,18 +133,18 @@ func handleClusterAPIDeploymentRequired(input *go_hook.HookInput) error {
 	configMapSnapshots := input.Snapshots["config_map"]
 	if len(configMapSnapshots) > 0 {
 		capiEnabledFromCM := configMapSnapshots[0].(bool)
-		input.Logger.Infof("Found ConfigMap d8-cloud-instance-manager/capi-controller-manager that indicated that CAPI should deployed: %v", capiEnabledFromCM)
+		input.Logger.Info("Found ConfigMap d8-cloud-instance-manager/capi-controller-manager that indicated that CAPI should deployed", "enabled", capiEnabledFromCM)
 
 		capiEnabled = hasCapiProvider || capiEnabledFromCM
 		capsEnabled = configMapSnapshots[0].(bool)
 
-		input.Logger.Infof("Calculated flags capiEnabled = %v capsEnabled = %v", capiEnabled, capsEnabled)
+		input.Logger.Info("Calculated flags", "capiEnabled", capiEnabled, "capsEnabled", capsEnabled)
 	} else {
 		input.Logger.Info("ConfigMap d8-cloud-instance-manager/capi-controller-manager that indicated that CAPI should deployed not found")
 
 		capiEnabled = hasCapiProvider || hasStaticInstancesField
 
-		input.Logger.Infof("Calculated flags capiEnabled = %v;  capsEnabled not set", capiEnabled)
+		input.Logger.Info("Calculated flags (capsEnabled not set)", "capiEnabled", capiEnabled)
 	}
 
 	if capiEnabled {
@@ -166,10 +170,14 @@ func handleClusterAPIDeploymentRequired(input *go_hook.HookInput) error {
 	capiControllerManagerEnabledAfterExecuting := input.Values.Get("nodeManager.internal.capiControllerManagerEnabled")
 	capsControllerManagerEnabledAfterExecuting := input.Values.Get("nodeManager.internal.capsControllerManagerEnabled")
 
-	input.Logger.Infof("Flags after executing: capiControllerManagerEnabled (exists: %v; value %v) capsControllerManagerEnabled (exists: %v; value %v)",
+	input.Logger.Info("Flags after executing",
+		"capiControllerManagerEnabled_exists",
 		capiControllerManagerEnabledAfterExecuting.Exists(),
+		"capiControllerManagerEnabled",
 		capiControllerManagerEnabledAfterExecuting.Bool(),
+		"capsControllerManagerEnabled_exists",
 		capsControllerManagerEnabledAfterExecuting.Exists(),
+		"capsControllerManagerEnabled",
 		capsControllerManagerEnabledAfterExecuting.Bool(),
 	)
 


### PR DESCRIPTION
## Description
Add additional logs to enable_cluster_api_cloud_and_static hook describes all steps and values changes in the hook.

## Why do we need it, and what problem does it solve?

During the elimination of one accident, it was discovered that the resource `d8-cloud-instance-manager cluster/static` was deleted by deckhouse-controller and we have situation when CAPS bootstrap and cleanup nodes in the cycle. These resources are rendered in helm templates under certain conditions. These conditions are calculated in the hook enable_cluster_api_cloud_and_static. When debugging the problem, no logs were found as to why the resource was not rendered. Therefore, it was decided to add logs that describe the process of the necessary flags for rendering.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Add additional logs to enable_cluster_api_cloud_and_static hook.
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
