### PR TITLE
[user-authn] fix dex oidc connector insecureSkipVerify and rootCAData options

### DIFF
--- a/modules/150-user-authn/images/dex/patches/005-oidc-httpclient-to-context.patch
+++ b/modules/150-user-authn/images/dex/patches/005-oidc-httpclient-to-context.patch
@@ -1,0 +1,14 @@
+diff --git a/connector/oidc/oidc.go b/connector/oidc/oidc.go
+index 1ea0c1fc..99f20f0d 100644
+--- a/connector/oidc/oidc.go
++++ b/connector/oidc/oidc.go
+@@ -420,6 +420,9 @@ func (c *oidcConnector) Refresh(ctx context.Context, s connector.Scopes, identit
+ 
+ func (c *oidcConnector) TokenIdentity(ctx context.Context, subjectTokenType, subjectToken string) (connector.Identity, error) {
+ 	var identity connector.Identity
++
++	ctx = context.WithValue(ctx, oauth2.HTTPClient, c.httpClient)
++
+ 	token := &oauth2.Token{
+ 		AccessToken: subjectToken,
+ 		TokenType:   subjectTokenType,

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -20,3 +20,9 @@ To avoid this, this patch makes refresh requests to declare and utilize their ow
 ### 004-static-user-groups.patch
 
 Adding group entity to kubernetes authentication.
+
+### 005-oidc-httpclient-to-context.patch
+
+This patch fixes the issue with the `insecureSkipVerify` and `rootCAs` options which do not work in OIDC connector.
+
+Upstream PR: https://github.com/dexidp/dex/pull/4223


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Backport of  https://github.com/deckhouse/deckhouse/pull/14524

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: fix dex oidc connector insecureSkipVerify and rootCAData options
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
