### PR TITLE
[docs] Added settings. for external modules parameters rendering

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
@@ -4,36 +4,36 @@
   .data — a map, containing the JSON schema.
   .langData — map, containing the preferable language data. Can be empty.
   */}}
-  
+
   {{- $data := .data }}
   {{- $conversions := .conversions }}
   {{- $langData := .langData }}
-    
+
   {{- $configVersion := 1 }}
   {{- if index $data "x-config-version" }}
     {{- $configVersion = index $data "x-config-version" }}
   {{- end }}
-  
+
   {{/* TODO: format_examples $data */}}
-  
+
   {{/* Reading all conversions files */}}
-  
+
   {{/* Conversions rendering */}}
   {{- if and $conversions (gt (len $conversions) 0) }}
       <h2>{{ T "conversions_title" }}</h2>
-  
+
       <p>{{ T "conversion_action_message" }}:</p>
-  
+
       {{- range $conversion := $conversions }}
         {{- if $conversion }}
         <ul>
           <li>
             <p>{{ T "conversion_from_version" }} <b>{{ sub $conversion.version 1 }}</b> {{ T "conversion_to" }} <b>{{ $conversion.version }}</b>:</p>
-  
+
             {{/* Check description availability*/}}
             {{- $currentLang := site.Language.Lang | default "en" -}}
             {{- $hasDescription := false -}}
-  
+
             {{- if $conversion.description -}}
               {{- if reflect.IsMap $conversion.description -}}
                 {{- $description := index $conversion.description $currentLang | default $conversion.description.en -}}
@@ -46,11 +46,11 @@
                 {{- $hasDescription = true -}}
               {{- end -}}
             {{- end -}}
-  
+
             {{/* If no description */}}
             {{- if not $hasDescription -}}
               <p>{{ T "conversion_missing_description" }}</p>
-  
+
               {{/* Rendering details block only if there is no description, but there are expressions */}}
               {{- if $conversion.conversions -}}
               <div class="details" markdown="0">
@@ -76,14 +76,14 @@
         {{- end }}
       {{- end }}
   <h2>{{ T "parameters" | humanize }}</h2>
-  
+
   {{- end }}
   {{/* END Conversions rendering */}}
-  
+
   {{- if gt (len $data.properties) 0 }}
   <h2 style="text-transform: capitalize;">{{ T "parameters" }}</h2>
   <p><font size="-1">{{ T "version_of_schema" }}: {{ $configVersion }}</font></p>
-  
+
   <ul class="resources">
     <li>
       <div class="resources__prop_wrap"><div id="parameters-settings" data-anchor-id="parameters-settings" class="resources__prop_name anchored">
@@ -94,13 +94,12 @@
       {{- range $property, $propertyData := $data.properties }}
         {{- if eq $property "status" }}{{ continue }}{{ end }} {{/* skip .status for now*/}}
         {{- $propertyLangData := index $langData.properties $property }}
-        {{- partial "openapi/format-schema" ( dict "name" $property "data" $propertyData "langData" $propertyLangData "resourceName" "parameters" "mode" "build_configuration") }}
+        {{- partial "openapi/format-schema" ( dict "name" $property "data" $propertyData "langData" $propertyLangData "resourceName" "parameters" "type" "module_configuration") }}
       {{- end }}
       </ul>
     <li>
   </ul>
-  
+
   {{- else }}
   <p>{{ T "no_custom_configuration" }}</p>
   {{- end }}
-  

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
@@ -8,7 +8,7 @@
   {{- $data := .data }}
   {{- $conversions := .conversions }}
   {{- $langData := .langData }}
-  
+    
   {{- $configVersion := 1 }}
   {{- if index $data "x-config-version" }}
     {{- $configVersion = index $data "x-config-version" }}
@@ -94,7 +94,7 @@
       {{- range $property, $propertyData := $data.properties }}
         {{- if eq $property "status" }}{{ continue }}{{ end }} {{/* skip .status for now*/}}
         {{- $propertyLangData := index $langData.properties $property }}
