### PR TITLE
[deckhouse] Make keepalived and network-policy-engine functional

### DIFF
--- a/ee/modules/450-keepalived/module.yaml
+++ b/ee/modules/450-keepalived/module.yaml
@@ -1,6 +1,5 @@
 name: keepalived
 stage: "General Availability"
-weight: 450
 subsystems:
   - infrastructure
 namespace: d8-keepalived

--- a/ee/modules/450-network-gateway/module.yaml
+++ b/ee/modules/450-network-gateway/module.yaml
@@ -1,5 +1,6 @@
 name: network-gateway
 stage: "General Availability"
+critical: true
 weight: 450
 subsystems:
   - networking

--- a/modules/050-network-policy-engine/module.yaml
+++ b/modules/050-network-policy-engine/module.yaml
@@ -1,6 +1,5 @@
 name: network-policy-engine
 stage: "General Availability"
-weight: 50
 subsystems:
   - networking
 namespace: d8-system


### PR DESCRIPTION
## Description
Made keepalived and network-policy-engine modules functional.

## Why do we need it, and what problem does it solve?
These module are not required during bootstrapping the cluster

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Made keepalived and network-policy-engine modules functional.
```
