### PR TITLE
[cni-cilium] Fixing the egressgateway controller for large setups

### DIFF
--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery.go
@@ -133,6 +133,10 @@ func applyEgressGatewayInstanceFilter(obj *unstructured.Unstructured) (go_hook.F
 		return nil, err
 	}
 
+	for i := range egi.Status.Conditions {
+		egi.Status.Conditions[i].LastHeartbeatTime = metav1.Time{}
+	}
+
 	return EgressGatewayInstanceInfo{
 		Name:            egi.GetName(),
 		NodeName:        egi.Spec.NodeName,


### PR DESCRIPTION
## Description

This PR reduces the deckhouse hook execution queue for the egressgateway by hook filter. 

## Why do we need it, and what problem does it solve?

The Deckhouse queue overflows and starts consuming a lot of RAM, which negatively affects the performance of the cluster node.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: EgressGateway controller optimized for large setups with lot's of EgressGateways.
```
