### PR TITLE
[docs] Remove port 22322 from setup docs

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -228,7 +228,7 @@ groups:
     en: External traffic to masters
     ru: Внешний трафик к master-узлам
   destinations:
-  - ports: "22, 22322"
+  - ports: "22"
     protocol: TCP
     description:
       en: SSH for Deckhouse Kubernetes Platform initialization


### PR DESCRIPTION
## Description
Remove unused port from docs

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
