### PR TITLE
[user-authn] Fix logic for transfer labels and annotations to secret from dexclient

### DIFF
--- a/modules/150-user-authn/crds/dex-client.yaml
+++ b/modules/150-user-authn/crds/dex-client.yaml
@@ -76,8 +76,8 @@ spec:
                         pattern: '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
                       maxProperties: 100
                       x-kubernetes-validations:
-                        - rule: "self.all(key, key.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?(.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'))"
-                          message: "Label key must match the pattern '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'"
+                        - rule: "self.all(key, key.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'))"
+                          message: "Label key must match the pattern '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'"
                     annotations:
                       type: object
                       additionalProperties:

--- a/modules/150-user-authn/crds/dex-client.yaml
+++ b/modules/150-user-authn/crds/dex-client.yaml
@@ -76,8 +76,8 @@ spec:
                         pattern: '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
                       maxProperties: 100
                       x-kubernetes-validations:
-                        - rule: "self.all(key, key.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'))"
-                          message: "Label key must match the pattern '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'"
+                        - rule: "self.all(key, key.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?(.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'))"
+                          message: "Label key must match the pattern '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'"
                     annotations:
                       type: object
                       additionalProperties:

--- a/modules/150-user-authn/crds/dex-client.yaml
+++ b/modules/150-user-authn/crds/dex-client.yaml
@@ -64,6 +64,18 @@ spec:
                     [Details...](https://developers.google.com/identity/protocols/CrossClientAuth)
                   items:
                     type: string
+                secretMetadata:
+                  type: object
+                  description: 'A list of labels and an annotations that will be transferred to the metadata secrets of the DexClient resource.'
+                  properties:
+                    labels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    annotations:
+                      type: object
+                      additionalProperties:
+                        type: string
     - name: v1
       served: true
       storage: true

--- a/modules/150-user-authn/crds/dex-client.yaml
+++ b/modules/150-user-authn/crds/dex-client.yaml
@@ -72,6 +72,12 @@ spec:
                       type: object
                       additionalProperties:
                         type: string
+                        maxLength: 63
+                        pattern: '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
+                      maxProperties: 100
+                      x-kubernetes-validations:
+                        - rule: "self.all(key, key.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'))"
+                          message: "Label key must match the pattern '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'"
                     annotations:
                       type: object
                       additionalProperties:

--- a/modules/150-user-authn/crds/dex-client.yaml
+++ b/modules/150-user-authn/crds/dex-client.yaml
@@ -76,7 +76,7 @@ spec:
                         pattern: '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
                       maxProperties: 100
                       x-kubernetes-validations:
-                        - rule: "self.all(key, key.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'))"
+                        - rule: "self.all(key, key.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'))"
                           message: "Label key must match the pattern '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'"
                     annotations:
                       type: object

--- a/modules/150-user-authn/crds/dex-client.yaml
+++ b/modules/150-user-authn/crds/dex-client.yaml
@@ -77,7 +77,7 @@ spec:
                       maxProperties: 100
                       x-kubernetes-validations:
                         - rule: "self.all(key, key.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'))"
-                          message: "Label key must match the pattern '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'"
+                          message: "Label key must match the pattern '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$'"
                     annotations:
                       type: object
                       additionalProperties:

--- a/modules/150-user-authn/crds/doc-ru-dex-client.yaml
+++ b/modules/150-user-authn/crds/doc-ru-dex-client.yaml
@@ -32,6 +32,9 @@ spec:
                     ID клиентов, которым позволена cross-аутентификация.
 
                     [Подробнее...](https://developers.google.com/identity/protocols/CrossClientAuth)
+                secretMetadata:
+                    description: |
+                        Список лейблов и аннотаций, которые будут перенесены в метаданные секретов ресурса DexClient.
     - name: v1
       served: true
       storage: false

--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"fmt"
+
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	v1 "k8s.io/api/core/v1"

--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -18,8 +18,6 @@ package hooks
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	v1 "k8s.io/api/core/v1"
@@ -73,41 +71,27 @@ func applyDexClientFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 	id := fmt.Sprintf("dex-client-%s@%s", name, namespace)
 	legacyID := fmt.Sprintf("dex-client-%s:%s", name, namespace)
 
-	labels := obj.GetLabels()
+	labels, _, err := unstructured.NestedStringMap(obj.Object, "spec", "secretMetadata", "labels")
+	if err != nil {
+		return nil, fmt.Errorf("cannot get secretMetadata.labels: %v", err)
+	}
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	// Secrets with that label lead to D8CertmanagerOrphanSecretsChecksFailed alerts.
-	// argocd.argoproj.io is used by ArgoCD to identify secrets managed by it.
-	// app.kubernetes.io/managed-by is used by Helm to identify secrets managed by it.
-	// Delete labels that should not be transferred to the secret
-	labelKeysToIgnore := []string{
-		"app",
-		"heritage",
-		"module",
-		"name",
-		"app.kubernetes.io/managed-by",
-		"argocd.argoproj.io/secret-type",
-		"argocd.argoproj.io/instance",
-		"certmanager.k8s.io/certificate-name",
-	}
-	for _, key := range labelKeysToIgnore {
-		delete(labels, key)
-	}
 
-	annotations := obj.GetAnnotations()
+	annotations, _, err := unstructured.NestedStringMap(obj.Object, "spec", "secretMetadata", "annotations")
+	if err != nil {
+		return nil, fmt.Errorf("cannot get secretMetadata.annotations: %v", err)
+	}
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
 
-	delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
-	for key := range annotations {
-		if strings.Contains(key, "werf.io/") || strings.Contains(key, "helm.sh/") {
-			delete(annotations, key)
-		}
+	if value, exists := obj.GetAnnotations()["dexclient.deckhouse.io/allow-access-to-kubernetes"]; exists {
+		annotations["dexclient.deckhouse.io/allow-access-to-kubernetes"] = value
 	}
 
-	_, allowAccessToKubernetes := annotations["dexclient.deckhouse.io/allow-access-to-kubernetes"]
+	_, allowAccessToKubernetes := obj.GetAnnotations()["dexclient.deckhouse.io/allow-access-to-kubernetes"]
 
 	return DexClient{
 		ID:                      id,

--- a/modules/150-user-authn/hooks/get_dex_client_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds_test.go
@@ -121,13 +121,8 @@ spec:
   "legacyID": "dex-client-opendistro:test",
   "legacyEncodedID": "mrsxqlldnruwk3tufvxxazlomruxg5dsn45hizltotf7fhheqqrcgji",
   "clientSecret": "test",
-  "labels": {
-    "test-label": "test-value"
-  },
-  "annotations": {
-    "test-annotation": "test-value",
-    "new-annotation": "test-new-value"
-  },
+  "labels": {},
+  "annotations": {},
   "allowAccessToKubernetes": false
 }]`))
 			})
@@ -285,7 +280,6 @@ metadata:
   labels:
     test-label: test-value
     certmanager.k8s.io/certificate-name: test-cert-name
-    argocd.argoproj.io/instance: test-instance
     argocd.argoproj.io/secret-type: secret-type
     app.kubernetes.io/managed-by: Helm
     app: should-be-removed
@@ -294,7 +288,6 @@ metadata:
     name: should-be-removed
   annotations:
     test-annotation: test-value
-    new-annotation: test-new-value
     kubectl.kubernetes.io/last-applied-configuration: should-be-removed
     meta.helm.sh/release-name: opendistro
     meta.helm.sh/release-namespace: test
@@ -312,6 +305,11 @@ metadata:
 spec:
   redirectURIs:
   - https://opendistro.example.com/callback
+  secretMetadata:
+    labels:
+      test-label: test-value
+    annotations:
+      test-annotation: test-value
 ---
 apiVersion: deckhouse.io/v1
 kind: DexClient
@@ -346,14 +344,25 @@ spec:
   "legacyEncodedID": "mrsxqlldnruwk3tufvxxazlomruxg5dsn45hizltotf7fhheqqrcgji",
   "name": "opendistro",
   "namespace": "test",
-  "spec": {"redirectURIs": ["https://opendistro.example.com/callback"]},
+  "spec": {
+    "redirectURIs": [
+      "https://opendistro.example.com/callback"
+    ],
+    "secretMetadata": {
+      "annotations": {
+        "test-annotation": "test-value"
+      },
+      "labels": {
+        "test-label": "test-value"
+      }
+    }
+  },
   "clientSecret": "test",
   "labels": {
     "test-label": "test-value"
   },
   "annotations": {
-    "test-annotation": "test-value",
-    "new-annotation": "test-new-value"
+    "test-annotation": "test-value"
   },
   "allowAccessToKubernetes": false
 }]`))


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Now we keep secret only those labels and annotations that we explicitly specify in the DexClient  resource.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix implicit behavior when using argocd labels added in [PR](https://github.com/deckhouse/deckhouse/pull/10883)
Argocd labels may be different and we can't determine whether to pass it on to the secret or not automatically.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: The logic of label transfer and annotation to secret has been changed for DexClient
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
