### PR TITLE
[docs] Refactor table of supported OS versions

### DIFF
--- a/docs/documentation/_data/supported_versions.yml
+++ b/docs/documentation/_data/supported_versions.yml
@@ -9,7 +9,11 @@ osDistributions:
         - '8 СП (релиз 10)'
     ce_support:
       versions:
-        - '8 СП (релиз 10)'
+        - '10.0'
+        - '10.1'
+        - '10.2'
+        - '11'
+        - 'p10'
   astra:
     name: Astra Linux Special Edition
     url: https://astralinux.ru/products/astra-linux-special-edition/
@@ -18,6 +22,10 @@ osDistributions:
     cse_support:
       versions:
         - '1.7'
+    ce_support:
+      versions:
+        - '1.7'
+        - '1.8'
       note_content:
         ru: |
           В версии <b>1.7.6</b> модуль <b>runtime-audit-engine будет работать с ядром <a href='./modules/runtime-audit-engine/#%D1%82%D1%80%D0%B5%D0%B1%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D1%8F'>5.15-generic</a></b>.
@@ -67,14 +75,24 @@ osDistributions:
     cse_support:
       versions:
         - '7.3'
+    ce_support:
+      versions:
+        - '7.3'
+        - '8.0'
   'rosa':
     name: 'РОСА Сервер'
     url: https://rosa.ru
     ru_support: 'true'
     en_support: 'false'
-    note_content:
-      ru: |
-        Невозможна работа модуля runtime-audit-engine (из-за отсутствия поддержки ядром BPF Type Format (BTF)). Для <strong>РОСА «КОБАЛЬТ» Сервер</strong> рекомендуется установка ядра не ниже версии <b>5.15.33</b> (пакет <b>kernel-ml</b>)
+    ce_support:
+      versions:
+        - '7.9'
+        - '12.4'
+        - '12.5'
+        - '12.6'
+      note_content:
+        ru: |
+          Невозможна работа модуля runtime-audit-engine (из-за отсутствия поддержки ядром BPF Type Format (BTF)). Для <strong>РОСА «КОБАЛЬТ» Сервер</strong> рекомендуется установка ядра не ниже версии <b>5.15.33</b> (пакет <b>kernel-ml</b>)
   '_mosos-arbat':
     name: 'МОС ОС'
     url: https://os.mos.ru/

--- a/docs/documentation/_data/supported_versions.yml
+++ b/docs/documentation/_data/supported_versions.yml
@@ -7,6 +7,9 @@ osDistributions:
     cse_support:
       versions:
         - '8 СП (релиз 10)'
+    ce_support:
+      versions:
+        - '8 СП (релиз 10)'
   astra:
     name: Astra Linux Special Edition
     url: https://astralinux.ru/products/astra-linux-special-edition/

--- a/docs/documentation/_includes/SUPPORTED_VERSIONS.liquid
+++ b/docs/documentation/_includes/SUPPORTED_VERSIONS.liquid
@@ -15,8 +15,8 @@
 {{ site.data.i18n.common['os_supported_phrase'][page.lang] }}:
 
 <div markdown="0">
-<table class="supported_versions fixed-header-table">
-<thead class="versioning-table">
+  <table class="supported_versions fixed-header-table">
+    <thead class="versioning-table">
     <tr class="header-row">
       <th class="name" style="text-align: center; white-space: nowrap;">{{site.data.i18n.common['linux_distro'][page.lang] }}</th>
       <th class="text-align: center; versions" style="white-space: nowrap;">{{ site.data.i18n.common['versions_supported'][page.lang] | capitalize }}</th>
@@ -31,178 +31,24 @@
       <td></td>
       <td></td>
       {%- if page.lang == 'ru' %}
-        <td style="text-align: center; width: 170px; font-weight: 600; padding: 0 10px;">CE</td>
-        <td style="text-align: center; width: 170px; font-weight: 600; padding: 5px 10px;">CSE Lite, CSE Pro</td>
-        <td style="text-align: center; width: 170px; white-space: nowrap; font-weight: 600; padding: 0 10px;">BE, SE, SE+, EE</td>
+      <td style="text-align: center; width: 170px; font-weight: 600; padding: 0 10px;">CE</td>
+      <td style="text-align: center; width: 170px; font-weight: 600; padding: 5px 10px;">CSE Lite, CSE Pro</td>
+      <td style="text-align: center; width: 170px; white-space: nowrap; font-weight: 600; padding: 0 10px;">BE, SE, SE+, EE</td>
       {%- else %}
