### PR TITLE
Backport #14352: Run changelog check only on tag pushes to enforce release documentation

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -1,3 +1,29 @@
+{!{ define "check_changelog_template" }!}
+# <template: check_changelog_template>
+check_changelog:
+  name: Check changelog
+  runs-on: ubuntu-latest
+  steps:
+  {!{ tmpl.Exec "checkout_step"                . | strings.Indent 4 }!}
+    - name: Check for tag
+      run: |
+        if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
+          echo "Not a tag push, skipping changelog check."
+          exit 0
+        fi
+
+        TAG_VERSION="${GITHUB_REF#refs/tags/}"
+        FILE="./CHANGELOG/CHANGELOG-${TAG_VERSION}.yml"
+
+        if [ ! -f "$FILE" ]; then
+          echo "❌ Expected changelog file $FILE not found. Please create it before pushing the release tag."
+          exit 1
+        else
+          echo "✅ Changelog file $FILE found."
+        fi
+# </template: check_changelog_template>
+{!{ end }!}
+
 {!{ define "go_generate_template" }!}
 # <template: go_generate_template>
 runs-on: [self-hosted, regular]

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -122,12 +122,15 @@ jobs:
       - check_branch_name
 {!{ tmpl.Exec "workflow_render_template" $ctx | strings.Indent 4 }!}
 
+{!{ tmpl.Exec "check_changelog_template" $ctx | strings.Indent 2 }!}
+
   build_fe:
     name: Build FE
     needs:
       - git_info
       - go_generate
       - workflow_render
+      - check_changelog
     env:
       WERF_ENV: "FE"
       SVACE_ANALYZE_HOST: "${{ secrets.SVACE_ANALYZE_HOST }}"

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -337,12 +337,44 @@ jobs:
     # </template: workflow_render_template>
 
 
+
+  # <template: check_changelog_template>
+  check_changelog:
+    name: Check changelog
+    runs-on: ubuntu-latest
+    steps:
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+
+      # </template: checkout_step>
+      - name: Check for tag
+        run: |
+          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
+            echo "Not a tag push, skipping changelog check."
+            exit 0
+          fi
+
+          TAG_VERSION="${GITHUB_REF#refs/tags/}"
+          FILE="./CHANGELOG/CHANGELOG-${TAG_VERSION}.yml"
+
+          if [ ! -f "$FILE" ]; then
+            echo "❌ Expected changelog file $FILE not found. Please create it before pushing the release tag."
+            exit 1
+          else
+            echo "✅ Changelog file $FILE found."
+          fi
+  # </template: check_changelog_template>
+
+
   build_fe:
     name: Build FE
     needs:
       - git_info
       - go_generate
       - workflow_render
+      - check_changelog
     env:
       WERF_ENV: "FE"
       SVACE_ANALYZE_HOST: "${{ secrets.SVACE_ANALYZE_HOST }}"


### PR DESCRIPTION
## Description

Added the `check-changelog` job that always runs, but performs a changelog file check **only on tag pushes**.  
If the current ref is a tag, the job looks for the file `./CHANGELOG/CHANGELOG-${TAG_VERSION}.yml` and fails if it is missing.  
On non-tag pushes, the job exits successfully without doing anything.

This ensures that every release tag is accompanied by a changelog, without affecting regular CI flows.

## Tests

-  [Tag push, changelog exists — job succeeds](https://github.com/deckhouse/deckhouse-test-2/actions/runs/16452624195/job/46501551158)
- [Tag push, changelog missing — job fails](https://github.com/deckhouse/deckhouse-test-2/actions/runs/16452651743/job/46501647539)
- [Non-tag push — job skips check, exits 0; `build_fe` not triggered due to `git_info` failure](https://github.com/deckhouse/deckhouse-test-2/actions/runs/16452694720)


## Why do we need it, and what problem does it solve?

Ensures a changelog is present for each release. If the file is missing, the CI fails. Skipped on regular (non-tag) pushes.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Run changelog check only on tag pushes to enforce release documentation
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
