### PR TITLE
Ensure latest image is used by adding explicit docker pull before docker run

### DIFF
--- a/.github/scripts/validation_bashible.sh
+++ b/.github/scripts/validation_bashible.sh
@@ -172,6 +172,7 @@ config=config.yaml
 volumesRoot=$(pwd)
 printf "%s\n" "$CONFIG_YAML" > "$volumesRoot/$config"
 dockerExit=0
+docker pull ${REGISTRY}/deckhouse/ee/install:stable
 cat <<'SCRIPT_END' | docker run -i --rm \
   -v ${volumesRoot}/candi/bashible:/deckhouse/candi/bashible \
   -v ${volumesRoot}/candi/cloud-providers:/deckhouse/candi/cloud-providers \

--- a/candi/cloud-providers/aws/bashible/common-steps/all/000_set_cloud_variables.sh.tpl
+++ b/candi/cloud-providers/aws/bashible/common-steps/all/000_set_cloud_variables.sh.tpl
@@ -16,7 +16,7 @@
 
 shutdown_grace_period="225"
 shutdown_grace_period_critical_pods="15"
-{{ lslds }}
+
 cat << EOF > /var/lib/bashible/cloud-provider-variables
 shutdown_grace_period="$shutdown_grace_period"
 shutdown_grace_period_critical_pods="$shutdown_grace_period_critical_pods"


### PR DESCRIPTION
## Description

Added an explicit `docker pull` before `docker run` to ensure the latest image is used.

## Why do we need it, and what problem does it solve?

Without `docker pull`, Docker may use an outdated local image. This change prevents such cases.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Ensure latest image is used by adding explicit docker pull before docker run
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