-        <td style="text-align: center; width: 170px; font-weight: 600; padding: 0 10px;">CE, BE, SE, SE+, EE</td>
+      <td style="text-align: center; width: 170px; font-weight: 600; padding: 0 10px;">CE, BE, SE, SE+, EE</td>
       {%- endif %}
       <td></td>
     </tr>
-</thead>
-<tbody>
-{%- for osItem in osVersions %}
-{%- assign osKey = osItem[0] %}
-{%- assign osName = site.data.supported_versions.osDistributions[osKey].name | default: osKey  %}
-{%- if site.data.supported_versions.osDistributions[osKey][langSupportKey] and site.data.supported_versions.osDistributions[osKey][langSupportKey] != "true" %}{% continue %}{% endif %}
-{% if site.data.supported_versions.osDistributions[osKey]['cse_support'] %}
-{% assign comma_counter = 1 %}
-<tr>
-  <!-- OS name -->
-  <td class="name" rowspan="2">
-    <span>
-      {%- if site.data.supported_versions.osDistributions[osKey].url %}
-        <a href="{{ site.data.supported_versions.osDistributions[osKey].url }}" target="_blank">{{ osName }}</a>
-      {%- else %}{{ osName }}
-      {%- endif %}
-    </span>
-  </td>
-  <!-- Versions list -->
-  <td class="versions">
-{%- for osData in osItem[1] %}
-{%- assign osVersion = osData[0] %}
-  {%- assign exclude = false %}
-  {%- for excludedVersion in site.data.supported_versions.osDistributions[osKey]['cse_support']['versions'] %}
-    {%- if excludedVersion == osVersion %}{%- assign exclude = true %}{%- endif %}
-  {%- endfor %}
-  {%- if exclude == true %}
-{{ osVersion }}{% if site.data.supported_versions.osDistributions[osKey]['versions'][osVersion] %} ({{ site.data.supported_versions.osDistributions[osKey]['versions'][osVersion]['name'] }}){% endif %}
-    {%- if comma_counter < site.data.supported_versions.osDistributions[osKey]['cse_support']['versions'].size %},{%- endif %}
-    {%- assign comma_counter = comma_counter | plus: 1 %}
-  {%- endif %}
-{%- endfor %}
-  </td>
-  {%- if page.lang == 'ru' %}
-  <!-- CE row (ru) -->
-  <td style="text-align: center; width: 170px;">
-    <div class="icon">
-      {% if site.data.supported_versions.osDistributions[osKey]['ru_support'] == "true" %}
-        <img src="{{ partially_supported_img_url }}" data-tippy-content="{{ site.data.i18n.common['note_ce_notguaranteed'][page.lang] }}">
-      {% else %}
-        <img src="{{ supported_img_url }}">
-      {% endif %}
-    </div>
-  </td>
-  <!-- CSE row -->
-  <td style="text-align: center; width: 170px;">
-    <div class="icon">
-      <img src="{{ supported_img_url }}">
-    </div>
-    </td>
-  {%- endif %}
-  <td style="text-align: center; width: 170px;">
-    <div class="icon">
-      <img src="{{ supported_img_url }}">
-    </div>
-  </td>
-  <td style="text-align: center;">
-    <div class="icon">
-      {% if site.data.supported_versions.osDistributions[osKey]['cse_support']['note_content'] %}
-        <img src="{{ notes_img_url }}" data-tippy-content="{{ site.data.supported_versions.osDistributions[osKey]['cse_support']['note_content'][page.lang] }}">
-      {% endif %}
-    </div>
-  </td>
-</tr>
-<tr>
-   <!-- The second raw, for the not supported by CSE -->
-   <!-- Versions list -->
-  <td class="versions">
-{%- for osData in osItem[1] %}
-  {%- assign osVersion = osData[0] %}
-  {%- assign exclude = false %}
-  {%- for excludedVersion in site.data.supported_versions.osDistributions[osKey]['cse_support']['versions'] %}
-    {%- if excludedVersion == osVersion %}{%- assign exclude = true %}{%- endif %}
-  {%- endfor %}
-  {%- if exclude != true %}
-    {{ osVersion }}{% if site.data.supported_versions.osDistributions[osKey]['versions'][osVersion] %} ({{ site.data.supported_versions.osDistributions[osKey]['versions'][osVersion]['name'] }}){% endif %}
-    {%- unless forloop.last %},{% endunless %}
-  {%- endif %}
-{%- endfor %}
-    </td>
-    <td style="text-align: center; width: 170px;">
-      <div class="icon">
-        {% if site.data.supported_versions.osDistributions[osKey]['ru_support'] == "true" %}
-          <img src="{{ partially_supported_img_url }}" data-tippy-content="Работоспособность в Community Edition не гарантируется.">
-        {% else %}
-          <img src="{{ supported_img_url }}">
-        {% endif %}
-      </div>
-    </td>
-    <td style="text-align: center; width: 170px;">
-      <div class="icon"><img src="{{ not_supported_img_url }}"></div>
-    </td>
-    <!-- BE, SE, SE+, EE row -->
-    <td style="text-align: center; width: 170px;">
-      <div class="icon">
-        <img src="{{ supported_img_url }}">
-      </div></td>
-    <td style="text-align: center;">
-      <div class="icon">
-        {% if site.data.supported_versions.osDistributions[osKey]['note_content'] %}
-          <img src="{{ notes_img_url }}" data-tippy-content="{{ site.data.supported_versions.osDistributions[osKey]['note_content'][page.lang] }}">
-        {% endif %}
-      </div>
-  </td>
-</tr>
-{% else %}
-  <tr>
-    <!-- OS name -->
-    <td class="name">
-    <span>
-      {%- if site.data.supported_versions.osDistributions[osKey].url %}
-        <a href="{{ site.data.supported_versions.osDistributions[osKey].url }}" target="_blank">{{ osName }}</a>
-      {%- else %}{{ osName }}
-      {%- endif %}
-    </span>
-    </td>
-  <!-- Versions list -->
-    <td class="versions">
-      {%- for osData in osItem[1] %}
-        {%- assign osVersion = osData[0] %}
-        {{ osVersion }}{% if site.data.supported_versions.osDistributions[osKey]['versions'][osVersion] %} ({{ site.data.supported_versions.osDistributions[osKey]['versions'][osVersion]['name'] }}){% endif %}
-        {%- unless forloop.last %},{% endunless %}
-      {%- endfor %}
-    </td>
-    {%- if page.lang == 'ru' %}
-      <!-- CE row (ru) -->
-      <td style="text-align: center; width: 170px;">
-        <div class="icon">
-          {% if site.data.supported_versions.osDistributions[osKey]['ru_support'] == "true" %}
-            <img src="{{ partially_supported_img_url }}" data-tippy-content="Работоспособность в Community Edition не гарантируется.">
-          {% else %}
-            <img src="{{ supported_img_url }}">
-          {% endif %}
-        </div>
-      </td>
-      <td style="text-align: center; width: 170px;">
-        <div class="icon">
-          {% if site.data.supported_versions.osDistributions[osKey]['cse_support'] == "true" %}
-            <img src="{{ supported_img_url }}">
-          {% else %}
-            <img src="{{ not_supported_img_url }}">
-          {% endif %}
-        </div>
-      </td>
-    {%- endif %}
-    <td style="text-align: center; width: 170px;">
-      <div class="icon">
-        <img src="{{ supported_img_url }}">
-      </div>
-    </td>
-    <td style="text-align: center;">
-      <div class="icon">
-        {% if site.data.supported_versions.osDistributions[osKey]['note_content'] %}
-          <img src="{{ notes_img_url }}" data-tippy-content="{{ site.data.supported_versions.osDistributions[osKey]['note_content'][page.lang] }}">
-        {% endif %}
-      </div>
-    </td>
-  </tr>
-{% endif %}
-{%- endfor %}
-</tbody>
-</table>
-{% if page.lang == 'ru' %}
-{%  endif %}
+    </thead>
+    <tbody>
+    {%- for osItem in osVersions %}
+    {%- assign osKey = osItem[0] %}
+    {%- assign osName = site.data.supported_versions.osDistributions[osKey].name | default: osKey  %}
+    {%- if site.data.supported_versions.osDistributions[osKey][langSupportKey] and site.data.supported_versions.osDistributions[osKey][langSupportKey] != "true" %}{% continue %}{% endif %}
+    {%- include partials/supported-table-line.liquid osItem=osItem osName=osName osKey=osKey %}
+    {% endfor %}
+    </tbody>
+  </table>
 </div>
 
 ## Kubernetes

