### PR TITLE
[node-manager] Containerd v2 rewrite host auth patch

### DIFF
--- a/modules/007-registrypackages/images/containerd/patches/containerd/2.1.3/003-hosts-auth.patch
+++ b/modules/007-registrypackages/images/containerd/patches/containerd/2.1.3/003-hosts-auth.patch
@@ -1,33 +1,173 @@
-Subject: [PATCH] hosts auth
----
-Index: core/remotes/docker/registry.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/core/remotes/docker/registry.go b/core/remotes/docker/registry.go
---- a/core/remotes/docker/registry.go	(revision a54a81848c395cb4500bc38a2398079cb38885a8)
-+++ b/core/remotes/docker/registry.go	(date 1752687815244)
-@@ -78,6 +78,7 @@
- 	Capabilities HostCapabilities
- 	Header       http.Header
- 	RepoRewrites []RegistryHostRepoRewrite
-+	Credentials  func(host string) (string, string, error)
+diff --git a/core/remotes/docker/config/hosts.go b/core/remotes/docker/config/hosts.go
+index 40d451af0..c9210e5e0 100644
+--- a/core/remotes/docker/config/hosts.go
++++ b/core/remotes/docker/config/hosts.go
+@@ -20,6 +20,7 @@ package config
+ import (
+ 	"context"
+ 	"crypto/tls"
++	"encoding/base64"
+ 	"fmt"
+ 	"net"
+ 	"net/http"
+@@ -59,9 +60,19 @@ type hostConfig struct {
+ 
+ 	rewrites []hostPathRewrite
+ 
++	auth authConfig
++
+ 	// TODO: Add credential configuration (domain alias, username)
  }
-
- type RegistryHostRepoRewrite struct {
-Index: core/remotes/docker/config/hosts_test.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
+ 
++// authConfig holds authentication-related parameters for interacting with a registry.
++type authConfig struct {
++	userName      string
++	password      string
++	auth          string
++	identityToken string
++}
++
+ // HostPathRewrite is used to confirure rewrite paths in the mirror hosts
+ type hostPathRewrite struct {
+ 	regexp      *regexp.Regexp
+@@ -166,19 +177,39 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
+ 			}
+ 		}
+ 
+-		authOpts := []docker.AuthorizerOpt{docker.WithAuthClient(client)}
+-		if options.Credentials != nil {
+-			authOpts = append(authOpts, docker.WithAuthCreds(options.Credentials))
+-		}
+-		authOpts = append(authOpts, options.AuthorizerOpts...)
+-		authorizer := docker.NewDockerAuthorizer(authOpts...)
+-
+ 		rhosts := make([]docker.RegistryHost, len(hosts))
+ 		for i, host := range hosts {
+ 			// Allow setting for each host as well
+ 			explicitTLSFromHost := host.caCerts != nil || host.clientPairs != nil || host.skipVerify != nil
+ 			explicitTLS := tlsConfigured || explicitTLSFromHost
+ 
++			authOpts := []docker.AuthorizerOpt{docker.WithAuthClient(client)}
++			hostAuth := host.auth // copy to local variable from loop variable
++
++			var credsFunc func(host string) (string, string, error)
++
++			if options.Credentials != nil {
++				optsCreds := options.Credentials // copy to local variable
++
++				credsFunc = func(host string) (string, string, error) {
++					u, p, err := optsCreds(host)
++
++					if (u != "" && p != "") || err != nil {
++						return u, p, err
++					}
++
++					// use creds from registry config options as fallback in the case
++					// of credentials from puller is empty
++					return parseAuth(&hostAuth)
++				}
++			} else {
++				credsFunc = func(host string) (string, string, error) {
++					return parseAuth(&hostAuth)
++				}
++			}
++			authOpts = append(authOpts, docker.WithAuthCreds(credsFunc))
++			authOpts = append(authOpts, options.AuthorizerOpts...)
++
+ 			if explicitTLSFromHost || host.dialTimeout != nil || len(host.header) != 0 {
+ 				c := *client
+ 				if explicitTLSFromHost || host.dialTimeout != nil {
+@@ -217,7 +248,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
+ 				rhosts[i].Authorizer = docker.NewDockerAuthorizer(append(authOpts, docker.WithAuthClient(&c))...)
+ 			} else {
+ 				rhosts[i].Client = client
+-				rhosts[i].Authorizer = authorizer
++				rhosts[i].Authorizer = docker.NewDockerAuthorizer(authOpts...)
+ 			}
+ 
+ 			// When TLS has been configured for the operation or host and
+@@ -240,6 +271,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
+ 			rhosts[i].Path = host.path
+ 			rhosts[i].Capabilities = host.capabilities
+ 			rhosts[i].Header = host.header
++			rhosts[i].Credentials = credsFunc
+ 
+ 			if len(host.rewrites) > 0 {
+ 				rhosts[i].RepoRewrites = make([]docker.RegistryHostRepoRewrite, len(host.rewrites))
+@@ -398,6 +430,19 @@ type hostFileConfig struct {
+ 		Replacement string `toml:"replace"`
+ 	} `toml:"rewrite"`
+ 
++	Auth struct {
++		// Username is the username to login the registry.
++		Username string `toml:"username" json:"username"`
++		// Password is the password to login the registry.
++		Password string `toml:"password" json:"password"`
++		// Auth is a base64 encoded string from the concatenation of the username,
++		// a colon, and the password.
++		Auth string `toml:"auth" json:"auth"`
++		// IdentityToken is used to authenticate the user and get
++		// an access token for the registry.
++		IdentityToken string `toml:"identitytoken" json:"identitytoken"`
++	} `toml:"auth"`
++
+ 	// TODO: Credentials: helper? name? username? alternate domain? token?
+ }
+ 
+@@ -583,6 +628,13 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
+ 		}
+ 	}
+ 
++	result.auth = authConfig{
++		userName:      config.Auth.Username,
++		password:      config.Auth.Password,
++		auth:          config.Auth.Auth,
++		identityToken: config.Auth.IdentityToken,
++	}
++
+ 	return result, nil
+ }
+ 
+@@ -687,3 +739,31 @@ func loadCertFiles(ctx context.Context, certsDir string) ([]hostConfig, error) {
+ 	}
+ 	return hosts, nil
+ }
++
++// parseAuth parses AuthConfig and returns username and password/secret required by containerd.
++func parseAuth(auth *authConfig) (string, string, error) {
++	if auth == nil {
++		return "", "", nil
++	}
++	if auth.userName != "" {
++		return auth.userName, auth.password, nil
++	}
++	if auth.identityToken != "" {
++		return "", auth.identityToken, nil
++	}
++	if auth.auth != "" {
++		decLen := base64.StdEncoding.DecodedLen(len(auth.auth))
++		decoded := make([]byte, decLen)
++		_, err := base64.StdEncoding.Decode(decoded, []byte(auth.auth))
++		if err != nil {
++			return "", "", err
++		}
++		user, passwd, ok := strings.Cut(string(decoded), ":")
++		if !ok {
++			return "", "", fmt.Errorf("invalid decoded auth: %q", decoded)
++		}
++		return user, strings.Trim(passwd, "\x00"), nil
++	}
++
++	return "", "", nil
++}
 diff --git a/core/remotes/docker/config/hosts_test.go b/core/remotes/docker/config/hosts_test.go