-        {{- partial "openapi/format-schema" ( dict "name" $property "data" $propertyData "langData" $propertyLangData "resourceName" "parameters") }}
+        {{- partial "openapi/format-schema" ( dict "name" $property "data" $propertyData "langData" $propertyLangData "resourceName" "parameters" "mode" "build_configuration") }}
       {{- end }}
       </ul>
     <li>

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
@@ -8,7 +8,7 @@
 {{ $apiVersion := .apiVersion }} {{/* A string. APIVersion of the resource of the parameter, to build the parameter HTML id (for links). Optional. */}}
 {{ $resourceName := .resourceName }} {{/* A string. The name of the resource of the parameter, to build the parameter HTML id (for links). Required. */}}
 {{ $required  := .required }} {{/* Array of the required parameters. */}}
-{{ $mode := .mode}}
+{{ $type := .type }}  {{/* A string. "module_configuration" for ModuleConfig schema or nil */}}
 
 {{- $description :=  "" }}
 
@@ -52,7 +52,7 @@
     <div class="resources__prop_name anchored" data-anchor-id="{{ $linkAnchor }}"  id="{{ $linkAnchor }}">
       <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
       <span class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-      {{ if eq .mode "build_configuration" }}
+      {{ if eq .type "module_configuration" }}
         <div><span class="ancestors">settings.{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div><span title="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span>
       {{ else }}
         <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div><span title="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span>
@@ -62,7 +62,7 @@
     <div class="resources__prop_name anchored" data-anchor-id="{{ $linkAnchor }}"  id="{{ $linkAnchor }}">
       <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
       <span class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-      {{ if eq .mode "build_configuration" }}
+      {{ if eq .type "module_configuration" }}
         <div><span class="ancestors">settings.{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div>
       {{ else }}
         <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div>
@@ -96,7 +96,7 @@
   {{- range $subParameterName, $subParameterAttributes := $data.properties }}
     {{- $subParameterLangData := index $langData.properties $subParameterName }}
 
-    {{ partial "openapi/format-schema" ( dict "name" $subParameterName "data" $subParameterAttributes "langData" $subParameterLangData "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "required" $requiredParameters "mode" $mode) }}
+    {{ partial "openapi/format-schema" ( dict "name" $subParameterName "data" $subParameterAttributes "langData" $subParameterLangData "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "required" $requiredParameters "type" $type) }}
   {{ end }}
   </ul>
 {{- else if and (reflect.IsMap $data) $data.items }}
@@ -105,7 +105,7 @@
     <ul>
     {{- range $subParameterName, $subParameterAttributes := $data.items.properties }}
       {{- $subParameterLangData := index $langData.items.properties $subParameterName }}
-      {{- partial "openapi/format-schema" ( dict "name" $subParameterName "data" $subParameterAttributes "langData" $subParameterLangData "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "mode" $mode) }}
+      {{- partial "openapi/format-schema" ( dict "name" $subParameterName "data" $subParameterAttributes "langData" $subParameterLangData "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "type" $type) }}
     {{- end }}
     </ul>
   {{- else }}{{/* Array of non-objects (string, integer, etc.) */}}
@@ -117,7 +117,7 @@
 
     {{- if $keysToShowIsExist }}
       <ul>
-      {{- partial "openapi/format-schema" ( dict "name" "" "data" $data.items "langData" $langData.items "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "mode" $mode) }}
+      {{- partial "openapi/format-schema" ( dict "name" "" "data" $data.items "langData" $langData.items "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "type" $type) }}
       </ul>
     {{- end }}
 

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
@@ -8,6 +8,7 @@
 {{ $apiVersion := .apiVersion }} {{/* A string. APIVersion of the resource of the parameter, to build the parameter HTML id (for links). Optional. */}}
 {{ $resourceName := .resourceName }} {{/* A string. The name of the resource of the parameter, to build the parameter HTML id (for links). Required. */}}
 {{ $required  := .required }} {{/* Array of the required parameters. */}}
+{{ $mode := .mode}}
 
 {{- $description :=  "" }}
 
@@ -95,7 +96,7 @@
   {{- range $subParameterName, $subParameterAttributes := $data.properties }}
     {{- $subParameterLangData := index $langData.properties $subParameterName }}
 
-    {{ partial "openapi/format-schema" ( dict "name" $subParameterName "data" $subParameterAttributes "langData" $subParameterLangData "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "required" $requiredParameters ) }}
+    {{ partial "openapi/format-schema" ( dict "name" $subParameterName "data" $subParameterAttributes "langData" $subParameterLangData "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "required" $requiredParameters "mode" $mode) }}
   {{ end }}
   </ul>
 {{- else if and (reflect.IsMap $data) $data.items }}
@@ -104,7 +105,7 @@
     <ul>
     {{- range $subParameterName, $subParameterAttributes := $data.items.properties }}
       {{- $subParameterLangData := index $langData.items.properties $subParameterName }}
-      {{- partial "openapi/format-schema" ( dict "name" $subParameterName "data" $subParameterAttributes "langData" $subParameterLangData "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName) }}
+      {{- partial "openapi/format-schema" ( dict "name" $subParameterName "data" $subParameterAttributes "langData" $subParameterLangData "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "mode" $mode) }}
     {{- end }}
     </ul>
   {{- else }}{{/* Array of non-objects (string, integer, etc.) */}}
@@ -116,7 +117,7 @@
 
     {{- if $keysToShowIsExist }}
       <ul>
-      {{- partial "openapi/format-schema" ( dict "name" "" "data" $data.items "langData" $langData.items "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName) }}
+      {{- partial "openapi/format-schema" ( dict "name" "" "data" $data.items "langData" $langData.items "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "mode" $mode) }}
       </ul>
     {{- end }}
 

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
@@ -51,13 +51,13 @@
     <div class="resources__prop_name anchored" data-anchor-id="{{ $linkAnchor }}"  id="{{ $linkAnchor }}">
       <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
       <span class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-      <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div><span title="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span>
+      <div><span class="ancestors">settings.{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div><span title="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span>
     </div>
   {{- else }}
     <div class="resources__prop_name anchored" data-anchor-id="{{ $linkAnchor }}"  id="{{ $linkAnchor }}">
       <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
       <span class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-      <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div>
+      <div><span class="ancestors">settings.{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div>
     </div>
   {{- end }}
 

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
@@ -51,13 +51,21 @@
     <div class="resources__prop_name anchored" data-anchor-id="{{ $linkAnchor }}"  id="{{ $linkAnchor }}">
       <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
       <span class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-      <div><span class="ancestors">settings.{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div><span title="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span>
+      {{ if eq .mode "build_configuration" }}
+        <div><span class="ancestors">settings.{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div><span title="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span>
+      {{ else }}
+        <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div><span title="{{ T "deprecated_parameter_hint" }}" class="resources__prop_is_deprecated">{{ T "deprecated_parameter" }}</span>
+      {{ end }}
     </div>
   {{- else }}
     <div class="resources__prop_name anchored" data-anchor-id="{{ $linkAnchor }}"  id="{{ $linkAnchor }}">
       <span class="plus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none"><path d="M5.00005 1.5V4.99995M5.00005 4.99995V8.5M5.00005 4.99995H1.5M5.00005 4.99995H8.5" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
       <span class="minus-icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1.5 3.99982L8.5 3.99982" stroke="#0D69F2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-      <div><span class="ancestors">settings.{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div>
+      {{ if eq .mode "build_configuration" }}
+        <div><span class="ancestors">settings.{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div>
+      {{ else }}
+        <div><span class="ancestors">{{ $ancestorsPathString }}</span><span>{{ $parameterTitle }}</span></div>
+      {{ end }}
     </div>
   {{- end }}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added settings. for external modules parameters rendering.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Before:

<img width="685" height="547" alt="sett before" src="https://github.com/user-attachments/assets/b5ebe9cf-5a4a-4bc8-a5bb-e070cee441d6" />


After:

<img width="1094" height="575" alt="sett after" src="https://github.com/user-attachments/assets/096ca1e9-1657-4535-8fc5-e1205017dfed" />


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Added settings. for external modules parameters rendering.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
