### PR TITLE
[ingress−nginx] Ensure that validationEnabled is always set to false

### DIFF
--- a/modules/402-ingress-nginx/hooks/get_ingress_controllers.go
+++ b/modules/402-ingress-nginx/hooks/get_ingress_controllers.go
@@ -119,6 +119,9 @@ func applyControllerFilter(obj *unstructured.Unstructured) (go_hook.FilterResult
 		}
 	}
 
+	// Set spec.validationEnabled = false to resolve high resource utilization issue
+	spec["validationEnabled"] = false
+
 	return Controller{Name: name, Spec: spec}, nil
 }
 

--- a/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
+++ b/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
@@ -95,7 +95,7 @@ spec:
     }
   },
   "underscoresInHeaders": false,
-  "validationEnabled": true
+  "validationEnabled": false
 }
 }]`))
 			})
@@ -203,7 +203,7 @@ spec:
   }
 },
 "underscoresInHeaders": false,
-"validationEnabled": true
+"validationEnabled": false
 }`))
 
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers.1.name").String()).To(Equal("test-2"))
@@ -244,7 +244,7 @@ spec:
   }
 },
 "underscoresInHeaders": false,
-"validationEnabled": true,
+"validationEnabled": false,
 "controllerLogLevel": "Info"
 }`))
 
@@ -276,7 +276,7 @@ spec:
   }
 },
 "underscoresInHeaders": false,
-"validationEnabled": true,
+"validationEnabled": false,
 "controllerLogLevel": "Info"
 }`))
 		})


### PR DESCRIPTION
## Description
This PR ensures that `validationEnabled` is always set to `false`.

## Why do we need it, and what problem does it solve?
This change is necessary to reduce high resource consumption caused by additional validation `pods` in ingress-nginx. Enabling validation can lead to significant CPU and memory consumption in large clusters with many `IngressNginxController` resources.

## Why do we need it in the patch release (if we do)?
High resource utilization is a blocking factor for future Deckhouse updates.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ingress-nginx
type: fix
summary: Validation is switched off temporarily.
```