### PR TITLE
[user-authn] Add custom CA to dexProvider gitlab

### DIFF
--- a/modules/150-user-authn/crds/dex-provider.yaml
+++ b/modules/150-user-authn/crds/dex-provider.yaml
@@ -131,6 +131,18 @@ spec:
                         It is possible for a user to change their own user name but it is very rare for them to do so.
 
                         Equals to false by default.
+                    rootCAData:
+                      type: string
+                      description: |
+                        A CA chain to validate the provider in PEM format.
+                      x-doc-examples:
+                        - |
+                          ```yaml
+                          rootCAData: |
+                            -----BEGIN CERTIFICATE-----
+                            MIIFaDC...
+                            -----END CERTIFICATE-----
+                          ```
                 bitbucketCloud: &bitbucketCloud
                   type: object
                   required: ['clientID', 'clientSecret']

--- a/modules/150-user-authn/images/dex/patches/007-provide-custom-CA-to-gitlab-connector.patch
+++ b/modules/150-user-authn/images/dex/patches/007-provide-custom-CA-to-gitlab-connector.patch
@@ -1,5 +1,5 @@
 diff --git a/connector/gitlab/gitlab.go b/connector/gitlab/gitlab.go
-index 7aa44398..3b91bdf6 100644
+index 7aa44398..de3bc040 100644
 --- a/connector/gitlab/gitlab.go
 +++ b/connector/gitlab/gitlab.go
 @@ -3,6 +3,9 @@ package gitlab
