### PR TITLE
[cloud-provider-dvp] fix vmClassName in terraform

### DIFF
--- a/candi/cloud-providers/dvp/layouts/standard/master-node/main.tf
+++ b/candi/cloud-providers/dvp/layouts/standard/master-node/main.tf
@@ -41,26 +41,27 @@ module "ipv4-address" {
 }
 
 module "master" {
-  source                 = "../../../terraform-modules/master"
-  prefix                 = local.prefix
-  node_group             = local.node_group
-  namespace              = local.namespace
-  node_index             = local.node_index
-  root_disk              = module.root-disk
-  kubernetes_data_disk   = module.kubernetes-data-disk
-  ipv4_address           = module.ipv4-address
-  memory_size            = local.memory_size
-  bootloader             = local.bootloader
-  cpu                    = local.cpu
-  ssh_public_key         = local.ssh_public_key
-  hostname               = local.hostname
-  cluster_uuid           = local.cluster_uuid
-  additional_labels      = local.additional_labels
-  additional_annotations = local.additional_annotations
-  priority_class_name    = local.priority_class_name
-  node_selector          = local.node_selector
-  tolerations            = local.tolerations
-  region                 = local.region
-  zone                   = local.zone
-  cloud_config           = local.user_data
+  source                     = "../../../terraform-modules/master"
+  prefix                     = local.prefix
+  node_group                 = local.node_group
+  namespace                  = local.namespace
+  node_index                 = local.node_index
+  root_disk                  = module.root-disk
+  kubernetes_data_disk       = module.kubernetes-data-disk
+  ipv4_address               = module.ipv4-address
+  memory_size                = local.memory_size
+  virtual_machine_class_name = local.virtual_machine_class_name
+  bootloader                 = local.bootloader
+  cpu                        = local.cpu
+  ssh_public_key             = local.ssh_public_key
+  hostname                   = local.hostname
+  cluster_uuid               = local.cluster_uuid
+  additional_labels          = local.additional_labels
+  additional_annotations     = local.additional_annotations
+  priority_class_name        = local.priority_class_name
+  node_selector              = local.node_selector
+  tolerations                = local.tolerations
+  region                     = local.region
+  zone                       = local.zone
+  cloud_config               = local.user_data
 }

--- a/candi/cloud-providers/dvp/layouts/standard/master-node/variables.tf
+++ b/candi/cloud-providers/dvp/layouts/standard/master-node/variables.tf
@@ -55,8 +55,9 @@ locals {
     cores         = local.instance_class.virtualMachine.cpu.cores
     core_fraction = lookup(local.instance_class.virtualMachine.cpu, "coreFraction", "100%")
   }
-  memory_size = local.instance_class.virtualMachine.memory.size
-  bootloader  = lookup(local.instance_class.virtualMachine, "bootloader", null)
+  memory_size                = local.instance_class.virtualMachine.memory.size
+  virtual_machine_class_name = local.instance_class.virtualMachine.virtualMachineClassName
+  bootloader                 = lookup(local.instance_class.virtualMachine, "bootloader", null)
 
   ssh_public_key = var.providerClusterConfiguration.sshPublicKey
 

--- a/candi/cloud-providers/dvp/layouts/standard/static-node/main.tf
+++ b/candi/cloud-providers/dvp/layouts/standard/static-node/main.tf
@@ -31,25 +31,26 @@ module "ipv4-address" {
 }
 
 module "static-node" {
-  source                 = "../../../terraform-modules/static-node/"
-  prefix                 = local.prefix
-  node_group             = local.node_group
-  namespace              = local.namespace
-  node_index             = local.node_index
-  root_disk              = module.root-disk
-  ipv4_address           = module.ipv4-address
-  memory_size            = local.memory_size
-  bootloader             = local.bootloader
-  cpu                    = local.cpu
-  ssh_public_key         = local.ssh_public_key
-  hostname               = local.hostname
-  cluster_uuid           = local.cluster_uuid
-  additional_labels      = local.additional_labels
-  additional_annotations = local.additional_annotations
-  priority_class_name    = local.priority_class_name
-  node_selector          = local.node_selector
-  tolerations            = local.tolerations
-  region                 = local.region
-  zone                   = local.zone
-  cloud_config           = local.user_data
+  source                     = "../../../terraform-modules/static-node/"
+  prefix                     = local.prefix
+  node_group                 = local.node_group
+  namespace                  = local.namespace
+  node_index                 = local.node_index
+  root_disk                  = module.root-disk
+  ipv4_address               = module.ipv4-address
+  memory_size                = local.memory_size
+  virtual_machine_class_name = local.virtual_machine_class_name
+  bootloader                 = local.bootloader
+  cpu                        = local.cpu
+  ssh_public_key             = local.ssh_public_key
+  hostname                   = local.hostname
+  cluster_uuid               = local.cluster_uuid
+  additional_labels          = local.additional_labels
+  additional_annotations     = local.additional_annotations
+  priority_class_name        = local.priority_class_name
+  node_selector              = local.node_selector
+  tolerations                = local.tolerations
+  region                     = local.region
+  zone                       = local.zone
+  cloud_config               = local.user_data
 }

--- a/candi/cloud-providers/dvp/layouts/standard/static-node/variables.tf
+++ b/candi/cloud-providers/dvp/layouts/standard/static-node/variables.tf
@@ -59,7 +59,8 @@ locals {
     cores         = local.instance_class.virtualMachine.cpu.cores
     core_fraction = lookup(local.instance_class.virtualMachine.cpu, "coreFraction", "100%")
   }
-  memory_size = local.instance_class.virtualMachine.memory.size
+  memory_size                = local.instance_class.virtualMachine.memory.size
+  virtual_machine_class_name = local.instance_class.virtualMachine.virtualMachineClassName
 
   bootloader = lookup(local.instance_class.virtualMachine, "bootloader", null)
 


### PR DESCRIPTION
## Description
fix virtualMachineClassName in terraform
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
PR refinement #13779 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: fix virtualMachineClassName in terraform
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
