### PR TITLE
[ingress-nginx] Update Ingress controller to run as deckhouse user

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/curl-chroot-wrapper.sh
+++ b/modules/402-ingress-nginx/images/controller-1-10/curl-chroot-wrapper.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-unshare  -S 101 -R /chroot /usr/bin/curl "$@"
+unshare  -S 64535 -R /chroot /usr/bin/curl "$@"

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/010-nginx-build.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/010-nginx-build.patch
@@ -276,7 +276,7 @@ diff --git a/images/nginx-1.25/rootfs/build.sh b/images/nginx-1.25/rootfs/build.
  );
 
 -adduser -S -D -H -u 101 -h /usr/local/nginx -s /sbin/nologin -G www-data -g www-data www-data
-+adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
++adduser -r -U -u 64535 -d /usr/local/nginx -s /sbin/nologin -c deckhouse deckhouse
 
  for dir in "${writeDirs[@]}"; do
    mkdir -p ${dir};

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -1,4 +1,6 @@
 {{- $controllerBranch := "controller-v1.10.4" }}
+{{- $controllerUser := "deckhouse" }}
+{{- $controllerUID := "64535" }}
 
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -216,7 +218,8 @@ shell:
   setup:
   - cp -R /usr/lib64/* /chroot/usr/lib64/
   - ln -s /usr/local/nginx/sbin/nginx /sbin/nginx
-  - adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
+  - groupadd -g {{ $controllerUID }} {{ $controllerUser }}
+  - adduser -r -u {{ $controllerUID }} -g {{ $controllerUID }} -d /usr/local/nginx -s /sbin/nologin -c {{ $controllerUser }} {{ $controllerUser }}
   - |
     bash -eu -c '
     writeDirs=(
@@ -246,13 +249,13 @@ shell:
     );
     for dir in "${writeDirs[@]}"; do
       mkdir -p ${dir};
-      chown -R www-data:www-data ${dir};
+      chown -R {{ $controllerUser }}:{{ $controllerUser }} ${dir};
     done'
   - mkdir -p /chroot/lib /chroot/lib64 /chroot/proc /chroot/usr /chroot/bin /chroot/dev /chroot/run /chroot/usr/lib64 /chroot/usr/local/modsecurity /chroot/usr/local/share
   - cp /etc/passwd /etc/group /etc/hosts /chroot/etc/
   # Create opentelemetry.toml file as it doesn't present in controller_image
   - touch /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml
-  - chown -R www-data:www-data /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml
+  - chown -R {{ $controllerUser }}:{{ $controllerUser }} /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml
   - cp -a /etc/pki /chroot/etc/pki
   - cp -a /usr/share/ca-certificates /chroot/usr/share/ca-certificates
   - cp -a /usr/bin/curl /chroot/usr/bin/curl
@@ -284,7 +287,7 @@ shell:
   - cp -a /usr/local/modsecurity/lib/libmodsecurity.* /chroot/usr/lib64/
   - cp -a /usr/local/nginx /chroot/usr/local/
   - cp -a /usr/bin/valgrind /chroot/usr/local/
-  - chown www-data:www-data /chroot/etc
+  - chown -R {{ $controllerUser }}:{{ $controllerUser }} /chroot/etc
   - cp -R /src/rootfs/etc/* /chroot/etc
   - rm -rf /src/rootfs/etc
 ---
@@ -336,10 +339,10 @@ shell:
   - cp -a /usr/lib/locale/* /chroot/usr/lib/locale/
   - rm -rf /src/rootfs/etc/
   - ln -s /usr/local/nginx/sbin/nginx /sbin/nginx
-  - adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
-  - chown www-data:www-data /usr/bin/nginx
-  - chown www-data:www-data /usr/bin/curl
-  - chown www-data:www-data /chroot/etc
+  - groupadd -g {{ $controllerUID }} {{ $controllerUser }}
+  - adduser -r -u {{ $controllerUID }} -g {{ $controllerUID }} -d /usr/local/nginx -s /sbin/nologin -c {{ $controllerUser }} {{ $controllerUser }}
+  - chown {{ $controllerUser }}:{{ $controllerUser }} /usr/bin/nginx
+  - chown {{ $controllerUser }}:{{ $controllerUser }} /usr/bin/curl
   - chmod 1777 /tmp /chroot/tmp /chroot/tmp/nginx
   - mkdir -p /chroot/var/log/valgrind
   - setcap cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
@@ -354,9 +357,9 @@ shell:
   - ln -sf /chroot/etc/ingress-controller /etc/ingress-controller
   - ln -sf /chroot/var/log/nginx /var/log/nginx
   - touch /chroot/var/log/nginx/access.log
-  - chown www-data:www-data /chroot/var/log/nginx/access.log
+  - chown {{ $controllerUser }}:{{ $controllerUser }} /chroot/var/log/nginx/access.log
   - echo "" > /chroot/etc/resolv.conf
-  - chown -R www-data:www-data /var/log /chroot/var/log /chroot/etc/resolv.conf
+  - chown -R {{ $controllerUser }}:{{ $controllerUser }} /var/log /chroot/var/log /chroot/etc/resolv.conf
   - mknod -m 0666 /chroot/dev/null c 1 3
   - mknod -m 0666 /chroot/dev/random c 1 8
   - mknod -m 0666 /chroot/dev/urandom c 1 9
@@ -378,7 +381,7 @@ shell:
 imageSpec:
   config:
     workingDir: /
-    user: "www-data"
+    user: "{{ $controllerUser }}"
     expose: ["80", "443"]
     entrypoint: ["/usr/bin/dumb-init", "--"]
     cmd: ["/nginx-ingress-controller"]

--- a/modules/402-ingress-nginx/images/controller-1-9/curl-chroot-wrapper.sh
+++ b/modules/402-ingress-nginx/images/controller-1-9/curl-chroot-wrapper.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-unshare  -S 101 -R /chroot /usr/bin/curl "$@"
+unshare  -S 64535 -R /chroot /usr/bin/curl "$@"

--- a/modules/402-ingress-nginx/images/controller-1-9/nginx-chroot-wrapper.sh
+++ b/modules/402-ingress-nginx/images/controller-1-9/nginx-chroot-wrapper.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 cat /etc/resolv.conf > /chroot/etc/resolv.conf
-unshare  -S 101 -R /chroot /usr/local/nginx/sbin/nginx "$@"
+unshare  -S 64535 -R /chroot /usr/local/nginx/sbin/nginx "$@"

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/011-nginx-build.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/011-nginx-build.patch
@@ -5,7 +5,7 @@ index 8bf372f21..fad97e00e 100755
 @@ -14,6 +14,9 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
- 
+
 +SOURCE_REPO="${SOURCE_REPO}"
 +CONTROLLER_BRANCH="${CONTROLLER_BRANCH}"
 +
@@ -14,16 +14,16 @@ index 8bf372f21..fad97e00e 100755
  set -o pipefail
 @@ -126,6 +129,7 @@ export LUA_RESTY_GLOBAL_THROTTLE_VERSION=0.2.0
  export MIMALOC_VERSION=1.7.6
- 
+
  export BUILD_PATH=/tmp/build
 +export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64/
- 
+
  ARCH=$(uname -m)
- 
+
 @@ -150,170 +154,12 @@ get_src()
    rm -rf "$f"
  }
- 
+
 -# install required packages to build
 -apk add \
 -  bash \
@@ -64,10 +64,10 @@ index 8bf372f21..fad97e00e 100755
 -  coreutils
 -
  mkdir -p /etc/nginx
- 
+
  mkdir --verbose -p "$BUILD_PATH"
  cd "$BUILD_PATH"
- 
+
 -# download, verify and extract the source files
 -get_src 66dc7081488811e9f925719e34d1b4504c2801c81dee2920e5452a86b11405ae \
 -        "https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
@@ -189,11 +189,11 @@ index 8bf372f21..fad97e00e 100755
 -get_src d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da \
 -        "https://github.com/microsoft/mimalloc/archive/refs/tags/v${MIMALOC_VERSION}.tar.gz"
 +git clone -b "$CONTROLLER_BRANCH" "${SOURCE_REPO}/kubernetes/ingress-nginx-deps.git" .
- 
+
  # improve compilation times
  CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))
 @@ -465,15 +311,16 @@ make install
- 
+
  # Get Brotli source and deps
  cd "$BUILD_PATH"
 -git clone --depth=100 https://github.com/google/ngx_brotli.git
@@ -204,15 +204,15 @@ index 8bf372f21..fad97e00e 100755
  git submodule init
 +git submodule set-url deps/brotli "${SOURCE_REPO}/google/brotli.git"
  git submodule update
- 
+
  cd "$BUILD_PATH"
 -git clone --depth=1 https://github.com/ssdeep-project/ssdeep
 +git clone --depth=1 "${SOURCE_REPO}/ssdeep-project/ssdeep"
  cd ssdeep/
- 
+
  ./bootstrap
 @@ -484,10 +331,13 @@ make install
- 
+
  # build modsecurity library
  cd "$BUILD_PATH"
 -git clone -n https://github.com/SpiderLabs/ModSecurity
@@ -224,17 +224,17 @@ index 8bf372f21..fad97e00e 100755
 +git submodule set-url others/libinjection "${SOURCE_REPO}/libinjection/libinjection.git"
 +git submodule set-url bindings/python "${SOURCE_REPO}/SpiderLabs/ModSecurity-Python-bindings.git"
  git submodule update
- 
+
  sh build.sh
 @@ -517,7 +367,7 @@ echo "SecAuditLogStorageDir /var/log/audit/" >> /etc/nginx/modsecurity/modsecuri
  # Download owasp modsecurity crs
  cd /etc/nginx/
- 
+
 -git clone -b $OWASP_MODSECURITY_CRS_VERSION https://github.com/coreruleset/coreruleset
 +git clone -b $OWASP_MODSECURITY_CRS_VERSION "${SOURCE_REPO}/coreruleset/coreruleset"
  mv coreruleset owasp-modsecurity-crs
  cd owasp-modsecurity-crs
- 
+
 @@ -582,6 +432,7 @@ WITH_FLAGS="--with-debug \
    --with-http_realip_module \
    --with-http_auth_request_module \
@@ -246,9 +246,9 @@ index 8bf372f21..fad97e00e 100755
 @@ -729,7 +580,7 @@ writeDirs=( \
    /var/log/nginx \
  );
- 
+
 -adduser -S -D -H -u 101 -h /usr/local/nginx -s /sbin/nologin -G www-data -g www-data www-data
-+adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
- 
++adduser -r -U -u 64535 -d /usr/local/nginx -s /sbin/nologin -c deckhouse deckhouse
+
  for dir in "${writeDirs[@]}"; do
    mkdir -p ${dir};

--- a/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
@@ -1,4 +1,6 @@
 {{- $controllerBranch := "controller-v1.9.5" }}
+{{- $controllerUser := "deckhouse" }}
+{{- $controllerUID := "64535" }}
 
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -278,7 +280,8 @@ shell:
   - apt-get -y install ca-certificates curl libxml2-devel libyajl libyajl-devel libmaxminddb libmaxminddb-devel libpcre-devel
   setup:
   - ln -s /usr/local/nginx/sbin/nginx /sbin/nginx
-  - adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
+  - groupadd -g {{ $controllerUID }} {{ $controllerUser }}
+  - adduser -r -u {{ $controllerUID }} -g {{ $controllerUID }} -d /usr/local/nginx -s /sbin/nologin -c {{ $controllerUser }} {{ $controllerUser }}
   - |
     bash -eu -c '
     writeDirs=(
@@ -292,7 +295,7 @@ shell:
     );
     for dir in "${writeDirs[@]}"; do
       mkdir -p ${dir};
-      chown -R www-data:www-data ${dir};
+      chown -R {{ $controllerUser }}:{{ $controllerUser }} ${dir};
     done'
   - |
     bash -eu -c '
@@ -321,13 +324,13 @@ shell:
     );
     for dir in "${writeDirs[@]}"; do
       mkdir -p ${dir};
-      chown -R www-data:www-data ${dir};
+      chown -R {{ $controllerUser }}:{{ $controllerUser }} ${dir};
     done'
   - mkdir -p /chroot/etc/nginx/geoip
   - mkdir -p /chroot/lib /chroot/proc /chroot/usr /chroot/bin /chroot/dev /chroot/run /chroot/lib64 /chroot/usr/local/modsecurity /chroot/usr/local/share
   - cp /etc/passwd /etc/group /etc/hosts /chroot/etc/
   - touch /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml
-  - chown -R www-data:www-data /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml
+  - chown -R {{ $controllerUser }}:{{ $controllerUser }} /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml
   - cp -a /etc/pki /chroot/etc/pki
   - cp -a /usr/share/ca-certificates /chroot/usr/share/ca-certificates
   - cp -a /usr/bin/curl /chroot/usr/bin/curl
@@ -356,6 +359,7 @@ shell:
   - cp -a /usr/local/modsecurity/lib/libmodsecurity.* /chroot/usr/lib64/
   - cp -a /usr/local/nginx /chroot/usr/local/
   - cp -R /src/rootfs/etc/* /chroot/etc/
+  - chown -R {{ $controllerUser }}:{{ $controllerUser }} /chroot/etc
   - rm -rf /src/rootfs/etc
   - ln -s /etc/nginx/geoip /chroot/etc/ingress-controller/geoip
 
@@ -409,9 +413,11 @@ shell:
   - export LUA_CPATH="/usr/local/lib/lua/?/?.so;/usr/local/lib/lua/?.so;;"
   - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib:/usr/local/lib64:/modules_mount/etc/nginx/modules/otel"
   - ln -s /usr/local/nginx/sbin/nginx /sbin/nginx
-  - adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
-  - chown www-data:www-data /usr/bin/nginx
-  - chown www-data:www-data /usr/bin/curl
+  - groupadd -g {{ $controllerUID }} {{ $controllerUser }}
+  - adduser -r -u {{ $controllerUID }} -g {{ $controllerUID }} -d /usr/local/nginx -s /sbin/nologin -c {{ $controllerUser }} {{ $controllerUser }}
+  - chown {{ $controllerUser }}:{{ $controllerUser }} /usr/bin/nginx
+  - chown {{ $controllerUser }}:{{ $controllerUser }} /usr/bin/curl
+  - chown -R {{ $controllerUser }}:{{ $controllerUser }} /chroot/etc
   - chmod 1777 /tmp
   - setcap cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
   - setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
@@ -431,9 +437,9 @@ shell:
   - ln -sf /chroot/var/log/nginx /var/log/nginx
   - ln -sf /chroot/modules_mount /modules_mount
   - touch /chroot/var/log/nginx/access.log
-  - chown www-data:www-data /chroot/var/log/nginx/access.log
+  - chown {{ $controllerUser }}:{{ $controllerUser }} /chroot/var/log/nginx/access.log
   - echo "" > /chroot/etc/resolv.conf
-  - chown -R www-data:www-data /var/log /chroot/var/log /chroot/etc/resolv.conf
+  - chown -R {{ $controllerUser }}:{{ $controllerUser }} /var/log /chroot/var/log /chroot/etc/resolv.conf
   - mknod -m 0666 /chroot/dev/null c 1 3
   - mknod -m 0666 /chroot/dev/random c 1 8
   - mknod -m 0666 /chroot/dev/urandom c 1 9
@@ -455,7 +461,7 @@ shell:
 imageSpec:
   config:
     workingDir: /
-    user: "www-data"
+    user: "{{ $controllerUser }}"
     expose: ["80", "443"]
     entrypoint: ["/usr/bin/dumb-init", "--"]
     cmd: ["/nginx-ingress-controller"]

--- a/modules/402-ingress-nginx/images/proxy-failover/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/proxy-failover/werf.inc.yaml
@@ -54,6 +54,15 @@ import:
 - image: {{ .ModuleName }}/nginx-static-artifact
   add: /opt/nginx-static
   before: setup
+- image: tools/libcap
+  add: /usr/sbin/setcap
+  to: /tools/setcap
+  before: setup
+shell:
+  setup:
+    - /tools/setcap cap_net_raw,cap_net_admin,cap_net_bind_service=+eip /proxy-failover-controller  # Need for run from deckhouse user
 imageSpec:
   config:
+    workingDir: /tools
+    clearWorkingDir: true # a hack to delete the setcap binary from final image
     entrypoint: ["/proxy-failover-controller"]

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -179,6 +179,8 @@ spec:
           capabilities:
             add:
             - SYS_ADMIN
+        {{- else }}
+        {{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 8 }}
         {{- end }}
         env:
         - name: POD_NAME

--- a/modules/402-ingress-nginx/templates/validator/deployment.yml
+++ b/modules/402-ingress-nginx/templates/validator/deployment.yml
@@ -77,6 +77,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple $ctx "any-node") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple $ctx "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list $ctx (dict "app" "validator" "name" $name )) | nindent 6 }}
+      {{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse" $ctx | nindent 6 }}
       serviceAccountName: validator
       automountServiceAccountToken: true
       terminationGracePeriodSeconds: 420


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The www-data user has been replaced with the deckhouse user as the owner of the process running the Ingress NGINX controller.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This change is part of a platform-wide initiative to improve security and consistency across all components of the Deckhouse platform. By standardizing process ownership under the dedicated deckhouse system user, we reduce permission fragmentation, simplify access control, and ensure uniform behavior across modules.

## Manual testing

### Checking the basic functionality of the controller.
---
1. Set options in resource ingressnginxcontrollers.deckhouse.io:
```
controllerVersion:  "1.9"
```
3. Go to grafana dashboard - it should open. Check the status of the pods, the pods open and work without restarts.

4. Repeat for versions 1.10, 1.12

---

### Checking with version 1.10 profiling enabled.

1. Set optinons in resource ingressnginxcontrollers.deckhouse.io:

```
   spec:
     nginxProfilingEnabled: true
     controllerVersion: "1.10"
```

2. Go to grafana dashboard - it should open. Check the status of the pods, the pods open and work without restarts.

3. make sure that the logs in the /var/log/valgrind directory in frontend host are present and they have information about the memory usage of the NGINX process.
---

Checking GeoIP DB download working properly for version 1.12

1. Set controller options:

```yaml
spec:
  controllerVersion: "1.12"
  geoIP2:
    maxmindEditionIDs:
    - GeoLite2-Country
    maxmindLicenseKey:  license***
```

2. Check the logs of the controller.
3. Check on the file system that the database file has appeared.
<details>
<summary>Screnshot</summary>
<img width="665" height="285" alt="image" src="https://github.com/user-attachments/assets/aa7210c5-f088-40e1-a2d9-c171961f3a23" />
</details>

---

Checking GeoIP DB download working properly for version 1.10

1. Set controller options:

```yaml
spec:
  controllerVersion: "1.10"
  geoIP2:
    maxmindEditionIDs:
    - GeoLite2-Country
    maxmindLicenseKey:  license***
```

2. Check the logs of the controller.
3. Check on the file system that the database file has appeared.
<details>
<summary>Screnshot</summary>
<img width="621" height="190" alt="image" src="https://github.com/user-attachments/assets/b88a9628-efbc-4d23-a6ad-cd8f6338bd38" />
</details>

---

Checking GeoIP DB download working properly for version 1.9

1. Set controller options:

```yaml
spec:
  controllerVersion: "1.9"
  geoIP2:
    maxmindEditionIDs:
    - GeoLite2-Country
    maxmindLicenseKey:  license***
```

2. Check the logs of the controller.
3. Check on the file system that the database file has appeared.
<details>
<summary>Screnshot</summary>
<img width="1270" height="122" alt="image" src="https://github.com/user-attachments/assets/ce2aa0ae-2fd7-4111-82ab-d2fdbd2c5850" />
</details>


Checking GeoIP DB download working properly for version 1.10 and enabled profiling by valgrind.

1. Set parameters of controller:


```yaml
  controllerVersion: "1.10"
  geoIP2:
    maxmindEditionIDs:
    - GeoLite2-Country
  nginxProfilingEnabled: true
```
2. View logs of controller

<details>
<summary>Screnshot</summary>
<img width="1471" height="490" alt="image" src="https://github.com/user-attachments/assets/a41e4a5f-41f7-4fd6-81d7-646ab7f8c2b5" />
---
<img width="921" height="108" alt="image" src="https://github.com/user-attachments/assets/cd0ecb2b-9da5-41fc-84ff-4468163e82fe" />

</details>


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: chore
summary: Ingress controller now runs under the deckhouse user (instead of www-data).
impact: Ingress-nginx Controllers will be restarted, which will cause traffic interruption.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
