### PR TITLE
[deckhouse-controller] New HookInput Snapshot logic [third-iteration]

### DIFF
--- a/modules/040-node-manager/hooks/migration/migrate_add_status_subresource_to_node_user.go
+++ b/modules/040-node-manager/hooks/migration/migrate_add_status_subresource_to_node_user.go
@@ -17,12 +17,15 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -58,13 +61,16 @@ func applyNodeUsersFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 }
 
 func addStatusSubresourceForNodeUser(input *go_hook.HookInput) error {
-	nodeUserSnap := input.Snapshots["node_user"]
-	if len(nodeUserSnap) == 0 {
+	nodeUserSnaps := input.NewSnapshots.Get("node_user")
+	if len(nodeUserSnaps) == 0 {
 		return nil
 	}
 
-	for _, item := range nodeUserSnap {
-		nu := item.(existingStatus)
+	for nu, err := range sdkobjectpatch.SnapshotIter[existingStatus](nodeUserSnaps) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'node_user' snapshot: %w", err)
+		}
+
 		if nu.StatusExists {
 			input.Logger.Debug("Status already exists for node user", slog.String("user", nu.UserName))
 			continue

--- a/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
+++ b/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
@@ -29,8 +29,9 @@ import (
 	"k8s.io/utils/ptr"
 
 	v1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
-	"github.com/deckhouse/deckhouse/pkg/log"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 const (

--- a/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
+++ b/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
@@ -28,9 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
 
-	v1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 
+	v1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 

--- a/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
+++ b/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -29,6 +30,7 @@ import (
 
 	v1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
 	"github.com/deckhouse/deckhouse/pkg/log"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 const (
@@ -102,14 +104,17 @@ func configMapName(obj *unstructured.Unstructured) (go_hook.FilterResult, error)
 }
 
 func systemReserve(input *go_hook.HookInput) error {
-	if cmSnapshotNew := input.Snapshots["cmNew"]; len(cmSnapshotNew) > 0 {
+	if cmSnapshotNew := input.NewSnapshots.Get("cmNew"); len(cmSnapshotNew) > 0 {
 		log.Debug("System reserved Nodes are already migrated, skipping...")
 		return nil
 	}
 
-	ngsSnapshot := input.Snapshots["ngs"]
-	for _, ngRaw := range ngsSnapshot {
-		ng := ngRaw.(*NodeGroup)
+	ngsSnapshot := input.NewSnapshots.Get("ngs")
+	for ng, err := range sdkobjectpatch.SnapshotIter[NodeGroup](ngsSnapshot) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'ngs' snapshot: %w", err)
+		}
+
 		skipMigration := ng.ResourceReservationMode != ""
 		input.Logger.Info("Migration requirements", slog.String("node_group_name", ng.Name), slog.String("kubelet_resource_reservation_mode", ng.ResourceReservationMode), slog.Bool("skip_migration", skipMigration))
 		if skipMigration {
@@ -137,7 +142,7 @@ func systemReserve(input *go_hook.HookInput) error {
 		},
 	})
 
-	if cmSnapshot := input.Snapshots["cm"]; len(cmSnapshot) > 0 {
+	if cmSnapshot := input.NewSnapshots.Get("cm"); len(cmSnapshot) > 0 {
 		log.Debug("Delete old migration configmap", slog.String("configmap", "(d8-system/"+systemReserveMigrationCM+")"))
 		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", systemReserveMigrationCM)
 	}

--- a/modules/040-node-manager/hooks/upmeter_discovery.go
+++ b/modules/040-node-manager/hooks/upmeter_discovery.go
@@ -23,11 +23,11 @@ import (
 	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/deckhouse/module-sdk/pkg"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
 	"github.com/deckhouse/deckhouse/go_lib/set"
 	ngv1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
-	"github.com/deckhouse/module-sdk/pkg"
-
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 // filterDynamicProbeNodeGroups returns the name of a nodegroup to consider or emptystring if it should be skipped

--- a/modules/040-node-manager/hooks/upmeter_discovery.go
+++ b/modules/040-node-manager/hooks/upmeter_discovery.go
@@ -26,6 +26,7 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/set"
 	ngv1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
 	"github.com/deckhouse/module-sdk/pkg"
+
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 

--- a/modules/040-node-manager/hooks/upmeter_discovery.go
+++ b/modules/040-node-manager/hooks/upmeter_discovery.go
@@ -17,12 +17,16 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
+
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/go_lib/set"
 	ngv1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
+	"github.com/deckhouse/module-sdk/pkg"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 // filterDynamicProbeNodeGroups returns the name of a nodegroup to consider or emptystring if it should be skipped
@@ -78,8 +82,13 @@ type upmeterDiscovery struct {
 func collectDynamicProbeConfig(input *go_hook.HookInput) error {
 	// Input
 	key := "nodeManager.internal.upmeterDiscovery"
+	parseNodeGroupNames, err := parseNames(input.NewSnapshots.Get("nodegroups"))
+	if err != nil {
+		return fmt.Errorf("failed to parse nodegroup names: %w", err)
+	}
+
 	discovery := upmeterDiscovery{
-		EphemeralNodeGroupNames: parseNames(input.Snapshots["nodegroups"]),
+		EphemeralNodeGroupNames: parseNodeGroupNames,
 	}
 
 	// Output
@@ -88,11 +97,16 @@ func collectDynamicProbeConfig(input *go_hook.HookInput) error {
 }
 
 // parseNames parses filter string result to a sorted strings slice
-func parseNames(results []go_hook.FilterResult) []string {
+func parseNames(results []pkg.Snapshot) ([]string, error) {
 	s := set.New()
-	for _, name := range results {
-		s.Add(name.(string))
+
+	for name, err := range sdkobjectpatch.SnapshotIter[string](results) {
+		if err != nil {
+			return nil, fmt.Errorf("failed to iterate over 'nodegroups' snapshot: %w", err)
+		}
+
+		s.Add(name)
 	}
 	s.Delete("") // throw away invalid ones
-	return s.Slice()
+	return s.Slice(), nil
 }

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/go_lib/set"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 const (
@@ -227,53 +228,37 @@ func deleteMachines(input *go_hook.HookInput) error {
 		nodeGroupNameToNodeGroupStatus = make(map[string]*NodeGroupStatus)
 	)
 
-	for _, mcRaw := range input.Snapshots["mcs"] {
-		if mcRaw == nil {
-			continue
+	for mc, err := range sdkobjectpatch.SnapshotIter[string](input.NewSnapshots.Get("mcs")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'mcs' snapshot: %w", err)
 		}
 
-		ic, ok := mcRaw.(string)
-		if !ok {
-			return fmt.Errorf("failed to assert to string")
-		}
-
-		preemptibleMachineClassesSet.Add(ic)
+		preemptibleMachineClassesSet.Add(mc)
 	}
 
 	if preemptibleMachineClassesSet.Size() == 0 {
 		return nil
 	}
 
-	for _, nodeRaw := range input.Snapshots["nodes"] {
-		if nodeRaw == nil {
-			continue
+	for node, err := range sdkobjectpatch.SnapshotIter[Node](input.NewSnapshots.Get("nodes")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'nodes' snapshot: %w", err)
 		}
 
-		node, ok := nodeRaw.(*Node)
-		if !ok {
-			return fmt.Errorf("failed to assert to *Node")
-		}
-
-		nodeNameToNodeMap[node.Name] = node
+		nodeNameToNodeMap[node.Name] = &node
 	}
 
-	for _, ngStatusRaw := range input.Snapshots["nodegroupstatuses"] {
-		if ngStatusRaw == nil {
-			continue
+	for ngStatus, err := range sdkobjectpatch.SnapshotIter[NodeGroupStatus](input.NewSnapshots.Get("nodegroupstatuses")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'nodegroupstatuses' snapshot: %w", err)
 		}
 
-		ngStatus, ok := ngStatusRaw.(*NodeGroupStatus)
-		if !ok {
-			return fmt.Errorf("failed to assert to *NodeGroupStatus")
-		}
-
-		nodeGroupNameToNodeGroupStatus[ngStatus.Name] = ngStatus
+		nodeGroupNameToNodeGroupStatus[ngStatus.Name] = &ngStatus
 	}
 
-	for _, machineRaw := range input.Snapshots["machines"] {
-		machine, ok := machineRaw.(*Machine)
-		if !ok {
-			return fmt.Errorf("failed to assert to *Machine")
+	for machine, err := range sdkobjectpatch.SnapshotIter[Machine](input.NewSnapshots.Get("machines")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'machines' snapshot: %w", err)
 		}
 
 		if machine.Terminating {
@@ -309,7 +294,7 @@ func deleteMachines(input *go_hook.HookInput) error {
 			continue
 		}
 
-		machines = append(machines, machine)
+		machines = append(machines, &machine)
 	}
 
 	if len(machines) == 0 {

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances.go
@@ -231,7 +231,7 @@ func deleteMachines(input *go_hook.HookInput) error {
 
 	for mc, err := range sdkobjectpatch.SnapshotIter[string](input.NewSnapshots.Get("mcs")) {
 		if err != nil {
-			return fmt.Errorf("failed to iterate over 'mcs' snapshot: %w", err)
+			return fmt.Errorf("failed to assert to string: failed to iterate over 'mcs' snapshot: %w", err)
 		}
 
 		preemptibleMachineClassesSet.Add(mc)
@@ -243,7 +243,7 @@ func deleteMachines(input *go_hook.HookInput) error {
 
 	for node, err := range sdkobjectpatch.SnapshotIter[Node](input.NewSnapshots.Get("nodes")) {
 		if err != nil {
-			return fmt.Errorf("failed to iterate over 'nodes' snapshot: %w", err)
+			return fmt.Errorf("failed to assert to Node: failed to iterate over 'nodes' snapshot: %w", err)
 		}
 
 		nodeNameToNodeMap[node.Name] = &node
@@ -251,7 +251,7 @@ func deleteMachines(input *go_hook.HookInput) error {
 
 	for ngStatus, err := range sdkobjectpatch.SnapshotIter[NodeGroupStatus](input.NewSnapshots.Get("nodegroupstatuses")) {
 		if err != nil {
-			return fmt.Errorf("failed to iterate over 'nodegroupstatuses' snapshot: %w", err)
+			return fmt.Errorf("failed to assert to NodeGroupStatus: failed to iterate over 'nodegroupstatuses' snapshot: %w", err)
 		}
 
 		nodeGroupNameToNodeGroupStatus[ngStatus.Name] = &ngStatus
@@ -259,7 +259,7 @@ func deleteMachines(input *go_hook.HookInput) error {
 
 	for machine, err := range sdkobjectpatch.SnapshotIter[Machine](input.NewSnapshots.Get("machines")) {
 		if err != nil {
-			return fmt.Errorf("failed to iterate over 'machines' snapshot: %w", err)
+			return fmt.Errorf("failed to assert to Machine: failed to iterate over 'machines' snapshot: %w", err)
 		}
 
 		if machine.Terminating {

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances.go
@@ -28,8 +28,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/deckhouse/deckhouse/go_lib/set"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/go_lib/set"
 )
 
 const (

--- a/modules/042-kube-dns/hooks/migration_deployment.go
+++ b/modules/042-kube-dns/hooks/migration_deployment.go
@@ -80,7 +80,7 @@ func applyDeploymentCorednsPortsFilter(obj *unstructured.Unstructured) (go_hook.
 }
 
 func ensureCorednsPorts(input *go_hook.HookInput) error {
-	portsSnap := input.Snapshots[snap]
+	portsSnap := input.NewSnapshots.Get(snap)
 	if len(portsSnap) == 0 {
 		return nil
 	}

--- a/modules/042-kube-dns/hooks/remove_old_coredns_deploy_and_svc.go
+++ b/modules/042-kube-dns/hooks/remove_old_coredns_deploy_and_svc.go
@@ -63,9 +63,15 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func removeKubeDNSDeployAndService(input *go_hook.HookInput) error {
 	input.PatchCollector.DeleteNonCascading("apps/v1", "Deployment", "kube-system", "coredns")
 
-	kubeDNSSVCIsClusterIPTypeSnap := input.Snapshots["kube_dns_svc"]
+	kubeDNSSVCIsClusterIPTypeSnap := input.NewSnapshots.Get("kube_dns_svc")
 	if len(kubeDNSSVCIsClusterIPTypeSnap) > 0 {
-		if kubeDNSSVCIsClusterIPTypeSnap[0].(bool) {
+		var startKubeDNSSVCIsClusterIPTypeSnap bool
+		err := kubeDNSSVCIsClusterIPTypeSnap[0].UnmarshalTo(&startKubeDNSSVCIsClusterIPTypeSnap)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal kube_dns_svc snapshot: %w", err)
+		}
+
+		if startKubeDNSSVCIsClusterIPTypeSnap {
 			input.PatchCollector.Delete("v1", "Service", "kube-system", "kube-dns")
 		}
 	}

--- a/modules/101-cert-manager/hooks/create_registry_secret_for_solver.go
+++ b/modules/101-cert-manager/hooks/create_registry_secret_for_solver.go
@@ -190,7 +190,7 @@ func handleChallenge(input *go_hook.HookInput) error {
 	}
 
 	var regSecret registrySecret
-	err := d8RegistrySnap[0].UnmarshalTo(regSecret)
+	err := d8RegistrySnap[0].UnmarshalTo(&regSecret)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal d8_registry_secret snapshot: %w", err)
 	}

--- a/modules/101-cert-manager/hooks/create_registry_secret_for_solver.go
+++ b/modules/101-cert-manager/hooks/create_registry_secret_for_solver.go
@@ -26,8 +26,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/deckhouse/deckhouse/go_lib/set"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/go_lib/set"
 )
 
 const (

--- a/modules/101-cert-manager/hooks/create_registry_secret_for_solver.go
+++ b/modules/101-cert-manager/hooks/create_registry_secret_for_solver.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/go_lib/set"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 const (
@@ -182,13 +183,19 @@ func prepareSolverRegistryServiceAccount(namespace string) *corev1.ServiceAccoun
 //	In future we want to rid all of patches in cert-manager
 //	and use vanilla cert-manager
 func handleChallenge(input *go_hook.HookInput) error {
-	d8RegistrySnap := input.Snapshots[d8RegistrySnapshot]
+	d8RegistrySnap := input.NewSnapshots.Get(d8RegistrySnapshot)
 	if len(d8RegistrySnap) == 0 {
 		input.Logger.Warn("Registry secret not found. Skip")
 		return nil
 	}
 
-	registryCfg := d8RegistrySnap[0].(registrySecret).Config
+	var regSecret registrySecret
+	err := d8RegistrySnap[0].UnmarshalTo(regSecret)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal d8_registry_secret snapshot: %w", err)
+	}
+
+	registryCfg := regSecret.Config
 
 	challengesNss := set.NewFromSnapshot(input.NewSnapshots.Get(challengesSnapshot))
 
@@ -197,8 +204,11 @@ func handleChallenge(input *go_hook.HookInput) error {
 	// namespace -> .dockerconfigjson content
 	secretsByNs := map[string]string{}
 
-	for _, sRaw := range input.Snapshots[secretsSnapshot] {
-		regSecret := sRaw.(registrySecret)
+	for regSecret, err := range sdkobjectpatch.SnapshotIter[registrySecret](input.NewSnapshots.Get(secretsSnapshot)) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'd8_registry_secret' snapshot: %w", err)
+		}
+
 		secretsByNs[regSecret.Namespace] = regSecret.Config
 	}
 

--- a/modules/101-cert-manager/hooks/discover_clusterissuer_email.go
+++ b/modules/101-cert-manager/hooks/discover_clusterissuer_email.go
@@ -81,12 +81,18 @@ func discoverClusterIssuerEmail(input *go_hook.HookInput) error {
 		return nil
 	}
 
-	snapshots := input.Snapshots["ClusterIssuers"]
+	snapshots := input.NewSnapshots.Get("ClusterIssuers")
 	if len(snapshots) == 0 {
 		return nil
 	}
 
-	if issuerEmail := snapshots[0].(*clusterIssuer).Email; len(issuerEmail) > 0 {
+	var clustIssuer clusterIssuer
+	err := snapshots[0].UnmarshalTo(&clustIssuer)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal ClusterIssuer snapshot: %w", err)
+	}
+
+	if issuerEmail := clustIssuer.Email; len(issuerEmail) > 0 {
 		input.Values.Set("certManager.internal.email", issuerEmail)
 	}
 	return nil

--- a/modules/110-istio/hooks/discovery_ambient_mesh_secret_configmap.go
+++ b/modules/110-istio/hooks/discovery_ambient_mesh_secret_configmap.go
@@ -17,6 +17,8 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
+
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
@@ -68,13 +70,19 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, monitorAmbientModeConfigMap)
 
 func monitorAmbientModeConfigMap(input *go_hook.HookInput) error {
-	if len(input.Snapshots["ambientmode_configmap"]) == 0 {
+	configMapSnaps := input.NewSnapshots.Get("ambientmode_configmap")
+	if len(configMapSnaps) == 0 {
 		// ConfigMap doesn't exist
 		input.Values.Set(ambientModeValuesKey, false)
 		return nil
 	}
 
-	configMapInfo := input.Snapshots["ambientmode_configmap"][0].(ConfigMapInfo)
+	var configMapInfo ConfigMapInfo
+	err := configMapSnaps[0].UnmarshalTo(&configMapInfo)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal first 'ambientmode_configmap' snapshot: %w", err)
+	}
+
 	if configMapInfo.Exists {
 		// ConfigMap exists - enable ambient mode
 		input.Values.Set(ambientModeValuesKey, true)

--- a/modules/110-istio/hooks/discovery_application_namespaces.go
+++ b/modules/110-istio/hooks/discovery_application_namespaces.go
@@ -26,10 +26,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/deckhouse/module-sdk/pkg"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
-	"github.com/deckhouse/module-sdk/pkg"
 )
 
 const (

--- a/modules/110-istio/hooks/discovery_application_namespaces.go
+++ b/modules/110-istio/hooks/discovery_application_namespaces.go
@@ -26,9 +26,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 	"github.com/deckhouse/module-sdk/pkg"
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 const (

--- a/modules/110-istio/hooks/discovery_application_namespaces.go
+++ b/modules/110-istio/hooks/discovery_application_namespaces.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -26,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+	"github.com/deckhouse/module-sdk/pkg"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 const (
@@ -154,20 +157,26 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func applicationNamespacesDiscovery(input *go_hook.HookInput) error {
 	var applicationNamespaces = make([]string, 0)
 	var applicationNamespacesToMonitor = make([]string, 0)
-	var namespacesSnapshots = make([]go_hook.FilterResult, 0)
+	var namespacesSnapshots = make([]pkg.Snapshot, 0)
 	var namespacesMap = make(map[string]IstioNamespaceFilterResult)
 
-	for _, ns := range input.Snapshots["all_namespaces"] {
-		nsInfo := ns.(IstioNamespaceFilterResult)
+	for nsInfo, err := range sdkobjectpatch.SnapshotIter[IstioNamespaceFilterResult](input.NewSnapshots.Get("all_namespaces")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'all_namespaces' snapshot: %w", err)
+		}
+
 		namespacesMap[nsInfo.Name] = nsInfo
 	}
 
-	namespacesSnapshots = append(namespacesSnapshots, input.Snapshots["namespaces_definite_revision"]...)
-	namespacesSnapshots = append(namespacesSnapshots, input.Snapshots["namespaces_global_revision"]...)
-	namespacesSnapshots = append(namespacesSnapshots, input.Snapshots["istio_pod_global_rev"]...)
-	namespacesSnapshots = append(namespacesSnapshots, input.Snapshots["istio_pod_definite_rev"]...)
-	for _, ns := range namespacesSnapshots {
-		nsInfo := ns.(IstioNamespaceFilterResult)
+	namespacesSnapshots = append(namespacesSnapshots, input.NewSnapshots.Get("namespaces_definite_revision")...)
+	namespacesSnapshots = append(namespacesSnapshots, input.NewSnapshots.Get("namespaces_global_revision")...)
+	namespacesSnapshots = append(namespacesSnapshots, input.NewSnapshots.Get("istio_pod_global_rev")...)
+	namespacesSnapshots = append(namespacesSnapshots, input.NewSnapshots.Get("istio_pod_definite_rev")...)
+	for nsInfo, err := range sdkobjectpatch.SnapshotIter[IstioNamespaceFilterResult](namespacesSnapshots) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over namespace snapshots: %w", err)
+		}
+
 		if nsInfo.DeletionTimestampExists {
 			continue
 		}

--- a/modules/110-istio/hooks/discovery_ingress_controllers.go
+++ b/modules/110-istio/hooks/discovery_ingress_controllers.go
@@ -23,8 +23,9 @@ import (
 	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 )
 
 type IstioIngressGatewayController struct {

--- a/modules/110-istio/hooks/discovery_istiod_health.go
+++ b/modules/110-istio/hooks/discovery_istiod_health.go
@@ -26,9 +26,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib/istio_versions"
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 const isGlobalVersionIstiodReadyPath = "istio.internal.isGlobalVersionIstiodReady"
@@ -135,7 +136,6 @@ func discoveryIstiodHealthHook(input *go_hook.HookInput) error {
 
 	webhookSnaps := input.NewSnapshots.Get("istio_sidecar_injector_global_webhook")
 	if len(webhookSnaps) == 1 {
-
 		err := webhookSnaps[0].UnmarshalTo(&injectorGlobalFullVer)
 		if err != nil {
 			return fmt.Errorf("failed to unmarshal 'istio_sidecar_injector_global_webhook' snapshot: %w", err)

--- a/modules/110-istio/hooks/discovery_operator_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install.go
@@ -26,11 +26,12 @@ import (
 	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib/crd"
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib/istio_versions"
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 const (

--- a/modules/110-istio/hooks/discovery_preflight_check.go
+++ b/modules/110-istio/hooks/discovery_preflight_check.go
@@ -79,6 +79,7 @@ func applyClusterConfigurationYamlFilter(obj *unstructured.Unstructured) (go_hoo
 }
 
 func discoveryIsK8sVersionAutomatic(input *go_hook.HookInput) error {
+	//todo
 	var kubernetesVersionStr string
 	clusterConfigurationSnapshots, ok := input.Snapshots["cluster-configuration"]
 	if !ok || len(clusterConfigurationSnapshots) == 0 {

--- a/modules/110-istio/hooks/discovery_preflight_check.go
+++ b/modules/110-istio/hooks/discovery_preflight_check.go
@@ -79,17 +79,19 @@ func applyClusterConfigurationYamlFilter(obj *unstructured.Unstructured) (go_hoo
 }
 
 func discoveryIsK8sVersionAutomatic(input *go_hook.HookInput) error {
-	//todo
 	var kubernetesVersionStr string
-	clusterConfigurationSnapshots, ok := input.Snapshots["cluster-configuration"]
-	if !ok || len(clusterConfigurationSnapshots) == 0 {
+	clusterConfigurationSnapshots := input.NewSnapshots.Get("cluster-configuration")
+	if len(clusterConfigurationSnapshots) == 0 {
 		versionParts := strings.Split(input.Values.Get("global.discovery.kubernetesVersion").String(), ".")
 		if len(versionParts) < 2 {
 			return errors.New("cluster configuration kubernetesVersion is empty or invalid")
 		}
 		kubernetesVersionStr = versionParts[0] + "." + versionParts[1]
 	} else {
-		kubernetesVersionStr = clusterConfigurationSnapshots[0].(string)
+		err := clusterConfigurationSnapshots[0].UnmarshalTo(&kubernetesVersionStr)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal 'cluster-configuration' snapshot: %w", err)
+		}
 	}
 
 	// Get array of compatibility k8s versions for every operator version

--- a/modules/110-istio/hooks/external_service_monitoring.go
+++ b/modules/110-istio/hooks/external_service_monitoring.go
@@ -19,13 +19,14 @@ package hooks
 import (
 	"fmt"
 
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 // There is an issue in [istio](https://github.com/istio/istio/issues/20703) with [staled solution](https://github.com/istio/istio/issues/37331)

--- a/modules/110-istio/hooks/generate_ca.go
+++ b/modules/110-istio/hooks/generate_ca.go
@@ -78,6 +78,7 @@ func generateCA(input *go_hook.HookInput) error {
 			istioCA.Root = istioCA.Cert
 		}
 	} else {
+		// todo
 		certs := input.Snapshots["secret_ca"]
 		if len(certs) == 1 {
 			var ok bool

--- a/modules/110-istio/hooks/generate_ca.go
+++ b/modules/110-istio/hooks/generate_ca.go
@@ -81,7 +81,7 @@ func generateCA(input *go_hook.HookInput) error {
 		certs := input.NewSnapshots.Get("secret_ca")
 		if len(certs) == 1 {
 			if err := certs[0].UnmarshalTo(&istioCA); err != nil {
-				return fmt.Errorf("failed to unmarshal 'secret_ca' snapshot: %w", err)
+				return fmt.Errorf("cannot convert certificate to certificate authority: failed to unmarshal 'secret_ca' snapshot: %w", err)
 			}
 		} else {
 			selfSignedCA, err := certificate.GenerateCA(input.Logger, "d8-istio", certificate.WithGroups("d8-istio"), certificate.WithKeyRequest(&csr.KeyRequest{

--- a/modules/110-istio/hooks/generate_ca.go
+++ b/modules/110-istio/hooks/generate_ca.go
@@ -78,13 +78,10 @@ func generateCA(input *go_hook.HookInput) error {
 			istioCA.Root = istioCA.Cert
 		}
 	} else {
-		// todo
-		certs := input.Snapshots["secret_ca"]
+		certs := input.NewSnapshots.Get("secret_ca")
 		if len(certs) == 1 {
-			var ok bool
-			istioCA, ok = certs[0].(lib.IstioCA)
-			if !ok {
-				return fmt.Errorf("cannot convert certificate to certificate authority")
+			if err := certs[0].UnmarshalTo(&istioCA); err != nil {
+				return fmt.Errorf("failed to unmarshal 'secret_ca' snapshot: %w", err)
 			}
 		} else {
 			selfSignedCA, err := certificate.GenerateCA(input.Logger, "d8-istio", certificate.WithGroups("d8-istio"), certificate.WithKeyRequest(&csr.KeyRequest{

--- a/modules/110-istio/hooks/generate_kiali_signing_key.go
+++ b/modules/110-istio/hooks/generate_kiali_signing_key.go
@@ -65,9 +65,13 @@ func applyKialiSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 
 func generateKialiSigningKey(input *go_hook.HookInput) error {
 	kialiSigningKey := ""
-	//todo
-	if len(input.Snapshots["kiali_signing_key_secret"]) == 1 {
-		secret := input.Snapshots["kiali_signing_key_secret"][0].(kialiSecret)
+	snapshots := input.NewSnapshots.Get("kiali_signing_key_secret")
+	if len(snapshots) == 1 {
+		var secret kialiSecret
+		err := snapshots[0].UnmarshalTo(&secret)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal 'kiali_signing_key_secret' snapshot: %w", err)
+		}
 		kialiSigningKey = secret.SigningKey
 	}
 	if len(kialiSigningKey) != 32 {

--- a/modules/110-istio/hooks/generate_kiali_signing_key.go
+++ b/modules/110-istio/hooks/generate_kiali_signing_key.go
@@ -65,6 +65,7 @@ func applyKialiSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 
 func generateKialiSigningKey(input *go_hook.HookInput) error {
 	kialiSigningKey := ""
+	//todo
 	if len(input.Snapshots["kiali_signing_key_secret"]) == 1 {
 		secret := input.Snapshots["kiali_signing_key_secret"][0].(kialiSecret)
 		kialiSigningKey = secret.SigningKey

--- a/modules/110-istio/hooks/hack_iop_reconciling.go
+++ b/modules/110-istio/hooks/hack_iop_reconciling.go
@@ -24,6 +24,7 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -36,6 +37,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib/crd"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 const validatingErrorStr = `failed calling webhook`
@@ -124,15 +126,21 @@ func applyIstioOperatorPodFilter(obj *unstructured.Unstructured) (go_hook.Filter
 func hackIopReconcilingHook(input *go_hook.HookInput) error {
 	operatorPodMap := make(map[string]string)
 
-	for _, operatorPodRaw := range input.Snapshots["istio_operator_pods"] {
-		operatorPod := operatorPodRaw.(IstioOperatorPodSnapshot)
+	for operatorPod, err := range sdkobjectpatch.SnapshotIter[IstioOperatorPodSnapshot](input.NewSnapshots.Get("istio_operator_pods")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'istio_operator_pods' snapshot: %w", err)
+		}
+
 		if time.Now().After(operatorPod.CreationTimestamp.Add(time.Minute*5)) && operatorPod.Phase == v1.PodRunning {
 			operatorPodMap[operatorPod.Revision] = operatorPod.Name
 		}
 	}
 
-	for _, iopRaw := range input.Snapshots["istio_operators"] {
-		iop := iopRaw.(IstioOperatorCrdSnapshot)
+	for iop, err := range sdkobjectpatch.SnapshotIter[IstioOperatorCrdSnapshot](input.NewSnapshots.Get("istio_operators")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'istio_operators' snapshot: %w", err)
+		}
+
 		if iop.NeedPunch {
 			input.Logger.Info("iop with rev needs to punch.", slog.String("rev", iop.Revision))
 			if podName, ok := operatorPodMap[iop.Revision]; ok {

--- a/modules/110-istio/hooks/hack_iop_reconciling.go
+++ b/modules/110-istio/hooks/hack_iop_reconciling.go
@@ -35,9 +35,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib/crd"
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 const validatingErrorStr = `failed calling webhook`

--- a/modules/110-istio/hooks/migration_adopt_serviceaccounts.go
+++ b/modules/110-istio/hooks/migration_adopt_serviceaccounts.go
@@ -26,8 +26,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 )
 
 const (

--- a/modules/110-istio/hooks/migration_delete_legacy_roles.go
+++ b/modules/110-istio/hooks/migration_delete_legacy_roles.go
@@ -17,12 +17,15 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
+
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 // This hook deletes legacy roles and rolebindings created by operator (not DH) in both scopes
@@ -104,29 +107,41 @@ func applyClusterRoleBindingFilter(obj *unstructured.Unstructured) (go_hook.Filt
 
 func deleteLegacyRBACs(input *go_hook.HookInput) error {
 	// remove legacy Roles
-	for _, resource := range input.Snapshots["role_for_delete"] {
-		role := resource.(objectInfo)
+	for role, err := range sdkobjectpatch.SnapshotIter[objectInfo](input.NewSnapshots.Get("role_for_delete")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'role_for_delete' snapshot: %w", err)
+		}
+
 		input.Logger.Info("remove legacy Role %s in %s namespace", role.Name, role.Namespace)
 		input.PatchCollector.Delete("rbac.authorization.k8s.io/v1", "Role", role.Namespace, role.Name)
 	}
 
 	// remove legacy RoleBindings
-	for _, resource := range input.Snapshots["rolebinding_for_delete"] {
-		roleBinding := resource.(objectInfo)
+	for roleBinding, err := range sdkobjectpatch.SnapshotIter[objectInfo](input.NewSnapshots.Get("rolebinding_for_delete")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'rolebinding_for_delete' snapshot: %w", err)
+		}
+
 		input.Logger.Info("remove legacy RoleBinding %s in %s namespace", roleBinding.Name, roleBinding.Namespace)
 		input.PatchCollector.Delete("rbac.authorization.k8s.io/v1", "RoleBinding", roleBinding.Namespace, roleBinding.Name)
 	}
 
 	// remove legacy ClusterRoles
-	for _, resource := range input.Snapshots["clusterrole_for_delete"] {
-		clusterRoleName := resource.(string)
+	for clusterRoleName, err := range sdkobjectpatch.SnapshotIter[string](input.NewSnapshots.Get("clusterrole_for_delete")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'clusterrole_for_delete' snapshot: %w", err)
+		}
+
 		input.Logger.Info("remove legacy ClusterRole %s", clusterRoleName)
 		input.PatchCollector.Delete("rbac.authorization.k8s.io/v1", "ClusterRole", "", clusterRoleName)
 	}
 
 	// remove legacy ClusterRoleBindings
-	for _, resource := range input.Snapshots["clusterrolebinding_for_delete"] {
-		clusterRoleBindingName := resource.(string)
+	for clusterRoleBindingName, err := range sdkobjectpatch.SnapshotIter[string](input.NewSnapshots.Get("clusterrolebinding_for_delete")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'clusterrolebinding_for_delete' snapshot: %w", err)
+		}
+
 		input.Logger.Info("remove legacy ClusterRoleBinding %s", clusterRoleBindingName)
 		input.PatchCollector.Delete("rbac.authorization.k8s.io/v1", "ClusterRoleBinding", "", clusterRoleBindingName)
 	}

--- a/modules/110-istio/hooks/migration_delete_legacy_roles.go
+++ b/modules/110-istio/hooks/migration_delete_legacy_roles.go
@@ -24,8 +24,9 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 )
 
 // This hook deletes legacy roles and rolebindings created by operator (not DH) in both scopes

--- a/modules/110-istio/hooks/migration_service_with_many_ports.go
+++ b/modules/110-istio/hooks/migration_service_with_many_ports.go
@@ -25,8 +25,9 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 )
 
 type serviceInfo struct {

--- a/modules/110-istio/hooks/migration_service_with_many_ports.go
+++ b/modules/110-istio/hooks/migration_service_with_many_ports.go
@@ -17,6 +17,8 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
+
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
@@ -24,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 type serviceInfo struct {
@@ -64,9 +67,12 @@ func applyServiceFilterHelmFix(obj *unstructured.Unstructured) (go_hook.FilterRe
 }
 
 func patchServiceWithManyPorts(input *go_hook.HookInput) error {
-	serviceSnapshots := input.Snapshots["service_helm_fix"]
-	for _, serviceSnapshot := range serviceSnapshots {
-		serviceInfoObj := serviceSnapshot.(serviceInfo)
+	serviceSnapshots := input.NewSnapshots.Get("service_helm_fix")
+	for serviceInfoObj, err := range sdkobjectpatch.SnapshotIter[serviceInfo](serviceSnapshots) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'service_helm_fix' snapshot: %w", err)
+		}
+
 		input.PatchCollector.Delete(
 			"v1",
 			"Service",

--- a/modules/140-user-authz/hooks/alert_deprecated_spec.go
+++ b/modules/140-user-authz/hooks/alert_deprecated_spec.go
@@ -25,6 +25,8 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -68,8 +70,11 @@ func applyClusterAuthorizationRuleFilter(obj *unstructured.Unstructured) (go_hoo
 
 func handleClusterAuthorizationRulesWithDeprecatedSpec(input *go_hook.HookInput) error {
 	input.MetricsCollector.Expire("d8_deprecated_car_spec")
-	for _, obj := range input.Snapshots["cluster_authorization_rules"] {
-		car := obj.(ObjectCAR)
+	for car, err := range sdkobjectpatch.SnapshotIter[ObjectCAR](input.NewSnapshots.Get("cluster_authorization_rules")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'cluster_authorization_rules' snapshot: %w", err)
+		}
+
 		if car.Deprecated {
 			input.MetricsCollector.Set("d8_deprecated_car_spec", 1, map[string]string{"kind": car.Kind, "name": car.Name}, metrics.WithGroup("d8_deprecated_car_spec"))
 		}

--- a/modules/140-user-authz/hooks/generate_webhook_certs.go
+++ b/modules/140-user-authz/hooks/generate_webhook_certs.go
@@ -30,7 +30,7 @@ const (
 var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLSHookConf{
 	BeforeHookCheck: func(input *go_hook.HookInput) bool {
 		var (
-			secretExists        = len(input.Snapshots[tls_certificate.SnapshotKey]) > 0
+			secretExists        = len(input.NewSnapshots.Get(tls_certificate.SnapshotKey)) > 0
 			multitenancyEnabled = input.Values.Get("userAuthz.enableMultiTenancy").Bool()
 		)
 

--- a/modules/140-user-authz/hooks/handle_custom_cluster_roles.go
+++ b/modules/140-user-authz/hooks/handle_custom_cluster_roles.go
@@ -23,10 +23,11 @@ import (
 	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/deckhouse/deckhouse/go_lib/set"
-	"github.com/deckhouse/deckhouse/modules/140-user-authz/hooks/internal"
 	"github.com/deckhouse/module-sdk/pkg"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/go_lib/set"
+	"github.com/deckhouse/deckhouse/modules/140-user-authz/hooks/internal"
 )
 
 const (

--- a/modules/140-user-authz/hooks/handle_custom_cluster_roles.go
+++ b/modules/140-user-authz/hooks/handle_custom_cluster_roles.go
@@ -17,12 +17,16 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
+
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/140-user-authz/hooks/internal"
+	"github.com/deckhouse/module-sdk/pkg"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 const (
@@ -69,7 +73,12 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, customClusterRolesHandler)
 
 func customClusterRolesHandler(input *go_hook.HookInput) error {
-	input.Values.Set("userAuthz.internal.customClusterRoles", snapshotsToInternalValuesCustomClusterRoles(input.Snapshots[customClusterRoleSnapshots]))
+	customClusterRoles, err := snapshotsToInternalValuesCustomClusterRoles(input.NewSnapshots.Get(customClusterRoleSnapshots))
+	if err != nil {
+		return fmt.Errorf("failed to convert custom cluster roles snapshots: %w", err)
+	}
+
+	input.Values.Set("userAuthz.internal.customClusterRoles", customClusterRoles)
 	return nil
 }
 
@@ -82,7 +91,7 @@ type internalValuesCustomClusterRoles struct {
 	ClusterAdmin   []string `json:"clusterAdmin"`
 }
 
-func snapshotsToInternalValuesCustomClusterRoles(snapshots []go_hook.FilterResult) internalValuesCustomClusterRoles {
+func snapshotsToInternalValuesCustomClusterRoles(snapshots []pkg.Snapshot) (internalValuesCustomClusterRoles, error) {
 	var (
 		userRoleNames           = set.New()
 		privilegedUserRoleNames = set.New()
@@ -92,11 +101,11 @@ func snapshotsToInternalValuesCustomClusterRoles(snapshots []go_hook.FilterResul
 		clusterAdminRoleNames   = set.New()
 	)
 
-	for _, snapshot := range snapshots {
-		if snapshot == nil {
-			continue
+	for customRole, err := range sdkobjectpatch.SnapshotIter[customClusterRole](snapshots) {
+		if err != nil {
+			return internalValuesCustomClusterRoles{}, fmt.Errorf("failed to iterate over '%s' snapshot: %w", customClusterRoleSnapshots, err)
 		}
-		customRole := snapshot.(*customClusterRole)
+
 		switch customRole.Role {
 		case accessLevelUser:
 			userRoleNames.Add(customRole.Name)
@@ -127,5 +136,5 @@ func snapshotsToInternalValuesCustomClusterRoles(snapshots []go_hook.FilterResul
 		ClusterAdmin:   clusterAdminRoleNames.Slice(),
 	}
 
-	return values
+	return values, nil
 }

--- a/modules/140-user-authz/hooks/handle_dict_bindings.go
+++ b/modules/140-user-authz/hooks/handle_dict_bindings.go
@@ -101,12 +101,11 @@ func ensureDictBindings(input *go_hook.HookInput) error {
 		}
 	}
 
-	for _, binding := range input.Snapshots["dictBindings"] {
-		if binding == nil {
-			continue
+	for parsed, err := range sdkobjectpatch.SnapshotIter[filteredManageBinding](input.NewSnapshots.Get("dictBindings")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'dictBindings' snapshot: %w", err)
 		}
 
-		parsed := binding.(*filteredManageBinding)
 		if parsed.Subjects == nil {
 			continue
 		}

--- a/modules/140-user-authz/hooks/handle_dict_bindings.go
+++ b/modules/140-user-authz/hooks/handle_dict_bindings.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -83,12 +84,11 @@ func filterUseBinding(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 
 func ensureDictBindings(input *go_hook.HookInput) error {
 	subjects := make(map[string]rbacv1.Subject)
-	for _, binding := range input.Snapshots["useBindings"] {
-		if binding == nil {
-			continue
+	for parsed, err := range sdkobjectpatch.SnapshotIter[filteredUseBinding](input.NewSnapshots.Get("useBindings")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'useBindings' snapshot: %w", err)
 		}
 
-		parsed := binding.(*filteredUseBinding)
 		if len(parsed.Subjects) == 0 {
 			continue
 		}

--- a/modules/140-user-authz/hooks/handle_dict_bindings.go
+++ b/modules/140-user-authz/hooks/handle_dict_bindings.go
@@ -20,13 +20,14 @@ import (
 	"fmt"
 	"strings"
 
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{

--- a/modules/140-user-authz/hooks/handle_manage_bindings.go
+++ b/modules/140-user-authz/hooks/handle_manage_bindings.go
@@ -19,8 +19,6 @@ package hooks
 import (
 	"fmt"
 
-	"github.com/deckhouse/module-sdk/pkg"
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -28,6 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/module-sdk/pkg"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{

--- a/modules/140-user-authz/hooks/handle_manage_bindings.go
+++ b/modules/140-user-authz/hooks/handle_manage_bindings.go
@@ -19,6 +19,8 @@ package hooks
 import (
 	"fmt"
 
+	"github.com/deckhouse/module-sdk/pkg"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -124,19 +126,27 @@ func filterManageRole(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 
 func syncBindings(input *go_hook.HookInput) error {
 	expected := make(map[string]bool)
-	for _, snap := range input.Snapshots["manageBindings"] {
-		binding := snap.(*filteredManageBinding)
-		role, namespaces := roleAndNamespacesByBinding(input.Snapshots["manageRoles"], binding.RoleName)
+	for binding, err := range sdkobjectpatch.SnapshotIter[filteredManageBinding](input.NewSnapshots.Get("manageBindings")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'manageBindings' snapshot: %w", err)
+		}
+		role, namespaces, err := roleAndNamespacesByBinding(input.NewSnapshots.Get("manageRoles"), binding.RoleName)
+		if err != nil {
+			return fmt.Errorf("failed to get role and namespaces for binding '%s': %w", binding.Name, err)
+		}
+
 		useBindingName := fmt.Sprintf("d8:use:%s:binding:%s", role, binding.Name)
 		for namespace := range namespaces {
-			input.PatchCollector.CreateOrUpdate(createBinding(binding, role, namespace))
+			input.PatchCollector.CreateOrUpdate(createBinding(&binding, role, namespace))
 			expected[useBindingName] = true
 		}
 	}
 
 	// delete excess use bindings
-	for _, snap := range input.Snapshots["useBindings"] {
-		existing := snap.(*filteredUseBinding)
+	for existing, err := range sdkobjectpatch.SnapshotIter[filteredUseBinding](input.NewSnapshots.Get("useBindings")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'useBindings' snapshot: %w", err)
+		}
 		if _, ok := expected[existing.Name]; !ok {
 			input.PatchCollector.Delete("rbac.authorization.k8s.io/v1", "RoleBinding", existing.Namespace, existing.Name)
 		}
@@ -145,26 +155,32 @@ func syncBindings(input *go_hook.HookInput) error {
 	return nil
 }
 
-func roleAndNamespacesByBinding(manageRoles []go_hook.FilterResult, roleName string) (string, map[string]bool) {
+func roleAndNamespacesByBinding(manageRoles []pkg.Snapshot, roleName string) (string, map[string]bool, error) {
 	var useRole string
 	var found *filteredManageRole
-	for _, snap := range manageRoles {
-		if role := snap.(*filteredManageRole); role.Name == roleName {
-			found = role
+	for role, err := range sdkobjectpatch.SnapshotIter[filteredManageRole](manageRoles) {
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to iterate over 'manageRoles' snapshot: %w", err)
+		}
+		if role.Name == roleName {
+			found = &role
 			var ok bool
 			if useRole, ok = found.Labels["rbac.deckhouse.io/use-role"]; !ok {
-				return "", nil
+				return "", nil, nil
 			}
 			break
 		}
 	}
 	if found == nil {
-		return "", nil
+		return "", nil, nil
 	}
 
 	var namespaces = make(map[string]bool)
-	for _, snap := range manageRoles {
-		role := snap.(*filteredManageRole)
+	for role, err := range sdkobjectpatch.SnapshotIter[filteredManageRole](manageRoles) {
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to iterate over 'manageRoles' snapshot: %w", err)
+		}
+
 		if matchAggregationRule(found.Rule, role.Labels) {
 			if role.Rule == nil {
 				if namespace, ok := role.Labels["rbac.deckhouse.io/namespace"]; ok {
@@ -172,8 +188,10 @@ func roleAndNamespacesByBinding(manageRoles []go_hook.FilterResult, roleName str
 				}
 				continue
 			}
-			for _, nestedSnap := range manageRoles {
-				nested := nestedSnap.(*filteredManageRole)
+			for nested, err := range sdkobjectpatch.SnapshotIter[filteredManageRole](manageRoles) {
+				if err != nil {
+					return "", nil, fmt.Errorf("failed to iterate over 'manageRoles' snapshot: %w", err)
+				}
 				if matchAggregationRule(role.Rule, nested.Labels) {
 					if namespace, ok := nested.Labels["rbac.deckhouse.io/namespace"]; ok {
 						namespaces[namespace] = true
@@ -183,7 +201,7 @@ func roleAndNamespacesByBinding(manageRoles []go_hook.FilterResult, roleName str
 		}
 	}
 
-	return useRole, namespaces
+	return useRole, namespaces, nil
 }
 
 func matchAggregationRule(rule *rbacv1.AggregationRule, roleLabels map[string]string) bool {

--- a/modules/140-user-authz/hooks/internal/auth_rule_handler.go
+++ b/modules/140-user-authz/hooks/internal/auth_rule_handler.go
@@ -20,8 +20,11 @@ import (
 	"fmt"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/deckhouse/module-sdk/pkg"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 type authorizationRule struct {
@@ -50,19 +53,22 @@ func ApplyAuthorizationRuleFilter(obj *unstructured.Unstructured) (go_hook.Filte
 
 func AuthorizationRulesHandler(valuesPath, snapshotKey string) func(input *go_hook.HookInput) error {
 	return func(input *go_hook.HookInput) error {
-		input.Values.Set(valuesPath, snapshotsToAuthorizationRulesSlice(input.Snapshots[snapshotKey]))
+		authorizationRules, err := snapshotsToAuthorizationRulesSlice(input.NewSnapshots.Get(snapshotKey))
+		if err != nil {
+			return fmt.Errorf("failed to convert '%s' snapshot to authorization rules: %w", snapshotKey, err)
+		}
+		input.Values.Set(valuesPath, authorizationRules)
 		return nil
 	}
 }
 
-func snapshotsToAuthorizationRulesSlice(snapshots []go_hook.FilterResult) []authorizationRule {
+func snapshotsToAuthorizationRulesSlice(snapshots []pkg.Snapshot) ([]authorizationRule, error) {
 	ars := make([]authorizationRule, 0, len(snapshots))
-	for _, snapshot := range snapshots {
-		if snapshot == nil {
-			continue
+	for ar, err := range sdkobjectpatch.SnapshotIter[authorizationRule](snapshots) {
+		if err != nil {
+			return nil, fmt.Errorf("failed to iterate over snapshot: %w", err)
 		}
-		ar := snapshot.(*authorizationRule)
-		ars = append(ars, *ar)
+		ars = append(ars, ar)
 	}
-	return ars
+	return ars, nil
 }

--- a/modules/140-user-authz/hooks/internal/auth_rule_handler.go
+++ b/modules/140-user-authz/hooks/internal/auth_rule_handler.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/deckhouse/module-sdk/pkg"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/deckhouse/module-sdk/pkg"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 

--- a/modules/150-user-authn/hooks/discover_apiserver_endpoints.go
+++ b/modules/150-user-authn/hooks/discover_apiserver_endpoints.go
@@ -121,13 +121,13 @@ func discoverApiserverEndpoints(input *go_hook.HookInput) error {
 		return fmt.Errorf("kubernetes service endpoints was not discovered")
 	}
 
-	portData := make(map[string]interface{})
+	var portData int32
 	err := ports[0].UnmarshalTo(&portData)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal 'port' snapshot: %w", err)
 	}
 
-	endPortData := make(map[string]interface{})
+	var endPortData kubernetesEndpoints
 	err = endpoints[0].UnmarshalTo(&endPortData)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal 'endpoints' snapshot: %w", err)

--- a/modules/150-user-authn/hooks/discover_apiserver_endpoints.go
+++ b/modules/150-user-authn/hooks/discover_apiserver_endpoints.go
@@ -111,17 +111,29 @@ func discoverApiserverEndpoints(input *go_hook.HookInput) error {
 		return nil
 	}
 
-	ports := input.Snapshots["port"]
+	ports := input.NewSnapshots.Get("port")
 	if len(ports) == 0 {
 		return fmt.Errorf("kubernetes service pod was not discovered")
 	}
 
-	endpoints := input.Snapshots["endpoints"]
+	endpoints := input.NewSnapshots.Get("endpoints")
 	if len(endpoints) == 0 {
 		return fmt.Errorf("kubernetes service endpoints was not discovered")
 	}
 
-	input.Values.Set(targetPortPath, ports[0])
-	input.Values.Set(addressesPath, endpoints[0])
+	portData := make(map[string]interface{})
+	err := ports[0].UnmarshalTo(&portData)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal 'port' snapshot: %w", err)
+	}
+
+	endPortData := make(map[string]interface{})
+	err = endpoints[0].UnmarshalTo(&endPortData)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal 'endpoints' snapshot: %w", err)
+	}
+
+	input.Values.Set(targetPortPath, portData)
+	input.Values.Set(addressesPath, endPortData)
 	return nil
 }

--- a/modules/150-user-authn/hooks/discover_dex_ca.go
+++ b/modules/150-user-authn/hooks/discover_dex_ca.go
@@ -112,7 +112,7 @@ func discoverDexCA(input *go_hook.HookInput) error {
 		dexCASnapshots := input.NewSnapshots.Get("secret")
 		for dexCAFromSnapshot, err := range sdkobjectpatch.SnapshotIter[DexCA](dexCASnapshots) {
 			if err != nil {
-				return fmt.Errorf("failed to iterate over 'secret' snapshot: %w", err)
+				return fmt.Errorf("cannot convert dex ca certificate from snaphots: failed to iterate over 'secret' snapshot: %w", err)
 			}
 
 			if dexCAFromSnapshot.Name == secretKey {

--- a/modules/150-user-authn/hooks/discover_dex_ca.go
+++ b/modules/150-user-authn/hooks/discover_dex_ca.go
@@ -25,8 +25,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/deckhouse/deckhouse/go_lib/module"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/go_lib/module"
 )
 
 const (

--- a/modules/150-user-authn/hooks/discover_publish_api_cert.go
+++ b/modules/150-user-authn/hooks/discover_publish_api_cert.go
@@ -25,8 +25,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/deckhouse/deckhouse/go_lib/module"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/go_lib/module"
 )
 
 type PublishAPICert struct {

--- a/modules/150-user-authn/hooks/expire_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/expire_dex_user_crds.go
@@ -83,7 +83,7 @@ func expireDexUsers(input *go_hook.HookInput) error {
 
 	for dexUserExpire, err := range sdkobjectpatch.SnapshotIter[DexUserExpire](input.NewSnapshots.Get("users")) {
 		if err != nil {
-			return fmt.Errorf("cannot iterate over 'users' snapshot: %v", err)
+			return fmt.Errorf("cannot convert user to dex expire: cannot iterate over 'users' snapshot: %v", err)
 		}
 
 		if dexUserExpire.CheckExpire && dexUserExpire.ExpireAt.Before(now) {

--- a/modules/150-user-authn/hooks/expire_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/expire_dex_user_crds.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"time"
 
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 type DexUserExpire struct {

--- a/modules/150-user-authn/hooks/generate_basic_auth_proxy_cert.go
+++ b/modules/150-user-authn/hooks/generate_basic_auth_proxy_cert.go
@@ -141,9 +141,12 @@ func generateProxyAuthCert(input *go_hook.HookInput, dc dependency.Container) er
 	}
 
 	// check certificate renewal necessity
-	snap := input.Snapshots["secret"]
+	snap := input.NewSnapshots.Get("secret")
 	if len(snap) > 0 {
-		secret := snap[0].(secret)
+		var secret secret
+		if err := snap[0].UnmarshalTo(&secret); err != nil {
+			return fmt.Errorf("failed to unmarshal 'secret' snapshot: %w", err)
+		}
 
 		// if cert is valid more than two days - skip renewal
 		expiring, err := certificate.IsCertificateExpiringSoon(secret.Crt, 2*24*time.Hour)

--- a/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
+++ b/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
@@ -70,7 +70,7 @@ func kubernetesDexClientAppSecret(input *go_hook.HookInput) error {
 		var secretContent []byte
 		err := kubernetesSecrets[0].UnmarshalTo(&secretContent)
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal 'kubernetes_secret' snapshot: %w", err)
+			return fmt.Errorf("cannot conver kubernetes secret to bytes: failed to unmarshal 'kubernetes_secret' snapshot: %w", err)
 		}
 
 		// if secret field was removed, generate a new one

--- a/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
+++ b/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
@@ -65,11 +65,12 @@ func kubernetesDexClientAppSecret(input *go_hook.HookInput) error {
 		return nil
 	}
 
-	kubernetesSecrets, ok := input.Snapshots["kubernetes_secret"]
-	if ok && len(kubernetesSecrets) > 0 {
-		secretContent, ok := kubernetesSecrets[0].([]byte)
-		if !ok {
-			return fmt.Errorf("cannot conver kubernetes secret to bytes")
+	kubernetesSecrets := input.NewSnapshots.Get("kubernetes_secret")
+	if len(kubernetesSecrets) > 0 {
+		var secretContent []byte
+		err := kubernetesSecrets[0].UnmarshalTo(&secretContent)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal 'kubernetes_secret' snapshot: %w", err)
 		}
 
 		// if secret field was removed, generate a new one

--- a/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
+++ b/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
@@ -70,7 +70,7 @@ func kubernetesDexClientAppSecret(input *go_hook.HookInput) error {
 		var secretContent []byte
 		err := kubernetesSecrets[0].UnmarshalTo(&secretContent)
 		if err != nil {
-			return fmt.Errorf("cannot conver kubernetes secret to bytes: failed to unmarshal 'kubernetes_secret' snapshot: %w", err)
+			return fmt.Errorf("cannot convert kubernetes secret to bytes: failed to unmarshal 'kubernetes_secret' snapshot: %w", err)
 		}
 
 		// if secret field was removed, generate a new one

--- a/modules/150-user-authn/hooks/generate_selfsigned_ca.go
+++ b/modules/150-user-authn/hooks/generate_selfsigned_ca.go
@@ -78,12 +78,11 @@ func generateSelfSignedCA(input *go_hook.HookInput) error {
 
 	var sefSignedCA certificate.Authority
 
-	certs := input.Snapshots["cert"]
+	certs := input.NewSnapshots.Get("cert")
 	if len(certs) == 1 {
-		var ok bool
-		sefSignedCA, ok = certs[0].(certificate.Authority)
-		if !ok {
-			return fmt.Errorf("cannot convert sefsigned certificate to certificate authority")
+		err := certs[0].UnmarshalTo(&sefSignedCA)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal 'cert' snapshot: %w", err)
 		}
 	} else {
 		var err error

--- a/modules/150-user-authn/hooks/generate_selfsigned_ca.go
+++ b/modules/150-user-authn/hooks/generate_selfsigned_ca.go
@@ -82,7 +82,7 @@ func generateSelfSignedCA(input *go_hook.HookInput) error {
 	if len(certs) == 1 {
 		err := certs[0].UnmarshalTo(&sefSignedCA)
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal 'cert' snapshot: %w", err)
+			return fmt.Errorf("cannot convert sefsigned certificate to certificate authority: failed to unmarshal 'cert' snapshot: %w", err)
 		}
 	} else {
 		var err error

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
@@ -25,9 +25,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
 	"github.com/deckhouse/deckhouse/go_lib/encoding"
 	"github.com/deckhouse/deckhouse/go_lib/pwgen"
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 type DexAuthenticator struct {

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
@@ -135,7 +135,7 @@ func getDexAuthenticator(input *go_hook.HookInput) error {
 
 	for dexSecret, err := range sdkobjectpatch.SnapshotIter[DexAuthenticatorSecret](credentials) {
 		if err != nil {
-			return fmt.Errorf("failed to iterate over 'credentials' snapshot: %w", err)
+			return fmt.Errorf("cannot convert dex authenticator secret: failed to iterate over 'credentials' snapshot: %w", err)
 		}
 
 		credentialsByID[dexSecret.ID] = dexSecret.Credentials
@@ -144,7 +144,7 @@ func getDexAuthenticator(input *go_hook.HookInput) error {
 	dexAuthenticators := make([]DexAuthenticator, 0, len(authenticators))
 	for dexAuthenticator, err := range sdkobjectpatch.SnapshotIter[DexAuthenticator](authenticators) {
 		if err != nil {
-			return fmt.Errorf("failed to iterate over 'authenticators' snapshot: %w", err)
+			return fmt.Errorf("cannot convert dex authenticaor: failed to iterate over 'authenticators' snapshot: %w", err)
 		}
 
 		existedCredentials, ok := credentialsByID[fmt.Sprintf("dex-authenticator-%s", dexAuthenticator.ID)]

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/go_lib/encoding"
 	"github.com/deckhouse/deckhouse/go_lib/pwgen"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 type DexAuthenticator struct {
@@ -126,25 +127,23 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, getDexAuthenticator)
 
 func getDexAuthenticator(input *go_hook.HookInput) error {
-	authenticators := input.Snapshots["authenticators"]
-	credentials := input.Snapshots["credentials"]
+	authenticators := input.NewSnapshots.Get("authenticators")
+	credentials := input.NewSnapshots.Get("credentials")
 
 	credentialsByID := make(map[string]Credentials, len(credentials))
 
-	for _, secret := range credentials {
-		dexSecret, ok := secret.(DexAuthenticatorSecret)
-		if !ok {
-			return fmt.Errorf("cannot convert dex authenticator secret")
+	for dexSecret, err := range sdkobjectpatch.SnapshotIter[DexAuthenticatorSecret](credentials) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'credentials' snapshot: %w", err)
 		}
 
 		credentialsByID[dexSecret.ID] = dexSecret.Credentials
 	}
 
 	dexAuthenticators := make([]DexAuthenticator, 0, len(authenticators))
-	for _, authenticator := range authenticators {
-		dexAuthenticator, ok := authenticator.(DexAuthenticator)
-		if !ok {
-			return fmt.Errorf("cannot convert dex authenticaor")
+	for dexAuthenticator, err := range sdkobjectpatch.SnapshotIter[DexAuthenticator](authenticators) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'authenticators' snapshot: %w", err)
 		}
 
 		existedCredentials, ok := credentialsByID[fmt.Sprintf("dex-authenticator-%s", dexAuthenticator.ID)]

--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -25,9 +25,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
 	"github.com/deckhouse/deckhouse/go_lib/encoding"
 	"github.com/deckhouse/deckhouse/go_lib/pwgen"
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 type DexClient struct {

--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -160,7 +160,7 @@ func getDexClient(input *go_hook.HookInput) error {
 
 	for dexSecret, err := range sdkobjectpatch.SnapshotIter[DexClientSecret](credentials) {
 		if err != nil {
-			return fmt.Errorf("failed to iterate over 'credentials' snapshot: %w", err)
+			return fmt.Errorf("cannot convert dex client secret: failed to iterate over 'credentials' snapshot: %w", err)
 		}
 
 		credentialsByID[dexSecret.ID] = string(dexSecret.Secret)
@@ -169,7 +169,7 @@ func getDexClient(input *go_hook.HookInput) error {
 	dexClients := make([]DexClient, 0, len(clients))
 	for dexClient, err := range sdkobjectpatch.SnapshotIter[DexClient](clients) {
 		if err != nil {
-			return fmt.Errorf("failed to iterate over 'clients' snapshot: %w", err)
+			return fmt.Errorf("cannot convert dex client: failed to iterate over 'clients' snapshot: %w", err)
 		}
 
 		existedSecret, ok := credentialsByID[dexClient.ID]

--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/go_lib/encoding"
 	"github.com/deckhouse/deckhouse/go_lib/pwgen"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 type DexClient struct {
@@ -151,25 +152,23 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, getDexClient)
 
 func getDexClient(input *go_hook.HookInput) error {
-	clients := input.Snapshots["clients"]
-	credentials := input.Snapshots["credentials"]
+	clients := input.NewSnapshots.Get("clients")
+	credentials := input.NewSnapshots.Get("credentials")
 
 	credentialsByID := make(map[string]string, len(credentials))
 
-	for _, secret := range credentials {
-		dexSecret, ok := secret.(DexClientSecret)
-		if !ok {
-			return fmt.Errorf("cannot convert dex client secret")
+	for dexSecret, err := range sdkobjectpatch.SnapshotIter[DexClientSecret](credentials) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'credentials' snapshot: %w", err)
 		}
 
 		credentialsByID[dexSecret.ID] = string(dexSecret.Secret)
 	}
 
 	dexClients := make([]DexClient, 0, len(clients))
-	for _, client := range clients {
-		dexClient, ok := client.(DexClient)
-		if !ok {
-			return fmt.Errorf("cannot convert dex client")
+	for dexClient, err := range sdkobjectpatch.SnapshotIter[DexClient](clients) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'clients' snapshot: %w", err)
 		}
 
 		existedSecret, ok := credentialsByID[dexClient.ID]

--- a/modules/150-user-authn/hooks/get_dex_providers_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_providers_crds.go
@@ -54,7 +54,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, getDexProviders)
 
 func getDexProviders(input *go_hook.HookInput) error {
-	providers, err := sdkobjectpatch.UnmarshalToStruct[[]interface{}](input.NewSnapshots, "providers")
+	providers, err := sdkobjectpatch.UnmarshalToStruct[map[string]interface{}](input.NewSnapshots, "providers")
 
 	if err != nil {
 		input.Values.Set("userAuthn.internal.providers", []interface{}{})

--- a/modules/150-user-authn/hooks/get_dex_providers_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_providers_crds.go
@@ -22,6 +22,8 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 type DexProvider map[string]interface{}
@@ -52,8 +54,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, getDexProviders)
 
 func getDexProviders(input *go_hook.HookInput) error {
-	providers, ok := input.Snapshots["providers"]
-	if !ok {
+	providers, err := sdkobjectpatch.UnmarshalToStruct[[]interface{}](input.NewSnapshots, "providers")
+
+	if err != nil {
 		input.Values.Set("userAuthn.internal.providers", []interface{}{})
 		return nil
 	}

--- a/modules/150-user-authn/hooks/get_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds.go
@@ -136,7 +136,7 @@ func getDexUsers(input *go_hook.HookInput) error {
 
 	for dexUser, err := range sdkobjectpatch.SnapshotIter[DexUser](input.NewSnapshots.Get("users")) {
 		if err != nil {
-			return fmt.Errorf("cannot iterate over 'users' snapshot: %v", err)
+			return fmt.Errorf("cannot convert user to dex user: cannot iterate over 'users' snapshot: %v", err)
 		}
 
 		var groups []string

--- a/modules/150-user-authn/hooks/get_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds.go
@@ -28,10 +28,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/deckhouse/deckhouse/go_lib/encoding"
-	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/module-sdk/pkg"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/go_lib/encoding"
+	"github.com/deckhouse/deckhouse/go_lib/set"
 )
 
 type expirePatch struct {

--- a/modules/150-user-authn/hooks/get_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/deckhouse/deckhouse/go_lib/encoding"
 	"github.com/deckhouse/deckhouse/go_lib/set"
+	"github.com/deckhouse/module-sdk/pkg"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 type expirePatch struct {
@@ -116,19 +118,24 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, getDexUsers)
 
 func getDexUsers(input *go_hook.HookInput) error {
-	users := make([]DexUserInternalValues, 0, len(input.Snapshots["users"]))
+	users := make([]DexUserInternalValues, 0, len(input.NewSnapshots.Get("users")))
 	mapOfUsersToGroups := map[string]map[string]bool{}
 
-	groupsSnap := input.Snapshots["groups"]
-	for _, obj := range groupsSnap {
-		group := obj.(*DexGroup)
-		makeUserGroupsMap(groupsSnap, group.Spec.Name, []string{}, mapOfUsersToGroups)
+	groupsSnap := input.NewSnapshots.Get("groups")
+	for group, err := range sdkobjectpatch.SnapshotIter[DexGroup](groupsSnap) {
+		if err != nil {
+			return fmt.Errorf("cannot iterate over 'groups' snapshot: %v", err)
+		}
+
+		err = makeUserGroupsMap(groupsSnap, group.Spec.Name, []string{}, mapOfUsersToGroups)
+		if err != nil {
+			return fmt.Errorf("error while make user groups map for group %s: %v", group.Spec.Name, err)
+		}
 	}
 
-	for _, user := range input.Snapshots["users"] {
-		dexUser, ok := user.(*DexUser)
-		if !ok {
-			return fmt.Errorf("cannot convert user to dex user")
+	for dexUser, err := range sdkobjectpatch.SnapshotIter[DexUser](input.NewSnapshots.Get("users")) {
+		if err != nil {
+			return fmt.Errorf("cannot iterate over 'users' snapshot: %v", err)
 		}
 
 		var groups []string
@@ -205,24 +212,31 @@ func applyDexUserFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, e
 	return user, nil
 }
 
-func findGroup(groups []go_hook.FilterResult, groupName string) *DexGroup {
-	for _, obj := range groups {
-		group := obj.(*DexGroup)
+func findGroup(groups []pkg.Snapshot, groupName string) (*DexGroup, error) {
+	for group, err := range sdkobjectpatch.SnapshotIter[DexGroup](groups) {
+		if err != nil {
+			return nil, fmt.Errorf("cannot iterate over 'groups' snapshot: %v", err)
+		}
+
 		if group.Spec.Name == groupName {
-			return group
+			return &group, err
 		}
 	}
-	return nil
+	return nil, nil
 }
 
-func makeUserGroupsMap(groups []go_hook.FilterResult, targetGroup string, accumulatedGroupList []string, mapOfUsersToGroups map[string]map[string]bool) {
+func makeUserGroupsMap(groups []pkg.Snapshot, targetGroup string, accumulatedGroupList []string, mapOfUsersToGroups map[string]map[string]bool) error {
 	if len(groups) == 0 {
-		return
+		return nil
 	}
-	group := findGroup(groups, targetGroup)
+	group, err := findGroup(groups, targetGroup)
+	if err != nil {
+		return fmt.Errorf("error while find group %s: %v", targetGroup, err)
+	}
 	if group == nil {
-		return
+		return nil
 	}
+
 	skipAddGroup := false
 	for _, g := range accumulatedGroupList {
 		if g == targetGroup {
@@ -242,7 +256,11 @@ func makeUserGroupsMap(groups []go_hook.FilterResult, targetGroup string, accumu
 				mapOfUsersToGroups[member.Name][g] = true
 			}
 		case "Group":
-			makeUserGroupsMap(groups, member.Name, accumulatedGroupList, mapOfUsersToGroups)
+			err := makeUserGroupsMap(groups, member.Name, accumulatedGroupList, mapOfUsersToGroups)
+			if err != nil {
+				return fmt.Errorf("error while make user groups map for group %s: %v", member.Name, err)
+			}
 		}
 	}
+	return nil
 }

--- a/modules/300-prometheus/hooks/alertmanager_crd_discovery.go
+++ b/modules/300-prometheus/hooks/alertmanager_crd_discovery.go
@@ -28,10 +28,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
 	"github.com/deckhouse/deckhouse/go_lib/hooks/set_cr_statuses"
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{

--- a/modules/300-prometheus/hooks/calculate_storage_capacity.go
+++ b/modules/300-prometheus/hooks/calculate_storage_capacity.go
@@ -21,12 +21,13 @@ import (
 	"math"
 	"strings"
 
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 const defaultDiskSizeGiB = 40

--- a/modules/300-prometheus/hooks/custom_rules.go
+++ b/modules/300-prometheus/hooks/custom_rules.go
@@ -20,12 +20,13 @@ import (
 	"errors"
 	"fmt"
 
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 type CustomRule struct {

--- a/modules/300-prometheus/hooks/detect_vpa_max.go
+++ b/modules/300-prometheus/hooks/detect_vpa_max.go
@@ -81,7 +81,7 @@ func calculateNodesCapacity(input *go_hook.HookInput) error {
 
 	var totalPodsCapacity int64
 
-	for node, err := range sdkobjectpatch.SnapshotIter[*Node](nodeSnap) {
+	for node, err := range sdkobjectpatch.SnapshotIter[Node](nodeSnap) {
 		if err != nil {
 			return fmt.Errorf("cannot iterate over 'nodes' snapshot: %v", err)
 		}

--- a/modules/300-prometheus/hooks/detect_vpa_max.go
+++ b/modules/300-prometheus/hooks/detect_vpa_max.go
@@ -19,12 +19,13 @@ package hooks
 import (
 	"fmt"
 
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 type Node struct {

--- a/modules/300-prometheus/hooks/disk_metrics.go
+++ b/modules/300-prometheus/hooks/disk_metrics.go
@@ -39,6 +39,7 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
 	"github.com/deckhouse/deckhouse/pkg/log"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -104,8 +105,10 @@ func prometheusDiskMetrics(input *go_hook.HookInput, dc dependency.Container) er
 		return err
 	}
 
-	for _, obj := range input.Snapshots["pods"] {
-		pod := obj.(PodFilter)
+	for pod, err := range sdkobjectpatch.SnapshotIter[PodFilter](input.NewSnapshots.Get("pods")) {
+		if err != nil {
+			return fmt.Errorf("cannot iterate over 'pods' snapshot: %v", err)
+		}
 
 		if !pod.PrometheusContainerReady {
 			continue

--- a/modules/300-prometheus/hooks/disk_metrics.go
+++ b/modules/300-prometheus/hooks/disk_metrics.go
@@ -36,10 +36,11 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
 	"github.com/deckhouse/deckhouse/pkg/log"
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{


### PR DESCRIPTION
## Description
Third iteration of [New Snapshot logic](https://github.com/deckhouse/deckhouse/pull/12513)

Refactored access to snapshots by replacing direct indexing (input.Snapshots["snapshot_name"]) with method calls via the new field NewSnapshots. Access to snapshots is now performed using the .Get() method. For example, instead of casting like `input.Snapshots["snapshot_name"][0].(NodeInfo)` we use:

### WARNING
**!!We ignore all nil results in new snapshots realization!!!**

```go
var node NodeInfo
err := inputs.NewSnapshots.Get("snapshot_name")[0].UnmarshalTo(&node)
```
Additionally, two new methods provided by the library `sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"` have been introduced:

- **SnapshotIter**: Enables catching type cast errors during iteration over objects. Replaces manual checks like `policy, ok := policySnap.(EgressGatewayPolicyInfo); if !ok { continue }`.
- **UnmarshalToStruct**: Allows directly unmarshalling snapshot values into structures without additional steps, eliminating the need for intermediate variables and explicit marshal/unmarshal actions.

## Why do we need it, and what problem does it solve?
The previous approach relied heavily on unsafe type assertions and direct index accesses which led to potential runtime panics and inconsistencies. By switching to structured methods and proper error handling, the refactoring reduces the risk of bugs caused by incorrect types or missing elements, thus improving stability and maintainability of the codebase.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: change hook input interface, refactor old snapshot logic (part third)
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
