### PR TITLE
[docs] Update hugo image in script for local module docs running

### DIFF
--- a/tools/docs/run_external_modules.sh
+++ b/tools/docs/run_external_modules.sh
@@ -60,7 +60,7 @@ function prepare_channels() {
 }
 
 function run_hugo() {
-    docker run --rm -p 1313:1313 -v $BUILDER_TEMPLATE_PATH:/src klakegg/hugo:0.111.3-ext-alpine server --renderToDisk --disableFastRender --environment production
+    docker run --rm -p 1313:1313 -v $BUILDER_TEMPLATE_PATH:/src -w /src cibuilds/hugo:0.147.7 hugo server --disableFastRender --environment production
 }
 
 if [ "$1" = "clean" ]; then


### PR DESCRIPTION
## Description

This pull request updates the Docker image used for running Hugo in the `tools/docs/run_external_modules.sh` script to ensure compatibility with newer versions and improve stability.

Key change:

* Updated the Docker image from `klakegg/hugo:0.111.3-ext-alpine` to `cibuilds/hugo:0.147.7` in the `run_hugo` function. Additionally, the working directory (`-w /src`) was specified to align with the new image's requirements.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Updates hugo image in the script for local run modules docs.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
