### PR TITLE
feat: add name truncation with hash for dex-authenticator resources to fit 63 chars limit

### DIFF
--- a/modules/150-user-authn/templates/_helpers.tpl
+++ b/modules/150-user-authn/templates/_helpers.tpl
@@ -19,3 +19,34 @@
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{- /* Function to truncate long names with MD5 hash to ensure they don't exceed 63 characters */ -}}
+{{- define "truncate_name_with_hash" -}}
+  {{- $name := . -}}
+  {{- $suffix := "-dex-authenticator" -}}
+  {{- $fullName := printf "%s%s" $name $suffix -}}
+  {{- if gt (len $fullName) 63 -}}
+    {{- $hash := $name | sha256sum | trunc 8 -}}
+    {{- $maxNameLength := sub 63 (add (len $suffix) (len $hash) 1) -}}
+    {{- $truncatedName := $name | trunc $maxNameLength -}}
+    {{- printf "%s-%s%s" $truncatedName $hash $suffix -}}
+  {{- else -}}
+    {{- $fullName -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Function to generate full name with namespace for initContainer */ -}}
+{{- define "truncate_name_with_hash_full" -}}
+  {{- $name := .name -}}
+  {{- $namespace := .namespace -}}
+  {{- $suffix := "-dex-authenticator" -}}
+  {{- $fullName := printf "%s%s" $name $suffix -}}
+  {{- if gt (len $fullName) 63 -}}
+    {{- $hash := $name | sha256sum | trunc 8 -}}
+    {{- $maxNameLength := sub 63 (add (len $suffix) (len $hash) 1) -}}
+    {{- $truncatedName := $name | trunc $maxNameLength -}}
+    {{- printf "%s-%s%s.%s" $truncatedName $hash $suffix $namespace -}}
+  {{- else -}}
+    {{- printf "%s%s.%s" $name $suffix $namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -15,14 +15,14 @@ memory: 25Mi
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ $crd.name }}-dex-authenticator
+  name: {{ include "truncate_name_with_hash" $crd.name }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment
-    name: {{ $crd.name }}-dex-authenticator
+    name: {{ include "truncate_name_with_hash" $crd.name }}
   updatePolicy:
     updateMode: "Auto"
   resourcePolicy:
@@ -44,7 +44,7 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ $crd.name }}-dex-authenticator
+  name: {{ include "truncate_name_with_hash" $crd.name }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -57,7 +57,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $crd.name }}-dex-authenticator
+  name: {{ include "truncate_name_with_hash" $crd.name }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -105,8 +105,8 @@ spec:
         emptyDir: {}
       initContainers:
       - args:
-        - {{ $crd.name }}-dex-authenticator.{{ $crd.namespace }}
-        - {{ $crd.name }}-dex-authenticator.{{ $crd.namespace }}.svc
+        - {{ include "truncate_name_with_hash_full" (dict "name" $crd.name "namespace" $crd.namespace) }}
+        - {{ include "truncate_name_with_hash_full" (dict "name" $crd.name "namespace" $crd.namespace) }}.svc
         image: {{ include "helm_lib_module_image" (list $context "selfSignedGenerator") }}
         name: self-signed-generator
         volumeMounts:
@@ -126,7 +126,7 @@ spec:
         image: {{ include "helm_lib_module_image" (list $context "dexAuthenticator") }}
         args:
         - --provider=oidc
-        - --client-id={{ $crd.name }}-{{ $crd.namespace }}-dex-authenticator
+        - --client-id={{ include "truncate_name_with_hash" $crd.name }}-{{ $crd.namespace }}
     {{- if ne (include "helm_lib_module_uri_scheme" $context ) "https" }}
         - --cookie-secure=false
     {{- end }}
@@ -172,12 +172,12 @@ spec:
         - name: OAUTH2_PROXY_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: dex-authenticator-{{ $crd.name }}
+              name: dex-authenticator-{{ include "truncate_name_with_hash" $crd.name }}
               key: client-secret
         - name: OAUTH2_PROXY_COOKIE_SECRET
           valueFrom:
             secretKeyRef:
-              name: dex-authenticator-{{ $crd.name }}
+              name: dex-authenticator-{{ include "truncate_name_with_hash" $crd.name }}
               key: cookie-secret
         - name: TRUSTED_ROOT_CA_FILE
           value: /certs/ca.crt

--- a/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
   {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |-
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  name: {{ $crd.name }}{{ $nameSuffix }}-dex-authenticator
+  name: {{ include "truncate_name_with_hash" $crd.name }}{{ $nameSuffix }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -31,7 +31,7 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ $crd.name }}-dex-authenticator
+            name: {{ include "truncate_name_with_hash" $crd.name }}
             port:
               number: 443
         path: /dex-authenticator
@@ -55,7 +55,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /dex-authenticator/sign_out
     nginx.ingress.kubernetes.io/configuration-snippet: |-
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  name: {{ $crd.name }}{{ $nameSuffix }}-dex-authenticator-sign-out
+  name: {{ include "truncate_name_with_hash" $crd.name }}{{ $nameSuffix }}-sign-out
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -66,7 +66,7 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ $crd.name }}-dex-authenticator
+            name: {{ include "truncate_name_with_hash" $crd.name }}
             port:
               number: 443
         path: {{ $app.signOutURL }}

--- a/modules/150-user-authn/templates/dex-authenticator/secret.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/secret.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dex-authenticator-{{ $crd.name }}
+  name: dex-authenticator-{{ include "truncate_name_with_hash" $crd.name }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator" "name" "credentials")) | nindent 2 }}
 data:

--- a/modules/150-user-authn/templates/dex-authenticator/service.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $crd.name }}-dex-authenticator
+  name: {{ include "truncate_name_with_hash" $crd.name }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:


### PR DESCRIPTION
## Description

When using long CRD names, we encountered situations where dex-authenticator object names became excessively long, sometimes exceeding 63 characters. This made their usage impossible.

## Why do we need it, and what problem does it solve?

A length limitation for dex-authenticator objects is imposed to resolve issues with applying cluster changes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: add name truncation with hash for dex-authenticator resources to fit 63 chars limit
impact_level: default
```
