### PR TITLE
[user-authn][docs] Correct package name for htpasswd

### DIFF
--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -357,7 +357,7 @@ echo -n '3xAmpl3Pa$$wo#d' | htpasswd -BinC 10 "" | cut -d: -f2 | tr -d '\n' | ba
 ```
 
 {% alert level="info" %}
-If `htpasswd` command not found, you need to install `apache2-utils` package for Debian-based distribution and `httpd-utils` for CentOS-based distribution.
+If `htpasswd` command not found, you need to install `apache2-utils` package for Debian-based distribution, `httpd-tools` for CentOS-based distribution and `apache2-htpasswd` for ALT Linux.
 {% endalert %}
 
 Alternatively, you can use the [online service](https://bcrypt-generator.com/) to calculate the password hash.

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -362,7 +362,7 @@ echo -n '3xAmpl3Pa$$wo#d' | htpasswd -BinC 10 "" | cut -d: -f2 | tr -d '\n' | ba
 ```
 
 {% alert level="info" %}
-Если команда `htpasswd` не найдена установите пакет `apache2-utils` для Debian-основанных дистрибутивов и `httpd-utils` для CentOS-основанных дистрибутивов.
+Если команда `htpasswd` не найдена установите пакет `apache2-utils` для Debian-основанных дистрибутивов, `httpd-tools` для CentOS-основанных дистрибутивов и `apache2-htpasswd` для ALT Linux.
 {% endalert %}
 
 Также можно воспользоваться [онлайн-сервисом](https://bcrypt-generator.com/).


### PR DESCRIPTION
## Description
Fix package name for CentOS-based OS, and add package name for ALT Linux.

## Why do we need it, and what problem does it solve?
Mistake in https://github.com/deckhouse/deckhouse/pull/14142

```
[root@cf2fc10dbe52 /]# yum provides \*bin/htpasswd
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Red Hat Universal Base Image 10 (RPMs) - BaseOS                                                                                                     194 kB/s | 472 kB     00:02
Red Hat Universal Base Image 10 (RPMs) - AppStream                                                                                                  335 kB/s | 1.2 MB     00:03
Red Hat Universal Base Image 10 (RPMs) - CodeReady Builder                                                                                           36 kB/s |  73 kB     00:02
httpd-tools-2.4.63-1.el10.aarch64 : Tools for use with the Apache HTTP Server
Repo        : ubi-10-for-aarch64-appstream-rpms
Matched from:
Other       : *bin/htpasswd
```

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: chore
summary: Correct package name for htpasswd.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
