### PR TITLE
[user-authz] add patch verb for service accounts for use managers

### DIFF
--- a/modules/140-user-authz/templates/rbacv2/global/use/capabilities/manage_security.yaml
+++ b/modules/140-user-authz/templates/rbacv2/global/use/capabilities/manage_security.yaml
@@ -32,6 +32,7 @@ rules:
       - watch
       - create
       - update
+      - patch
       - delete
       - impersonate
   - apiGroups:


### PR DESCRIPTION
## Description
It adds patch verb for sa.

## Why do we need it, and what problem does it solve?
Use manager can not patch service accounts.

## Why do we need it in the patch release (if we do)?
Use manager can not patch service accounts.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: Add patch verb for service accounts
impact_level: low
```