### PR TITLE
[candi] Add bashible step to check for upgrade k8s to 1.31

### DIFF
--- a/candi/bashible/common-steps/all/001_check_kubernetes_version.sh.tpl
+++ b/candi/bashible/common-steps/all/001_check_kubernetes_version.sh.tpl
@@ -19,7 +19,11 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   currentVersion=$(kubelet --version |egrep -o "1.[0-9]+")
   desiredVersion={{ $kubernetesVersion }}
 
-  if [[ "${desiredVersion}" = "1.31" && -n "$currentVersion" && ("${currentVersion}" != "${desiredVersion}") ]]
+  if [[ "${desiredVersion}" = "1.31" && -n "$currentVersion" && ("${currentVersion}" != "${desiredVersion}") && "$currentVersion" = "1.30" ]]
+    then
+      bb-deckhouse-get-disruptive-update-approval
+  fi
+    if [[ "${desiredVersion}" = "1.30" && -n "$currentVersion" && ("${currentVersion}" != "${desiredVersion}") && "$currentVersion" = "1.31" ]]
     then
       bb-deckhouse-get-disruptive-update-approval
   fi

--- a/candi/bashible/common-steps/all/001_check_kubernetes_version.sh.tpl
+++ b/candi/bashible/common-steps/all/001_check_kubernetes_version.sh.tpl
@@ -18,12 +18,15 @@ function kubectl_exec() {
 }
 
 {{ $kubernetesVersion := .kubernetesVersion | toString }}
-currentVersion=$(kubectl_exec get no "$(D8_NODE_HOSTNAME)" -o json |jq -r '.status.nodeInfo.kubeletVersion' |sed -E "s/v([0-9]+[.][0-9]+)[.].+/\1/")
-desiredVersion={{ $kubernetesVersion }}
 
-if [[ "${desiredVersion}" = "1.31" && ("${currentVersion}" != "${desiredVersion}") ]]
-  then
-    bb-deckhouse-get-disruptive-update-approval
+if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
+  currentVersion=$(kubectl_exec get no "$(D8_NODE_HOSTNAME)" -o json |jq -r '.status.nodeInfo.kubeletVersion' |sed -E "s/v([0-9]+[.][0-9]+)[.].+/\1/")
+  desiredVersion={{ $kubernetesVersion }}
+
+  if [[ "${desiredVersion}" = "1.31" && ("${currentVersion}" != "${desiredVersion}") ]]
+    then
+      bb-deckhouse-get-disruptive-update-approval
+  fi
 fi
 
 {{- end }}

--- a/candi/bashible/common-steps/all/001_check_kubernetes_version.sh.tpl
+++ b/candi/bashible/common-steps/all/001_check_kubernetes_version.sh.tpl
@@ -19,11 +19,11 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   currentVersion=$(kubelet --version |egrep -o "1.[0-9]+")
   desiredVersion={{ $kubernetesVersion }}
 
-  if [[ "${desiredVersion}" = "1.31" && -n "$currentVersion" && ("${currentVersion}" != "${desiredVersion}") && "$currentVersion" = "1.30" ]]
+  if [[ "${desiredVersion}" = "1.31" && -n "$currentVersion" && "$currentVersion" = "1.30" ]]
     then
       bb-deckhouse-get-disruptive-update-approval
   fi
-    if [[ "${desiredVersion}" = "1.30" && -n "$currentVersion" && ("${currentVersion}" != "${desiredVersion}") && "$currentVersion" = "1.31" ]]
+  if [[ "${desiredVersion}" = "1.30" && -n "$currentVersion" && "$currentVersion" = "1.31" ]]
     then
       bb-deckhouse-get-disruptive-update-approval
   fi

--- a/candi/bashible/common-steps/all/001_check_kubernetes_version.sh.tpl
+++ b/candi/bashible/common-steps/all/001_check_kubernetes_version.sh.tpl
@@ -13,14 +13,10 @@
 # limitations under the License.
 
 {{- if eq .runType "Normal" }}
-function kubectl_exec() {
-  kubectl --request-timeout 60s --kubeconfig=/etc/kubernetes/kubelet.conf ${@}
-}
-
 {{ $kubernetesVersion := .kubernetesVersion | toString }}
 
 if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
-  currentVersion=$(kubectl_exec get no "$(D8_NODE_HOSTNAME)" -o json |jq -r '.status.nodeInfo.kubeletVersion' |sed -E "s/v([0-9]+[.][0-9]+)[.].+/\1/")
+  currentVersion=$(kubelet --version |egrep -o "1.[0-9]+")
   desiredVersion={{ $kubernetesVersion }}
 
   if [[ "${desiredVersion}" = "1.31" && [ -n "$currentVersion" ] && ("${currentVersion}" != "${desiredVersion}") ]]

--- a/candi/bashible/common-steps/all/001_check_kubernetes_version.sh.tpl
+++ b/candi/bashible/common-steps/all/001_check_kubernetes_version.sh.tpl
@@ -23,7 +23,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   currentVersion=$(kubectl_exec get no "$(D8_NODE_HOSTNAME)" -o json |jq -r '.status.nodeInfo.kubeletVersion' |sed -E "s/v([0-9]+[.][0-9]+)[.].+/\1/")
   desiredVersion={{ $kubernetesVersion }}
 
-  if [[ "${desiredVersion}" = "1.31" && ("${currentVersion}" != "${desiredVersion}") ]]
+  if [[ "${desiredVersion}" = "1.31" && [ -n "$currentVersion" ] && ("${currentVersion}" != "${desiredVersion}") ]]
     then
       bb-deckhouse-get-disruptive-update-approval
   fi

--- a/candi/bashible/common-steps/all/001_check_kubernetes_version.sh.tpl
+++ b/candi/bashible/common-steps/all/001_check_kubernetes_version.sh.tpl
@@ -19,7 +19,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   currentVersion=$(kubelet --version |egrep -o "1.[0-9]+")
   desiredVersion={{ $kubernetesVersion }}
 
-  if [[ "${desiredVersion}" = "1.31" && [ -n "$currentVersion" ] && ("${currentVersion}" != "${desiredVersion}") ]]
+  if [[ "${desiredVersion}" = "1.31" && -n "$currentVersion" && ("${currentVersion}" != "${desiredVersion}") ]]
     then
       bb-deckhouse-get-disruptive-update-approval
   fi


### PR DESCRIPTION
## Description

Add bashible step to check for upgrade k8s to 1.31 and ask for approval

## Why do we need it, and what problem does it solve?

Due upgrade from 1.30 to 1.31, all pods on the node will be restarted, what causes downtime. So we should check if it's upgrade to 1.31 and ask for approval.

## Why do we need it in the patch release (if we do)?

We should backport it to all releases, when 1.31 is available.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Add bashible step to check for upgrade k8s to 1.31 and ask for approval.
impact: Upgrade process on the node will be stopped  until it's not approved.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
