### PR TITLE
[cloud-providers-vSphere] fix main network escaping for names with sp…

### DIFF
--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
@@ -43,7 +43,7 @@ data "vsphere_resource_pool" "resource_pool" {
 }
 
 data "vsphere_network" "main" {
-  name          = local.master_instance_class.mainNetwork
+  name          = replace(replace(local.master_instance_class.mainNetwork, "[", "\\["), "[", "\\[")
   datacenter_id = data.vsphere_dynamic.datacenter_id.id
 }
 

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
@@ -43,7 +43,7 @@ data "vsphere_resource_pool" "resource_pool" {
 }
 
 data "vsphere_network" "main" {
-  name          = replace(replace(local.master_instance_class.mainNetwork, "[", "\\["), "[", "\\[")
+  name          = replace(replace(local.master_instance_class.mainNetwork, "[", "\\["), "]", "\\]")
   datacenter_id = data.vsphere_dynamic.datacenter_id.id
 }
 


### PR DESCRIPTION
fix main network escaping for names with special symbols

## Description
This PR adds proper escaping for square brackets in vsphere network names to prevent terraform regex

## Why do we need it, and what problem does it solve?

It fixes "network not found" errors when using network names containing "[" or "]"

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: fix main network escaping for names with special symbols
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
