### PR TITLE
[node-local-dns] Updated plugin cache settings for node-local-dns

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2355,6 +2355,36 @@ alerts:
         The {{ $labels.node }} Node is not managed by the node-manager module.
       severity: "9"
       markupFormat: markdown
+    - name: D8NodeLocalDNSCacheDenialEvictionsHigh
+      sourceFile: ee/be/modules/350-node-local-dns/monitoring/prometheus-rules/cache-plugin.yaml
+      moduleUrl: 350-node-local-dns
+      module: node-local-dns
+      edition: be
+      description: |
+        The `denial` (NXDOMAIN) cache in node-local-dns is evicting entries frequently.
+
+        This might indicate denial cache size is insufficient (e.g. `denial 9984`).
+
+        Affected node: `{{$labels.node}}`
+      summary: |
+        node-local-dns denial cache is being frequently evicted.
+      severity: "6"
+      markupFormat: markdown
+    - name: D8NodeLocalDNSCacheSuccessEvictionsHigh
+      sourceFile: ee/be/modules/350-node-local-dns/monitoring/prometheus-rules/cache-plugin.yaml
+      moduleUrl: 350-node-local-dns
+      module: node-local-dns
+      edition: be
+      description: |
+        The `success` cache in node-local-dns is evicting entries frequently (>100 in 5 minutes).
+
+        This could mean cache capacity is too small (e.g. `success 39936`), or traffic patterns changed.
+
+        Affected node: `{{$labels.node}}`
+      summary: |
+        node-local-dns success cache is being frequently evicted.
+      severity: "6"
+      markupFormat: markdown
     - name: D8NodeUpdateStuckWaitingForDisruptionApproval
       sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
       moduleUrl: 040-node-manager
@@ -6361,6 +6391,7 @@ modules-having-alerts:
     - monitoring-kubernetes
     - monitoring-kubernetes-control-plane
     - monitoring-ping
+    - node-local-dns
     - node-manager
     - okmeter
     - openvpn

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2363,7 +2363,7 @@ alerts:
       description: |
         The `denial` (NXDOMAIN) cache in node-local-dns is evicting entries frequently.
 
-        This might indicate denial cache size is insufficient (e.g. `denial 9984`).
+        This might indicate that there are Services that are being recreated too often in cluster. So, denial cache size is not enough (`denial 9984` is currently configured).
 
         Affected node: `{{$labels.node}}`
       summary: |
@@ -2378,7 +2378,7 @@ alerts:
       description: |
         The `success` cache in node-local-dns is evicting entries frequently (>100 in 5 minutes).
 
-        This could mean cache capacity is too small (e.g. `success 39936`), or traffic patterns changed.
+        This could mean there are too many different DNS records application have to resolve (to many Services?). So, node-local-dns cache capacity is too small (`success 39936` is currently configured), or traffic patterns changed.
 
         Affected node: `{{$labels.node}}`
       summary: |

--- a/ee/be/modules/350-node-local-dns/monitoring/prometheus-rules/cache-plugin.yaml
+++ b/ee/be/modules/350-node-local-dns/monitoring/prometheus-rules/cache-plugin.yaml
@@ -14,7 +14,7 @@
         description: |
           The `success` cache in node-local-dns is evicting entries frequently (>100 in 5 minutes).
 
-          This could mean cache capacity is too small (e.g. `success 39936`), or traffic patterns changed.
+          This could mean there are too many different DNS records application have to resolve (to many Services?). So, node-local-dns cache capacity is too small (`success 39936` is currently configured), or traffic patterns changed.
 
           Affected node: `{{$labels.node}}`
 
@@ -32,6 +32,6 @@
         description: |
           The `denial` (NXDOMAIN) cache in node-local-dns is evicting entries frequently.
 
-          This might indicate denial cache size is insufficient (e.g. `denial 9984`).
+          This might indicate that there are Services that are being recreated too often in cluster. So, denial cache size is not enough (`denial 9984` is currently configured).
 
           Affected node: `{{$labels.node}}`

