### PR TITLE
[prometheus] Add .spec.source = deckhouse to prompp ModuleConfig

### DIFF
--- a/modules/300-prometheus/hooks/enable_prompp.go
+++ b/modules/300-prometheus/hooks/enable_prompp.go
@@ -97,6 +97,7 @@ func enablePrompp(input *go_hook.HookInput) error {
 		},
 		"spec": map[string]any{
 			"enabled": true,
+			"source": "deckhouse",
 		},
 	}}
 

--- a/modules/300-prometheus/hooks/enable_prompp.go
+++ b/modules/300-prometheus/hooks/enable_prompp.go
@@ -97,7 +97,7 @@ func enablePrompp(input *go_hook.HookInput) error {
 		},
 		"spec": map[string]any{
 			"enabled": true,
-			"source": "deckhouse",
+			"source":  "deckhouse",
 		},
 	}}
 


### PR DESCRIPTION
## Description
If there are several ModuleSources with the module it's mandatory to specify the correct one in the ModuleConfig, otherwise module will end up in the "Conflict" state and a corresponding alert is emitted. This PR sets the `.spec.source` field of the prompp `ModuleConfig` to "deckhouse" by default avoiding the conflict state.

## Why do we need it, and what problem does it solve?
There are handful of clusters which have several ModuleSources, e.g. for the production and dev modules. The Deckhouse e2e-tests cluster is known to be the one. If there are active alerts in this cluster, e2e tests considered failed.

## Why do we need it in the patch release (if we do)?
Yes, to fix e2e tests

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: fix
summary: use the "deckhouse" ModuleSource as the default for the prompp ModuleConfig
impact: if there are several ModuleSources with the prompp module available, the "deckhouse" ModuleSource will be used.
impact_level: default
```