### PR TITLE
[etcd] etcd update to v3.6.1

### DIFF
--- a/modules/040-control-plane-manager/images/etcd/patches/002-etcdctl-snapshot-pipe.patch
+++ b/modules/040-control-plane-manager/images/etcd/patches/002-etcdctl-snapshot-pipe.patch
@@ -1,101 +1,16 @@
-Subject: [PATCH] feature: support for piping snapshot to stdout
+Subject: [PATCH] add pipe func patch
 ---
-Index: etcdctl/ctlv3/command/snapshot_command.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/etcdctl/ctlv3/command/snapshot_command.go b/etcdctl/ctlv3/command/snapshot_command.go
---- a/etcdctl/ctlv3/command/snapshot_command.go	(revision f20bbadd404b57c776d1e8876cefd1ac29b03fb5)
-+++ b/etcdctl/ctlv3/command/snapshot_command.go	(date 1727874859931)
-@@ -20,11 +20,12 @@
- 	"os"
- 
- 	"github.com/spf13/cobra"
-+	"go.uber.org/zap"
-+
- 	"go.etcd.io/etcd/client/pkg/v3/logutil"
- 	snapshot "go.etcd.io/etcd/client/v3/snapshot"
- 	"go.etcd.io/etcd/etcdutl/v3/etcdutl"
- 	"go.etcd.io/etcd/pkg/v3/cobrautl"
--	"go.uber.org/zap"
- )
- 
- const (
-@@ -45,6 +46,14 @@
- 	initialMmapSize     uint64
- )
- 
-+func NewSnapshotPipeCommand() *cobra.Command {
-+	return &cobra.Command{
-+		Use:   "pipe",
-+		Short: "Streams an etcd node backend snapshot to stdout",
-+		Run:   snapshotPipeCommandFunc,
-+	}
-+}
-+
- // NewSnapshotCommand returns the cobra command for "snapshot".
- func NewSnapshotCommand() *cobra.Command {
- 	cmd := &cobra.Command{
-@@ -54,6 +63,7 @@
- 	cmd.AddCommand(NewSnapshotSaveCommand())
- 	cmd.AddCommand(NewSnapshotRestoreCommand())
- 	cmd.AddCommand(newSnapshotStatusCommand())
-+	cmd.AddCommand(NewSnapshotPipeCommand())
- 	return cmd
- }
- 
-@@ -78,6 +88,27 @@
- 	}
- }
- 
-+func snapshotPipeCommandFunc(cmd *cobra.Command, args []string) {
-+
-+	lg, err := logutil.CreateDefaultZapLogger(zap.InfoLevel)
-+	if err != nil {
-+		cobrautl.ExitWithError(cobrautl.ExitError, err)
-+	}
-+	cfg := mustClientCfgFromCmd(cmd)
-+
-+	// if user does not specify "--command-timeout" flag, there will be no timeout for snapshot pipe command
-+	ctx, cancel := context.WithCancel(context.Background())
-+	if isCommandTimeoutFlagSet(cmd) {
-+		ctx, cancel = commandCtx(cmd)
-+	}
-+	defer cancel()
-+
-+	err = snapshot.Pipe(ctx, lg, *cfg, os.Stdout)
-+	if err != nil {
-+		cobrautl.ExitWithError(cobrautl.ExitInterrupted, err)
-+	}
-+}
-+
- func NewSnapshotRestoreCommand() *cobra.Command {
- 	cmd := &cobra.Command{
- 		Use:   "restore <filename> [options]",
 Index: client/v3/snapshot/v3_snapshot.go
 IDEA additional info:
 Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 <+>UTF-8
 ===================================================================
 diff --git a/client/v3/snapshot/v3_snapshot.go b/client/v3/snapshot/v3_snapshot.go
---- a/client/v3/snapshot/v3_snapshot.go	(revision f20bbadd404b57c776d1e8876cefd1ac29b03fb5)
-+++ b/client/v3/snapshot/v3_snapshot.go	(date 1727874821225)
-@@ -23,9 +23,10 @@
- 	"time"
- 
- 	"github.com/dustin/go-humanize"
-+	"go.uber.org/zap"
-+
- 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
- 	"go.etcd.io/etcd/client/v3"
--	"go.uber.org/zap"
- )
- 
- // hasChecksum returns "true" if the file size "n"
-@@ -97,3 +98,46 @@
+--- a/client/v3/snapshot/v3_snapshot.go	(revision a4708beb0f5dfba937145762516ac98f15797940)
++++ b/client/v3/snapshot/v3_snapshot.go	(date 1750164009008)
+@@ -121,3 +121,46 @@
  	lg.Info("saved", zap.String("path", dbPath))
- 	return nil
+ 	return resp.Version, nil
  }
 +
 +// Pipe fetches snapshot from remote etcd server and pipes data
