### PR TITLE
[cloud-providers-aws] Make creation of default security groups optional

### DIFF
--- a/candi/cloud-providers/aws/layouts/standard/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/standard/base-infrastructure/main.tf
@@ -27,6 +27,7 @@ module "security-groups" {
   vpc_id = module.vpc.id
   tags = local.tags
   ssh_allow_list = local.ssh_allow_list
+  disable_default_security_group = local.disable_default_sg
 }
 
 data "aws_availability_zones" "available" {}

--- a/candi/cloud-providers/aws/layouts/standard/base-infrastructure/variables.tf
+++ b/candi/cloud-providers/aws/layouts/standard/base-infrastructure/variables.tf
@@ -41,5 +41,5 @@ locals {
   tags                     = lookup(var.providerClusterConfiguration, "tags", {})
   ssh_allow_list           = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
   additional_role_policies = lookup(var.providerClusterConfiguration, "additionalRolePolicies", [])
-
+  disable_default_sg       = lookup(var.providerClusterConfiguration, "disableDefaultSecurityGroup", false)
 }

--- a/candi/cloud-providers/aws/layouts/standard/master-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/standard/master-node/main.tf
@@ -25,4 +25,6 @@ module "master-node" {
   zones = local.zones
   tags = local.tags
   resourceManagementTimeout = var.resourceManagementTimeout
+  disable_default_security_group = local.disable_default_sg
+  ssh_allow_list = local.ssh_allow_list
 }

--- a/candi/cloud-providers/aws/layouts/standard/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/standard/master-node/variables.tf
@@ -48,4 +48,6 @@ locals {
   actual_zones = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
   zones = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", {}) != {} ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(var.providerClusterConfiguration.masterNodeGroup, "additionalTags", {}))
+  ssh_allow_list = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
+  disable_default_sg = lookup(var.providerClusterConfiguration, "disableDefaultSecurityGroup", false)
 }

--- a/candi/cloud-providers/aws/layouts/standard/static-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/standard/static-node/main.tf
@@ -25,4 +25,6 @@ module "static-node" {
   zones = local.zones
   tags = local.tags
   resourceManagementTimeout = var.resourceManagementTimeout
+  disable_default_security_group = local.disable_default_sg
+  ssh_allow_list = local.ssh_allow_list
 }

--- a/candi/cloud-providers/aws/layouts/standard/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/standard/static-node/variables.tf
@@ -54,4 +54,6 @@ locals {
   actual_zones = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
   zones = lookup(local.node_group, "zones", {}) != {} ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.node_group, "additionalTags", {}))
+  disable_default_sg       = lookup(var.providerClusterConfiguration, "disableDefaultSecurityGroup", false)
+  ssh_allow_list           = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
@@ -27,6 +27,7 @@ module "security-groups" {
   vpc_id = module.vpc.id
   tags = local.tags
   ssh_allow_list = local.ssh_allow_list
+  disable_default_security_group = local.disable_default_sg
 }
 
 data "aws_availability_zones" "available" {}

