### PR TITLE
[docs] Added bracket escaping for d8 reference generator

### DIFF
--- a/docs/documentation/_plugins/reference_generator.rb
+++ b/docs/documentation/_plugins/reference_generator.rb
@@ -66,6 +66,11 @@ module ReferenceGenerator
       signature = "d8 #{full_path}" unless parent_titles.empty?
       prepare_signature(signature) if signature
     end
+    
+    # Escape `{{...}}`
+    def escape_liquid_tags(text)
+      text.gsub(/\{\{(.*?)\}\}/) { |match| "{% raw %}#{match}{% endraw %}" }
+    end
 
     def render_flags(flags, depth)
       return '' unless flags && flags.size > 0
@@ -100,9 +105,10 @@ module ReferenceGenerator
     end
 
     def render_flag_item(flag_name, flag_data)
+      description = escape_liquid_tags(flag_data['description'])
       result = %Q(<li><code>--#{flag_name}</code>)
       result += %Q(, <code>-#{flag_data['shorthand']}</code>) if flag_data['shorthand'].to_s.size > 0
-      result += %Q(<div style="white-space: pre-wrap; margin: 0.5em 0 0 0; line-height: 1.7em;">#{flag_data['description']}</div></li>)
+      result += %Q(<div style="white-space: pre-wrap; margin: 0.5em 0 0 0; line-height: 1.7em;">#{description}</div></li>)
     end
 
     def renderD8Section(data, depth, parent_titles)
@@ -126,7 +132,10 @@ module ReferenceGenerator
         end
       end
 
-      result += "<p>#{data['description']}</p>\n" if data['description']
+      if data['description']
+        description = escape_liquid_tags(data['description'])
+        result += "<p>#{description}</p>\n"
+      end
 
       # Render flags
       result += render_flags(data['flags'], depth) if data['flags'] && data['flags'].size > 0


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added bracket escaping for d8 reference generator.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Added bracket escaping for d8 reference generator.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
