### PR TITLE
[deckhouse-controller] Add synh notify user

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_kubernetes_version.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_kubernetes_version.go
@@ -73,7 +73,7 @@ func kubernetesVersionHandler(mm moduleManager) http.Handler {
 			}
 		}
 
-		return allowResult("")
+		return allowResult(nil)
 	})
 
 	// Create webhook.

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module.go
@@ -35,7 +35,7 @@ func moduleValidationHandler() http.Handler {
 			return rejectResult("manual Module change is forbidden")
 		}
 
-		return allowResult("")
+		return allowResult(nil)
 	})
 
 	// Create webhook.

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -172,7 +172,7 @@ func moduleConfigValidationHandler(
 			// Please specify a source in ModuleConfig.
 
 			if cfg.Spec.Source == "" && len(module.Properties.AvailableSources) > 1 {
-				warnings = append(warnings, fmt.Sprintf("module '%s' is enabled but didn’t run because multiple sources were found (%v), please specify a source in ModuleConfig resource ", cfg.GetName(), module.Properties.AvailableSources))
+				warnings = append(warnings, fmt.Sprintf("module '%s' is enabled but didn’t run because multiple sources were found (%s), please specify a source in ModuleConfig resource ", cfg.GetName(), strings.Join(module.Properties.AvailableSources, ", ")))
 			}
 		}
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -168,9 +168,6 @@ func moduleConfigValidationHandler(
 				return rejectResult(fmt.Sprintf("the '%s' module source is an unavailable source for the '%s' module, available sources: %v", cfg.Spec.Source, cfg.Name, module.Properties.AvailableSources))
 			}
 
-			// Module prometheus is enabled but didn’t run because multiple sources were found (<source-one>, <source-two>, …).
-			// Please specify a source in ModuleConfig.
-
 			if cfg.Spec.Enabled != nil && *cfg.Spec.Enabled && cfg.Spec.Source == "" && len(module.Properties.AvailableSources) > 1 {
 				warnings = append(warnings, fmt.Sprintf("module '%s' is enabled but didn’t run because multiple sources were found (%s), please specify a source in ModuleConfig resource ", cfg.GetName(), strings.Join(module.Properties.AvailableSources, ", ")))
 			}

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -168,8 +168,11 @@ func moduleConfigValidationHandler(
 				return rejectResult(fmt.Sprintf("the '%s' module source is an unavailable source for the '%s' module, available sources: %v", cfg.Spec.Source, cfg.Name, module.Properties.AvailableSources))
 			}
 
+			// Module prometheus is enabled but didn’t run because multiple sources were found (<source-one>, <source-two>, …).
+			// Please specify a source in ModuleConfig.
+
 			if cfg.Spec.Source == "" && len(module.Properties.AvailableSources) > 1 {
-				warnings = append(warnings, fmt.Sprintf("the '%s' module has several available sources, please set it in ModuleConfig.Spec.Source. available sources: %v ", cfg.Name, module.Properties.AvailableSources))
+				warnings = append(warnings, fmt.Sprintf("module '%s' is enabled but didn’t run because multiple sources were found (%v), please specify a source in ModuleConfig resource ", cfg.GetName(), module.Properties.AvailableSources))
 			}
 		}
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -171,7 +171,7 @@ func moduleConfigValidationHandler(
 			// Module prometheus is enabled but didn’t run because multiple sources were found (<source-one>, <source-two>, …).
 			// Please specify a source in ModuleConfig.
 
-			if cfg.Spec.Source == "" && len(module.Properties.AvailableSources) > 1 {
+			if cfg.Spec.Enabled != nil && *cfg.Spec.Enabled && cfg.Spec.Source == "" && len(module.Properties.AvailableSources) > 1 {
 				warnings = append(warnings, fmt.Sprintf("module '%s' is enabled but didn’t run because multiple sources were found (%s), please specify a source in ModuleConfig resource ", cfg.GetName(), strings.Join(module.Properties.AvailableSources, ", ")))
 			}
 		}

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_update_policy.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_update_policy.go
@@ -52,7 +52,7 @@ func updatePolicyHandler(cli client.Client) http.Handler {
 			}
 		}
 
-		return allowResult("")
+		return allowResult(nil)
 	})
 
 	// Create webhook.

