### PR TITLE
[registry] Use ctr for bb-rp-fetch when registry module is used

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -199,6 +199,8 @@ function main() {
   export FIRST_BASHIBLE_RUN="no"
   export NODE_GROUP="{{ .nodeGroup.name }}"
   export TMPDIR="/opt/deckhouse/tmp"
+  export REGISTRY_MODULE_ENABLE="{{ (.registry).registryModuleEnable | default "false" }}" # Deprecated
+  export REGISTRY_MODULE_ADDRESS="registry.d8-system.svc:5001" # Deprecated
 {{- if .packagesProxy }}
   export PACKAGES_PROXY_ADDRESSES="{{ .packagesProxy.addresses | join "," }}"
   export PACKAGES_PROXY_TOKEN="{{ .packagesProxy.token }}"


### PR DESCRIPTION
## Description
The registry module, in managed mode, configures mirrors using the `hosts.toml` mechanism.  
Because of this, direct access to the registry API at `registry.d8-system.svc` is unavailable.

This PR resolves the issue with downloading packages for external modules.

How it works:

- If the request goes to `registry.d8-system.svc:5001`, `ctr` is used to fetch the packages;
- Otherwise, curl is used (default behavior);

The changes affect the following functions:

- `bb-rp-fetch`;  
- `bb-rp-install` (which uses `bb-rp-fetch`);  
- `bb-rp-module-install` (which uses `bb-rp-install`);

`bb-rp-module-install` usage example:
   - ~[module sds-replicated-volum](https://github.com/deckhouse/sds-replicated-volume/blob/main/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml#L37)~. [When deckhouse version < 1.63](https://github.com/deckhouse/sds-replicated-volume/blob/main/templates/nodegroupconfiguration-drbd-install-altlinux-like.yaml#L59-L63)

## Why do we need it, and what problem does it solve?
Fixes package download issues when the registry module is in managed mode.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

`bb-rp-install`:
<img width="841" alt="image" src="https://github.com/user-attachments/assets/258da03b-520a-4146-abd4-e900c006a6b5" />

`bb-rp-fetch`:
<img width="850" alt="image" src="https://github.com/user-attachments/assets/e1c52e6d-cea9-4d1e-9555-10a4576b4b81" />

[sds-replicated-volume:v0.3.4](https://github.com/deckhouse/sds-replicated-volume/blob/v0.3.4/templates/nodegroupconfiguration-drbd-install-debian-like.yaml#L132)
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/00b3ddad-2f71-4b44-b611-d93e54637fb6" />
<img width="465" alt="image" src="https://github.com/user-attachments/assets/e54be566-0103-4d1e-bb97-54b193f3aebe" />



## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: use ctr for bb-rp-fetch
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
