### PR TITLE
[modules] 'Enabled' scripts add reason

### DIFF
--- a/modules/036-kube-proxy/enabled
+++ b/modules/036-kube-proxy/enabled
@@ -21,6 +21,7 @@ function __main__() {
     echo "true" > $MODULE_ENABLED_RESULT
   else
     echo "false" > $MODULE_ENABLED_RESULT
+    echo "Module disabled: global.enabledModules does not contain 'cni-simple-bridge' or 'cni-flannel'" > "$MODULE_ENABLED_REASON"  
   fi
 }
 

--- a/modules/040-control-plane-manager/enabled
+++ b/modules/040-control-plane-manager/enabled
@@ -21,6 +21,7 @@ function __main__() {
     echo "true" > "$MODULE_ENABLED_RESULT"
   else
     echo "false" > "$MODULE_ENABLED_RESULT"
+    echo "Module disabled: required value global.clusterConfiguration is not set" > "$MODULE_ENABLED_REASON"
   fi
 }
 

--- a/modules/040-terraform-manager/enabled
+++ b/modules/040-terraform-manager/enabled
@@ -18,13 +18,17 @@ source /deckhouse/shell_lib.sh
 
 function __main__() {
   enabled::disable_module_if_cluster_is_not_bootstraped
-  if kubectl -n kube-system get secret d8-provider-cluster-configuration >/dev/null 2>&1 ; then
-    if kubectl -n d8-system get secret d8-cluster-terraform-state >/dev/null 2>&1 ; then
-      echo "true" > "$MODULE_ENABLED_RESULT"
-      return
-    fi
+
+  if ! kubectl -n kube-system get secret d8-provider-cluster-configuration >/dev/null 2>&1 ; then
+    echo "false" > "$MODULE_ENABLED_RESULT"
+    echo "Module disabled: secret 'kube-system/d8-provider-cluster-configuration' is not present" > "$MODULE_ENABLED_REASON"
+
+  elif ! kubectl -n d8-system get secret d8-cluster-terraform-state >/dev/null 2>&1 ; then
+    echo "false" > "$MODULE_ENABLED_RESULT"
+    echo "Module disabled: secret 'd8-system/d8-cluster-terraform-state' is not present" > "$MODULE_ENABLED_REASON"
+  else
+    echo "true" > "$MODULE_ENABLED_RESULT"
   fi
-  echo "false" > "$MODULE_ENABLED_RESULT"
 }
 
 enabled::run "$@"

