### PR TITLE
Fix rerun workflow with multiple editions labels

### DIFF
--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -170,7 +170,6 @@ pull_request_info:
   outputs:
     ref: ${{ steps.pr_props.outputs.ref }}
     ref_slug: ${{ steps.pr_props.outputs.ref_slug }}
-    edition: ${{ steps.pr_props.outputs.edition }}
     pr_title: ${{ steps.pr_props.outputs.pr_title }}
     pr_description: ${{ steps.pr_props.outputs.pr_description }}
     diff_url: ${{ steps.pr_props.outputs.diff_url }}
@@ -178,6 +177,11 @@ pull_request_info:
     security_rootless_scan: ${{ steps.pr_props.outputs.security_rootless_scan }}
     changes_docs: ${{ steps.changes.outputs.docs }}
     changes_not_markdown: ${{ steps.changes.outputs.not_markdown }}
+    edition_ce: ${{ steps.pr_props.outputs.edition_ce }}
+    edition_be: ${{ steps.pr_props.outputs.edition_be }}
+    edition_se: ${{ steps.pr_props.outputs.edition_se }}
+    edition_se-plus: ${{ steps.pr_props.outputs.edition_se-plus }}
+    edition_ee: ${{ steps.pr_props.outputs.edition_ee }}
 
   # Skip pull_request and pull_request_target triggers for PRs authored by deckhouse-BOaTswain, e.g. changelog PRs, don't skip if Pull Request title contains "[run ci]".
   if: ${{ ! (startsWith(github.event_name, 'pull_request') && github.event.pull_request.user.login == 'deckhouse-BOaTswain' && !contains(github.event.pull_request.title, '[run ci]')) }}
@@ -309,27 +313,9 @@ pull_request_info:
             core.notice(`PR#{pr.number} may be dangerous, will check file changes.`)
           }
 
-          // Set edition from current labels.
-          const defaultEdition = process.env.WERF_ENV ? process.env.WERF_ENV : 'FE';
-          const hasEE = pr.labels.some((l) => l.name === 'edition/ee');
-          const hasCE = pr.labels.some((l) => l.name === 'edition/ce');
-          const hasBE = pr.labels.some((l) => l.name === 'edition/be');
-          const hasSE = pr.labels.some((l) => l.name === 'edition/se');
-          const hasSE_plus = pr.labels.some((l) => l.name === 'edition/se+');
-          let edition = defaultEdition;
-          if (hasCE) {
-            edition = 'CE';
-          } else if (hasEE) {
-            edition = 'EE';
-          } else if (hasBE) {
-            edition = 'BE';
-          } else if (hasSE) {
-            edition = 'SE';
-          } else if (hasSE_plus) {
-            edition = 'SE-plus';
-          }
-          core.info(`Edition labels: 'edition/ce':${hasCE}, 'edition/ee':${hasEE}, 'edition/be':${hasBE}, 'edition/se':${hasSE}, 'edition/se+':${hasSE_plus}`);
-          core.notice(`Enable '${edition}' edition for '${context.eventName}' trigger.`);
+          // Set editions from current labels to build_ce, build_ee and so on.
+          const build_editions = input_labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
+
           // Set security rootless scan from labels.
           const security_rootless_scan = pr.labels.some((l) => l.name === 'security/rootless');
           // Construct head commit ref using pr number.
@@ -349,14 +335,18 @@ pull_request_info:
           core.setOutput('should_check', shouldCheckFiles.toString());
           core.setOutput('ref', ref);
           core.setOutput('ref_slug', `pr${pr.number}`);
-          core.setOutput('edition', edition);
           core.setOutput('pr_title', pr.title);
           core.setOutput('pr_description', pr.body);
           core.setOutput('diff_url', diff_url);
           core.setOutput('labels', JSON.stringify(pr.labels));
           core.setOutput('security_rootless_scan', security_rootless_scan);
+          core.startGroup('Set build editions based on pr labels')
+          for (build_edition of build_editions) {
+            core.setOutput(build_edition, 'true');
+            core.info(`${build_edition}`)
+          }
+          core.endGroup()
           core.setCommandEcho(false);
-          core.info(JSON.stringify(pr.labels))
 
     # Checkhout the head commit of the PR branch.
     - name: Checkout PR head commit

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -314,7 +314,7 @@ pull_request_info:
           }
 
           // Set editions from current labels to build_ce, build_ee and so on.
-          const build_editions = input_labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
+          const build_editions = pr.labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
 
           // Set security rootless scan from labels.
           const security_rootless_scan = pr.labels.some((l) => l.name === 'security/rootless');

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -177,11 +177,11 @@ pull_request_info:
     security_rootless_scan: ${{ steps.pr_props.outputs.security_rootless_scan }}
     changes_docs: ${{ steps.changes.outputs.docs }}
     changes_not_markdown: ${{ steps.changes.outputs.not_markdown }}
