### PR TITLE
[node-manager] Disruption approved annotation removal

### DIFF
--- a/ee/modules/040-node-manager/templates/nvidia-gpu/nvidia-mig-config.yml
+++ b/ee/modules/040-node-manager/templates/nvidia-gpu/nvidia-mig-config.yml
@@ -464,6 +464,7 @@ data:
       kubectl uncordon "${NODE_NAME}"
       kubectl annotate node "${NODE_NAME}" update.node.deckhouse.io/drained-
       kubectl taint nodes "${NODE_NAME}" mig-reconfigure=true:NoSchedule-
+      kubectl annotate node ${NODE_NAME} update.node.deckhouse.io/disruption-approved-
 
       exit ${exit_code}
     }


### PR DESCRIPTION
## Description

Remove `update.node.deckhouse.io/disruption-approved` annotation after mig-manager has finished reconfiguring the node

## Why do we need it, and what problem does it solve?

For now, after mig-manager has finished reconfiguring the node, annotation `update.node.deckhouse.io/disruption-approved` keeps on the node. It should be removed.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fix mig-manager behavior related to update.node.deckhouse.io/disruption-approved annotation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
