### PR TITLE
feat: Add dex authenticator name and secret name helpers for consistent naming

### DIFF
--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
@@ -281,16 +281,16 @@ spec:
 
 			dexAuthenticators := f.ValuesGet("userAuthn.internal.dexAuthenticatorCRDs").Array()
 			Expect(dexAuthenticators).To(HaveLen(1))
-			
+
 			authenticator := dexAuthenticators[0]
 			finalName := authenticator.Get("finalName").String()
-			
+
 			// Final name should be exactly 63 characters
 			Expect(len(finalName)).To(Equal(63))
-			
+
 			// Final name should end with "-dex-authenticator"
 			Expect(finalName).To(HaveSuffix("-dex-authenticator"))
-			
+
 			// Should contain hash (8 characters before "-dex-authenticator")
 			Expect(finalName).To(MatchRegexp(`^.+-[a-f0-9]{8}-dex-authenticator$`))
 		})

--- a/modules/150-user-authn/openapi/values.yaml
+++ b/modules/150-user-authn/openapi/values.yaml
@@ -132,6 +132,8 @@ properties:
                   type: string
                 appDexSecret:
                   type: string
+            finalName:
+              type: string
       dexClientCRDs:
         type: array
         default: []

--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorCRDs", `
 - name: test
   encodedName: justForTest
+  finalName: test-d8-test-dex-authenticator
   namespace: d8-test
   credentials:
     appDexSecret: dexSecret
@@ -75,6 +76,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
       value: bar
 - name: test-2
   encodedName: justForTest2
+  finalName: test-2-d8-test-dex-authenticator
   namespace: d8-test
   credentials:
     appDexSecret: dexSecret
@@ -91,6 +93,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
     sendAuthorizationHeader: false
 - name: test-3
   encodedName: justForTest3
+  finalName: test-3-d8-test-dex-authenticator
   namespace: d8-test
   credentials:
     appDexSecret: dexSecret
@@ -100,6 +103,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
     keepUsersLoggedInFor: "19m"
 - name: test-4
   encodedName: justForTest4
+  finalName: test-4-d8-test-dex-authenticator
   namespace: d8-test
   credentials:
     appDexSecret: dexSecret
@@ -124,6 +128,8 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 
 			oauth2clientTest := hec.KubernetesResource("OAuth2Client", "d8-user-authn", "justForTest")
 			Expect(oauth2clientTest.Exists()).To(BeTrue())
+			Expect(oauth2clientTest.Field("id").String()).To(Equal("test-d8-test-dex-authenticator"))
+			Expect(oauth2clientTest.Field("name").String()).To(Equal("test-d8-test-dex-authenticator"))
 			Expect(oauth2clientTest.Field("redirectURIs").String()).To(MatchJSON(`["https://authenticator.example.com/dex-authenticator/callback","https://authenticator-two.example.com/dex-authenticator/callback"]`))
 			Expect(oauth2clientTest.Field("secret").String()).To(Equal("dexSecret"))
 			Expect(oauth2clientTest.Field("allowedEmails").String()).To(MatchJSON(`["test@mail.io"]`))
@@ -172,6 +178,8 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 
 			oauth2client2 := hec.KubernetesResource("OAuth2Client", "d8-user-authn", "justForTest2")
 			Expect(oauth2client2.Exists()).To(BeTrue())
+			Expect(oauth2client2.Field("id").String()).To(Equal("test-2-d8-test-dex-authenticator"))
+			Expect(oauth2client2.Field("name").String()).To(Equal("test-2-d8-test-dex-authenticator"))
 			Expect(oauth2client2.Field("redirectURIs").String()).To(MatchJSON(`["https://authenticator.com/dex-authenticator/callback","https://authenticator-two.com/dex-authenticator/callback"]`))
 			Expect(oauth2client2.Field("secret").String()).To(Equal("dexSecret"))
 

--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package template_tests
 
 import (
-	"strings"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -243,99 +241,4 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 		})
 	})
 
