### PR TITLE
[operator-trivy] operator-trivy respects k8s 1.31+

### DIFF
--- a/ee/modules/500-operator-trivy/images/operator/patches/011-support-new-jobs.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/011-support-new-jobs.patch
@@ -1,0 +1,29 @@
+diff --git a/pkg/configauditreport/controller/nodecollector.go b/pkg/configauditreport/controller/nodecollector.go
+index 52c15419..2603eb1d 100644
+--- a/pkg/configauditreport/controller/nodecollector.go
++++ b/pkg/configauditreport/controller/nodecollector.go
+@@ -72,9 +72,9 @@ func (r *NodeCollectorJobController) reconcileJobs() reconcile.Func {
+ 		}
+ 
+ 		switch jobCondition := job.Status.Conditions[0].Type; jobCondition {
+-		case batchv1.JobComplete:
++		case batchv1.JobComplete, batchv1.JobSuccessCriteriaMet:
+ 			err = r.processCompleteScanJob(ctx, job)
+-		case batchv1.JobFailed:
++		case batchv1.JobFailed, batchv1.JobFailureTarget:
+ 			err = r.processFailedScanJob(ctx, job)
+ 		default:
+ 			err = fmt.Errorf("unrecognized scan job condition: %v", jobCondition)
+diff --git a/pkg/vulnerabilityreport/controller/scanjob.go b/pkg/vulnerabilityreport/controller/scanjob.go
+index b5bdca94..cdf5956a 100644
+--- a/pkg/vulnerabilityreport/controller/scanjob.go
++++ b/pkg/vulnerabilityreport/controller/scanjob.go
+@@ -76,7 +76,7 @@ func (r *ScanJobController) reconcileJobs() reconcile.Func {
+ 		}
+ 
+ 		switch jobCondition := job.Status.Conditions[0].Type; jobCondition {
+-		case batchv1.JobComplete, batchv1.JobFailed:
++		case batchv1.JobComplete, batchv1.JobSuccessCriteriaMet, batchv1.JobFailed, batchv1.JobFailureTarget:
+ 			completedContainers, err := r.completedContainers(ctx, job)
+ 			if err != nil {
+ 				return ctrl.Result{}, r.deleteJob(ctx, job)

--- a/ee/modules/500-operator-trivy/images/operator/patches/README.md
+++ b/ee/modules/500-operator-trivy/images/operator/patches/README.md
@@ -43,3 +43,10 @@ The operator of v0.22.0 cannot re-download policies if the image of the policies
 ### 010-use-local-policies.patch
 
 Uses policies from the "/local/policies" directory if "OPERATOR_USE_LOCAL_POLICIES" is set to "true"
+
+### 011-support-new-jobs.patch
+
+The current version of operator does not support kubernetes v1.31+ because of new job resources, this patch fixes it.
+
+[PR](https://github.com/aquasecurity/trivy-operator/pull/2292)
+[Issue](https://github.com/aquasecurity/trivy-operator/issues/2251)


### PR DESCRIPTION
## Description
It fixes operator-trivy does not respect kubernetes 1.31+

## Why do we need it, and what problem does it solve?
Operator-trivy 0.22 does not support kubernetes 1.31+

Upstream [issue](https://github.com/aquasecurity/trivy-operator/pull/2292)
Upstream [fix](https://github.com/aquasecurity/trivy-operator/pull/2292)

## Why do we need it in the patch release (if we do)?
This problem probably affects all versions of deckhouse.

Symptoms:

Logs with errors
```
{"level":"error","ts":"2025-06-25T12:52:42Z","msg":"Reconciler error","controller":"job","controllerGroup":"batch","controllerKind":"Job","Job":{"name":"scan-vulnerabilityreport-56d7ddd967","namespace":"d8-operator-trivy"},"namespace":"d8-operator-trivy","name":"scan-vulnerabilityreport-56d7ddd967","reconcileID":"9c7ab8bb-8380-4d39-ace7-5ff225a46485","error":"unrecognized scan job condition: SuccessCriteriaMet","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224"}
{"level":"error","ts":"2025-06-25T12:52:46Z","msg":"Reconciler error","controller":"job","controllerGroup":"batch","controllerKind":"Job","Job":{"name":"scan-vulnerabilityreport-5cc56f4945","namespace":"d8-operator-trivy"},"namespace":"d8-operator-trivy","name":"scan-vulnerabilityreport-5cc56f4945","reconcileID":"c1b77d27-553f-444f-832e-b61796563db0","error":"unrecognized scan job condition: SuccessCriteriaMet","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224"}
{"level":"error","ts":"2025-06-25T12:52:46Z","msg":"Reconciler error","controller":"job","controllerGroup":"batch","controllerKind":"Job","Job":{"name":"scan-vulnerabilityreport-84dc9cf8d9","namespace":"d8-operator-trivy"},"namespace":"d8-operator-trivy","name":"scan-vulnerabilityreport-84dc9cf8d9","reconcileID":"0db56945-191b-471f-aeaf-89be2e7513f4","error":"unrecognized scan job condition: SuccessCriteriaMet","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224"}
```

Jobs cannot get completed
```
root@paksashvili-master-0:~# k get po -n d8-operator-trivy 
NAME                                        READY   STATUS      RESTARTS   AGE
operator-76ffdd47d6-87b77                   2/2     Running     0          31m
scan-vulnerabilityreport-56d7ddd967-qwcls   0/1     Completed   0          29m
scan-vulnerabilityreport-5cc56f4945-z6ztg   0/1     Completed   0          28m
scan-vulnerabilityreport-849f767785-g6t6d   0/1     Completed   0          28m
scan-vulnerabilityreport-84dc9cf8d9-p4bpd   0/1     Completed   0          29m
scan-vulnerabilityreport-9c9cd7ccc-j7l7n    0/1     Completed   0          28m
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: operator-trivy
type: fix
summary: Fix operator-trivy does not respect k8s 1.31+.
```
