### PR TITLE
[500-cilium-hubble] Define stage to module.yaml

### DIFF
--- a/modules/500-cilium-hubble/module.yaml
+++ b/modules/500-cilium-hubble/module.yaml
@@ -1,4 +1,5 @@
 name: cilium-hubble
+stage: "General Availability"
 subsystems:
   - networking
 namespace: d8-cni-cilium


### PR DESCRIPTION
## Description
Added the `stage` field to the `module.yaml` of 500-cilium-hubble module.

This metadata field explicitly declares the [lifecycle stage](https://deckhouse.io/products/kubernetes-platform/documentation/v1/module-development/versioning/#how-do-i-figure-out-how-stable-a-module-is) of each network module. It improves clarity and helps consumers of the module (both internal tools and users) make informed decisions regarding stability, risk, and expected support level.


## Why do we need it, and what problem does it solve?
Currently, there is no consistent way to determine the maturity or readiness level of a module from its metadata. This creates ambiguity for both users and automated tooling when evaluating which modules are safe to use in production environments.

✅ This change introduces no runtime behavior modifications and is fully backward compatible.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cilium-hubble
type: chore
summary: Added the `stage` field to the `module.yaml` of 500-cilium-hubble module
impact_level: low
```