### PR TITLE
[ci] Update E2E test configurations

### DIFF
--- a/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/EKS/WithoutNAT/configuration.tpl.yaml
@@ -96,5 +96,5 @@ kind: ModuleConfig
 metadata:
   name: istio
 spec:
-  version: 2
+  version: 3
   enabled: true

--- a/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/Standard/configuration.tpl.yaml
@@ -74,7 +74,7 @@ kind: ModuleConfig
 metadata:
   name: istio
 spec:
-  version: 2
+  version: 3
   enabled: true
   settings:
 ---
@@ -97,4 +97,4 @@ spec:
       placement:
         customTolerationKeys:
           - node
-  version: 1
+  version: 2

--- a/testing/cloud_layouts/Static/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Static/configuration.tpl.yaml
@@ -46,7 +46,7 @@ spec:
       placement:
         customTolerationKeys:
           - node
-  version: 1
+  version: 2
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
@@ -72,7 +72,7 @@ kind: ModuleConfig
 metadata:
   name: istio
 spec:
-  version: 2
+  version: 3
   enabled: true
   settings:
 ---

--- a/testing/cloud_layouts/VCD/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/VCD/Standard/configuration.tpl.yaml
@@ -29,7 +29,7 @@ spec:
       placement:
         customTolerationKeys:
           - node
-  version: 1
+  version: 2
 
 ---
 apiVersion: deckhouse.io/v1alpha1
@@ -85,6 +85,6 @@ kind: ModuleConfig
 metadata:
   name: istio
 spec:
-  version: 2
+  version: 3
   enabled: true
   settings:

--- a/testing/cloud_layouts/vSphere/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/vSphere/Standard/configuration.tpl.yaml
@@ -85,13 +85,13 @@ spec:
       placement:
         customTolerationKeys:
           - node
-  version: 1
+  version: 2
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: istio
 spec:
-  version: 2
+  version: 3
   enabled: true
   settings:


### PR DESCRIPTION
## Description
Update ModuleConfigs in E2E test configurations.

## Why do we need it, and what problem does it solve?
This change is necessary to keep tests up to date.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Update E2E test configurations.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
