### PR TITLE
[ingress-ngixn] fix validation pod node-selector

### DIFF
--- a/modules/402-ingress-nginx/templates/validator/deployment.yml
+++ b/modules/402-ingress-nginx/templates/validator/deployment.yml
@@ -75,7 +75,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple $ctx "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple $ctx "any-node") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple $ctx "system-cluster-critical") | nindent 6 }}
-      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "validator" "name" $name )) | nindent 6 }}
+      {{- include "helm_lib_pod_anti_affinity_for_ha" (list $ctx (dict "app" "validator" "name" $name )) | nindent 6 }}
       serviceAccountName: validator
       automountServiceAccountToken: true
       terminationGracePeriodSeconds: 420


### PR DESCRIPTION
## Description
Fixed `node-selector` and `tolerations` in validator `pod`.

## Why do we need it, and what problem does it solve?
The issue prevents pods from scheduling properly to master nodes.

## Why do we need it in the patch release (if we do)?
This issue is blocking the use of the validator pod.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ingress-nginx
type: fix
summary: fixed `node-selector` and `tolerations` in validator `pod`
impact_level: low
```