@@ -139,4 +54,67 @@ diff --git a/client/v3/snapshot/v3_snapshot.go b/client/v3/snapshot/v3_snapshot.
 +	)
 +
 +	return nil
++}
+Index: etcdctl/ctlv3/command/snapshot_command.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/etcdctl/ctlv3/command/snapshot_command.go b/etcdctl/ctlv3/command/snapshot_command.go
+--- a/etcdctl/ctlv3/command/snapshot_command.go	(revision a4708beb0f5dfba937145762516ac98f15797940)
++++ b/etcdctl/ctlv3/command/snapshot_command.go	(date 1750164008881)
+@@ -17,6 +17,7 @@
+ import (
+ 	"context"
+ 	"fmt"
++	"os"
+ 
+ 	"github.com/spf13/cobra"
+ 	"go.uber.org/zap"
+@@ -54,6 +55,7 @@
+ 		Example: snapshotExample,
+ 	}
+ 	cmd.AddCommand(NewSnapshotSaveCommand())
++	cmd.AddCommand(NewSnapshotPipeCommand())
+ 	return cmd
+ }
+ 
+@@ -66,6 +68,14 @@
+ 	}
+ }
+ 
++func NewSnapshotPipeCommand() *cobra.Command {
++	return &cobra.Command{
++		Use:   "pipe",
++		Short: "Streams an etcd node backend snapshot to stdout",
++		Run:   snapshotPipeCommandFunc,
++	}
++}
++
+ func snapshotSaveCommandFunc(cmd *cobra.Command, args []string) {
+ 	if len(args) != 1 {
+ 		err := fmt.Errorf("snapshot save expects one argument <filename>")
+@@ -95,3 +105,23 @@
+ 		fmt.Printf("Server version %s\n", version)
+ 	}
+ }
++
++func snapshotPipeCommandFunc(cmd *cobra.Command, args []string) {
++	lg, err := logutil.CreateDefaultZapLogger(zap.InfoLevel)
++	if err != nil {
++		cobrautl.ExitWithError(cobrautl.ExitError, err)
++	}
++	cfg := mustClientCfgFromCmd(cmd)
++
++	// if user does not specify "--command-timeout" flag, there will be no timeout for snapshot pipe command
++	ctx, cancel := context.WithCancel(context.Background())
++	if isCommandTimeoutFlagSet(cmd) {
++		ctx, cancel = commandCtx(cmd)
++	}
++	defer cancel()
++
++	err = snapshot.Pipe(ctx, lg, *cfg, os.Stdout)
++	if err != nil {
++		cobrautl.ExitWithError(cobrautl.ExitInterrupted, err)
++	}
 +}

--- a/modules/040-control-plane-manager/images/etcd/patches/002-etcdctl-snapshot-pipe.patch
+++ b/modules/040-control-plane-manager/images/etcd/patches/002-etcdctl-snapshot-pipe.patch
@@ -1,4 +1,4 @@
-Subject: [PATCH] add pipe func patch
+Subject: [PATCH] feature: support for piping snapshot to stdout
 ---
 Index: client/v3/snapshot/v3_snapshot.go
 IDEA additional info:

