### PR TITLE
[deckhouse-controller] Change log level to warn for check/cleanup functions

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -55,18 +55,19 @@ import (
 )
 
 const (
-	metricUpdatingFailedGroup = "d8_updating_is_failed"
-	serviceName               = "check-release"
-	ltsChannelName            = "lts"
+	metricUpdatingFailedGroup   = "d8_updating_is_failed"
+	serviceName                 = "check-release"
+	ltsChannelName              = "lts"
+	checkDeckhouseReleasePeriod = 3 * time.Minute
 )
 
 func (r *deckhouseReleaseReconciler) checkDeckhouseReleaseLoop(ctx context.Context) {
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		err := r.checkDeckhouseRelease(ctx)
 		if err != nil {
-			r.logger.Error("check Deckhouse release", log.Err(err))
+			r.logger.Warn("check Deckhouse release", log.Err(err))
 		}
-	}, 3*time.Minute)
+	}, checkDeckhouseReleasePeriod)
 }
 
 type DeckhouseReleaseFetcherConfig struct {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/cleanup_deckhouse_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/cleanup_deckhouse_release.go
@@ -33,13 +33,15 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
+const cleanupDeckhouseReleasePeriod = 24 * time.Hour
+
 func (r *deckhouseReleaseReconciler) cleanupDeckhouseReleaseLoop(ctx context.Context) {
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		err := r.cleanupDeckhouseRelease(ctx)
 		if err != nil {
-			r.logger.Error("check Deckhouse release", log.Err(err))
+			r.logger.Warn("cleaup Deckhouse release", log.Err(err))
 		}
-	}, 24*time.Hour)
+	}, cleanupDeckhouseReleasePeriod)
 }
 
 func (r *deckhouseReleaseReconciler) cleanupDeckhouseRelease(ctx context.Context) error {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: change log level to warn for check/cleanup functions
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
