### PR TITLE
[deckhouse] Change deckhouse pod resource and add alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3437,6 +3437,17 @@ alerts:
         Alerting dead man's switch.
       severity: "4"
       markupFormat: default
+    - name: DeckhouseHighMemoryUsage
+      sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+      moduleUrl: 340-monitoring-deckhouse
+      module: monitoring-deckhouse
+      edition: ce
+      description: |
+        Deckhouse memory usage is too high.
+      summary: |
+        Deckhouse pod {{ $labels.pod }} on node {{ $labels.node }} has high memory usage.  Please, if possible, get the memory dump for debugging purpose: curl -s &quot;http://$(kubectl -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/heap?seconds=60&quot; &gt; /tmp/heap and send this file (/tmp/heap) to the support team.
+      severity: "3"
+      markupFormat: markdown
     - name: DeckhouseModuleUpdatingFailedBrokenSequence
       sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
       moduleUrl: 340-monitoring-deckhouse

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -1,14 +1,14 @@
 {{- define "deckhouse_resources" }}
-{{- if and (.Values.global.enabledModules | has "vertical-pod-autoscaler") (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+{{- if or (.Values.global.discovery.apiVersions | has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 cpu: 100m
-memory: 1000Mi
+memory: 300Mi
 {{- else }}
 cpu: 150m
-memory: 1000Mi
+memory: 600Mi
 {{- end }}
 {{- end }}
 
-{{- if and (.Values.global.enabledModules | has "vertical-pod-autoscaler") (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+{{- if or (.Values.global.discovery.apiVersions | has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -26,15 +26,16 @@ spec:
     kind: Deployment
     name: deckhouse
   updatePolicy:
-    updateMode: "Initial"
+    updateMode: "Auto"
   resourcePolicy:
     containerPolicies:
     - containerName: deckhouse
+      controlledValues: RequestsOnly
       minAllowed:
         {{- include "deckhouse_resources" . | nindent 8 }}
       maxAllowed:
         cpu: 1000m
-        memory: 2000Mi
+        memory: 1500Mi
     {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
 {{- end }}
 ---
@@ -109,7 +110,7 @@ spec:
         {{- .Values.deckhouse.tolerations | toYaml | nindent 8 }}
         - key: node.deckhouse.io/uninitialized
           operator: "Exists"
-          effect: "NoSchedule"        
+          effect: "NoSchedule"
 {{- else }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
 {{- end }}
@@ -246,7 +247,7 @@ spec:
               value: "/chroot"
 {{- end }}
             - name: TRACING_OTLP_ENDPOINT
-              valueFrom: 
+              valueFrom:
                 secretKeyRef:
                   name: d8-otlp-tracing
                   key: endpoint
@@ -271,6 +272,8 @@ spec:
             periodSeconds: 5
             failureThreshold: 120
           resources:
+            limits:
+              memory: 6Gi # heavy load usage ~1.5Gi (x4)
             requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 100 | nindent 14 }}
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
@@ -315,7 +318,7 @@ spec:
                     namespace: d8-system
                     apiGroup: apps
                     apiVersion: v1
-                    resource: deployment
+                    resource: deployments
                     subresource: http
                     name: debugSrv
           ports:

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -293,3 +293,18 @@
         ```bash
         kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
         ```
+
+  - alert: DeckhouseHighMemoryUsage
+    expr: max by (pod, node) (container_memory_working_set_bytes{namespace="d8-system", container="deckhouse"} / container_spec_memory_limit_bytes{namespace="d8-system", container="deckhouse"} > 0.9)
+    for: 1m
+    labels:
+      severity_level: "3"
+    annotations:
+      plk_markup_format: "markdown"
+      plk_protocol_version: "1"
+      summary: |
+        Deckhouse pod `{{ $labels.pod }}` on node `{{ $labels.node }}` has high memory usage.
+
+        Please, if possible, get the memory dump for debugging purpose: `curl -s "http://$(kubectl -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/heap?seconds=60" > /tmp/heap` and send this file (/tmp/heap) to the support team.
+      description: |
+        Deckhouse memory usage is too high.


### PR DESCRIPTION
## Description
According to the research: https://loop.flant.ru/flant/pl/1qzum1k5gbdpjqeutkeq5in3za
Deckhouse need around 300-400Mi for normal usage.
Also, based on the monitoring metrics 
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/02955738-8341-4f21-b365-f6a7345ae40b" />
heavy usage is around 1.5-2Gi of memory.

## Why do we need it, and what problem does it solve?
So, I guess we can change requests for the deckhouse. And set limit x3 of maximum requests.
Also, add an alert to have a change to get memory dump before the OOM.
It's much better to restart deckhouse while node will get the global OOM

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Change requests and limits for the pod, based on the medium usage. Prevent node OOM in the corner cases.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
