### PR TITLE
Backport: [chore] Improve internal modules comparison #14618

### DIFF
--- a/.github/scripts/python/compare_internal_modules.py
+++ b/.github/scripts/python/compare_internal_modules.py
@@ -17,19 +17,34 @@
 import json
 import os
 import sys
+import re
 
 whitelist = [
-    "dev",
+    "base-for-go",
+    "common-base",
+    "common/shell-operator",
+    "control-plane-manager/control-plane-manager.*",
+    "control-plane-manager/kube-apiserver.*",
+    "control-plane-manager/kube-controller-manager.*",
+    "control-plane-manager/kube-scheduler.*",
+    "deckhouse/webhook-handler",
     "dev-prebuild",
-    "dev/install",
+    "dev",
     "dev/install-standalone",
+    "dev/install",
     "documentation/web",
+    "e2e-opentofu-eks",
     "e2e-terraform",
     "images-digests",
+    "kube-proxy/kube-proxy.*",
     "node-manager/bashible-apiserver",
+    "prometheus/grafana-dashboard-provisioner",
+    "registrypackages/kubeadm.*",
+    "registrypackages/kubectl.*",
+    "registrypackages/kubelet.*",
     "release-channel-version-prebuild",
+    "tests-prebuild",
     "tests",
-    "tests-prebuild"
 ]
 
 # Find and read build reports
@@ -53,7 +68,7 @@ for image in unique_images:
         if image in reports[edition]:
             digests.add(reports[edition][image]['DockerImageDigest'])
     if len(digests) > 1:
-        if image not in whitelist:
+        if not [image for pattern in whitelist if re.fullmatch(pattern, image)]:
             found = True
             print(f'Found differing image digests for image {image}:')
         else:

--- a/.github/workflow_templates/build-and-test_pre-release.yml
+++ b/.github/workflow_templates/build-and-test_pre-release.yml
@@ -301,3 +301,24 @@ jobs:
             echo "No released versions exist. Skipping."
           fi
       {!{ tmpl.Exec "send_fail_report" . | strings.Indent 6 }!}
+
+  compare_internal_modules:
+    name: Compare internal modules
+    needs:
+      - build_fe
+      - build_ee
+      - build_ce
+      - build_be
+      - build_se
+      - build_se_plus
+    if: ${{ always() && needs.build_fe.result == 'success' }}
+    runs-on: regular
+    steps:
+      - uses: actions/setup-python@v5.6.0
+        with:
+          python-version: '3.12.3'
+      {!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
+      - name: Get artifacts
+        uses: {!{ index (ds "actions") "actions/download-artifact" }!}
+      - name: Compare modules
+        run: python .github/scripts/python/compare_internal_modules.py

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3484,3 +3484,29 @@ jobs:
         run: |
           bash ./.github/scripts/send-report.sh
       # </template: send_fail_report>
+
+  compare_internal_modules:
+    name: Compare internal modules
+    needs:
+      - build_fe
+      - build_ee
+      - build_ce
+      - build_be
+      - build_se
+      - build_se_plus
+    if: ${{ always() && needs.build_fe.result == 'success' }}
+    runs-on: regular
+    steps:
+      - uses: actions/setup-python@v5.6.0
+        with:
+          python-version: '3.12.3'
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+
+      # </template: checkout_step>
+      - name: Get artifacts
+        uses: actions/download-artifact@v4.1.8
+      - name: Compare modules
+        run: python .github/scripts/python/compare_internal_modules.py


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This pr extends list of the internal modules, which can be assembled different based on edition. Also, internal module comparison validation will be performed for release branches, to warn about the issue in advance before tag build.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We need it to fix the validation failure on release builds and to improve this check by performing it in advance on release branches.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Improve internal modules comparison
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
