### PR TITLE
[docs] Added settings for external modules configuration

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
@@ -1,98 +1,106 @@
 {{/* Renders a module configuration.
 
-Context:
-.data — a map, containing the JSON schema.
-.langData — map, containing the preferable language data. Can be empty.
-*/}}
-
-{{- $data := .data }}
-{{- $conversions := .conversions }}
-{{- $langData := .langData }}
-
-{{- $configVersion := 1 }}
-{{- if index $data "x-config-version" }}
-  {{- $configVersion = index $data "x-config-version" }}
-{{- end }}
-
-{{/* TODO: format_examples $data */}}
-
-{{/* Reading all conversions files */}}
-
-{{/* Conversions rendering */}}
-{{- if and $conversions (gt (len $conversions) 0) }}
-    <h2>{{ T "conversions_title" }}</h2>
-
-    <p>{{ T "conversion_action_message" }}:</p>
-
-    {{- range $conversion := $conversions }}
-      {{- if $conversion }}
-      <ul>
-        <li>
-          <p>{{ T "conversion_from_version" }} <b>{{ sub $conversion.version 1 }}</b> {{ T "conversion_to" }} <b>{{ $conversion.version }}</b>:</p>
-
-          {{/* Check description availability*/}}
-          {{- $currentLang := site.Language.Lang | default "en" -}}
-          {{- $hasDescription := false -}}
-
-          {{- if $conversion.description -}}
-            {{- if reflect.IsMap $conversion.description -}}
-              {{- $description := index $conversion.description $currentLang | default $conversion.description.en -}}
-              {{- if $description -}}
-                <p>{{ $description | markdownify }}</p>
+  Context:
+  .data — a map, containing the JSON schema.
+  .langData — map, containing the preferable language data. Can be empty.
+  */}}
+  
+  {{- $data := .data }}
+  {{- $conversions := .conversions }}
+  {{- $langData := .langData }}
+  
+  {{- $configVersion := 1 }}
+  {{- if index $data "x-config-version" }}
+    {{- $configVersion = index $data "x-config-version" }}
+  {{- end }}
+  
+  {{/* TODO: format_examples $data */}}
+  
+  {{/* Reading all conversions files */}}
+  
+  {{/* Conversions rendering */}}
+  {{- if and $conversions (gt (len $conversions) 0) }}
+      <h2>{{ T "conversions_title" }}</h2>
+  
+      <p>{{ T "conversion_action_message" }}:</p>
+  
+      {{- range $conversion := $conversions }}
+        {{- if $conversion }}
+        <ul>
+          <li>
+            <p>{{ T "conversion_from_version" }} <b>{{ sub $conversion.version 1 }}</b> {{ T "conversion_to" }} <b>{{ $conversion.version }}</b>:</p>
+  
+            {{/* Check description availability*/}}
+            {{- $currentLang := site.Language.Lang | default "en" -}}
+            {{- $hasDescription := false -}}
+  
+            {{- if $conversion.description -}}
+              {{- if reflect.IsMap $conversion.description -}}
+                {{- $description := index $conversion.description $currentLang | default $conversion.description.en -}}
+                {{- if $description -}}
+                  <p>{{ $description | markdownify }}</p>
+                  {{- $hasDescription = true -}}
+                {{- end -}}
+              {{- else -}}
+                <p>{{ $conversion.description | markdownify }}</p>
                 {{- $hasDescription = true -}}
               {{- end -}}
-            {{- else -}}
-              <p>{{ $conversion.description | markdownify }}</p>
-              {{- $hasDescription = true -}}
             {{- end -}}
