### PR TITLE
[docs] Fixed rendering for Customizing istio-proxy sidecar resource management article

### DIFF
--- a/modules/110-istio/docs/EXAMPLES.md
+++ b/modules/110-istio/docs/EXAMPLES.md
@@ -674,6 +674,7 @@ You can override the global istio-proxy sidecar resource limits for specific wor
 ### Supported annotations
 
 Use these Pod annotations to customize sidecar resources:
+
 | Annotation                          | Description                 | Example Value |
 |-------------------------------------|-----------------------------|---------------|
 | `sidecar.istio.io/proxyCPU`         | CPU request for sidecar     | `200m`        |
@@ -685,11 +686,11 @@ Use these Pod annotations to customize sidecar resources:
 
 For Deployments:
 
-```shell
+```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  ...
+# ...
 spec:
   template:
     metadata:
@@ -703,11 +704,11 @@ spec:
 
 For ReplicaSets:
 
-```shell
+```yaml
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-  ...
+# ...
 spec:
   template:
     metadata:
@@ -721,7 +722,7 @@ spec:
 
 For Pod:
 
-```shell
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:

--- a/modules/110-istio/docs/EXAMPLES_RU.md
+++ b/modules/110-istio/docs/EXAMPLES_RU.md
@@ -687,11 +687,11 @@ kubectl get pods -A -o json | jq --arg revision "v1x19" \
 
 Для Deployment:
 
-```shell
+```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  ...
+# ...
 spec:
   template:
     metadata:
@@ -705,11 +705,11 @@ spec:
 
 Для ReplicaSet:
 
-```shell
+```yaml
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-  ...
+# ...
 spec:
   template:
     metadata:
@@ -723,7 +723,7 @@ spec:
 
 Для Pod:
 
-```shell
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -735,4 +735,4 @@ metadata:
 # ... остальная часть манифеста
 ```
 
-{% alert level="warning" %}Все четыре параметра должны быть указаны вместе - `sidecar.istio.io/proxyCPU`, `sidecar.istio.io/proxyCPULimit`, `sidecar.istio.io/proxyMemory`, and `sidecar.istio.io/proxyMemoryLimit`. Частичная конфигурация не поддерживается.{% endalert %}
+{% alert level="warning" %}Все четыре параметра должны быть указаны вместе — `sidecar.istio.io/proxyCPU`, `sidecar.istio.io/proxyCPULimit`, `sidecar.istio.io/proxyMemory` и `sidecar.istio.io/proxyMemoryLimit`. Частичная конфигурация не поддерживается.{% endalert %}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed rendering for Customizing istio-proxy sidecar resource management article.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Before:

<img width="544" height="691" alt="before" src="https://github.com/user-attachments/assets/55ae3de4-240e-4dba-a128-98420531ac15" />

After:

<img width="576" height="627" alt="after" src="https://github.com/user-attachments/assets/417d8eb6-b895-4ee4-96d7-eea9e33cd95f" />

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fixed rendering for Customizing istio-proxy sidecar resource management article.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
