### PR TITLE
[dhctl] fix(dhctl-for-commander): fix config.ParseConfig error handling

### DIFF
--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -83,11 +83,11 @@ func (b *ClusterBootstrapper) initSSHClient() error {
 
 func (b *ClusterBootstrapper) doRunBootstrapAbort(ctx context.Context, forceAbortFromCache bool) error {
 	metaConfig, err := config.ParseConfig(app.ConfigPaths)
-	b.InfrastructureContext = infrastructure.NewContextWithProvider(infrastructureprovider.ExecutorProvider(metaConfig))
-
 	if err != nil {
 		return err
 	}
+
+	b.InfrastructureContext = infrastructure.NewContextWithProvider(infrastructureprovider.ExecutorProvider(metaConfig))
 
 	cachePath := metaConfig.CachePath()
 	log.InfoF("State config for prefix %s:  %s\n", metaConfig.ClusterPrefix, cachePath)

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
@@ -35,11 +35,11 @@ func (b *ClusterBootstrapper) BaseInfrastructure(ctx context.Context) error {
 	}
 
 	metaConfig, err := config.ParseConfig(app.ConfigPaths)
-	b.InfrastructureContext = infrastructure.NewContextWithProvider(infrastructureprovider.ExecutorProvider(metaConfig))
-
 	if err != nil {
 		return err
 	}
+
+	b.InfrastructureContext = infrastructure.NewContextWithProvider(infrastructureprovider.ExecutorProvider(metaConfig))
 
 	if metaConfig.ClusterType != config.CloudClusterType {
 		return fmt.Errorf(bootstrapPhaseBaseInfraNonCloudMessage)


### PR DESCRIPTION
## Description
Fix config.ParseConfig error handling. It will prevent panics

```
2025-06-25T21:39:32Z - [DEBUG] - Job execution failed: panic: meta config must be provided, goroutine 69 [running]:
runtime/debug.Stack()
    /usr/lib/golang/src/runtime/debug/stack.go:26 +0x5e
github.com/deckhouse/deckhouse/dhctl/pkg/server/rpc/dhctl.panicMessage({0x26f84b0, 0xc0007e32c0}, {0x1eca260, 0x26d3a50})
    /dhctl/pkg/server/rpc/dhctl/service.go:224 +0x3f
github.com/deckhouse/deckhouse/dhctl/pkg/server/rpc/dhctl.(*Service).abortSafe.func1()
    /dhctl/pkg/server/rpc/dhctl/abort.go:139 +0x51
panic({0x1eca260?, 0x26d3a50?})
    /usr/lib/golang/src/runtime/panic.go:791 +0x132
github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider.ExecutorProvider(0xc00038b240?)
    /dhctl/pkg/infrastructureprovider/get.go:37 +0x5e
github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap.(*ClusterBootstrapper).doRunBootstrapAbort(0xc0008c6750, {0x26f84b0, 0xc0007e32c0}, 0x0)
    /dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go:86 +0x99
github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap.(*ClusterBootstrapper).Abort.func1()
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix dhctl output in case of invalid config
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
