### PR TITLE
[istio] Examples for redefine limit/request on sidecars in pod/deployment

### DIFF
--- a/modules/110-istio/docs/EXAMPLES.md
+++ b/modules/110-istio/docs/EXAMPLES.md
@@ -671,7 +671,7 @@ To automate istio-sidecar upgrading, set a label `istio.deckhouse.io/auto-upgrad
 
 You can override the global istio-proxy sidecar resource limits for specific workloads by adding annotations to your application Pods.
 
-### Supported Annotations
+### Supported annotations
 
 Use these annotations to customize sidecar resources:
 | Annotation                          | Description                 | Example Value |

--- a/modules/110-istio/docs/EXAMPLES.md
+++ b/modules/110-istio/docs/EXAMPLES.md
@@ -666,3 +666,108 @@ kubectl get pods -A -o json | jq --arg revision "v1x19" \
 {% alert level="warning" %}Available only in Enterprise Edition.{% endalert %}
 
 To automate istio-sidecar upgrading, set a label `istio.deckhouse.io/auto-upgrade="true"` on the application `Namespace` or on the individual resources — `Deployment`, `DaemonSet` or `StatefulSet`.
+
+## Customizing Istio Sidecar Resources
+
+You can override the global Istio sidecar resource limits for specific workloads by adding annotations to your Deployment, ReplicaSet, or Pod resources.
+
+### Supported Annotations
+Use these annotations to customize sidecar resources:
+| Annotation                          | Description                 | Example Value |
+|-------------------------------------|-----------------------------|---------------|
+| `sidecar.istio.io/proxyCPU`         | CPU request for sidecar     | `200m`        |
+| `sidecar.istio.io/proxyCPULimit`    | CPU limit for sidecar       | `"1"`         |
+| `sidecar.istio.io/proxyMemory`      | Memory request for sidecar  | `128Mi`       |
+| `sidecar.istio.io/proxyMemoryLimit` | Memory limit for sidecar    | `512Mi`       |
+
+### Configuration Examples
+
+For Deployments:
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    sidecar.istio.io/proxyCPU: 200m
+    sidecar.istio.io/proxyCPULimit: "1"
+    sidecar.istio.io/proxyMemory: 128Mi
+    sidecar.istio.io/proxyMemoryLimit: 512Mi
+# ... rest of your deployment spec
+```
+
+For ReplicaSets:
+```yaml
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  annotations:
+    sidecar.istio.io/proxyCPU: 200m
+    sidecar.istio.io/proxyCPULimit: "1"
+    sidecar.istio.io/proxyMemory: 128Mi
+    sidecar.istio.io/proxyMemoryLimit: 512Mi
+# ... rest of your replicaset spec
+```
+
+For Pod:
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    sidecar.istio.io/proxyCPU: 200m
+    sidecar.istio.io/proxyCPULimit: "1"
+    sidecar.istio.io/proxyMemory: 128Mi
+    sidecar.istio.io/proxyMemoryLimit: 512Mi
+# ... rest of your pod spec
+```
+
+{% alert level="warning" %}All four parameters must be defined together - if you set any of these annotations, you must specify all four (proxyCPU, proxyCPULimit, proxyMemory, and proxyMemoryLimit).{% endalert %}
+
+<!-- There are parameters for setting Sidecars limits and requests (#specify link). These are global settings and they may differ for different high-load applications. To redefine the global settings of Sidecars limits and requests, you can use the addition of `Deployment`, `ReplicaSet`, or `Pod` resources to the `annotations`:
+* `sidecar.istio.io/proxyCPU` - Requested CPU for sidecar container
+* `sidecar.istio.io/proxyCPULimit` - Requested CPU limit for sidecar container
+* `sidecar.istio.io/proxyMemory` - Requested memory for sidecar container
+* `sidecar.istio.io/proxyMemoryLimit` - Requested memory limit for sidecar container
+
+For `Deployment`:
+```shell
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+    sidecar.istio.io/proxyCPU: 200m
+    sidecar.istio.io/proxyCPULimit: "1"
+    sidecar.istio.io/proxyMemory: 128Mi
+    sidecar.istio.io/proxyMemoryLimit: 512Mi
+```
+
+For `ReplicaSet`:
+```shell
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  annotations:
+    deployment.kubernetes.io/desired-replicas: "1"
+    deployment.kubernetes.io/max-replicas: "2"
+    deployment.kubernetes.io/revision: "1"
+    sidecar.istio.io/proxyCPU: 200m
+    sidecar.istio.io/proxyCPULimit: "1"
+    sidecar.istio.io/proxyMemory: 128Mi
+    sidecar.istio.io/proxyMemoryLimit: 512Mi
+```
+
+For `Pod`:
+```shell
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    istio.io/rev: v1x21
+    sidecar.istio.io/proxyCPU: 200m
+    sidecar.istio.io/proxyCPULimit: "1"
+    sidecar.istio.io/proxyMemory: 128Mi
+    sidecar.istio.io/proxyMemoryLimit: 512Mi
+```
+
+{% alert level="warning" %}For this functionality to work, all parameters must be redefined `sidecar.istio.io/proxyCPU`, `sidecar.istio.io/proxyCPULimit`, `sidecar.istio.io/proxyMemory`, `sidecar.istio.io/proxyMemoryLimit`.{% endalert %} -->

--- a/modules/110-istio/docs/EXAMPLES.md
+++ b/modules/110-istio/docs/EXAMPLES.md
@@ -689,11 +689,15 @@ For Deployments:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    sidecar.istio.io/proxyCPU: 200m
-    sidecar.istio.io/proxyCPULimit: "1"
-    sidecar.istio.io/proxyMemory: 128Mi
-    sidecar.istio.io/proxyMemoryLimit: 512Mi
+  ...
+spec:
+  template:
+    metadata:
+      annotations:
+          sidecar.istio.io/proxyCPU: 200m
+          sidecar.istio.io/proxyCPULimit: "1"
+          sidecar.istio.io/proxyMemory: 128Mi
+          sidecar.istio.io/proxyMemoryLimit: 512Mi
 # ... rest of your deployment spec
 ```
 

