### PR TITLE
[ingress-nginx] fix bug with proxy client cert in validator

### DIFF
--- a/modules/402-ingress-nginx/templates/validator/deployment.yml
+++ b/modules/402-ingress-nginx/templates/validator/deployment.yml
@@ -154,6 +154,8 @@ spec:
               containerPort: 8443
               protocol: TCP
           volumeMounts:
+            - name: secret-nginx-auth-tls
+              mountPath: /chroot/etc/nginx/ssl/
             - name: webhook-cert
               mountPath: /chroot/etc/nginx/webhook-ssl/
               readOnly: true
@@ -163,6 +165,9 @@ spec:
               readOnly: true
             {{- end}}
       volumes:
+        - name: secret-nginx-auth-tls
+          secret:
+            secretName: ingress-nginx-{{ $crd.name }}-auth-tls
         - name: webhook-cert
           secret:
             secretName: ingress-admission-certificate


### PR DESCRIPTION
## Description
This patch adds mounting of the ingress-nginx-{{ $crd.name }}-auth-tls secret into the validator Deployment in the 402-ingress-nginx module. The mounted secret contains TLS certificates required for secure communication and authentication by NGINX components.

## Why do we need it, and what problem does it solve?
Without this secret, the validator component cannot correctly execute `nginx -t`, which is used to validate the NGINX configuration.

## Why do we need it in the patch release (if we do)?
Yes, we need this in a patch release because the absence of the auth-tls secret causes a runtime error in the validator during configuration validation (`nginx -t`). All d8 Ingress-resources has references to this secret.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: fix
summary: fix missing proxy client cert in validator deployment
impact_level: low
```
