### PR TITLE
[docs][ingress-nginx] Fix selectors in L2 MetalLB example

### DIFF
--- a/modules/402-ingress-nginx/docs/EXAMPLES.md
+++ b/modules/402-ingress-nginx/docs/EXAMPLES.md
@@ -164,7 +164,7 @@ metallb:
        - 192.168.2.100-192.168.2.150
      isDefault: false
      nodeSelector:
-       node-role.kubernetes.io/loadbalancer: "" # node-balancer selector
+       node-role.kubernetes.io/loadbalancer: "" # label on load-balancing nodes
      type: L2
    ```
 
@@ -181,9 +181,16 @@ metallb:
      loadBalancer:
        loadBalancerClass: ingress
        annotations:
-       # The number of addresses that will be allocated from the pool described in _MetalLoadBalancerClass_.
+       # The number of addresses that will be allocated from the pool declared in MetalLoadBalancerClass.
        network.deckhouse.io/l2-load-balancer-external-ips-count: "3"
-   ```
+     # Label selector and tolerations. Ingress-controller pods must be scheduled on same nodes as MetalLB speaker pods.
+     nodeSelector:
+        node-role.kubernetes.io/loadbalancer: ""
+     tolerations:
+     - effect: NoSchedule
+       key: node-role/loadbalancer
+       operator: Exists
+      ```
 
 1. The platform will create a service with the type `LoadBalancer`, to which a specified number of addresses will be assigned:
 

--- a/modules/402-ingress-nginx/docs/EXAMPLES_RU.md
+++ b/modules/402-ingress-nginx/docs/EXAMPLES_RU.md
@@ -181,8 +181,15 @@ metallb:
      loadBalancer:
        loadBalancerClass: ingress
        annotations:
-         # Количество адресов, которые будут выделены из пула, описанного в _MetalLoadBalancerClass_.
+         # Количество адресов, которые будут выделены из пула, объявленного в MetalLoadBalancerClass.
          network.deckhouse.io/l2-load-balancer-external-ips-count: "3"
+     # Селектор и tolerations. Поды ingress-controller должны быть размещены на тех же нодах, что и поды MetalLB speaker.
+     nodeSelector:
+        node-role.kubernetes.io/loadbalancer: ""
+     tolerations:
+     - effect: NoSchedule
+       key: node-role/loadbalancer
+       operator: Exists
    ```
 
 1. Платформа создаст сервис с типом `LoadBalancer`, которому будет присвоено заданное количество адресов:


### PR DESCRIPTION
## Description
Add selector/tolerations to ingressnginxcontroller manifest to clarify that speakers and ingress-controllers must be scheduled on the same node.

## Why do we need it, and what problem does it solve?
Previous example was misleading for copy and paste deployment.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: chore
summary: Fix ingress-nginx L2 MetalLB example
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
