### PR TITLE
[node-manager] fix standby-ng calculation

### DIFF
--- a/modules/040-node-manager/hooks/discover_standby_ng.go
+++ b/modules/040-node-manager/hooks/discover_standby_ng.go
@@ -288,7 +288,7 @@ func discoverStandbyNGHandler(input *go_hook.HookInput) error {
 		// Convert memory to Mi and format as a string. 1 Mi = 1024 * 1024 bytes.
 		reserveMemoryInMi := standbyRequestMemory.Value() / (1024 * 1024)
 		reserveMemoryMi := fmt.Sprintf("%dMi", reserveMemoryInMi)
-		resource.Mega
+
 		standbyNodeGroups = append(standbyNodeGroups, StandbyNodeGroupForValues{
 			Name:          nodeGroup.Name,
 			Standby:       desiredStandby,

--- a/modules/040-node-manager/hooks/discover_standby_ng.go
+++ b/modules/040-node-manager/hooks/discover_standby_ng.go
@@ -285,12 +285,15 @@ func discoverStandbyNGHandler(input *go_hook.HookInput) error {
 		// calculate standby request as percent of the node
 		standbyRequestCPU := resource.NewScaledQuantity(nodeAllocatableCPU.ScaledValue(resource.Milli)/100*nodeGroup.OverprovisioningRate, resource.Milli)
 		standbyRequestMemory := resource.NewScaledQuantity(nodeAllocatableMemory.ScaledValue(resource.Milli)/100*nodeGroup.OverprovisioningRate, resource.Milli)
-
+		// Convert memory to Mi and format as a string. 1 Mi = 1024 * 1024 bytes.
+		reserveMemoryInMi := standbyRequestMemory.Value() / (1024 * 1024)
+		reserveMemoryMi := fmt.Sprintf("%dMi", reserveMemoryInMi)
+		resource.Mega
 		standbyNodeGroups = append(standbyNodeGroups, StandbyNodeGroupForValues{
 			Name:          nodeGroup.Name,
 			Standby:       desiredStandby,
 			ReserveCPU:    standbyRequestCPU.String(),
-			ReserveMemory: fmt.Sprintf("%dMi", standbyRequestMemory.ScaledValue(resource.Mega)),
+			ReserveMemory: reserveMemoryMi,
 			Taints:        nodeGroup.Taints,
 		})
 	}

--- a/modules/040-node-manager/hooks/discover_standby_ng_test.go
+++ b/modules/040-node-manager/hooks/discover_standby_ng_test.go
@@ -405,7 +405,7 @@ status:
 
 		It("Hook must not fail; standby NG should be discovered", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"standby-absolute","standby":5,"reserveCPU":"2","reserveMemory": "4295Mi","taints":[{"key":"ship-class","value":"frigate","effect":"NoExecute"}]}`))
+			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"standby-absolute","standby":5,"reserveCPU":"2","reserveMemory": "4096Mi","taints":[{"key":"ship-class","value":"frigate","effect":"NoExecute"}]}`))
 		})
 	})
 
@@ -419,7 +419,7 @@ status:
 
 		It("Hook must not fail; standby NG should be discovered", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name": "standby-absolute", "standby": 5, "reserveCPU": "3","reserveMemory": "2064Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
+			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name": "standby-absolute", "standby": 5, "reserveCPU": "3","reserveMemory": "1967Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
 		})
 	})
 
@@ -433,7 +433,7 @@ status:
 
 		It("Hook must not fail; standby NG should be discovered", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name": "standby-absolute", "standby": 18, "reserveCPU": "3","reserveMemory": "2064Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
+			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name": "standby-absolute", "standby": 18, "reserveCPU": "3","reserveMemory": "1967Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
 		})
 	})
 
@@ -446,7 +446,7 @@ status:
 
 		It("Hook must not fail; standby NG should be discovered", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name": "standby-percent", "standby": 12, "reserveCPU": "3","reserveMemory": "2064Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
+			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name": "standby-percent", "standby": 12, "reserveCPU": "3","reserveMemory": "1967Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
 		})
 	})
 
