### PR TITLE
[docs] Fix item title trimming in sidebar

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/_partials/sidebar.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/sidebar.html
@@ -129,11 +129,10 @@
   {{- if in .Site.Data.helpers.knownPageNames .File.TranslationBaseName }}
     {{- $pageTitle = T (printf "moduleLinkTitle%s" .File.TranslationBaseName) }}
   {{- else if .LinkTitle }}
-    {{- $pageTitle = .LinkTitle }}
+    {{- $pageTitle = strings.TrimSpace .LinkTitle }}
   {{- else if .Title }}
-    {{- $pageTitle = .Title }}
+    {{- $pageTitle = strings.TrimSpace .Title }}
   {{- end }}
-  {{- $pageTitle = strings.TrimSpace .Title }}
   {{- if not $pageTitle }}{{ continue }}{{ end }}
        <li class="sidebar__submenu-item {{ if or (.IsAncestor page) (eq . page) }}active{{ end }}">
           <a href="{{ if .IsPage }}{{ replaceRE "/readme.html$" "/" .RelPermalink }}{{ else }}#{{ end }}">


### PR DESCRIPTION
## Description
Fix module template when trimming whitespaces from a sidebar title.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix module template when trimming whitespaces from a sidebar title.
impact_level: low
```
