### PR TITLE
Run changelog check only on tag pushes to enforce release documentation

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -1,3 +1,39 @@
+{!{ define "check_changelog_template" }!}
+# <template: check_changelog_template>
+runs-on: ubuntu-latest
+outputs:
+  should-run: ${{ steps.check-tag.outputs.should_run }}
+steps:
+  {!{ tmpl.Exec "checkout_step"                . | strings.Indent 2 }!}
+
+  - name: Check if this is a tag
+    id: check-tag
+    run: |
+      if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+        echo "This is a tag push"
+        echo "should_run=true" >> $GITHUB_OUTPUT
+      else
+        echo "Not a tag push"
+        echo "should_run=false" >> $GITHUB_OUTPUT
+
+  - name: Extract TAG version
+    if: ${{ steps.check-tag.outputs.should_run == 'true' }}
+    id: get_tag
+    run: |
+      TAG_VERSION="${GITHUB_REF#refs/tags/}"
+      echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
+
+  - name: Check if changelog exists
+    if: ${{ steps.check-tag.outputs.should_run == 'true' }}
+    run: |
+      FILE="./CHANGELOG/CHANGELOG-${TAG_VERSION}.yml"
+      if [ ! -f "$FILE" ]; then
+        echo "❌ Changelog file $FILE not found"
+        exit 1
+      fi
+# </template: check_changelog_template>
+{!{ end }!}
+
 {!{ define "go_generate_template" }!}
 # <template: go_generate_template>
 runs-on: [self-hosted, regular]

--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -15,6 +15,7 @@ steps:
       else
         echo "Not a tag push"
         echo "should_run=false" >> $GITHUB_OUTPUT
+      fi
 
   - name: Extract TAG version
     if: ${{ steps.check-tag.outputs.should_run == 'true' }}

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -124,7 +124,6 @@ jobs:
   check_changelog:
     name: Check changelog
 {!{ tmpl.Exec "check_changelog_template" $ctx | strings.Indent 4 }!}
-
   build_fe:
     name: Build FE
     needs:

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -121,6 +121,9 @@ jobs:
       - git_info
       - check_branch_name
 {!{ tmpl.Exec "workflow_render_template" $ctx | strings.Indent 4 }!}
+  check_changelog:
+    name: Check changelog
+{!{ tmpl.Exec "check_changelog_template" $ctx | strings.Indent 4 }!}
 
   build_fe:
     name: Build FE
@@ -128,6 +131,8 @@ jobs:
       - git_info
       - go_generate
       - workflow_render
+      - check_changelog
+    if: ${{ needs.check_changelog.outputs.should-run == 'false' || success() }}
     env:
       WERF_ENV: "FE"
       SVACE_ANALYZE_HOST: "${{ secrets.SVACE_ANALYZE_HOST }}"

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -336,6 +336,48 @@ jobs:
           git diff --exit-code
     # </template: workflow_render_template>
 
+  check_changelog:
+    name: Check changelog
+
+    # <template: check_changelog_template>
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check-tag.outputs.should_run }}
+    steps:
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+
+      # </template: checkout_step>
+
+      - name: Check if this is a tag
+        id: check-tag
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "This is a tag push"
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "Not a tag push"
+            echo "should_run=false" >> $GITHUB_OUTPUT
+
+      - name: Extract TAG version
+        if: ${{ steps.check-tag.outputs.should_run == 'true' }}
+        id: get_tag
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/}"
+          echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
+
+      - name: Check if changelog exists
+        if: ${{ steps.check-tag.outputs.should_run == 'true' }}
+        run: |
+          FILE="./CHANGELOG/CHANGELOG-${TAG_VERSION}.yml"
+          if [ ! -f "$FILE" ]; then
+            echo "❌ Changelog file $FILE not found"
+            exit 1
+          fi
+    # </template: check_changelog_template>
+
 
   build_fe:
     name: Build FE
@@ -343,6 +385,8 @@ jobs:
       - git_info
       - go_generate
       - workflow_render
+      - check_changelog
+    if: ${{ needs.check_changelog.outputs.should-run == 'false' || success() }}
     env:
       WERF_ENV: "FE"
       SVACE_ANALYZE_HOST: "${{ secrets.SVACE_ANALYZE_HOST }}"

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -360,6 +360,7 @@ jobs:
           else
             echo "Not a tag push"
             echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Extract TAG version
         if: ${{ steps.check-tag.outputs.should_run == 'true' }}
@@ -377,7 +378,6 @@ jobs:
             exit 1
           fi
     # </template: check_changelog_template>
-
 
   build_fe:
     name: Build FE


### PR DESCRIPTION
## Description

Added the `check-changelog` job that runs only on tag pushes and checks for the file `./CHANGELOG/CHANGELOG-${TAG_VERSION}.yml`.

## Why do we need it, and what problem does it solve?

Ensures a changelog is present for each release. If the file is missing, the CI fails. Skipped on regular (non-tag) pushes.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Run changelog check only on tag pushes to enforce release documentation
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