--- a/docs/documentation/_includes/partials/supported-table-line.liquid
+++ b/docs/documentation/_includes/partials/supported-table-line.liquid
@@ -1,0 +1,220 @@
+{%- if page.lang == 'ru' %}
+<!-- Prepare CE list -->
+{% assign ceVersions = "" | split: "," %}
+{%- for osData in osItem[1] %}
+  {%- assign osVersion = osData[0] %}
+  {%- for ceVersion in site.data.supported_versions.osDistributions[osKey]['ce_support']['versions'] %}
+  {%- if ceVersion == osVersion %}
+    {% assign ceVersions = ceVersions | push: ceVersion %}
+  {%- endif %}
+  {%- endfor %}
+{%- endfor %}
+
+<!-- Prepare CSE list -->
+{% assign cseVersions = "" | split: "," %}
+{%- for osData in osItem[1] %}
+  {%- assign osVersion = osData[0] %}
+  {%- for cseVersion in site.data.supported_versions.osDistributions[osKey]['cse_support']['versions'] %}
+    {%- if cseVersion == osVersion %}
+      {% assign cseVersions = cseVersions | push: cseVersion %}
+    {%- endif %}
+  {%- endfor %}
+{%- endfor %}
+
+<!-- Prepare common list -->
+{% assign commonVersions = "" | split: "," %}
+{%- for os in ceVersions %}
+  {% if cseVersions contains os %}
+    {% assign commonVersions = commonVersions | push: os %}
+  {% endif %}
+{%- endfor %}
+
+<!-- Update CE list -->
+{% assign ceVersions = "" | split: "," %}
+{%- for osData in osItem[1] %}
+  {%- assign osVersion = osData[0] %}
+  {%- for ceVersion in site.data.supported_versions.osDistributions[osKey]['ce_support']['versions'] %}
+    {%- if ceVersion == osVersion %}
+      {% assign exclude = false %}
+      {% for commonVersion in commonVersions %}
+        {%- if commonVersion == ceVersion %}{% assign exclude = true %}{% endif %}
+      {% endfor %}
+      {% if exclude == false %}{% assign ceVersions = ceVersions | push: ceVersion %}{% endif %}
+    {%- endif %}
+  {%- endfor %}
+{%- endfor %}
+
+<!-- Update CSE list -->
+{% assign cseVersions = "" | split: "," %}
+{%- for osData in osItem[1] %}
+  {%- assign osVersion = osData[0] %}
+  {%- for cseVersion in site.data.supported_versions.osDistributions[osKey]['cse_support']['versions'] %}
+    {%- if cseVersion == osVersion %}
+      {% assign exclude = false %}
+      {% for commonVersion in commonVersions %}
+        {%- if commonVersion == cseVersion %}{% assign exclude = true %}{% endif %}
+      {% endfor %}
+      {% if exclude == false %}{% assign cseVersions = cseVersions | push: cseVersion %}{% endif %}
+    {%- endif %}
+  {%- endfor %}
+{%- endfor %}
+
+<!-- Prepare other list -->
+{% assign otherVersions = "" | split: "," %}
+{%- for osData in osItem[1] %}
+  {%- assign osVersion = osData[0] %}
+  {% assign exclude = false %}
+  {% for commonVersion in commonVersions %}
+    {%- if commonVersion == osVersion %}{% assign exclude = true %}{% endif %}
+  {% endfor %}
+  {% for cseVersion in cseVersions %}
+    {%- if cseVersion == osVersion %}{% assign exclude = true %}{% endif %}
+  {% endfor %}
+  {% for ceVersion in ceVersions %}
+    {%- if ceVersion == osVersion %}{% assign exclude = true %}{% endif %}
+  {% endfor %}
+  {% if exclude == false %}{% assign otherVersions = otherVersions | push: osVersion %}{% endif %}
+{%- endfor %}
+
+{% assign rowsCount = 0 %}
+{% if commonVersions.size > 0 %}{% assign rowsCount = rowsCount | plus: 1 %}{% assign commonExists = true %}{% endif %}
+{% if ceVersions.size > 0 %}{% assign rowsCount = rowsCount | plus: 1 %}{% assign ceExists = true %}{% endif %}
+{% if cseVersions.size > 0 %}{% assign rowsCount = rowsCount | plus: 1 %}{% assign cseExists = true %}{% endif %}
+{% if otherVersions.size > 0 %}{% assign rowsCount = rowsCount | plus: 1 %}{% assign otherExists = true %}{% endif %}
+
+{% for i in (1..rowsCount) %}
+<tr>
+  <!-- OS name -->
+  {% if i == 1 %}
+  <td class="name" {% if rowsCount > 1 %}rowspan="{{ rowsCount }}"{% endif %}>
+    <span>
+      {%- if site.data.supported_versions.osDistributions[osKey].url %}
+        <a href="{{ site.data.supported_versions.osDistributions[osKey].url }}" target="_blank">{{ osName }}</a>
+      {%- else %}{{ osName }}
+      {%- endif %}
+    </span>
+  </td>
+  {% endif %}
+  {% if commonExists == true %}
+  <td class="versions">
+    {% for commonVersion in commonVersions %}
+    {{ commonVersion }}{%- unless forloop.last %},{% endunless %}
+    {% endfor %}
+    {% assign commonExists = false %}
+  </td>
+  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td>
+    <div class="icon">
+      {% if site.data.supported_versions.osDistributions[osKey]['cse_support']['note_content'] or site.data.supported_versions.osDistributions[osKey]['ce_support']['note_content'] %}
+      <img src="{{ notes_img_url }}" data-tippy-content="{{ site.data.supported_versions.osDistributions[osKey]['cse_support']['note_content'][page.lang] }}<br>{{ site.data.supported_versions.osDistributions[osKey]['ce_support']['note_content'][page.lang] }}">
+      {% endif %}
+    </div>
+  </td>
+  </tr>
+  {% continue %}
+  {% endif %}
+  {% if cseExists == true %}
+  <td class="versions">
+    {% for cseVersion in cseVersions %}
+    {{ cseVersion }}{%- unless forloop.last %},{% endunless %}
+    {% endfor %}
+    {% assign cseExists = false %}
+  </td>
+  <td><div class="icon"><img src="{{ partially_supported_img_url }}" data-tippy-content="Работоспособность в Community Edition не гарантируется."></div></td>
+  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td>
+    <div class="icon">
+      {% if site.data.supported_versions.osDistributions[osKey]['cse_support']['note_content'] %}
+      <img src="{{ notes_img_url }}" data-tippy-content="{{ site.data.supported_versions.osDistributions[osKey]['cse_support']['note_content'][page.lang] }}">
+      {% endif %}
+    </div>
+  </td>
+  </tr>
+{% continue %}
+  {% endif %}
+  {% if ceExists == true %}
+  <td class="versions">
+    {% for ceVersion in ceVersions %}
+    {{ ceVersion }}{%- unless forloop.last %},{% endunless %}
+    {% endfor %}
+    {% assign ceExists = false %}
+  </td>
+  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td><div class="icon"><img src="{{ not_supported_img_url }}"></div></td>
+  <td><<div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td>
+    <div class="icon">
+      {% if site.data.supported_versions.osDistributions[osKey]['ce_support']['note_content'] %}
+      <img src="{{ notes_img_url }}" data-tippy-content="{{ site.data.supported_versions.osDistributions[osKey]['ce_support']['note_content'][page.lang] }}">
+      {% endif %}
+    </div>
+  </td>
+</tr>
+{% continue %}
+  {% endif %}
+  {% if otherExists == true %}
+  <td class="versions">
+    {% for otherVersion in otherVersions %}
+    {{ otherVersion }}{%- unless forloop.last %},{% endunless %}
+    {% endfor %}
+    {% assign otherExists = false %}
+  </td>
+  <td>
+    <div class="icon">
+      {% if site.data.supported_versions.osDistributions[osKey]['ru_support'] == "true" %}
+      <img src="{{ partially_supported_img_url }}" data-tippy-content="Работоспособность в Community Edition не гарантируется.">
+      {% else %}
+      <img src="{{ supported_img_url }}">
+      {% endif %}
+    </div>
+  </td>
+  <td><div class="icon"><img src="{{ not_supported_img_url }}"></div></td>
+  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td>
+    <div class="icon">
+      {% if site.data.supported_versions.osDistributions[osKey]['note_content'] %}
+      <img src="{{ notes_img_url }}" data-tippy-content="{{ site.data.supported_versions.osDistributions[osKey]['note_content'][page.lang] }}">
+      {% endif %}
+    </div>
+  </td>
+</tr>
+{% continue %}
+  {% endif %}
+{% endfor %}
+{% endif %}
+
+{%- if page.lang == 'en' %}
+<tr>
+  <!-- OS name -->
+  <td class="name">
+    <span>
+      {%- if site.data.supported_versions.osDistributions[osKey].url %}
+        <a href="{{ site.data.supported_versions.osDistributions[osKey].url }}" target="_blank">{{ osName }}</a>
+      {%- else %}{{ osName }}
+      {%- endif %}
+    </span>
+  </td>
+  <td class="versions">
+    {%- for osData in osItem[1] %}
+    {%- assign osVersion = osData[0] %}
+    {{ osVersion }}{% if site.data.supported_versions.osDistributions[osKey]['versions'][osVersion] %} ({{ site.data.supported_versions.osDistributions[osKey]['versions'][osVersion]['name'] }}){% endif %}
+    {%- unless forloop.last %},{% endunless %}
+    {%- endfor %}
+  </td>
+  <td style="text-align: center; width: 170px;">
+    <div class="icon">
+      <img src="{{ supported_img_url }}">
+    </div>
+  </td>
+  <td style="text-align: center;">
+    <div class="icon">
+      {% if site.data.supported_versions.osDistributions[osKey]['note_content'] %}
+      <img src="{{ notes_img_url }}" data-tippy-content="{{ site.data.supported_versions.osDistributions[osKey]['note_content'][page.lang] }}">
+      {% endif %}
+    </div>
+  </td>
+</tr>
+{% endif %}

