### PR TITLE
[cloud-provider-vsphere] add /tmp emptyDir for csi-node-legacy

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/csi-legacy/controller.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/csi-legacy/controller.yaml
@@ -53,7 +53,7 @@
 
 {{- define "csi_node_legacy_volumes" }}
 - name: tmp
-  emptyDir:
+  emptyDir: {}
 {{- end }}
 
 {{- define "csi_node_legacy_volume_mounts" }}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/csi-legacy/controller.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/csi-legacy/controller.yaml
@@ -51,12 +51,24 @@
 {{- include "helm_lib_envs_for_proxy" . }}
 {{- end }}
 
+{{- define "csi_node_legacy_volumes" }}
+- name: tmp
+  emptyDir:
+{{- end }}
+
+{{- define "csi_node_legacy_volume_mounts" }}
+- mountPath: /tmp
+  name: tmp
+{{- end }}
+
 {{- $csiNodeConfig := dict }}
 {{- $_ := set $csiNodeConfig "fullname" "csi-node-legacy" }}
 {{- $_ := set $csiNodeConfig "nodeImage" $csiControllerImage }}
 {{- $_ := set $csiNodeConfig "driverFQDN" "vsphere.csi.vmware.com" }}
 {{- $_ := set $csiNodeConfig "additionalNodeEnvs" (include "csi_node_legacy_envs" . | fromYamlArray) }}
 {{- $_ := set $csiNodeConfig "additionalNodeEnvs" (include "csi_node_envs" . | fromYamlArray) }}
+{{- $_ := set $csiNodeConfig "additionalNodeVolumes" (include "csi_node_legacy_volumes" . | fromYamlArray) }}
+{{- $_ := set $csiNodeConfig "additionalNodeVolumeMounts" (include "csi_node_legacy_volume_mounts" . | fromYamlArray) }}
 
 {{- if ne .Values.cloudProviderVsphere.internal.compatibilityFlag "none" }}
 {{- include "helm_lib_csi_node_manifests" (list . $csiNodeConfig) }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add /tmp emptyDir for csi-node-legacy for the `node` container of `csi-node-legacy`.

This PR is analog for https://github.com/deckhouse/deckhouse/pull/14197 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

`csi-node-legacy` needs to write files in /tmp

```
log: exiting because of error: log: cannot create log: open /tmp/vsphere-csi.s-apimng-ks-node-tekton-pipelines-d601158f-75b58-hxt6l.root.log.WARNING.20250626-153509.1: read-only file system
```


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: Add /tmp emptyDir for csi-node-legacy
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
