### PR TITLE
[monitoring-custom] Fix typo in  'allow-unready-pods' 

### DIFF
--- a/ee/fe/modules/340-monitoring-applications/templates/base-service-monitor.yaml
+++ b/ee/fe/modules/340-monitoring-applications/templates/base-service-monitor.yaml
@@ -13,7 +13,7 @@
 - regex: endpoint
   action: labeldrop
 
-- sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready, __meta_kubernetes_service_annotation_prometheus_deckhouse_io_allows_unready_pods]
+- sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready, __meta_kubernetes_service_annotation_prometheus_deckhouse_io_allow_unready_pods]
   regex: ^(.*)true(.*)$
   action: keep
 

--- a/modules/340-monitoring-custom/templates/_helpers.tpl
+++ b/modules/340-monitoring-custom/templates/_helpers.tpl
@@ -7,7 +7,7 @@
   {{- end }}
 
 # Check whether pod is ready or the annotation on it allows scarping unready pods
-- sourceLabels: [{{ $label }}, __meta_kubernetes_{{ $scrapeType }}_annotation_prometheus_deckhouse_io_allows_unready_pods]
+- sourceLabels: [{{ $label }}, __meta_kubernetes_{{ $scrapeType }}_annotation_prometheus_deckhouse_io_allow_unready_pods]
   regex: ^(.*)true(.*)$
   action: keep
 


### PR DESCRIPTION
## Description

Fix typo in `alow-unready-pods` parameter name.

## Why do we need it, and what problem does it solve?

Makes the name of the parameter consistent with the documentation.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section:  monitoring-custom
type: fix
summary: Fix typo in 'allow-unready-pods' parameter name
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
