### PR TITLE
[deckhouse] Fix merge patch issues in deployment template

### DIFF
--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -157,6 +157,7 @@ spec:
   # managed by Deckhouse: use API-proxy
             - name: KUBERNETES_SERVICE_HOST
               value: 127.0.0.1
+              valueFrom: null # a hack for explicit wiping valueFrom field, helm has problems with arrays merge patching
             - name: KUBERNETES_SERVICE_PORT
               value: "6445"
   {{- else }}


### PR DESCRIPTION
## Description
Fixed an issue when the KUBERNETES_SERVICE_HOST var in Deckhouse deployment is being changed.
Due to merge patch problems, the array element:
```yaml
            - name: KUBERNETES_SERVICE_HOST
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: status.hostIP
```
Had to be changed to:
```yaml
            - name: KUBERNETES_SERVICE_HOST
              value: 127.0.0.1
```
But in fact was changed to:
```yaml
            - name: KUBERNETES_SERVICE_HOST
              value: 127.0.0.1
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: status.hostIP
```
Which is illegal.

The fix is setting valueFrom to null.

## Why do we need it, and what problem does it solve?

Sometimes helm can't handle array modifications properly.

## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fixed a helm issue with patching arrays in deckhouse deployment.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