--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
@@ -236,7 +236,7 @@ resource "aws_instance" "bastion" {
   instance_type          = local.instance_class.instanceType
   key_name               = local.prefix
   subnet_id              = local.subnet_id
-  vpc_security_group_ids = concat([module.security-groups.security_group_id_node, module.security-groups.security_group_id_ssh_accessible], local.additional_security_groups)
+  vpc_security_group_ids = compact(concat([module.security-groups.security_group_id_node, module.security-groups.security_group_id_ssh_accessible], local.additional_security_groups))
   source_dest_check      = false
   iam_instance_profile   = "${local.prefix}-node"
 

--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/variables.tf
@@ -48,4 +48,5 @@ locals {
   tags                     = lookup(var.providerClusterConfiguration, "tags", {})
   ssh_allow_list           = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
   additional_role_policies = lookup(var.providerClusterConfiguration, "additionalRolePolicies", [])
+  disable_default_sg = lookup(var.providerClusterConfiguration, "disableDefaultSecurityGroup", false)
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/master-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/master-node/main.tf
@@ -26,4 +26,6 @@ module "master-node" {
   tags = local.tags
   associate_ssh_accessible_sg = local.bastion_instance != {} ? false : true
   resourceManagementTimeout = var.resourceManagementTimeout
+  disable_default_security_group = local.disable_default_sg
+  ssh_allow_list = local.ssh_allow_list
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/master-node/variables.tf
@@ -50,4 +50,6 @@ locals {
   actual_zones = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
   zones = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", {}) != {} ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(var.providerClusterConfiguration.masterNodeGroup, "additionalTags", {}))
+  ssh_allow_list = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
+  disable_default_sg = lookup(var.providerClusterConfiguration, "disableDefaultSecurityGroup", false)
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/static-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/static-node/main.tf
@@ -25,4 +25,6 @@ module "static-node" {
   zones = local.zones
   tags = local.tags
   resourceManagementTimeout = var.resourceManagementTimeout
+  disable_default_security_group = local.disable_default_sg
+  ssh_allow_list = local.ssh_allow_list
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/static-node/variables.tf
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 variable "clusterConfiguration" {
   type = any
 }
@@ -54,4 +53,6 @@ locals {
   actual_zones = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
   zones = lookup(local.node_group, "zones", {}) != {} ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.node_group, "additionalTags", {}))
+  disable_default_sg       = lookup(var.providerClusterConfiguration, "disableDefaultSecurityGroup", false)
+  ssh_allow_list           = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
 }

--- a/candi/cloud-providers/aws/layouts/without-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/base-infrastructure/main.tf
@@ -27,6 +27,7 @@ module "security-groups" {
   vpc_id = module.vpc.id
   tags = local.tags
   ssh_allow_list = local.ssh_allow_list
+  disable_default_security_group = local.disable_default_sg
 }
 
 data "aws_availability_zones" "available" {}

--- a/candi/cloud-providers/aws/layouts/without-nat/base-infrastructure/variables.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/base-infrastructure/variables.tf
@@ -41,4 +41,5 @@ locals {
   tags                     = lookup(var.providerClusterConfiguration, "tags", {})
   ssh_allow_list           = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
   additional_role_policies = lookup(var.providerClusterConfiguration, "additionalRolePolicies", [])
+  disable_default_sg       = lookup(var.providerClusterConfiguration, "disableDefaultSecurityGroup", false)
 }

--- a/candi/cloud-providers/aws/layouts/without-nat/master-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/master-node/main.tf
@@ -26,4 +26,5 @@ module "master-node" {
   zones = local.zones
   tags = local.tags
   resourceManagementTimeout = var.resourceManagementTimeout
+  disable_default_security_group = local.disable_default_sg
 }

--- a/candi/cloud-providers/aws/layouts/without-nat/master-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/master-node/main.tf
@@ -27,4 +27,5 @@ module "master-node" {
   tags = local.tags
   resourceManagementTimeout = var.resourceManagementTimeout
   disable_default_security_group = local.disable_default_sg
+  ssh_allow_list = local.ssh_allow_list
 }

--- a/candi/cloud-providers/aws/layouts/without-nat/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/master-node/variables.tf
@@ -47,4 +47,5 @@ locals {
   additional_security_groups = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalSecurityGroups", [])
   zones = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", data.aws_availability_zones.available.names)
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(var.providerClusterConfiguration.masterNodeGroup, "additionalTags", {}))
+  disable_default_sg       = lookup(var.providerClusterConfiguration, "disableDefaultSecurityGroup", false)
 }

--- a/candi/cloud-providers/aws/layouts/without-nat/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/master-node/variables.tf
@@ -45,6 +45,7 @@ locals {
   root_volume_size = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskSizeGb", 20)
   root_volume_type = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskType", "gp2")
   additional_security_groups = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalSecurityGroups", [])
+  ssh_allow_list           = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
   zones = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", data.aws_availability_zones.available.names)
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(var.providerClusterConfiguration.masterNodeGroup, "additionalTags", {}))
   disable_default_sg       = lookup(var.providerClusterConfiguration, "disableDefaultSecurityGroup", false)

--- a/candi/cloud-providers/aws/layouts/without-nat/static-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/static-node/main.tf
@@ -26,4 +26,5 @@ module "static-node" {
   zones = local.zones
   tags = local.tags
   resourceManagementTimeout = var.resourceManagementTimeout
+  disable_default_security_group = local.disable_default_sg
 }

--- a/candi/cloud-providers/aws/layouts/without-nat/static-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/static-node/main.tf
@@ -27,4 +27,5 @@ module "static-node" {
   tags = local.tags
   resourceManagementTimeout = var.resourceManagementTimeout
   disable_default_security_group = local.disable_default_sg
+  ssh_allow_list = local.ssh_allow_list
 }

--- a/candi/cloud-providers/aws/layouts/without-nat/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/static-node/variables.tf
@@ -55,4 +55,5 @@ locals {
   zones = lookup(local.node_group, "zones", {}) != {} ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.node_group, "additionalTags", {}))
   disable_default_sg       = lookup(var.providerClusterConfiguration, "disableDefaultSecurityGroup", false)
+  ssh_allow_list           = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
 }

