### PR TITLE
[operator-trivy] Specify db-repository image tag

### DIFF
--- a/ee/modules/500-operator-trivy/templates/configmap.yaml
+++ b/ee/modules/500-operator-trivy/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{ $trivyServerURL := printf "http://trivy-server.d8-%s.svc.%s:4954" .Chart.Name .Values.global.discovery.clusterDomain | quote }}
-{{ $dbRepository := printf "%s/security/trivy-db" .Values.global.modulesImages.registry.base | quote }}
+{{ $dbRepository := printf "%s/security/trivy-db:2" .Values.global.modulesImages.registry.base | quote }}
 {{ $javaDbRepository := printf "%s/security/trivy-java-db:1" .Values.global.modulesImages.registry.base | quote }}
 {{ $policiesBundleRepository := printf "%s/security/trivy-checks:0" .Values.global.modulesImages.registry.base | quote }}
 ---


### PR DESCRIPTION
## Description
Specify db-repository image tag

## Why do we need it, and what problem does it solve?
Before we have INFO message in logs like this:

```
~ $ kubectl -n d8-operator-trivy logs trivy-server-0
Defaulted container "server" out of: server, chown-volume-data (init)
2025-06-23T21:44:09Z	INFO	Adding schema version to the DB repository for backward compatibility	repository="registry.deckhouse.io/deckhouse/ee/security/trivy-db:2"
2025-06-23T21:44:09Z	INFO	Listening 0.0.0.0:4954...
```

After just:
```
~ $ kubectl -n d8-operator-trivy logs trivy-server-0
Defaulted container "server" out of: server, chown-volume-data (init)
2025-06-23T21:46:26Z	INFO	Listening 0.0.0.0:4954...
```

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: chore
summary: Specify db-repository image tag
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
