### PR TITLE
[docs][new structure] Translate event audit architecture page

### DIFF
--- a/docs/documentation/pages/architecture/security/RUNTIME-AUDIT.md
+++ b/docs/documentation/pages/architecture/security/RUNTIME-AUDIT.md
@@ -40,9 +40,6 @@ DKP provides the following types of built-in rules:
 
 - **Kubernetes audit rules**: Help detect security issues in DKP and in the audit mechanism itself.
   These rules are located in the `falco` container at `/etc/falco/k8s_audit_rules.yaml`.
-- **Compliance rules**: Designed to meet the requirements of the FSTEC of Russia Order No. 118 dated July 4, 2022,
-  "Information security requirements for containerization tools."
-  These `fstec` rules are defined using the [FalcoAuditRules](/modules/runtime-audit-engine/cr.html#falcoauditrules) custom resource.
 
 ### Custom rules
 

--- a/docs/documentation/pages/architecture/security/RUNTIME-AUDIT.md
+++ b/docs/documentation/pages/architecture/security/RUNTIME-AUDIT.md
@@ -2,3 +2,56 @@
 title: Architecture of security event audit
 permalink: en/architecture/security/runtime-audit.html
 ---
+
+The Deckhouse Kubernetes Platform (DKP) security event audit is based on the [Falco](https://falco.org/) threat detection system.
+Deckhouse deploys Falco agents on each node as part of a DaemonSet.
+Once started, the agents begin collecting OS system calls and Kubernetes audit data.
+
+{% alert level="info" %}
+Falco developers recommend running it as a systemd service,
+which can be challenging in Kubernetes clusters that support autoscaling.
+DKP includes additional security mechanisms such as multitenancy and resource control policies.
+Combined with the DaemonSet deployment, these mechanisms ensure a high level of protection.
+{% endalert %}
+
+![Falco agents on DKP cluster nodes](../../images/runtime-audit-engine/falco_daemonset.svg)
+<!--- Source: https://docs.google.com/drawings/d/1NZ91z8NXNiuS50ybcMoMsZI3SbQASZXJGLANdaNNm_U --->
+
+Each cluster node runs a Falco Pod with the following components:
+
+- `falco`: Collects events, enriches them with metadata, and outputs them to stdout.
+- `rules-loader`: Retrieves rule data from [FalcoAuditRules](/modules/runtime-audit-engine/cr.html#falcoauditrules) custom resources
+  and stores them in a shared directory.
+- [`falcosidekick`](https://github.com/falcosecurity/falcosidekick): Receives events from `falco`
+  and exports them as metrics to external systems.
+- `kube-rbac-proxy`: Protects the `falcosidekick` metrics endpoint from unauthorized access.
+
+![Falco Pod components](../../images/runtime-audit-engine/falco_pod.svg)
+<!--- Source: https://docs.google.com/drawings/d/1rxSuJFs0tumfZ56WbAJ36crtPoy_NiPBHE6Hq5lejuI --->
+
+## Audit rules
+
+Security event analysis is performed using rules that define suspicious behavior patterns.
+Each rule consists of a condition expression written in accordance with [Falco's condition syntax](https://falco.org/docs/concepts/rules/conditions/).
+
+### Built-in rules
+
+DKP provides the following types of built-in rules:
+
+- **Kubernetes audit rules**: Help detect security issues in DKP and in the audit mechanism itself.
+  These rules are located in the `falco` container at `/etc/falco/k8s_audit_rules.yaml`.
+- **Compliance rules**: Designed to meet the requirements of the FSTEC of Russia Order No. 118 dated July 4, 2022,
+  "Information security requirements for containerization tools."
+  These `fstec` rules are defined using the [FalcoAuditRules](/modules/runtime-audit-engine/cr.html#falcoauditrules) custom resource.
+
+### Custom rules
+
+Custom rules can be defined using the [FalcoAuditRules](/modules/runtime-audit-engine/cr.html#falcoauditrules) custom resource.
+
+Each Falco agent includes a sidecar container with a [`shell-operator`](https://github.com/flant/shell-operator) instance.
+This instance reads rules from Kubernetes resources, converts them into Falco rule format,
+and stores them in the `/etc/falco/rules.d/` directory inside the Pod.
+When a new rule is added, Falco automatically reloads the configuration.
+
+![Shell-operator handling Falco rules](../../images/runtime-audit-engine/falco_shop.svg)
+<!--- Source: https://docs.google.com/drawings/d/13MFYtiwH4Y66SfEPZIcS7S2wAY6vnKcoaztxsmX1hug --->


### PR DESCRIPTION
## Description

This PR adds translation of the security event audit page in the Architecture section of the new docs structure.
