### PR TITLE
[openvpn] change logic renew CA (#14033)

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -5931,6 +5931,19 @@ alerts:
         OpenVPN client certificate expires for {{ $labels.client }} in less than 7 days.
       severity: "5"
       markupFormat: markdown
+    - name: OpenVPNClientsNeedRenewDueToNewCA
+      sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+      moduleUrl: 500-openvpn
+      module: openvpn
+      edition: ce
+      description: |-
+        The OpenVPN client certificate for **{{ $labels.client }}** has expired, while current CA is valid for more than 10 years.
+
+        This likely indicates that the CA was recently rotated and client certificates need to be reissued.
+      summary: |
+        Expired OpenVPN client certificate detected after CA renewal for {{ $labels.client }}
+      severity: "5"
+      markupFormat: markdown
     - name: OpenVPNServerCACertificateExpired
       sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
       moduleUrl: 500-openvpn
@@ -5943,6 +5956,19 @@ alerts:
       summary: |
         OpenVPN CA certificate has expired.
       severity: "4"
+      markupFormat: markdown
+    - name: OpenVPNServerCACertificateExpiresTomorrow
+      sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+      moduleUrl: 500-openvpn
+      module: openvpn
+      edition: ce
+      description: |-
+        The OpenVPN CA certificate will expire in less than 1 day.
+
+        The hook should rotate CA and server certificates before expiry.
+      summary: |
+        OpenVPN CA certificate will expire tomorrow
+      severity: "5"
       markupFormat: markdown
     - name: OpenVPNServerCACertificateExpiringInAWeek
       sourceFile: modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml

--- a/modules/500-openvpn/hooks/renew_ca_cert.go
+++ b/modules/500-openvpn/hooks/renew_ca_cert.go
@@ -26,22 +26,25 @@ import (
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
+type CertInfo struct {
+	CertData []byte
+}
+
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "check_server_cert_expiry",
-			Crontab: "0 */6 * * *", // Every 6 hours
+			Crontab: "*/10 * * * *", // Every 10 minutes
 		},
 	},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:       "openvpn_pki_server",
+			Name:       "openvpn_pki_ca",
 			ApiVersion: "v1",
 			Kind:       "Secret",
 			NamespaceSelector: &types.NamespaceSelector{
@@ -50,30 +53,14 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 				},
 			},
 			NameSelector: &types.NameSelector{
-				MatchNames: []string{"openvpn-pki-server"},
+				MatchNames: []string{"openvpn-pki-ca"},
 			},
-			FilterFunc: applyServerSecretFilter,
-		},
-		{
-			Name:       "openvpn_client_secrets",
-			ApiVersion: "v1",
-			Kind:       "Secret",
-			NamespaceSelector: &types.NamespaceSelector{
-				NameSelector: &types.NameSelector{
-					MatchNames: []string{"d8-openvpn"},
-				},
-			},
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"type": "clientAuth",
-				},
-			},
-			FilterFunc: applyClientSecretFilter,
+			FilterFunc: applyCASecretFilter,
 		},
 	},
 }, checkServerCertExpiry)
 
-func applyServerSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+func applyCASecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	var secret v1.Secret
 	err := sdk.FromUnstructured(obj, &secret)
 	if err != nil {
@@ -86,66 +73,39 @@ func applyServerSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 		return nil, nil
 	}
 
