### PR TITLE
[Registry] Fixed enable script

### DIFF
--- a/modules/038-registry/enabled
+++ b/modules/038-registry/enabled
@@ -27,15 +27,17 @@ function __main__() {
   #    and the module must not be enabled.
   #    This check is consistent with the validation performed by the control-plane-manager on startup.
 
-  # 2. global.clusterConfiguration.defaultCRI is set and not equal to "NotManaged" —
-  #    the module depends on Deckhouse being able to manage Containerd settings.
+  # 2. global.clusterConfiguration.defaultCRI is set and is in the allowed list
+  #    of container runtimes the module supports.
 
   if values::has global.clusterConfiguration && values::has global.clusterConfiguration.defaultCRI; then
     containerd_mode=$(values::get global.clusterConfiguration.defaultCRI)
 
-    if [ "$containerd_mode" != "NotManaged" ]; then
-      echo "true" >"$MODULE_ENABLED_RESULT"
-    fi
+    case "$containerd_mode" in
+      "Containerd" | "ContainerdV2")
+        echo "true" >"$MODULE_ENABLED_RESULT"
+        ;;
+    esac
   fi
 }
 

--- a/modules/038-registry/enabled
+++ b/modules/038-registry/enabled
@@ -15,16 +15,27 @@
 # limitations under the License.
 
 source /deckhouse/shell_lib.sh
-# The Registry module runs only in Deckhouse-managed clusters.
-# It is not supported in cloud-managed environments like AWS, Yandex Cloud, etc.
-# Enablement is based on the presence of global.clusterConfiguration.
-# Its absence means the cluster is externally managed and the module will be disabled.
-# This check is similar to the one performed during the startup of the control-plane-manager.
+
 function __main__() {
-  if values::has global.clusterConfiguration ; then
-    echo "true" > "$MODULE_ENABLED_RESULT"
-  else
-    echo "false" > "$MODULE_ENABLED_RESULT"
+  # By default, the module is disabled
+  echo "false" >"$MODULE_ENABLED_RESULT"
+
+  # Enable the module only if all of the following conditions are met:
+
+  # 1. global.clusterConfiguration exists — this indicates that the cluster is managed by Deckhouse.
+  #    If it's missing, the cluster is considered externally managed (e.g., AWS, Yandex Cloud),
+  #    and the module must not be enabled.
+  #    This check is consistent with the validation performed by the control-plane-manager on startup.
+
+  # 2. global.clusterConfiguration.defaultCRI is set and not equal to "NotManaged" —
+  #    the module depends on Deckhouse being able to manage Containerd settings.
+
+  if values::has global.clusterConfiguration && values::has global.clusterConfiguration.defaultCRI; then
+    containerd_mode=$(values::get global.clusterConfiguration.defaultCRI)
+
+    if [ "$containerd_mode" != "NotManaged" ]; then
+      echo "true" >"$MODULE_ENABLED_RESULT"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Description

Enable the module only if all of the following conditions are met:

1. global.clusterConfiguration exists — this indicates that the cluster is managed by Deckhouse.

2. global.clusterConfiguration.defaultCRI is set and is in the allowed list of container runtimes the module supports.

## Examples

### **`defaultCRI: Containerd`**:
<img width="1056" height="465" alt="image" src="https://github.com/user-attachments/assets/5a89cbb3-bdc1-47bd-a854-f61b8f65396d" />

### **`defaultCRI: ContainerdV2`**:
<img width="1052" height="618" alt="image" src="https://github.com/user-attachments/assets/1d3be3b0-40ff-4017-8c45-8be9d66a7206" />

### **`static node with defaultCRI: NotManaged`**:
<img width="1066" height="31" alt="image" src="https://github.com/user-attachments/assets/9c0d43de-bc43-491b-90ca-91a85c7da06b" />
Without `moduleConfig`:
<img width="1063" height="341" alt="image" src="https://github.com/user-attachments/assets/ead5c714-59db-4501-a68c-c5cac2582c0e" />
With `moduleConfig`:
<img width="1133" height="511" alt="image" src="https://github.com/user-attachments/assets/6e8f9173-3ed1-41a5-9164-2d2643a7c7ba" />

if try to change `moduleConfig/deckhouse`:

```ayml
# moduleconfigs.deckhouse.io "deckhouse" was not valid:
# * : ValidatingAdmissionPolicy 'deckhouse-module-registry-disabled' with binding 'deckhouse-module-registry-disabled' denied request: Changing spec.settings.registry is forbidden when the registry module is disabled. Please enable the module to make changes.
```

### **`EKS cluster`**:
Without `moduleConfig`:
<img width="450" height="326" alt="image" src="https://github.com/user-attachments/assets/b0664d74-c63a-466b-b55a-24c00111827e" />
<img width="1008" height="35" alt="image" src="https://github.com/user-attachments/assets/02b6827e-84e0-47b5-a08b-e40f7662a7e8" />
With `moduleConfig`:
<img width="1133" height="269" alt="image" src="https://github.com/user-attachments/assets/d075153b-5192-4098-b294-df847a6ce9f8" />
<img width="513" height="33" alt="image" src="https://github.com/user-attachments/assets/24274adc-f983-45d0-8784-f6554fba3d06" />
<img width="1058" height="34" alt="image" src="https://github.com/user-attachments/assets/a990c68e-abeb-4178-ad19-cefdf9a82c06" />

if try to change `moduleConfig/deckhouse`:

```yaml
# moduleconfigs.deckhouse.io "deckhouse" was not valid:
# * : ValidatingAdmissionPolicy 'deckhouse-module-registry-disabled' with binding 'deckhouse-module-registry-disabled' denied request: Changing spec.settings.registry is forbidden when the registry module is disabled. Please enable the module to make changes.
```




## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry
type: fix
summary: fixed enable script for registry module
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
