### PR TITLE
[node-manager][docs]  Make NodeUser passwordHash parameter optional

### DIFF
--- a/modules/040-node-manager/crds/nodeuser.yaml
+++ b/modules/040-node-manager/crds/nodeuser.yaml
@@ -69,7 +69,6 @@ spec:
                   - ['ssh-rsa AAABBB', 'cert-authority,principals="name" ssh-rsa BBBCCC']
                 passwordHash:
                   type: string
-                  x-doc-required: true
                   description: |
                     Hashed user password.
 
@@ -174,7 +173,6 @@ spec:
                   - ['ssh-rsa AAABBB', 'cert-authority,principals="name" ssh-rsa BBBCCC']
                 passwordHash:
                   type: string
-                  x-doc-required: true
                   description: |
                     Hashed user password.
 


### PR DESCRIPTION
## Description

Make NodeUser passwordHash parameter optional in the documentation.

Ref: https://github.com/deckhouse/deckhouse/pull/13623/

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Make NodeUser passwordHash parameter optional in the documentation.
impact_level: low
```
