### PR TITLE
[runtime-audit-engine] Falco build werf fixes for CSE release.

### DIFF
--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -94,18 +94,18 @@ shell:
   - cd /src
   {{- if $.DistroPackagesProxy }}
   # build in the closed env
-  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/falcosecurity-libs-repo/CMakeLists.txt
-  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/cxxopts.cmake
-  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/njson.cmake
-  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/driver-repo/CMakeLists.txt
-  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/yaml-cpp.cmake
-  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/cpp-httplib.cmake
-  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/falcoctl.cmake
-  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/curl.cmake
-  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/jemalloc.cmake
-  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/openssl.cmake
-  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/cares.cmake
-  - sed -i "s|https://download.falco.org|http://dev-registry-cse.deckhouse.ru:8081/repository/download-falco-org|g" cmake/modules/rules.cmake  
+  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/falcosecurity-libs-repo/CMakeLists.txt
+  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/cxxopts.cmake
+  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/njson.cmake
+  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/driver-repo/CMakeLists.txt
+  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/yaml-cpp.cmake
+  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/cpp-httplib.cmake
+  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/falcoctl.cmake
+  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/curl.cmake
+  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/jemalloc.cmake
+  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/openssl.cmake
+  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/cares.cmake
+  - sed -i "s|https://download.falco.org|http://{{ $.DistroPackagesProxy }}/repository/download-falco-org|g" cmake/modules/rules.cmake  
   {{- end }}
   - mkdir -p /src/build
   - cd /src/build
@@ -118,7 +118,7 @@ shell:
     for f in `grep -lari 'URL "https://github.com'`; do
       sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" $f
     done
-  - sed -i "s|https://download.falco.org|http://dev-registry-cse.deckhouse.ru:8081/repository/download-falco-org|g" falcosecurity-libs-repo/falcosecurity-libs-prefix/src/falcosecurity-libs/cmake/modules/container_plugin.cmake 
+  - sed -i "s|https://download.falco.org|http://{{ $.DistroPackagesProxy }}/repository/download-falco-org|g" falcosecurity-libs-repo/falcosecurity-libs-prefix/src/falcosecurity-libs/cmake/modules/container_plugin.cmake 
   - find . -maxdepth 1 -type d ! -name "falcosecurity-libs-repo" ! -name "." -print0 | xargs -0 rm -rf
   - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DRIVER=OFF -DCPACK_GENERATOR=TGZ -DBUILD_BPF=OFF -DBUILD_FALCO_MODERN_BPF=ON -DBUILD_WARNINGS_AS_ERRORS=OFF -DFALCO_VERSION={{ $falcoVersion }} -DUSE_BUNDLED_DEPS=ON -DFORCE_UPDATE_DEPS=ON /src
   - sed -i 's|cd /src/build/tbb-prefix/src/tbb && /usr/bin/cmake -E touch /src/build/tbb-prefix/src/tbb-stamp/tbb-configure|&\n\tsed -i "s\|-D_FORTIFY_SOURCE=2\|-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2\|g" /src/build/tbb-prefix/src/tbb/src/tbb/CMakeFiles/tbb.dir/flags.make|' CMakeFiles/tbb.dir/build.make

--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -151,6 +151,7 @@ shell:
   - export GCC_VERSION=12
   - mkdir -p /out/usr/share/falco/plugins
   {{- if $.DistroPackagesProxy }}
+  # build in the closed env
   - sed -i "s|https://raw.githubusercontent.com|http://{{ $.DistroPackagesProxy }}/repository/githubusercontent|g" /src/plugins/k8smeta/test/CMakeLists.txt
   {{- end }}
   - cd /src/plugins/json

--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -94,14 +94,18 @@ shell:
   - cd /src
   {{- if $.DistroPackagesProxy }}
   # build in the closed env
-  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/falcosecurity-libs-repo/CMakeLists.txt
-  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/cxxopts.cmake
-  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/njson.cmake
-  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/driver-repo/CMakeLists.txt
-  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/yaml-cpp.cmake
-  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/cpp-httplib.cmake
-  - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/falcoctl.cmake
-  - sed -i "s|https://download.falco.org|http://{{ $.DistroPackagesProxy }}/repository/download-falco-org|g" cmake/modules/rules.cmake
+  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/falcosecurity-libs-repo/CMakeLists.txt
+  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/cxxopts.cmake
+  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/njson.cmake
+  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/driver-repo/CMakeLists.txt
+  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/yaml-cpp.cmake
+  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/cpp-httplib.cmake
+  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/falcoctl.cmake
+  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/curl.cmake
+  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/jemalloc.cmake
+  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/openssl.cmake
+  - sed -i "s|https://github.com|http://dev-registry-cse.deckhouse.ru:8081/repository/github-com|g" cmake/modules/cares.cmake
+  - sed -i "s|https://download.falco.org|http://dev-registry-cse.deckhouse.ru:8081/repository/download-falco-org|g" cmake/modules/rules.cmake  
   {{- end }}
   - mkdir -p /src/build
   - cd /src/build
@@ -114,6 +118,10 @@ shell:
     for f in `grep -lari 'URL "https://github.com'`; do
       sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" $f
     done
+  - sed -i "s|https://download.falco.org|http://dev-registry-cse.deckhouse.ru:8081/repository/download-falco-org|g" falcosecurity-libs-repo/falcosecurity-libs-prefix/src/falcosecurity-libs/cmake/modules/container_plugin.cmake 
+  - find . -maxdepth 1 -type d ! -name "falcosecurity-libs-repo" ! -name "." -print0 | xargs -0 rm -rf
+  - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DRIVER=OFF -DCPACK_GENERATOR=TGZ -DBUILD_BPF=OFF -DBUILD_FALCO_MODERN_BPF=ON -DBUILD_WARNINGS_AS_ERRORS=OFF -DFALCO_VERSION={{ $falcoVersion }} -DUSE_BUNDLED_DEPS=ON -DFORCE_UPDATE_DEPS=ON /src
+  - sed -i 's|cd /src/build/tbb-prefix/src/tbb && /usr/bin/cmake -E touch /src/build/tbb-prefix/src/tbb-stamp/tbb-configure|&\n\tsed -i "s\|-D_FORTIFY_SOURCE=2\|-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2\|g" /src/build/tbb-prefix/src/tbb/src/tbb/CMakeFiles/tbb.dir/flags.make|' CMakeFiles/tbb.dir/build.make
   {{- end }}
   - make falco -j ${BUILD_THREADS}
   - make install DESTDIR=/out
@@ -143,8 +151,7 @@ shell:
   - export GCC_VERSION=12
   - mkdir -p /out/usr/share/falco/plugins
   {{- if $.DistroPackagesProxy }}
-  - # build in the closed env
-  - sed -i "s|https://raw.githubusercontent.com|http://{{ $.DistroPackagesProxy }}/repository/githubusercontent|g" src/k8smeta/test/CMakeLists.txt
+  - sed -i "s|https://raw.githubusercontent.com|http://{{ $.DistroPackagesProxy }}/repository/githubusercontent|g" /src/plugins/k8smeta/test/CMakeLists.txt
   {{- end }}
   - cd /src/plugins/json
   - make


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
this pr add werf fixes for build image falco artifacts fro CSE release.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this resolve falco build artifacts for cse release.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: fix
summary: falco build fixes for CSE
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
