### PR TITLE
[cloud-provider-openstack] migrate openstack_compute_floatingip_v2 to openstack_networking_floatingip_v2

### DIFF
--- a/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
@@ -140,21 +140,15 @@ resource "openstack_compute_instance_v2" "bastion" {
   metadata = length(local.metadata_tags) > 0 ? local.metadata_tags : null
 }
 
-resource "openstack_compute_floatingip_v2" "bastion" {
+resource "openstack_networking_floatingip_v2" "bastion" {
   count = local.bastion_instance != {} ? 1 : 0
   pool  = data.openstack_networking_network_v2.external.name
 }
 
-resource "openstack_compute_floatingip_associate_v2" "bastion" {
-  count                 = local.bastion_instance != {} ? 1 : 0
-  floating_ip           = openstack_compute_floatingip_v2.bastion[0].address
-  instance_id           = openstack_compute_instance_v2.bastion[0].id
-  wait_until_associated = true
-  lifecycle {
-    ignore_changes = [
-      wait_until_associated,
-    ]
-  }
+resource "openstack_networking_floatingip_associate_v2" "bastion" {
+  count       = local.bastion_instance != {} ? 1 : 0
+  floating_ip = openstack_networking_floatingip_v2.bastion[0].address
+  port_id     = openstack_networking_port_v2.bastion[0].id
 }
 
 resource "openstack_compute_servergroup_v2" "server_group" {

--- a/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/outputs.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/outputs.tf
@@ -24,5 +24,5 @@ output "cloud_discovery_data" {
 }
 
 output "bastion_ip_address_for_ssh" {
-  value = local.bastion_instance != {} ? openstack_compute_floatingip_v2.bastion[0].address : ""
+  value = local.bastion_instance != {} ? openstack_networking_floatingip_v2.bastion[0].address : ""
 }

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
@@ -95,20 +95,13 @@ resource "openstack_compute_instance_v2" "master" {
   }
 }
 
-resource "openstack_compute_floatingip_v2" "master" {
+resource "openstack_networking_floatingip_v2" "master" {
   count = var.floating_ip_network == "" ? 0 : 1
   pool  = var.floating_ip_network
 }
 
-resource "openstack_compute_floatingip_associate_v2" "master" {
-  count                 = var.floating_ip_network == "" ? 0 : 1
-  floating_ip           = openstack_compute_floatingip_v2.master[0].address
-  instance_id           = openstack_compute_instance_v2.master.id
-  wait_until_associated = true
-
-  lifecycle {
-    ignore_changes = [
-      wait_until_associated,
-    ]
-  }
+resource "openstack_networking_floatingip_associate_v2" "master" {
+  count       = var.floating_ip_network == "" ? 0 : 1
+  floating_ip = openstack_networking_floatingip_v2.master[0].address
+  port_id     = var.network_port_ids[0]
 }

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/outputs.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/outputs.tf
@@ -10,5 +10,5 @@ output "node_internal_ip_address" {
 }
 
 output "master_ip_address_for_ssh" {
-  value = var.floating_ip_network == "" ? lookup(openstack_compute_instance_v2.master.network[0], "fixed_ip_v4") : openstack_compute_floatingip_v2.master[0].address
+  value = var.floating_ip_network == "" ? lookup(openstack_compute_instance_v2.master.network[0], "fixed_ip_v4") : openstack_networking_floatingip_v2.master[0].address
 }

--- a/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
@@ -112,20 +112,13 @@ resource "openstack_compute_instance_v2" "node" {
   metadata = length(local.metadata_tags) > 0 ? local.metadata_tags : {}
 }
 
-resource "openstack_compute_floatingip_v2" "floating_ip" {
+resource "openstack_networking_floatingip_v2" "floating_ip" {
   count = length(local.floating_ip_pools)
   pool  = local.floating_ip_pools[count.index]
 }
 
-resource "openstack_compute_floatingip_associate_v2" "node" {
-  count                 = length(local.floating_ip_pools)
-  floating_ip           = openstack_compute_floatingip_v2.floating_ip[count.index].address
-  instance_id           = openstack_compute_instance_v2.node.id
-  wait_until_associated = true
-
-  lifecycle {
-    ignore_changes = [
-      wait_until_associated,
-    ]
-  }
+resource "openstack_networking_floatingip_associate_v2" "node" {
+  count       = length(local.floating_ip_pools)
+  floating_ip = openstack_networking_floatingip_v2.floating_ip[count.index].address
+  port_id     = openstack_networking_port_v2.port[count.index].id
 }


### PR DESCRIPTION
## Description
This PR replaces `openstack_compute_floatingip_v2` resource with `openstack_networking_floatingip_v2`

## Why do we need it, and what problem does it solve?
In the 17th version of OpenStack, there was a significant change in the API regarding the Terraform provider for floating IPs.
The previous object `openstack_compute_floatingip_v2` was replaced with `openstack_networking_floatingip_associate_v2`, eliminating backwards compatibility.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: migrate openstack_compute_floatingip_v2 to openstack_networking_floatingip_v2
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