-	Context("With long DexAuthenticator name", func() {
-		BeforeEach(func() {
-			hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorCRDs", `
-- name: very-long-dex-authenticator-name-that-exceeds-sixty-three-characters-limit
-  encodedName: justForTestLongName
-  finalName: very-long-dex-authenticator-name-that-exceeds-sixty-three-characters-limit-d8-test-dex-authenticator
-  namespace: d8-test
-  credentials:
-    appDexSecret: dexSecret
-    cookieSecret: cookieSecret
-  allowAccessToKubernetes: true
-  spec:
-    applications:
-    - domain: authenticator.example.com
-      ingressClassName: test
-      ingressSecretName: test
-    - domain: authenticator-two.example.com
-      ingressClassName: test-two
-      ingressSecretName: test
-    sendAuthorizationHeader: true
-    keepUsersLoggedInFor: "1020h"
-    allowedGroups:
-    - everyone
-    - admins
-    allowedEmails:
-    - test@mail.io
-    nodeSelector:
-      testnode: ""
-    tolerations:
-    - key: foo
-      operator: Equal
-      value: bar
-`)
-			hec.ValuesSet("userAuthn.internal.dexTLS.crt", "plainstring")
-			hec.ValuesSet("userAuthn.internal.dexTLS.key", "plainstring")
-			hec.ValuesSet("userAuthn.idTokenTTL", "2h20m4s")
-			hec.HelmRender()
-		})
-
-		It("Should create desired objects with truncated names", func() {
-			// Find the service by iterating through all services in the namespace
-			var serviceName string
-			for idx := range hec.AllObjects() {
-				if idx.Kind == "Service" && idx.Namespace == "d8-test" && strings.HasSuffix(idx.Name, "-dex-authenticator") && strings.HasPrefix(idx.Name, "very-long-dex-authenticator-name-that-") {
-					serviceName = idx.Name
-					break
-				}
-			}
-
-			Expect(serviceName).NotTo(Equal(""), "Service with truncated name should exist")
-
-			// The service name should be exactly 63 characters (truncated)
-			Expect(len(serviceName)).To(Equal(63))
-
-			// Verify the service name contains a hash (pattern: name-hash-dex-authenticator)
-			Expect(serviceName).To(MatchRegexp(`^very-long-dex-authenticator-name-that-\w+-[a-f0-9]{8}-dex-authenticator$`))
-
-			// Check that other resources use the same truncated name
-			Expect(hec.KubernetesResource("PodDisruptionBudget", "d8-test", serviceName).Exists()).To(BeTrue())
-			Expect(hec.KubernetesResource("VerticalPodAutoscaler", "d8-test", serviceName).Exists()).To(BeTrue())
-			Expect(hec.KubernetesResource("Deployment", "d8-test", serviceName).Exists()).To(BeTrue())
-
-			// Find the secret by iterating through all secrets in the namespace
-			var secretName string
-			for idx := range hec.AllObjects() {
-				if idx.Kind == "Secret" && idx.Namespace == "d8-test" && strings.HasPrefix(idx.Name, "dex-authenticator-very-long-dex-authenticator-name-that-") {
-					secretName = idx.Name
-					break
-				}
-			}
-
-			Expect(secretName).NotTo(Equal(""), "Secret with truncated name should exist")
-
-			// The secret name should be exactly 63 characters (truncated)
-			Expect(len(secretName)).To(Equal(63))
-
-			// Verify the secret name contains a hash
-			Expect(secretName).To(MatchRegexp(`^dex-authenticator-very-long-dex-authenticator-name-that-\w+-[a-f0-9]{8}$`))
-
-			// Find ingress resources - there should be 2 (one for each application)
-			var ingressNames []string
-			for idx := range hec.AllObjects() {
-				if idx.Kind == "Ingress" && idx.Namespace == "d8-test" && strings.HasPrefix(idx.Name, "very-long-dex-authenticator-name-that-") {
-					ingressNames = append(ingressNames, idx.Name)
-				}
-			}
-
-			Expect(len(ingressNames)).To(Equal(2), "Should have 2 ingress resources")
-
-			// Check that both ingress names are exactly 63 characters
-			for _, ingress := range ingressNames {
-				Expect(len(ingress)).To(Equal(63))
-			}
-		})
-	})
 })

--- a/modules/150-user-authn/templates/_helpers.tpl
+++ b/modules/150-user-authn/templates/_helpers.tpl
@@ -37,12 +37,20 @@
     {{- $hash := $name | sha256sum | trunc 8 }}
     {{- if $suffix }}
       {{- $maxNameLen := sub 63 (add (len $prefix) (len $hash) (len $suffix) 3) }}
-      {{- $truncatedName := $name | trunc $maxNameLen }}
-      {{- printf "%s-%s-%s-%s" $truncatedName $hash $suffix $prefix }}
+      {{- if gt $maxNameLen 0 }}
+        {{- $truncatedName := $name | trunc $maxNameLen }}
+        {{- printf "%s-%s-%s-%s" $truncatedName $hash $suffix $prefix }}
+      {{- else }}
+        {{- printf "%s-%s-%s" $hash $suffix $prefix }}
+      {{- end }}
     {{- else }}
       {{- $maxNameLen := sub 63 (add (len $prefix) (len $hash) 2) }}
-      {{- $truncatedName := $name | trunc $maxNameLen }}
-      {{- printf "%s-%s-%s" $truncatedName $hash $prefix }}
+      {{- if gt $maxNameLen 0 }}
+        {{- $truncatedName := $name | trunc $maxNameLen }}
+        {{- printf "%s-%s-%s" $truncatedName $hash $prefix }}
+      {{- else }}
+        {{- printf "%s-%s" $hash $prefix }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
@@ -57,8 +65,12 @@
   {{- else }}
     {{- $hash := $name | sha256sum | trunc 8 }}
     {{- $maxNameLen := sub 63 (add (len $prefix) (len $hash) 2) }}
-    {{- $truncatedName := $name | trunc $maxNameLen }}
-    {{- printf "%s-%s-%s" $prefix $truncatedName $hash }}
+    {{- if gt $maxNameLen 0 }}
+      {{- $truncatedName := $name | trunc $maxNameLen }}
+      {{- printf "%s-%s-%s" $prefix $truncatedName $hash }}
+    {{- else }}
+      {{- printf "%s-%s" $prefix $hash }}
+    {{- end }}
   {{- end }}
 {{- end }}
 

--- a/modules/150-user-authn/templates/_helpers.tpl
+++ b/modules/150-user-authn/templates/_helpers.tpl
@@ -19,3 +19,33 @@
     {{- end }}
   {{- end }}
 {{- end }}
+
+
+{{- define "dex_authenticator_name" }}
+  {{- $crdName := .crdName }}
+  {{- $prefix := "dex-authenticator" }}
+  {{- $fullName := printf "%s-%s" $crdName $prefix }}
+  {{- if le (len $fullName) 63 }}
+    {{- $fullName }}
+  {{- else }}
+    {{- $hash := $crdName | sha256sum | trunc 8 }}
+    {{- $maxCrdNameLen := sub 63 (add (len $prefix) (len $hash) 2) }}
+    {{- $truncatedName := $crdName | trunc $maxCrdNameLen }}
+    {{- printf "%s-%s-%s" $truncatedName $hash $prefix }}
+  {{- end }}
+{{- end }}
+
+
+{{- define "dex_authenticator_secret_name" }}
+  {{- $crdName := .crdName }}
+  {{- $prefix := "dex-authenticator" }}
+  {{- $fullName := printf "%s-%s" $prefix $crdName }}
+  {{- if le (len $fullName) 63 }}
+    {{- $fullName }}
+  {{- else }}
+    {{- $hash := $crdName | sha256sum | trunc 8 }}
+    {{- $maxCrdNameLen := sub 63 (add (len $prefix) (len $hash) 2) }}
+    {{- $truncatedName := $crdName | trunc $maxCrdNameLen }}
+    {{- printf "%s-%s-%s" $prefix $truncatedName $hash }}
+  {{- end }}
+{{- end }}

--- a/modules/150-user-authn/templates/_helpers.tpl
+++ b/modules/150-user-authn/templates/_helpers.tpl
@@ -49,3 +49,4 @@
     {{- printf "%s-%s-%s" $prefix $truncatedName $hash }}
   {{- end }}
 {{- end }}
+

--- a/modules/150-user-authn/templates/_helpers.tpl
+++ b/modules/150-user-authn/templates/_helpers.tpl
@@ -22,30 +22,42 @@
 
 
 {{- define "dex_authenticator_name" }}
-  {{- $finalName := .finalName }}
+  {{- $name := .name }}
+  {{- $suffix := .suffix | default "" }}
   {{- $prefix := "dex-authenticator" }}
-  {{- $fullName := printf "%s-%s" $finalName $prefix }}
+  {{- $fullName := "" }}
+  {{- if $suffix }}
+    {{- $fullName = printf "%s-%s-%s" $name $suffix $prefix }}
+  {{- else }}
+    {{- $fullName = printf "%s-%s" $name $prefix }}
+  {{- end }}
   {{- if le (len $fullName) 63 }}
     {{- $fullName }}
   {{- else }}
-    {{- $hash := $finalName | sha256sum | trunc 8 }}
-    {{- $maxFinalNameLen := sub 63 (add (len $prefix) (len $hash) 2) }}
-    {{- $truncatedName := $finalName | trunc $maxFinalNameLen }}
-    {{- printf "%s-%s-%s" $truncatedName $hash $prefix }}
+    {{- $hash := $name | sha256sum | trunc 8 }}
+    {{- if $suffix }}
+      {{- $maxNameLen := sub 63 (add (len $prefix) (len $hash) (len $suffix) 3) }}
+      {{- $truncatedName := $name | trunc $maxNameLen }}
+      {{- printf "%s-%s-%s-%s" $truncatedName $hash $suffix $prefix }}
+    {{- else }}
+      {{- $maxNameLen := sub 63 (add (len $prefix) (len $hash) 2) }}
+      {{- $truncatedName := $name | trunc $maxNameLen }}
+      {{- printf "%s-%s-%s" $truncatedName $hash $prefix }}
+    {{- end }}
   {{- end }}
 {{- end }}
 
 
 {{- define "dex_authenticator_secret_name" }}
-  {{- $finalName := .finalName }}
+  {{- $name := .name }}
   {{- $prefix := "dex-authenticator" }}
-  {{- $fullName := printf "%s-%s" $prefix $finalName }}
+  {{- $fullName := printf "%s-%s" $prefix $name }}
   {{- if le (len $fullName) 63 }}
     {{- $fullName }}
   {{- else }}
-    {{- $hash := $finalName | sha256sum | trunc 8 }}
-    {{- $maxFinalNameLen := sub 63 (add (len $prefix) (len $hash) 2) }}
-    {{- $truncatedName := $finalName | trunc $maxFinalNameLen }}
+    {{- $hash := $name | sha256sum | trunc 8 }}
+    {{- $maxNameLen := sub 63 (add (len $prefix) (len $hash) 2) }}
+    {{- $truncatedName := $name | trunc $maxNameLen }}
     {{- printf "%s-%s-%s" $prefix $truncatedName $hash }}
   {{- end }}
 {{- end }}

--- a/modules/150-user-authn/templates/_helpers.tpl
+++ b/modules/150-user-authn/templates/_helpers.tpl
@@ -22,30 +22,30 @@
 
 
 {{- define "dex_authenticator_name" }}
-  {{- $crdName := .crdName }}
+  {{- $finalName := .finalName }}
   {{- $prefix := "dex-authenticator" }}
-  {{- $fullName := printf "%s-%s" $crdName $prefix }}
+  {{- $fullName := printf "%s-%s" $finalName $prefix }}
   {{- if le (len $fullName) 63 }}
     {{- $fullName }}
   {{- else }}
-    {{- $hash := $crdName | sha256sum | trunc 8 }}
-    {{- $maxCrdNameLen := sub 63 (add (len $prefix) (len $hash) 2) }}
-    {{- $truncatedName := $crdName | trunc $maxCrdNameLen }}
+    {{- $hash := $finalName | sha256sum | trunc 8 }}
+    {{- $maxFinalNameLen := sub 63 (add (len $prefix) (len $hash) 2) }}
+    {{- $truncatedName := $finalName | trunc $maxFinalNameLen }}
     {{- printf "%s-%s-%s" $truncatedName $hash $prefix }}
   {{- end }}
 {{- end }}
 
 
 {{- define "dex_authenticator_secret_name" }}
-  {{- $crdName := .crdName }}
+  {{- $finalName := .finalName }}
   {{- $prefix := "dex-authenticator" }}
-  {{- $fullName := printf "%s-%s" $prefix $crdName }}
+  {{- $fullName := printf "%s-%s" $prefix $finalName }}
   {{- if le (len $fullName) 63 }}
     {{- $fullName }}
   {{- else }}
-    {{- $hash := $crdName | sha256sum | trunc 8 }}
-    {{- $maxCrdNameLen := sub 63 (add (len $prefix) (len $hash) 2) }}
-    {{- $truncatedName := $crdName | trunc $maxCrdNameLen }}
+    {{- $hash := $finalName | sha256sum | trunc 8 }}
+    {{- $maxFinalNameLen := sub 63 (add (len $prefix) (len $hash) 2) }}
+    {{- $truncatedName := $finalName | trunc $maxFinalNameLen }}
     {{- printf "%s-%s-%s" $prefix $truncatedName $hash }}
   {{- end }}
 {{- end }}

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -15,14 +15,14 @@ memory: 25Mi
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
+  name: {{ include "dex_authenticator_name" (dict "name" $crd.name) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment
-    name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
+    name: {{ include "dex_authenticator_name" (dict "name" $crd.name) }}
   updatePolicy:
     updateMode: "Auto"
   resourcePolicy:
@@ -44,7 +44,7 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
+  name: {{ include "dex_authenticator_name" (dict "name" $crd.name) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -57,7 +57,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
+  name: {{ include "dex_authenticator_name" (dict "name" $crd.name) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -105,8 +105,8 @@ spec:
         emptyDir: {}
       initContainers:
       - args:
-        - {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
-        - {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}.svc
+        - {{ include "dex_authenticator_name" (dict "name" $crd.name) }}
+        - {{ include "dex_authenticator_name" (dict "name" $crd.name) }}.svc
         image: {{ include "helm_lib_module_image" (list $context "selfSignedGenerator") }}
         name: self-signed-generator
         volumeMounts:
@@ -172,12 +172,12 @@ spec:
         - name: OAUTH2_PROXY_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: {{ include "dex_authenticator_secret_name" (dict "finalName" $crd.finalName) }}
+              name: {{ include "dex_authenticator_secret_name" (dict "name" $crd.name) }}
               key: client-secret
         - name: OAUTH2_PROXY_COOKIE_SECRET
           valueFrom:
             secretKeyRef:
-              name: {{ include "dex_authenticator_secret_name" (dict "finalName" $crd.finalName) }}
+              name: {{ include "dex_authenticator_secret_name" (dict "name" $crd.name) }}
               key: cookie-secret
         - name: TRUSTED_ROOT_CA_FILE
           value: /certs/ca.crt

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -15,14 +15,14 @@ memory: 25Mi
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ $crd.name }}-dex-authenticator
+  name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment
-    name: {{ $crd.name }}-dex-authenticator
+    name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
   updatePolicy:
     updateMode: "Auto"
   resourcePolicy:
@@ -44,7 +44,7 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ $crd.name }}-dex-authenticator
+  name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -57,7 +57,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $crd.name }}-dex-authenticator
+  name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -105,8 +105,8 @@ spec:
         emptyDir: {}
       initContainers:
       - args:
-        - {{ $crd.name }}-dex-authenticator.{{ $crd.namespace }}
-        - {{ $crd.name }}-dex-authenticator.{{ $crd.namespace }}.svc
+        - {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}.{{ $crd.namespace }}
+        - {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}.{{ $crd.namespace }}.svc
         image: {{ include "helm_lib_module_image" (list $context "selfSignedGenerator") }}
         name: self-signed-generator
         volumeMounts:
@@ -172,12 +172,12 @@ spec:
         - name: OAUTH2_PROXY_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: dex-authenticator-{{ $crd.name }}
+              name: {{ include "dex_authenticator_secret_name" (dict "crdName" $crd.name) }}
               key: client-secret
         - name: OAUTH2_PROXY_COOKIE_SECRET
           valueFrom:
             secretKeyRef:
-              name: dex-authenticator-{{ $crd.name }}
+              name: {{ include "dex_authenticator_secret_name" (dict "crdName" $crd.name) }}
               key: cookie-secret
         - name: TRUSTED_ROOT_CA_FILE
           value: /certs/ca.crt

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -105,8 +105,8 @@ spec:
         emptyDir: {}
       initContainers:
       - args:
-        - {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}.{{ $crd.namespace }}
-        - {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}.{{ $crd.namespace }}.svc
+        - {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
+        - {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}.svc
         image: {{ include "helm_lib_module_image" (list $context "selfSignedGenerator") }}
         name: self-signed-generator
         volumeMounts:

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -15,14 +15,14 @@ memory: 25Mi
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
+  name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment
-    name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
+    name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
   updatePolicy:
     updateMode: "Auto"
   resourcePolicy:
@@ -44,7 +44,7 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
+  name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -57,7 +57,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
+  name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -105,8 +105,8 @@ spec:
         emptyDir: {}
       initContainers:
       - args:
-        - {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}.{{ $crd.namespace }}
-        - {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}.{{ $crd.namespace }}.svc
+        - {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}.{{ $crd.namespace }}
+        - {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}.{{ $crd.namespace }}.svc
         image: {{ include "helm_lib_module_image" (list $context "selfSignedGenerator") }}
         name: self-signed-generator
         volumeMounts:
@@ -172,12 +172,12 @@ spec:
         - name: OAUTH2_PROXY_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: {{ include "dex_authenticator_secret_name" (dict "crdName" $crd.name) }}
+              name: {{ include "dex_authenticator_secret_name" (dict "finalName" $crd.finalName) }}
               key: client-secret
         - name: OAUTH2_PROXY_COOKIE_SECRET
           valueFrom:
             secretKeyRef:
-              name: {{ include "dex_authenticator_secret_name" (dict "crdName" $crd.name) }}
+              name: {{ include "dex_authenticator_secret_name" (dict "finalName" $crd.finalName) }}
               key: cookie-secret
         - name: TRUSTED_ROOT_CA_FILE
           value: /certs/ca.crt

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -126,7 +126,7 @@ spec:
         image: {{ include "helm_lib_module_image" (list $context "dexAuthenticator") }}
         args:
         - --provider=oidc
-        - --client-id={{ $crd.name }}-{{ $crd.namespace }}-dex-authenticator
+        - --client-id={{ $crd.finalName }}
     {{- if ne (include "helm_lib_module_uri_scheme" $context ) "https" }}
         - --cookie-secure=false
     {{- end }}

--- a/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
   {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |-
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  name: {{ include "dex_authenticator_name" (dict "finalName" (printf "%s%s" $crd.finalName $nameSuffix)) }}
+  name: {{ include "dex_authenticator_name" (dict "name" $crd.name "suffix" (ternary (trimPrefix "-" $nameSuffix) "" $nameSuffix)) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -31,7 +31,7 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
+            name: {{ include "dex_authenticator_name" (dict "name" $crd.name) }}
             port:
               number: 443
         path: /dex-authenticator
@@ -55,7 +55,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /dex-authenticator/sign_out
     nginx.ingress.kubernetes.io/configuration-snippet: |-
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  name: {{ include "dex_authenticator_name" (dict "finalName" (printf "%s%s" $crd.finalName $nameSuffix)) }}-sign-out
+  name: {{ include "dex_authenticator_name" (dict "name" $crd.name "suffix" (ternary (trimPrefix "-" $nameSuffix) "" $nameSuffix)) }}-sign-out
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -66,7 +66,7 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
+            name: {{ include "dex_authenticator_name" (dict "name" $crd.name) }}
             port:
               number: 443
         path: {{ $app.signOutURL }}

--- a/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
   {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |-
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  name: {{ include "dex_authenticator_name" (dict "name" $crd.name "suffix" (ternary (trimPrefix "-" $nameSuffix) "" $nameSuffix)) }}
+  name: {{ include "dex_authenticator_name" (dict "name" $crd.name "suffix" (ternary (trimPrefix "-" $nameSuffix) "" (ne $nameSuffix ""))) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -55,7 +55,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /dex-authenticator/sign_out
     nginx.ingress.kubernetes.io/configuration-snippet: |-
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  name: {{ include "dex_authenticator_name" (dict "name" $crd.name "suffix" (ternary (trimPrefix "-" $nameSuffix) "" $nameSuffix)) }}-sign-out
+  name: {{ include "dex_authenticator_name" (dict "name" $crd.name "suffix" (ternary (trimPrefix "-" $nameSuffix) "" (ne $nameSuffix ""))) }}-sign-out
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:

--- a/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
   {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |-
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  name: {{ $crd.name }}{{ $nameSuffix }}-dex-authenticator
+  name: {{ include "dex_authenticator_name" (dict "crdName" (printf "%s%s" $crd.name $nameSuffix)) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -31,7 +31,7 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ $crd.name }}-dex-authenticator
+            name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
             port:
               number: 443
         path: /dex-authenticator
@@ -55,7 +55,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /dex-authenticator/sign_out
     nginx.ingress.kubernetes.io/configuration-snippet: |-
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  name: {{ $crd.name }}{{ $nameSuffix }}-dex-authenticator-sign-out
+  name: {{ include "dex_authenticator_name" (dict "crdName" (printf "%s%s" $crd.name $nameSuffix)) }}-sign-out
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -66,7 +66,7 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ $crd.name }}-dex-authenticator
+            name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
             port:
               number: 443
         path: {{ $app.signOutURL }}

--- a/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
   {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |-
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  name: {{ include "dex_authenticator_name" (dict "crdName" (printf "%s%s" $crd.name $nameSuffix)) }}
+  name: {{ include "dex_authenticator_name" (dict "finalName" (printf "%s%s" $crd.finalName $nameSuffix)) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -31,7 +31,7 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
+            name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
             port:
               number: 443
         path: /dex-authenticator
@@ -55,7 +55,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /dex-authenticator/sign_out
     nginx.ingress.kubernetes.io/configuration-snippet: |-
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  name: {{ include "dex_authenticator_name" (dict "crdName" (printf "%s%s" $crd.name $nameSuffix)) }}-sign-out
+  name: {{ include "dex_authenticator_name" (dict "finalName" (printf "%s%s" $crd.finalName $nameSuffix)) }}-sign-out
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
@@ -66,7 +66,7 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
+            name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
             port:
               number: 443
         path: {{ $app.signOutURL }}

--- a/modules/150-user-authn/templates/dex-authenticator/oauth2client.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/oauth2client.yaml
@@ -7,8 +7,8 @@ metadata:
   name: {{ $crd.encodedName }}
   namespace: d8-{{ $context.Chart.Name }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex")) | nindent 2 }}
-id: {{ $crd.name }}-{{ $crd.namespace }}-dex-authenticator
-name: {{ $crd.name }}-{{ $crd.namespace }}-dex-authenticator
+id: {{ $crd.finalName }}
+name: {{ $crd.finalName }}
 secret: {{ $crd.credentials.appDexSecret }}
     {{- if $crd.spec.allowedEmails }}
 allowedEmails:

--- a/modules/150-user-authn/templates/dex-authenticator/secret.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/secret.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dex-authenticator-{{ $crd.name }}
+  name: {{ include "dex_authenticator_secret_name" (dict "crdName" $crd.name) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator" "name" "credentials")) | nindent 2 }}
 data:

--- a/modules/150-user-authn/templates/dex-authenticator/secret.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/secret.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "dex_authenticator_secret_name" (dict "crdName" $crd.name) }}
+  name: {{ include "dex_authenticator_secret_name" (dict "finalName" $crd.finalName) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator" "name" "credentials")) | nindent 2 }}
 data:

--- a/modules/150-user-authn/templates/dex-authenticator/secret.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/secret.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "dex_authenticator_secret_name" (dict "finalName" $crd.finalName) }}
+  name: {{ include "dex_authenticator_secret_name" (dict "name" $crd.name) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator" "name" "credentials")) | nindent 2 }}
 data:

--- a/modules/150-user-authn/templates/dex-authenticator/service.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
+  name: {{ include "dex_authenticator_name" (dict "name" $crd.name) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:

--- a/modules/150-user-authn/templates/dex-authenticator/service.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $crd.name }}-dex-authenticator
+  name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:

--- a/modules/150-user-authn/templates/dex-authenticator/service.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "dex_authenticator_name" (dict "crdName" $crd.name) }}
+  name: {{ include "dex_authenticator_name" (dict "finalName" $crd.finalName) }}
   namespace: {{ $crd.namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:

--- a/testing/helm/init.go
+++ b/testing/helm/init.go
@@ -68,6 +68,10 @@ func (hec *Config) KubernetesResource(kind, namespace, name string) object_store
 	return hec.objectStore.KubernetesResource(kind, namespace, name)
 }
 
+func (hec *Config) AllObjects() map[object_store.MetaIndex]object_store.KubeObject {
+	return hec.objectStore
+}
+
 func SetupHelmConfig(values string) *Config {
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: decrease dex-authenticator object names
impact_level: default
```
