### PR TITLE
[ci] Fix listing of changed modules

### DIFF
--- a/.github/scripts/python/compare_version_modules.py
+++ b/.github/scripts/python/compare_version_modules.py
@@ -78,13 +78,13 @@ results.sort()
 
 dangerous_results = [i for i in results if any(m in i for m in dangerous_modules)]
 
-if len(results) != 0:
+if len(results) > 0:
     print("Found changes in following module images:")
     print(*results, sep="\n")
 else:
     print("No changed module images found.")
 
-if len(dangerous_results != 0):
+if len(dangerous_results) > 0:
     print("Found possibly dangerous changes in following module images:")
     print(*dangerous_results, sep="\n")
     exit(1)


### PR DESCRIPTION
## Description
Fix listing of changed modules.

## Why do we need it, and what problem does it solve?
Changed modules checker script is broken.

## Why do we need it in the patch release (if we do)?
Changed modules check is necessary for every patch-release.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix listing of changed modules.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
