### PR TITLE
[candi] Add rosa 12.6 version to bashbooster

### DIFF
--- a/candi/bashible/bashbooster/56_detect_bundle.sh
+++ b/candi/bashible/bashbooster/56_detect_bundle.sh
@@ -37,7 +37,7 @@ bb-is-bundle(){
       case "$VERSION_ID" in 7.9)
         os="rosa" ;;
       esac
-      case "$VERSION" in 12.4|12.5.*|12.6.*)
+      case "$VERSION" in 12.4|12.5.*|12.6|12.6.*)
         os="rosa" ;;
       esac
     ;;


### PR DESCRIPTION
## Description
Add rosa 12.6 version to bashbooster `bb-is-bundle` function

## Why do we need it, and what problem does it solve?
Bashible can't detect operating system if in `/etc/os-release` `ROSA_OS_VERSION=12.6` without patch number

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: feature
summary: Add rosa 12.6.
impact_level: default
```
