### PR TITLE
[huaweicloud-cloud-provider] fixed documentation

### DIFF
--- a/ee/candi/cloud-providers/huaweicloud/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/huaweicloud/openapi/cluster_configuration.yaml
@@ -33,6 +33,7 @@ apiVersions:
         masterNodeGroup:
           replicas: 1
           instanceClass:
+            flavorName: m1.large
             rootDiskSize: 50
             imageName: "debian-11-genericcloud-amd64-20220911-1135"
         nodeGroups:
@@ -42,13 +43,6 @@ apiVersions:
               flavorName: m1.large
               imageName: "debian-11-genericcloud-amd64-20220911-1135"
               rootDiskSize: 50
-              configDrive: false
-              floatingIPPools:
-                - public
-                - shared
-              additionalSecurityGroups:
-                - sec_group_1
-                - sec_group_2
             zones:
               - eu-1a
               - eu-1b
@@ -114,6 +108,8 @@ apiVersions:
                   The size of a root disk in gigabytes.
 
                   This parameter also affects the type of a root disk.
+                example: 50
+                default: 50
                 type: integer
               etcdDiskSizeGb:
                 description: |


### PR DESCRIPTION
## Description
Fixed documentation and examples for huaweicloud provider
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: huaweicloud-cloud-provider
type: fix
summary: Fixed documentation and examples for huaweicloud provider
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