--- a/modules/110-istio/docs/EXAMPLES.md
+++ b/modules/110-istio/docs/EXAMPLES.md
@@ -673,7 +673,7 @@ You can override the global istio-proxy sidecar resource limits for specific wor
 
 ### Supported annotations
 
-Use these annotations to customize sidecar resources:
+Use these Pod annotations to customize sidecar resources:
 | Annotation                          | Description                 | Example Value |
 |-------------------------------------|-----------------------------|---------------|
 | `sidecar.istio.io/proxyCPU`         | CPU request for sidecar     | `200m`        |

--- a/modules/110-istio/docs/EXAMPLES.md
+++ b/modules/110-istio/docs/EXAMPLES.md
@@ -725,4 +725,4 @@ metadata:
 # ... rest of your pod spec
 ```
 
-{% alert level="warning" %}All four parameters must be defined together - if you set any of these annotations, you must specify all four (proxyCPU, proxyCPULimit, proxyMemory, and proxyMemoryLimit).{% endalert %}
+{% alert level="warning" %}All four parameters must be defined together - if you set any of these annotations, you must specify all four (`sidecar.istio.io/proxyCPU`, `sidecar.istio.io/proxyCPULimit`, `sidecar.istio.io/proxyMemory`, and `sidecar.istio.io/proxyMemoryLimit`).{% endalert %}

--- a/modules/110-istio/docs/EXAMPLES.md
+++ b/modules/110-istio/docs/EXAMPLES.md
@@ -669,7 +669,7 @@ To automate istio-sidecar upgrading, set a label `istio.deckhouse.io/auto-upgrad
 
 ## Customizing istio-proxy sidecar resource management
 
-You can override the global Istio sidecar resource limits for specific workloads by adding annotations to your Deployment, ReplicaSet, or Pod resources.
+You can override the global istio-proxy sidecar resource limits for specific workloads by adding annotations to your application Pods.
 
 ### Supported Annotations
 

--- a/modules/110-istio/docs/EXAMPLES.md
+++ b/modules/110-istio/docs/EXAMPLES.md
@@ -667,7 +667,7 @@ kubectl get pods -A -o json | jq --arg revision "v1x19" \
 
 To automate istio-sidecar upgrading, set a label `istio.deckhouse.io/auto-upgrade="true"` on the application `Namespace` or on the individual resources — `Deployment`, `DaemonSet` or `StatefulSet`.
 
-## Customizing Istio Sidecar Resources
+## Customizing istio-proxy sidecar resource management
 
 You can override the global Istio sidecar resource limits for specific workloads by adding annotations to your Deployment, ReplicaSet, or Pod resources.
 

