### PR TITLE
[node-manager] Remove duplicate fields from bashible context

### DIFF
--- a/candi/bashible/common-steps/all/005_check_gpu.sh.tpl
+++ b/candi/bashible/common-steps/all/005_check_gpu.sh.tpl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- if eq .runType "Normal" }}
-  {{ if .gpu }}
+  {{ if .nodeGroup.gpu }}
 
 if ! command -v /usr/bin/nvidia-container-runtime >/dev/null 2>&1; then
     bb-log-error "'/usr/bin/nvidia-container-runtime' doesn't exist. It's require for Nvdia GPU nodes."

--- a/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
@@ -47,7 +47,7 @@ bb-event-on 'containerd-config-file-changed' '_on_containerd_config_changed'
   {{- end }}
 
   {{- $default_runtime := "runc" }}
-  {{- if .gpu }}
+  {{- if .nodeGroup.gpu }}
     {{ $default_runtime = "nvidia" }}
 sed -i "s/net.core.bpf_jit_harden = 2/net.core.bpf_jit_harden = 1/" /etc/sysctl.d/99-sysctl.conf # https://github.com/NVIDIA/nvidia-container-toolkit/issues/117#issuecomment-1758781872
 sed -i "s/net.core.bpf_jit_harden = 2/net.core.bpf_jit_harden = 1/" /etc/sysctl.conf # REDOS 
@@ -168,7 +168,7 @@ oom_score = 0
       default_runtime_name = {{ $default_runtime | quote }}
       ignore_blockio_not_enabled_errors = false
       ignore_rdt_not_enabled_errors = false
-  {{- if .gpu }}
+  {{- if .nodeGroup.gpu }}
       [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes]
         [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.nvidia]
           privileged_without_host_devices = false
@@ -379,7 +379,7 @@ oom_score = 0
           base_runtime_spec = ""
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
             SystemdCgroup = ${systemd_cgroup}
-  {{- if .gpu }}
+  {{- if .nodeGroup.gpu }}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
           privileged_without_host_devices = false
           runtime_engine = ""

--- a/candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl
+++ b/candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl
@@ -66,7 +66,7 @@ sysctl -w kernel.numa_balancing=0 # disable the overly smart NUMA node balancer 
 sysctl -w fs.inotify.max_user_watches=524288 # Increase inotify (https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers#the-technical-details)
 sysctl -w fs.inotify.max_user_instances=5120
 sysctl -w kernel.pid_max=2000000
-{{- if .gpu }}
+{{- if .nodeGroup.gpu }}
 sysctl -w net.core.bpf_jit_harden=1 # https://github.com/NVIDIA/nvidia-container-toolkit/issues/117#issuecomment-1758781872
 {{- end }}
 

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
@@ -303,7 +303,6 @@ func (cb *ContextBuilder) newBundleNGContext(ng nodeGroup, freq interface{}, clo
 		tplContextCommon:          contextCommon,
 		KubernetesVersion:         ng.KubernetesVersion(),
 		CRI:                       ng.CRIType(),
-		GPU:                       ng.GPUSharingType(),
 		NodeGroup:                 ng,
 		CloudProvider:             cloudProvider,
 		NodeStatusUpdateFrequency: freq,
@@ -411,16 +410,6 @@ func (ng nodeGroup) CRIType() string {
 	if cri, ok := ng["cri"]; ok {
 		if typ, ok := cri.(map[string]interface{})["type"]; ok {
 			return typ.(string)
-		}
-	}
-
-	return ""
-}
-
-func (ng nodeGroup) GPUSharingType() string {
-	if gpu, ok := ng["gpu"]; ok {
-		if gputype, ok := gpu.(map[string]interface{})["sharing"]; ok {
-			return gputype.(string)
 		}
 	}
 

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
@@ -481,7 +481,6 @@ type bundleNGContext struct {
 
 	KubernetesVersion string      `json:"kubernetesVersion" yaml:"kubernetesVersion"`
 	CRI               string      `json:"cri" yaml:"cri"`
-	GPU               string      `json:"gpu,omitempty" yaml:"gpu,omitempty"`
 	NodeGroup         nodeGroup   `json:"nodeGroup" yaml:"nodeGroup"`
 	CloudProvider     interface{} `json:"cloudProvider,omitempty" yaml:"cloudProvider,omitempty"`
 


### PR DESCRIPTION
## Description

Remove duplicate fields from bashible context

## Why do we need it, and what problem does it solve?

Reduce bashible-apiserver cognitive complexity 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Remove duplicate fields from bashible context.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
