### PR TITLE
[prometheus] Switch from Prometheus to Deckhouse Prom++ by default

### DIFF
--- a/modules/300-prometheus/hooks/enable_prompp.go
+++ b/modules/300-prometheus/hooks/enable_prompp.go
@@ -85,7 +85,7 @@ func enablePrompp(input *go_hook.HookInput) error {
 	}
 
 	if hasModuleConfig {
-		input.Logger.Info("prompp module is already enabled, nothing to do")
+		input.Logger.Info("prompp ModuleConfig is present, nothing to do")
 		return nil
 	}
 

--- a/modules/300-prometheus/hooks/enable_prompp.go
+++ b/modules/300-prometheus/hooks/enable_prompp.go
@@ -62,7 +62,7 @@ func applyModuleFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, er
 		return nil, fmt.Errorf("cannot convert object to module: %v", err)
 	}
 
-	return mc, nil
+	return mc.Name, nil
 }
 
 func applyModuleConfigFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -72,7 +72,7 @@ func applyModuleConfigFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 		return nil, fmt.Errorf("cannot convert object to moduleconfig: %v", err)
 	}
 
-	return mc, nil
+	return mc.Name, nil
 }
 
 func enablePrompp(input *go_hook.HookInput) error {
@@ -92,10 +92,10 @@ func enablePrompp(input *go_hook.HookInput) error {
 	mc := unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "deckhouse.io/v1alpha1",
 		"kind":       "ModuleConfig",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name": promppModuleName,
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"enabled": true,
 		},
 	}}

--- a/modules/300-prometheus/hooks/enable_prompp.go
+++ b/modules/300-prometheus/hooks/enable_prompp.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+)
+
+const (
+	promppModuleName = "prompp"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 9},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "prompp_module",
+			ApiVersion: "deckhouse.io/v1alpha1",
+			Kind:       "Module",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{promppModuleName},
+			},
+			FilterFunc: applyModuleFilter,
+		},
+		{
+			Name:       "prompp_moduleconfig",
+			ApiVersion: "deckhouse.io/v1alpha1",
+			Kind:       "ModuleConfig",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{promppModuleName},
+			},
+			FilterFunc: applyModuleConfigFilter,
+		},
+	},
+}, enablePrompp)
+
+func applyModuleFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	mc := &v1alpha1.Module{}
+	err := sdk.FromUnstructured(obj, mc)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert object to module: %v", err)
+	}
+
+	return mc, nil
+}
+
+func applyModuleConfigFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	mc := &v1alpha1.ModuleConfig{}
+	err := sdk.FromUnstructured(obj, mc)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert object to moduleconfig: %v", err)
+	}
+
+	return mc, nil
+}
+
+func enablePrompp(input *go_hook.HookInput) error {
+	hasModule := len(input.Snapshots["prompp_module"]) > 0
+	hasModuleConfig := len(input.Snapshots["prompp_moduleconfig"]) > 0
+
+	if !hasModule {
+		input.Logger.Info("no prompp module found, won't create ModuleConfig")
+		return nil
+	}
+
+	if hasModuleConfig {
+		input.Logger.Info("prompp module is already enabled, nothing to do")
+		return nil
+	}
+
+	mc := unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "deckhouse.io/v1alpha1",
+		"kind":       "ModuleConfig",
+		"metadata": map[string]interface{}{
+			"name": promppModuleName,
+		},
+		"spec": map[string]interface{}{
+			"enabled": true,
+		},
+	}}
+
+	input.PatchCollector.CreateIfNotExists(&mc)
+
+	return nil
+}

--- a/modules/300-prometheus/hooks/enable_prompp_test.go
+++ b/modules/300-prometheus/hooks/enable_prompp_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Prometheus hooks :: enable prompp ::", func() {
+	f := HookExecutionConfigInit(``, ``)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "Module", false)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
+	Context("Empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(``, 1))
+			f.RunHook()
+		})
+
+		Context("No prompp module found", func() {
+			It("Should not create prompp ModuleConfig", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				mc := f.KubernetesGlobalResource("ModuleConfig", promppModuleName)
+				Expect(mc.Exists()).To(BeFalse())
+			})
+		})
+	})
+	Context("Cluster with prompp module", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: prompp
+spec: {}
+`, 1))
+			f.RunHook()
+		})
+
+		It("Should create prompp ModuleConfig", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			mc := f.KubernetesGlobalResource("ModuleConfig", promppModuleName)
+			Expect(mc.Exists()).To(BeTrue())
+			Expect(mc.Field("spec.enabled").Bool()).To(BeTrue())
+		})
+	})
+	Context("Cluster with prompp module being explicitly disabled in ModuleConfig", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: prompp
+spec: {}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: prompp
+spec:
+  enabled: false
+`, 2))
+			f.RunHook()
+		})
+
+		It("Should leave prompp ModuleConfig intact", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			mc := f.KubernetesGlobalResource("ModuleConfig", promppModuleName)
+			Expect(mc.Exists()).To(BeTrue())
+			Expect(mc.Field("spec.enabled").Bool()).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
## Description
Prompp is a drop-in replacement for the Prometheus which drastically reduces resource consumption by the monitoring stack. This PR enables the Deckhouse Prom++ module by default effectively replacing Prometheus with  Deckhouse Prom++.

If there are significant reasons for sticking with the Prometheus, the following `ModuleConfig` has to be created prior to the platform upgrade: 
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: prompp
spec:
  enabled: false
```

## Why do we need it, and what problem does it solve?
The Deckhouse Prom++ is known to be much more efficient compared to the Prometheus, thus reducing cluster running costs. The Deckhouse Prom++ is considered mature enough to be the default metrics store in the Deckhouse Kubernetes Platform.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: feature
summary: Deckhouse Prom++ is now the default metrics-collecting software in the Deckhouse Kubernetes Platform
impact: Prometheus is replaced by the Deckhouse Prom++ by default in all editions of the Deckhouse Kubernetes Platform
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