--- a/modules/110-istio/docs/EXAMPLES.md
+++ b/modules/110-istio/docs/EXAMPLES.md
@@ -672,6 +672,7 @@ To automate istio-sidecar upgrading, set a label `istio.deckhouse.io/auto-upgrad
 You can override the global Istio sidecar resource limits for specific workloads by adding annotations to your Deployment, ReplicaSet, or Pod resources.
 
 ### Supported Annotations
+
 Use these annotations to customize sidecar resources:
 | Annotation                          | Description                 | Example Value |
 |-------------------------------------|-----------------------------|---------------|
@@ -683,7 +684,7 @@ Use these annotations to customize sidecar resources:
 ### Configuration Examples
 
 For Deployments:
-```yaml
+```shell
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -696,7 +697,7 @@ metadata:
 ```
 
 For ReplicaSets:
-```yaml
+```shell
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
@@ -709,7 +710,7 @@ metadata:
 ```
 
 For Pod:
-```yaml
+```shell
 apiVersion: v1
 kind: Pod
 metadata:

--- a/modules/110-istio/docs/EXAMPLES.md
+++ b/modules/110-istio/docs/EXAMPLES.md
@@ -684,6 +684,7 @@ Use these annotations to customize sidecar resources:
 ### Configuration Examples
 
 For Deployments:
+
 ```shell
 apiVersion: apps/v1
 kind: Deployment
@@ -697,6 +698,7 @@ metadata:
 ```
 
 For ReplicaSets:
+
 ```shell
 apiVersion: apps/v1
 kind: ReplicaSet
@@ -710,6 +712,7 @@ metadata:
 ```
 
 For Pod:
+
 ```shell
 apiVersion: v1
 kind: Pod
@@ -723,52 +726,3 @@ metadata:
 ```
 
 {% alert level="warning" %}All four parameters must be defined together - if you set any of these annotations, you must specify all four (proxyCPU, proxyCPULimit, proxyMemory, and proxyMemoryLimit).{% endalert %}
-
-<!-- There are parameters for setting Sidecars limits and requests (#specify link). These are global settings and they may differ for different high-load applications. To redefine the global settings of Sidecars limits and requests, you can use the addition of `Deployment`, `ReplicaSet`, or `Pod` resources to the `annotations`:
-* `sidecar.istio.io/proxyCPU` - Requested CPU for sidecar container
-* `sidecar.istio.io/proxyCPULimit` - Requested CPU limit for sidecar container
-* `sidecar.istio.io/proxyMemory` - Requested memory for sidecar container
-* `sidecar.istio.io/proxyMemoryLimit` - Requested memory limit for sidecar container
-
-For `Deployment`:
-```shell
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-    sidecar.istio.io/proxyCPU: 200m
-    sidecar.istio.io/proxyCPULimit: "1"
-    sidecar.istio.io/proxyMemory: 128Mi
-    sidecar.istio.io/proxyMemoryLimit: 512Mi
-```
-
-For `ReplicaSet`:
-```shell
-apiVersion: apps/v1
-kind: ReplicaSet
-metadata:
-  annotations:
-    deployment.kubernetes.io/desired-replicas: "1"
-    deployment.kubernetes.io/max-replicas: "2"
-    deployment.kubernetes.io/revision: "1"
-    sidecar.istio.io/proxyCPU: 200m
-    sidecar.istio.io/proxyCPULimit: "1"
-    sidecar.istio.io/proxyMemory: 128Mi
-    sidecar.istio.io/proxyMemoryLimit: 512Mi
-```
-
-For `Pod`:
-```shell
-apiVersion: v1
-kind: Pod
-metadata:
-  annotations:
-    istio.io/rev: v1x21
-    sidecar.istio.io/proxyCPU: 200m
-    sidecar.istio.io/proxyCPULimit: "1"
-    sidecar.istio.io/proxyMemory: 128Mi
-    sidecar.istio.io/proxyMemoryLimit: 512Mi
-```
-
-{% alert level="warning" %}For this functionality to work, all parameters must be redefined `sidecar.istio.io/proxyCPU`, `sidecar.istio.io/proxyCPULimit`, `sidecar.istio.io/proxyMemory`, `sidecar.istio.io/proxyMemoryLimit`.{% endalert %} -->

--- a/modules/110-istio/docs/EXAMPLES.md
+++ b/modules/110-istio/docs/EXAMPLES.md
@@ -707,12 +707,16 @@ For ReplicaSets:
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-  annotations:
-    sidecar.istio.io/proxyCPU: 200m
-    sidecar.istio.io/proxyCPULimit: "1"
-    sidecar.istio.io/proxyMemory: 128Mi
-    sidecar.istio.io/proxyMemoryLimit: 512Mi
-# ... rest of your replicaset spec
+  ...
+spec:
+  template:
+    metadata:
+      annotations:
+          sidecar.istio.io/proxyCPU: 200m
+          sidecar.istio.io/proxyCPULimit: "1"
+          sidecar.istio.io/proxyMemory: 128Mi
+          sidecar.istio.io/proxyMemoryLimit: 512Mi
+# ... rest of your deployment spec
 ```
 
 For Pod:

