### PR TITLE
[deckhouse-controller] Backport 1.70: fix move awaiting after force, skip, await

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -557,10 +557,6 @@ func (r *reconciler) handlePendingRelease(ctx context.Context, release *v1alpha1
 		return res, err
 	}
 
-	if !task.IsSingle && !task.IsPatch && !isModuleReady(r.moduleManager, release.GetModuleName()) {
-		return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
-	}
-
 	if release.GetForce() {
 		r.log.Warn("forced release found")
 
@@ -596,6 +592,27 @@ func (r *reconciler) handlePendingRelease(ctx context.Context, release *v1alpha1
 		})
 		if err != nil {
 			r.log.Warn("await order status update ", slog.String("release", release.GetName()), log.Err(err))
+		}
+
+		return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
+	}
+
+	if !task.IsSingle && !task.IsPatch && !isModuleReady(r.moduleManager, release.GetModuleName()) {
+		r.log.Debug("module is not ready, waiting")
+
+		drs := &v1alpha1.ModuleReleaseStatus{
+			Phase: v1alpha1.ModuleReleasePhasePending,
+		}
+
+		drs.Message = "awaiting for module to be ready"
+
+		if task.DeployedReleaseInfo != nil {
+			drs.Message = fmt.Sprintf("awaiting for module v%s to be ready", task.DeployedReleaseInfo.Version.String())
+		}
+
+		updateErr := r.updateReleaseStatus(ctx, release, drs)
+		if updateErr != nil {
+			r.log.Warn("module release status update failed", log.Err(err))
 		}
 
 		return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
@@ -426,7 +426,7 @@ func (suite *ReleaseControllerTestSuite) TestCreateReconcile() {
 			_, err = suite.ctr.handleRelease(context.TODO(), suite.getModuleRelease("upmeter-v1.70.0"))
 			require.NoError(suite.T(), err)
 			_, err = suite.ctr.handleRelease(context.TODO(), suite.getModuleRelease("upmeter-v1.71.0"))
-			require.Error(suite.T(), err)
+			require.NoError(suite.T(), err)
 			_, err = suite.ctr.handleRelease(context.TODO(), suite.getModuleRelease("upmeter-v1.72.0"))
 			require.NoError(suite.T(), err)
 		})

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-notready.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-notready.yaml
@@ -61,11 +61,14 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleRelease
 metadata:
   creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/exist-on-fs
   labels:
     module: upmeter
     modules.deckhouse.io/update-policy: foxtrot-alpha
     release-checksum: 98d00f741c99e06e6c6c4d18b763c550
     source: foxtrot
+    status: deployed
   name: upmeter-v1.71.0
   ownerReferences:
   - apiVersion: deckhouse.io/v1alpha1
@@ -73,7 +76,7 @@ metadata:
     kind: ModuleSource
     name: foxtrot
     uid: 71d2300f-700b-452a-896a-6a3805f9cef7
-  resourceVersion: "999"
+  resourceVersion: "1000"
 spec:
   changelog:
     features:
@@ -84,7 +87,7 @@ spec:
 status:
   approved: false
   message: ""
-  phase: Downloaded
+  phase: Deployed
   pullDuration: 0s
   size: 0
   transitionTime: "2024-05-03T20:55:49Z"
@@ -105,7 +108,7 @@ metadata:
     kind: ModuleSource
     name: foxtrot
     uid: 71d2300f-700b-452a-896a-6a3805f9cef7
-  resourceVersion: "999"
+  resourceVersion: "1000"
 spec:
   changelog:
     features:
@@ -115,7 +118,7 @@ spec:
   weight: 950
 status:
   approved: false
-  message: ""
+  message: awaiting for module v1.71.0 to be ready
   phase: Pending
   pullDuration: 0s
   size: 0

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/sequential-processing-minor-notready.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/sequential-processing-minor-notready.yaml
@@ -79,7 +79,7 @@ spec:
 status:
   approved: false
   message: ""
-  phase: Downloaded
+  phase: Deployed
   pullDuration: 0s
   size: 0
   transitionTime: "2024-05-03T20:55:49Z"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

We have a bug with wrong behavior of Pending ModuleReleases
It din't want to be Skipped, because of wrong waiting algorythm.

Now this process was fixed and

### Before
```
NAME              PHASE      UPDATE POLICY   TRANSITIONTIME   MESSAGE
p-o-test-v0.3.0   Pending                    16h              Initial module config validation failed:...
p-o-test-v0.3.1   Deployed                   16h              
```

### After
```
NAME              PHASE      UPDATE POLICY   TRANSITIONTIME   MESSAGE
p-o-test-v0.3.0   Skipped                    10s               
p-o-test-v0.3.1   Deployed                   16h     
```

Additionally added verbosity for waiting Pending ModuleReleases
```
status:
  message: awaiting for module v1.71.0 to be ready
  phase: Pending
  transitionTime: "2024-05-03T20:55:49Z"
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
