### PR TITLE
TEST

### DIFF
--- a/ee/candi/cloud-providers/huaweicloud/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/huaweicloud/layouts/standard/base-infrastructure/main.tf
@@ -12,6 +12,7 @@ module "network_security" {
   prefix         = local.prefix
   ssh_allow_list = local.ssh_allow_list
   enabled        = local.network_security
+  enterprise_project_id = local.enterprise_project_id
 }
 
 module "keypair" {
@@ -25,6 +26,7 @@ data "huaweicloud_availability_zones" "zones" {}
 resource "huaweicloud_vpc" "vpc" {
   name = local.prefix
   cidr = local.internal_network_cidr
+  enterprise_project_id = local.enterprise_project_id
 }
 
 resource "huaweicloud_vpc_subnet" "subnet" {
@@ -48,6 +50,7 @@ resource "huaweicloud_nat_gateway" "nat_gateway" {
   spec      = "1"
   vpc_id    = huaweicloud_vpc.vpc.id
   subnet_id = huaweicloud_vpc_subnet.subnet.id
+  enterprise_project_id = local.enterprise_project_id
 }
 
 resource "huaweicloud_nat_snat_rule" "nat_gateway_snat_rule" {
@@ -66,4 +69,6 @@ resource "huaweicloud_vpc_eip" "nat_gateway_vpc_eip" {
     size       = 100
     share_type = "PER"
   }
+
+  enterprise_project_id = local.enterprise_project_id
 }

--- a/ee/candi/cloud-providers/huaweicloud/layouts/standard/master-node/main.tf
+++ b/ee/candi/cloud-providers/huaweicloud/layouts/standard/master-node/main.tf
@@ -44,6 +44,7 @@ module "master" {
   volume_zone           = module.volume_zone.zone
   server_group          = local.server_group
   subnet                = local.prefix
+  enterprise_project_id = local.enterprise_project_id
 }
 
 module "kubernetes_data" {
@@ -55,6 +56,7 @@ module "kubernetes_data" {
   volume_type = local.volume_type
   volume_zone = module.volume_zone.zone
   tags        = local.tags
+  enterprise_project_id = local.enterprise_project_id
 }
 
 module "security_groups" {
@@ -62,6 +64,7 @@ module "security_groups" {
   security_group_names        = local.security_group_names
   layout_security_group_ids   = module.network_security_info.security_group_ids
   layout_security_group_names = module.network_security_info.security_group_names
+  enterprise_project_id = local.enterprise_project_id
 }
 
 data "huaweicloud_availability_zones" "zones" {}

--- a/ee/candi/cloud-providers/huaweicloud/layouts/standard/static-node/main.tf
+++ b/ee/candi/cloud-providers/huaweicloud/layouts/standard/static-node/main.tf
@@ -33,6 +33,7 @@ module "node" {
   server_group          = local.server_group
   node_group_name       = var.nodeGroupName
   subnet                = local.prefix
+  enterprise_project_id = local.enterprise_project_id
 }
 
 module "security_groups" {
@@ -40,6 +41,7 @@ module "security_groups" {
   security_group_names        = local.security_group_names
   layout_security_group_ids   = module.network_security_info.security_group_ids
   layout_security_group_names = module.network_security_info.security_group_names
+  enterprise_project_id = local.enterprise_project_id
 }
 
 data "huaweicloud_availability_zones" "zones" {}

--- a/ee/candi/cloud-providers/huaweicloud/layouts/standard/static-node/variables.tf
+++ b/ee/candi/cloud-providers/huaweicloud/layouts/standard/static-node/variables.tf
@@ -52,4 +52,5 @@ locals {
   flavor_name           = local.instance_class["flavorName"]
   root_disk_size        = lookup(local.instance_class, "rootDiskSize", 50) # Huaweicloud can have disks predefined within vm flavours, so we do not set any defaults here
   additional_tags       = lookup(local.instance_class, "additionalTags", {})
+  enterprise_project_id = lookup(var.providerClusterConfiguration.provider, "enterpriseProjectID", "")
 }

--- a/ee/candi/cloud-providers/huaweicloud/layouts/standard/variables.tf
+++ b/ee/candi/cloud-providers/huaweicloud/layouts/standard/variables.tf
@@ -38,4 +38,5 @@ locals {
   ssh_allow_list        = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
   server_group          = lookup(var.providerClusterConfiguration.masterNodeGroup, "serverGroup", {})
   server_group_policy   = lookup(local.server_group, "policy", "")
+  enterprise_project_id = lookup(var.providerClusterConfiguration.provider, "enterpriseProjectID", "")
 }

--- a/ee/candi/cloud-providers/huaweicloud/layouts/vpc-peering/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/huaweicloud/layouts/vpc-peering/base-infrastructure/main.tf
@@ -13,6 +13,7 @@ module "network_security" {
   prefix         = local.prefix
   ssh_allow_list = local.ssh_allow_list
   enabled        = local.network_security
+  enterprise_project_id = local.enterprise_project_id
 }
 
 module "keypair" {

--- a/ee/candi/cloud-providers/huaweicloud/layouts/vpc-peering/master-node/main.tf
+++ b/ee/candi/cloud-providers/huaweicloud/layouts/vpc-peering/master-node/main.tf
@@ -45,6 +45,7 @@ module "master" {
   volume_zone           = module.volume_zone.zone
   server_group          = local.server_group
   subnet                = local.subnet
+  enterprise_project_id = local.enterprise_project_id
 }
 
 module "kubernetes_data" {
@@ -56,6 +57,7 @@ module "kubernetes_data" {
   volume_type = local.volume_type
   volume_zone = module.volume_zone.zone
   tags        = local.tags
+  enterprise_project_id = local.enterprise_project_id
 }
 
 module "security_groups" {
@@ -63,6 +65,7 @@ module "security_groups" {
   security_group_names        = local.security_group_names
   layout_security_group_ids   = module.network_security_info.security_group_ids
   layout_security_group_names = module.network_security_info.security_group_names
+  enterprise_project_id = local.enterprise_project_id
 }
 
 data "huaweicloud_availability_zones" "zones" {}

--- a/ee/candi/cloud-providers/huaweicloud/layouts/vpc-peering/static-node/main.tf
+++ b/ee/candi/cloud-providers/huaweicloud/layouts/vpc-peering/static-node/main.tf
@@ -33,6 +33,7 @@ module "node" {
   server_group          = local.server_group
   node_group_name       = var.nodeGroupName
   subnet                = local.subnet
+  enterprise_project_id = local.enterprise_project_id
 }
 
 module "security_groups" {
@@ -40,6 +41,7 @@ module "security_groups" {
   security_group_names        = local.security_group_names
   layout_security_group_ids   = module.network_security_info.security_group_ids
   layout_security_group_names = module.network_security_info.security_group_names
+  enterprise_project_id = local.enterprise_project_id
 }
 
 data "huaweicloud_availability_zones" "zones" {}

--- a/ee/candi/cloud-providers/huaweicloud/layouts/vpc-peering/static-node/variables.tf
+++ b/ee/candi/cloud-providers/huaweicloud/layouts/vpc-peering/static-node/variables.tf
@@ -52,4 +52,5 @@ locals {
   root_disk_size        = lookup(local.instance_class, "rootDiskSize", 50) # Huaweicloud can have disks predefined within vm flavours, so we do not set any defaults here
   additional_tags       = lookup(local.instance_class, "additionalTags", {})
   subnet                = var.providerClusterConfiguration.vpcPeering.subnet
+  enterprise_project_id = lookup(var.providerClusterConfiguration.provider, "enterpriseProjectID", "")
 }

--- a/ee/candi/cloud-providers/huaweicloud/layouts/vpc-peering/variables.tf
+++ b/ee/candi/cloud-providers/huaweicloud/layouts/vpc-peering/variables.tf
@@ -37,4 +37,5 @@ locals {
   ssh_allow_list        = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
   server_group          = lookup(var.providerClusterConfiguration.masterNodeGroup, "serverGroup", {})
   server_group_policy   = lookup(local.server_group, "policy", "")
+  enterprise_project_id = lookup(var.providerClusterConfiguration.provider, "enterpriseProjectID", "")
 }

--- a/ee/candi/cloud-providers/huaweicloud/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/huaweicloud/openapi/cluster_configuration.yaml
@@ -331,3 +331,7 @@ apiVersions:
             type: string
             description: |
               The project ID.
+          enterpriseProjectID:
+            type: string
+            description: |
+              The enterprise project ID.

--- a/ee/candi/cloud-providers/huaweicloud/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/huaweicloud/openapi/doc-ru-cluster_configuration.yaml
@@ -193,3 +193,6 @@ apiVersions:
           projectID:
             description: |
               Идентификатор проекта.
+          enterpriseProjectID:
+            description: |
+              Идентификатор подпроекта.

--- a/ee/candi/cloud-providers/huaweicloud/terraform-modules/kubernetes-data/main.tf
+++ b/ee/candi/cloud-providers/huaweicloud/terraform-modules/kubernetes-data/main.tf
@@ -8,6 +8,7 @@ resource "huaweicloud_evs_volume" "kubernetes_data" {
   volume_type       = var.volume_type
   availability_zone = var.volume_zone
   tags              = var.tags
+  enterprise_project_id = var.enterprise_project_id
   lifecycle {
     ignore_changes = [
       tags,

--- a/ee/candi/cloud-providers/huaweicloud/terraform-modules/kubernetes-data/variables.tf
+++ b/ee/candi/cloud-providers/huaweicloud/terraform-modules/kubernetes-data/variables.tf
@@ -28,3 +28,7 @@ variable "volume_zone" {
 variable "tags" {
   type = map(string)
 }
+
+variable "enterprise_project_id" {
+  type = string
+}

--- a/ee/candi/cloud-providers/huaweicloud/terraform-modules/master/main.tf
+++ b/ee/candi/cloud-providers/huaweicloud/terraform-modules/master/main.tf
@@ -23,6 +23,7 @@ resource "huaweicloud_compute_instance" "master" {
   user_data          = var.cloud_config == "" ? null : base64decode(var.cloud_config)
   availability_zone  = var.zone
   security_group_ids = var.security_group_ids
+  enterprise_project_id = var.enterprise_project_id
 
   network {
     uuid = data.huaweicloud_vpc_subnet.subnet.id
@@ -64,6 +65,8 @@ resource "huaweicloud_vpc_eip" "master" {
     size       = 100
     share_type = "PER"
   }
+
+  enterprise_project_id = var.enterprise_project_id
 }
 
 resource "huaweicloud_compute_eip_associate" "master" {

--- a/ee/candi/cloud-providers/huaweicloud/terraform-modules/master/variables.tf
+++ b/ee/candi/cloud-providers/huaweicloud/terraform-modules/master/variables.tf
@@ -68,3 +68,7 @@ variable "server_group" {
 variable "subnet" {
   type = string
 }
+
+variable "enterprise_project_id" {
+  type = string
+}

--- a/ee/candi/cloud-providers/huaweicloud/terraform-modules/network-security/main.tf
+++ b/ee/candi/cloud-providers/huaweicloud/terraform-modules/network-security/main.tf
@@ -4,6 +4,7 @@
 resource "huaweicloud_networking_secgroup" "kube" {
   count = var.enabled ? 1 : 0
   name = var.prefix
+  enterprise_project_id = var.enterprise_project_id
 }
 
 resource "huaweicloud_networking_secgroup_rule" "allow_ssh" {

--- a/ee/candi/cloud-providers/huaweicloud/terraform-modules/network-security/outputs.tf
+++ b/ee/candi/cloud-providers/huaweicloud/terraform-modules/network-security/outputs.tf
@@ -6,5 +6,5 @@ output "security_group_names" {
 }
 
 output "security_group_id" {
-  value = var.enabled ? huaweicloud_networking_secgroup.kube[0].id : null
+  value = var.enabled ? huaweicloud_networking_secgroup.kube[0].id : ""
 }

--- a/ee/candi/cloud-providers/huaweicloud/terraform-modules/network-security/variables.tf
+++ b/ee/candi/cloud-providers/huaweicloud/terraform-modules/network-security/variables.tf
@@ -13,3 +13,7 @@ variable "enabled" {
 variable "ssh_allow_list" {
   type = list(string)
 }
+
+variable "enterprise_project_id" {
+  type = string
+}

--- a/ee/candi/cloud-providers/huaweicloud/terraform-modules/security-groups/main.tf
+++ b/ee/candi/cloud-providers/huaweicloud/terraform-modules/security-groups/main.tf
@@ -4,4 +4,5 @@
 data "huaweicloud_networking_secgroup" "group" {
   count = length(var.security_group_names)
   name = element(var.security_group_names, count.index)
+  enterprise_project_id = var.enterprise_project_id
 }

--- a/ee/candi/cloud-providers/huaweicloud/terraform-modules/security-groups/variables.tf
+++ b/ee/candi/cloud-providers/huaweicloud/terraform-modules/security-groups/variables.tf
@@ -14,3 +14,7 @@ variable "layout_security_group_names" {
 variable "security_group_names" {
   type = list(string)
 }
+
+variable "enterprise_project_id" {
+  type = string
+}

--- a/ee/candi/cloud-providers/huaweicloud/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/huaweicloud/terraform-modules/static-node/main.tf
@@ -23,6 +23,7 @@ resource "huaweicloud_compute_instance" "node" {
   user_data          = var.cloud_config == "" ? null : base64decode(var.cloud_config)
   availability_zone  = var.zone
   security_group_ids = var.security_group_ids
+  enterprise_project_id = var.enterprise_project_id
 
   network {
     uuid = data.huaweicloud_vpc_subnet.subnet.id
@@ -64,6 +65,8 @@ resource "huaweicloud_vpc_eip" "node" {
     size       = 100
     share_type = "PER"
   }
+
+  enterprise_project_id = var.enterprise_project_id
 }
 
 resource "huaweicloud_compute_eip_associate" "node" {

--- a/ee/candi/cloud-providers/huaweicloud/terraform-modules/static-node/variables.tf
+++ b/ee/candi/cloud-providers/huaweicloud/terraform-modules/static-node/variables.tf
@@ -72,3 +72,7 @@ variable "node_group_name" {
 variable "subnet" {
   type = string
 }
+
+variable "enterprise_project_id" {
+  type = string
+}

--- a/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
@@ -18,10 +18,10 @@ secrets:
   value: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}
 shell:
   install:
-  - export COMMON_VERSION="v0.4.0"
-  - export VERSION="v0.2.0"
+  - export VERSION="v0.3.0"
+  - export VERSION_COMMON="v0.5.0"
   - git clone --depth 1 --branch ${VERSION} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/caphc-controller-manager.git /src
-  - git clone --depth 1 --branch ${COMMON_VERSION} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/huaweicloud-common.git /src/huaweicloud-common
+  - git clone --depth 1 --branch ${VERSION_COMMON} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/huaweicloud-common.git /src/huaweicloud-common
   - cd /src/huaweicloud-common
   - rm -rf .git
   - cd /src

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/003-enterprise-project-id.patch
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/003-enterprise-project-id.patch
@@ -1,0 +1,49 @@
+diff --git a/pkg/cloudprovider/huaweicloud/sharedloadbalancer.go b/pkg/cloudprovider/huaweicloud/sharedloadbalancer.go
+index 3a52f0b8..37a6efb1 100644
+--- a/pkg/cloudprovider/huaweicloud/sharedloadbalancer.go
++++ b/pkg/cloudprovider/huaweicloud/sharedloadbalancer.go
+@@ -319,12 +319,13 @@ func (l *SharedLoadBalancer) createLoadbalancer(clusterName, subnetID string, se
+ 	provider := elbmodel.GetCreateLoadbalancerReqProviderEnum().VLB
+ 	desc := fmt.Sprintf("Created by the ELB service(%s/%s) of the k8s cluster(%s).",
+ 		service.Namespace, service.Name, clusterName)
+ 	loadbalancer, err := l.sharedELBClient.CreateInstanceCompleted(&elbmodel.CreateLoadbalancerReq{
+-		Name:        &name,
+-		VipSubnetId: subnetID,
+-		Provider:    &provider,
+-		Description: &desc,
++		Name:                &name,
++		VipSubnetId:         subnetID,
++		Provider:            &provider,
++		Description:         &desc,
++		EnterpriseProjectId: &l.cloudConfig.AuthOpts.EnterpriseProjectID,
+ 	})
+ 	if err != nil {
+ 		return nil, err
+ 	}
+diff --git a/pkg/config/config.go b/pkg/config/config.go
+index 1e366bc7..79edcd19 100644
+--- a/pkg/config/config.go
++++ b/pkg/config/config.go
+@@ -45,14 +45,15 @@ type VpcOptions struct {
+ 	SecurityGroupID string `gcfg:"security-group-id"`
+ }
+
+ type AuthOptions struct {
+-	Cloud     string `gcfg:"cloud"`
+-	AuthURL   string `gcfg:"auth-url"`
+-	Region    string `gcfg:"region"`
+-	AccessKey string `gcfg:"access-key"`
+-	SecretKey string `gcfg:"secret-key"`
+-	ProjectID string `gcfg:"project-id"`
++	Cloud               string `gcfg:"cloud"`
++	AuthURL             string `gcfg:"auth-url"`
++	Region              string `gcfg:"region"`
++	AccessKey           string `gcfg:"access-key"`
++	SecretKey           string `gcfg:"secret-key"`
++	ProjectID           string `gcfg:"project-id"`
++	EnterpriseProjectID string `gcfg:"enterprise-project-id"`
+ }
+
+ func (a *AuthOptions) GetCredentials() *basic.Credentials {
+ 	return basic.NewCredentialsBuilder().
+

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/README.md
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/README.md
@@ -9,3 +9,7 @@ Update dependencies
 ### 002-fix-cluster-name-handling.patch
 
 For each `Service`, two load balancers were provisioned: one with the correct cluster name and another with the default cluster name. It is incorrect to have two load balancers for the same service. This patch fixes the issue by ensuring that only one load balancer is created with the correct cluster name.
+
+### 003-enterprise-project-id.patch
+
+Add support enterprise-project-id

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
@@ -39,8 +39,8 @@ secrets:
   value: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}
 shell:
   install:
-  - export VERSION="v0.4.0"
-  - export VERSION_COMMON="v0.4.0"
+  - export VERSION="v0.5.0"
+  - export VERSION_COMMON="v0.5.0"
   - git clone --depth 1 --branch ${VERSION} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/cloud-data-discoverer.git /src
   - git clone --depth 1 --branch ${VERSION_COMMON} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/huaweicloud-common.git /src/huaweicloud-common
   - mv /deckhouse/go_lib /src

--- a/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/patches/002-enterprise-project-id.patch
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/patches/002-enterprise-project-id.patch
@@ -1,0 +1,83 @@
+diff --git a/pkg/config/cloud.go b/pkg/config/cloud.go
+index 6908bc0..66f6764 100644
+--- a/pkg/config/cloud.go
++++ b/pkg/config/cloud.go
+@@ -16,15 +16,16 @@ const (
+
+ // CloudCredentials define
+ type CloudCredentials struct {
+ 	Global struct {
+-		Cloud     string `gcfg:"cloud"`
+-		AuthURL   string `gcfg:"auth-url"`
+-		Region    string `gcfg:"region"`
+-		AccessKey string `gcfg:"access-key"`
+-		SecretKey string `gcfg:"secret-key"`
+-		ProjectID string `gcfg:"project-id"`
+-		Idc       bool   `gcfg:"idc"`
++		Cloud               string `gcfg:"cloud"`
++		AuthURL             string `gcfg:"auth-url"`
++		Region              string `gcfg:"region"`
++		AccessKey           string `gcfg:"access-key"`
++		SecretKey           string `gcfg:"secret-key"`
++		ProjectID           string `gcfg:"project-id"`
++		Idc                 bool   `gcfg:"idc"`
++		EnterpriseProjectID string `gcfg:"enterprise-project-id"`
+ 	}
+
+ 	Vpc struct {
+ 		ID              string `gcfg:"id"`
+diff --git a/pkg/evs/controllerserver.go b/pkg/evs/controllerserver.go
+index ef6b11d..6e09b4a 100644
+--- a/pkg/evs/controllerserver.go
++++ b/pkg/evs/controllerserver.go
+@@ -82,16 +82,17 @@ func (cs *ControllerServer) CreateVolume(_ context.Context, req *csi.CreateVolum
+
+ 	metadata := cs.parseMetadata(req, snapshotID)
+ 	createOpts := &cloudvolumes.CreateOpts{
+ 		Volume: cloudvolumes.VolumeOpts{
+-			Name:             volName,
+-			Size:             sizeGB,
+-			VolumeType:       volumeType,
+-			AvailabilityZone: volumeAz,
+-			SnapshotID:       snapshotID,
+-			Metadata:         metadata,
+-			IOPS:             iops,
+-			Throughput:       throughput,
++			Name:                volName,
++			Size:                sizeGB,
++			VolumeType:          volumeType,
++			AvailabilityZone:    volumeAz,
++			SnapshotID:          snapshotID,
++			Metadata:            metadata,
++			IOPS:                iops,
++			Throughput:          throughput,
++			EnterpriseProjectID: credentials.Global.EnterpriseProjectID,
+ 		},
+ 		Scheduler: &cloudvolumes.SchedulerOpts{
+ 			StorageID: dssID,
+ 		},
+diff --git a/pkg/evs/nodeserver.go b/pkg/evs/nodeserver.go
+index 2c99b51..277960a 100644
+--- a/pkg/evs/nodeserver.go
++++ b/pkg/evs/nodeserver.go
+@@ -516,13 +516,14 @@ func nodePublishEphemeral(req *csi.NodePublishVolumeRequest, ns *nodeServer) (*c
+ 	metadata[DssIDKey] = req.VolumeContext[DssIDKey]
+
+ 	volumeID, err = services.CreateVolumeCompleted(cc, &cloudvolumes.CreateOpts{
+ 		Volume: cloudvolumes.VolumeOpts{
+-			Name:             volumeName,
+-			Size:             size,
+-			VolumeType:       volumeType,
+-			AvailabilityZone: volAvailability,
+-			Metadata:         metadata,
++			Name:                volumeName,
++			Size:                size,
++			VolumeType:          volumeType,
++			AvailabilityZone:    volAvailability,
++			Metadata:            metadata,
++			EnterpriseProjectID: cc.Global.EnterpriseProjectID,
+ 		},
+ 		Scheduler: &cloudvolumes.SchedulerOpts{
+ 			StorageID: req.VolumeContext[DssIDKey],
+ 		},
+

--- a/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/patches/README.md
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/patches/README.md
@@ -3,3 +3,7 @@
 ### 001-go-mod.patch
 
 Update dependencies
+
+### 002-enterprise-project-id.patch
+
+Add support enterprise-project-id

--- a/ee/modules/030-cloud-provider-huaweicloud/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/openapi/values.yaml
@@ -345,6 +345,10 @@ properties:
                 type: string
                 description: |
                   The project ID.
+              enterpriseProjectID:
+                type: string
+                description: |
+                  The enterprise project ID.
       providerDiscoveryData:
         type: object
         additionalProperties: false

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $providerClusterConfiguration := .Values.cloudProviderHuaweicloud.internal.providerClusterConfiguration | required "internal.providerClusterConfiguration is required" }}
 {{- define "huaweicloud_controller_manager_resources" }}
 cpu: 25m
 memory: 50Mi
@@ -106,6 +107,13 @@ spec:
               secretKeyRef:
                 name: huaweicloud-credentials
                 key: project-id
+          {{- if $providerClusterConfiguration.provider.enterpriseProjectID }}
+          - name: HUAWEICLOUD_ENTERPRISE_PROJECT_ID
+            valueFrom:
+              secretKeyRef:
+                name: huaweicloud-credentials
+                key: enterprise-project-id
+          {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/secret.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/secret.yaml
@@ -16,6 +16,9 @@ auth-url = {{ $providerClusterConfiguration.provider.authURL | quote }}
   {{- if $providerClusterConfiguration.provider.domainName }}
 domain-name = {{ $providerClusterConfiguration.provider.domainName | quote }}
   {{- end }}
+  {{- if $providerClusterConfiguration.provider.enterpriseProjectID }}
+enterprise-project-id = {{ $providerClusterConfiguration.provider.enterpriseProjectID | quote }}
+  {{- end }}
 [Vpc]
 subnet-id = {{ $providerDiscoveryData.instances.vpcIPv4SubnetId | quote }}
 security-group-id = {{ $providerDiscoveryData.instances.securityGroupId | quote }}

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/csi/secret.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/csi/secret.yaml
@@ -15,6 +15,9 @@ auth-url = {{ $providerClusterConfiguration.provider.authURL | quote }}
   {{- if $providerClusterConfiguration.provider.domainName }}
 domain-name = {{ $providerClusterConfiguration.provider.domainName | quote }}
   {{- end }}
+  {{- if $providerClusterConfiguration.provider.enterpriseProjectID }}
+enterprise-project-id = {{ $providerClusterConfiguration.provider.enterpriseProjectID | quote }}
+  {{- end }}
 {{- end }}
 ---
 apiVersion: v1

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/secret.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/secret.yaml
@@ -20,3 +20,6 @@ data:
 {{- if $providerClusterConfiguration.provider.projectID }}
   project-id: {{ $providerClusterConfiguration.provider.projectID | toString | b64enc | quote }}
 {{- end }}
+{{- if $providerClusterConfiguration.provider.enterpriseProjectID }}
+  enterprise-project-id: {{ $providerClusterConfiguration.provider.enterpriseProjectID | toString | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
fix



fixes



bump versions



use providerClusterConfiguration.provider.enterpriseProjectID instead of providerClusterConfiguration.enterpriseProjectID



[cloud-provider-huaweicloud] add enterprise-project-id



fix caphc templates



TEST



enterpriseProjectID



enterprise_project_id - init

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
