### PR TITLE
[cloud-provider-vsphere] disable readOnlyRootFilesystem for csi-node-legacy

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/csi-legacy/controller.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/csi-legacy/controller.yaml
@@ -55,6 +55,7 @@
 {{- $_ := set $csiNodeConfig "fullname" "csi-node-legacy" }}
 {{- $_ := set $csiNodeConfig "nodeImage" $csiControllerImage }}
 {{- $_ := set $csiNodeConfig "driverFQDN" "vsphere.csi.vmware.com" }}
+{{- $_ := set $csiNodeConfig "readOnlyRootFilesystem" true }}
 {{- $_ := set $csiNodeConfig "additionalNodeEnvs" (include "csi_node_legacy_envs" . | fromYamlArray) }}
 {{- $_ := set $csiNodeConfig "additionalNodeEnvs" (include "csi_node_envs" . | fromYamlArray) }}
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
@@ -17,6 +17,7 @@ memory: 25Mi
   {{- $nodeImage := $config.nodeImage | required "$config.nodeImage is required" }}
   {{- $driverFQDN := $config.driverFQDN | required "$config.driverFQDN is required" }}
   {{- $serviceAccount := $config.serviceAccount | default "" }}
+  {{- $readOnlyRootFilesystem := $config.readOnlyRootFilesystem | default true }}
   {{- $additionalNodeVPA := $config.additionalNodeVPA }}
   {{- $additionalNodeEnvs := $config.additionalNodeEnvs }}
   {{- $additionalNodeArgs := $config.additionalNodeArgs }}
@@ -172,7 +173,7 @@ spec:
       - name: node
         securityContext:
           privileged: true
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: {{ $readOnlyRootFilesystem }}
         image: {{ $nodeImage }}
         args:
       {{- if $additionalNodeArgs }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Disable the `readOnlyRootFilesystem` option in the `securityContext` for the `node` container of `csi-node-legacy`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

`csi-node-legacy` don't start with readOnlyRootFilesystem:

```
log: exiting because of error: log: cannot create log: open /tmp/vsphere-csi.s-apimng-ks-node-tekton-pipelines-d601158f-75b58-hxt6l.root.log.WARNING.20250626-153509.1: read-only file system
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

This fix unblocks further 1.70 patch releases.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: disable readOnlyRootFilesystem for csi-node-legacy
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
