### PR TITLE
[cni-cilium] fix CiliumLocalRedirectPolicy

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/010-fix-cilium-local-redirect-policy.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/010-fix-cilium-local-redirect-policy.patch
@@ -1,0 +1,34 @@
+diff --git a/pkg/redirectpolicy/manager.go b/pkg/redirectpolicy/manager.go
+index 9c12fd38cc..dc50d56f83 100644
+--- a/pkg/redirectpolicy/manager.go
++++ b/pkg/redirectpolicy/manager.go
+@@ -758,16 +758,24 @@ func (rpm *Manager) upsertService(config *LRPConfig, frontendMapping *feMapping)
+ 			L3n4Addr: be.L3n4Addr,
+ 		})
+ 	}
++	LoadBalancerAlgorithm := lb.ToSVCLoadBalancingAlgorithm(option.Config.NodePortAlg)
++	if LoadBalancerAlgorithm == lb.SVCLoadBalancingAlgorithmUndef {
++		log.WithFields(logrus.Fields{
++			"service": config.id.Name,
++		}).Warn("LoadBalancer algorithm not configured, falling back to random")
++		LoadBalancerAlgorithm = lb.SVCLoadBalancingAlgorithmRandom
++	}
+ 	p := &lb.SVC{
+ 		Name: lb.ServiceName{
+ 			Name:      config.id.Name + localRedirectSvcStr,
+ 			Namespace: config.id.Namespace,
+ 		},
+-		Type:             lb.SVCTypeLocalRedirect,
+-		Frontend:         frontendAddr,
+-		Backends:         backendAddrs,
+-		ExtTrafficPolicy: lb.SVCTrafficPolicyCluster,
+-		IntTrafficPolicy: lb.SVCTrafficPolicyCluster,
++		Type:                  lb.SVCTypeLocalRedirect,
++		Frontend:              frontendAddr,
++		Backends:              backendAddrs,
++		ExtTrafficPolicy:      lb.SVCTrafficPolicyCluster,
++		IntTrafficPolicy:      lb.SVCTrafficPolicyCluster,
++		LoadBalancerAlgorithm: LoadBalancerAlgorithm,
+ 	}
+ 
+ 	if _, _, err := rpm.svcManager.UpsertService(p); err != nil {

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -50,3 +50,7 @@ Please remove this change after `CES` becomes Stable. <https://github.com/cilium
 ## 009-wireguard-port.patch
 
 Changing the hardcoded wireguard port from `51871` to `4287` (a port within our range).
+
+## 010-fix-cilium-local-redirect-policy.patch
+
+When the `bpf-lb-algorithm-annotation` option is enabled, the `CiliumLocalRedirectPolicy` in Cilium version 1.17.4 stops working. This patch solves the problem with the way the LoadBalancerAlgorithm processes.


### PR DESCRIPTION
## Description

If the `bpf-lb-algorithm-annotation` parameter is enabled in Cilium settings, `CiliumLocalRedirectPolicy` stops working. This affects the DNS service because `CiliumLocalRedirectPolicy` is used for redirecting DNS traffic to `node-local-dns` pods.

## Why do we need it, and what problem does it solve?

Enabling the `bpf-lb-algorithm-annotation` parameter is required for PR #13867, where we introduce a custom "Least Connections" algorithm and enable per-service load balancing algorithm selection.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Fixed CiliumLocalRedirectPolicy working if bpf-lb-algorithm-annotation parameter is enabled.
impact_level: default
```