### PR TITLE
Add check for path exist in custom metrics in kubestate metrics

### DIFF
--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/deployment.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/deployment.yaml
@@ -95,14 +95,12 @@ spec:
                       help: "VPA container minimal allowed memory according to VPA rules"
                       each:
                         type: Gauge
-                        foreach:
+                        gauge:
+                          nilIsZero: true
                           path: [spec, resourcePolicy, containerPolicies]
                           labelsFromPath:
                             container: [containerName]
-                        gauge:
-                          valueFrom:
-                            path: [minAllowed, memory]
-                            ifExists: true
+                          valueFrom: [minAllowed, memory]
                       commonLabels:
                         resource: "memory"
                         unit: "byte"
@@ -110,14 +108,12 @@ spec:
                       help: "VPA container minimal allowed cpu according to VPA rules"
                       each:
                         type: Gauge
-                        foreach:
+                        gauge:
+                          nilIsZero: true
                           path: [spec, resourcePolicy, containerPolicies]
                           labelsFromPath:
                             container: [containerName]
-                        gauge:
-                          valueFrom:
-                            path: [minAllowed, cpu]
-                            ifExists: true
+                          valueFrom: [minAllowed, cpu]
                       commonLabels:
                         resource: "cpu"
                         unit: "core"
@@ -126,6 +122,7 @@ spec:
                       each:
                         type: Gauge
                         gauge:
+                          nilIsZero: true
                           path: [spec, resourcePolicy, containerPolicies]
                           labelsFromPath:
                             container: [containerName]
@@ -138,6 +135,7 @@ spec:
                       each:
                         type: Gauge
                         gauge:
+                          nilIsZero: true
                           path: [spec, resourcePolicy, containerPolicies]
                           labelsFromPath:
                             container: [containerName]


### PR DESCRIPTION
## Description  
This PR adds `nilIsZero: true` to the `custom metrics` group for VPA (Vertical Pod Autoscaler) in KSM (kube-state-metrics). The group affected is: `VPA container maximum|minimum allowed cpu|memory according to VPA rules`.  

The change ensures that when a VPA resource does not specify `resourcePolicy.containerPolicies.maxAllowed` or `minAllowed` (e.g., when `updateMode: "Off"` is set), KSM will no longer log errors like:  
`kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed” err=“[spec,resourcePolicy,containerPolicies]: got nil while resolving path`.  

Instead, these cases will now emit `0` for the corresponding metrics. These particular metrics are not referenced anywhere in DKP's dashboards or alerting rules, so the change has no operational impact.

## Why do we need it, and what problem does it solve?  
Currently, KSM generates noisy error logs when encountering VPAs without `resourcePolicy.containerPolicies` defined. This is particularly common with VPAs that have `updateMode: "Off"`. For example:

```yaml
apiVersion: autoscaling.k8s.io/v1
kind: VerticalPodAutoscaler
metadata:
  name: example-vpa
spec:
  targetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: example-app
  updatePolicy:
    updateMode: "Off"  # No resourcePolicy needed in this mode
```

While this is a perfectly valid VPA configuration, KSM currently treats it as an error. This fix:

1. **Eliminates false-positive errors** in logs for valid VPA configurations
2. **Reduces log spam** in clusters with many VPAs in "Off" mode
3. **Maintains current behavior** - since these metrics aren't used in DKP, emitting `0` values is harmless

## Why do we need it in the patch release (if we do)?  
Not necessarily. The issue is non-critical only affecting logs.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fix KSM error logs for VPAs without resourcePolicy.containerPolicies  
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
