### PR TITLE
[docs] Added Release Notes 1.71 at documentation

### DIFF
--- a/docs/documentation/_includes/release-notes/RELEASE-NOTES.md
+++ b/docs/documentation/_includes/release-notes/RELEASE-NOTES.md
@@ -2,6 +2,121 @@
 
 ### Important
 
+- Prometheus has been replaced with Deckhouse Prom++. If you want to keep using Prometheus, disable the `prompp` module manually before upgrading DKP by running the command `d8 platform module disable prompp`.
+
+- Support for Kubernetes 1.33 has been added, while support for Kubernetes 1.28 has been discontinued. In future DKP releases, support for Kubernetes 1.29 will be removed. The default Kubernetes version (used when the [`kubernetesVersion`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/installing/configuration.html#clusterconfiguration-kubernetesversion) parameter is set to `Automatic`) has been changed to [1.31](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/supported_versions.html#kubernetes).
+
+- Upgrading the cluster to Kubernetes 1.31 requires a sequential update of all nodes, with each node drained. You can control how node updates requiring workload disruptions are applied using the [`disruptions`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/node-manager/cr.html#nodegroup-v1-spec-disruptions) parameter section.
+
+- The built-in `snapshot-controller` and `static-routing-manager` modules will now be replaced with their external counterparts of the same name, sourced via ModuleSource deckhouse.
+
+- The new version of Cilium requires nodes to run Linux kernel version 5.8 or newer. If any node in the cluster has a kernel older than 5.8, the Deckhouse Kubernetes Platform upgrade will be blocked. In addition, Cilium Pods will be restarted, and some functionality may change.
+
+### Major changes
+
+- You can now enforce two-factor authentication for static users. This is configured via the [`staticUsers2FA`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/user-authn/configuration.html#parameters-staticusers2fa) parameter section of the `user-authn` module.
+
+- When enabling a module (with `d8 platform module enable`) or editing a ModuleConfig resource, a warning is now displayed if multiple module sources are found. In such a case, explicitly specify the module source using the [source](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/cr.html#moduleconfig-v1alpha1-spec-source) parameter in the module’s configuration.
+
+- Improved error handling for module configuration. Module-related errors no longer block DKP operations. Instead, they are now displayed in the status fields of Module and ModuleRelease objects.
+
+- Improved virtualization support:
+  - Added a provider for integration with [Deckhouse Virtualization Platform (DVP)](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/cloud-provider-dvp/), enabling deployment of DKP clusters on top of DVP.
+  - Added support for nested virtualization on nodes in the `cni-cilium` module.
+
+- The `node-manager` module now includes several enhancements for improved node reliability and manageability:
+  - You can now prevent a node from restarting if it still hosts critical Pods (labeled with `pod.deckhouse.io/inhibit-node-shutdown`). This can be necessary for workloads with stateful components, such as long-running data migrations.
+  - Introduced API version `v1alpha2` for the [SSHCredential](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/node-manager/cr.html#sshcredentials) resource, where the [`sudoPasswordEncoded`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/node-manager/cr.html#sshcredentials-v1alpha2-spec-sudopasswordencoded) parameter allows specifying the `sudo` password in Base64 format.
+  - The [`capiEmergencyBrake`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/node-manager/configuration.html#parameters-capiemergencybrake) parameter allows you to disable Cluster API (CAPI) in emergency scenarios, preventing potentially destructive changes. Its behavior is similar to the existing [`mcmEmergencyBrake`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/node-manager/configuration.html#parameters-mcmemergencybrake) setting.
+
+- Added a pre-installation check to verify connectivity to the DKP container image registry.
+
+- Improved the log file rotation mechanism when using short-term log storage (via the `loki` module). Added the [`LokiInsufficientDiskForRetention`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/alerts.html#loki-lokiinsufficientdiskforretention) alert to warn about insufficient disk space for log retention.
+
+- The documentation now includes a [reference for the Deckhouse CLI](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/deckhouse-cli/reference/) (`d8` utility) commands and parameters.
+
+- When using CEF encoding for collecting logs from [Apache Kafka](https://deckhouse.io/products/kubernetes-platform/documentation/latest/modules/log-shipper/cr.html#clusterlogdestination-v1alpha1-spec-kafka-encoding-cef) or [socket](https://deckhouse.io/products/kubernetes-platform/documentation/latest/modules/log-shipper/cr.html#clusterlogdestination-v1alpha1-spec-socket-encoding-cef) sources, you can now configure auxiliary CEF fields such as Device Product, Device Vendor, and Device ID.
+
+- The [`passwordHash`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/node-manager/cr.html#nodeuser-v1-spec-passwordhash) field in the NodeUser resource is no longer required. This allows you to create users without passwords — for example, in clusters that use external authentication systems (such as PAM or LDAP).
+
+- Added support for CRI Containerd v2 with CgroupsV2. The new version introduces a different configuration format and includes a mechanism to migrate between Containerd v1 and v2. You can change the CRI type used on nodes via the [`cri.type`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/node-manager/cr.html#nodegroup-v1-spec-cri-type) parameter and configure it using [`cri.containerdV2`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/node-manager/cr.html#nodegroup-v1-spec-cri-containerdv2).
+
+### Security
+
+- [Container image signature verification](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/admission-policy-engine/cr.html#securitypolicy-v1alpha1-spec-policies-verifyimagesignatures) is now available in DKP SE+. This feature is now supported in DKP SE+ and EE.
+
+- The `log-shipper`, `deckhouse-controller`, and `Istio` (version 1.21) modules have been migrated to distroless builds. This improves security and ensures a more transparent and controlled build process.
+
+- New audit rules have been added to track interactions with containerd. The following are now monitored: access to the `/run/containerd/containerd.sock` socket, modifications to the `/etc/containerd` and `/var/lib/containerd` directories and the `/opt/deckhouse/bin/containerd` file.
+
+- Known vulnerabilities have been fixed in the following modules: `loki`, `extended-monitoring`, `operator-prometheus`, `prometheus`, `prometheus-metrics-adapter`, `user-authn`, and `cloud-provider-zvirt`.
+
+- Added support for Istio version 1.25.2, which uses the Sail operator instead of the deprecated Istio Operator. Also added support for Kiali version 2.7, without Ambient Mesh support. Istio version 1.19 is now considered deprecated.
+
+- Added support for encrypting traffic between nodes and Pods using the WireGuard protocol (via the [`encryption.mode`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/cni-cilium/configuration.html#parameters-encryption-mode) parameter).
+
+- Fixed the logic for determining service readiness in the [ServiceWithHealthcheck](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/service-with-healthchecks/cr.html#servicewithhealthchecks) resource. Previously, Pods without an IP address (for example, in `Pending` state) could be mistakenly included in the load balancing list.
+
+- Added support for the least-conn load balancing algorithm. This algorithm directs traffic to the service backend with the fewest active connections, improving performance for connection-heavy applications (such as WebSocket services). To use this algorithm, enable the [`extraLoadBalancerAlgorithmsEnabled`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/modules/cni-cilium/configuration.html#parameters-extraloadbalanceralgorithmsenabled) parameter in the `cni-cilium` module settings and use the `cilium.io/bpf-lb-algorithm` annotation on the service and set it to a supported value: random, maglev, or least-conn.
+
+- Fixed an issue in Cilium 1.17 `cilium-operator` where IP addresses were not reused after a `CiliumEndpoint` was deleted. The issue was caused by improper cleanup of priority filters, which could lead to IP pool exhaustion in large clusters.
+
+- Refined the [list of ports used for networking](https://deckhouse.io/products/kubernetes-platform/documentation/v1.71/network_security_setup.html):
+  - Added and updated:
+    - `4287/UDP`: WireGuard port used for CNI Cilium traffic encryption.
+    - Instead of `4298/UDP` and `4299/UDP`, the range `4295–4299/UDP` is now used for VXLAN traffic encapsulation between Pods.
+  - Removed:
+    - `49152`, `49153/TCP`: Previously used for live migration of virtual machines (in the virtualization module). Migration now occurs over the Pod network.
+
+### Component version updates
+
+The following DKP components have been updated:
+
+- `cilium`: 1.17.4
+- `golang.org/x/net`: v0.40.0
+- `etcd`: v3.6.1
+- `terraform-provider-azure`: 3.117.1
+- `Deckhouse CLI`: 0.13.2
+- `Falco`: 0.41.1
+- `falco-ctl`: 0.11.2
+- `gcpaudit`: v0.6.0
+- `Grafana`: 10.4.19
+- `Vertical pod autoscaler`: 1.4.1
+- `dhctl-kube-client`: v1.3.1
+- `cloud-provider-dynamix dynamix-common`: v0.5.0
+- `cloud-provider-dynamix capd-controller-manager`: v0.5.0
+- `cloud-provider-dynamix cloud-controller-manager`: v0.4.0
+- `cloud-provider-dynamix cloud-data-discoverer`: v0.6.0
+- `cloud-provider-huaweicloud huaweicloud-common`: v0.5.0
+- `cloud-provider-huaweicloud caphc-controller-manager`: v0.3.0
+- `cloud-provider-huaweicloud cloud-data-discoverer`: v0.5.0
+- `registry-packages-containerdv2`: 2.1.3
+- `registry-packages-containerdv2-runc`: 1.3.0
+- `cilium`: 1.17.4
+- `cilium envoy-bazel`: 6.5.0
+- `cilium cni-plugins`: 1.7.1
+- `cilium protoc`: 30.2
+- `cilium grpc-go`: 1.5.1
+- `cilium protobuf-go`: 1.36.6
+- `cilium protoc-gen-go-json`: 1.5.0
+- `cilium gops`: 0.3.27
+- `cilium llvm`: 18.1.8
+- `cilium llvm-build-cache`: llvmorg-18.1.8-alt-p11-gcc11-v2-180225
+- `User-authn basic-auth-proxy go`: 1.23.0
+- `Prometheus alerts-reciever go`: 1.23.0
+- `Prometheus memcached_exporter`: 0.15.3
+- `Prometheus mimir`: 2.14.3
+- `Prometheus promxy`: 0.0.93
+- `vertical-pod-autoscaler`: 1.4.1
+- `Extended-monitoring k8s-image-availability-exporter`: 0.13.0
+- `Extended-monitoring x509-certificate-exporter`: 3.19.1
+- `Cilium-hubble hubble-ui`: 0.13.2
+- `Cilium-hubble hubble-ui-frontend-assets`: 0.13.2
+
+## Version 1.70
+
+### Important
+
 - The `ceph-csi` module has been removed. Use the `csi-ceph` module instead. Deckhouse will not be updated as long as `ceph-csi` is enabled in the cluster. For `csi-ceph` migration instructions, refer to the [module documentation](https://deckhouse.io/products/kubernetes-platform/modules/csi-ceph/stable/).
 
 - Version 1.12 of the NGINX Ingress Controller has been added. The default controller version has been changed to 1.10. All Ingress controllers that do not have an explicitly specified version (via the [`controllerVersion`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.70/modules/ingress-nginx/cr.html#ingressnginxcontroller-v1-spec-controllerversion) parameter in the IngressNginxController resource or the [`defaultControllerVersion`](https://deckhouse.io/products/kubernetes-platform/documentation/v1.70/modules/ingress-nginx/configuration.html#parameters-defaultcontrollerversion) parameter in the `ingress-nginx` module) will be restarted.

--- a/docs/documentation/_includes/release-notes/RELEASE-NOTES_RU.md
+++ b/docs/documentation/_includes/release-notes/RELEASE-NOTES_RU.md
@@ -1,3 +1,120 @@
+## Версия 1.71
+
+### Обратите внимание
+
+- Prometheus заменён на Deckhouse Prom++. Если вы хотите продолжать использовать Prometheus, **до обновления платформы** явно выключите модуль `prompp` командой `d8 platform module disable prompp`.
+
+- Добавлена поддержка Kubernetes 1.33 и прекращена поддержка Kubernetes 1.28. В будущих релизах DKP поддержка Kubernetes 1.29 будет прекращена. Версия Kubernetes используемая по умолчанию (параметр [`kubernetesVersion`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/installing/configuration.html#clusterconfiguration-kubernetesversion) установлен в `Automatic`) изменена на [1.31](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/supported_versions.html#kubernetes).
+
+- Обновление кластера до версии Kubernetes 1.31 требует последовательного обновления всех узлов с остановкой нагрузки (drain узла). Управлять настройками применения обновлений узла, требующих остановки нагрузки, можно с помощью секции параметров [`disruptions`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/node-manager/cr.html#nodegroup-v1-spec-disruptions).
+
+- Вместо встроенных модулей `snapshot-controller` и `static-routing-manager` автоматически будут использоваться модули `snapshot-controlle`r` и `static-routing-manager`, загружаемые из внешнего источника (ModuleSource deckhouse).
+
+- Новая версия Cilium требует, чтобы ядро Linux на узлах было версии 5.8 или новее. Если на каком-либо из узлов кластера установлено ядро версии ниже 5.8, обновление Deckhouse Kubernetes Platform будет заблокировано. Также будут перезапущены поды `cilium`, и часть функциональности может измениться.
+
+### Основные изменения
+
+- Добавлена возможность включения обязательного использования двухфакторной аутентификации для статических пользователей. Управляется секцией параметров [`staticUsers2FA`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/user-authn/configuration.html#parameters-staticusers2fa) модуля `user-authn`.
+
+- При включении модуля (`d8 platform module enable`) или при редактировании ресурса ModuleConfig, теперь выводится предупреждение, если для модуля найдено несколько источников модуля. В этом случае требуется явно указать источник модуля в параметре [`source`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/cr.html#moduleconfig-v1alpha1-spec-source) конфигурации модуля.
+
+- Улучшена обработка ошибок конфигурации модулей. Теперь ошибки при работе модуля не блокируют работу DKP, а отображаются в статусах объектов Module и ModuleRelease.
+
+- Улучшена поддержка виртуализации:
+  - Добавлен [провайдер интеграции с платформой виртуализации](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/cloud-provider-dvp/) (Deckhouse Virtualization Platform). Новый провайдер позволяет разворачивать кластеры DKP поверх DVP.
+  - В модуле `cni-cilium` добавлена поддержка вложенной виртуализации на узлах.
+
+- В модуле `node-manager` добавлены новые возможности для повышения надёжности и управляемости узлов:
+  - Добавлена возможность запретить перезапуск узла, если на нем все еще расположены критичные поды (отмеченные лейблом `pod.deckhouse.io/inhibit-node-shutdown`). Это может быть необходимо для обеспечения корректной работы со stateful-нагрузками (например, выполняющих долгую миграцию данных).
+  - Добавлена новая версия API `v1alpha2` ресурса [SSHCredential](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/node-manager/cr.html#sshcredentials), в которой параметр [`sudoPasswordEncoded`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/node-manager/cr.html#sshcredentials) позволяет задавать пароль `sudo` в формате Base64.
+  - Параметр [`capiEmergencyBrake`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/node-manager/configuration.html#parameters-capiemergencybrake) позволяет отключить CAPI в экстренной ситуации, предотвращая потенциально разрушительные изменения. Поведение аналогично существующей настройке [`mcmEmergencyBrake`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/node-manager/configuration.html#parameters-mcmemergencybrake).
+
+- Добавлена проверка подключения к хранилищу образов контейнеров DKP перед установкой.
+
+- Улучшен механизм ротации файлов при использовании кратковременного хранилища логов (модуль `loki`). Добавлен алерт [`LokiInsufficientDiskForRetention`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/alerts.html#loki-lokiinsufficientdiskforretention), предупреждающий о нехватке размера хранилища.
+
+- В документацию добавлена [справка](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/deckhouse-cli/reference/) по командам и параметрам Deckhouse CLI (утилита `d8`).
+
+- При использовании кодирования CEF при сборе логов из [Apache Kafka](https://deckhouse.ru/products/kubernetes-platform/documentation/latest/modules/log-shipper/cr.html#clusterlogdestination-v1alpha1-spec-kafka-encoding-cef) или из сокета, появилась возможность настраивать служебные поля формата, такие как Device Product, Device Vendor и Device ID.
+
+- Поле [`passwordHash`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/node-manager/cr.html#nodeuser-v1-spec-passwordhash) в ресурсе NodeUser больше не является обязательным. Это позволяет создавать пользователей без пароля, например, в кластерах с внешними системами аутентификации (например, PAM, LDAP).
+
+- Добавлена поддержка CRI Containerd версии 2, использующей CgroupsV2. В новой версии применяется другой формат конфигурации, а также реализован механизм миграции между Containerd V1 и V2. Изменить тип используемого на узлах CRI можно с помощью параметра [`cri.type`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/node-manager/cr.html#nodegroup-v1-spec-cri-type), а управлять настройками - с помощью параметра [`cri.containerdV2`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/node-manager/cr.html#nodegroup-v1-spec-cri-containerdv2).
+
+### Безопасность
+
+- Возможность [проверки подписей контейнерных образов](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/admission-policy-engine/cr.html#securitypolicy-v1alpha1-spec-policies-verifyimagesignatures) стала доступна в редакции DKP SE+. Теперь эта возможность доступна в DKP SE+, EE и CSE.
+
+- Модули `log-shipper`, `deckhouse-controller` и `Istio` (версия 1.21) переведены на distroless-сборку. Это повышает безопасность и обеспечивает более прозрачный и контролируемый процесс сборки.
+
+- Добавлены правила аудита для регистрации взаимодействия с containerd. Отслеживается доступ к сокету `/run/containerd/containerd.sock`, изменение директорий `/etc/containerd`, `/var/lib/containerd` и файла `/opt/deckhouse/bin/containerd`.
+
+- Закрыты известные уязвимости в модулях `loki`, `extended-monitoring`, `operator-prometheus`, `prometheus`, `prometheus-metrics-adapter`, `user-authn`, `cloud-provider-zvirt`, `cloud-provider-dynamix`.
+
+### Сеть
+
+- Добавлена поддержка Istio версии 1.25.2. Для этой версии используется оператор Sail вместо Istio Operator, поддержка которого прекращена. Также добавлена поддержка Kiali версии 2.7, без поддержки Ambient Mesh. Версия Istio 1.19 считается устаревшей.
+
+- Добавлена возможность шифрования трафика между узлами и подами с использованием протокола WireGuard (параметр [`encryption.mode`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/cni-cilium/configuration.html#parameters-encryption-mode)).
+
+- Исправлена логика определения готовности сервиса (ресурс [ServiceWithHealthcheck](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/service-with-healthchecks/cr.html#servicewithhealthchecks)). Ранее поды без IP-адреса (например, находящихся в состоянии `Pending`) могли ошибочно попадать в список балансировки.
+
+- Добавлена поддержка алгоритма балансировки нагрузки least-conn для сервисов. Алгоритм least-conn направляет трафик на бэкенд сервиса с наименьшим числом активных подключений, что повышает производительность приложений с большим количеством соединений (например, WebSocket). Чтобы управлять алгоритмом балансировки, необходимо включить параметр [`extraLoadBalancerAlgorithmsEnabled`](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/modules/cni-cilium/configuration.html#parameters-extraloadbalanceralgorithmsenabled) в настройках модуля `cni-cilium`, и использовать на уровне сервиса аннотацию `cilium.io/bpf-lb-algorithm`, выбрав поддерживаемый алгоритм (random, maglev или least-conn).
+
+- В Cilium 1.17 исправлена ошибка в `cilium-operator`, из-за которой IP-адреса могли не переиспользоваться после удаления `CiliumEndpoint`. Это происходило из-за некорректной очистки фильтра приоритетов, что могло привести к исчерпанию IP-пула в больших кластерах.
+
+- Детализирован [список портов, используемых при сетевом взаимодействии](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.71/network_security_setup.html):
+  - Добавлено и обновлено:
+    - `4287/UDP` — порт WireGuard для шифрования трафика в CNI Cilium.
+    - Вместо портов `4298/UDP`, `4299/UDP` теперь используется диапазон `4295–4299/UDP` — для VXLAN-инкапсуляции трафика между подами.
+  - Удалено:
+    - `49152`, `49153/TCP` — порты использовались для live-миграции виртуальных машин (модуль `virtualization`). Теперь миграция работает через сеть подов.  
+
+### Обновление версий компонентов
+
+Обновлены следующие компоненты DKP:
+
+- `cilium`: 1.17.4
+- `golang.org/x/net`: v0.40.0
+- `etcd`: v3.6.1
+- `terraform-provider-azure`: 3.117.1
+- `Deckhouse CLI`: 0.13.2
+- `Falco`: 0.41.1
+- `falco-ctl`: 0.11.2
+- `gcpaudit`: v0.6.0
+- `Grafana`: 10.4.19
+- `Vertical pod autoscaler`: 1.4.1
+- `dhctl-kube-client`: v1.3.1
+- `cloud-provider-dynamix dynamix-common`: v0.5.0
+- `cloud-provider-dynamix capd-controller-manager`: v0.5.0
+- `cloud-provider-dynamix cloud-controller-manager`: v0.4.0
+- `cloud-provider-dynamix cloud-data-discoverer`: v0.6.0
+- `cloud-provider-huaweicloud huaweicloud-common`: v0.5.0
+- `cloud-provider-huaweicloud caphc-controller-manager`: v0.3.0
+- `cloud-provider-huaweicloud cloud-data-discoverer`: v0.5.0
+- `registry-packages-containerdv2`: 2.1.3
+- `registry-packages-containerdv2-runc`: 1.3.0
+- `cilium`: 1.17.4
+- `cilium envoy-bazel`: 6.5.0
+- `cilium cni-plugins`: 1.7.1
+- `cilium protoc`: 30.2
+- `cilium grpc-go`: 1.5.1
+- `cilium protobuf-go`: 1.36.6
+- `cilium protoc-gen-go-json`: 1.5.0
+- `cilium gops`: 0.3.27
+- `cilium llvm`: 18.1.8
+- `cilium llvm-build-cache`: llvmorg-18.1.8-alt-p11-gcc11-v2-180225
+- `User-authn basic-auth-proxy go`: 1.23.0
+- `Prometheus alerts-reciever go`: 1.23.0
+- `Prometheus memcached_exporter`: 0.15.3
+- `Prometheus mimir`: 2.14.3
+- `Prometheus promxy`: 0.0.93
+- `vertical-pod-autoscaler`: 1.4.1
+- `Extended-monitoring k8s-image-availability-exporter`: 0.13.0
+- `Extended-monitoring x509-certificate-exporter`: 3.19.1
+- `Cilium-hubble hubble-ui`: 0.13.2
+- `Cilium-hubble hubble-ui-frontend-assets`: 0.13.2
+
 ## Версия 1.70
 
 ### Обратите внимание


### PR DESCRIPTION
## Description
Added Release Notes 1.71 at documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Added Release Notes 1.71 at documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
