### PR TITLE
[chore] Remove references to the Deckhouse work board and roadmap from the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,3 @@ In addition to common GitHub features, here are some other online resources rela
 * [Twitter](https://twitter.com/deckhouseio) to stay informed about everything happening around Deckhouse;
 * [Telegram chat](https://t.me/deckhouse) to discuss (there's a dedicated [Telegram chat in Russian](https://t.me/deckhouse_ru) as well);
 * [Deckhouse blog](https://blog.deckhouse.io/) to read the latest articles about Deckhouse.
-* Check our [work board](https://github.com/orgs/deckhouse/projects/2) and [roadmap](https://github.com/orgs/deckhouse/projects/6) for more insights.


### PR DESCRIPTION
## Description
Remove references to the Deckhouse work board and roadmap from the README.md.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Remove references to the Deckhouse work board and roadmap from the README.md.
impact_level: low
```
