### PR TITLE
[docs] Update the link to the documentation in the header and the footer

### DIFF
--- a/docs/site/_data/footer.json
+++ b/docs/site/_data/footer.json
@@ -94,7 +94,7 @@
           },
           {
             "title": "Documentation",
-            "url": "/documentations/",
+            "url": "/docs/",
             "target": "",
             "rel": ""
           },

--- a/docs/site/_includes/header.html
+++ b/docs/site/_includes/header.html
@@ -225,7 +225,7 @@
       <div class="header__right-box">
         <div class="header__buttons">
           {%- unless site.mode == "module" %}
-            <a href="/documentations/" class="button button--outline">{{ site.data.i18n.common['documentation_title'][page.lang] }}</a>
+            <a href="/docs/" class="button button--outline">{{ site.data.i18n.common['documentation_title'][page.lang] }}</a>
             <a data-open-modal="request_callback" href="#" class="button button--contact">{{ site.data.i18n.common['contact_us_button'][page.lang] }}</a>
           {%- endunless %}
         </div>


### PR DESCRIPTION
## Description

Update the link to the documentation in the header and the footer.

Ref: https://github.com/deckhouse/deckhouse/pull/14329

## Changelog entries
```changes
section: docs
type: chore
summary: Update the link to the documentation in the header and the footer.
impact_level: low
```