--- a/ee/be/modules/350-node-local-dns/monitoring/prometheus-rules/cache-plugin.yaml
+++ b/ee/be/modules/350-node-local-dns/monitoring/prometheus-rules/cache-plugin.yaml
@@ -1,0 +1,37 @@
+- name: d8.node-local-dns.cache
+  rules:
+    - alert: D8NodeLocalDNSCacheSuccessEvictionsHigh
+      expr: |
+        increase(coredns_cache_evictions_total{type="success", job="node-local-dns"}[5m]) > 100
+      for: 5m
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: markdown
+        plk_protocol_version: "1"
+        summary: node-local-dns success cache is being frequently evicted.
+        description: |
+          The `success` cache in node-local-dns is evicting entries frequently (>100 in 5 minutes).
+
+          This could mean cache capacity is too small (e.g. `success 39936`), or traffic patterns changed.
+
+          Affected node: `{{$labels.node}}`
+
+    - alert: D8NodeLocalDNSCacheDenialEvictionsHigh
+      expr: |
+        increase(coredns_cache_evictions_total{type="denial", job="node-local-dns"}[5m]) > 100
+      for: 5m
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: markdown
+        plk_protocol_version: "1"
+        summary: node-local-dns denial cache is being frequently evicted.
+        description: |
+          The `denial` (NXDOMAIN) cache in node-local-dns is evicting entries frequently.
+
+          This might indicate denial cache size is insufficient (e.g. `denial 9984`).
+
+          Affected node: `{{$labels.node}}`

--- a/ee/be/modules/350-node-local-dns/templates/configmap.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/configmap.yaml
@@ -13,8 +13,8 @@ data:
         consolidate 10s ".* write: operation not permitted$"
       }
       cache {
-        success 39936 30 5
-        denial 9984 5 5
+        success 39936 30 5 # <cache size> <TTL max> <TTL min>
+        denial 9984 5 5    # <cache size> <TTL max> <TTL min>
         prefetch 10 1m 25%
         serve_stale 1h immediate
       }

--- a/ee/be/modules/350-node-local-dns/templates/configmap.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/configmap.yaml
@@ -13,8 +13,8 @@ data:
         consolidate 10s ".* write: operation not permitted$"
       }
       cache {
-        success 39936
-        denial 9984
+        success 39936 30 5
+        denial 9984 5 5
         prefetch 10 1m 25%
         serve_stale 1h immediate
       }

--- a/ee/be/modules/350-node-local-dns/templates/monitoring.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/monitoring.yaml
@@ -1,1 +1,2 @@
 {{- include "helm_lib_grafana_dashboard_definitions" . }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-system") }}

--- a/modules/042-kube-dns/templates/configmap.yaml
+++ b/modules/042-kube-dns/templates/configmap.yaml
@@ -33,7 +33,9 @@ data:
           {{ get $transportProtocolModeDict $.Values.kubeDns.transportProtocolMode }}
 {{- end }}
         }
+{{- if not (.Values.global.enabledModules | has "node-local-dns") }}
         cache 30
+{{- end }}
         loop
         reload
         loadbalance


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

We set explicit max and min TTL values for the success and denial parameters of the CoreDNS cache plugin. Additionally, we reduce the denial max TTL to 5 seconds to minimize the delay in propagating new or recreated DNS records (e.g., after a pod or service rollout).

To improve DNS responsiveness and avoid double caching, we also disable the cache in the upstream kube-dns only if the node-local-dns module is enabled. In such cases, DNS caching is handled exclusively at the node level (in node-local-dns), which ensures faster propagation and more accurate resolution of changes in the cluster's DNS records.

<details>
<summary>Screenshots</summary>

<img width="1911" height="702" alt="image" src="https://github.com/user-attachments/assets/944d15ae-a959-4549-ac16-24c770646f19" />

</details>

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

use case: if the service resource was instantly recreated or became unavailable for a while, the erroneous response from the DNS server will be cached for 30 secs by default.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-local-dns
type: chore
summary: Updated the maximum and minimum TTL values for the success and denial parameters in the core dns cache settings.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
