### PR TITLE
[prometheus] Remove Grafana v8 name from Certificate

### DIFF
--- a/modules/300-prometheus/templates/grafana/certificate.yaml
+++ b/modules/300-prometheus/templates/grafana/certificate.yaml
@@ -13,7 +13,6 @@ spec:
   secretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
   {{ include "helm_lib_module_generate_common_name" (list . "grafana") | nindent 2 }}
   dnsNames:
-    - {{ include "helm_lib_module_public_domain" (list . "grafana-v8") }}
     - {{ include "helm_lib_module_public_domain" (list . "grafana") }}
     - {{ include "helm_lib_module_public_domain" (list . "prometheus") }}
   issuerRef:


### PR DESCRIPTION
## Description
 Remove Grafana v8 name from Certificate

## Why do we need it, and what problem does it solve?
To remove an old grafana-v8 name from Certificate and keep dnsNames in fresh state

## Why do we need it in the patch release (if we do)?
Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix 
summary: Remove Grafana v8 name from Certificate
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
