### PR TITLE
Fix docker login session for CVE Scan

### DIFF
--- a/.github/scripts/cve_scan.sh
+++ b/.github/scripts/cve_scan.sh
@@ -36,12 +36,33 @@ DEV_REGISTRY_DECKHOUSE_IMAGE="${DEV_REGISTRY}/sys/deckhouse-oss"
 
 login_prod_registry() {
   echo "Log in to PROD registry"
-  echo "${PROD_REGISTRY_PASSWORD}" | docker login --username="${PROD_REGISTRY_USER}" --password-stdin ${PROD_REGISTRY}
+  docker login ${PROD_REGISTRY}
 }
 login_dev_registry() {
   echo "Log in to DEV registry"
-  echo "${DEV_REGISTRY_PASSWORD}" | docker login --username="${DEV_REGISTRY_USER}" --password-stdin ${DEV_REGISTRY}
+  docker login ${DEV_REGISTRY}
 }
+
+# Create docker config file to use during this CI Job
+echo "----------------------------------------------"
+echo ""
+echo "Preparing DOCKER_CONFIG"
+mkdir -p "${WORKDIR}/docker"
+export DOCKER_CONFIG="${WORKDIR}/docker"
+echo "Docker config path: ${DOCKER_CONFIG}/config.json"
+cat > "${DOCKER_CONFIG}/config.json" << EOL
+{
+        "auths": {
+                "${PROD_REGISTRY}": {
+                        "auth": "$(echo "${PROD_REGISTRY_USER}:${PROD_REGISTRY_PASSWORD}" | base64)"
+                },
+                {
+                "${DEV_REGISTRY}": {
+                        "auth": "$(echo "${DEV_REGISTRY_USER}:${DEV_REGISTRY_PASSWORD}" | base64)"
+                }
+        }
+}
+EOL
 
 echo "----------------------------------------------"
 echo ""


### PR DESCRIPTION
## Description
Use temporary separate DOCKER_CONFIG file for registry authentication

## Why do we need it, and what problem does it solve?
Sometimes docker session overrides by another docker login command on the runner with different creds during CVE Scan process, so scan fails because of docker authentication error

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix docker login session for CVE Scan
impact: none
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
