### PR TITLE
[dhctl] Fix staticinstance ip duplication preflight check

### DIFF
--- a/dhctl/pkg/preflight/staticinstances_ip_duplication.go
+++ b/dhctl/pkg/preflight/staticinstances_ip_duplication.go
@@ -17,13 +17,13 @@ package preflight
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 	"gopkg.in/yaml.v3"
 )
 
 func (pc *Checker) CheckStaticInstancesIPDuplication(_ context.Context) error {
-	documents := strings.Split(pc.metaConfig.ResourcesYAML, "---")
+	documents := input.YAMLSplitRegexp.Split(pc.metaConfig.ResourcesYAML, -1)
 	instances := make(map[string]string)
 	for _, doc := range documents {
 		var result map[string]interface{}


### PR DESCRIPTION
## Description

Fix the issue that check can fail if somewhere in `resources.yaml` three minus signs in a row are used not for split yaml

## Why do we need it, and what problem does it solve?

Fix false-positive preflight fails

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix false-positive staticinstance ip duplication preflight checks fails.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
