### PR TITLE
[docs] Changed generating page titles in documentation

### DIFF
--- a/docs/site/_includes/head.html
+++ b/docs/site/_includes/head.html
@@ -33,8 +33,20 @@
 {%- assign page_url_without_lang = page_url_without_lang | append: '/' %}
 {%- endif %}
 
-{%- assign generated_title = title_parts | reverse | join: " / " %}
-<title>{{ generated_title }} | {{ site.site_title }}</title>
+{%- assign generated_title = title_parts | reverse | join: "" %}
+
+{%- assign words = page.product_code | replace: '-', ' ' | split: ' ' -%}
+{%- assign additional_title = "" -%}
+{%- for word in words -%}
+  {%- assign capitalized_word = word | capitalize -%}
+  {%- if additional_title == "" -%}
+    {%- assign additional_title = capitalized_word -%}
+  {%- else -%}
+    {%- assign additional_title = additional_title | append: " " | append: capitalized_word -%}
+  {%- endif -%}
+{%- endfor -%}
+<title>{{ generated_title }} | {{ site.site_title }} {{ additional_title }}</title>
+
 {%- if page.description %}
     {%- assign description = page.description | strip_html | strip_newlines | strip | truncate: 200 %}
 {%- else %}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

 Changed generating page titles in documentation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary:  Changed generating page titles in documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
