### PR TITLE
[cloud-provider-vsphere] Made internalNetworkCIDR as optional parameter

### DIFF
--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
@@ -78,7 +78,7 @@ locals {
     } : tomap({})
   ))
 
-  internalNodeNetworkPrefix = split("/", var.providerClusterConfiguration.internalNetworkCIDR)[1]
+  internalNodeNetworkPrefix = try(split("/", var.providerClusterConfiguration.internalNetworkCIDR)[1], "")
   first_interface_index     = 192
 
   additional_interface_configurations = {

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/variables.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/variables.tf
@@ -9,7 +9,7 @@ variable "providerClusterConfiguration" {
   type = any
 
   validation {
-    condition     = cidrsubnet(var.providerClusterConfiguration.internalNetworkCIDR, 0, 0) == var.providerClusterConfiguration.internalNetworkCIDR
+    condition     = contains(keys(var.providerClusterConfiguration.masterNodeGroup.instanceClass), "additionalNetworks") ? can(cidrhost(var.providerClusterConfiguration.internalNetworkCIDR, 0)): true
     error_message = "Invalid internalNetworkCIDR in VsphereClusterConfiguration."
   }
 


### PR DESCRIPTION
## Description
This PR made internalNetworkCIDR optional.

## Why do we need it, and what problem does it solve?
`internalNetworkCIDR` is needed only when `additionalNetworks` are used.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: Made internalNetworkCIDR optional.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