--- a/docs/documentation/_includes/partials/supported-table-line.liquid
+++ b/docs/documentation/_includes/partials/supported-table-line.liquid
@@ -144,7 +144,7 @@
   </td>
   <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
   <td><div class="icon"><img src="{{ not_supported_img_url }}"></div></td>
-  <td><<div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
   <td>
     <div class="icon">
       {% if site.data.supported_versions.osDistributions[osKey]['ce_support']['note_content'] %}


### PR DESCRIPTION
## Description

This pull request refactors the supported versions documentation by introducing a new partial template to simplify the rendering logic and adding support for Community Edition (CE) versions. 

### Refactoring and Template Updates:
* **Introduction of `partials/supported-table-line.liquid`**: Created a new partial template to consolidate and simplify the logic for rendering supported OS versions in tabular format. This includes preparing separate lists for CE, CSE, and other versions, as well as handling multilingual support (Russian and English).
* **Replacement of inline logic in `SUPPORTED_VERSIONS.liquid`**: Removed extensive inline logic for rendering supported versions and replaced it with the new partial template, significantly reducing code duplication and improving readability.

### Addition of Community Edition (CE) Support:
* **Update to `supported_versions.yml`**: Added CE support information, including supported versions, to the `osDistributions` section of the YAML configuration file.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Refactored table of supported OS versions.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