-	return certData, nil
-}
-
-func applyClientSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	var secret v1.Secret
-	err := sdk.FromUnstructured(obj, &secret)
-	if err != nil {
-		return nil, err
-	}
-	return secret.Name, nil
-}
-
-type CertInfo struct {
-	CertData []byte
+	return CertInfo{certData}, nil
 }
 
 func checkServerCertExpiry(input *go_hook.HookInput) error {
-	snapshots := input.Snapshots["openvpn_pki_server"]
+	snapshotsCa := input.Snapshots["openvpn_pki_ca"]
 
-	if len(snapshots) == 0 {
-		input.Logger.Warn("Secret openvpn-pki-server not found, skipping")
+	if len(snapshotsCa) == 0 {
+		input.Logger.Warn("Secret openvpn-pki-server or openvpn-pki-ca not found, skipping")
 		return nil
 	}
 
-	certData := snapshots[0].([]byte)
-
-	block, _ := pem.Decode(certData)
-	if block == nil || block.Type != "CERTIFICATE" {
-		input.Logger.Errorf("Failed to decode PEM block from tls.crt")
-		return nil
-	}
-
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		input.Logger.Errorf("Failed to parse certificate: %v", err)
-		return nil
-	}
-
-	// // Check if cert expires within 6 hours
 	now := time.Now()
-	if cert.NotAfter.Sub(now) <= 6*time.Hour {
-		input.Logger.Infof("Server certificate expired at %s, initiating cleanup and restart", cert.NotAfter)
+	caCertNotAfter := certNotAfter(snapshotsCa[0].(CertInfo), input)
 
-		// Remove openvpn-pki-ca
-		input.PatchCollector.Delete("v1", "Secret", "d8-openvpn", "openvpn-pki-ca")        // Ca cert
-		input.PatchCollector.Delete("v1", "Secret", "d8-openvpn", "openvpn-pki-server")    // Server cert
-		input.PatchCollector.Delete("v1", "Secret", "d8-openvpn", "openvpn-pki-crl")       // Certificate Revocation List
-		input.PatchCollector.Delete("v1", "Secret", "d8-openvpn", "openvpn-pki-index-txt") // list client certs
-		input.Logger.Info("Secret openvpn-pki-ca, openvpn-pki-server, openvpn-pki-crl scheduled for deletion")
+	if caCertNotAfter == nil {
+		input.Logger.Error("Failed to parse certificates, skipping")
+		return nil
+	}
 
-		// Remove clients certs
-		snapshotsClients := input.Snapshots["openvpn_client_secrets"]
-		if len(snapshotsClients) == 0 {
-			input.Logger.Warn("No client secrets with type=clientAuth found")
-		}
-		for _, snapshot := range snapshotsClients {
-			clientSecretName := snapshot.(string)
-			input.PatchCollector.Delete("v1", "Secret", "d8-openvpn", clientSecretName)
-			input.Logger.Infof("Client secret %s scheduled for deletion", clientSecretName)
-		}
+	daysLeftCa := int(caCertNotAfter.Sub(now).Hours() / 24)
+
+	input.Logger.Info("Certificate status",
+		slog.Int("ca_days_left", daysLeftCa),
+	)
+
+	// We check whether the CA expires in the next 24 hours
+	if caCertNotAfter.Sub(now) <= 24*time.Hour {
+		input.Logger.Info("Server certificate expired, initiating cleanup server cert and restart ovpn StateFullSet")
+
+		// Remove openvpn-pki-server
+		input.PatchCollector.Delete("v1", "Secret", "d8-openvpn", "openvpn-pki-server") // Server cert
+		input.PatchCollector.Delete("v1", "Secret", "d8-openvpn", "openvpn-pki-ca")     // CA cert
+		input.Logger.Info("Secret openvpn-pki-server, openvpn-pki-ca scheduled for deletion")
 
 		// Patch spec.template.metadata.annotations for reload SS
 		patch := map[string]interface{}{
@@ -159,11 +119,28 @@ func checkServerCertExpiry(input *go_hook.HookInput) error {
 				},
 			},
 		}
-		input.PatchCollector.MergePatch(patch, "apps/v1", "StatefulSet", "d8-openvpn", "openvpn")
+
+		input.PatchCollector.PatchWithMerge(patch, "apps/v1", "StatefulSet", "d8-openvpn", "openvpn")
 		input.Logger.Info("StatefulSet openvpn scheduled for restart")
 	} else {
-		input.Logger.Infof("Server certificate is valid until %s", cert.NotAfter)
+		input.Logger.Info("Server CA certificate is valid", slog.Time("until", *caCertNotAfter))
 	}
 
 	return nil
+}
+
+func certNotAfter(certInfo CertInfo, input *go_hook.HookInput) *time.Time {
+	block, _ := pem.Decode(certInfo.CertData)
+	if block == nil || block.Type != "CERTIFICATE" {
+		input.Logger.Error("Failed to decode PEM block from tls.crt")
+		return nil
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		input.Logger.Error("Failed to parse certificate", log.Err(err))
+		return nil
+	}
+
+	return &cert.NotAfter
 }

--- a/modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+++ b/modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
@@ -1,7 +1,7 @@
 - name: openvpn.admin.info
   rules:
     - alert: OpenVPNClientCertificateExpired
-      expr: ovpn_client_cert_expire == 0
+      expr: ovpn_client_cert_expire <= 0
       for: 1m
       labels:
         severity_level: "4"
@@ -112,7 +112,22 @@
 
           Immediate renewal is recommended.
 
-    - alert: OpenVPNServerCACertificateExpired
+    - alert: OpenVPNServerCACertificateExpiresTomorrow # The alert is triggered when there are more than 24 hours until the end of certification
+      expr: ovpn_server_ca_cert_expire == 1
+      for: 10m
+      labels:
+        severity_level: "5"
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        summary: "OpenVPN CA certificate will expire tomorrow"
+        description: |-
+          The OpenVPN CA certificate will expire in less than 1 day.
+
+          The hook should rotate CA and server certificates before expiry.
+
+
+    - alert: OpenVPNServerCACertificateExpired # The alert is triggered when the end of certification is less than 24 hours away
       expr: ovpn_server_ca_cert_expire == 0
       for: 1m
       labels:
@@ -125,3 +140,19 @@
           The OpenVPN CA certificate has expired.
 
           To restore VPN functionality, renew the expired certificate as soon as possible.
+
+    - alert: OpenVPNClientsNeedRenewDueToNewCA
+      expr: (ovpn_client_cert_expire <= 0) and ignoring(client) (ovpn_server_ca_cert_expire > 3650)
+      for: 5m
+      labels:
+        severity_level: "5"
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        summary: "Expired OpenVPN client certificate detected after CA renewal for {{ $labels.client }}"
+        description: |-
+          The OpenVPN client certificate for **{{ $labels.client }}** has expired, while current CA is valid for more than 10 years.
+
+          This likely indicates that the CA was recently rotated and client certificates need to be reissued.
+
+


### PR DESCRIPTION
## Description
backport https://github.com/deckhouse/deckhouse/pull/14033
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: openvpn
type: chore
summary: The logic of clearing expired certificates has been changed.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
