### PR TITLE
[deckhouse] Always set resource requests

### DIFF
--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -272,13 +272,14 @@ spec:
             periodSeconds: 5
             failureThreshold: 120
           resources:
+            {{- if .Values.global.clusterIsBootstrapped }}
+            {{/* VPA is not exist at bootstrap and k8s will set requests == limits */}}
             limits:
               memory: 6Gi # heavy load usage ~2Gi (x3)
+            {{- end }}
             requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 100 | nindent 14 }}
-{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
               {{- include "deckhouse_resources" . | nindent 14 }}
-{{- end }}
           workingDir: /deckhouse
           volumeMounts:
           - mountPath: /tmp

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -272,11 +272,8 @@ spec:
             periodSeconds: 5
             failureThreshold: 120
           resources:
-            {{- if .Values.global.clusterIsBootstrapped }}
-            {{/* VPA is not exist at bootstrap and k8s will set requests == limits */}}
             limits:
               memory: 6Gi # heavy load usage ~2Gi (x3)
-            {{- end }}
             requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 100 | nindent 14 }}
               {{- include "deckhouse_resources" . | nindent 14 }}


### PR DESCRIPTION
## Description
Always set resource requests for deckhouse

## Why do we need it, and what problem does it solve?
Without that on bootstrap deckhouse will set request == limit and will wait for 6Gi of memory. We can set the initial requests to the container and then VPA will change them if required

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Set resource requests even if VPA is enabled.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
