### PR TITLE
[cert-manager] Add support for ACME HTTP-01 challenges method in ingressClass

### DIFF
--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -135,4 +135,5 @@ properties:
     type: string
     x-examples: ["nginx"]
     description: |
-      The name of the ingressClass used to confirm ownership of domain using the ACME http01 method.
+      The name of the ingressClass used to confirm ownership of domain using the [ACME HTTP01](https://cert-manager.io/docs/configuration/acme/http01/) method.
+      If the parameter is omitted, the default ingressClass is used.

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -135,5 +135,5 @@ properties:
     type: string
     x-examples: ["nginx"]
     description: |
-      The name of the ingressClass used to confirm ownership of domain using the [ACME HTTP01](https://cert-manager.io/docs/configuration/acme/http01/) method.
-      If the parameter is omitted, the default ingressClass is used.
+      The name of the `ingressClass` used to confirm ownership of domain using the [ACME HTTP01](https://cert-manager.io/docs/configuration/acme/http01/) method.  
+      If the parameter is omitted, the default `ingressClass` is used.

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -130,3 +130,10 @@ properties:
     description: |
       Enable CAInjector. It only needs to inject CA certs into `ValidatingWebhookConfiguration`, `MutatingWebhookConfiguration`, `CustomResourceDefinition` and `APIService`.
       Deckhouse does not use CAInjector, so you have to enable it only if you use custom CA injections in your services.
+
+  ingressClassHttp01:
+    type: string
+    x-examples: ["ingress-nginx"]
+    description: |
+      The ingress class for http01 challenge
+      

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -133,7 +133,6 @@ properties:
 
   ingressClassHttp01:
     type: string
-    x-examples: ["ingress-nginx"]
+    x-examples: ["nginx"]
     description: |
-      The ingress class for http01 challenge
-      
+      The name of the ingressClass used to confirm ownership of domain using the ACME http01 method.

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -135,5 +135,5 @@ properties:
     type: string
     x-examples: ["nginx"]
     description: |
-      The name of the `ingressClass` used to confirm ownership of domain using the [ACME HTTP01](https://cert-manager.io/docs/configuration/acme/http01/) method.  
+      The name of the `ingressClass` used to confirm ownership of domain using the [ACME HTTP-01](https://cert-manager.io/docs/configuration/acme/http01/) challenges method.
       If the parameter is omitted, the default `ingressClass` is used.

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -67,6 +67,4 @@ properties:
     x-examples: ["nginx"]
     description: |
       Имя `ingressClass` используемого для подтверждения владения доменом методом [ACME HTTP-01](https://cert-manager.io/docs/configuration/acme/http01/).  
-      Если параметр не указан, то используется `ingressClass` по умолчанию.
-  
-      
+      Если параметр не указан, то используется `ingressClass` по умолчанию.      

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -66,6 +66,7 @@ properties:
     type: string
     x-examples: ["nginx"]
     description: |
-      Имя ingressClass используемого для подтверждения владения доменом ACME методом http01.
+      Имя ingressClass используемого для подтверждения владения доменом методом [ACME HTTP01](https://cert-manager.io/docs/configuration/acme/http01/).
+      Если параметр не указан, то используется ingressClass по умолчанию.
   
       

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -66,7 +66,7 @@ properties:
     type: string
     x-examples: ["nginx"]
     description: |
-      Имя `ingressClass` используемого для подтверждения владения доменом методом [ACME HTTP01](https://cert-manager.io/docs/configuration/acme/http01/).  
+      Имя `ingressClass` используемого для подтверждения владения доменом методом [ACME HTTP-01](https://cert-manager.io/docs/configuration/acme/http01/).  
       Если параметр не указан, то используется `ingressClass` по умолчанию.
   
       

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -61,3 +61,11 @@ properties:
     description: |
       Включить CAInjector. Он необходим только для инъекции CA-сертификатов в `ValidatingWebhookConfiguration`, `MutatingWebhookConfiguration`, `CustomResourceDefinition` и `APIService`.
       Deckhouse не использует CAInjector, поэтому включать нужно только в том случае, если вы используете в своих сервисах пользовательские инъекции CA.
+
+  ingressClassHttp01:
+    type: string
+    x-examples: ["ingress-nginx"]
+    description: |
+      ingressClass используемы для подтверждения сертификата методом http01.
+  
+      

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -64,8 +64,8 @@ properties:
 
   ingressClassHttp01:
     type: string
-    x-examples: ["ingress-nginx"]
+    x-examples: ["nginx"]
     description: |
-      ingressClass используемы для подтверждения сертификата методом http01.
+      Имя ingressClass используемого для подтверждения владения доменом ACME методом http01.
   
       

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -66,7 +66,7 @@ properties:
     type: string
     x-examples: ["nginx"]
     description: |
-      Имя ingressClass используемого для подтверждения владения доменом методом [ACME HTTP01](https://cert-manager.io/docs/configuration/acme/http01/).
-      Если параметр не указан, то используется ingressClass по умолчанию.
+      Имя `ingressClass` используемого для подтверждения владения доменом методом [ACME HTTP01](https://cert-manager.io/docs/configuration/acme/http01/).  
+      Если параметр не указан, то используется `ingressClass` по умолчанию.
   
       

--- a/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt-staging.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt-staging.yaml
@@ -16,7 +16,9 @@ spec:
     solvers:
     - http01:
         ingress:
-          {{- if hasKey .Values.global.modules "ingressClass" }}
+          {{- if hasKey .Values.certManager "ingressClassHttp01" }}
+          ingressClassName: {{ .Values.certManager.ingressClassHttp01 }}
+          {{- else if hasKey .Values.global.modules "ingressClass" }}
           ingressClassName: {{ .Values.global.modules.ingressClass }}
           {{- end }}
           podTemplate:

--- a/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt.yaml
@@ -16,7 +16,9 @@ spec:
     solvers:
     - http01:
         ingress:
-          {{- if hasKey .Values.global.modules "ingressClass" }}
+          {{- if hasKey .Values.certManager "ingressClassHttp01" }}
+          ingressClassName: {{ .Values.certManager.ingressClassHttp01 }}
+          {{- else if hasKey .Values.global.modules "ingressClass" }}
           ingressClassName: {{ .Values.global.modules.ingressClass }}
           {{- end }}
           podTemplate:


### PR DESCRIPTION
## Description
Introduces a new parameter to the cert-manager module. 
The parameter allows users to specify which ingress-class to use for domain ownership verification via the `http01` method.

## Why do we need it, and what problem does it solve?
By allowing the selection of an ingress-class, users can better control traffic routing when verifying domain ownership. This update addresses issues where the default ingress controller might not be suitable for certain application setups.

Resolve #13923 issue

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cert-manager
type: feature 
summary: Added ingressClass selection for ACME HTTP-01 challenge method.
impact_level: low
```