--- a/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
@@ -32,7 +32,7 @@ import:
   includePaths:
   - etcd
   - etcdctl
-  - etcdutil
+  - etcdutl
   before: setup
 imageSpec:
   config:
@@ -58,4 +58,4 @@ shell:
     - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - cd server && go build -ldflags="-s -w" -o /etcd . && cd ..
     - cd etcdctl && go build -ldflags="-s -w" -o /etcdctl . && cd ..
-    - cd etcdutil && go build -ldflags="-s -w" -o /etcdutil . && cd ..
+    - cd etcdutl && go build -ldflags="-s -w" -o /etcdutl . && cd ..

--- a/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
@@ -13,7 +13,7 @@ secrets:
   value: {{ .SOURCE_REPO }}
 shell:
   install:
-  - git clone -b v3.5.21 --depth 1 $(cat /run/secrets/SOURCE_REPO)/etcd-io/etcd.git /src
+  - git clone -b v3.6.1 --depth 1 $(cat /run/secrets/SOURCE_REPO)/etcd-io/etcd.git /src
   - cd /src
   - git apply /patches/*.patch --verbose
   - rm -rf tools

--- a/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
@@ -32,6 +32,7 @@ import:
   includePaths:
   - etcd
   - etcdctl
+  - etcdutil
   before: setup
 imageSpec:
   config:
@@ -57,3 +58,4 @@ shell:
     - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - cd server && go build -ldflags="-s -w" -o /etcd . && cd ..
     - cd etcdctl && go build -ldflags="-s -w" -o /etcdctl . && cd ..
+    - cd etcdutil && go build -ldflags="-s -w" -o /etcdutil . && cd ..


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
this pr add support etcd version 3.6.1 and add etcdutl for support snapshot options because of https://github.com/etcd-io/etcd/pull/13809.
single-master bootstrap
```
/opt/deckhouse/bin/kubectl -nkube-system exec -it etcd-standalone-master-0 -- etcd --version
etcd Version: 3.6.1
Git SHA: Not provided (use ./build instead of go build)
Go Version: go1.24.3
Go OS/Arch: linux/amd64

/opt/deckhouse/bin/kubectl -nkube-system exec -it etcd-standalone-master-0 -- etcdctl version
etcdctl version: 3.6.1
API version: 3.6

/opt/deckhouse/bin/kubectl -nkube-system exec -it etcd-standalone-master-0 -- etcdutl version
etcdutl version: 3.6.1
API version: 3.6
```
multi-master bootstrap and migrate from v3.5.21 to v3.6.1.
```
+--------------------------+------------------+---------+-----------------+---------+--------+-----------------------+--------+-----------+------------+-----------+------------+--------------------+--------+--------------------------+-------------------+
|         ENDPOINT         |        ID        | VERSION | STORAGE VERSION | DB SIZE | IN USE | PERCENTAGE NOT IN USE | QUOTA  | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS | DOWNGRADE TARGET VERSION | DOWNGRADE ENABLED |
+--------------------------+------------------+---------+-----------------+---------+--------+-----------------------+--------+-----------+------------+-----------+------------+--------------------+--------+--------------------------+-------------------+
| https://10.100.2.12:2379 | 4fe56929e74dac4d |  3.5.21 |                 |  140 MB |  50 MB |                   65% |    0 B |      true |      false |         4 |    1469665 |            1469665 |        |                          |             false |
| https://10.100.0.34:2379 | 500d1a3aac5ba6f9 |   3.6.1 |           3.5.0 |  134 MB |  50 MB |                   63% | 2.1 GB |     false |      false |         4 |    1469665 |            1469665 |        |                          |             false |
|  https://10.100.6.9:2379 | e31d7f878f7d4128 |  3.5.21 |                 |  134 MB |  50 MB |                   63% |    0 B |     false |      false |         4 |    1469665 |            1469665 |        |                          |             false |
+--------------------------+------------------+---------+-----------------+---------+--------+-----------------------+--------+-----------+------------+-----------+------------+--------------------+--------+--------------------------+-------------------+
+--------------------------+------------------+---------+-----------------+---------+--------+-----------------------+--------+-----------+------------+-----------+------------+--------------------+--------+--------------------------+-------------------+
|         ENDPOINT         |        ID        | VERSION | STORAGE VERSION | DB SIZE | IN USE | PERCENTAGE NOT IN USE | QUOTA  | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS | DOWNGRADE TARGET VERSION | DOWNGRADE ENABLED |
+--------------------------+------------------+---------+-----------------+---------+--------+-----------------------+--------+-----------+------------+-----------+------------+--------------------+--------+--------------------------+-------------------+
| https://10.100.2.12:2379 | 4fe56929e74dac4d |   3.6.1 |           3.5.0 |  141 MB |  41 MB |                   71% | 2.1 GB |     false |      false |         5 |    1475491 |            1475491 |        |                          |             false |
| https://10.100.0.34:2379 | 500d1a3aac5ba6f9 |   3.6.1 |           3.5.0 |  134 MB |  41 MB |                   70% | 2.1 GB |     false |      false |         5 |    1475492 |            1475492 |        |                          |             false |
|  https://10.100.6.9:2379 | e31d7f878f7d4128 |  3.5.21 |                 |  134 MB |  41 MB |                   70% |    0 B |      true |      false |         5 |    1475493 |            1475493 |        |                          |             false |
+--------------------------+------------------+---------+-----------------+---------+--------+-----------------------+--------+-----------+------------+-----------+------------+--------------------+--------+--------------------------+-------------------+
+--------------------------+------------------+---------+-----------------+---------+--------+-----------------------+--------+-----------+------------+-----------+------------+--------------------+--------+--------------------------+-------------------+
|         ENDPOINT         |        ID        | VERSION | STORAGE VERSION | DB SIZE | IN USE | PERCENTAGE NOT IN USE | QUOTA  | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS | DOWNGRADE TARGET VERSION | DOWNGRADE ENABLED |
+--------------------------+------------------+---------+-----------------+---------+--------+-----------------------+--------+-----------+------------+-----------+------------+--------------------+--------+--------------------------+-------------------+
| https://10.100.2.12:2379 | 4fe56929e74dac4d |   3.6.1 |           3.6.0 |  141 MB |  44 MB |                  69% | 2.1 GB |     false |      false |         6 |    1477071 |            1477071 |        |                          |             false |
| https://10.100.0.34:2379 | 500d1a3aac5ba6f9 |   3.6.1 |           3.6.0 |  134 MB |  44 MB |                   68% | 2.1 GB |      true |      false |         6 |    1477071 |            1477071 |        |                         |             false |
|  https://10.100.6.9:2379 | e31d7f878f7d4128 |   3.6.1 |           3.6.0 |  134 MB |  44 MB |                   68% | 2.1 GB |     false |      false |         6 |    1477071 |            1477071 |        |                          |             false |
+--------------------------+------------------+---------+-----------------+---------+--------+-----------------------+--------+-----------+------------+-----------+------------+--------------------+--------+--------------------------+-------------------+
```
checked backup snapshot and restore with etcdutl on multimaster,
```
endpoint health -w table --cluster
+--------------------------+--------+-------------+-------+
|         ENDPOINT         | HEALTH |    TOOK     | ERROR |
+--------------------------+--------+-------------+-------+
| https://10.100.2.12:2379 |   true | 23.147938ms |       |
| https://10.100.0.34:2379 |   true | 35.713592ms |       |
| https://10.100.6.9:2379 |   true | 40.684393ms |       |
+--------------------------+--------+-------------+-------+
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
upgrade to newer version

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: etcd update to v3.6.1
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
