### PR TITLE
[control-plane-manager] Kubeadm v1beta4 fix

### DIFF
--- a/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
@@ -160,7 +160,7 @@ apiServer:
     {{ if .apiserver.auditWebhookURL }}
     - name: audit-webhook-config-file
       value: /etc/kubernetes/deckhouse/extra-files/audit-webhook-config.yaml
-    {{- end -}}
+    {{- end }}
     - name: profiling
       value: "false"
     - name: request-timeout

--- a/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
@@ -143,6 +143,24 @@ apiServer:
     - name: oidc-issuer-url
       value: {{ .apiserver.oidcIssuerURL }}
     {{- end }}
+    {{ if .apiserver.webhookURL }}
+    - name: authorization-mode
+      value: Node,Webhook,RBAC
+    - name: authorization-webhook-config-file
+      value: /etc/kubernetes/deckhouse/extra-files/webhook-config.yaml
+    {{- end -}}
+    {{ if .apiserver.authnWebhookURL }}
+    - name: authentication-token-webhook-config-file
+      value: /etc/kubernetes/deckhouse/extra-files/authn-webhook-config.yaml
+    {{- end -}}
+    {{ if .apiserver.authnWebhookCacheTTL }}
+    - name: authentication-token-webhook-cache-ttl
+      value: {{.apiserver.authnWebhookCacheTTL | quote }}
+    {{- end -}}
+    {{ if .apiserver.auditWebhookURL }}
+    - name: audit-webhook-config-file
+      value: /etc/kubernetes/deckhouse/extra-files/audit-webhook-config.yaml
+    {{- end -}}
     - name: profiling
       value: "false"
     - name: request-timeout

--- a/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
@@ -34,12 +34,10 @@ https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 kubernetesVersion: {{ printf "%s.%s" (.clusterConfiguration.kubernetesVersion | toString) (index .k8s .clusterConfiguration.kubernetesVersion "patch" | toString) }}
-clusterName: "kubernetes"
 controlPlaneEndpoint: "127.0.0.1:6445"
 certificatesDir: /etc/kubernetes/pki
 certificateValidityPeriod: 8760h0m0s
 caCertificateValidityPeriod: 87600h0m0s
-imageRepository: "registry.k8s.io"
 encryptionAlgorithm: {{ .clusterConfiguration.encryptionAlgorithm }}
 networking:
   serviceSubnet: {{ .clusterConfiguration.serviceSubnetCIDR | quote }}

--- a/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
@@ -34,12 +34,12 @@ https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 kubernetesVersion: {{ printf "%s.%s" (.clusterConfiguration.kubernetesVersion | toString) (index .k8s .clusterConfiguration.kubernetesVersion "patch" | toString) }}
-clusterName: {{ .clusterConfiguration.clusterName | default "kubernetes" }}
+clusterName: "kubernetes"
 controlPlaneEndpoint: "127.0.0.1:6445"
 certificatesDir: /etc/kubernetes/pki
 certificateValidityPeriod: 8760h0m0s
 caCertificateValidityPeriod: 87600h0m0s
-imageRepository: {{ .clusterConfiguration.imageRepository | default "registry.k8s.io" }}
+imageRepository: "registry.k8s.io"
 encryptionAlgorithm: {{ .clusterConfiguration.encryptionAlgorithm }}
 networking:
   serviceSubnet: {{ .clusterConfiguration.serviceSubnetCIDR | quote }}


### PR DESCRIPTION
## Description

After upgrading to v1beta4 in https://github.com/deckhouse/deckhouse/pull/13153 I lost a few fields

## Why do we need it, and what problem does it solve?

fix kubeadm v1beta4 config

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: fix kubeadm v1beta4 config
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
