### PR TITLE
[ci] move deckhouse-controller to static build

### DIFF
--- a/.werf/defines/base.tmpl
+++ b/.werf/defines/base.tmpl
@@ -283,7 +283,7 @@ import:
 {{ include "base components imports" (dict "k8sVersions" $context.k8sVersions "CandiVersionMap" $context.CandiVersionMap) }}
 shell:
   beforeInstall:
-  - apk add --no-cache findutils sed make git
+  - apk add --no-cache findutils sed make git coreutils
   {{- include "base components" (dict "Files" $context.Files "prefix" $context.prefix "k8sVersions" $context.k8sVersions) | nindent 2 }}
 
 {{- end }}

--- a/.werf/defines/base.tmpl
+++ b/.werf/defines/base.tmpl
@@ -278,12 +278,12 @@ imageSpec:
 {{- $context := . -}}
 
 image: base-for-go
-fromImage: builder/alt
+fromImage: builder/golang-alpine
 import:
 {{ include "base components imports" (dict "k8sVersions" $context.k8sVersions "CandiVersionMap" $context.CandiVersionMap) }}
 shell:
   beforeInstall:
-  - apt-get install -y golang make git gcc
+  - apk add --no-cache find sed make git
   {{- include "base components" (dict "Files" $context.Files "prefix" $context.prefix "k8sVersions" $context.k8sVersions) | nindent 2 }}
 
 {{- end }}

--- a/.werf/defines/base.tmpl
+++ b/.werf/defines/base.tmpl
@@ -283,7 +283,7 @@ import:
 {{ include "base components imports" (dict "k8sVersions" $context.k8sVersions "CandiVersionMap" $context.CandiVersionMap) }}
 shell:
   beforeInstall:
-  - apk add --no-cache findutils sed make git coreutils
+  - apk add --no-cache findutils sed make git coreutils libcap-setcap
   {{- include "base components" (dict "Files" $context.Files "prefix" $context.prefix "k8sVersions" $context.k8sVersions) | nindent 2 }}
 
 {{- end }}

--- a/.werf/defines/base.tmpl
+++ b/.werf/defines/base.tmpl
@@ -283,7 +283,7 @@ import:
 {{ include "base components imports" (dict "k8sVersions" $context.k8sVersions "CandiVersionMap" $context.CandiVersionMap) }}
 shell:
   beforeInstall:
-  - apk add --no-cache findutils sed make git coreutils libcap-setcap
+  - apk add --no-cache findutils sed make git coreutils libcap-setcap bash
   {{- include "base components" (dict "Files" $context.Files "prefix" $context.prefix "k8sVersions" $context.k8sVersions) | nindent 2 }}
 
 {{- end }}

--- a/.werf/defines/base.tmpl
+++ b/.werf/defines/base.tmpl
@@ -283,7 +283,7 @@ import:
 {{ include "base components imports" (dict "k8sVersions" $context.k8sVersions "CandiVersionMap" $context.CandiVersionMap) }}
 shell:
   beforeInstall:
-  - apk add --no-cache find sed make git
+  - apk add --no-cache findutils sed make git
   {{- include "base components" (dict "Files" $context.Files "prefix" $context.prefix "k8sVersions" $context.k8sVersions) | nindent 2 }}
 
 {{- end }}

--- a/.werf/defines/dev-prebuild.tmpl
+++ b/.werf/defines/dev-prebuild.tmpl
@@ -39,10 +39,6 @@
   add: /usr/bin/jq
   to: /usr/bin/jq
   after: setup
-- image: libs/glibc
-  add: /lib64
-  to: /lib64
-  after: setup
 - image: version-map-artifact
   add: /version_map_{{ $context.Env }}.yml
   to: /deckhouse/candi/version_map.yml

--- a/deckhouse-controller/go-build.sh
+++ b/deckhouse-controller/go-build.sh
@@ -25,7 +25,7 @@ if [ -z ${defaultKubernetesVer} ]; then
   echo "DEFAULT_KUBERNETES_VERSION is not set"
   exit 1
 fi
-GOOS=linux \
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     go build \
      -ldflags="-s -w -X 'main.DeckhouseVersion=$deckhouseVer' -X 'main.AddonOperatorVersion=$addonOpVer' -X 'main.ShellOperatorVersion=$shellOpVer' -X 'github.com/deckhouse/deckhouse/modules/040-control-plane-manager/hooks.DefaultKubernetesVersion=$defaultKubernetesVer'" \
      -o ./deckhouse-controller \


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Move deckhouse-controller to static build
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: move deckhouse-controller to static build
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
