### PR TITLE
[docs] Update used network port list

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -158,7 +158,7 @@ groups:
       en: "`sds-replicated-volume` agent metrics"
       ru: "Метрики агента `sds-replicated-volume`"
   - ports: "4218"
-    protocol: TCP
+    protocol: TCP/UDP
     description:
       en: "Synchronization of the `speaker` components in `metallb` modules via memberlist protocol"
       ru: "Синхронизация компонентов `speaker` модулей `metallb` через протокол memberlist"
@@ -173,7 +173,7 @@ groups:
       en: "`node-local-dns` metrics"
       ru: "Метрики `node-local-dns`"
   - ports: "4225"
-    protocol: UDP
+    protocol: TCP/UDP
     description:
       en: "Synchronization of the `speaker` components in `metallb` modules via memberlist protocol"
       ru: "Синхронизация компонентов `speaker` модулей `metallb` через протокол memberlist"


### PR DESCRIPTION
## Description

Update used network port list in the documentation:
- Changed protocol for port 4218 from TCP to TCP/UDP.
- Changed protocol for port 4225 from UDP to TCP/UDP.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update used network port list in the documentation.
impact_level: low
```