@@ -27,7 +27,7 @@ index 7aa44398..3b91bdf6 100644
 +
 +	var httpClient *http.Client
 +	if len(c.RootCAData) > 0 {
-+		fmt.Printf("Using root CA data: %s\n", base64.StdEncoding.EncodeToString(c.RootCAData))
++		logger.Info("config refresh tokens rotation", base64.StdEncoding.EncodeToString(c.RootCAData))
 +		caCert, err := base64.StdEncoding.DecodeString(string(c.RootCAData))
 +		if err != nil {
 +			return nil, fmt.Errorf("failed to decode Base64 CA certificate: %v", err)

--- a/modules/150-user-authn/images/dex/patches/007-provide-custom-CA-to-gitlab-connector.patch
+++ b/modules/150-user-authn/images/dex/patches/007-provide-custom-CA-to-gitlab-connector.patch
@@ -1,18 +1,17 @@
 diff --git a/connector/gitlab/gitlab.go b/connector/gitlab/gitlab.go
-index 7aa44398..de3bc040 100644
+index 7aa44398..36152483 100644
 --- a/connector/gitlab/gitlab.go
 +++ b/connector/gitlab/gitlab.go
-@@ -3,6 +3,9 @@ package gitlab
+@@ -3,6 +3,8 @@ package gitlab
 
  import (
  	"context"
 +	"crypto/tls"
 +	"crypto/x509"
-+	"encoding/base64"
  	"encoding/json"
  	"errors"
  	"fmt"
-@@ -35,6 +38,7 @@ type Config struct {
+@@ -35,6 +37,7 @@ type Config struct {
  	Groups              []string `json:"groups"`
  	UseLoginAsID        bool     `json:"useLoginAsID"`
  	GetGroupsPermission bool     `json:"getGroupsPermission"`
@@ -20,18 +19,14 @@ index 7aa44398..de3bc040 100644
  }
 
  type gitlabUser struct {
-@@ -51,6 +55,33 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
+@@ -51,6 +54,29 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
  	if c.BaseURL == "" {
  		c.BaseURL = "https://gitlab.com"
  	}
 +
 +	var httpClient *http.Client
 +	if len(c.RootCAData) > 0 {
-+		logger.Info("config refresh tokens rotation", base64.StdEncoding.EncodeToString(c.RootCAData))
-+		caCert, err := base64.StdEncoding.DecodeString(string(c.RootCAData))
-+		if err != nil {
-+			return nil, fmt.Errorf("failed to decode Base64 CA certificate: %v", err)
-+		}
++		caCert := c.RootCAData
 +
 +		caCertPool := x509.NewCertPool()
 +		if !caCertPool.AppendCertsFromPEM(caCert) {
@@ -54,7 +49,7 @@ index 7aa44398..de3bc040 100644
  	return &gitlabConnector{
  		baseURL:             c.BaseURL,
  		redirectURI:         c.RedirectURI,
-@@ -60,6 +91,7 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
+@@ -60,6 +86,7 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
  		groups:              c.Groups,
  		useLoginAsID:        c.UseLoginAsID,
  		getGroupsPermission: c.GetGroupsPermission,

--- a/modules/150-user-authn/images/dex/patches/007-provide-custom-CA-to-gitlab-connector.patch
+++ b/modules/150-user-authn/images/dex/patches/007-provide-custom-CA-to-gitlab-connector.patch
@@ -1,5 +1,5 @@
 diff --git a/connector/gitlab/gitlab.go b/connector/gitlab/gitlab.go
-index 7aa44398..471b6d54 100644
+index 7aa44398..3b91bdf6 100644
 --- a/connector/gitlab/gitlab.go
 +++ b/connector/gitlab/gitlab.go
 @@ -3,6 +3,9 @@ package gitlab
@@ -27,7 +27,7 @@ index 7aa44398..471b6d54 100644
 +
 +	var httpClient *http.Client
 +	if len(c.RootCAData) > 0 {
-+
++		fmt.Printf("Using root CA data: %s\n", base64.StdEncoding.EncodeToString(c.RootCAData))
 +		caCert, err := base64.StdEncoding.DecodeString(string(c.RootCAData))
 +		if err != nil {
 +			return nil, fmt.Errorf("failed to decode Base64 CA certificate: %v", err)

--- a/modules/150-user-authn/images/dex/patches/007-provide-custom-CA-to-gitlab-connector.patch
+++ b/modules/150-user-authn/images/dex/patches/007-provide-custom-CA-to-gitlab-connector.patch
@@ -1,0 +1,67 @@
+diff --git a/connector/gitlab/gitlab.go b/connector/gitlab/gitlab.go
+index 7aa44398..471b6d54 100644
+--- a/connector/gitlab/gitlab.go
++++ b/connector/gitlab/gitlab.go
+@@ -3,6 +3,9 @@ package gitlab
+
+ import (
+ 	"context"
++	"crypto/tls"
++	"crypto/x509"
++	"encoding/base64"
+ 	"encoding/json"
+ 	"errors"
+ 	"fmt"
+@@ -35,6 +38,7 @@ type Config struct {
+ 	Groups              []string `json:"groups"`
+ 	UseLoginAsID        bool     `json:"useLoginAsID"`
+ 	GetGroupsPermission bool     `json:"getGroupsPermission"`
++	RootCAData          []byte   `json:"rootCAData"`
+ }
+
+ type gitlabUser struct {
+@@ -51,6 +55,33 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
+ 	if c.BaseURL == "" {
+ 		c.BaseURL = "https://gitlab.com"
+ 	}
++
++	var httpClient *http.Client
++	if len(c.RootCAData) > 0 {
++
++		caCert, err := base64.StdEncoding.DecodeString(string(c.RootCAData))
++		if err != nil {
++			return nil, fmt.Errorf("failed to decode Base64 CA certificate: %v", err)
++		}
++
++		caCertPool := x509.NewCertPool()
++		if !caCertPool.AppendCertsFromPEM(caCert) {
++			return nil, fmt.Errorf("failed to parse CA certificate")
++		}
++
++		tlsConfig := &tls.Config{
++			RootCAs: caCertPool,
++		}
++		transport := &http.Transport{
++			TLSClientConfig: tlsConfig,
++		}
++		httpClient = &http.Client{
++			Transport: transport,
++		}
++	} else {
++		httpClient = http.DefaultClient
++	}
++
+ 	return &gitlabConnector{
+ 		baseURL:             c.BaseURL,
+ 		redirectURI:         c.RedirectURI,
+@@ -60,6 +91,7 @@ func (c *Config) Open(id string, logger *slog.Logger) (connector.Connector, erro
+ 		groups:              c.Groups,
+ 		useLoginAsID:        c.UseLoginAsID,
+ 		getGroupsPermission: c.GetGroupsPermission,
++		httpClient:          httpClient,
+ 	}, nil
+ }
+
+--
+2.39.5 (Apple Git-154)
+

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -33,3 +33,7 @@ Upstream PR: https://github.com/dexidp/dex/pull/3712
 This patch fixes the issue with the `insecureSkipVerify` and `rootCAs` options which do not work in OIDC connector.
 
 Upstream PR: https://github.com/dexidp/dex/pull/4223
+
+### 007-provide-custom-CA-to-gitlab-connector.patch
+
+This patch allows Gitlab connector to use custom CA for HTTPS connections.

--- a/modules/150-user-authn/templates/dex/config.yaml
+++ b/modules/150-user-authn/templates/dex/config.yaml
@@ -95,6 +95,9 @@
           {{- end }}
         {{- end }}
       {{- end }}
+        {{- if $provider.gitlab.rootCAData }}
+        rootCAData: {{ $provider.gitlab.rootCAData | b64enc }}
+        {{- end }}
 
       {{- if eq $provider.type "BitbucketCloud" }}
     - type: bitbucket-cloud

--- a/modules/150-user-authn/templates/dex/config.yaml
+++ b/modules/150-user-authn/templates/dex/config.yaml
@@ -94,10 +94,10 @@
         - {{ $group | quote }}
           {{- end }}
         {{- end }}
-      {{- end }}
         {{- if $provider.gitlab.rootCAData }}
         rootCAData: {{ $provider.gitlab.rootCAData | b64enc }}
         {{- end }}
+      {{- end }}
 
       {{- if eq $provider.type "BitbucketCloud" }}
     - type: bitbucket-cloud


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Adds support for a custom CA for the gitlab provider dex, this is necessary to support self-hosted solutions in a closed environment.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
If you use self-hosted gitlab as well as your own certificate authority, you must provide a root certificate for tls verification used gitlab instance.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: feature
summary: Adds support for a custom CA for the gitlab provider dex
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