---- a/core/remotes/docker/config/hosts_test.go	(revision a54a81848c395cb4500bc38a2398079cb38885a8)
-+++ b/core/remotes/docker/config/hosts_test.go	(date 1752686278642)
-@@ -300,6 +300,70 @@
+index bfa1dde8c..2faebea32 100644
+--- a/core/remotes/docker/config/hosts_test.go
++++ b/core/remotes/docker/config/hosts_test.go
+@@ -300,6 +300,70 @@ replace = "/other/path2"
  	}
  }
-
+ 
 +func TestParseHostFileWithAuth(t *testing.T) {
 +	const testtoml = `
 +server = "https://test-default.registry"
@@ -94,8 +234,8 @@ diff --git a/core/remotes/docker/config/hosts_test.go b/core/remotes/docker/conf
 +
  func TestLoadCertFiles(t *testing.T) {
  	dir := t.TempDir()
-
-@@ -656,6 +720,20 @@
+ 
+@@ -656,6 +720,20 @@ func compareHostConfig(j, k hostConfig) bool {
  			return false
  		}
  	}
@@ -115,8 +255,8 @@ diff --git a/core/remotes/docker/config/hosts_test.go b/core/remotes/docker/conf
 +
  	return true
  }
-
-@@ -680,6 +758,7 @@
+ 
+@@ -680,6 +758,7 @@ func printHostConfig(hc []hostConfig) string {
  		if hc[i].rewrites != nil {
  			fmt.Fprintf(b, "\t\trewrites: %#v\n", hc[i].rewrites)
  		}
@@ -124,164 +264,15 @@ diff --git a/core/remotes/docker/config/hosts_test.go b/core/remotes/docker/conf
  		fmt.Fprintf(b, "\n")
  	}
  	return b.String()
-Index: core/remotes/docker/config/hosts.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/core/remotes/docker/config/hosts.go b/core/remotes/docker/config/hosts.go
---- a/core/remotes/docker/config/hosts.go	(revision a54a81848c395cb4500bc38a2398079cb38885a8)
-+++ b/core/remotes/docker/config/hosts.go	(date 1752687945645)
-@@ -20,6 +20,7 @@
- import (
- 	"context"
- 	"crypto/tls"
-+	"encoding/base64"
- 	"fmt"
- 	"net"
- 	"net/http"
-@@ -59,9 +60,19 @@
-
- 	rewrites []hostPathRewrite
-
-+	auth authConfig
-+
- 	// TODO: Add credential configuration (domain alias, username)
+diff --git a/core/remotes/docker/registry.go b/core/remotes/docker/registry.go
+index 574a5dc35..e0a9850ef 100644
+--- a/core/remotes/docker/registry.go
++++ b/core/remotes/docker/registry.go
+@@ -78,6 +78,7 @@ type RegistryHost struct {
+ 	Capabilities HostCapabilities
+ 	Header       http.Header
+ 	RepoRewrites []RegistryHostRepoRewrite
++	Credentials  func(host string) (string, string, error)
  }
-
-+// authConfig holds authentication-related parameters for interacting with a registry.
-+type authConfig struct {
-+	userName      string
-+	password      string
-+	auth          string
-+	identityToken string
-+}
-+
- // HostPathRewrite is used to confirure rewrite paths in the mirror hosts
- type hostPathRewrite struct {
- 	regexp      *regexp.Regexp
-@@ -166,19 +177,34 @@
- 			}
- 		}
-
--		authOpts := []docker.AuthorizerOpt{docker.WithAuthClient(client)}
--		if options.Credentials != nil {
--			authOpts = append(authOpts, docker.WithAuthCreds(options.Credentials))
--		}
--		authOpts = append(authOpts, options.AuthorizerOpts...)
--		authorizer := docker.NewDockerAuthorizer(authOpts...)
--
- 		rhosts := make([]docker.RegistryHost, len(hosts))
- 		for i, host := range hosts {
- 			// Allow setting for each host as well
- 			explicitTLSFromHost := host.caCerts != nil || host.clientPairs != nil || host.skipVerify != nil
- 			explicitTLS := tlsConfigured || explicitTLSFromHost
-
-+			authOpts := []docker.AuthorizerOpt{docker.WithAuthClient(client)}
-+			hostAuth := host.auth // copy to local variable from loop variable
-+
-+			credsFunc := func(host string) (string, string, error) {
-+				if options.Credentials != nil {
-+					optsCreds := options.Credentials // copy to local variable
-+					u, p, err := optsCreds(host)
-+
-+					if (u != "" && p != "") || err != nil {
-+						return u, p, err
-+					}
-+
-+					// use creds from registry config options as fallback in the case
-+					// of credentials from puller is empty
-+					return parseAuth(&hostAuth)
-+				}
-+				return parseAuth(&hostAuth)
-+			}
-+
-+			creds := docker.WithAuthCreds(credsFunc)
-+			authOpts = append(authOpts, creds)
-+
- 			if explicitTLSFromHost || host.dialTimeout != nil || len(host.header) != 0 {
- 				c := *client
- 				if explicitTLSFromHost || host.dialTimeout != nil {
-@@ -217,7 +243,7 @@
- 				rhosts[i].Authorizer = docker.NewDockerAuthorizer(append(authOpts, docker.WithAuthClient(&c))...)
- 			} else {
- 				rhosts[i].Client = client
--				rhosts[i].Authorizer = authorizer
-+				rhosts[i].Authorizer = docker.NewDockerAuthorizer(authOpts...)
- 			}
-
- 			// When TLS has been configured for the operation or host and
-@@ -240,6 +266,7 @@
- 			rhosts[i].Path = host.path
- 			rhosts[i].Capabilities = host.capabilities
- 			rhosts[i].Header = host.header
-+			rhosts[i].Credentials = credsFunc
-
- 			if len(host.rewrites) > 0 {
- 				rhosts[i].RepoRewrites = make([]docker.RegistryHostRepoRewrite, len(host.rewrites))
-@@ -398,6 +425,19 @@
- 		Replacement string `toml:"replace"`
- 	} `toml:"rewrite"`
-
-+	Auth struct {
-+		// Username is the username to login the registry.
-+		Username string `toml:"username" json:"username"`
-+		// Password is the password to login the registry.
-+		Password string `toml:"password" json:"password"`
-+		// Auth is a base64 encoded string from the concatenation of the username,
-+		// a colon, and the password.
-+		Auth string `toml:"auth" json:"auth"`
-+		// IdentityToken is used to authenticate the user and get
-+		// an access token for the registry.
-+		IdentityToken string `toml:"identitytoken" json:"identitytoken"`
-+	} `toml:"auth"`
-+
- 	// TODO: Credentials: helper? name? username? alternate domain? token?
- }
-
-@@ -583,6 +623,13 @@
- 		}
- 	}
-
-+	result.auth = authConfig{
-+		userName:      config.Auth.Username,
-+		password:      config.Auth.Password,
-+		auth:          config.Auth.Auth,
-+		identityToken: config.Auth.IdentityToken,
-+	}
-+
- 	return result, nil
- }
-
-@@ -687,3 +734,31 @@
- 	}
- 	return hosts, nil
- }
-+
-+// parseAuth parses AuthConfig and returns username and password/secret required by containerd.
-+func parseAuth(auth *authConfig) (string, string, error) {
-+	if auth == nil {
-+		return "", "", nil
-+	}
-+	if auth.userName != "" {
-+		return auth.userName, auth.password, nil
-+	}
-+	if auth.identityToken != "" {
-+		return "", auth.identityToken, nil
-+	}
-+	if auth.auth != "" {
-+		decLen := base64.StdEncoding.DecodedLen(len(auth.auth))
-+		decoded := make([]byte, decLen)
-+		_, err := base64.StdEncoding.Decode(decoded, []byte(auth.auth))
-+		if err != nil {
-+			return "", "", err
-+		}
-+		user, passwd, ok := strings.Cut(string(decoded), ":")
-+		if !ok {
-+			return "", "", fmt.Errorf("invalid decoded auth: %q", decoded)
-+		}
-+		return user, strings.Trim(passwd, "\x00"), nil
-+	}
-+
-+	return "", "", nil
-+}
+ 
+ type RegistryHostRepoRewrite struct {

--- a/modules/007-registrypackages/images/containerd/patches/containerd/2.1.3/003-hosts-auth.patch
+++ b/modules/007-registrypackages/images/containerd/patches/containerd/2.1.3/003-hosts-auth.patch
@@ -1,164 +1,30 @@
-diff --git a/core/remotes/docker/config/hosts.go b/core/remotes/docker/config/hosts.go
-index 40d451af0..a59e2233c 100644
---- a/core/remotes/docker/config/hosts.go
-+++ b/core/remotes/docker/config/hosts.go
-@@ -20,6 +20,7 @@ package config
- import (
- 	"context"
- 	"crypto/tls"
-+	"encoding/base64"
- 	"fmt"
- 	"net"
- 	"net/http"
-@@ -59,9 +60,19 @@ type hostConfig struct {
-
- 	rewrites []hostPathRewrite
-
-+	auth authConfig
-+
- 	// TODO: Add credential configuration (domain alias, username)
+Subject: [PATCH] hosts auth
+---
+Index: core/remotes/docker/registry.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/core/remotes/docker/registry.go b/core/remotes/docker/registry.go
+--- a/core/remotes/docker/registry.go	(revision a54a81848c395cb4500bc38a2398079cb38885a8)
++++ b/core/remotes/docker/registry.go	(date 1752687815244)
+@@ -78,6 +78,7 @@
+ 	Capabilities HostCapabilities
+ 	Header       http.Header
+ 	RepoRewrites []RegistryHostRepoRewrite
++	Credentials  func(host string) (string, string, error)
  }
 
-+// authConfig holds authentication-related parameters for interacting with a registry.
-+type authConfig struct {
-+	userName      string
-+	password      string
-+	auth          string
-+	identityToken string
-+}
-+
- // HostPathRewrite is used to confirure rewrite paths in the mirror hosts
- type hostPathRewrite struct {
- 	regexp      *regexp.Regexp
-@@ -166,19 +177,41 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
- 			}
- 		}
-
--		authOpts := []docker.AuthorizerOpt{docker.WithAuthClient(client)}
--		if options.Credentials != nil {
--			authOpts = append(authOpts, docker.WithAuthCreds(options.Credentials))
--		}
--		authOpts = append(authOpts, options.AuthorizerOpts...)
--		authorizer := docker.NewDockerAuthorizer(authOpts...)
--
- 		rhosts := make([]docker.RegistryHost, len(hosts))
- 		for i, host := range hosts {
- 			// Allow setting for each host as well
- 			explicitTLSFromHost := host.caCerts != nil || host.clientPairs != nil || host.skipVerify != nil
- 			explicitTLS := tlsConfigured || explicitTLSFromHost
-
-+			authOpts := []docker.AuthorizerOpt{docker.WithAuthClient(client)}
-+			hostAuth := host.auth // copy to local variable from loop variable
-+
-+			if options.Credentials != nil {
-+				optsCreds := options.Credentials // copy to local variable
-+
-+				creds := docker.WithAuthCreds(func(host string) (string, string, error) {
-+					u, p, err := optsCreds(host)
-+
-+					if (u != "" && p != "") || err != nil {
-+						return u, p, err
-+					}
-+
-+					// use creds from registry config options as fallback in the case
-+					// of credentials from puller is empty
-+					return parseAuth(&hostAuth)
-+				})
-+
-+				authOpts = append(authOpts, creds)
-+			} else {
-+				creds := docker.WithAuthCreds(func(host string) (string, string, error) {
-+					return parseAuth(&hostAuth)
-+				})
-+
-+				authOpts = append(authOpts, creds)
-+			}
-+
-+			authOpts = append(authOpts, options.AuthorizerOpts...)
-+
- 			if explicitTLSFromHost || host.dialTimeout != nil || len(host.header) != 0 {
- 				c := *client
- 				if explicitTLSFromHost || host.dialTimeout != nil {
-@@ -217,7 +250,7 @@ func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHos
- 				rhosts[i].Authorizer = docker.NewDockerAuthorizer(append(authOpts, docker.WithAuthClient(&c))...)
- 			} else {
- 				rhosts[i].Client = client
--				rhosts[i].Authorizer = authorizer
-+				rhosts[i].Authorizer = docker.NewDockerAuthorizer(authOpts...)
- 			}
-
- 			// When TLS has been configured for the operation or host and
-@@ -398,6 +431,19 @@ type hostFileConfig struct {
- 		Replacement string `toml:"replace"`
- 	} `toml:"rewrite"`
-
-+	Auth struct {
-+		// Username is the username to login the registry.
-+		Username string `toml:"username" json:"username"`
-+		// Password is the password to login the registry.
-+		Password string `toml:"password" json:"password"`
-+		// Auth is a base64 encoded string from the concatenation of the username,
-+		// a colon, and the password.
-+		Auth string `toml:"auth" json:"auth"`
-+		// IdentityToken is used to authenticate the user and get
-+		// an access token for the registry.
-+		IdentityToken string `toml:"identitytoken" json:"identitytoken"`
-+	} `toml:"auth"`
-+
- 	// TODO: Credentials: helper? name? username? alternate domain? token?
- }
-
-@@ -583,6 +629,13 @@ func parseHostConfig(server string, baseDir string, config hostFileConfig) (host
- 		}
- 	}
-
-+	result.auth = authConfig{
-+		userName:      config.Auth.Username,
-+		password:      config.Auth.Password,
-+		auth:          config.Auth.Auth,
-+		identityToken: config.Auth.IdentityToken,
-+	}
-+
- 	return result, nil
- }
-
-@@ -687,3 +740,31 @@ func loadCertFiles(ctx context.Context, certsDir string) ([]hostConfig, error) {
- 	}
- 	return hosts, nil
- }
-+
-+// parseAuth parses AuthConfig and returns username and password/secret required by containerd.
-+func parseAuth(auth *authConfig) (string, string, error) {
-+	if auth == nil {
-+		return "", "", nil
-+	}
-+	if auth.userName != "" {
-+		return auth.userName, auth.password, nil
-+	}
-+	if auth.identityToken != "" {
-+		return "", auth.identityToken, nil
-+	}
-+	if auth.auth != "" {
-+		decLen := base64.StdEncoding.DecodedLen(len(auth.auth))
-+		decoded := make([]byte, decLen)
-+		_, err := base64.StdEncoding.Decode(decoded, []byte(auth.auth))
-+		if err != nil {
-+			return "", "", err
-+		}
-+		user, passwd, ok := strings.Cut(string(decoded), ":")
-+		if !ok {
-+			return "", "", fmt.Errorf("invalid decoded auth: %q", decoded)
-+		}
-+		return user, strings.Trim(passwd, "\x00"), nil
-+	}
-+
-+	return "", "", nil
-+}
+ type RegistryHostRepoRewrite struct {
+Index: core/remotes/docker/config/hosts_test.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
 diff --git a/core/remotes/docker/config/hosts_test.go b/core/remotes/docker/config/hosts_test.go
-index bfa1dde8c..2faebea32 100644
---- a/core/remotes/docker/config/hosts_test.go
-+++ b/core/remotes/docker/config/hosts_test.go
-@@ -300,6 +300,70 @@ replace = "/other/path2"
+--- a/core/remotes/docker/config/hosts_test.go	(revision a54a81848c395cb4500bc38a2398079cb38885a8)
++++ b/core/remotes/docker/config/hosts_test.go	(date 1752686278642)
+@@ -300,6 +300,70 @@
  	}
  }
 
@@ -229,7 +95,7 @@ index bfa1dde8c..2faebea32 100644
  func TestLoadCertFiles(t *testing.T) {
  	dir := t.TempDir()
 
-@@ -656,6 +720,20 @@ func compareHostConfig(j, k hostConfig) bool {
+@@ -656,6 +720,20 @@
  			return false
  		}
  	}
@@ -250,7 +116,7 @@ index bfa1dde8c..2faebea32 100644
  	return true
  }
 
-@@ -680,6 +758,7 @@ func printHostConfig(hc []hostConfig) string {
+@@ -680,6 +758,7 @@
  		if hc[i].rewrites != nil {
  			fmt.Fprintf(b, "\t\trewrites: %#v\n", hc[i].rewrites)
  		}
@@ -258,3 +124,164 @@ index bfa1dde8c..2faebea32 100644
  		fmt.Fprintf(b, "\n")
  	}
  	return b.String()
+Index: core/remotes/docker/config/hosts.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/core/remotes/docker/config/hosts.go b/core/remotes/docker/config/hosts.go
+--- a/core/remotes/docker/config/hosts.go	(revision a54a81848c395cb4500bc38a2398079cb38885a8)
++++ b/core/remotes/docker/config/hosts.go	(date 1752687945645)
+@@ -20,6 +20,7 @@
+ import (
+ 	"context"
+ 	"crypto/tls"
++	"encoding/base64"
+ 	"fmt"
+ 	"net"
+ 	"net/http"
+@@ -59,9 +60,19 @@
+
+ 	rewrites []hostPathRewrite
+
++	auth authConfig
++
+ 	// TODO: Add credential configuration (domain alias, username)
+ }
+
++// authConfig holds authentication-related parameters for interacting with a registry.
++type authConfig struct {
++	userName      string
++	password      string
++	auth          string
++	identityToken string
++}
++
+ // HostPathRewrite is used to confirure rewrite paths in the mirror hosts
+ type hostPathRewrite struct {
+ 	regexp      *regexp.Regexp
+@@ -166,19 +177,34 @@
+ 			}
+ 		}
+
+-		authOpts := []docker.AuthorizerOpt{docker.WithAuthClient(client)}
+-		if options.Credentials != nil {
+-			authOpts = append(authOpts, docker.WithAuthCreds(options.Credentials))
+-		}
+-		authOpts = append(authOpts, options.AuthorizerOpts...)
+-		authorizer := docker.NewDockerAuthorizer(authOpts...)
+-
+ 		rhosts := make([]docker.RegistryHost, len(hosts))
+ 		for i, host := range hosts {
+ 			// Allow setting for each host as well
+ 			explicitTLSFromHost := host.caCerts != nil || host.clientPairs != nil || host.skipVerify != nil
+ 			explicitTLS := tlsConfigured || explicitTLSFromHost
+
++			authOpts := []docker.AuthorizerOpt{docker.WithAuthClient(client)}
++			hostAuth := host.auth // copy to local variable from loop variable
++
++			credsFunc := func(host string) (string, string, error) {
++				if options.Credentials != nil {
++					optsCreds := options.Credentials // copy to local variable
++					u, p, err := optsCreds(host)
++
++					if (u != "" && p != "") || err != nil {
++						return u, p, err
++					}
++
++					// use creds from registry config options as fallback in the case
++					// of credentials from puller is empty
++					return parseAuth(&hostAuth)
++				}
++				return parseAuth(&hostAuth)
++			}
++
++			creds := docker.WithAuthCreds(credsFunc)
++			authOpts = append(authOpts, creds)
++
+ 			if explicitTLSFromHost || host.dialTimeout != nil || len(host.header) != 0 {
+ 				c := *client
+ 				if explicitTLSFromHost || host.dialTimeout != nil {
+@@ -217,7 +243,7 @@
+ 				rhosts[i].Authorizer = docker.NewDockerAuthorizer(append(authOpts, docker.WithAuthClient(&c))...)
+ 			} else {
+ 				rhosts[i].Client = client
+-				rhosts[i].Authorizer = authorizer
++				rhosts[i].Authorizer = docker.NewDockerAuthorizer(authOpts...)
+ 			}
+
+ 			// When TLS has been configured for the operation or host and
+@@ -240,6 +266,7 @@
+ 			rhosts[i].Path = host.path
+ 			rhosts[i].Capabilities = host.capabilities
+ 			rhosts[i].Header = host.header
++			rhosts[i].Credentials = credsFunc
+
+ 			if len(host.rewrites) > 0 {
+ 				rhosts[i].RepoRewrites = make([]docker.RegistryHostRepoRewrite, len(host.rewrites))
+@@ -398,6 +425,19 @@
+ 		Replacement string `toml:"replace"`
+ 	} `toml:"rewrite"`
+
++	Auth struct {
++		// Username is the username to login the registry.
++		Username string `toml:"username" json:"username"`
++		// Password is the password to login the registry.
++		Password string `toml:"password" json:"password"`
++		// Auth is a base64 encoded string from the concatenation of the username,
++		// a colon, and the password.
++		Auth string `toml:"auth" json:"auth"`
++		// IdentityToken is used to authenticate the user and get
++		// an access token for the registry.
++		IdentityToken string `toml:"identitytoken" json:"identitytoken"`
++	} `toml:"auth"`
++
+ 	// TODO: Credentials: helper? name? username? alternate domain? token?
+ }
+
+@@ -583,6 +623,13 @@
+ 		}
+ 	}
+
++	result.auth = authConfig{
++		userName:      config.Auth.Username,
++		password:      config.Auth.Password,
++		auth:          config.Auth.Auth,
++		identityToken: config.Auth.IdentityToken,
++	}
++
+ 	return result, nil
+ }
+
+@@ -687,3 +734,31 @@
+ 	}
+ 	return hosts, nil
+ }
++
++// parseAuth parses AuthConfig and returns username and password/secret required by containerd.
++func parseAuth(auth *authConfig) (string, string, error) {
++	if auth == nil {
++		return "", "", nil
++	}
++	if auth.userName != "" {
++		return auth.userName, auth.password, nil
++	}
++	if auth.identityToken != "" {
++		return "", auth.identityToken, nil
++	}
++	if auth.auth != "" {
++		decLen := base64.StdEncoding.DecodedLen(len(auth.auth))
++		decoded := make([]byte, decLen)
++		_, err := base64.StdEncoding.Decode(decoded, []byte(auth.auth))
++		if err != nil {
++			return "", "", err
++		}
++		user, passwd, ok := strings.Cut(string(decoded), ":")
++		if !ok {
++			return "", "", fmt.Errorf("invalid decoded auth: %q", decoded)
++		}
++		return user, strings.Trim(passwd, "\x00"), nil
++	}
++
++	return "", "", nil
++}

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -87,7 +87,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromCacheVersion: "2025-06-24.1"
+fromCacheVersion: "2025-06-24.2"
 fromImage: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts


### PR DESCRIPTION
## Description
For implement integrity check in container v2 we need to download manifest with signature. For it we will use additional function to get it. We need to get credentials from containerd config files. Function `ConfigureHosts` is source of truth for getting information about hosts for connecting. But this function returns callback which returns list of `RegistryHost` struct which contains only  `Authorizer` interface without credentials. We added field `Credentials`. It is callback which returns credentials and its callback can be used in another places for getting auth settings. Also we small rewrite logic for creating docker authorizer options in `ConfigureHosts` function. Now, for creating  authorizer options (for options we need to get credentials) will use same function which saved to `RegistryHost.Credentials` field.

## Why do we need it, and what problem does it solve?
Needs to implement integrity check in container v2.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Containerd v2 rewrite host auth patch
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
