### PR TITLE
Run Trivy CVE scan only when security/cve label is present

### DIFF
--- a/.github/ci_templates/cve_tests.yaml
+++ b/.github/ci_templates/cve_tests.yaml
@@ -1,3 +1,64 @@
+{!{ define "set_security_scan_requirement_status" }!}
+
+# <template: set_security_scan_requirement_status>
+set_security_scan_requirement_status: 
+  name: Set commit status after security scan run
+  runs-on: ubuntu-latest
+  needs: test_cve_report_main
+  if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+  steps:
+{!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
+    - name: Install GitHub CLI
+      run: sudo apt-get install gh -y
+    - name: Auth with GitHub CLI
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+    - name: Set PR Label
+      env:
+        PR_NUMBER: ${{ inputs.issue_number }}
+      run: |
+        echo "PR Number: $PR_NUMBER"
+        if [ "${{ needs.test_cve_report_main.result }}" == "success" ]; then
+          gh pr edit "$PR_NUMBER" --add-label "security/cve/success"
+        else
+          gh pr edit "$PR_NUMBER" --add-label "security/cve/failed"
+        fi
+# </template: set_security_scan_requirement_status>
+{!{- end -}!}
+
+{!{ define "remove_labels_job" }!}
+{!{- $ctx := . -}!}
+# <template: remove_labels_job>
+remove_labels:
+  name: Remove labels
+  runs-on: ubuntu-latest
+  if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+  steps:
+{!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
+    - name: Remove labels
+      id: remove
+      uses: {!{ index (ds "actions") "actions/github-script" }!}
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const label = "security/cve";
+          const ci = require('./.github/scripts/js/ci');
+          const issue_number = context.payload.inputs.issue_number;
+          console.log("Issue number is", issue_number);
+          return await ci.removeLabel({github, context, core, issue_number, label});
+# </template: remove_labels_job>
+{!{- end -}!}
+
+{!{ define "exctract_pr_number" }!}
+# <template: exctract_pr_number>
+- name: Extract PR number from ref
+  id: extract_pr
+  run: |
+    echo "REF=${{ github.event.inputs.pull_request_ref }}"
+    PR_NUMBER=$(echo "${{ github.event.inputs.pull_request_ref }}" | sed -E 's#refs/pull/([0-9]+)/head#\1#')
+    echo "PR_NUMBER=$PR_NUMBER"
+    echo "TAG=$PR_NUMBER" >> $GITHUB_ENV
+# </template: exctract_pr_number>
+{!{- end -}!}
 {!{ define "cve_scan_deckhouse_images" }!}
 # <template: cve_scan_deckhouse_images>
 - name: Set scan target type

--- a/.github/ci_templates/cve_tests.yaml
+++ b/.github/ci_templates/cve_tests.yaml
@@ -56,7 +56,7 @@ remove_labels:
     echo "REF=${{ github.event.inputs.pull_request_ref }}"
     PR_NUMBER=$(echo "${{ github.event.inputs.pull_request_ref }}" | sed -E 's#refs/pull/([0-9]+)/head#\1#')
     echo "PR_NUMBER=$PR_NUMBER"
-    echo "TAG=$PR_NUMBER" >> $GITHUB_ENV
+    echo "TAG=pr$PR_NUMBER" >> $GITHUB_ENV
 # </template: exctract_pr_number>
 {!{- end -}!}
 {!{ define "cve_scan_deckhouse_images" }!}
@@ -65,7 +65,7 @@ remove_labels:
   run: |
     if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref_name }}" == "main" ]; then
       echo "SCAN_TARGET=only_main" >> $GITHUB_ENV
-    elif [ "${{ github.event_name }}" == "pull_request" ]; then
+    elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.pull_request_ref }}" ]; then
       echo "SCAN_TARGET=pr" >> $GITHUB_ENV
     elif [ "${{ github.event_name }}" != "schedule" ] || [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
       echo "SCAN_TARGET=regular" >> $GITHUB_ENV

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -412,7 +412,7 @@ const removeLabel = async ({ github, context, core, issue_number, label }) => {
     core.endGroup();
   }
 };
