### PR TITLE
[metallb] fix overwriting of Service `status` field by module components

### DIFF
--- a/ee/se/modules/380-metallb/hooks/discovery_l2_load_balancers_test.go
+++ b/ee/se/modules/380-metallb/hooks/discovery_l2_load_balancers_test.go
@@ -91,6 +91,17 @@ spec:
     app: nginx2
   type: LoadBalancer
   loadBalancerClass: config_mlbc
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: 1 of 1 public IPs were assigned
+    reason: AllIPsAssigned
+    status: "True"
+    type: AllPublicIPsAssigned
+  loadBalancer:
+    ingress:
+    - ip: 10.3.29.200
+      ipMode: VIP
 ---
 apiVersion: v1
 kind: Service
@@ -110,6 +121,17 @@ spec:
   selector:
     app: nginx3
   type: LoadBalancer
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: 1 of 1 public IPs were assigned
+    reason: AllIPsAssigned
+    status: "True"
+    type: AllPublicIPsAssigned
+  loadBalancer:
+    ingress:
+    - ip: 10.3.29.200
+      ipMode: VIP
 ---
 apiVersion: network.deckhouse.io/v1alpha1
 kind: MetalLoadBalancerClass
@@ -305,21 +327,54 @@ metadata:
           }
 ]
 `))
-
-			status := svc.Field("status")
-			conditions := status.Get("conditions").Array()[0]
-			Expect(conditions.Get("message").String()).To(Equal("config_mlbc"))
-			Expect(conditions.Get("reason").String()).To(Equal("LoadBalancerClassBound"))
-			Expect(conditions.Get("status").String()).To(Equal("True"))
-			Expect(conditions.Get("type").String()).To(Equal("network.deckhouse.io/load-balancer-class"))
-
-			status = svc2.Field("status")
-			conditions = status.Get("conditions").Array()[0]
-			Expect(conditions.Get("message").String()).To(Equal("default_mlbc"))
-			Expect(conditions.Get("reason").String()).To(Equal("LoadBalancerClassBound"))
-			Expect(conditions.Get("status").String()).To(Equal("True"))
-			Expect(conditions.Get("type").String()).To(Equal("network.deckhouse.io/load-balancer-class"))
-
+			Expect(svc.Field("status").String()).To(MatchJSON(`{
+"conditions": [
+	{
+		"message": "1 of 1 public IPs were assigned",
+		"reason": "AllIPsAssigned",
+		"status": "True",
+		"type": "AllPublicIPsAssigned"
+	},
+	{
+		"message": "config_mlbc",
+		"reason": "LoadBalancerClassBound",
+		"status": "True",
+		"type": "network.deckhouse.io/load-balancer-class"
+	}
+],
+"loadBalancer": {
+	"ingress": [
+		{
+			"ip": "10.3.29.200",
+			"ipMode": "VIP"
+		}
+	]
+}
+}`))
+			Expect(svc2.Field("status").String()).To(MatchJSON(`{
+"conditions": [
+	{
+		"message": "1 of 1 public IPs were assigned",
+		"reason": "AllIPsAssigned",
+		"status": "True",
+		"type": "AllPublicIPsAssigned"
+	},
+	{
+		"message": "default_mlbc",
+		"reason": "LoadBalancerClassBound",
+		"status": "True",
+		"type": "network.deckhouse.io/load-balancer-class"
+	}
+],
+"loadBalancer": {
+	"ingress": [
+		{
+			"ip": "10.3.29.200",
+			"ipMode": "VIP"
+		}
+	]
+}
+}`))
 		})
 	})
 

--- a/ee/se/modules/380-metallb/hooks/types.go
+++ b/ee/se/modules/380-metallb/hooks/types.go
@@ -42,6 +42,7 @@ type ServiceInfo struct {
 	DesiredIPs                []string                        `json:"desiredIPs,omitempty"`
 	LBAllowSharedIP           string                          `json:"lbAllowSharedIP,omitempty"`
 	AnnotationMLBC            string                          `json:"annotationMLBC,omitempty"`
+	Conditions                []metav1.Condition              `json:"conditions,omitempty"`
 }
 
 type L2LBServiceStatusInfo struct {

--- a/ee/se/modules/380-metallb/hooks/update_service_status.go
+++ b/ee/se/modules/380-metallb/hooks/update_service_status.go
@@ -17,9 +17,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	sdkpkg "github.com/deckhouse/module-sdk/pkg"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{

--- a/ee/se/modules/380-metallb/hooks/update_service_status_test.go
+++ b/ee/se/modules/380-metallb/hooks/update_service_status_test.go
@@ -39,11 +39,15 @@ spec:
   loadBalancerClass: my-lb-class
 status:
   conditions:
-  - lastTransitionTime: "2025-07-23T15:17:03Z"
-    message: l2-default
+  - message: l2-default
     reason: LoadBalancerClassBound
     status: "True"
     type: network.deckhouse.io/load-balancer-class
+  - lastTransitionTime: null
+    message: 1 of 1 public IPs were assigned
+    reason: AllIPsAssigned
+    status: "True"
+    type: AllPublicIPsAssigned
 `
 )
 
@@ -111,7 +115,6 @@ status:
 			Expect(svc.Field("status").String()).To(MatchJSON(`{
 "conditions": [
 	{
-		"lastTransitionTime": "2025-07-23T15:17:03Z",
 		"message": "l2-default",
 		"reason": "LoadBalancerClassBound",
 		"status": "True",
@@ -198,7 +201,6 @@ spec:
 {
 	"conditions": [
 		{
-			"lastTransitionTime": "2025-07-23T15:17:03Z",
 			"message": "l2-default",
 			"reason": "LoadBalancerClassBound",
 			"status": "True",


### PR DESCRIPTION
## Description

There are many hooks in the module, two of which modify the `status` field in services. But each time they overwrite this field with new values. This PR allows them to add new values and update previously set `status` values.

## Why do we need it, and what problem does it solve?

The problem occurs if in a properly working cluster with MetalLB all `MetalLoadBalancerClass` are set to `isDefault: false` and no `loadBalancerClass` is specified, and then perform a pod Deckhouse reload. The module will stop announcing ARP and serving load-balancer IP addresses.

## Why do we need it in the patch release (if we do)?

The problem affects customers who are using the MetalLB module now.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: fix
summary: Fixed overwriting of Service `status` field by module components.
impact_level: default
```
