### PR TITLE
[candi] containerd migration fix

### DIFF
--- a/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
@@ -20,6 +20,9 @@ _on_containerd_config_changed() {
 
 migrate() {
   bb-log-info "start containerd migration"
+  systemctl stop kubelet.service
+  bb-flag-set kubelet-need-restart
+  crictl ps -q | xargs -r crictl stop -t 0 && crictl ps -a -q | xargs -r crictl rm -f
   systemctl stop containerd-deckhouse.service
   for i in $(mount | grep /var/lib/containerd | cut -d " " -f3); do umount $i; done
   if [ -d /var/lib/containerd/io.containerd.snapshotter.v1.erofs ]; then

--- a/candi/bashible/common-steps/all/076_install_d8_shutdown_inhibitor.sh.tpl
+++ b/candi/bashible/common-steps/all/076_install_d8_shutdown_inhibitor.sh.tpl
@@ -107,6 +107,7 @@ function inhibitor::start() {
   if bb-flag? reboot; then
     exit 0
   fi
+  bb-event-fire 'restart-inhibitor-if-needed'  
 
   # Do nothing if already started.
   if systemctl is-active --quiet "${inhibitor_service_name}"; then

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/scripts/d8-shutdown-inhibitor.service
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/scripts/d8-shutdown-inhibitor.service
@@ -6,6 +6,7 @@ After=network-online.target kubelet.service containerd-deckhouse.service
 
 [Service]
 Environment="PATH=/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
+ExecStartPre=/bin/bash -c 'until echo >/dev/tcp/127.0.0.1/6445; do sleep 1; done'
 ExecStart=/opt/deckhouse/bin/d8-shutdown-inhibitor
 Restart=always
 StartLimitInterval=0

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/scripts/d8-shutdown-inhibitor.service
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/scripts/d8-shutdown-inhibitor.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Shutdown inhibitor to allow manual Pod eviction
 Documentation=https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/node-manager/
-Wants=network-online.target
-After=network-online.target
+Wants=network-online.target kubelet.service containerd-deckhouse.service
+After=network-online.target kubelet.service containerd-deckhouse.service
 
 [Service]
 Environment="PATH=/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/app.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/app.go
@@ -106,6 +106,7 @@ func (a *App) wireAppTasks() []taskstarter.Task {
 	shutdownSignalCh := make(chan struct{})
 	// Event to unlock all inhibitors when shutdown requirements are met.
 	unlockInhibitorsCh := make(chan struct{})
+	startCordonCh := make(chan struct{})
 
 	return []taskstarter.Task{
 		&tasks.ShutdownInhibitor{
@@ -123,6 +124,7 @@ func (a *App) wireAppTasks() []taskstarter.Task {
 			PodsCheckingInterval:  a.config.PodsCheckingInterval,
 			WallBroadcastInterval: a.config.WallBroadcastInterval,
 			ShutdownSignalCh:      shutdownSignalCh,
+			StartCordonCh:         startCordonCh,
 			StopInhibitorsCh:      unlockInhibitorsCh,
 			PodMatchers: []kubernetes.PodMatcher{
 				kubernetes.WithLabel(a.config.PodLabel),
@@ -130,8 +132,9 @@ func (a *App) wireAppTasks() []taskstarter.Task {
 			},
 		},
 		&tasks.NodeCordoner{
-			NodeName:         a.config.NodeName,
-			ShutdownSignalCh: shutdownSignalCh,
+			NodeName:           a.config.NodeName,
+			StartCordonCh:      startCordonCh,
+			UnlockInhibitorsCh: unlockInhibitorsCh,
 		},
 		&tasks.NodeConditionSetter{
 			NodeName:           a.config.NodeName,

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/nodecondition/graceful_shutdown_postpone.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/nodecondition/graceful_shutdown_postpone.go
@@ -133,15 +133,15 @@ func uncordonOnStart(nodeName string) error {
 	// 3. isInhibitorShutdownActive?
 	podsPresentCondition, _ := k.GetCondition(nodeName, ReasonPodsArePresent)
 	isInhibited := isShutdownInhibitedByPods(podsPresentCondition)
-	fmt.Printf("uncordonOnStart: shutdownIsActive %t\n", isInhibited)
+	fmt.Printf("uncordonOnStart: isInhibited %t\n", isInhibited)
 
 	if !isReady && isInhibited {
 		fmt.Println("uncordonOnStart: Node is NotReady and a valid shutdown signal is active. Holding cordon")
 		return nil
 	}
-	if isReady && !isInhibited {
+	if isReady {
 		fmt.Println("uncordonOnStart: uncordonAndCleanup")
-		// 4. Uncordon: Node is Ready and shutdown inhibition is not active.
+		// 4. Uncordon
 		return uncordonAndCleanup(k, nodeName)
 	}
 	return nil

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/nodecondition/graceful_shutdown_postpone.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/nodecondition/graceful_shutdown_postpone.go
@@ -57,51 +57,90 @@ func patchGracefulShutdownPostponeCondition(nodeName, status, reason string) err
 	return reformatExitError(err)
 }
 
-func uncordonOnStart(nodeName string) error {
-	k := kubernetes.NewDefaultKubectl()
-
-	podArePresentCondition, err := k.GetCondition(nodeName, ReasonPodsArePresent)
-	if err != nil {
-		return reformatExitError(err)
-	}
-
-	// hold cordon if inhibitor is already in shutdown state
-	if podArePresentCondition != nil &&
-		podArePresentCondition.Status == "True" &&
-		podArePresentCondition.Type == GracefulShutdownPostponeType &&
-		podArePresentCondition.Reason == ReasonPodsArePresent {
-		return nil
-	}
-
+func nodeIsReady(k *kubernetes.Kubectl, nodeName string) (bool, error) {
 	nodeNotReadyCondition, err := k.GetCondition(nodeName, "KubeletNotReady")
 	if err != nil {
-		return reformatExitError(err)
+		return false, reformatExitError(err)
 	}
-
-	// wait until node is ready
 	if nodeNotReadyCondition != nil &&
 		nodeNotReadyCondition.Status == "False" &&
 		nodeNotReadyCondition.Type == "Ready" &&
 		nodeNotReadyCondition.Reason == "KubeletNotReady" {
-		return fmt.Errorf("node %q is not ready", nodeName)
+		return false, fmt.Errorf("node %q is not ready", nodeName)
 	}
+	return true, nil
+}
 
+func cordonedByInhibitor(k *kubernetes.Kubectl, nodeName string) (bool, error) {
 	cordonBy, err := k.GetAnnotationCordonedBy(nodeName)
 	if err != nil {
-		return reformatExitError(err)
+		fmt.Printf("uncordonOnStart: error getting cordonBy annotation: %v\n", err)
+		return false, reformatExitError(err)
 	}
 
 	if cordonBy == kubernetes.CordonAnnotationValue {
-		// check that 'cordon' was set by inhibitor.
-		if _, err := k.Uncordon(nodeName); err != nil {
-			return reformatExitError(err)
-		}
-		if _, err := k.RemoveCordonAnnotation(nodeName); err != nil {
-			return reformatExitError(err)
-		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func uncordonAndCleanup(k *kubernetes.Kubectl, nodeName string) error {
+	if _, err := k.Uncordon(nodeName); err != nil {
+		fmt.Printf("uncordonAndCleanup: error during Uncordon: %v\n", err)
+		return reformatExitError(err)
 	}
 
+	if _, err := k.RemoveCordonAnnotation(nodeName); err != nil {
+		fmt.Printf("uncordonAndCleanup: error removing cordon annotation: %v\n", err)
+		return reformatExitError(err)
+	}
 	return nil
+}
+
+func isGracefulShutdownPostpone(condition *kubernetes.Condition) bool {
+	fmt.Printf("isGracefulShutdownPostpone: condition=%+v\n", condition)
+	if condition == nil {
+		return false
+	}
+	return condition.Status == "True" &&
+		condition.Type == GracefulShutdownPostponeType &&
+		condition.Reason == ReasonPodsArePresent
+}
+
+func uncordonOnStart(nodeName string) error {
+	fmt.Printf("uncordonOnStart: start for node %q\n", nodeName)
+	k := kubernetes.NewDefaultKubectl()
+
+	// 1 isOurCordon?
+	isOurCordon, err := cordonedByInhibitor(k, nodeName)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("uncordonOnStart: isOurCordon %t\n", isOurCordon)
+
+	if !isOurCordon {
+		fmt.Println("uncordonOnStart: Node is not cordoned by inhibitor. No action needed")
+		return nil
+	}
+
+	// 1 nodeIsReady?
+	isReady, err := nodeIsReady(k, nodeName)
+	if err != nil {
+		isReady = false
+	}
+	fmt.Printf("uncordonOnStart: isReady %t\n", isReady)
+
+	// 3 isInhibitorShutdownActive?
+	podArePresentCondition, _ := k.GetCondition(nodeName, ReasonPodsArePresent)
+	shutdownIsActive := isGracefulShutdownPostpone(podArePresentCondition)
+	fmt.Printf("uncordonOnStart: shutdownIsActive %t\n", shutdownIsActive)
+
+	if !isReady && shutdownIsActive {
+		fmt.Println("uncordonOnStart: Node is NotReady and a valid shutdown signal is active. Holding cordon")
+		return nil
+	}
+	fmt.Println("uncordonOnStart: uncordonAndCleanup")
+	return uncordonAndCleanup(k, nodeName)
 }
 
 func reformatExitError(err error) error {

--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -150,7 +150,7 @@ type updateApprover struct {
 }
 
 func calculateConcurrency(ngCon *intstr.IntOrString, totalNodes int) int {
-	var concurrency = 1
+	concurrency := 1
 	switch ngCon.Type {
 	case intstr.Int:
 		concurrency = ngCon.IntValue()
@@ -218,7 +218,7 @@ func (ar *updateApprover) approveUpdates(input *go_hook.HookInput) error {
 
 		//     Allow one node, if 100% nodes in NodeGroup are ready
 		if ng.Status.Desired == ng.Status.Ready || ng.NodeType != ngv1.NodeTypeCloudEphemeral {
-			var allReady = true
+			allReady := true
 			for _, ngn := range nodeGroupNodes {
 				if !ngn.IsReady {
 					allReady = false
@@ -296,7 +296,7 @@ func (ar *updateApprover) approveDisruptions(input *go_hook.HookInput) error {
 		if !node.IsApproved {
 			continue
 		}
-		if node.IsDraining || (!node.IsDisruptionRequired && !node.IsRollingUpdate) {
+		if node.IsDraining || (!node.IsDisruptionRequired && !node.IsRollingUpdate) || node.IsDisruptionApproved {
 			continue
 		}
 


### PR DESCRIPTION
## Description

fixed containerd migration v1 <> v2
Related to:  https://github.com/deckhouse/deckhouse/pull/12674 https://github.com/deckhouse/deckhouse/pull/14370

## Why do we need it, and what problem does it solve?

- Added forced stopping and deleting of all containers. Stopping containerd-deckhouse.service is not guaranteed to stop containers. Especially relevant for single-master installations

- Minor fix in `modules/040-node-manager/hooks/update_approval.go` -  skip draining node if the annotation `update.node.deckhouse.io/disruption-approved=` is set

- Minor fix in the inhibitor - now it only launches nodeCordon if pods with the label `pod.deckhouse.io/inhibit-node-shutdown` are detected on the node.

- Minor fix in the  Inhibitor (candi) - it now restarts after update

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi, node-manager
type: fix
summary: containerd migration fix
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