--- a/candi/cloud-providers/aws/layouts/without-nat/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/static-node/variables.tf
@@ -54,4 +54,5 @@ locals {
   actual_zones = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
   zones = lookup(local.node_group, "zones", {}) != {} ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.node_group, "additionalTags", {}))
+  disable_default_sg       = lookup(var.providerClusterConfiguration, "disableDefaultSecurityGroup", false)
 }

--- a/candi/cloud-providers/aws/openapi/cloud_discovery_data.yaml
+++ b/candi/cloud-providers/aws/openapi/cloud_discovery_data.yaml
@@ -35,7 +35,7 @@ apiVersions:
         minLength: 1
       loadBalancerSecurityGroup:
         type: string
-        pattern: '^sg-[a-z0-9]+$'
+        pattern: '^$|^sg-[a-z0-9]+$'
       zoneToSubnetIdMap:
         type: object
         minProperties: 1

--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -390,6 +390,10 @@ apiVersions:
         type: string
         description: |
           A public key for accessing nodes.
+      disableDefaultSecurityGroup:
+        type: boolean
+        description: |
+          If `true`, the default security group will not be created.
       sshAllowList:
         type: array
         items:

--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -393,9 +393,15 @@ apiVersions:
       disableDefaultSecurityGroup:
         type: boolean
         description: |
-          If `true`, the default security group will not be created.
+          If set to `true`, the default security group will not be created.
 
-          * **Caution!** When using disableDefaultSecurityGroup: true, you must manually create security groups to allow access to your cluster nodes. You then need to specify these in the `additionalSecurityGroups` field of the `masterNodeGroup` section in `AWSClusterConfiguration` and in your `AWSInstanceClass`, as well as in the `nodeGroups.instanceClass.additionalSecurityGroups` section. To assign security groups to load balancers, use the `service.beta.kubernetes.io/aws-load-balancer-security-groups` annotation
+          **Warning.** When using `disableDefaultSecurityGroup: true`, you must manually create all required security groups to allow access to cluster nodes. Additionally, you must explicitly specify them in the following parameters:
+
+          - `additionalSecurityGroups` in the `masterNodeGroup` section of the `AWSClusterConfiguration` resource;
+          - `additionalSecurityGroups` in the `AWSInstanceClass` resource;
+          - `additionalSecurityGroups` in the `nodeGroups.instanceClass` section.
+
+          To configure the security groups used by load balancers, specify them using the `service.beta.kubernetes.io/aws-load-balancer-security-groups` annotation.
       sshAllowList:
         type: array
         items:

--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -394,6 +394,8 @@ apiVersions:
         type: boolean
         description: |
           If `true`, the default security group will not be created.
+
+          * **Caution!** When using disableDefaultSecurityGroup: true, you must manually create security groups to allow access to your cluster nodes. You then need to specify these in the `additionalSecurityGroups` field of the `masterNodeGroup` section in `AWSClusterConfiguration` and in your `AWSInstanceClass`, as well as in the `nodeGroups.instanceClass.additionalSecurityGroups` section. To assign security groups to load balancers, use the `service.beta.kubernetes.io/aws-load-balancer-security-groups` annotation
       sshAllowList:
         type: array
         items:

--- a/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
@@ -218,9 +218,15 @@ apiVersions:
           Публичный ключ для доступа на узлы.
       disableDefaultSecurityGroup:
         description: |
-          Если `true`, то не будут созданы security group'ы по умолчанию. 
+          Если установлено значение `true`, то security group по умолчанию создаваться не будут. 
 
