### PR TITLE
[deckhouse] Use in-place memory footprint instead of range usage

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3445,7 +3445,7 @@ alerts:
       description: |
         Deckhouse memory usage is too high.
       summary: |
-        Deckhouse pod {{ $labels.pod }} on node {{ $labels.node }} has high memory usage.  Please, if possible, get the memory dump for debugging purpose: curl -s &quot;http://$(kubectl -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/heap?seconds=60&quot; &gt; /tmp/heap and send this file (/tmp/heap) to the support team.
+        Deckhouse pod {{ $labels.pod }} on node {{ $labels.node }} has high memory usage.  Please, if possible, get the memory dump for debugging purpose: curl -s &quot;http://$(kubectl -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/heap&quot; &gt; /tmp/heap and send this file (/tmp/heap) to the support team.
       severity: "3"
       markupFormat: markdown
     - name: DeckhouseModuleUpdatingFailedBrokenSequence

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -305,6 +305,6 @@
       summary: |
         Deckhouse pod `{{ $labels.pod }}` on node `{{ $labels.node }}` has high memory usage.
 
-        Please, if possible, get the memory dump for debugging purpose: `curl -s "http://$(kubectl -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/heap?seconds=60" > /tmp/heap` and send this file (/tmp/heap) to the support team.
+        Please, if possible, get the memory dump for debugging purpose: `curl -s "http://$(kubectl -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/heap" > /tmp/heap` and send this file (/tmp/heap) to the support team.
       description: |
         Deckhouse memory usage is too high.


### PR DESCRIPTION
## Description
Follow-up https://github.com/deckhouse/deckhouse/pull/14189

## Why do we need it, and what problem does it solve?
We need to the last 60 seconds usage but the whole heap footprint

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
