### PR TITLE
[control-plane-manager] fix default  behaviour for etcd backup

### DIFF
--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -107,6 +107,8 @@ var _ = Describe("Module :: control-plane-manager :: helm template :: arguments 
     effectiveKubernetesVersion: "1.32"
     etcdServers:
       - https://192.168.199.186:2379
+    mastersNode:
+      - master-0
     pkiChecksum: checksum
     rolloutEpoch: 1857
 `
@@ -656,6 +658,20 @@ resources:
 				kubeApiserver, err := base64.StdEncoding.DecodeString(s.Field("data.kube-apiserver\\.yaml\\.tpl").String())
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(kubeApiserver).ToNot(ContainSubstring("--service-account-issuer"))
+			})
+		})
+		Context("cluster is bootstrapped", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("global", globalValues)
+				f.ValuesSet("global.modulesImages", GetModulesImages())
+				f.ValuesSet("global.clusterIsBootstrapped", true)
+				f.HelmRender()
+			})
+
+			It("cronjob for etcd backup should be exist by default", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				s := f.KubernetesResource("Cronjob", "kube-system", "d8-etcd-backup-039d00b17e10d07f52111429fc7d82e2c")
+				Expect(s.Exists()).To(BeTrue())
 			})
 		})
 	})

--- a/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
+++ b/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
@@ -3,7 +3,11 @@ cpu: 25m
 memory: 40Mi
 {{- end }}
 
-{{- $backupEnabled := (((.Values.controlPlaneManager).etcd).backup).enabled | default true -}}
+{{- $backupEnabled := true -}}
+{{- if hasKey (((.Values.controlPlaneManager).etcd).backup "enabled") -}}
+  {{- $backupEnabled = (((.Values.controlPlaneManager).etcd).backup).enabled -}}
+{{- end -}}
+
 {{- $backupSchedule := (((.Values.controlPlaneManager).etcd).backup).cronSchedule | default "0 0 * * *" -}}
 {{- $backupHostPath := (((.Values.controlPlaneManager).etcd).backup).hostPath | default "/var/lib/etcd" -}}
 {{- $etcdQuotaBackendBytes := (.Values.controlPlaneManager.internal).etcdQuotaBackendBytes | default "2147483648" -}}

--- a/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
+++ b/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
@@ -4,12 +4,13 @@ memory: 40Mi
 {{- end }}
 
 {{- $backupEnabled := true -}}
-{{- if hasKey (((.Values.controlPlaneManager).etcd).backup "enabled") -}}
-  {{- $backupEnabled = (((.Values.controlPlaneManager).etcd).backup).enabled -}}
+{{- $etcdBackup := ((.Values.controlPlaneManager).etcd).backup | default dict }}
+{{- if hasKey $etcdBackup "enabled" -}}
+  {{- $backupEnabled = $etcdBackup.enabled -}}
 {{- end -}}
 
-{{- $backupSchedule := (((.Values.controlPlaneManager).etcd).backup).cronSchedule | default "0 0 * * *" -}}
-{{- $backupHostPath := (((.Values.controlPlaneManager).etcd).backup).hostPath | default "/var/lib/etcd" -}}
+{{- $backupSchedule := $etcdBackup.cronSchedule | default "0 0 * * *" -}}
+{{- $backupHostPath := $etcdBackup.hostPath | default "/var/lib/etcd" -}}
 {{- $etcdQuotaBackendBytes := (.Values.controlPlaneManager.internal).etcdQuotaBackendBytes | default "2147483648" -}}
 
 {{- if $backupEnabled }}

--- a/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
+++ b/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
@@ -3,7 +3,7 @@ cpu: 25m
 memory: 40Mi
 {{- end }}
 
-{{- $backupEnabled := (((.Values.controlPlaneManager).etcd).backup).enabled -}}
+{{- $backupEnabled := (((.Values.controlPlaneManager).etcd).backup).enabled | default true -}}
 {{- $backupSchedule := (((.Values.controlPlaneManager).etcd).backup).cronSchedule | default "0 0 * * *" -}}
 {{- $backupHostPath := (((.Values.controlPlaneManager).etcd).backup).hostPath | default "/var/lib/etcd" -}}
 {{- $etcdQuotaBackendBytes := (.Values.controlPlaneManager.internal).etcdQuotaBackendBytes | default "2147483648" -}}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Since v1.70 we add custom properties for etcd backup and unintentionally changed default behaviour for backup job.

Related to: #13193

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Etcd backup should be enable by default.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Etcd backup should be enable by default.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fix default behaviour for etcd backup.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