-          {{- end -}}
-
-          {{/* If no description */}}
-          {{- if not $hasDescription -}}
-            <p>{{ T "conversion_missing_description" }}</p>
-
-            {{/* Rendering details block only if there is no description, but there are expressions */}}
-            {{- if $conversion.conversions -}}
-            <div class="details" markdown="0">
-              <p class="details__lnk">
-                <a href="javascript:void(0)" class="details__summary">
-                  {{ T "conversion_expressions" }}
-                </a>
-              </p>
-              <div class="details__content" markdown="0">
-                <div class="expand" markdown="0">
-                  <ul>
-                    {{- range $conversionExpr := $conversion.conversions }}
-                    <li><code class="language-plaintext highlighter-rouge">{{ $conversionExpr }}</code></li>
-                    {{- end }}
-                  </ul>
+  
+            {{/* If no description */}}
+            {{- if not $hasDescription -}}
+              <p>{{ T "conversion_missing_description" }}</p>
+  
+              {{/* Rendering details block only if there is no description, but there are expressions */}}
+              {{- if $conversion.conversions -}}
+              <div class="details" markdown="0">
+                <p class="details__lnk">
+                  <a href="javascript:void(0)" class="details__summary">
+                    {{ T "conversion_expressions" }}
+                  </a>
+                </p>
+                <div class="details__content" markdown="0">
+                  <div class="expand" markdown="0">
+                    <ul>
+                      {{- range $conversionExpr := $conversion.conversions }}
+                      <li><code class="language-plaintext highlighter-rouge">{{ $conversionExpr }}</code></li>
+                      {{- end }}
+                    </ul>
+                  </div>
                 </div>
               </div>
-            </div>
+              {{- end -}}
             {{- end -}}
-          {{- end -}}
-        </li>
-      </ul>
+          </li>
+        </ul>
+        {{- end }}
       {{- end }}
-    {{- end }}
-<h2>{{ T "parameters" | humanize }}</h2>
-
-{{- end }}
-{{/* END Conversions rendering */}}
-
-{{- if gt (len $data.properties) 0 }}
-<p><font size="-1">{{ T "version_of_schema" }}: {{ $configVersion }}</font></p>
-
-<ul class="resources">
-
-  {{- range $property, $propertyData := $data.properties }}
-    {{- if eq $property "status" }}{{ continue }}{{ end }} {{/* skip .status for now*/}}
-    {{- $propertyLangData := index $langData.properties $property }}
-    {{- partial "openapi/format-schema" ( dict "name" $property "data" $propertyData "langData" $propertyLangData "resourceName" "parameters") }}
+  <h2>{{ T "parameters" | humanize }}</h2>
+  
   {{- end }}
-
-</ul>
-
-{{- else }}
-<p>{{ T "no_custom_configuration" }}</p>
-{{- end }}
+  {{/* END Conversions rendering */}}
+  
+  {{- if gt (len $data.properties) 0 }}
+  <h2 style="text-transform: capitalize;">{{ T "parameters" }}</h2>
+  <p><font size="-1">{{ T "version_of_schema" }}: {{ $configVersion }}</font></p>
+  
+  <ul class="resources">
+    <li>
+      <div class="resources__prop_wrap"><div id="parameters-settings" data-anchor-id="parameters-settings" class="resources__prop_name anchored">
+        <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></svg></span>
+        <span class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></svg></span>
+        <div><span class="ancestors"></span><span>settings</span></div><a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="" href="#parameters-settings" style="font: 1em / 1 anchorjs-icons; padding-left: 0.375em;"></a></div><span class="resources__prop_type">{{ T "object" }}</span></div>
+      <ul>
+      {{- range $property, $propertyData := $data.properties }}
+        {{- if eq $property "status" }}{{ continue }}{{ end }} {{/* skip .status for now*/}}
+        {{- $propertyLangData := index $langData.properties $property }}
+        {{- partial "openapi/format-schema" ( dict "name" $property "data" $propertyData "langData" $propertyLangData "resourceName" "parameters") }}
+      {{- end }}
+      </ul>
+    <li>
+  </ul>
+  
+  {{- else }}
+  <p>{{ T "no_custom_configuration" }}</p>
+  {{- end }}
+  


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added settings for external modules configuration.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Before:

![Снимок экрана 2025-06-20 в 11 43 56](https://github.com/user-attachments/assets/2b915dc1-7d71-48a5-9868-7c86200f0468)

After:

![Снимок экрана 2025-06-20 в 11 44 08](https://github.com/user-attachments/assets/f43b8bc2-7d61-4ab9-bd95-7b843cf44e79)


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Added settings for external modules configuration.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
