### PR TITLE
[ingress-nginx] Fix used snapshots mechanism

### DIFF
--- a/modules/040-control-plane-manager/hooks/generate_admission_webhook_client_cert.go
+++ b/modules/040-control-plane-manager/hooks/generate_admission_webhook_client_cert.go
@@ -70,16 +70,11 @@ func filterAdmissionSecret(obj *unstructured.Unstructured) (go_hook.FilterResult
 }
 
 func generateValidateWebhookCert(input *go_hook.HookInput) error {
-	snapshots := input.NewSnapshots.Get(snapshotName)
+	snapshots := input.Snapshots[snapshotName]
 
 	// Try reuse certificate from Secret
 	if len(snapshots) > 0 {
-		secret := certificate.Certificate{}
-		err := snapshots[0].UnmarshalTo(&secret)
-		if err != nil {
-			input.Logger.Error(fmt.Sprintf("Failed to unmarshal certificate: %v", err))
-			return err
-		}
+		secret := snapshots[0].(certificate.Certificate)
 		input.Values.Set("controlPlaneManager.internal.admissionWebhookClientCertificateData.cert", secret.Cert)
 		input.Values.Set("controlPlaneManager.internal.admissionWebhookClientCertificateData.key", secret.Key)
 		return nil


### PR DESCRIPTION
## Description
Fixed an issue with the snapshot retrieval mechanism.

## Why do we need it, and what problem does it solve?
In the generate_admission_webhook_client_cert.go file, the logic for retrieving the secret snapshot was updated because the new snapshot mechanism is not yet available in version 1.70.

## Why do we need it in the patch release (if we do)?
This issue blocks correct builds, so a fix is required in the patch release.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: fix
summary: fixed an issue with the snapshot retrieval mechanism
impact_level: low
```