--- a/modules/050-network-policy-engine/enabled
+++ b/modules/050-network-policy-engine/enabled
@@ -18,8 +18,10 @@ source /deckhouse/shell_lib.sh
 
 function __main__() {
   enabled::disable_module_if_cluster_is_not_bootstraped
+ 
   if values::array_has global.enabledModules "cni-cilium" ; then
     echo "false" > "$MODULE_ENABLED_RESULT"
+    echo "Module disabled: global.enabledModules contains 'cni-cilium', which is mutually exclusive with this module" > "$MODULE_ENABLED_REASON"
   else
     echo "true" > "$MODULE_ENABLED_RESULT"
   fi

--- a/modules/150-user-authn/enabled
+++ b/modules/150-user-authn/enabled
@@ -25,9 +25,11 @@ function __main__() {
       echo "true" > $MODULE_ENABLED_RESULT
     else
       echo "false" > $MODULE_ENABLED_RESULT
+      echo "Module disabled: 'https.mode' for module has 'Disabled' value" > $MODULE_ENABLED_REASON
     fi
   else
     echo "false" > $MODULE_ENABLED_RESULT
+    echo "Module disabled: 'global.modules.publicDomainTemplate' is not set" > $MODULE_ENABLED_REASON
   fi
 }
 

--- a/modules/500-dashboard/enabled
+++ b/modules/500-dashboard/enabled
@@ -19,21 +19,38 @@ source /deckhouse/shell_lib.sh
 function __main__() {
   enabled::disable_module_if_cluster_is_not_bootstraped
 
-  echo "false" > $MODULE_ENABLED_RESULT
-  if values::has global.modules.publicDomainTemplate ; then
-    https_mode=$(values::get_first_defined dashboard.https.mode global.modules.https.mode)
-    if [ "$https_mode" != "Disabled" ] ; then
-      if values::array_has global.enabledModules "user-authz" ; then
-        if ! values::array_has global.enabledModules "user-authn"; then
-          if values::has dashboard.auth.externalAuthentication.authSignInURL && values::has dashboard.auth.externalAuthentication.authURL; then
-            echo "true" > $MODULE_ENABLED_RESULT
-          fi
-        else
-          echo "true" > $MODULE_ENABLED_RESULT
-        fi
-      fi
-    fi
+  if ! values::has global.modules.publicDomainTemplate ; then
+    echo "false" > "$MODULE_ENABLED_RESULT"
+    echo "Module disabled: required value global.modules.publicDomainTemplate is not set" > "$MODULE_ENABLED_REASON"
+    return
+  fi
+
+  https_mode=$(values::get_first_defined dashboard.https.mode global.modules.https.mode)
+  if [ "$https_mode" = "Disabled" ]; then
+    echo "false" > "$MODULE_ENABLED_RESULT"
+    echo "Module disabled: https.mode is set to 'Disabled' (from dashboard.https.mode or global.modules.https.mode)" > "$MODULE_ENABLED_REASON"
+    return
+  fi
+
+  if ! values::array_has global.enabledModules "user-authz" ; then
+    echo "false" > "$MODULE_ENABLED_RESULT"
+    echo "Module disabled: global.enabledModules does not contain 'user-authz'" > "$MODULE_ENABLED_REASON"
+    return
+  fi
+
+  if values::array_has global.enabledModules "user-authn" ; then
+    echo "true" > "$MODULE_ENABLED_RESULT"
+    return
+  fi
+
+  if values::has dashboard.auth.externalAuthentication.authSignInURL && \
+     values::has dashboard.auth.externalAuthentication.authURL ; then
+    echo "true" > "$MODULE_ENABLED_RESULT"
+  else
+    echo "false" > "$MODULE_ENABLED_RESULT"
+    echo "Module disabled: global.enabledModules does not contain 'user-authn' and required values dashboard.auth.externalAuthentication.authSignInURL or dashboard.auth.externalAuthentication.authURL are not set" > "$MODULE_ENABLED_REASON"
   fi
 }
 
-enabled::run $@
+
+enabled::run "$@"

--- a/shell_lib/enabled.sh
+++ b/shell_lib/enabled.sh
@@ -21,6 +21,7 @@ function enabled::run() {
 function enabled::disable_module_if_cluster_is_not_bootstraped() {
   if ! values::is_true global.clusterIsBootstrapped ; then
     echo "false" > $MODULE_ENABLED_RESULT
+    echo "Module disabled: global.clusterIsBootstrapped is not true" > "$MODULE_ENABLED_REASON"
     exit 0
   fi
 }
@@ -29,10 +30,14 @@ function enabled::disable_module_in_kubernetes_versions_less_than() {
   cluster_version=$(values::get global.discovery.kubernetesVersion)
   if [ "$(semver compare $cluster_version $1)" -eq "-1" ] ; then
     echo "false" > $MODULE_ENABLED_RESULT
+    echo "Module disabled: Kubernetes version $cluster_version is less than required minimum $1" > "$MODULE_ENABLED_REASON"
     exit 0
   fi
 }
 
+# TODO: it may be worth explicitly checking the return value enabled::fail_if_values_are_not_set
+# and not continue execution if the values are missing. 
+# Right now the function returns 1, but this is ignored.
 function enabled::fail_if_values_are_not_set() {
   for var in "$@"
   do


### PR DESCRIPTION
## Description
Currently, when enabled scripts disable a module, have no the reason, making it difficult to debug the actual cause without inspecting the script logic.  

This improvement adds support for a human-readable reason by introducing an environment variable (`$MODULE_ENABLED_REASON`). 

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Simplify error correction by providing clear reasons for errors

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: feature
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
