### PR TITLE
[deckhouse] make some modules functional

### DIFF
--- a/ee/modules/450-keepalived/module.yaml
+++ b/ee/modules/450-keepalived/module.yaml
@@ -1,6 +1,5 @@
 name: keepalived
 stage: "General Availability"
-critical: true
 weight: 450
 subsystems:
   - infrastructure

--- a/ee/modules/450-network-gateway/module.yaml
+++ b/ee/modules/450-network-gateway/module.yaml
@@ -1,6 +1,5 @@
 name: network-gateway
 stage: "General Availability"
-critical: true
 weight: 450
 subsystems:
   - networking

--- a/modules/050-network-policy-engine/module.yaml
+++ b/modules/050-network-policy-engine/module.yaml
@@ -1,6 +1,5 @@
 name: network-policy-engine
 stage: "General Availability"
-critical: true
 weight: 50
 subsystems:
   - networking


### PR DESCRIPTION
## Description
Make functional:
- keepalived
- network-gateway
- network-policy-engine

## Why do we need it, and what problem does it solve?
These module are not required during bootstrapping the cluster

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: keepalived, network-gateway,network-policy-engine
type: chore
summary: Make keepalived, network-gateway,network-policy-engine modules functional
```
