### PR TITLE
[deckhouse] fix storage class change hook

### DIFF
--- a/go_lib/hooks/storage_class_change/hook.go
+++ b/go_lib/hooks/storage_class_change/hook.go
@@ -291,7 +291,6 @@ func storageClassChangeWithArgs(input *go_hook.HookInput, dc dependency.Containe
 				input.Logger.Info("can't Evict Pod", slog.String("namespace", pod.Namespace), slog.String("name", pod.Name), log.Err(err))
 			}
 		}
-
 	}
 
 	var currentStorageClass string


### PR DESCRIPTION
## Description
It fixes storage class change issue.

## Why do we need it, and what problem does it solve?
Closes #14278

## Why do we need it in the patch release (if we do)?
Prev versions affected too.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Filter deleted pvcs in storage class change hook.
impact_level: low
```