### PR TITLE
[deckhouse] Add experimental flag for modules

### DIFF
--- a/go_lib/dependency/extenders/experimental/experimental.go
+++ b/go_lib/dependency/extenders/experimental/experimental.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package experimental
+
+import (
+	"fmt"
+	"log/slog"
+	"strconv"
+	"sync"
+
+	"github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders"
+	scherror "github.com/flant/addon-operator/pkg/module_manager/scheduler/extenders/error"
+	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+const (
+	// Name is the identifier of the extender returned to the scheduler
+	Name extenders.ExtenderName = "Experimental"
+
+	// The label/annotation key from which the module stage is obtained.
+	// Scheduler passes module metadata as a map[string]string into Filter()
+	stageLabelKey = "stage"
+
+	// The value that denotes an experimental module
+	experimentalStageValue = "Experimental"
+)
+
+var (
+	instance *Extender
+	once     sync.Once
+)
+
+type Extender struct {
+	allowExperimental bool
+	logger            *log.Logger
+}
+
+// Instance returns a singleton extender (same pattern as other extenders)
+func Instance() *Extender {
+	once.Do(func() {
+		instance = &Extender{
+			logger:            log.Default().With("extender", Name),
+			allowExperimental: false,
+		}
+	})
+	return instance
+}
+
+// Name returns the extender identifier
+func (e *Extender) Name() extenders.ExtenderName { return Name }
+
+// IsTerminator implements Extender interface, it is used by scheduler in addon-operator
+func (e *Extender) IsTerminator() bool { return true }
+
+// AddConstraint configures the cluster‑wide flag. The scheduler is expected
+// to call it once (for example when parsing Deckhouse values)
+func (e *Extender) AddConstraint(_ string, value string) error {
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		e.logger.Debug("failed to parse allowExperimentalModules flag", slog.String("value", value))
+		return err
+	}
+
+	e.allowExperimental = parsed
+	e.logger.Debug("allowExperimentalModules flag is set", slog.Bool("allowExperimentalModules", parsed))
+	return nil
+}
+
+// DeleteConstraint is a no‑op for this extender (flag remains unchanged)
+func (e *Extender) DeleteConstraint(_ string) {}
+
+// Filter blocks installation of modules with `stage: Experimental` unless the
+// flag allowExperimentalModules is true.
+//
+// If the module stage is not Experimental - pass (return nil, nil)
+// If the stage is Experimental and the flag is false - deny with an error
+// If the stage is Experimental and the flag is true  - allow (true, nil)
+func (e *Extender) Filter(name string, labels map[string]string) (*bool, error) {
+	if labels == nil {
+		return nil, nil
+	}
+
+	stage, ok := labels[stageLabelKey]
+	if !ok || stage != experimentalStageValue {
+		return nil, nil
+	}
+
+	if e.allowExperimental {
+		e.logger.Debug("experimental module allowed", slog.String("name", name))
+		return ptr.To(true), nil
+	}
+
+	e.logger.Error("experimental module installation is forbidden by policy", slog.String("name", name))
+	return ptr.To(false), &scherror.PermanentError{Err: fmt.Errorf("installation forbidden: experimental modules are disabled (allowExperimentalModules=false)")}
+}

--- a/go_lib/dependency/extenders/experimental/experimental_test.go
+++ b/go_lib/dependency/extenders/experimental/experimental_test.go
@@ -1,0 +1,43 @@
+package experimental
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestFilter(t *testing.T) {
+	truePtr, falsePtr := ptr.To(true), ptr.To(false)
+
+	cases := []struct {
+		name   string
+		flag   bool
+		labels map[string]string
+		want   *bool
+		err    bool
+	}{
+		{"skip-non-experimental", false, map[string]string{"stage": "Stable"}, nil, false},
+		{"deny-when-flag-false", false, map[string]string{"stage": "Experimental"}, falsePtr, true},
+		{"allow-when-flag-true", true, map[string]string{"stage": "Experimental"}, truePtr, false},
+		{"no-labels", false, nil, nil, false},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			e := Instance()
+			_ = e.AddConstraint("allowExperimentalModules", strconv.FormatBool(tt.flag))
+
+			got, err := e.Filter("foo", tt.labels)
+
+			if tt.err {
+				require.Error(t, err)
+				require.Equal(t, *tt.want, *got)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/go_lib/dependency/extenders/extenders.go
+++ b/go_lib/dependency/extenders/extenders.go
@@ -25,6 +25,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/extenders/bootstrapped"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/extenders/deckhouseversion"
+	"github.com/deckhouse/deckhouse/go_lib/dependency/extenders/experimental"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/extenders/kubernetesversion"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/extenders/moduledependency"
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -35,6 +36,7 @@ type ExtendersStack struct {
 	KubernetesVersion *kubernetesversion.Extender
 	Bootstrapped      *bootstrapped.Extender
 	ModuleDependency  *moduledependency.Extender
+	Experimental      *experimental.Extender
 }
 
 func NewExtendersStack(deckhouseVersion string, logger *log.Logger) *ExtendersStack {
@@ -43,6 +45,7 @@ func NewExtendersStack(deckhouseVersion string, logger *log.Logger) *ExtendersSt
 		KubernetesVersion: kubernetesversion.Instance(),
 		Bootstrapped:      bootstrapped.Instance(),
 		ModuleDependency:  moduledependency.Instance(),
+		Experimental:      experimental.Instance(),
 	}
 }
 
@@ -52,6 +55,7 @@ func (b *ExtendersStack) GetExtenders() []extenders.Extender {
 		b.KubernetesVersion,
 		b.Bootstrapped,
 		b.ModuleDependency,
+		b.Experimental,
 	}
 }
 
@@ -97,7 +101,6 @@ func (b *ExtendersStack) DeleteConstraints(module string) {
 
 func (b *ExtendersStack) CheckModuleReleaseRequirements(moduleName, moduleRelease string, moduleReleaseVersion *semver.Version, requirements *v1alpha1.ModuleReleaseRequirements) error {
 	if requirements == nil {
-		// no requirements
 		return nil
 	}
 


### PR DESCRIPTION
## Description

This PR introduces a new `Experimental` scheduler extender that blocks the installation of modules labeled with stage: Experimental unless explicitly allowed via the `allowExperimentalModules` flag.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Deckhouse currently allows installation of modules marked as `Experimental` even in production clusters. This behavior is risky and contradicts the purpose of the stage field.

The new `Experimental` extender enforces stricter gating for these modules:

- By default, it prevents scheduling of Experimental-stage modules.
- Clusters that want to opt-in (e.g., dev/staging) can explicitly enable support via a global flag.
- This helps to avoid accidental exposure of unstable or unfinished features in production environments.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Add experimental flag for modules
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
