### PR TITLE
[admission-policy-engine] Fix ValidatingAdmissionPolicy with skip-pss-label

### DIFF
--- a/modules/015-admission-policy-engine/templates/admission.yaml
+++ b/modules/015-admission-policy-engine/templates/admission.yaml
@@ -16,7 +16,8 @@ spec:
     - name: 'exclude-virtualization'
       expression: '!(request.userInfo.groups.exists(e, (e == "system:serviceaccounts:d8-virtualization")))'
     - name: 'exclude-existing-label'
-      expression: "object.metadata.labels['security.deckhouse.io/skip-pss-check'] != oldObject.metadata.labels['security.deckhouse.io/skip-pss-check']"
+      expression: "has(object.metadata.labels) && ('security.deckhouse.io/skip-pss-check' in object.metadata.labels) &&
+       object.metadata.labels['security.deckhouse.io/skip-pss-check'] != oldObject.metadata.labels['security.deckhouse.io/skip-pss-check']"
   validations:
     - expression: >-
         (!has(object.metadata.labels) ||

--- a/modules/015-admission-policy-engine/templates/admission.yaml
+++ b/modules/015-admission-policy-engine/templates/admission.yaml
@@ -15,11 +15,18 @@ spec:
   matchConditions:
     - name: 'exclude-virtualization'
       expression: '!(request.userInfo.groups.exists(e, (e == "system:serviceaccounts:d8-virtualization")))'
-    - name: 'exclude-existing-label'
+    - name: exclude-existing-label
       expression: >
         (
-          (has(object.metadata.labels) && 'security.deckhouse.io/skip-pss-check' in object.metadata.labels ? object.metadata.labels['security.deckhouse.io/skip-pss-check'] : '') !=
-          (has(oldObject.metadata.labels) && 'security.deckhouse.io/skip-pss-check' in oldObject.metadata.labels ? oldObject.metadata.labels['security.deckhouse.io/skip-pss-check'] : '')
+          (has(object.metadata) && has(object.metadata.labels) && 'security.deckhouse.io/skip-pss-check' in object.metadata.labels
+            ? object.metadata.labels['security.deckhouse.io/skip-pss-check']
+            : ''
+          )
+          !=
+          (has(oldObject.metadata) && has(oldObject.metadata.labels) && 'security.deckhouse.io/skip-pss-check' in oldObject.metadata.labels
+            ? oldObject.metadata.labels['security.deckhouse.io/skip-pss-check']
+            : ''
+          )
         )
   validations:
     - expression: >-

--- a/modules/015-admission-policy-engine/templates/admission.yaml
+++ b/modules/015-admission-policy-engine/templates/admission.yaml
@@ -16,8 +16,7 @@ spec:
     - name: 'exclude-virtualization'
       expression: '!(request.userInfo.groups.exists(e, (e == "system:serviceaccounts:d8-virtualization")))'
     - name: 'exclude-existing-label'
-      expression: "has(object.metadata.labels) && ('security.deckhouse.io/skip-pss-check' in object.metadata.labels) &&
-       object.metadata.labels['security.deckhouse.io/skip-pss-check'] != oldObject.metadata.labels['security.deckhouse.io/skip-pss-check']"
+      expression: "object.metadata.labels['security.deckhouse.io/skip-pss-check'] != oldObject.metadata.labels['security.deckhouse.io/skip-pss-check']"
   validations:
     - expression: >-
         (!has(object.metadata.labels) ||

--- a/modules/015-admission-policy-engine/templates/admission.yaml
+++ b/modules/015-admission-policy-engine/templates/admission.yaml
@@ -16,9 +16,11 @@ spec:
     - name: 'exclude-virtualization'
       expression: '!(request.userInfo.groups.exists(e, (e == "system:serviceaccounts:d8-virtualization")))'
     - name: 'exclude-existing-label'
-      expression: "has(object.metadata.labels) && has(oldObject.metadata.labels) &&
-       ('security.deckhouse.io/skip-pss-check' in object.metadata.labels) && ('security.deckhouse.io/skip-pss-check' in oldObject.metadata.labels) &&
-       object.metadata.labels['security.deckhouse.io/skip-pss-check'] != oldObject.metadata.labels['security.deckhouse.io/skip-pss-check']"
+      expression: >
+        (
+          (has(object.metadata.labels) && 'security.deckhouse.io/skip-pss-check' in object.metadata.labels ? object.metadata.labels['security.deckhouse.io/skip-pss-check'] : '') !=
+          (has(oldObject.metadata.labels) && 'security.deckhouse.io/skip-pss-check' in oldObject.metadata.labels ? oldObject.metadata.labels['security.deckhouse.io/skip-pss-check'] : '')
+        )
   validations:
     - expression: >-
         (!has(object.metadata.labels) ||

--- a/modules/015-admission-policy-engine/templates/admission.yaml
+++ b/modules/015-admission-policy-engine/templates/admission.yaml
@@ -16,7 +16,8 @@ spec:
     - name: 'exclude-virtualization'
       expression: '!(request.userInfo.groups.exists(e, (e == "system:serviceaccounts:d8-virtualization")))'
     - name: 'exclude-existing-label'
-      expression: "has(object.metadata.labels) && ('security.deckhouse.io/skip-pss-check' in object.metadata.labels) &&
+      expression: "has(object.metadata.labels) && has(oldObject.metadata.labels) &&
+       ('security.deckhouse.io/skip-pss-check' in object.metadata.labels) && ('security.deckhouse.io/skip-pss-check' in oldObject.metadata.labels) &&
        object.metadata.labels['security.deckhouse.io/skip-pss-check'] != oldObject.metadata.labels['security.deckhouse.io/skip-pss-check']"
   validations:
     - expression: >-

--- a/modules/015-admission-policy-engine/templates/admission.yaml
+++ b/modules/015-admission-policy-engine/templates/admission.yaml
@@ -15,6 +15,9 @@ spec:
   matchConditions:
     - name: 'exclude-virtualization'
       expression: '!(request.userInfo.groups.exists(e, (e == "system:serviceaccounts:d8-virtualization")))'
+    - name: 'exclude-existing-label'
+      expression: "has(object.metadata.labels) && ('security.deckhouse.io/skip-pss-check' in object.metadata.labels) &&
+       object.metadata.labels['security.deckhouse.io/skip-pss-check'] != oldObject.metadata.labels['security.deckhouse.io/skip-pss-check']"
   validations:
     - expression: >-
         (!has(object.metadata.labels) ||


### PR DESCRIPTION
## Description
Exclude pods check if skip-pss-check is not changed. These pods were not allowed to even change an annotations

## Why do we need it, and what problem does it solve?
Before
pod with pss-check label exists
```shell
❯ kubectl -n default get pods nginx-deployment-b67576676-f8pzn -o jsonpath='{.metadata.labels}' | jq .
{
  "app": "nginx",
  "pod-template-hash": "b67576676",
  "security.deckhouse.io/skip-pss-check": "true"
}
```

try to annotate the pod:
```shell
❯ kubectl -n default annotate pods nginx-deployment-b67576676-f8pzn a=b
The pods "nginx-deployment-b67576676-f8pzn" is invalid: : ValidatingAdmissionPolicy 'deny-pods-with-skip-pss-label' with binding 'deny-skip-pss-label-binding' denied request: Pods with label 'security.deckhouse.io/skip-pss-check=true' are not allowed
```

After:

```shell
❯ kubectl -n default annotate pods nginx-deployment-b67576676-f8pzn a=b
pod/nginx-deployment-b67576676-f8pzn annotated
```

remove all labels and annotations:
```shell
❯ kubectl patch pod nginx-deployment-b67576676-f8pzn -n default --type='json' -p='[
  {"op": "remove", "path": "/metadata/annotations"},
  {"op": "remove", "path": "/metadata/labels"}
]'
pod/nginx-deployment-b67576676-f8pzn patched
```

add annotation
```shell
❯ kubectl -n default annotate pods nginx-deployment-b67576676-f8pzn a=b
pod/nginx-deployment-b67576676-f8pzn annotated
```

try to add forbidden label:
```shell
❯ kubectl -n default label pod nginx-deployment-b67576676-f8pzn security.deckhouse.io/skip-pss-check=true
The pods "nginx-deployment-b67576676-f8pzn" is invalid: : ValidatingAdmissionPolicy 'deny-pods-with-skip-pss-label' with binding 'deny-skip-pss-label-binding' denied request: Pods with label 'security.deckhouse.io/skip-pss-check=true' are not allowed
```

```shell
❯ kubectl -n default label pod nginx-deployment-b67576676-f8pzn security.deckhouse.io/skip-pss-check=false
pod/nginx-deployment-b67576676-f8pzn labeled
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: fix 
summary: Fix validation policy for pods with skip-pss-check labels
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
