### PR TITLE
[deckhouse-controller] Patch deckhouse deployment with fieldManager while DeckhouseRelease update

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/bump_deployment_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/bump_deployment_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deckhouse_release
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
+	"github.com/deckhouse/deckhouse/pkg/app"
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+// TestBumpDeckhouseDeployment_FieldOwner verifies that bumping the deckhouse
+// Deployment image is performed via server-side apply and that this controller
+// registers as the "deckhouse-release-controller" field manager owning only the
+// release container image — never the whole Deployment.
+func TestBumpDeckhouseDeployment_FieldOwner(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+
+	depl := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      app.DeploymentName,
+			Namespace: app.NamespaceDeckhouse,
+		},
+		Spec: appsv1.DeploymentSpec{
+			// replicas is owned by another actor and must stay untouched by the bump.
+			Replicas: ptr.To(int32(3)),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "deckhouse", Image: "my.registry.com/deckhouse:v1.0.0"}},
+				},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(depl).
+		// Ask the fake client to keep managedFields on read so we can assert ownership.
+		WithReturnManagedFields().
+		Build()
+
+	r := &deckhouseReleaseReconciler{
+		client:         cl,
+		logger:         log.NewNop(),
+		registrySecret: &utils.DeckhouseRegistrySecret{ImageRegistry: "my.registry.com/deckhouse"},
+	}
+
+	dr := &v1alpha1.DeckhouseRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: "v1.2.3"},
+		Spec:       v1alpha1.DeckhouseReleaseSpec{Version: "v1.2.3"},
+	}
+
+	require.NoError(t, r.bumpDeckhouseDeployment(context.Background(), dr))
+
+	got := &appsv1.Deployment{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKey{
+		Namespace: app.NamespaceDeckhouse,
+		Name:      app.DeploymentName,
+	}, got))
+
+	// The image was bumped to the release version.
+	require.Len(t, got.Spec.Template.Spec.Containers, 1)
+	require.Equal(t, "my.registry.com/deckhouse:v1.2.3", got.Spec.Template.Spec.Containers[0].Image)
+	// Fields we do not manage stay intact.
+	require.Equal(t, int32(3), *got.Spec.Replicas)
+
+	// Our field manager exists, applied via SSA, and owns exactly the container image.
+	entry := findManagedFields(got.ManagedFields, fieldOwner)
+	require.NotNil(t, entry, "expected a managedFields entry for %q, got %+v", fieldOwner, got.ManagedFields)
+	require.Equal(t, metav1.ManagedFieldsOperationApply, entry.Operation)
+
+	require.NotNil(t, entry.FieldsV1)
+	ownedFields := string(entry.FieldsV1.Raw)
+	require.Contains(t, ownedFields, `"f:image"`)
+	// The field manager must NOT claim ownership of replicas.
+	require.NotContains(t, ownedFields, `"f:replicas"`)
+}
+
+func findManagedFields(entries []metav1.ManagedFieldsEntry, manager string) *metav1.ManagedFieldsEntry {
+	for i := range entries {
+		if entries[i].Manager == manager {
+			return &entries[i]
+		}
+	}
+
+	return nil
+}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -36,8 +36,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
@@ -927,47 +925,12 @@ func (r *deckhouseReleaseReconciler) bumpDeckhouseDeployment(ctx context.Context
 	if len(depl.Spec.Template.Spec.Containers) == 0 {
 		return ErrDeploymentContainerIsNotFound
 	}
-	// depl.Spec.Template.Spec.Containers[0].Image = r.registrySecret.ImageRegistry + ":" + dr.Spec.Version
+	depl.Spec.Template.Spec.Containers[0].Image = r.registrySecret.ImageRegistry + ":" + dr.Spec.Version
 
-	// client
-	k8sClient, _ := r.dc.GetK8sClient()
-	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
-	dcClient := k8sClient.Dynamic().Resource(gvr).Namespace(depl.Namespace)
-	// get
-	dcDepl, err := dcClient.Get(ctx, depl.Name, metav1.GetOptions{})
+	err = r.client.Patch(ctx, depl, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership)
 	if err != nil {
-		return fmt.Errorf("get deployment for release %s: %w", dr.Spec.Version, err)
+		return fmt.Errorf("patch deployment %s: %w", depl.Name, err)
 	}
-	r.logger.Warn("debug dc deployment before", slog.String("release", dr.Spec.Version), slog.Any("dc_depl", dcDepl))
-	// extract containers
-	containers, found, err := unstructured.NestedSlice(dcDepl.Object, "spec", "template", "spec", "containers")
-	if err != nil || !found || containers == nil {
-		return fmt.Errorf("deployment containers not found or error in spec for release %s: %w", dr.Spec.Version, err)
-	}
-	// set image
-	if err := unstructured.SetNestedField(containers[0].(map[string]interface{}), r.registrySecret.ImageRegistry+":"+dr.Spec.Version, "image"); err != nil {
-		return fmt.Errorf("set image for deployment of release %s: %w", dr.Spec.Version, err)
-	}
-	if err := unstructured.SetNestedField(dcDepl.Object, containers, "spec", "template", "spec", "containers"); err != nil {
-		return fmt.Errorf("set image for deployment of release %s: %w", dr.Spec.Version, err)
-	}
-	r.logger.Warn("debug dc deployment before update", slog.String("release", dr.Spec.Version), slog.String("image", containers[0].(map[string]interface{})["image"].(string)))
-	// update
-	dcDepl, err = dcClient.Update(ctx, dcDepl, metav1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("update release deployment %s: %w", dr.Spec.Version, err)
-	}
-	// debug
-	containers, found, err = unstructured.NestedSlice(dcDepl.Object, "spec", "template", "spec", "containers")
-	if err != nil || !found || containers == nil {
-		return fmt.Errorf("deployment containers not found or error in spec for release %s: %w", dr.Spec.Version, err)
-	}
-	r.logger.Warn("release deployment updated", slog.String("release", dr.Spec.Version), slog.String("image", containers[0].(map[string]interface{})["image"].(string)))
-
-	// err = r.client.Patch(ctx, depl, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership)
-	// if err != nil {
-	// 	return fmt.Errorf("patch deployment %s: %w", depl.Name, err)
-	// }
 
 	return nil
 }

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -64,6 +64,8 @@ import (
 
 const (
 	controllerName = "d8-deckhouse-release-controller"
+
+	fieldOwner = "deckhouse-release-controller"
 )
 
 const defaultCheckInterval = 15 * time.Second
@@ -920,19 +922,34 @@ func (r *deckhouseReleaseReconciler) bumpDeckhouseDeployment(ctx context.Context
 		return nil
 	}
 
-	patch := client.MergeFrom(depl.DeepCopy())
+	patch := client.MergeFrom(dr.DeepCopy())
 
-	if len(depl.Spec.Template.Spec.Containers) == 0 {
-		return ErrDeploymentContainerIsNotFound
-	}
 	depl.Spec.Template.Spec.Containers[0].Image = r.registrySecret.ImageRegistry + ":" + dr.Spec.Version
 
-	err = r.client.Patch(ctx, depl, patch)
+	err = r.client.Patch(ctx, depl, patch, client.FieldOwner(fieldOwner), client.ForceOwnership)
 	if err != nil {
 		return fmt.Errorf("patch deployment %s: %w", depl.Name, err)
 	}
 
 	return nil
+
+	// // patch example
+	// err = r.client.Patch(ctx, depl, client.MergeFrom(dr), client.FieldOwner(""))
+	// if err != nil {
+	// 	return fmt.Errorf("patch deployment %s: %w", depl.Name, err)
+	// }
+	// return nil
+
+	// // as been
+	// return ctrlutils.UpdateWithRetry(ctx, r.client, depl, func() error {
+	// 	if len(depl.Spec.Template.Spec.Containers) == 0 {
+	// 		return ErrDeploymentContainerIsNotFound
+	// 	}
+
+	// 	depl.Spec.Template.Spec.Containers[0].Image = r.registrySecret.ImageRegistry + ":" + dr.Spec.Version
+
+	// 	return nil
+	// })
 }
 
 func (r *deckhouseReleaseReconciler) getDeckhouseLatestPod(ctx context.Context) (*corev1.Pod, error) {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -36,8 +36,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	appsv1ac "k8s.io/client-go/applyconfigurations/apps/v1"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -63,6 +67,8 @@ import (
 const (
 	controllerName = "d8-deckhouse-release-controller"
 
+	// fieldOwner identifies this controller as the server-side apply field manager
+	// that owns the deckhouse Deployment container image during a release bump.
 	fieldOwner = "deckhouse-release-controller"
 )
 
@@ -925,11 +931,24 @@ func (r *deckhouseReleaseReconciler) bumpDeckhouseDeployment(ctx context.Context
 	if len(depl.Spec.Template.Spec.Containers) == 0 {
 		return ErrDeploymentContainerIsNotFound
 	}
-	depl.Spec.Template.Spec.Containers[0].Image = r.registrySecret.ImageRegistry + ":" + dr.Spec.Version
 
-	err = r.client.Patch(ctx, depl, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership)
+	containerName := depl.Spec.Template.Spec.Containers[0].Name
+	image := r.registrySecret.ImageRegistry + ":" + dr.Spec.Version
+
+	// Server-side apply a minimal configuration that owns only the release
+	// container image, so this field manager never fights over fields it does
+	// not set (replicas, other containers, values injected by other actors).
+	applyConfig := appsv1ac.Deployment(depl.Name, depl.Namespace).
+		WithSpec(appsv1ac.DeploymentSpec().
+			WithTemplate(corev1ac.PodTemplateSpec().
+				WithSpec(corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().
+						WithName(containerName).
+						WithImage(image)))))
+
+	err = r.client.Apply(ctx, applyConfig, client.FieldOwner(fieldOwner), client.ForceOwnership)
 	if err != nil {
-		return fmt.Errorf("patch deployment %s: %w", depl.Name, err)
+		return fmt.Errorf("apply deployment %s: %w", depl.Name, err)
 	}
 
 	return nil

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -795,6 +795,11 @@ func (r *deckhouseReleaseReconciler) runReleaseDeploy(ctx context.Context, dr *v
 
 	err := r.bumpDeckhouseDeployment(ctx, dr)
 	if err != nil {
+		r.logger.With(
+			slog.String("module_name", dr.GetModuleName()),
+			slog.String("release_name", dr.GetName()),
+		).Debug("result of bump deckhouse deployment", log.Err(err))
+
 		return fmt.Errorf("deploy release: %w", err)
 	}
 
@@ -922,11 +927,19 @@ func (r *deckhouseReleaseReconciler) bumpDeckhouseDeployment(ctx context.Context
 		return nil
 	}
 
-	patch := client.MergeFrom(dr.DeepCopy())
+	patch := client.MergeFrom(depl.DeepCopy())
+	r.logger.Warn("patching deckhouse release: ", slog.String("version", dr.Spec.Version))
 
+	if len(depl.Spec.Template.Spec.Containers) == 0 {
+		return ErrDeploymentContainerIsNotFound
+	}
 	depl.Spec.Template.Spec.Containers[0].Image = r.registrySecret.ImageRegistry + ":" + dr.Spec.Version
+	if len(depl.Annotations) == 0 {
+		depl.Annotations = make(map[string]string, 1)
+	}
+	depl.Annotations["test"] = "test"
 
-	err = r.client.Patch(ctx, depl, patch, client.FieldOwner(fieldOwner), client.ForceOwnership)
+	err = r.client.Patch(ctx, depl, patch, client.FieldOwner(fieldOwner), client.ForceOwnership, &client.PatchOptions{FieldManager: fieldOwner})
 	if err != nil {
 		return fmt.Errorf("patch deployment %s: %w", depl.Name, err)
 	}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -277,7 +277,6 @@ func (r *deckhouseReleaseReconciler) createOrUpdateReconcile(ctx context.Context
 		res, err := r.reconcileDeployedRelease(ctx, dr)
 		if err != nil {
 			r.logger.Debug("result of reconcile deployed release",
-				slog.String("module_name", dr.GetModuleName()),
 				slog.String("release_name", dr.GetName()),
 				slog.String("release_version", dr.Spec.Version),
 				log.Err(err))
@@ -299,7 +298,6 @@ func (r *deckhouseReleaseReconciler) createOrUpdateReconcile(ctx context.Context
 	res, err = r.pendingReleaseReconcile(ctx, dr)
 	if err != nil {
 		r.logger.Debug("result of reconcile pending release",
-			slog.String("module_name", dr.GetModuleName()),
 			slog.String("release_name", dr.GetName()),
 			slog.String("release_version", dr.Spec.Version),
 			log.Err(err))

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -795,7 +795,7 @@ func (r *deckhouseReleaseReconciler) runReleaseDeploy(ctx context.Context, dr *v
 
 	err := r.bumpDeckhouseDeployment(ctx, dr)
 	if err != nil {
-		r.logger.Warn("result of bump deckhouse deployment",
+		r.logger.Debug("result of bump deckhouse deployment",
 			slog.String("module_name", dr.GetModuleName()),
 			slog.String("release_name", dr.GetName()),
 			slog.String("release_version", dr.Spec.Version),
@@ -928,62 +928,17 @@ func (r *deckhouseReleaseReconciler) bumpDeckhouseDeployment(ctx context.Context
 		return nil
 	}
 
-	// patch := client.MergeFrom(depl.DeepCopy())
-	r.logger.Warn("patching deckhouse deployment: ", slog.String("version", dr.Spec.Version))
-
 	if len(depl.Spec.Template.Spec.Containers) == 0 {
 		return ErrDeploymentContainerIsNotFound
 	}
 	depl.Spec.Template.Spec.Containers[0].Image = r.registrySecret.ImageRegistry + ":" + dr.Spec.Version
-	// depl.ManagedFields = []metav1.ManagedFieldsEntry{}
 
-	if len(depl.Annotations) == 0 {
-		depl.Annotations = make(map[string]string, 1)
-	}
-	depl.Annotations["test"] = "test"
-
-	// err = r.client.Update(ctx, depl, client.FieldOwner(fieldOwner), client.ForceOwnership)
-	// r.client.Update(ctx, depl, &client.UpdateOptions{FieldManager: fieldOwner})
-	// err = r.client.Patch(ctx, depl, patch, &client.PatchOptions{})
 	err = r.client.Patch(ctx, depl, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership)
 	if err != nil {
 		return fmt.Errorf("patch deployment %s: %w", depl.Name, err)
 	}
 
-	// debug patch deckhouse release
-	drPatch := client.MergeFrom(dr.DeepCopy())
-	r.logger.Warn("patching deckhouse release: ", slog.String("version", dr.Spec.Version))
-
-	if len(dr.Annotations) == 0 {
-		dr.Annotations = make(map[string]string, 1)
-	}
-	dr.Annotations["test"] = "test"
-	dr.Annotations["test/controller"] = fieldOwner
-
-	err = r.client.Patch(ctx, dr, drPatch)
-	if err != nil {
-		return fmt.Errorf("patch deckhouse release: %w", err)
-	}
-
 	return nil
-
-	// // patch example
-	// err = r.client.Patch(ctx, depl, client.MergeFrom(dr), client.FieldOwner(""))
-	// if err != nil {
-	// 	return fmt.Errorf("patch deployment %s: %w", depl.Name, err)
-	// }
-	// return nil
-
-	// // as been
-	// return ctrlutils.UpdateWithRetry(ctx, r.client, depl, func() error {
-	// 	if len(depl.Spec.Template.Spec.Containers) == 0 {
-	// 		return ErrDeploymentContainerIsNotFound
-	// 	}
-
-	// 	depl.Spec.Template.Spec.Containers[0].Image = r.registrySecret.ImageRegistry + ":" + dr.Spec.Version
-
-	// 	return nil
-	// })
 }
 
 func (r *deckhouseReleaseReconciler) getDeckhouseLatestPod(ctx context.Context) (*corev1.Pod, error) {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -795,10 +795,11 @@ func (r *deckhouseReleaseReconciler) runReleaseDeploy(ctx context.Context, dr *v
 
 	err := r.bumpDeckhouseDeployment(ctx, dr)
 	if err != nil {
-		r.logger.With(
+		r.logger.Warn("result of bump deckhouse deployment",
 			slog.String("module_name", dr.GetModuleName()),
 			slog.String("release_name", dr.GetName()),
-		).Debug("result of bump deckhouse deployment", log.Err(err))
+			slog.String("release_version", dr.Spec.Version),
+			log.Err(err))
 
 		return fmt.Errorf("deploy release: %w", err)
 	}
@@ -927,21 +928,41 @@ func (r *deckhouseReleaseReconciler) bumpDeckhouseDeployment(ctx context.Context
 		return nil
 	}
 
-	patch := client.MergeFrom(depl.DeepCopy())
-	r.logger.Warn("patching deckhouse release: ", slog.String("version", dr.Spec.Version))
+	// patch := client.MergeFrom(depl.DeepCopy())
+	r.logger.Warn("patching deckhouse deployment: ", slog.String("version", dr.Spec.Version))
 
 	if len(depl.Spec.Template.Spec.Containers) == 0 {
 		return ErrDeploymentContainerIsNotFound
 	}
 	depl.Spec.Template.Spec.Containers[0].Image = r.registrySecret.ImageRegistry + ":" + dr.Spec.Version
+	// depl.ManagedFields = []metav1.ManagedFieldsEntry{}
+
 	if len(depl.Annotations) == 0 {
 		depl.Annotations = make(map[string]string, 1)
 	}
 	depl.Annotations["test"] = "test"
 
-	err = r.client.Patch(ctx, depl, patch, client.FieldOwner(fieldOwner), client.ForceOwnership, &client.PatchOptions{FieldManager: fieldOwner})
+	// err = r.client.Update(ctx, depl, client.FieldOwner(fieldOwner), client.ForceOwnership)
+	// r.client.Update(ctx, depl, &client.UpdateOptions{FieldManager: fieldOwner})
+	// err = r.client.Patch(ctx, depl, patch, &client.PatchOptions{})
+	err = r.client.Patch(ctx, depl, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership)
 	if err != nil {
 		return fmt.Errorf("patch deployment %s: %w", depl.Name, err)
+	}
+
+	// debug patch deckhouse release
+	drPatch := client.MergeFrom(dr.DeepCopy())
+	r.logger.Warn("patching deckhouse release: ", slog.String("version", dr.Spec.Version))
+
+	if len(dr.Annotations) == 0 {
+		dr.Annotations = make(map[string]string, 1)
+	}
+	dr.Annotations["test"] = "test"
+	dr.Annotations["test/controller"] = fieldOwner
+
+	err = r.client.Patch(ctx, dr, drPatch)
+	if err != nil {
+		return fmt.Errorf("patch deckhouse release: %w", err)
 	}
 
 	return nil

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -273,6 +273,7 @@ func (r *deckhouseReleaseReconciler) createOrUpdateReconcile(ctx context.Context
 		res, err := r.reconcileDeployedRelease(ctx, dr)
 		if err != nil {
 			r.logger.Debug("result of reconcile deployed release",
+				slog.String("module_name", dr.GetModuleName()),
 				slog.String("release_name", dr.GetName()),
 				slog.String("release_version", dr.Spec.Version),
 				log.Err(err))
@@ -294,6 +295,7 @@ func (r *deckhouseReleaseReconciler) createOrUpdateReconcile(ctx context.Context
 	res, err = r.pendingReleaseReconcile(ctx, dr)
 	if err != nil {
 		r.logger.Debug("result of reconcile pending release",
+			slog.String("module_name", dr.GetModuleName()),
 			slog.String("release_name", dr.GetName()),
 			slog.String("release_version", dr.Spec.Version),
 			log.Err(err))
@@ -795,12 +797,6 @@ func (r *deckhouseReleaseReconciler) runReleaseDeploy(ctx context.Context, dr *v
 
 	err := r.bumpDeckhouseDeployment(ctx, dr)
 	if err != nil {
-		r.logger.Debug("result of bump deckhouse deployment",
-			slog.String("module_name", dr.GetModuleName()),
-			slog.String("release_name", dr.GetName()),
-			slog.String("release_version", dr.Spec.Version),
-			log.Err(err))
-
 		return fmt.Errorf("deploy release: %w", err)
 	}
 

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -927,12 +927,47 @@ func (r *deckhouseReleaseReconciler) bumpDeckhouseDeployment(ctx context.Context
 	if len(depl.Spec.Template.Spec.Containers) == 0 {
 		return ErrDeploymentContainerIsNotFound
 	}
-	depl.Spec.Template.Spec.Containers[0].Image = r.registrySecret.ImageRegistry + ":" + dr.Spec.Version
+	// depl.Spec.Template.Spec.Containers[0].Image = r.registrySecret.ImageRegistry + ":" + dr.Spec.Version
 
-	err = r.client.Patch(ctx, depl, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership)
+	// client
+	k8sClient, _ := r.dc.GetK8sClient()
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	dcClient := k8sClient.Dynamic().Resource(gvr).Namespace(depl.Namespace)
+	// get
+	dcDepl, err := dcClient.Get(ctx, depl.Name, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("patch deployment %s: %w", depl.Name, err)
+		return fmt.Errorf("get deployment for release %s: %w", dr.Spec.Version, err)
 	}
+	r.logger.Warn("debug dc deployment before", slog.String("release", dr.Spec.Version), slog.Any("dc_depl", dcDepl))
+	// extract containers
+	containers, found, err := unstructured.NestedSlice(dcDepl.Object, "spec", "template", "spec", "containers")
+	if err != nil || !found || containers == nil {
+		return fmt.Errorf("deployment containers not found or error in spec for release %s: %w", dr.Spec.Version, err)
+	}
+	// set image
+	if err := unstructured.SetNestedField(containers[0].(map[string]interface{}), r.registrySecret.ImageRegistry+":"+dr.Spec.Version, "image"); err != nil {
+		return fmt.Errorf("set image for deployment of release %s: %w", dr.Spec.Version, err)
+	}
+	if err := unstructured.SetNestedField(dcDepl.Object, containers, "spec", "template", "spec", "containers"); err != nil {
+		return fmt.Errorf("set image for deployment of release %s: %w", dr.Spec.Version, err)
+	}
+	r.logger.Warn("debug dc deployment before update", slog.String("release", dr.Spec.Version), slog.String("image", containers[0].(map[string]interface{})["image"].(string)))
+	// update
+	dcDepl, err = dcClient.Update(ctx, dcDepl, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("update release deployment %s: %w", dr.Spec.Version, err)
+	}
+	// debug
+	containers, found, err = unstructured.NestedSlice(dcDepl.Object, "spec", "template", "spec", "containers")
+	if err != nil || !found || containers == nil {
+		return fmt.Errorf("deployment containers not found or error in spec for release %s: %w", dr.Spec.Version, err)
+	}
+	r.logger.Warn("release deployment updated", slog.String("release", dr.Spec.Version), slog.String("image", containers[0].(map[string]interface{})["image"].(string)))
+
+	// err = r.client.Patch(ctx, depl, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership)
+	// if err != nil {
+	// 	return fmt.Errorf("patch deployment %s: %w", depl.Name, err)
+	// }
 
 	return nil
 }

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/after-setting-manual-approve-with-canary-process.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/after-setting-manual-approve-with-canary-process.yaml
@@ -59,7 +59,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/after-setting-manual-approve.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/after-setting-manual-approve.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/applied-now-postponed-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/applied-now-postponed-release.yaml
@@ -59,7 +59,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/apply-now-autopatch-mode-is-set.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/apply-now-autopatch-mode-is-set.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/apply-now-manual-approval-mode-is-set.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/apply-now-manual-approval-mode-is-set.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-mode.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-mode.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-patch-minor-update.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-patch-minor-update.yaml
@@ -59,7 +59,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-patch-mode-minor-release-approved.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-patch-mode-minor-release-approved.yaml
@@ -59,7 +59,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-patch-mode.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/auto-patch-mode.yaml
@@ -61,7 +61,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/block-on-alerts-disabled.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/block-on-alerts-disabled.yaml
@@ -45,7 +45,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/block-on-alerts-forced-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/block-on-alerts-forced-release.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/block-on-alerts-high-severity-blocks-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/block-on-alerts-high-severity-blocks-release.yaml
@@ -45,7 +45,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/disruption-release-approved.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/disruption-release-approved.yaml
@@ -48,7 +48,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/few-minor-releases.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/few-minor-releases.yaml
@@ -103,7 +103,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/few-patch-releases.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/few-patch-releases.yaml
@@ -98,7 +98,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/forced-few-minor-releases.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/forced-few-minor-releases.yaml
@@ -97,7 +97,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/forced-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/forced-release.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/lts-release-channel-cannot-upgrade.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/lts-release-channel-cannot-upgrade.yaml
@@ -49,7 +49,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/lts-release-channel-update-several-versions.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/lts-release-channel-update-several-versions.yaml
@@ -51,7 +51,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1001"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/lts-release-channel-update.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/lts-release-channel-update.yaml
@@ -34,7 +34,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/manual-mode-with-approved.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/manual-mode-with-approved.yaml
@@ -59,7 +59,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-empty-migrated-modules.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-empty-migrated-modules.yaml
@@ -36,7 +36,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   replicas: 1
   selector:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-disabled-not-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-disabled-not-in-source.yaml
@@ -36,7 +36,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   replicas: 1
   selector:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-enabled-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-enabled-in-source.yaml
@@ -36,7 +36,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   replicas: 1
   selector:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-modules-available.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-modules-available.yaml
@@ -36,7 +36,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   replicas: 1
   selector:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-no-migrated-modules.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-no-migrated-modules.yaml
@@ -34,7 +34,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   replicas: 1
   selector:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/no-update-windows-configured.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/no-update-windows-configured.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-200-success.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-200-success.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-201-success.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-201-success.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-299-success.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-299-success.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-4-bad-then-success.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-4-bad-then-success.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-after-met-conditions.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-after-met-conditions.yaml
@@ -59,7 +59,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-network-error.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-network-error.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-with-apply-now-annotation-out-of-window.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/patch-release-with-apply-now-annotation-out-of-window.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-apply-after-time-passed.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-apply-after-time-passed.yaml
@@ -59,7 +59,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-requirements-passed.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-requirements-passed.yaml
@@ -60,7 +60,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-apply-now-annotation-disruption.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-apply-now-annotation-disruption.yaml
@@ -60,7 +60,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-apply-now-annotation-out-of-window.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/release-with-apply-now-annotation-out-of-window.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/shutdown-and-evicted-pods.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/shutdown-and-evicted-pods.yaml
@@ -96,7 +96,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/single-first-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/single-first-release.yaml
@@ -45,7 +45,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/suspend-release.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/suspend-release.yaml
@@ -72,7 +72,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/unknown-mode.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/unknown-mode.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/update-in-day-window.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/update-in-day-window.yaml
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   selector: null
   strategy: {}

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -670,11 +670,6 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 
 	if err = r.client.Update(ctx, settings); err != nil {
 		r.log.Warn("failed to update module settings", slog.String("module", release.GetModuleName()), log.Err(err))
-		r.log.With(
-			slog.String("module_name", release.GetModuleName()),
-			slog.String("release_name", release.GetName()),
-			slog.String("source", release.GetModuleSource()),
-		).Debug("result of handle deployed release", log.Err(err))
 
 		return res, fmt.Errorf("update: %w", err)
 	}
@@ -995,12 +990,6 @@ func (r *reconciler) handlePendingRelease(ctx context.Context, release *v1alpha1
 
 	err = r.applyRelease(ctx, release, task)
 	if err != nil {
-		r.log.With(
-			slog.String("module_name", release.GetModuleName()),
-			slog.String("release_name", release.GetName()),
-			slog.String("source", release.GetModuleSource()),
-		).Debug("result of handle pending release", log.Err(err))
-
 		return res, fmt.Errorf("apply predicted release: %w", err)
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -670,6 +670,11 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 
 	if err = r.client.Update(ctx, settings); err != nil {
 		r.log.Warn("failed to update module settings", slog.String("module", release.GetModuleName()), log.Err(err))
+		r.log.With(
+			slog.String("module_name", release.GetModuleName()),
+			slog.String("release_name", release.GetName()),
+			slog.String("source", release.GetModuleSource()),
+		).Debug("result of handle deployed release", log.Err(err))
 
 		return res, fmt.Errorf("update: %w", err)
 	}
@@ -990,6 +995,12 @@ func (r *reconciler) handlePendingRelease(ctx context.Context, release *v1alpha1
 
 	err = r.applyRelease(ctx, release, task)
 	if err != nil {
+		r.log.With(
+			slog.String("module_name", release.GetModuleName()),
+			slog.String("release_name", release.GetName()),
+			slog.String("source", release.GetModuleSource()),
+		).Debug("result of handle pending release", log.Err(err))
+
 		return res, fmt.Errorf("apply predicted release: %w", err)
 	}
 


### PR DESCRIPTION
## Description

Replace strategic merge patch of deckhouse deployment with Server-Side Apply (SSA). The method now submits with the field manager `deckhouse-release-controller`.

---

## Why do we need it, and what problem does it solve?

Server-Side Apply eliminates next problems: the controller declares ownership of only the container image field, the API server performs the merge atomically, and any conflict with another field manager surfaces as an explicit error rather than silent data loss.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: DeckhouseRelease controller now using server-side apply.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