@@ -460,8 +460,8 @@ status:
 
 		It("Hook must not fail; standby NGs should be discovered", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"standby-absolute","standby":5,"reserveCPU":"3","reserveMemory": "2064Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
-			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.1").String()).To(MatchJSON(`{"name":"standby-percent","standby":12,"reserveCPU":"2","reserveMemory": "1032Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
+			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"standby-absolute","standby":5,"reserveCPU":"3","reserveMemory": "1967Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
+			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.1").String()).To(MatchJSON(`{"name":"standby-percent","standby":12,"reserveCPU":"2","reserveMemory": "983Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
 		})
 	})
 
@@ -477,8 +477,8 @@ status:
 
 		It("Hook must not fail; standby NGs should be discovered; status standby should be set", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"standby-absolute","standby":5,"reserveCPU":"3","reserveMemory": "2064Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
-			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.1").String()).To(MatchJSON(`{"name":"standby-percent","standby":12,"reserveCPU":"2","reserveMemory": "1032Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
+			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"standby-absolute","standby":5,"reserveCPU":"3","reserveMemory": "1967Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
+			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.1").String()).To(MatchJSON(`{"name":"standby-percent","standby":12,"reserveCPU":"2","reserveMemory": "983Mi","taints":[{"effect":"NoExecute","key":"ship-class","value":"frigate"}]}`))
 
 			Expect(f.KubernetesGlobalResource("NodeGroup", "standby-absolute").Field("status").String()).To(MatchJSON(`{"standby":2}`))
 			Expect(f.KubernetesGlobalResource("NodeGroup", "standby-percent").Field("status").String()).To(MatchJSON(`{"standby":0}`))
@@ -495,7 +495,7 @@ status:
 
 		It("Hook must not fail; standby NGs should be discovered; status standby should be set", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"standby-absolute","standby":5,"reserveCPU":"3","reserveMemory": "2064Mi","taints": [{"key": "ship-class","value": "frigate","effect": "NoExecute"}]}`))
+			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"standby-absolute","standby":5,"reserveCPU":"3","reserveMemory": "1967Mi","taints": [{"key": "ship-class","value": "frigate","effect": "NoExecute"}]}`))
 
 			Expect(f.KubernetesGlobalResource("NodeGroup", "standby-absolute").Field("status").String()).To(MatchJSON(`{"standby":1}`))
 		})
@@ -511,7 +511,7 @@ status:
 
 		It("Hook must not fail; standby NGs should be discovered; status standby should be set", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"standby-absolute","standby":5,"reserveCPU":"4800m","reserveMemory": "3302Mi","taints": [{"key": "ship-class","value": "frigate","effect": "NoExecute"}]}`))
+			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"standby-absolute","standby":5,"reserveCPU":"4800m","reserveMemory": "3148Mi","taints": [{"key": "ship-class","value": "frigate","effect": "NoExecute"}]}`))
 
 			Expect(f.KubernetesGlobalResource("NodeGroup", "standby-absolute").Field("status").String()).To(MatchJSON(`{"standby":1}`))
 		})
@@ -527,7 +527,7 @@ status:
 
 		It("Hook must not fail; overprovisioning resources should be discovered from the latest node", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"standby-absolute","standby":5,"reserveCPU":"1","reserveMemory": "2064Mi","taints": [{"key": "ship-class","value": "frigate","effect": "NoExecute"}]}`))
+			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"standby-absolute","standby":5,"reserveCPU":"1","reserveMemory": "1967Mi","taints": [{"key": "ship-class","value": "frigate","effect": "NoExecute"}]}`))
 
 			Expect(f.KubernetesGlobalResource("NodeGroup", "standby-absolute").Field("status").String()).To(MatchJSON(`{"standby":1}`))
 		})
@@ -546,8 +546,7 @@ status:
 
 		It("Hook must not fail; standby NGs should be discovered", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"worker","standby":3,"reserveCPU":"2","reserveMemory": "1032Mi","taints":[]}`))
+			Expect(f.ValuesGet("nodeManager.internal.standbyNodeGroups.0").String()).To(MatchJSON(`{"name":"worker","standby":3,"reserveCPU":"2","reserveMemory": "983Mi","taints":[]}`))
 		})
 	})
-
 })


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed RAM size calculation in discover_standby_ng_test.go hook

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
There seems to be some mistake between MI (^2) and MB (^10).

4126652008 bytes /2 (50%) / 1024 / 1024 must be 1967 Mi
but now we have 2064Mi (looks like 4126652008/2/1000/1000)

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix 
summary: fix calculation of memory for standby holder
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
