### PR TITLE
[deckhouse] 1.69 fix config alerts stuck

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/config/status.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/status.go
@@ -72,7 +72,7 @@ func (r *reconciler) refreshModuleConfig(ctx context.Context, configName string)
 	r.log.Debug("refresh module config status", slog.String("name", configName))
 
 	// clear metrics
-	metricGroup := fmt.Sprintf("obsoleteVersion_%s", configName)
+	metricGroup := fmt.Sprintf(obsoleteConfigMetricGroup, configName)
 	r.metricStorage.Grouped().ExpireGroupMetrics(metricGroup)
 
 	moduleConfig := new(v1alpha1.ModuleConfig)


### PR DESCRIPTION
## Description
It fixes obsolete config alert stuck.

It is backport for [PR](https://github.com/deckhouse/deckhouse/pull/13853)

## Why do we need it, and what problem does it solve?
After deleting module config nobody expires alert. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix obsolete config alert stuck after deleting module config.
```
