### PR TITLE
[docs] Fixed title at Stronghold documentation

### DIFF
--- a/docs/site/pages/stronghold/documentation/user/ACCESS.md
+++ b/docs/site/pages/stronghold/documentation/user/ACCESS.md
@@ -1,5 +1,5 @@
 ---
-title: "Deckhouse Stronghold"
+title: "Configuring access to the project"
 permalink: en/stronghold/documentation/user/access.html
 ---
 

--- a/docs/site/pages/stronghold/documentation/user/ACCESS_RU.md
+++ b/docs/site/pages/stronghold/documentation/user/ACCESS_RU.md
@@ -1,5 +1,5 @@
 ---
-title: "Deckhouse Stronghold"
+title: "Настройка доступа к проекту"
 permalink: ru/stronghold/documentation/user/access.html
 lang: ru
 ---


### PR DESCRIPTION
## Description
Fixed title at Stronghold documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Fixed title at Stronghold documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
