### PR TITLE
[cilium] Disabling cni-exclusive when sdn module is enabled

### DIFF
--- a/modules/021-cni-cilium/hooks/discovery_cni_exclusive.go
+++ b/modules/021-cni-cilium/hooks/discovery_cni_exclusive.go
@@ -65,7 +65,11 @@ func daemonsetFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, erro
 func discoveryIsExclusiveCNIPluginEnabled(input *go_hook.HookInput) error {
 	istioCniDaemonSets := input.NewSnapshots.Get("istio-cni-daemonset")
 	sdnCniDaemonSets := input.NewSnapshots.Get("sdn-cni-daemonset")
-	isEnabled := len(istioCniDaemonSets) != 0 || len(sdnCniDaemonSets) != 0
-	input.Values.Set("cniCilium.internal.exclusiveCNIPlugin", isEnabled)
+	if len(istioCniDaemonSets) != 0 || len(sdnCniDaemonSets) != 0 {
+		input.Values.Set("cniCilium.internal.exclusiveCNIPlugin", false)
+	} else {
+		eCNIP := input.Values.Get("cniCilium.exclusiveCNIPlugin")
+		input.Values.Set("cniCilium.internal.exclusiveCNIPlugin", eCNIP)
+	}
 	return nil
 }

--- a/modules/021-cni-cilium/openapi/values.yaml
+++ b/modules/021-cni-cilium/openapi/values.yaml
@@ -10,7 +10,7 @@ properties:
         type: boolean
         default: false
         description: |
-          The switch indicates whether cni-exclusive feature of cilium agent must be disabled in the cluster.
+          The switch indicates whether cni-exclusive feature of cilium agent must be enabled in the cluster.
       minimalRequiredKernelVersionConstraint:
         type: string
         description: |

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -167,11 +167,7 @@ data:
 
   write-cni-conf-when-ready: /host/etc/cni/net.d/05-cilium.conflist
 
-  {{- if .Values.cniCilium.internal.exclusiveCNIPlugin }}
-  cni-exclusive: "false"
-  {{- else }}
-  cni-exclusive: {{ .Values.cniCilium.exclusiveCNIPlugin | quote }}
-  {{- end }}
+  cni-exclusive: {{ .Values.cniCilium.internal.exclusiveCNIPlugin | quote }}
 
   skip-crd-creation: "true"
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added hook for disable cni-exclusive when sdn agent daemonset was discovered.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Automate cilium agent configuration when deploying sdn module in cluster.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: feature
summary: Added hook for disable cni-exclusive when sdn agent daemonset was discovered.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
