### PR TITLE
[deckhouse-controller] add leader election mechanism for non ha clusters

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -97,16 +97,25 @@ func start(logger *log.Logger) func(_ *kingpin.ParseContext) error {
 
 		operator.StartAPIServer()
 
-		if os.Getenv("DECKHOUSE_HA") == "true" {
-			logger.Info("Deckhouse starts in HA mode")
-			runHAMode(ctx, operator, logger)
-			return nil
+		versionFile := "/deckhouse/version"
+
+		version := "unknown"
+		content, err := os.ReadFile(versionFile)
+		if err != nil {
+			logger.Warn("cannot get deckhouse version", log.Err(err))
+		} else {
+			version = strings.TrimSuffix(string(content), "\n")
 		}
 
-		if err := run(ctx, operator, logger); err != nil {
-			logger.Error("run", log.Err(err))
-			os.Exit(1)
+		if version == "dev" {
+			if err := run(ctx, operator, logger); err != nil {
+				logger.Error("run", log.Err(err))
+				os.Exit(1)
+			}
 		}
+
+		logger.Info("Deckhouse starts in HA mode")
+		runWithLeaderElection(ctx, operator, logger)
 
 		return nil
 	}
@@ -162,7 +171,7 @@ func entrypoint(logger *log.Logger) error {
 	return nil
 }
 
-func runHAMode(ctx context.Context, operator *addonoperator.AddonOperator, logger *log.Logger) {
+func runWithLeaderElection(ctx context.Context, operator *addonoperator.AddonOperator, logger *log.Logger) {
 	var identity string
 	podName := os.Getenv("DECKHOUSE_POD")
 	if len(podName) == 0 {
@@ -187,7 +196,7 @@ func runHAMode(ctx context.Context, operator *addonoperator.AddonOperator, logge
 		identity = fmt.Sprintf("%s.%s.%s.pod.%s", podName, strings.ReplaceAll(podIP, ".", "-"), podNs, clusterDomain)
 	}
 
-	if err := operator.WithLeaderElector(&leaderelection.LeaderElectionConfig{
+	err := operator.WithLeaderElector(&leaderelection.LeaderElectionConfig{
 		// Create a leaderElectionConfig for leader election
 		Lock: &resourcelock.LeaseLock{
 			LeaseMeta: v1.ObjectMeta{
@@ -217,8 +226,9 @@ func runHAMode(ctx context.Context, operator *addonoperator.AddonOperator, logge
 			},
 		},
 		ReleaseOnCancel: true,
-	}); err != nil {
-		operator.Logger.Error("run", log.Err(err))
+	})
+	if err != nil {
+		operator.Logger.Error("run with leader elector", log.Err(err))
 	}
 
 	go func() {

--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -107,7 +107,7 @@ func start(logger *log.Logger) func(_ *kingpin.ParseContext) error {
 			version = strings.TrimSuffix(string(content), "\n")
 		}
 
-		if version == "dev" {
+		if version == "dev" && os.Getenv("DECKHOUSE_HA") == "false" {
 			if err := run(ctx, operator, logger); err != nil {
 				logger.Error("run", log.Err(err))
 				os.Exit(1)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Currently, Deckhouse controller only enables leader election when running in High Availability (HA) mode. However, this creates a potential issue in single-master clusters:

When multiple Deckhouse controller instances operate concurrently, they can:
- Apply conflicting configuration changes
- Create race conditions in cluster state management  
- Generate inconsistent module configurations
- Cause unpredictable cluster behavior

The current implementation assumes that single-master mode means only one pod will ever exist. However, in practice:

- **Rolling updates**: New pod starts before old pod terminates
- **Pod migrations**: Node evictions causing pod restarts
- **Manual scaling**: Operators accidentally scale replicas > 1
- **Stuck deployments**: Old ReplicaSet pods fail to terminate properly
- **Network delays**: Pod termination isn't always immediate1

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Enable leader election even in single-master mode to ensure only one active controller instance at any time.

### Benefits

- **Prevents split-brain**: Only one pod processes cluster state
- **Safe rolling updates**: New pod waits for old pod to release leadership
- **Resilient to scaling errors**: Multiple replicas won't cause conflicts
- **Consistent behavior**: Same coordination mechanism in all modes

### Implementation Details

1. **Always enable leader election** regardless of HA mode
2. **Single-master behavior**: One pod will immediately acquire leadership

Now we have a mechanism which uses "/deckhouse/version" file. If dev version in it and DECKHOUSE_HA env is "false" (which means we 200% sertainly to not start ha mode) - we do not start HA.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: add leader election for non ha clusters
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