-    edition_ce: ${{ steps.pr_props.outputs.edition_ce }}
-    edition_be: ${{ steps.pr_props.outputs.edition_be }}
-    edition_se: ${{ steps.pr_props.outputs.edition_se }}
-    edition_se-plus: ${{ steps.pr_props.outputs.edition_se-plus }}
-    edition_ee: ${{ steps.pr_props.outputs.edition_ee }}
+    build_ce: ${{ steps.pr_props.outputs.build_ce }}
+    build_be: ${{ steps.pr_props.outputs.build_be }}
+    build_se: ${{ steps.pr_props.outputs.build_se }}
+    build_se-plus: ${{ steps.pr_props.outputs.build_se-plus }}
+    build_ee: ${{ steps.pr_props.outputs.build_ee }}
 
   # Skip pull_request and pull_request_target triggers for PRs authored by deckhouse-BOaTswain, e.g. changelog PRs, don't skip if Pull Request title contains "[run ci]".
   if: ${{ ! (startsWith(github.event_name, 'pull_request') && github.event.pull_request.user.login == 'deckhouse-BOaTswain' && !contains(github.event.pull_request.title, '[run ci]')) }}

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -356,6 +356,7 @@ pull_request_info:
           core.setOutput('labels', JSON.stringify(pr.labels));
           core.setOutput('security_rootless_scan', security_rootless_scan);
           core.setCommandEcho(false);
+          core.info(JSON.stringify(pr.labels))
 
     # Checkhout the head commit of the PR branch.
     - name: Checkout PR head commit

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -342,7 +342,7 @@ pull_request_info:
           core.setOutput('security_rootless_scan', security_rootless_scan);
           core.startGroup('Set build editions based on pr labels')
           for (build_edition of build_editions) {
-            core.setOutput(build_edition, 'true');
+            core.setOutput(`${build_edition}`, 'true');
             core.info(`${build_edition}`)
           }
           core.endGroup()

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -314,7 +314,7 @@ pull_request_info:
           }
 
           // Set editions from current labels to build_ce, build_ee and so on.