-          * **Важно!** Если вы используете `disableDefaultSecurityGroup: true`, то необходимо самостоятельно создать security group'ы для доступа к узлам кластера. А также указать их в параметре `additionalSecurityGroups` в секции `masterNodeGroup` в `AWSClusterConfiguration` и в `AWSInstanceClass` , а также в секции `nodeGroups.instanceClass.additionalSecurityGroups`. Для указания security group для loadbalancer'ов используйте аннотацию `service.beta.kubernetes.io/aws-load-balancer-security-groups`.
+          **Важно.** При использовании `disableDefaultSecurityGroup: true` вы обязаны самостоятельно создать все необходимые security group для доступа к узлам кластера. Кроме того, необходимо явно указать их в следующих параметрах:
+
+          - `additionalSecurityGroups` в секции `masterNodeGroup` ресурса AWSClusterConfiguration;
+          - `additionalSecurityGroups` в ресурсе AWSInstanceClass;
+          - `additionalSecurityGroups` в секции `nodeGroups.instanceClass`.
+
+          Для настройки security group, используемых балансировщиками нагрузки, укажите их через аннотацию `service.beta.kubernetes.io/aws-load-balancer-security-groups`.
       sshAllowList:
         description: |
           Список CIDR, разрешенных для подключения к узлам по SSH.

--- a/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
@@ -216,6 +216,11 @@ apiVersions:
       sshPublicKey:
         description: |
           Публичный ключ для доступа на узлы.
+      disableDefaultSecurityGroup:
+        description: |
+          Если `true`, то не будут созданы security group'ы по умолчанию. 
+
+          * **Важно!** Если вы используете `disableDefaultSecurityGroup: true`, то необходимо самостоятельно создать security group'ы для доступа к узлам кластера. А также указать их в параметре `additionalSecurityGroups` в секции `masterNodeGroup` в `AWSClusterConfiguration` и в `AWSInstanceClass` , а также в секции `nodeGroups.instanceClass.additionalSecurityGroups`. Для указания security group для loadbalancer'ов используйте аннотацию `service.beta.kubernetes.io/aws-load-balancer-security-groups`.
       sshAllowList:
         description: |
           Список CIDR, разрешенных для подключения к узлам по SSH.