--- a/deckhouse-controller/pkg/debug/module_enable.go
+++ b/deckhouse-controller/pkg/debug/module_enable.go
@@ -92,7 +92,7 @@ func setModuleConfigEnabled(ctx context.Context, kubeClient k8s.Client, name str
 
 	sources, ok, _ := unstructured.NestedSlice(unstructuredObjModule.Object, "properties", "availableSources")
 	if ok && len(sources) > 1 {
-		fmt.Printf("module '%s' is enabled but didn’t run because multiple sources were found (%v), please specify a source in ModuleConfig resource\n", name, sources)
+		fmt.Printf("Warning: module '%s' is enabled but didn’t run because multiple sources were found (%v), please specify a source in ModuleConfig resource\n", name, sources)
 	}
 
 	unstructuredObj, err := kubeClient.Dynamic().Resource(v1alpha1.ModuleConfigGVR).Get(ctx, name, metav1.GetOptions{})

--- a/deckhouse-controller/pkg/debug/module_enable.go
+++ b/deckhouse-controller/pkg/debug/module_enable.go
@@ -83,17 +83,19 @@ func setModuleConfigEnabled(ctx context.Context, kubeClient k8s.Client, name str
 		return fmt.Errorf("kubernetes client is not initialized")
 	}
 
-	unstructuredObjModule, err := kubeClient.Dynamic().Resource(v1alpha1.ModuleGVR).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return errors.New("module not found")
+	if enabled {
+		unstructuredObjModule, err := kubeClient.Dynamic().Resource(v1alpha1.ModuleGVR).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return errors.New("module not found")
+			}
+			return fmt.Errorf("get the '%s' module: %w", name, err)
 		}
-		return fmt.Errorf("get the '%s' module: %w", name, err)
-	}
 
-	sources, ok, _ := unstructured.NestedStringSlice(unstructuredObjModule.Object, "properties", "availableSources")
-	if ok && len(sources) > 1 {
-		fmt.Printf("Warning: module '%s' is enabled but didn’t run because multiple sources were found (%s), please specify a source in ModuleConfig resource\n", name, strings.Join(sources, ", "))
+		sources, ok, _ := unstructured.NestedStringSlice(unstructuredObjModule.Object, "properties", "availableSources")
+		if ok && len(sources) > 1 {
+			fmt.Printf("Warning: module '%s' is enabled but didn’t run because multiple sources were found (%s), please specify a source in ModuleConfig resource\n", name, strings.Join(sources, ", "))
+		}
 	}
 
 	unstructuredObj, err := kubeClient.Dynamic().Resource(v1alpha1.ModuleConfigGVR).Get(ctx, name, metav1.GetOptions{})

--- a/deckhouse-controller/pkg/debug/module_enable.go
+++ b/deckhouse-controller/pkg/debug/module_enable.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/flant/addon-operator/sdk"
 	kubeclient "github.com/flant/kube-client/client"
@@ -90,9 +91,9 @@ func setModuleConfigEnabled(ctx context.Context, kubeClient k8s.Client, name str
 		return fmt.Errorf("get the '%s' module: %w", name, err)
 	}
 
-	sources, ok, _ := unstructured.NestedSlice(unstructuredObjModule.Object, "properties", "availableSources")
+	sources, ok, _ := unstructured.NestedStringSlice(unstructuredObjModule.Object, "properties", "availableSources")
 	if ok && len(sources) > 1 {
-		fmt.Printf("Warning: module '%s' is enabled but didn’t run because multiple sources were found (%v), please specify a source in ModuleConfig resource\n", name, sources)
+		fmt.Printf("Warning: module '%s' is enabled but didn’t run because multiple sources were found (%s), please specify a source in ModuleConfig resource\n", name, strings.Join(sources, ", "))
 	}
 
 	unstructuredObj, err := kubeClient.Dynamic().Resource(v1alpha1.ModuleConfigGVR).Get(ctx, name, metav1.GetOptions{})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add user notification about multiple sources when enable module.

### Enable by deckhouse-controller command
### Before
```
deckhouse-controller module enable console
Module console enabled
```

### After
```
deckhouse-controller module enable console
Warning: module 'console' is enabled but didn’t run because multiple sources were found (deckhouse, deckhouse-prod), please specify a source in ModuleConfig resource
Module console enabled
```

### Enable by editing ModuleConfig resource

### Before
```
kubectl edit mc console                       
moduleconfig.deckhouse.io/console edited
```

### After
```
kubectl edit mc console                       
Warning: module 'console' is enabled but didn’t run because multiple sources were found (deckhouse, deckhouse-prod), please specify a source in ModuleConfig resource 
moduleconfig.deckhouse.io/console edited
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: add user notify when module config has conflict
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
