### PR TITLE
[observability] redis dash turn off stacking for mem graph

### DIFF
--- a/ee/fe/modules/340-monitoring-applications/applications/redis/grafana-dashboards/propagated-redis.json
+++ b/ee/fe/modules/340-monitoring-applications/applications/redis/grafana-dashboards/propagated-redis.json
@@ -889,7 +889,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"


### PR DESCRIPTION
## Description
Change stacking mode to none for "Total Memory Usage" graph in redis dashboard.


## Why do we need it, and what problem does it solve?
Solving the problem of incorrect visualization of memory consumption graph.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: monitoring-applications
type: fix
summary: redis dash turn off stacking for mem graph
impact_level: low
```