--- a/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
@@ -59,16 +59,20 @@ resource "aws_volume_attachment" "kubernetes_data" {
 }
 
 data "aws_security_group" "ssh-accessible" {
+  count = var.disable_default_security_group ? 0 : 1
   name = "${var.prefix}-ssh-accessible"
 }
 
 data "aws_security_group" "node" {
+  count = var.disable_default_security_group ? 0 : 1
   name = "${var.prefix}-node"
 }
 
 locals {
-  base_security_groups = var.associate_ssh_accessible_sg == true ? [data.aws_security_group.node.id, data.aws_security_group.ssh-accessible.id] : [data.aws_security_group.node.id]
-}
+  base_security_groups = var.disable_default_security_group ? [] : (
+    var.associate_ssh_accessible_sg ? [data.aws_security_group.ssh-accessible[0].id, data.aws_security_group.node[0].id] : [data.aws_security_group.node[0].id]
+  )
+  }
 
 resource "aws_instance" "master" {
   ami             = var.node_group.instanceClass.ami

--- a/candi/cloud-providers/aws/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/aws/terraform-modules/master-node/variables.tf
@@ -21,6 +21,10 @@ variable "disable_default_security_group" {
   default = false
 }
 
+variable "ssh_allow_list" {
+  type = any
+}
+
 variable "cluster_uuid" {
   type = string
 }

--- a/candi/cloud-providers/aws/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/aws/terraform-modules/master-node/variables.tf
@@ -16,6 +16,11 @@ variable "prefix" {
   type = string
 }
 
+variable "disable_default_security_group" {
+  type = bool
+  default = false
+}
+
 variable "cluster_uuid" {
   type = string
 }
@@ -40,7 +45,6 @@ variable "associate_public_ip_address" {
   type = bool
   default = false
 }
-
 variable "associate_ssh_accessible_sg" {
   type = bool
   default = true

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
@@ -35,7 +35,7 @@ resource "aws_security_group_rule" "lb-to-node" {
   from_port                = 0
   to_port                  = 65535
   security_group_id        = aws_security_group.node.id
-  source_security_group_id = aws_security_group.loadbalancer.id
+  source_security_group_id = aws_security_group.loadbalancer[0].id
 }
 
 resource "aws_security_group_rule" "node-to-node" {
@@ -57,17 +57,19 @@ resource "aws_security_group_rule" "to-node-icmp" {
 }
 
 resource "aws_security_group" "loadbalancer" {
+  count  = var.disable_default_security_group ? 0 : 1
   name   = "${var.prefix}-loadbalancer"
   vpc_id = var.vpc_id
   tags   = var.tags
 }
 
 resource "aws_security_group_rule" "allow-all-incoming-traffic-to-loadbalancer" {
+  count             = var.disable_default_security_group ? 0 : 1
   type              = "ingress"
   protocol          = "-1"
   from_port         = 0
   to_port           = 65535
-  security_group_id = aws_security_group.loadbalancer.id
+  security_group_id = aws_security_group.loadbalancer[0].id
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
@@ -76,7 +78,7 @@ resource "aws_security_group_rule" "allow-all-outgoing-traffic-to-nodes" {
   protocol                 = "-1"
   from_port                = 0
   to_port                  = 65535
-  security_group_id        = aws_security_group.loadbalancer.id
+  security_group_id        = aws_security_group.loadbalancer[0].id
   source_security_group_id = aws_security_group.node.id
 }
 

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 resource "aws_security_group" "node" {
+  count = var.disable_default_security_group ? 0 : 1
   name   = "${var.prefix}-node"
   vpc_id = var.vpc_id
 
@@ -40,6 +41,7 @@ resource "aws_security_group_rule" "lb-to-node" {
 }
 
 resource "aws_security_group_rule" "node-to-node" {
+  count                    = var.disable_default_security_group ? 0 : 1
   type                     = "ingress"
   protocol                 = "-1"
   from_port                = 0
@@ -49,6 +51,7 @@ resource "aws_security_group_rule" "node-to-node" {
 }
 
 resource "aws_security_group_rule" "to-node-icmp" {
+  count             = var.disable_default_security_group ? 0 : 1
   type              = "ingress"
   from_port         = -1
   to_port           = -1
@@ -75,7 +78,7 @@ resource "aws_security_group_rule" "allow-all-incoming-traffic-to-loadbalancer" 
 }
 
 resource "aws_security_group_rule" "allow-all-outgoing-traffic-to-nodes" {
-  count             = var.disable_default_security_group ? 0 : 1
+  count                    = var.disable_default_security_group ? 0 : 1
   type                     = "egress"
   protocol                 = "-1"
   from_port                = 0
@@ -85,16 +88,18 @@ resource "aws_security_group_rule" "allow-all-outgoing-traffic-to-nodes" {
 }
 
 resource "aws_security_group" "ssh-accessible" {
+  count       = var.disable_default_security_group ? 0 : 1
   name        = "${var.prefix}-ssh-accessible"
   vpc_id      = var.vpc_id
   tags        = var.tags
 }
 
 resource "aws_security_group_rule" "allow-ssh-for-everyone" {
-  type = "ingress"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = var.ssh_allow_list
+  count             = var.disable_default_security_group ? 0 : 1
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = var.ssh_allow_list
   security_group_id = aws_security_group.ssh-accessible.id
 }

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
@@ -30,6 +30,7 @@ resource "aws_security_group" "node" {
 }
 
 resource "aws_security_group_rule" "lb-to-node" {
+  count                    = var.disable_default_security_group ? 0 : 1
   type                     = "ingress"
   protocol                 = "-1"
   from_port                = 0

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
@@ -88,14 +88,14 @@ resource "aws_security_group_rule" "allow-all-outgoing-traffic-to-nodes" {
 }
 
 resource "aws_security_group" "ssh-accessible" {
-  count       = var.disable_default_security_group ? 0 : 1
+  count       = var.disable_default_security_group && length(var.ssh_allow_list) == 0 ? 0 : 1
   name        = "${var.prefix}-ssh-accessible"
   vpc_id      = var.vpc_id
   tags        = var.tags
 }
 
 resource "aws_security_group_rule" "allow-ssh-for-everyone" {
-  count             = var.disable_default_security_group ? 0 : 1
+  count             = var.disable_default_security_group && length(var.ssh_allow_list) == 0 ? 0 : 1
   type              = "ingress"
   from_port         = 22
   to_port           = 22

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
@@ -74,6 +74,7 @@ resource "aws_security_group_rule" "allow-all-incoming-traffic-to-loadbalancer" 
 }
 
 resource "aws_security_group_rule" "allow-all-outgoing-traffic-to-nodes" {
+  count             = var.disable_default_security_group ? 0 : 1
   type                     = "egress"
   protocol                 = "-1"
   from_port                = 0

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
@@ -36,7 +36,7 @@ resource "aws_security_group_rule" "lb-to-node" {
   protocol                 = "-1"
   from_port                = 0
   to_port                  = 65535
-  security_group_id        = aws_security_group.node.id
+  security_group_id        = aws_security_group.node[0].id
   source_security_group_id = aws_security_group.loadbalancer[0].id
 }
 
@@ -46,8 +46,8 @@ resource "aws_security_group_rule" "node-to-node" {
   protocol                 = "-1"
   from_port                = 0
   to_port                  = 65535
-  security_group_id        = aws_security_group.node.id
-  source_security_group_id = aws_security_group.node.id
+  security_group_id        = aws_security_group.node[0].id
+  source_security_group_id = aws_security_group.node[0].id
 }
 
 resource "aws_security_group_rule" "to-node-icmp" {
@@ -57,7 +57,7 @@ resource "aws_security_group_rule" "to-node-icmp" {
   to_port           = -1
   protocol          = "icmp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.node.id
+  security_group_id = aws_security_group.node[0].id
 }
 
 resource "aws_security_group" "loadbalancer" {
@@ -84,7 +84,7 @@ resource "aws_security_group_rule" "allow-all-outgoing-traffic-to-nodes" {
   from_port                = 0
   to_port                  = 65535
   security_group_id        = aws_security_group.loadbalancer[0].id
-  source_security_group_id = aws_security_group.node.id
+  source_security_group_id = aws_security_group.node[0].id
 }
 
 resource "aws_security_group" "ssh-accessible" {
@@ -101,5 +101,5 @@ resource "aws_security_group_rule" "allow-ssh-for-everyone" {
   to_port           = 22
   protocol          = "tcp"
   cidr_blocks       = var.ssh_allow_list
-  security_group_id = aws_security_group.ssh-accessible.id
+  security_group_id = aws_security_group.ssh-accessible[0].id
 }

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 output "additional_security_groups" {
-  value = length(aws_security_group.node) > 0 ? aws_security_group.node[0].id : []
+  value = length(aws_security_group.node) > 0 ? [aws_security_group.node[0].id] : []
 }
 
 output "load_balancer_security_group" {

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
@@ -21,9 +21,9 @@ output "load_balancer_security_group" {
 }
 
 output "security_group_id_node" {
-  value = length(aws_security_group.loadbalancer) > 0 ? aws_security_group.node.id : ""
+  value = length(aws_security_group.loadbalancer) > 0 ? aws_security_group.node[0].id : ""
 }
 
 output "security_group_id_ssh_accessible" {
-  value = length(aws_security_group.ssh-accessible) > 0 ? aws_security_group.ssh-accessible.id : ""
+  value = length(aws_security_group.ssh-accessible) > 0 ? aws_security_group.ssh-accessible[0].id : ""
 }

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
@@ -17,7 +17,7 @@ output "additional_security_groups" {
 }
 
 output "load_balancer_security_group" {
-  value = aws_security_group.loadbalancer.id
+  value = aws_security_group.loadbalancer[0].id
 }
 
 output "security_group_id_node" {

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 output "additional_security_groups" {
-  value = length(aws_security_group.node) > 0 ? aws_security_group.node[0].id : ""
+  value = length(aws_security_group.node) > 0 ? aws_security_group.node[0].id : []
 }
 
 output "load_balancer_security_group" {

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 output "additional_security_groups" {
-  value = [aws_security_group.node.id]
+  value = length(aws_security_group.node) > 0 ? aws_security_group.node[0].id : ""
 }
 
 output "load_balancer_security_group" {
@@ -21,9 +21,9 @@ output "load_balancer_security_group" {
 }
 
 output "security_group_id_node" {
-  value = aws_security_group.node.id
+  value = length(aws_security_group.loadbalancer) > 0 ? aws_security_group.node.id : ""
 }
 
 output "security_group_id_ssh_accessible" {
-  value = aws_security_group.ssh-accessible.id
+  value = length(aws_security_group.ssh-accessible) > 0 ? aws_security_group.ssh-accessible.id : ""
 }

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
@@ -17,7 +17,7 @@ output "additional_security_groups" {
 }
 
 output "load_balancer_security_group" {
-  value = aws_security_group.loadbalancer[0].id
+  value = length(aws_security_group.loadbalancer) > 0 ? aws_security_group.loadbalancer[0].id : null
 }
 
 output "security_group_id_node" {

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
@@ -17,7 +17,7 @@ output "additional_security_groups" {
 }
 
 output "load_balancer_security_group" {
-  value = length(aws_security_group.loadbalancer) > 0 ? aws_security_group.loadbalancer[0].id : null
+  value = length(aws_security_group.loadbalancer) > 0 ? aws_security_group.loadbalancer[0].id : ""
 }
 
 output "security_group_id_node" {

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/variables.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/variables.tf
@@ -31,3 +31,8 @@ variable "tags" {
 variable "ssh_allow_list" {
   type = any
 }
+
+variable "disable_default_security_group" {
+  type = bool
+  default = false
+}

--- a/candi/cloud-providers/aws/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/static-node/main.tf
@@ -36,6 +36,7 @@ locals {
 }
 
 data "aws_security_group" "node" {
+  count = var.disable_default_security_group ? 0 : 1
   name = "${var.prefix}-node"
 }
 
@@ -44,7 +45,7 @@ resource "aws_instance" "node" {
   instance_type   = var.node_group.instanceClass.instanceType
   key_name        = var.prefix
   subnet_id       = local.zone_to_subnet_id_map[local.zone]
-  vpc_security_group_ids = concat([data.aws_security_group.node.id], var.additional_security_groups)
+  vpc_security_group_ids = var.disable_default_security_group ? var.additional_security_groups : concat([data.aws_security_group.node[0].id], var.additional_security_groups)
   source_dest_check = false
   associate_public_ip_address = var.associate_public_ip_address
   user_data = var.cloud_config == "" ? "" : base64decode(var.cloud_config)

--- a/candi/cloud-providers/aws/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/aws/terraform-modules/static-node/variables.tf
@@ -16,6 +16,11 @@ variable "prefix" {
   type = string
 }
 
+variable "disable_default_security_group" {
+  type = bool
+  default = false
+}
+
 variable "cluster_uuid" {
   type = string
 }

--- a/candi/cloud-providers/aws/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/aws/terraform-modules/static-node/variables.tf
@@ -25,6 +25,10 @@ variable "cluster_uuid" {
   type = string
 }
 
+variable "ssh_allow_list" {
+  type = any
+}
+
 variable "node_group" {
   type = any
 }

--- a/testing/cloud_layouts/script-commander.sh
+++ b/testing/cloud_layouts/script-commander.sh
@@ -169,7 +169,7 @@ function prepare_environment() {
 
   "AWS")
     ssh_user="ec2-user"
-    cluster_template_id="12618f5b-f8db-462b-8603-5c21d3a0ab62"
+    cluster_template_id="22cb1387-f57c-463d-a43d-b5f0f506272a"
     values="{
       \"branch\": \"${DEV_BRANCH}\",
       \"prefix\": \"a${PREFIX}\",

--- a/testing/cloud_layouts/script-commander.sh
+++ b/testing/cloud_layouts/script-commander.sh
@@ -169,7 +169,7 @@ function prepare_environment() {
 
   "AWS")
     ssh_user="ec2-user"
-    cluster_template_id="22cb1387-f57c-463d-a43d-b5f0f506272a"
+    cluster_template_id="9b567623-91a9-4493-96de-f5c0b6acacfe"
     values="{
       \"branch\": \"${DEV_BRANCH}\",
       \"prefix\": \"a${PREFIX}\",

--- a/testing/cloud_layouts/script-commander.sh
+++ b/testing/cloud_layouts/script-commander.sh
@@ -169,7 +169,7 @@ function prepare_environment() {
 
   "AWS")
     ssh_user="ec2-user"
-    cluster_template_id="9b567623-91a9-4493-96de-f5c0b6acacfe"
+    cluster_template_id="12618f5b-f8db-462b-8603-5c21d3a0ab62"
     values="{
       \"branch\": \"${DEV_BRANCH}\",
       \"prefix\": \"a${PREFIX}\",


### PR DESCRIPTION
## Description
Make the creation of default security groups optional.

## Why do we need it, and what problem does it solve?
https://github.com/deckhouse/deckhouse/issues/9919


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: feature
summary: Make the creation of default security groups optional.
impact_level: default
```
