### PR TITLE
[deckhouse-controller] Replace Update to Patch in DeckhouseRelease update

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -447,6 +447,11 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 			Message: strings.Join(msgs, ";"),
 		})
 		if err != nil {
+			r.logger.Debug("result of update release status",
+				slog.String("module_name", dr.GetModuleName()),
+				slog.String("release_name", dr.GetName()),
+				slog.String("release_version", dr.Spec.Version),
+				log.Err(err))
 			r.logger.Warn("met requirements status update ", slog.String("name", dr.GetName()), log.Err(err))
 		}
 
@@ -456,12 +461,22 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 	// handling error inside function
 	err = r.PreApplyReleaseCheck(ctx, dr, task, metricLabels)
 	if err != nil {
+		r.logger.Debug("result of pre-apply release check",
+			slog.String("module_name", dr.GetModuleName()),
+			slog.String("release_name", dr.GetName()),
+			slog.String("release_version", dr.Spec.Version),
+			log.Err(err))
 		// ignore this err, just requeue because of check failed
 		return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
 	}
 
 	err = r.ApplyRelease(ctx, dr, task)
 	if err != nil {
+		r.logger.Debug("result of apply pending release",
+			slog.String("module_name", dr.GetModuleName()),
+			slog.String("release_name", dr.GetName()),
+			slog.String("release_version", dr.Spec.Version),
+			log.Err(err))
 		return res, fmt.Errorf("apply predicted release: %w", err)
 	}
 
@@ -1020,6 +1035,11 @@ func (r *deckhouseReleaseReconciler) reconcileDeployedRelease(ctx context.Contex
 			return nil
 		})
 		if err != nil {
+			r.logger.Debug("result of update deployed release",
+				slog.String("module_name", dr.GetModuleName()),
+				slog.String("release_name", dr.GetName()),
+				slog.String("release_version", dr.Spec.Version),
+				log.Err(err))
 			return res, err
 		}
 
@@ -1032,6 +1052,11 @@ func (r *deckhouseReleaseReconciler) reconcileDeployedRelease(ctx context.Contex
 			return nil
 		})
 		if err != nil {
+			r.logger.Debug("result of update status of deployed release",
+				slog.String("module_name", dr.GetModuleName()),
+				slog.String("release_name", dr.GetName()),
+				slog.String("release_version", dr.Spec.Version),
+				log.Err(err))
 			return res, err
 		}
 	}

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -544,11 +544,6 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 
 	if err = r.client.Update(ctx, settings); err != nil {
 		r.log.Warn("failed to update module settings", slog.String("module", release.GetModuleName()), log.Err(err))
-		r.log.With(
-			slog.String("module_name", release.GetModuleName()),
-			slog.String("release_name", release.GetName()),
-			slog.String("source", release.GetModuleSource()),
-		).Debug("result of handle deployed release", log.Err(err))
 
 		return res, err
 	}
@@ -780,12 +775,6 @@ func (r *reconciler) handlePendingRelease(ctx context.Context, release *v1alpha1
 
 	err = r.ApplyRelease(ctx, release, task)
 	if err != nil {
-		r.log.With(
-			slog.String("module_name", release.GetModuleName()),
-			slog.String("release_name", release.GetName()),
-			slog.String("source", release.GetModuleSource()),
-		).Debug("result of handle pending release", log.Err(err))
-
 		return res, fmt.Errorf("apply predicted release: %w", err)
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -544,6 +544,11 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 
 	if err = r.client.Update(ctx, settings); err != nil {
 		r.log.Warn("failed to update module settings", slog.String("module", release.GetModuleName()), log.Err(err))
+		r.log.With(
+			slog.String("module_name", release.GetModuleName()),
+			slog.String("release_name", release.GetName()),
+			slog.String("source", release.GetModuleSource()),
+		).Debug("result of handle deployed release", log.Err(err))
 
 		return res, err
 	}
@@ -775,6 +780,12 @@ func (r *reconciler) handlePendingRelease(ctx context.Context, release *v1alpha1
 
 	err = r.ApplyRelease(ctx, release, task)
 	if err != nil {
+		r.log.With(
+			slog.String("module_name", release.GetModuleName()),
+			slog.String("release_name", release.GetName()),
+			slog.String("source", release.GetModuleSource()),
+		).Debug("result of handle pending release", log.Err(err))
+
 		return res, fmt.Errorf("apply predicted release: %w", err)
 	}
 


### PR DESCRIPTION
## Description
This PR optimizes the DeckhouseRelease update mechanism by replacing Update operations with Patch for Deckhouse deployments.

Changes made:
- Replaced Update with Patch for modifying the deckhouse Deployment
- Added some debug-level logging
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Performance Optimization:
- Patch operations are more efficient than Update calls
- Reduces network payload and API server load
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: Deckhouse deployment upgrades now use Patch instead of Update
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
