### PR TITLE
[cert-manager] recursive settings

### DIFF
--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -144,7 +144,10 @@ properties:
       DNS recursion settings for ACME DNS-01 self-check.
     x-examples:
       - nameservers: ["8.8.8.8:53", "https://1.1.1.1:443"]
-        onlyRecursive: true
+        useOnlyRecursive: true
+    x-kubernetes-validations:
+      - rule: "self.useOnlyRecursive == false || size(self.nameservers) >= 1"
+        message: "At least one nameserver must be specified when useOnlyRecursive is true"
     properties:
       nameservers:
         type: array
@@ -158,14 +161,3 @@ properties:
         description: |
           When set to true, cert-manager restricts DNS-01 challenge validation to the specified recursive nameservers and will not fall back to authoritative name servers.
         default: false
-    allOf:
-      - if:
-          properties:
-            useOnlyRecursive:
-              const: true
-        then:
-          properties:
-            nameservers:
-              minItems: 1
-          required:
-            - nameservers

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -137,3 +137,35 @@ properties:
     description: |
       The name of the `ingressClass` used to confirm ownership of domain using the [ACME HTTP-01](https://cert-manager.io/docs/configuration/acme/http01/) challenges method.
       If the parameter is omitted, the default `ingressClass` is used.
+
+  recursiveSettings:
+    type: object
+    description: |
+      DNS recursion settings for ACME DNS-01 self-check.
+    x-examples:
+      - nameservers: ["8.8.8.8:53", "https://1.1.1.1:443"]
+        onlyRecursive: true
+    properties:
+      nameservers:
+        type: array
+        items:
+          type: string
+          description: |
+            List of recursive DNS servers (IP:port or HTTPS URLs) that cert-manager uses to validate ACME DNS-01 challenges via a self-check.
+          pattern: "^(?:[0-9]{1,3}(?:\\.[0-9]{1,3}){3}:\\d{1,5}|https?://[^\\s]+)$"
+      useOnlyRecursive:
+        type: boolean
+        description: |
+          When set to true, cert-manager restricts DNS-01 challenge validation to the specified recursive nameservers and will not fall back to authoritative name servers.
+        default: false
+    allOf:
+      - if:
+          properties:
+            useOnlyRecursive:
+              const: true
+        then:
+          properties:
+            nameservers:
+              minItems: 1
+          required:
+            - nameservers

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -143,7 +143,7 @@ properties:
     description: |
       DNS recursion settings for ACME DNS-01 self-check.
     x-examples:
-      - nameservers: ["8.8.8.8:53", "https://1.1.1.1:443"]
+      - nameservers: ["8.8.8.8:53", "https://1.1.1.1"]
         useOnlyRecursive: true
     x-kubernetes-validations:
       - rule: "self.useOnlyRecursive == false || size(self.nameservers) >= 1"
@@ -159,5 +159,5 @@ properties:
       useOnlyRecursive:
         type: boolean
         description: |
-          When set to true, cert-manager restricts DNS-01 challenge validation to the specified recursive nameservers and will not fall back to authoritative name servers.
+          When set to true, cert-manager restricts DNS-01 challenge validation to the specified recursive nameservers.
         default: false

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -74,7 +74,7 @@ properties:
       Параметры рекурсивных DNS для самопроверки ACME DNS-01:
     x-examples:
       - nameservers: ["8.8.8.8:53", "https://1.1.1.1:443"]
-        onlyRecursive: true
+        useOnlyRecursive: true
     properties:
       nameservers:
         description: |

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -73,7 +73,7 @@ properties:
     description: |
       Параметры рекурсивных DNS для самопроверки ACME DNS-01:
     x-examples:
-      - nameservers: ["8.8.8.8:53", "https://1.1.1.1:443"]
+      - nameservers: ["8.8.8.8:53", "https://1.1.1.1"]
         useOnlyRecursive: true
     properties:
       nameservers:
@@ -81,4 +81,4 @@ properties:
           Список рекурсивных DNS-серверов (IP:порт или HTTPS-URL), к которым cert-manager будет обращаться.
       useOnlyRecursive:
         description: |
-          Если значение true, cert-manager ограничивает проверку DNS-01 указанными рекурсивными DNS-серверами и не выполняет запросы к авторитетным DNS-серверам.
+          Если значение true, cert-manager ограничивает проверку DNS-01 указанными рекурсивными DNS-серверами.

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -67,4 +67,18 @@ properties:
     x-examples: ["nginx"]
     description: |
       Имя `ingressClass` используемого для подтверждения владения доменом методом [ACME HTTP-01](https://cert-manager.io/docs/configuration/acme/http01/).  
-      Если параметр не указан, то используется `ingressClass` по умолчанию.      
+      Если параметр не указан, то используется `ingressClass` по умолчанию.   
+
+  recursiveSettings:
+    description: |
+      Параметры рекурсивных DNS для самопроверки ACME DNS-01:
+    x-examples:
+      - nameservers: ["8.8.8.8:53", "https://1.1.1.1:443"]
+        onlyRecursive: true
+    properties:
+      nameservers:
+        description: |
+          Список рекурсивных DNS-серверов (IP:порт или HTTPS-URL), к которым cert-manager будет обращаться.
+      useOnlyRecursive:
+        description: |
+          Если значение true, cert-manager ограничивает проверку DNS-01 указанными рекурсивными DNS-серверами и не выполняет запросы к авторитетным DNS-серверам.

--- a/modules/101-cert-manager/templates/cert-manager/deployment.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/deployment.yaml
@@ -69,11 +69,13 @@ spec:
           {{- if $.Values.certManager.maxConcurrentChallenges }}
           - --max-concurrent-challenges={{ $.Values.certManager.maxConcurrentChallenges }}
           {{- end }}
-          {{- if .Values.certManager.recursiveSettings.nameservers }}
-          - --dns01-recursive-nameservers={{ join "," .Values.certManager.recursiveSettings.nameservers }}
-          {{- end }}
-          {{- if .Values.certManager.recursiveSettings.useOnlyRecursive }}
+          {{- with .Values.certManager.recursiveSettings }}
+            {{- if .nameservers }}
+          - --dns01-recursive-nameservers={{ join "," .nameservers }}
+            {{- end }}
+            {{- if .useOnlyRecursive }}
           - --dns01-recursive-nameservers-only
+            {{- end }}
           {{- end }}
 {{- if (hasKey $.Values.global.modules "https") }}
 {{- if eq $.Values.global.modules.https.mode "CertManager" }}

--- a/modules/101-cert-manager/templates/cert-manager/deployment.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/deployment.yaml
@@ -69,6 +69,12 @@ spec:
           {{- if $.Values.certManager.maxConcurrentChallenges }}
           - --max-concurrent-challenges={{ $.Values.certManager.maxConcurrentChallenges }}
           {{- end }}
+          {{- if .Values.certManager.recursiveSettings.nameservers }}
+          - --dns01-recursive-nameservers={{ join "," .Values.certManager.recursiveSettings.nameservers }}
+          {{- end }}
+          {{- if .Values.certManager.recursiveSettings.useOnlyRecursive }}
+          - --dns01-recursive-nameservers-only
+          {{- end }}
 {{- if (hasKey $.Values.global.modules "https") }}
 {{- if eq $.Values.global.modules.https.mode "CertManager" }}
           - --default-issuer-kind=ClusterIssuer


### PR DESCRIPTION
## Description
It provides recursive settings for cert-manager.

You can specify recursive nameservers via module config:
```
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: cert-manager
spec:
  enabled: true
  settings:
    recursiveSettings:
      nameservers:
         - 8.8.8.8:53
         - https://1.1.1.1
  version: 1
```

It adds ```--dns01-recursive-nameservers``` flag to the cert-manager deployment:
```
...
- --acme-http01-solver-resource-request-cpu=0
- --dns01-recursive-nameservers=8.8.8.8:53,https://1.1.1.1
...
```

If you want use only recusrive without fallback, you can specify use only recursive:
```
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: cert-manager
spec:
  enabled: true
  settings:
    recursiveSettings:
      useOnlyRecursive: true
      nameservers:
         - 8.8.8.8:53
        - https://1.1.1.1:443
  version: 1
```

It add ```--dns01-recursive-nameservers-only``` flag to the cert-manager deployment:
```
...
- --dns01-recursive-nameservers=8.8.8.8:53,https://1.1.1.1:443
- --dns01-recursive-nameservers-only
...
```

## Why do we need it, and what problem does it solve?
Closes #390

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cert-manager
type: feature
summary: Add recursive settings.
```
