### PR TITLE
[vertical-pod-autoscaler] Fix VPA admission resources

### DIFF
--- a/modules/302-vertical-pod-autoscaler/templates/admission.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/admission.yaml
@@ -1,6 +1,6 @@
 {{- if (semverCompare "< 1.33" .Values.global.discovery.kubernetesVersion) }}
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
 kind: ValidatingAdmissionPolicy
 metadata:
   name: "deny-vpa-in-place-mode"
@@ -20,7 +20,7 @@ spec:
         object.spec.updatePolicy.updateMode != 'InPlaceOrRecreate'
       message: "VerticalPodAutoscaler with updateMode=InPlaceOrRecreate is not allowed before kubernetes 1.33"
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: "deny-vpa-initial-mode-binding"


### PR DESCRIPTION
## Description
Fix apiVersion for ValidatingAdmissionPolicy

## Why do we need it, and what problem does it solve?
apiVersion is based on the kubernetes version

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: vertical-pod-autoscaler
type: fix 
summary: Fix apiVersion detection for ValidatingAdmissionPolicy.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
