### PR TITLE
[user-authn] Fix typo in config

### DIFF
--- a/modules/150-user-authn/templates/dex/config.yaml
+++ b/modules/150-user-authn/templates/dex/config.yaml
@@ -126,7 +126,7 @@
         {{- if $provider.ldap.insecureNoSSL }}
         insecureNoSSL: true
         {{- end }}
-        {{- if $provider.ldap.rootCAData }}Ï
+        {{- if $provider.ldap.rootCAData }}
         rootCAData: {{ $provider.ldap.rootCAData | b64enc }}
         {{- end }}
         {{- if $provider.ldap.bindDN  }}


### PR DESCRIPTION
## Description
Looks like in https://github.com/deckhouse/deckhouse/pull/14366 was added unnecessary symbol `Ï`

## Why do we need it, and what problem does it solve?
Remove unnecessary symbol `Ï` that could brake config

## Why do we need it in the patch release (if we do)?

Remove unnecessary symbol `Ï` that could brake config

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Remove unnecessary symbol `Ï` that could brake config.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
