### PR TITLE
[docs][cloud-provider-yandex] Add warning NAT-instance restarts if resources changed

### DIFF
--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -414,6 +414,8 @@ apiVersions:
           natInstanceResources:
             description: |
               Computing resources that are allocated to the NAT instance. If not specified, the default values will be used.
+
+              > **Warning!** If these parameters are changed, `terraform-auto-converger` will automatically restart NAT-instance if [autoConvergerEnabled](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/terraform-manager/configuration.html#parameters-autoconvergerenabled) is set to `true`. This could lead to network traffic interruption.
             type: object
             default: {"cores": 2, "memory": 2048}
             x-doc-default: {}

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -415,7 +415,7 @@ apiVersions:
             description: |
               Computing resources that are allocated to the NAT instance. If not specified, the default values will be used.
 
-              > **Warning!** If these parameters are changed, `terraform-auto-converger` will automatically restart NAT-instance if [autoConvergerEnabled](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/terraform-manager/configuration.html#parameters-autoconvergerenabled) is set to `true`. This could lead to network traffic interruption.
+              > **Warning.** If these parameters are changed, `terraform-auto-converger` will automatically restart NAT-instance if [autoConvergerEnabled](../../modules/terraform-manager/configuration.html#parameters-autoconvergerenabled) is set to `true`. This could lead to network traffic interruption.
             type: object
             default: {"cores": 2, "memory": 2048}
             x-doc-default: {}

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -415,7 +415,7 @@ apiVersions:
             description: |
               Computing resources that are allocated to the NAT instance. If not specified, the default values will be used.
 
-              > **Warning.** If these parameters are changed, `terraform-auto-converger` will automatically restart NAT-instance if [autoConvergerEnabled](../../modules/terraform-manager/configuration.html#parameters-autoconvergerenabled) is set to `true`. This could lead to network traffic interruption.
+              > **Warning.** If these parameters are changed, `terraform-auto-converger` will automatically restart NAT-instance if [autoConvergerEnabled](../../modules/terraform-manager/configuration.html#parameters-autoconvergerenabled) is set to `true`. This may result in a temporary interruption of network traffic in the cluster.
             type: object
             default: {"cores": 2, "memory": 2048}
             x-doc-default: {}

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -213,7 +213,7 @@ apiVersions:
             description: |
               Вычислительные ресурсы, выделяемые для NAT-инстанса. Если параметр не указан, будут использоваться значения по умолчанию.
 
-              > **Внимание.** При изменении этих параметров, `terraform-auto-converger` перезапустит машину NAT-инстанса автоматически, если включена настройка [autoConvergerEnabled](../../terraform-manager/configuration.html#parameters-autoconvergerenabled). Это может привести к обрыву трафика в кластере.
+              > **Внимание.** При изменении этих параметров, `terraform-auto-converger` перезапустит машину NAT-инстанса автоматически, если включена настройка [autoConvergerEnabled](../../terraform-manager/configuration.html#parameters-autoconvergerenabled). Это может привести к временному прерыванию трафика в кластере.
             type: object
             properties:
               cores:

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -212,6 +212,8 @@ apiVersions:
           natInstanceResources:
             description: |
               Вычислительные ресурсы, выделяемые для NAT-инстанса. Если параметр не указан, будут использоваться значения по умолчанию.
+
+              > **Внимание!** При изменении этих параметров, `terraform-auto-converger` перезапустит машину NAT-инстанса автоматически, если включена настройка [autoConvergerEnabled](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/modules/terraform-manager/configuration.html#parameters-autoconvergerenabled). Это может привести к обрыву трафика в кластере.
             type: object
             properties:
               cores:

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -213,7 +213,7 @@ apiVersions:
             description: |
               Вычислительные ресурсы, выделяемые для NAT-инстанса. Если параметр не указан, будут использоваться значения по умолчанию.
 
-              > **Внимание!** При изменении этих параметров, `terraform-auto-converger` перезапустит машину NAT-инстанса автоматически, если включена настройка [autoConvergerEnabled](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/modules/terraform-manager/configuration.html#parameters-autoconvergerenabled). Это может привести к обрыву трафика в кластере.
+              > **Внимание.** При изменении этих параметров, `terraform-auto-converger` перезапустит машину NAT-инстанса автоматически, если включена настройка [autoConvergerEnabled](../../terraform-manager/configuration.html#parameters-autoconvergerenabled). Это может привести к обрыву трафика в кластере.
             type: object
             properties:
               cores:


### PR DESCRIPTION
## Description
Add warning to `natInstanceResources` description that auto-converger would restart after it's interval NAT instance by default.

## Why do we need it, and what problem does it solve?
NAT instance is considered base-infra, therefore non-desctructive changes are applied automatically.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: chore
summary: Add warning NAT-instance restarts if resources changed
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
