### PR TITLE
[admission-policy-engine] Add skip-pss label

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-capabilities/constraint_pss_restricted.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-capabilities/constraint_pss_restricted.yaml
@@ -8,11 +8,16 @@ spec:
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
+    labelSelector:
+      matchExpressions:
+        - key: security.deckhouse.io/skip-pss-check
+          operator: NotIn
+          values: [ "true" ]
     namespaceSelector:
       matchExpressions:
         - key: security.deckhouse.io/pod-policy
           operator: In
-          values: 
+          values:
           - baseline
           - restricted
   parameters:

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-capabilities/test_samples/pss_restricted/allowed_with_skip_pss.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-capabilities/test_samples/pss_restricted/allowed_with_skip_pss.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: opa-disallowed
+  namespace: testns
+  labels:
+    security.deckhouse.io/skip-pss-check: "true"
+spec:
+  containers:
+    - name: nginx
+      image: nginx

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-capabilities/test_suite.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-capabilities/test_suite.yaml
@@ -41,6 +41,12 @@ tests:
         object: test_samples/pss_restricted/allowed_drop.yaml
         assertions:
           - violations: no
+      - name: example-skip-pss-label
+        inventory:
+          - ../common/test_samples/ns.yaml
+        object: test_samples/pss_restricted/allowed_with_skip_pss.yaml
+        assertions:
+          - violations: no
       - name: example-disallowed
         inventory:
           - ../common/test_samples/ns.yaml

--- a/modules/015-admission-policy-engine/templates/_helpers.tpl
+++ b/modules/015-admission-policy-engine/templates/_helpers.tpl
@@ -71,6 +71,11 @@ spec:
     kinds:
       - apiGroups: [""]
         kinds: ["Pod"]
+    labelSelector:
+      matchExpressions:
+        - key: security.deckhouse.io/skip-pss-check
+          operator: NotIn
+          values: ["true"]
     namespaceSelector:
       matchExpressions:
       {{- if eq $standard "baseline" }}

--- a/modules/015-admission-policy-engine/templates/admission.yaml
+++ b/modules/015-admission-policy-engine/templates/admission.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "deny-pods-with-skip-pss-label"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+  matchConditions:
+    - name: 'exclude-virtualization'
+      expression: '!(request.userInfo.groups.exists(e, (e == "system:serviceaccounts:d8-virtualization")))'
+  validations:
+    - expression: >-
+        (!has(object.metadata.labels) ||
+         !('security.deckhouse.io/skip-pss-check' in object.metadata.labels) ||
+         object.metadata.labels['security.deckhouse.io/skip-pss-check'] != 'true')
+      message: "Pods with label 'security.deckhouse.io/skip-pss-check=true' are not allowed"
+---
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "deny-skip-pss-label-binding"
+spec:
+  policyName: "deny-pods-with-skip-pss-label"
+  matchResources:
+    namespaceSelector: {}  # Applies to all namespaces
+  validationActions: [Deny]

--- a/modules/015-admission-policy-engine/templates/admission.yaml
+++ b/modules/015-admission-policy-engine/templates/admission.yaml
@@ -3,6 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "deny-pods-with-skip-pss-label"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "gatekeeper")) | nindent 2 }}
 spec:
   failurePolicy: Fail
   matchConstraints:
@@ -25,6 +26,7 @@ apiVersion: admissionregistration.k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "deny-skip-pss-label-binding"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "gatekeeper")) | nindent 2 }}
 spec:
   policyName: "deny-pods-with-skip-pss-label"
   matchResources:


### PR DESCRIPTION
## Description
Add label to skip PodSecurityStandard check for pods
Add policy to allow such pods only from the virtualization module

## Why do we need it, and what problem does it solve?
Virtualization pods couldn't correspond the standards.

Deny other pods to create:
```
The pods "demo" is invalid: : ValidatingAdmissionPolicy 'deny-pods-with-skip-pss-label' with binding 'deny-skip-pss-label-binding' denied request: Pods with label 'security.deckhouse.io/skip-pss-check=true' are not allowed
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: feature
summary: Add label to skip PodSecurityStandards for some pods.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
