### PR TITLE
[node-manager] Correct processing of the NodeUser in the bootstrap configuration

### DIFF
--- a/modules/040-node-manager/webhooks/validating/node_user
+++ b/modules/040-node-manager/webhooks/validating/node_user
@@ -52,10 +52,7 @@ function __main__() {
   nodeGroups=$(context::jq -r '.review.request.object.spec.nodeGroups[]')
   operation=$(context::jq -r '.review.request.operation')
 
-  snapshots=$(context::jq -cr '[.snapshots.nodeUsers[].filterResult]')
-  if [ "$operation" = "UPDATE" ]; then
-    snapshots=$(context::jq -cr --arg name "$name" '[.snapshots.nodeUsers[].filterResult | select(.name==$name | not)]')
-  fi
+  snapshots=$(context::jq -cr --arg name "$name" '[.snapshots.nodeUsers[].filterResult | select(.name==$name | not)]')
 
   if [ $(jq -cr --arg uid "$uid" '[.[] | select(.uid==($uid | tonumber)) | select(.nodeGroups | index("*"))] | length' <<< "$snapshots") -gt 0 ]; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix [issue](https://github.com/deckhouse/deckhouse/issues/13377). Correct processing of the NodeUser in the bootstrap configuration/
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We handle`403 status code` from webhook before apiserver `409 AlreadyExists` [by check](https://github.com/deckhouse/deckhouse/blob/dd54a54157edb00b1cb507df885a4fa702c0c022/dhctl/pkg/kubernetes/actions/task.go#L44C14-L44C29) and get `Error: create resource` if nodeUser and same uuid exists in cluster (nodes was not cleaned up correctly by bootstrap-phase abort)
## Why do we need it in the patch release (if we do)?
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Correct processing of the NodeUser in the bootstrap configuration.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
