### PR TITLE
[terraform-manager] probes for kube-rbac-proxy

### DIFF
--- a/modules/040-terraform-manager/.dmtlint.yaml
+++ b/modules/040-terraform-manager/.dmtlint.yaml
@@ -8,17 +8,3 @@ linters-settings:
         - kind: Deployment
           name: terraform-state-exporter
           container: exporter
-      liveness-probe:
-        - kind: Deployment
-          name: terraform-auto-converger
-          container: kube-rbac-proxy
-        - kind: Deployment
-          name: terraform-state-exporter
-          container: kube-rbac-proxy
-      readiness-probe:
-        - kind: Deployment
-          name: terraform-auto-converger
-          container: kube-rbac-proxy
-        - kind: Deployment
-          name: terraform-state-exporter
-          container: kube-rbac-proxy

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
@@ -134,6 +134,16 @@ spec:
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
+       livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
         ports:
         - containerPort: 9100
           name: https-metrics

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
@@ -134,11 +134,11 @@ spec:
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
-       livenessProbe:
-          httpGet:
-            path: /livez
-            port: 8080
-            scheme: HTTPS
+        livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+              scheme: HTTPS
         readinessProbe:
           httpGet:
             path: /livez

--- a/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
@@ -104,6 +104,16 @@ spec:
         - "--v=2"
         - "--logtostderr=true"
         - "--stale-cache-interval=1h30m"
+        livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+              scheme: HTTPS
+          readinessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+              scheme: HTTPS
         ports:
         - containerPort: 9100
           name: https-metrics

--- a/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
@@ -109,11 +109,11 @@ spec:
               path: /livez
               port: 8080
               scheme: HTTPS
-          readinessProbe:
-            httpGet:
-              path: /livez
-              port: 8080
-              scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
         ports:
         - containerPort: 9100
           name: https-metrics


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added missing probes for kube-rbac-proxy in all cloud-providers. This primarily relates to cloud-data-discoverer.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This PR partly resolves https://github.com/deckhouse/deckhouse/issues/11295

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: terraform-manager
type: fix
summary: Added probes for `kube-rbac-proxy`
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
