### PR TITLE
[docs] Adjust memory limits for documentation pods

### DIFF
--- a/docs/documentation/.helm/templates/10-app.yaml
+++ b/docs/documentation/.helm/templates/10-app.yaml
@@ -76,6 +76,7 @@ metadata:
   name: {{ .Chart.Name }}-{{ .VersionDNSNormalized }}
 spec:
   maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       service: {{ .Chart.Name }}-{{ .VersionDNSNormalized }}

--- a/docs/documentation/.helm/templates/_helpers.tpl
+++ b/docs/documentation/.helm/templates/_helpers.tpl
@@ -3,5 +3,5 @@ resources:
   requests:
     memory: {{ pluck .Values.web.env .Values.resources.requests.memory | first | default .Values.resources.requests.memory._default }}
   limits:
-    memory: {{ pluck .Values.web.env .Values.resources.requests.memory | first | default .Values.resources.requests.memory._default }}
+    memory: {{ pluck .Values.web.env .Values.resources.limits.memory | first | default .Values.resources.limits.memory._default }}
 {{- end }}

--- a/docs/documentation/.helm/values.yaml
+++ b/docs/documentation/.helm/values.yaml
@@ -11,4 +11,8 @@ resources:
     memory:
       _default: 30M
       web-production: 250M
+  limits:
+    memory:
+      _default: 100M
+      web-production: 500M
 


### PR DESCRIPTION
## Description
Adjust memory limits for documentation pods.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Adjust memory limits for documentation pods.
impact_level: low
```
