### PR TITLE
[docs] Update Selectel getting started guide

### DIFF
--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.other.inc
@@ -145,9 +145,7 @@ standard:
   internalNetworkDNSServers:
     - 8.8.8.8
     - 8.8.4.4
-  # [<en>] SecurityGroups are not supported by Selectel VPC.
-  # [<ru>] SecurityGroups не поддерживаются в Selectel VPC.
-  internalNetworkSecurity: false
+  internalNetworkSecurity: true
 # [<en>] OpenStack API access parameters
 # [<ru>] параметры доступа к OpenStack API
 provider:

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.other.inc
@@ -145,9 +145,7 @@ standard:
   internalNetworkDNSServers:
     - 8.8.8.8
     - 8.8.4.4
-  # [<en>] SecurityGroups are not supported by Selectel VPC.
-  # [<ru>] SecurityGroups не поддерживаются в Selectel VPC.
-  internalNetworkSecurity: false
+  internalNetworkSecurity: true
 # [<en>] OpenStack API access parameters
 # [<ru>] параметры доступа к OpenStack API
 provider:


### PR DESCRIPTION
## Description

This PR updates the `internalNetworkSecurity` parameter in the Selectel configuration file within the getting started guide.

## Changelog entries

```changes
section: docs
type: chore
summary: Updated Selectel getting started guide.
impact_level: low
```