### PR TITLE
[istio] Fix for collecting debugging resources in collect-debug-info about Istio

### DIFF
--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -211,12 +211,12 @@ func createTarball() *bytes.Buffer {
 		{
 			File: "d8-istio-envoy-config.json",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl port-forward daemonset/ingressgateway -n d8-istio 15000:15000 & sleep 5; (curl http://localhost:15000/config_dump?include_eds=true | jq 'del(.configs[6].dynamic_active_secrets)' && kill $!) || { kill $!; exit 1; }`},
+			Args: []string{"-c", `kubectl port-forward daemonset/ingressgateway -n d8-istio 15000:15000 & sleep 5; (curl http://localhost:15000/config_dump?include_eds=true | jq 'del(.configs[6].dynamic_active_secrets)' && kill $!) || { kill $!; exit 0; }`},
 		},
 		{
 			File: "d8-istio-system-logs.txt",
 			Cmd:  "bash",
-			Args: []string{"-c", `kubectl -n d8-istio logs deployments -l app=istiod`},
+			Args: []string{"-c", `kubectl -n d8-istio logs -l app=istiod || true`},
 		},
 		{
 			File: "d8-istio-ingress-logs.txt",


### PR DESCRIPTION
## Description
Fixing errors when collecting debugging resources in collect-debug-info about Istio.

## Why do we need it in the patch release (if we do)?
When called collect-debug-info command in cluster without enabled Istio modules or deployed components, user see errors, but archive create correct.
After this fix command collect-debug-info worked without errors.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: fix
summary:  Fix for collecting debugging resources in collect-debug-info about Istio
impact: When called collect-debug-info command in cluster without Istio, user see errors, but archive create correct
impact_level: low
```