### PR TITLE
[dhctl] Add umask before creating first-control-plane-bashible-ran file

### DIFF
--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -468,12 +468,11 @@ func RunBashiblePipeline(ctx context.Context, nodeInterface node.Interface, cfg 
 		// in end of pipeline steps bashible write "OK" to this file
 		// we need creating it before because we do not want handle errors from cat
 		return retry.NewLoop(fmt.Sprintf("Prepare %s", DHCTLEndBootstrapBashiblePipeline), 30, 10*time.Second).RunContext(ctx, func() error {
-			cmd := nodeInterface.Command("touch", DHCTLEndBootstrapBashiblePipeline)
+			cmd := nodeInterface.Command("sh", "-c", fmt.Sprintf("umask 0022 ; touch %s", DHCTLEndBootstrapBashiblePipeline))
 			cmd.Sudo(ctx)
 			if err := cmd.Run(ctx); err != nil {
 				return fmt.Errorf("touch error %s: %w", DHCTLEndBootstrapBashiblePipeline, err)
 			}
-
 			return nil
 		})
 	})


### PR DESCRIPTION
## Description
Sometimes there are cases when due to security policies the default permission mask when creating files in the system is `640`(for example in `/etc/login.defs` file UMASK directive). In such cases, the cluster bootstrap crashes at the step of checking the file `/opt/deckhouse/first-control-plane-bashible-ran`. The cat command cannot be executed due to insufficient rights - permission denied. 

## Logs
```
2025-07-21 09:11:25 - Attempt #1 of 30 |
        Checking bashible already ran failed, next attempt will be in 10s"
2025-07-21 09:11:25 -   Error: execute command 'cat': exit status 1`
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Add umask before creating first-control-plane-bashible-ran file
impact_level: low
```
