### PR TITLE
[Prometheus]  Increase target samples limit for aggregation-proxy

### DIFF
--- a/modules/300-prometheus/templates/aggregating-proxy/servicemonitor.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
 spec:
   jobLabel: app
-  sampleLimit: 1500
+  sampleLimit: 3000
   endpoints:
     - port: https
       scheme: https


### PR DESCRIPTION
## Description
This PR increases the number of samples limit for the aggregation-proxy component from 1500 to a higher value to better handle large clusters with significant metrics volume.

## Why do we need it, and what problem does it solve?
In large clusters with huge amount of metrics, the previous limit of 1500 samples proved insufficient, causing metrics collection issues. The new higher limit will:
- Prevent metrics loss in large environments

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Increased target samples limit for aggregation-proxy
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
