### PR TITLE
[ci] Corrections to support closed-loop assembly

### DIFF
--- a/ee/modules/110-istio/images/api-proxy/werf.inc.yaml
+++ b/ee/modules/110-istio/images/api-proxy/werf.inc.yaml
@@ -20,6 +20,9 @@ import:
   before: install
 mount:
 {{ include "mount points for golang builds" . }}
+secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
 shell:
   beforeInstall:
   {{- include "alpine packages proxy" . | nindent 2 }}

--- a/modules/000-common/images/init/werf.inc.yaml
+++ b/modules/000-common/images/init/werf.inc.yaml
@@ -13,9 +13,9 @@ fromImage: common/relocate-artifact
 final: false
 shell:
   beforeInstall:
-  - apt-get update
+  {{- include "alt packages proxy" . | nindent 2 }}
   - apt-get install -y netcat
-  - rm -rf /var/lib/apt/lists/* /var/cache/apt/* && mkdir -p /var/lib/apt/lists/partial /var/cache/apt/archives/partial
+  - find /var/lib/apt/ /var/cache/apt/ -type f -delete
   install:
   - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
 

--- a/modules/000-common/images/relocate/werf.inc.yaml
+++ b/modules/000-common/images/relocate/werf.inc.yaml
@@ -11,4 +11,5 @@ git:
     - '**/*'
 shell:
   install:
+  {{- include "alt packages proxy" . | nindent 2 }}
   - apt-get install -y glibc-utils

--- a/modules/402-ingress-nginx/images/protobuf-exporter/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/protobuf-exporter/werf.inc.yaml
@@ -19,9 +19,13 @@ import:
   before: install
 mount:
 {{ include "mount points for golang builds" . }}
+secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
 shell:
   install:
     - cd /src
+    - export GOPROXY=$(cat /run/secrets/GOPROXY)
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags='-extldflags "-static" -s -w' -o ./protobuf_exporter ./main.go
     - chown 64535:64535 ./protobuf_exporter
     - chmod 0755 ./protobuf_exporter


### PR DESCRIPTION
## Description

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Corrections to support closed-loop assembly.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Corrections to support closed-loop assembly
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
