### PR TITLE
[metallb] Avoid double prefixing in dashboard resources

### DIFF
--- a/ee/se/modules/380-metallb/templates/monitoring.yaml
+++ b/ee/se/modules/380-metallb/templates/monitoring.yaml
@@ -1,6 +1,6 @@
 {{- /* The dashboard will be imported only if the customer enables BGP balancing */ -}}
 {{- if and .Values.metallb.bgpPeers (gt (len .Values.metallb.bgpPeers) 0) }}
-  {{- $resourceName := "d8-metallb-kubernetes-cluster-metallb-bgp" }}
+  {{- $resourceName := "metallb-kubernetes-cluster-metallb-bgp" }}
   {{- $definition := .Files.Get "monitoring/grafana-dashboards/kubernetes-cluster/metallb-bgp.json" }}
   {{- $folder := "Kubernetes Cluster" }}
   {{- include "helm_lib_single_dashboard" (list . $resourceName $folder $definition) }}
@@ -8,14 +8,14 @@
 
 {{- /* The dashboard will be imported only if the customer enables L2 balancing */ -}}
 {{- if and .Values.metallb.internal.l2loadbalancers (gt (len .Values.metallb.internal.l2loadbalancers) 0) }}
-  {{- $resourceName := "d8-metallb-kubernetes-cluster-metallb-l2" }}
+  {{- $resourceName := "metallb-kubernetes-cluster-metallb-l2" }}
   {{- $definition := .Files.Get "monitoring/grafana-dashboards/kubernetes-cluster/metallb-l2.json" }}
   {{- $folder := "Kubernetes Cluster" }}
   {{- include "helm_lib_single_dashboard" (list . $resourceName $folder $definition) }}
 {{- end }}
 
 {{/* Dashboard with a IP pool is always imported */}}
-{{- $resourceName := "d8-metallb-kubernetes-cluster-metallb-pools" }}
+{{- $resourceName := "metallb-kubernetes-cluster-metallb-pools" }}
 {{- $definition := .Files.Get "monitoring/grafana-dashboards/kubernetes-cluster/metallb-pools.json" }}
 {{- $folder := "Kubernetes Cluster" }}
 {{- include "helm_lib_single_dashboard" (list . $resourceName $folder $definition) }}


### PR DESCRIPTION
## Description
`helm_lib_single_dashboard` helper adds the `d8-` to the resource names, so we should avoid using extra prefix while arranging the template

## Why do we need it, and what problem does it solve?
#13478 has the dashboard rename side effect, leading the `ClusterObservabilityDashboard` deploy stuck on the unique dashboard uid constraint.

## Why do we need it in the patch release (if we do)?
Yes, it's better to fix the issue now, until it reaches the stable channels where metallb module is used extensively.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: metallb
type: fix
summary: avoid double prefixes in the dashboard names.
impact: default
```