### PR TITLE
[deckhouse] 1.71 fix storage class change hook

### DIFF
--- a/go_lib/hooks/storage_class_change/hook.go
+++ b/go_lib/hooks/storage_class_change/hook.go
@@ -272,10 +272,13 @@ func storageClassChangeWithArgs(input *go_hook.HookInput, dc dependency.Containe
 		return Pod{}, fmt.Errorf("pod with volume name [%s] not found", pvcName)
 	}
 
+	var existingPvcs []PVC
 	for _, pvc := range pvcs {
 		if !pvc.IsDeleted {
+			existingPvcs = append(existingPvcs, pvc)
 			continue
 		}
+
 		pod, err := findPodByPVCName(pvc.Name)
 		if err == nil {
 			// if someone deleted pvc then evict the pod.
@@ -291,8 +294,8 @@ func storageClassChangeWithArgs(input *go_hook.HookInput, dc dependency.Containe
 	}
 
 	var currentStorageClass string
-	if len(pvcs) > 0 {
-		currentStorageClass = pvcs[0].StorageClassName
+	if len(existingPvcs) > 0 {
+		currentStorageClass = existingPvcs[0].StorageClassName
 	}
 
 	effectiveStorageClass, err := calculateEffectiveStorageClass(input, args, currentStorageClass)
@@ -302,7 +305,7 @@ func storageClassChangeWithArgs(input *go_hook.HookInput, dc dependency.Containe
 	if !storageClassesAreEqual(currentStorageClass, effectiveStorageClass) {
 		wasPvc := !isEmptyOrFalseStr(currentStorageClass)
 		if wasPvc {
-			for _, pvc := range pvcs {
+			for _, pvc := range existingPvcs {
 				input.Logger.Info("PVC StorageClass changed. Deleting PersistentVolumeClaim", slog.String("namespace", pvc.Namespace), slog.String("name", pvc.Name))
 				err = kubeClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
 				if err != nil {


### PR DESCRIPTION
## Description
It fixes storage class change issue.

It is a manual backport for https://github.com/deckhouse/deckhouse/pull/14286

## Why do we need it, and what problem does it solve?
Closes #14278

## Why do we need it in the patch release (if we do)?
Prev versions affected too.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Filter deleted pvcs in storage class change hook.
impact_level: low
```