--- a/modules/110-istio/docs/EXAMPLES_RU.md
+++ b/modules/110-istio/docs/EXAMPLES_RU.md
@@ -669,3 +669,59 @@ kubectl get pods -A -o json | jq --arg revision "v1x19" \
 {% alert level="warning" %}Доступно в редакциях Enterprise Edition и Certified Security Edition Pro (1.67).{% endalert %}
 
 Для автоматизации обновления istio-sidecar'ов установите лейбл `istio.deckhouse.io/auto-upgrade="true"` на `Namespace` либо на отдельный ресурс — `Deployment`, `DaemonSet` или `StatefulSet`.
+
+## Настройка ресурсов Sidecar в Istio
+
+Для переопределения глобальных ограничений ресурсов для Sidecar в отдельных рабочих нагрузках через аннотации, поддерживаются следующие аннотации:
+
+### Поддерживаемые аннотации
+
+| Аннотация                          | Описание                     | Пример значения |
+|-------------------------------------|-----------------------------|---------------|
+| `sidecar.istio.io/proxyCPU`         | Запрос CPU для sidecar      | `200m`        |
+| `sidecar.istio.io/proxyCPULimit`    | Лимит CPU для sidecar       | `"1"`         |
+| `sidecar.istio.io/proxyMemory`      | Запрос памяти для sidecar   | `128Mi`       |
+| `sidecar.istio.io/proxyMemoryLimit` | Лимит памяти для sidecar    | `512Mi`       |
+
+### Примеры конфигурации
+
+Для Deployment:
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    sidecar.istio.io/proxyCPU: 200m
+    sidecar.istio.io/proxyCPULimit: "1"
+    sidecar.istio.io/proxyMemory: 128Mi
+    sidecar.istio.io/proxyMemoryLimit: 512Mi
+# ... остальная часть манифеста
+```
+
+Для ReplicaSet:
+```
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  annotations:
+    sidecar.istio.io/proxyCPU: 200m
+    sidecar.istio.io/proxyCPULimit: "1"
+    sidecar.istio.io/proxyMemory: 128Mi
+    sidecar.istio.io/proxyMemoryLimit: 512Mi
+# ... остальная часть манифеста
+```
+
+Для Pod:
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    sidecar.istio.io/proxyCPU: 200m
+    sidecar.istio.io/proxyCPULimit: "1"
+    sidecar.istio.io/proxyMemory: 128Mi
+    sidecar.istio.io/proxyMemoryLimit: 512Mi
+# ... остальная часть манифеста
+```
+
+{% alert level="warning" %}Все четыре параметра должны быть указаны вместе - proxyCPU, proxyCPULimit, proxyMemory, and proxyMemoryLimit. Частичная конфигурация не поддерживается.{% endalert %}

--- a/modules/110-istio/docs/EXAMPLES_RU.md
+++ b/modules/110-istio/docs/EXAMPLES_RU.md
@@ -727,4 +727,4 @@ metadata:
 # ... остальная часть манифеста
 ```
 
-{% alert level="warning" %}Все четыре параметра должны быть указаны вместе - proxyCPU, proxyCPULimit, proxyMemory, and proxyMemoryLimit. Частичная конфигурация не поддерживается.{% endalert %}
+{% alert level="warning" %}Все четыре параметра должны быть указаны вместе - `sidecar.istio.io/proxyCPU`, `sidecar.istio.io/proxyCPULimit`, `sidecar.istio.io/proxyMemory`, and `sidecar.istio.io/proxyMemoryLimit`. Частичная конфигурация не поддерживается.{% endalert %}

--- a/modules/110-istio/docs/EXAMPLES_RU.md
+++ b/modules/110-istio/docs/EXAMPLES_RU.md
@@ -686,6 +686,7 @@ kubectl get pods -A -o json | jq --arg revision "v1x19" \
 ### Примеры конфигурации
 
 Для Deployment:
+
 ```shell
 apiVersion: apps/v1
 kind: Deployment
