### PR TITLE
[multitenancy-manager] fix rendering properties with additionalProperties

### DIFF
--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/client.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/client.go
@@ -302,6 +302,21 @@ func mergeWithDefaults(schema *spec.Schema, projectValues map[string]interface{}
 		}
 	}
 
+	// handle additionalProperties (map types)
+	if schema.AdditionalProperties != nil {
+		mapResult := make(map[string]interface{})
+		for key, value := range projectValues {
+			// skip keys that are already handled as properties
+			if _, exists := schema.Properties[key]; exists {
+				continue
+			}
+
+			mapResult[key] = value
+		}
+
+		result = mapResult
+	}
+
 	return result
 }
 

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/project.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/project.yaml
@@ -3,10 +3,6 @@ kind: Project
 metadata:
   name: test
 spec:
-  resourceLabels:
-    key: val
-  resourceAnnotations:
-    key: val
   description: This is an example from the Deckhouse documentation.
   projectTemplateName: default
   parameters:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
@@ -3,12 +3,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations:
-    key: val
   labels:
     extended-monitoring.deckhouse.io/enabled: ""
     heritage: multitenancy-manager
-    key: val
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: default
     security.deckhouse.io/pod-policy: baseline
@@ -18,11 +15,8 @@ metadata:
 apiVersion: deckhouse.io/v1alpha1
 kind: AuthorizationRule
 metadata:
-  annotations:
-    key: val
   labels:
     heritage: multitenancy-manager
-    key: val
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: default
   name: user-gmail.com
@@ -37,11 +31,8 @@ spec:
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  annotations:
-    key: val
   labels:
     heritage: multitenancy-manager
-    key: val
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: default
   name: all-pods
@@ -55,11 +46,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  annotations:
-    key: val
   labels:
     heritage: multitenancy-manager
-    key: val
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: default
   name: isolated
@@ -104,11 +92,8 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: OperationPolicy
 metadata:
-  annotations:
-    key: val
   labels:
     heritage: multitenancy-manager
-    key: val
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: default
   name: required-requests-9f86d081

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
@@ -129,9 +129,6 @@ spec:
     kind: Namespace
     metadata:
       name: {{ .projectName }}
-      # to test adopt annotation deletion
-      annotations:
-        projects.deckhouse.io/adopt: ""
       labels:
         {{ with .parameters.podSecurityProfile }}security.deckhouse.io/pod-policy: "{{ lower . }}"{{ end }}
         {{ if .parameters.extendedMonitoringEnabled }}extended-monitoring.deckhouse.io/enabled: ""{{ end }}

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/empty_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/empty_case/resources.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     heritage: multitenancy-manager
     projects.deckhouse.io/project: test
-    projects.deckhouse.io/project-template: empty
+    projects.deckhouse.io/project-template: ""
   name: test
 spec: {}
 status: {}

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
@@ -3,7 +3,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations: {}
   labels:
     extended-monitoring.deckhouse.io/enabled: ""
     heritage: multitenancy-manager
@@ -17,7 +16,6 @@ metadata:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  annotations: {}
   labels:
     heritage: multitenancy-manager
     projects.deckhouse.io/project: test
@@ -64,7 +62,6 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: OperationPolicy
 metadata:
-  annotations: {}
   labels:
     heritage: multitenancy-manager
     projects.deckhouse.io/project: test
@@ -87,7 +84,6 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: SecurityPolicy
 metadata:
-  annotations: {}
   labels:
     heritage: multitenancy-manager
     projects.deckhouse.io/project: test
@@ -112,7 +108,6 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: AuthorizationRule
 metadata:
-  annotations: {}
   labels:
     heritage: multitenancy-manager
     projects.deckhouse.io/project: test
@@ -129,7 +124,6 @@ spec:
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  annotations: {}
   labels:
     heritage: multitenancy-manager
     projects.deckhouse.io/project: test

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
@@ -3,7 +3,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations: {}
+  annotations:
+    scheduler.alpha.kubernetes.io/node-selector: node-role/gpu-shared=
   labels:
     extended-monitoring.deckhouse.io/enabled: ""
     heritage: multitenancy-manager
@@ -97,7 +98,6 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: OperationPolicy
 metadata:
-  annotations: {}
   labels:
     heritage: multitenancy-manager
     projects.deckhouse.io/project: test
@@ -120,7 +120,6 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: FalcoAuditRules
 metadata:
-  annotations: {}
   labels:
     heritage: multitenancy-manager
     projects.deckhouse.io/project: test
@@ -153,7 +152,6 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: SecurityPolicy
 metadata:
-  annotations: {}
   labels:
     heritage: multitenancy-manager
     projects.deckhouse.io/project: test

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
@@ -3,12 +3,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations:
-    my: key
   creationTimestamp: null
   labels:
     heritage: multitenancy-manager
-    my: key
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: without_ns
   name: test
@@ -19,11 +16,8 @@ status: {}
 apiVersion: deckhouse.io/v1alpha1
 kind: AuthorizationRule
 metadata:
-  annotations:
-    my: key
   labels:
     heritage: multitenancy-manager
-    my: key
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: without_ns
   name: user-gmail.com
@@ -38,11 +32,8 @@ spec:
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  annotations:
-    my: key
   labels:
     heritage: multitenancy-manager
-    my: key
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: without_ns
   name: all-pods
@@ -56,11 +47,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  annotations:
-    my: key
   labels:
     heritage: multitenancy-manager
-    my: key
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: without_ns
   name: isolated
@@ -105,11 +93,8 @@ spec:
 apiVersion: deckhouse.io/v1alpha1
 kind: OperationPolicy
 metadata:
-  annotations:
-    my: key
   labels:
     heritage: multitenancy-manager
-    my: key
     projects.deckhouse.io/project: test
     projects.deckhouse.io/project-template: without_ns
   name: required-requests-9f86d081

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/manager/namespace/manager.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/manager/namespace/manager.go
@@ -36,8 +36,6 @@ import (
 )
 
 const (
-	projectEmpty = "empty"
-
 	managedByHelm = "Helm"
 )
 


### PR DESCRIPTION
## Description
It fixes rendering properties with additionalProperties.

## Why do we need it, and what problem does it solve?
[This](https://github.com/deckhouse/deckhouse/pull/11096) added supporting default values, but it skips properties with additionalProperties so they are not rendered. But because there is only one such property, only now the bug appears.  

## Why do we need it in the patch release (if we do)?
This bug exists since this [PR](https://github.com/deckhouse/deckhouse/pull/11096).

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: fix
summary: Fix rendering properties with additionalProperties.
```