-
+exports.removeLabel = removeLabel;
 /**
  * Set outputs to enable e2e jobs from workflow_dispatch inputs.
  *
@@ -1045,6 +1045,10 @@ module.exports.runWorkflowForPullRequest = async ({ github, context, core, ref }
       if (labelInfo.security === 'rootless' && event.action === 'labeled') {
         command.workflows = ['build-and-test_dev.yml'];
         command.rerunWorkflow = true;
+      }
+      if (labelInfo.security == 'cve' && event.action === 'labeled') {
+        command.workflows = ['cve-pr.yml'];
+        command.triggerWorkflowDispatch = true;
       }
     }
   } finally {

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -78,7 +78,8 @@ const labels = {
   'e2e/use/cis': { type: 'e2e-use', cis: true },
 
   // security validation for images
-  'security/rootless': { type: 'security', security: 'rootless' }
+  'security/rootless': { type: 'security', security: 'rootless' },
+  'security/cve': { type: 'security', security: 'cve' }
 };
 module.exports.knownLabels = labels;
 

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -43,15 +43,6 @@ on:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
         required: false
 
-  # pull_request:
-  #   types: [opened, reopened, labeled, synchronize]
-
-# Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-#   cancel-in-progress: true
-
-
 jobs:
 {!{ tmpl.Exec "block-until-image-is-not-ready" . | strings.Indent 2 }!}
 

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -15,18 +15,42 @@
 {!{- $workflowName              := "Trivy CVE scan on PR" -}!}
 {!{- $enableWorkflowOnTestRepos := true -}!}
 
-
 {!{- $ctx := . }!}
 
 name: '{!{ $workflowName }!}'
 on:
-  pull_request:
-    types: [opened, reopened, labeled, synchronize]
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'ID of issue where label was set'
+        required: false
+      issue_number:
+        description: 'Number of issue where label was set'
+        required: false
+      comment_id:
+        description: 'ID of comment in issue where to put workflow run status'
+        required: false
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
+        required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
+
+  # pull_request:
+  #   types: [opened, reopened, labeled, synchronize]
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-  cancel-in-progress: true
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+#   cancel-in-progress: true
+
 
 jobs:
 {!{ tmpl.Exec "block-until-image-is-not-ready" . | strings.Indent 2 }!}
@@ -35,16 +59,17 @@ jobs:
     name: Trivy scan dev images
     needs:
     - block-until-image-is-not-ready
-    if: |
-      github.event.label.name == 'security/cve' ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [self-hosted, large]
     env:
       WORKDIR: "cve_scan"
-      TAG: pr${{ github.event.number }}
     steps:
 {!{ tmpl.Exec "checkout_full_step"           $ctx | strings.Indent 6 }!}
 {!{ tmpl.Exec "link_bin_step"                     | strings.Indent 6 }!}
+{!{ tmpl.Exec "exctract_pr_number"                | strings.Indent 6 }!}
 {!{ tmpl.Exec "cve_scan_deckhouse_images"         | strings.Indent 6 }!}
 {!{ tmpl.Exec "cve_tests_upload_reports_artifacts"| strings.Indent 6 }!}
 {!{ tmpl.Exec "unlink_bin_step"                   | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "workflow,final,no-skipped,restore-separate" $workflowName) | strings.Indent 6 }!}
+
+{!{ tmpl.Exec "remove_labels_job" $ctx | strings.Indent 2 }!}
+{!{ tmpl.Exec "set_security_scan_requirement_status" slice | strings.Indent 2 }!}

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -42,15 +42,6 @@ on:
         description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
         required: false
 
-  # pull_request:
-  #   types: [opened, reopened, labeled, synchronize]
-
-# Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-#   cancel-in-progress: true
-
-
 jobs:
 
   # </template: block-until-image-is-not-ready>
@@ -139,7 +130,7 @@ jobs:
           echo "REF=${{ github.event.inputs.pull_request_ref }}"
           PR_NUMBER=$(echo "${{ github.event.inputs.pull_request_ref }}" | sed -E 's#refs/pull/([0-9]+)/head#\1#')
           echo "PR_NUMBER=$PR_NUMBER"
-          echo "TAG=$PR_NUMBER" >> $GITHUB_ENV
+          echo "TAG=pr$PR_NUMBER" >> $GITHUB_ENV
       # </template: exctract_pr_number>
 
       # <template: cve_scan_deckhouse_images>
@@ -147,7 +138,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref_name }}" == "main" ]; then
             echo "SCAN_TARGET=only_main" >> $GITHUB_ENV
-          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.pull_request_ref }}" ]; then
             echo "SCAN_TARGET=pr" >> $GITHUB_ENV
           elif [ "${{ github.event_name }}" != "schedule" ] || [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
             echo "SCAN_TARGET=regular" >> $GITHUB_ENV

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -18,13 +18,38 @@
 
 name: 'Trivy CVE scan on PR'
 on:
-  pull_request:
-    types: [opened, reopened, labeled, synchronize]
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'ID of issue where label was set'
+        required: false
+      issue_number:
+        description: 'Number of issue where label was set'
+        required: false
+      comment_id:
+        description: 'ID of comment in issue where to put workflow run status'
+        required: false
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
+        required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
+
+  # pull_request:
+  #   types: [opened, reopened, labeled, synchronize]
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-  cancel-in-progress: true
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+#   cancel-in-progress: true
+
 
 jobs:
 
@@ -88,13 +113,9 @@ jobs:
     name: Trivy scan dev images
     needs:
     - block-until-image-is-not-ready
-    if: |
-      github.event.label.name == 'security/cve' ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'security/cve'))
     runs-on: [self-hosted, large]
     env:
       WORKDIR: "cve_scan"
-      TAG: pr${{ github.event.number }}
     steps:
 
       # <template: checkout_full_step>
@@ -110,6 +131,16 @@ jobs:
         run: |
           ln -s ~/deckhouse-bin-cache bin
       # </template: link_bin_step>
+
+      # <template: exctract_pr_number>
+      - name: Extract PR number from ref
+        id: extract_pr
+        run: |
+          echo "REF=${{ github.event.inputs.pull_request_ref }}"
+          PR_NUMBER=$(echo "${{ github.event.inputs.pull_request_ref }}" | sed -E 's#refs/pull/([0-9]+)/head#\1#')
+          echo "PR_NUMBER=$PR_NUMBER"
+          echo "TAG=$PR_NUMBER" >> $GITHUB_ENV
+      # </template: exctract_pr_number>
 
       # <template: cve_scan_deckhouse_images>
       - name: Set scan target type
@@ -180,3 +211,89 @@ jobs:
         run: |
           rm bin
       # </template: unlink_bin_step>
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v6.4.1
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          retries: 3
+          script: |
+            const statusConfig = 'workflow,final,no-skipped,restore-separate';
+            const name = 'Trivy CVE scan on PR';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+  # <template: remove_labels_job>
+  remove_labels:
+    name: Remove labels
+    runs-on: ubuntu-latest
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+    steps:
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+
+      # </template: checkout_step>
+      - name: Remove labels
+        id: remove
+        uses: actions/github-script@v6.4.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const label = "security/cve";
+            const ci = require('./.github/scripts/js/ci');
+            const issue_number = context.payload.inputs.issue_number;
+            console.log("Issue number is", issue_number);
+            return await ci.removeLabel({github, context, core, issue_number, label});
+  # </template: remove_labels_job>
+
+
+  # <template: set_security_scan_requirement_status>
+  set_security_scan_requirement_status: 
+    name: Set commit status after security scan run
+    runs-on: ubuntu-latest
+    needs: test_cve_report_main
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+    steps:
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+
+      # </template: checkout_step>
+      - name: Install GitHub CLI
+        run: sudo apt-get install gh -y
+      - name: Auth with GitHub CLI
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+      - name: Set PR Label
+        env:
+          PR_NUMBER: ${{ inputs.issue_number }}
+        run: |
+          echo "PR Number: $PR_NUMBER"
+          if [ "${{ needs.test_cve_report_main.result }}" == "success" ]; then
+            gh pr edit "$PR_NUMBER" --add-label "security/cve/success"
+          else
+            gh pr edit "$PR_NUMBER" --add-label "security/cve/failed"
+          fi
+  # </template: set_security_scan_requirement_status>

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref_name }}" == "main" ]; then
             echo "SCAN_TARGET=only_main" >> $GITHUB_ENV
-          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.pull_request_ref }}" ]; then
             echo "SCAN_TARGET=pr" >> $GITHUB_ENV
           elif [ "${{ github.event_name }}" != "schedule" ] || [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
             echo "SCAN_TARGET=regular" >> $GITHUB_ENV


### PR DESCRIPTION
## Description

This PR updates the trigger conditions for the **Trivy CVE scan on PR** workflow.  
Previously, the workflow was executed on every pull request unconditionally.  
Now, it runs **only if the pull request contains the `security/cve` label**, ensuring targeted scanning only where required.

## Why do we need it, and what problem does it solve?

Running the Trivy CVE scan on every PR was redundant and resource-consuming for changes unrelated to security.  
This change optimizes CI resource usage by limiting CVE scanning to PRs explicitly marked with the `security/cve` label.

This prevents unnecessary scan jobs, reduces noise in PR checks, and ensures that security scanning is performed only where relevant.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: This PR updates the trigger conditions for the **Trivy CVE scan on PR** workflow.  
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