@@ -699,6 +700,7 @@ metadata:
 ```
 
 Для ReplicaSet:
+
 ```shell
 apiVersion: apps/v1
 kind: ReplicaSet
@@ -712,6 +714,7 @@ metadata:
 ```
 
 Для Pod:
+
 ```shell
 apiVersion: v1
 kind: Pod

--- a/modules/110-istio/docs/EXAMPLES_RU.md
+++ b/modules/110-istio/docs/EXAMPLES_RU.md
@@ -686,7 +686,7 @@ kubectl get pods -A -o json | jq --arg revision "v1x19" \
 ### Примеры конфигурации
 
 Для Deployment:
-```yaml
+```shell
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -699,7 +699,7 @@ metadata:
 ```
 
 Для ReplicaSet:
-```
+```shell
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
@@ -712,7 +712,7 @@ metadata:
 ```
 
 Для Pod:
-```
+```shell
 apiVersion: v1
 kind: Pod
 metadata:

--- a/modules/110-istio/docs/EXAMPLES_RU.md
+++ b/modules/110-istio/docs/EXAMPLES_RU.md
@@ -670,9 +670,9 @@ kubectl get pods -A -o json | jq --arg revision "v1x19" \
 
 Для автоматизации обновления istio-sidecar'ов установите лейбл `istio.deckhouse.io/auto-upgrade="true"` на `Namespace` либо на отдельный ресурс — `Deployment`, `DaemonSet` или `StatefulSet`.
 
-## Настройка ресурсов Sidecar в Istio
+## Настройка ресурсов istio-proxy sidecar
 
-Для переопределения глобальных ограничений ресурсов для Sidecar в отдельных рабочих нагрузках через аннотации, поддерживаются следующие аннотации:
+Для переопределения глобальных ограничений ресурсов для istio-proxy sidecar в отдельных рабочих нагрузках через аннотации, поддерживаются следующие аннотации:
 
 ### Поддерживаемые аннотации
 
@@ -691,11 +691,15 @@ kubectl get pods -A -o json | jq --arg revision "v1x19" \
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    sidecar.istio.io/proxyCPU: 200m
-    sidecar.istio.io/proxyCPULimit: "1"
-    sidecar.istio.io/proxyMemory: 128Mi
-    sidecar.istio.io/proxyMemoryLimit: 512Mi
+  ...
+spec:
+  template:
+    metadata:
+      annotations:
+          sidecar.istio.io/proxyCPU: 200m
+          sidecar.istio.io/proxyCPULimit: "1"
+          sidecar.istio.io/proxyMemory: 128Mi
+          sidecar.istio.io/proxyMemoryLimit: 512Mi
 # ... остальная часть манифеста
 ```
 
@@ -705,11 +709,15 @@ metadata:
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-  annotations:
-    sidecar.istio.io/proxyCPU: 200m
-    sidecar.istio.io/proxyCPULimit: "1"
-    sidecar.istio.io/proxyMemory: 128Mi
-    sidecar.istio.io/proxyMemoryLimit: 512Mi
+  ...
+spec:
+  template:
+    metadata:
+      annotations:
+          sidecar.istio.io/proxyCPU: 200m
+          sidecar.istio.io/proxyCPULimit: "1"
+          sidecar.istio.io/proxyMemory: 128Mi
+          sidecar.istio.io/proxyMemoryLimit: 512Mi
 # ... остальная часть манифеста
 ```
 


### PR DESCRIPTION
## Description
This change adds documentation on how to redefine Istio sidecar limit/request for applications. The guidance is intended for users who need to add more resources for Istio sidecar, when is used high load application.

## Why do we need it, and what problem does it solve?
Some environments require more limits and requests for Istio Sidecar in applications than are globally specified. However, instructions on how to do this were previously missing from the documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Examples for redefine limit/request on sidecars in pod/deployment
impact_level: low
```