-          const build_editions = pr.labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
+          const build_editions = pr.labels.map(l => l.name).filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
 
           // Set security rootless scan from labels.
           const security_rootless_scan = pr.labels.some((l) => l.name === 'security/rootless');

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -393,7 +393,7 @@ module.exports.checkLabel = checkLabel;
  * @returns {Promise<void|*>}
  */
 const removeLabel = async ({ github, context, core, issue_number, label }) => {
-  core.startGroup(`Remove label '${label}' from ${context.payload.pull_request ? 'PR' : 'issue'} #${issue_number} ...`);
+  core.startGroup(`Remove label '${label}' from issue ${issue_number} ...`);
   try {
     const response = await github.rest.issues.removeLabel({
       owner: context.repo.owner,

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -1022,30 +1022,10 @@ module.exports.runWorkflowForPullRequest = async ({ github, context, core, ref }
       command.workflows = ['build-and-test_dev.yml', 'validation.yml'];
       command.rerunWorkflow = true;
     }
-    // Rerun build workflow if edition label is added or all edition labels are removed.
-    if (labelType === 'edition') {
-      // Gather other edition labels on PR.
-      let removeEditions = [];
-      prLabels.map((l) => {
-        const info = knownLabels[l.name];
-        if (info && info.type === 'edition' && l.name !== label) {
-          removeEditions.push(l.name);
-        }
-      });
-
-      if (event.action === 'labeled' && removeEditions.length > 0) {
-        // If edition/ce label is set, edition/ee label should be removed and vice versa.
-        for (const edition of removeEditions) {
-          core.notice(`Remove label '${edition}' from PR#${prNumber}`);
-          await removeLabel({ github, context, core, issue_number: prNumber, label: edition });
-        }
-      }
-
-      // Re-run workflow if labeled with edition label or no edition labels left on PR.
-      if (event.action === 'labeled' || (event.action === 'unlabeled' && removeEditions.length === 0)) {
-        command.workflows = ['build-and-test_dev.yml'];
-        command.rerunWorkflow = true;
-      }
+    // Rerun build workflow if edition label is added, ignore 'unlabeled' action.
+    if (labelType === 'edition' && event.action === 'labeled') {
+      command.workflows = ['build-and-test_dev.yml'];
+      command.rerunWorkflow = true;
     }
     if (labelType === 'security') {
       if (labelInfo.security === 'rootless' && event.action === 'labeled') {

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -393,7 +393,7 @@ module.exports.checkLabel = checkLabel;
  * @returns {Promise<void|*>}
  */
 const removeLabel = async ({ github, context, core, issue_number, label }) => {
-  core.startGroup(`Remove label '${label}' from issue ${issue_number} ...`);
+  core.startGroup(`Remove label '${label}' from ${context.payload.pull_request ? 'PR' : 'issue'} #${issue_number} ...`);
   try {
     const response = await github.rest.issues.removeLabel({
       owner: context.repo.owner,
@@ -1037,7 +1037,7 @@ module.exports.runWorkflowForPullRequest = async ({ github, context, core, ref }
         // If edition/ce label is set, edition/ee label should be removed and vice versa.
         for (const edition of removeEditions) {
           core.notice(`Remove label '${edition}' from PR#${prNumber}`);
-          await removeLabel({ github, context, core, issue_number, label: edition });
+          await removeLabel({ github, context, core, issue_number: prNumber, label: edition });
         }
       }
 

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -51,7 +51,7 @@ jobs:
 
   build_ee:
     name: Build EE
-    if: ${{ needs.pull_request_info.outputs.edition_ee == 'true' }}
+    if: ${{ needs.pull_request_info.outputs.build_ee == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -62,7 +62,7 @@ jobs:
 
   build_se:
     name: Build SE
-    if: ${{ needs.pull_request_info.outputs.edition_se == 'true' }}
+    if: ${{ needs.pull_request_info.outputs.build_se == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -73,7 +73,7 @@ jobs:
 
   build_se_plus:
     name: Build SE-plus
-    if: ${{ needs.pull_request_info.outputs.edition_se-plus == 'true' }}
+    if: ${{ needs.pull_request_info.outputs.build_se-plus == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -84,7 +84,7 @@ jobs:
 
   build_be:
     name: Build BE
-    if: ${{ needs.pull_request_info.outputs.edition_be == 'true' }}
+    if: ${{ needs.pull_request_info.outputs.build_be == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -95,7 +95,7 @@ jobs:
 
   build_ce:
     name: Build CE
-    if: ${{ needs.pull_request_info.outputs.edition_ce == 'true' }}
+    if: ${{ needs.pull_request_info.outputs.build_ce == 'true' }}
     needs:
       - git_info
       - pull_request_info

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -51,7 +51,7 @@ jobs:
 
   build_ee:
     name: Build EE
-    if: contains(github.event.pull_request.labels.*.name, 'edition/ee')
+    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/ee')
     needs:
       - git_info
       - pull_request_info
@@ -62,7 +62,7 @@ jobs:
 
   build_se:
     name: Build SE
-    if: contains(github.event.pull_request.labels.*.name, 'edition/se')
+    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/se')
     needs:
       - git_info
       - pull_request_info
@@ -73,7 +73,7 @@ jobs:
 
   build_se_plus:
     name: Build SE-plus
-    if: contains(github.event.pull_request.labels.*.name, 'edition/se-plus')
+    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/se-plus')
     needs:
       - git_info
       - pull_request_info
@@ -84,7 +84,7 @@ jobs:
 
   build_be:
     name: Build BE
-    if: contains(github.event.pull_request.labels.*.name, 'edition/be')
+    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/be')
     needs:
       - git_info
       - pull_request_info
@@ -95,7 +95,7 @@ jobs:
 
   build_ce:
     name: Build CE
-    if: contains(github.event.pull_request.labels.*.name, 'edition/ce')
+    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/ce')
     needs:
       - git_info
       - pull_request_info

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -51,7 +51,7 @@ jobs:
 
   build_ee:
     name: Build EE
-    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/ee')
+    if: contains(needs.pull_request_info.outputs.labels, 'edition/ee')
     needs:
       - git_info
       - pull_request_info
@@ -62,7 +62,7 @@ jobs:
 
   build_se:
     name: Build SE
-    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/se')
+    if: contains(needs.pull_request_info.outputs.labels, 'edition/se')
     needs:
       - git_info
       - pull_request_info
@@ -73,7 +73,7 @@ jobs:
 
   build_se_plus:
     name: Build SE-plus
-    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/se-plus')
+    if: contains(needs.pull_request_info.outputs.labels, 'edition/se-plus')
     needs:
       - git_info
       - pull_request_info
@@ -84,7 +84,7 @@ jobs:
 
   build_be:
     name: Build BE
-    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/be')
+    if: contains(needs.pull_request_info.outputs.labels, 'edition/be')
     needs:
       - git_info
       - pull_request_info
@@ -95,7 +95,7 @@ jobs:
 
   build_ce:
     name: Build CE
-    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/ce')
+    if: contains(needs.pull_request_info.outputs.labels, 'edition/ce')
     needs:
       - git_info
       - pull_request_info

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -51,7 +51,7 @@ jobs:
 
   build_ee:
     name: Build EE
-    if: contains(needs.pull_request_info.outputs.labels, 'edition/ee')
+    if: ${{ needs.pull_request_info.outputs.edition_ee == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -62,7 +62,7 @@ jobs:
 
   build_se:
     name: Build SE
-    if: contains(needs.pull_request_info.outputs.labels, 'edition/se')
+    if: ${{ needs.pull_request_info.outputs.edition_se == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -73,7 +73,7 @@ jobs:
 
   build_se_plus:
     name: Build SE-plus
-    if: contains(needs.pull_request_info.outputs.labels, 'edition/se-plus')
+    if: ${{ needs.pull_request_info.outputs.edition_se-plus == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -84,7 +84,7 @@ jobs:
 
   build_be:
     name: Build BE
-    if: contains(needs.pull_request_info.outputs.labels, 'edition/be')
+    if: ${{ needs.pull_request_info.outputs.edition_be == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -95,7 +95,7 @@ jobs:
 
   build_ce:
     name: Build CE
-    if: contains(needs.pull_request_info.outputs.labels, 'edition/ce')
+    if: ${{ needs.pull_request_info.outputs.edition_ce == 'true' }}
     needs:
       - git_info
       - pull_request_info

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -214,7 +214,7 @@ jobs:
             }
 
             // Set editions from current labels to build_ce, build_ee and so on.
-            const build_editions = input_labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
+            const build_editions = pr.labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
 
             // Set security rootless scan from labels.
             const security_rootless_scan = pr.labels.some((l) => l.name === 'security/rootless');

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -70,7 +70,6 @@ jobs:
     outputs:
       ref: ${{ steps.pr_props.outputs.ref }}
       ref_slug: ${{ steps.pr_props.outputs.ref_slug }}
-      edition: ${{ steps.pr_props.outputs.edition }}
       pr_title: ${{ steps.pr_props.outputs.pr_title }}
       pr_description: ${{ steps.pr_props.outputs.pr_description }}
       diff_url: ${{ steps.pr_props.outputs.diff_url }}
@@ -78,6 +77,11 @@ jobs:
       security_rootless_scan: ${{ steps.pr_props.outputs.security_rootless_scan }}
       changes_docs: ${{ steps.changes.outputs.docs }}
       changes_not_markdown: ${{ steps.changes.outputs.not_markdown }}
+      edition_ce: ${{ steps.pr_props.outputs.edition_ce }}
+      edition_be: ${{ steps.pr_props.outputs.edition_be }}
+      edition_se: ${{ steps.pr_props.outputs.edition_se }}
+      edition_se-plus: ${{ steps.pr_props.outputs.edition_se-plus }}
+      edition_ee: ${{ steps.pr_props.outputs.edition_ee }}
 
     # Skip pull_request and pull_request_target triggers for PRs authored by deckhouse-BOaTswain, e.g. changelog PRs, don't skip if Pull Request title contains "[run ci]".
     if: ${{ ! (startsWith(github.event_name, 'pull_request') && github.event.pull_request.user.login == 'deckhouse-BOaTswain' && !contains(github.event.pull_request.title, '[run ci]')) }}
@@ -209,27 +213,9 @@ jobs:
               core.notice(`PR#{pr.number} may be dangerous, will check file changes.`)
             }
 
-            // Set edition from current labels.
-            const defaultEdition = process.env.WERF_ENV ? process.env.WERF_ENV : 'FE';
-            const hasEE = pr.labels.some((l) => l.name === 'edition/ee');
-            const hasCE = pr.labels.some((l) => l.name === 'edition/ce');
-            const hasBE = pr.labels.some((l) => l.name === 'edition/be');
-            const hasSE = pr.labels.some((l) => l.name === 'edition/se');
-            const hasSE_plus = pr.labels.some((l) => l.name === 'edition/se+');
-            let edition = defaultEdition;
-            if (hasCE) {
-              edition = 'CE';
-            } else if (hasEE) {
-              edition = 'EE';
-            } else if (hasBE) {
-              edition = 'BE';
-            } else if (hasSE) {
-              edition = 'SE';
-            } else if (hasSE_plus) {
-              edition = 'SE-plus';
-            }
-            core.info(`Edition labels: 'edition/ce':${hasCE}, 'edition/ee':${hasEE}, 'edition/be':${hasBE}, 'edition/se':${hasSE}, 'edition/se+':${hasSE_plus}`);
-            core.notice(`Enable '${edition}' edition for '${context.eventName}' trigger.`);
+            // Set editions from current labels to build_ce, build_ee and so on.
+            const build_editions = input_labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
+
             // Set security rootless scan from labels.
             const security_rootless_scan = pr.labels.some((l) => l.name === 'security/rootless');
             // Construct head commit ref using pr number.
@@ -249,14 +235,18 @@ jobs:
             core.setOutput('should_check', shouldCheckFiles.toString());
             core.setOutput('ref', ref);
             core.setOutput('ref_slug', `pr${pr.number}`);
-            core.setOutput('edition', edition);
             core.setOutput('pr_title', pr.title);
             core.setOutput('pr_description', pr.body);
             core.setOutput('diff_url', diff_url);
             core.setOutput('labels', JSON.stringify(pr.labels));
             core.setOutput('security_rootless_scan', security_rootless_scan);
+            core.startGroup('Set build editions based on pr labels')
+            for (build_edition of build_editions) {
+              core.setOutput(build_edition, 'true');
+              core.info(`${build_edition}`)
+            }
+            core.endGroup()
             core.setCommandEcho(false);
-            core.info(JSON.stringify(pr.labels))
 
       # Checkhout the head commit of the PR branch.
       - name: Checkout PR head commit
@@ -701,7 +691,7 @@ jobs:
 
   build_ee:
     name: Build EE
-    if: contains(needs.pull_request_info.outputs.labels, 'edition/ee')
+    if: ${{ needs.pull_request_info.outputs.edition_ee == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -1018,7 +1008,7 @@ jobs:
 
   build_se:
     name: Build SE
-    if: contains(needs.pull_request_info.outputs.labels, 'edition/se')
+    if: ${{ needs.pull_request_info.outputs.edition_se == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -1335,7 +1325,7 @@ jobs:
 
   build_se_plus:
     name: Build SE-plus
-    if: contains(needs.pull_request_info.outputs.labels, 'edition/se-plus')
+    if: ${{ needs.pull_request_info.outputs.edition_se-plus == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -1652,7 +1642,7 @@ jobs:
 
   build_be:
     name: Build BE
-    if: contains(needs.pull_request_info.outputs.labels, 'edition/be')
+    if: ${{ needs.pull_request_info.outputs.edition_be == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -1969,7 +1959,7 @@ jobs:
 
   build_ce:
     name: Build CE
-    if: contains(needs.pull_request_info.outputs.labels, 'edition/ce')
+    if: ${{ needs.pull_request_info.outputs.edition_ce == 'true' }}
     needs:
       - git_info
       - pull_request_info

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -700,7 +700,7 @@ jobs:
 
   build_ee:
     name: Build EE
-    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/ee')
+    if: contains(needs.pull_request_info.outputs.labels, 'edition/ee')
     needs:
       - git_info
       - pull_request_info
@@ -1017,7 +1017,7 @@ jobs:
 
   build_se:
     name: Build SE
-    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/se')
+    if: contains(needs.pull_request_info.outputs.labels, 'edition/se')
     needs:
       - git_info
       - pull_request_info
@@ -1334,7 +1334,7 @@ jobs:
 
   build_se_plus:
     name: Build SE-plus
-    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/se-plus')
+    if: contains(needs.pull_request_info.outputs.labels, 'edition/se-plus')
     needs:
       - git_info
       - pull_request_info
@@ -1651,7 +1651,7 @@ jobs:
 
   build_be:
     name: Build BE
-    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/be')
+    if: contains(needs.pull_request_info.outputs.labels, 'edition/be')
     needs:
       - git_info
       - pull_request_info
@@ -1968,7 +1968,7 @@ jobs:
 
   build_ce:
     name: Build CE
-    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/ce')
+    if: contains(needs.pull_request_info.outputs.labels, 'edition/ce')
     needs:
       - git_info
       - pull_request_info

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -700,7 +700,7 @@ jobs:
 
   build_ee:
     name: Build EE
-    if: contains(github.event.pull_request.labels.*.name, 'edition/ee')
+    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/ee')
     needs:
       - git_info
       - pull_request_info
@@ -1017,7 +1017,7 @@ jobs:
 
   build_se:
     name: Build SE
-    if: contains(github.event.pull_request.labels.*.name, 'edition/se')
+    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/se')
     needs:
       - git_info
       - pull_request_info
@@ -1334,7 +1334,7 @@ jobs:
 
   build_se_plus:
     name: Build SE-plus
-    if: contains(github.event.pull_request.labels.*.name, 'edition/se-plus')
+    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/se-plus')
     needs:
       - git_info
       - pull_request_info
@@ -1651,7 +1651,7 @@ jobs:
 
   build_be:
     name: Build BE
-    if: contains(github.event.pull_request.labels.*.name, 'edition/be')
+    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/be')
     needs:
       - git_info
       - pull_request_info
@@ -1968,7 +1968,7 @@ jobs:
 
   build_ce:
     name: Build CE
-    if: contains(github.event.pull_request.labels.*.name, 'edition/ce')
+    if: contains(needs.pull_request_info.outputs.labels.*.name, 'edition/ce')
     needs:
       - git_info
       - pull_request_info

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -214,7 +214,7 @@ jobs:
             }
 
             // Set editions from current labels to build_ce, build_ee and so on.
-            const build_editions = pr.labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
+            const build_editions = pr.labels.map(l => l.name).filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
 
             // Set security rootless scan from labels.
             const security_rootless_scan = pr.labels.some((l) => l.name === 'security/rootless');

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -77,11 +77,11 @@ jobs:
       security_rootless_scan: ${{ steps.pr_props.outputs.security_rootless_scan }}
       changes_docs: ${{ steps.changes.outputs.docs }}
       changes_not_markdown: ${{ steps.changes.outputs.not_markdown }}
-      edition_ce: ${{ steps.pr_props.outputs.edition_ce }}
-      edition_be: ${{ steps.pr_props.outputs.edition_be }}
-      edition_se: ${{ steps.pr_props.outputs.edition_se }}
-      edition_se-plus: ${{ steps.pr_props.outputs.edition_se-plus }}
-      edition_ee: ${{ steps.pr_props.outputs.edition_ee }}
+      build_ce: ${{ steps.pr_props.outputs.build_ce }}
+      build_be: ${{ steps.pr_props.outputs.build_be }}
+      build_se: ${{ steps.pr_props.outputs.build_se }}
+      build_se-plus: ${{ steps.pr_props.outputs.build_se-plus }}
+      build_ee: ${{ steps.pr_props.outputs.build_ee }}
 
     # Skip pull_request and pull_request_target triggers for PRs authored by deckhouse-BOaTswain, e.g. changelog PRs, don't skip if Pull Request title contains "[run ci]".
     if: ${{ ! (startsWith(github.event_name, 'pull_request') && github.event.pull_request.user.login == 'deckhouse-BOaTswain' && !contains(github.event.pull_request.title, '[run ci]')) }}
@@ -691,7 +691,7 @@ jobs:
 
   build_ee:
     name: Build EE
-    if: ${{ needs.pull_request_info.outputs.edition_ee == 'true' }}
+    if: ${{ needs.pull_request_info.outputs.build_ee == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -1008,7 +1008,7 @@ jobs:
 
   build_se:
     name: Build SE
-    if: ${{ needs.pull_request_info.outputs.edition_se == 'true' }}
+    if: ${{ needs.pull_request_info.outputs.build_se == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -1325,7 +1325,7 @@ jobs:
 
   build_se_plus:
     name: Build SE-plus
-    if: ${{ needs.pull_request_info.outputs.edition_se-plus == 'true' }}
+    if: ${{ needs.pull_request_info.outputs.build_se-plus == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -1642,7 +1642,7 @@ jobs:
 
   build_be:
     name: Build BE
-    if: ${{ needs.pull_request_info.outputs.edition_be == 'true' }}
+    if: ${{ needs.pull_request_info.outputs.build_be == 'true' }}
     needs:
       - git_info
       - pull_request_info
@@ -1959,7 +1959,7 @@ jobs:
 
   build_ce:
     name: Build CE
-    if: ${{ needs.pull_request_info.outputs.edition_ce == 'true' }}
+    if: ${{ needs.pull_request_info.outputs.build_ce == 'true' }}
     needs:
       - git_info
       - pull_request_info

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -256,6 +256,7 @@ jobs:
             core.setOutput('labels', JSON.stringify(pr.labels));
             core.setOutput('security_rootless_scan', security_rootless_scan);
             core.setCommandEcho(false);
+            core.info(JSON.stringify(pr.labels))
 
       # Checkhout the head commit of the PR branch.
       - name: Checkout PR head commit

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -242,7 +242,7 @@ jobs:
             core.setOutput('security_rootless_scan', security_rootless_scan);
             core.startGroup('Set build editions based on pr labels')
             for (build_edition of build_editions) {
-              core.setOutput(build_edition, 'true');
+              core.setOutput(`${build_edition}`, 'true');
               core.info(`${build_edition}`)
             }
             core.endGroup()

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -33,7 +33,6 @@ jobs:
     outputs:
       ref: ${{ steps.pr_props.outputs.ref }}
       ref_slug: ${{ steps.pr_props.outputs.ref_slug }}
-      edition: ${{ steps.pr_props.outputs.edition }}
       pr_title: ${{ steps.pr_props.outputs.pr_title }}
       pr_description: ${{ steps.pr_props.outputs.pr_description }}
       diff_url: ${{ steps.pr_props.outputs.diff_url }}
@@ -41,6 +40,11 @@ jobs:
       security_rootless_scan: ${{ steps.pr_props.outputs.security_rootless_scan }}
       changes_docs: ${{ steps.changes.outputs.docs }}
       changes_not_markdown: ${{ steps.changes.outputs.not_markdown }}
+      edition_ce: ${{ steps.pr_props.outputs.edition_ce }}
+      edition_be: ${{ steps.pr_props.outputs.edition_be }}
+      edition_se: ${{ steps.pr_props.outputs.edition_se }}
+      edition_se-plus: ${{ steps.pr_props.outputs.edition_se-plus }}
+      edition_ee: ${{ steps.pr_props.outputs.edition_ee }}
 
     # Skip pull_request and pull_request_target triggers for PRs authored by deckhouse-BOaTswain, e.g. changelog PRs, don't skip if Pull Request title contains "[run ci]".
     if: ${{ ! (startsWith(github.event_name, 'pull_request') && github.event.pull_request.user.login == 'deckhouse-BOaTswain' && !contains(github.event.pull_request.title, '[run ci]')) }}
@@ -172,27 +176,9 @@ jobs:
               core.notice(`PR#{pr.number} may be dangerous, will check file changes.`)
             }
 
-            // Set edition from current labels.
-            const defaultEdition = process.env.WERF_ENV ? process.env.WERF_ENV : 'FE';
-            const hasEE = pr.labels.some((l) => l.name === 'edition/ee');
-            const hasCE = pr.labels.some((l) => l.name === 'edition/ce');
-            const hasBE = pr.labels.some((l) => l.name === 'edition/be');
-            const hasSE = pr.labels.some((l) => l.name === 'edition/se');
-            const hasSE_plus = pr.labels.some((l) => l.name === 'edition/se+');
-            let edition = defaultEdition;
-            if (hasCE) {
-              edition = 'CE';
-            } else if (hasEE) {
-              edition = 'EE';
-            } else if (hasBE) {
-              edition = 'BE';
-            } else if (hasSE) {
-              edition = 'SE';
-            } else if (hasSE_plus) {
-              edition = 'SE-plus';
-            }
-            core.info(`Edition labels: 'edition/ce':${hasCE}, 'edition/ee':${hasEE}, 'edition/be':${hasBE}, 'edition/se':${hasSE}, 'edition/se+':${hasSE_plus}`);
-            core.notice(`Enable '${edition}' edition for '${context.eventName}' trigger.`);
+            // Set editions from current labels to build_ce, build_ee and so on.
+            const build_editions = input_labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
+
             // Set security rootless scan from labels.
             const security_rootless_scan = pr.labels.some((l) => l.name === 'security/rootless');
             // Construct head commit ref using pr number.
@@ -212,14 +198,18 @@ jobs:
             core.setOutput('should_check', shouldCheckFiles.toString());
             core.setOutput('ref', ref);
             core.setOutput('ref_slug', `pr${pr.number}`);
-            core.setOutput('edition', edition);
             core.setOutput('pr_title', pr.title);
             core.setOutput('pr_description', pr.body);
             core.setOutput('diff_url', diff_url);
             core.setOutput('labels', JSON.stringify(pr.labels));
             core.setOutput('security_rootless_scan', security_rootless_scan);
+            core.startGroup('Set build editions based on pr labels')
+            for (build_edition of build_editions) {
+              core.setOutput(build_edition, 'true');
+              core.info(`${build_edition}`)
+            }
+            core.endGroup()
             core.setCommandEcho(false);
-            core.info(JSON.stringify(pr.labels))
 
       # Checkhout the head commit of the PR branch.
       - name: Checkout PR head commit

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -177,7 +177,7 @@ jobs:
             }
 
             // Set editions from current labels to build_ce, build_ee and so on.
-            const build_editions = input_labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
+            const build_editions = pr.labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
 
             // Set security rootless scan from labels.
             const security_rootless_scan = pr.labels.some((l) => l.name === 'security/rootless');

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -219,6 +219,7 @@ jobs:
             core.setOutput('labels', JSON.stringify(pr.labels));
             core.setOutput('security_rootless_scan', security_rootless_scan);
             core.setCommandEcho(false);
+            core.info(JSON.stringify(pr.labels))
 
       # Checkhout the head commit of the PR branch.
       - name: Checkout PR head commit

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -177,7 +177,7 @@ jobs:
             }
 
             // Set editions from current labels to build_ce, build_ee and so on.
-            const build_editions = pr.labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
+            const build_editions = pr.labels.map(l => l.name).filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
 
             // Set security rootless scan from labels.
             const security_rootless_scan = pr.labels.some((l) => l.name === 'security/rootless');

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -205,7 +205,7 @@ jobs:
             core.setOutput('security_rootless_scan', security_rootless_scan);
             core.startGroup('Set build editions based on pr labels')
             for (build_edition of build_editions) {
-              core.setOutput(build_edition, 'true');
+              core.setOutput(`${build_edition}`, 'true');
               core.info(`${build_edition}`)
             }
             core.endGroup()

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -40,11 +40,11 @@ jobs:
       security_rootless_scan: ${{ steps.pr_props.outputs.security_rootless_scan }}
       changes_docs: ${{ steps.changes.outputs.docs }}
       changes_not_markdown: ${{ steps.changes.outputs.not_markdown }}
-      edition_ce: ${{ steps.pr_props.outputs.edition_ce }}
-      edition_be: ${{ steps.pr_props.outputs.edition_be }}
-      edition_se: ${{ steps.pr_props.outputs.edition_se }}
-      edition_se-plus: ${{ steps.pr_props.outputs.edition_se-plus }}
-      edition_ee: ${{ steps.pr_props.outputs.edition_ee }}
+      build_ce: ${{ steps.pr_props.outputs.build_ce }}
+      build_be: ${{ steps.pr_props.outputs.build_be }}
+      build_se: ${{ steps.pr_props.outputs.build_se }}
+      build_se-plus: ${{ steps.pr_props.outputs.build_se-plus }}
+      build_ee: ${{ steps.pr_props.outputs.build_ee }}
 
     # Skip pull_request and pull_request_target triggers for PRs authored by deckhouse-BOaTswain, e.g. changelog PRs, don't skip if Pull Request title contains "[run ci]".
     if: ${{ ! (startsWith(github.event_name, 'pull_request') && github.event.pull_request.user.login == 'deckhouse-BOaTswain' && !contains(github.event.pull_request.title, '[run ci]')) }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -219,7 +219,7 @@ jobs:
             }
 
             // Set editions from current labels to build_ce, build_ee and so on.
-            const build_editions = pr.labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
+            const build_editions = pr.labels.map(l => l.name).filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
 
             // Set security rootless scan from labels.
             const security_rootless_scan = pr.labels.some((l) => l.name === 'security/rootless');

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -247,7 +247,7 @@ jobs:
             core.setOutput('security_rootless_scan', security_rootless_scan);
             core.startGroup('Set build editions based on pr labels')
             for (build_edition of build_editions) {
-              core.setOutput(build_edition, 'true');
+              core.setOutput(`${build_edition}`, 'true');
               core.info(`${build_edition}`)
             }
             core.endGroup()

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -82,11 +82,11 @@ jobs:
       security_rootless_scan: ${{ steps.pr_props.outputs.security_rootless_scan }}
       changes_docs: ${{ steps.changes.outputs.docs }}
       changes_not_markdown: ${{ steps.changes.outputs.not_markdown }}
-      edition_ce: ${{ steps.pr_props.outputs.edition_ce }}
-      edition_be: ${{ steps.pr_props.outputs.edition_be }}
-      edition_se: ${{ steps.pr_props.outputs.edition_se }}
-      edition_se-plus: ${{ steps.pr_props.outputs.edition_se-plus }}
-      edition_ee: ${{ steps.pr_props.outputs.edition_ee }}
+      build_ce: ${{ steps.pr_props.outputs.build_ce }}
+      build_be: ${{ steps.pr_props.outputs.build_be }}
+      build_se: ${{ steps.pr_props.outputs.build_se }}
+      build_se-plus: ${{ steps.pr_props.outputs.build_se-plus }}
+      build_ee: ${{ steps.pr_props.outputs.build_ee }}
 
     # Skip pull_request and pull_request_target triggers for PRs authored by deckhouse-BOaTswain, e.g. changelog PRs, don't skip if Pull Request title contains "[run ci]".
     if: ${{ ! (startsWith(github.event_name, 'pull_request') && github.event.pull_request.user.login == 'deckhouse-BOaTswain' && !contains(github.event.pull_request.title, '[run ci]')) }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -261,6 +261,7 @@ jobs:
             core.setOutput('labels', JSON.stringify(pr.labels));
             core.setOutput('security_rootless_scan', security_rootless_scan);
             core.setCommandEcho(false);
+            core.info(JSON.stringify(pr.labels))
 
       # Checkhout the head commit of the PR branch.
       - name: Checkout PR head commit

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -75,7 +75,6 @@ jobs:
     outputs:
       ref: ${{ steps.pr_props.outputs.ref }}
       ref_slug: ${{ steps.pr_props.outputs.ref_slug }}
-      edition: ${{ steps.pr_props.outputs.edition }}
       pr_title: ${{ steps.pr_props.outputs.pr_title }}
       pr_description: ${{ steps.pr_props.outputs.pr_description }}
       diff_url: ${{ steps.pr_props.outputs.diff_url }}
@@ -83,6 +82,11 @@ jobs:
       security_rootless_scan: ${{ steps.pr_props.outputs.security_rootless_scan }}
       changes_docs: ${{ steps.changes.outputs.docs }}
       changes_not_markdown: ${{ steps.changes.outputs.not_markdown }}
+      edition_ce: ${{ steps.pr_props.outputs.edition_ce }}
+      edition_be: ${{ steps.pr_props.outputs.edition_be }}
+      edition_se: ${{ steps.pr_props.outputs.edition_se }}
+      edition_se-plus: ${{ steps.pr_props.outputs.edition_se-plus }}
+      edition_ee: ${{ steps.pr_props.outputs.edition_ee }}
 
     # Skip pull_request and pull_request_target triggers for PRs authored by deckhouse-BOaTswain, e.g. changelog PRs, don't skip if Pull Request title contains "[run ci]".
     if: ${{ ! (startsWith(github.event_name, 'pull_request') && github.event.pull_request.user.login == 'deckhouse-BOaTswain' && !contains(github.event.pull_request.title, '[run ci]')) }}
@@ -214,27 +218,9 @@ jobs:
               core.notice(`PR#{pr.number} may be dangerous, will check file changes.`)
             }
 
-            // Set edition from current labels.
-            const defaultEdition = process.env.WERF_ENV ? process.env.WERF_ENV : 'FE';
-            const hasEE = pr.labels.some((l) => l.name === 'edition/ee');
-            const hasCE = pr.labels.some((l) => l.name === 'edition/ce');
-            const hasBE = pr.labels.some((l) => l.name === 'edition/be');
-            const hasSE = pr.labels.some((l) => l.name === 'edition/se');
-            const hasSE_plus = pr.labels.some((l) => l.name === 'edition/se+');
-            let edition = defaultEdition;
-            if (hasCE) {
-              edition = 'CE';
-            } else if (hasEE) {
-              edition = 'EE';
-            } else if (hasBE) {
-              edition = 'BE';
-            } else if (hasSE) {
-              edition = 'SE';
-            } else if (hasSE_plus) {
-              edition = 'SE-plus';
-            }
-            core.info(`Edition labels: 'edition/ce':${hasCE}, 'edition/ee':${hasEE}, 'edition/be':${hasBE}, 'edition/se':${hasSE}, 'edition/se+':${hasSE_plus}`);
-            core.notice(`Enable '${edition}' edition for '${context.eventName}' trigger.`);
+            // Set editions from current labels to build_ce, build_ee and so on.
+            const build_editions = input_labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
+
             // Set security rootless scan from labels.
             const security_rootless_scan = pr.labels.some((l) => l.name === 'security/rootless');
             // Construct head commit ref using pr number.
@@ -254,14 +240,18 @@ jobs:
             core.setOutput('should_check', shouldCheckFiles.toString());
             core.setOutput('ref', ref);
             core.setOutput('ref_slug', `pr${pr.number}`);
-            core.setOutput('edition', edition);
             core.setOutput('pr_title', pr.title);
             core.setOutput('pr_description', pr.body);
             core.setOutput('diff_url', diff_url);
             core.setOutput('labels', JSON.stringify(pr.labels));
             core.setOutput('security_rootless_scan', security_rootless_scan);
+            core.startGroup('Set build editions based on pr labels')
+            for (build_edition of build_editions) {
+              core.setOutput(build_edition, 'true');
+              core.info(`${build_edition}`)
+            }
+            core.endGroup()
             core.setCommandEcho(false);
-            core.info(JSON.stringify(pr.labels))
 
       # Checkhout the head commit of the PR branch.
       - name: Checkout PR head commit

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -219,7 +219,7 @@ jobs:
             }
 
             // Set editions from current labels to build_ce, build_ee and so on.
-            const build_editions = input_labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
+            const build_editions = pr.labels.filter(l => l.startsWith('edition/')).map(e => e.replace('edition/', 'build_')).map(e => e.replace('se+','se-plus'));
 
             // Set security rootless scan from labels.
             const security_rootless_scan = pr.labels.some((l) => l.name === 'security/rootless');


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix rerun workflow with multiple editions labels.
This fix removes edition labels deletion and change build condition for PR's based on pr info collected by the job it depends on.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
It fixes rerun PR's build workflow, which was labeled by multiple editions.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix rerun workflow with multiple editions labels.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
