### PR TITLE
[runtime-audit-engine] No JEMALLOC

### DIFF
--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -14,10 +14,6 @@ import:
   - usr/share/falco/plugins/libcontainer.so
   - lib64
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-falcoctl-artifact
-  add: /out/falcoctl
-  to: /usr/bin/falcoctl
-  before: install
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-plugins-artifact
   add: /out/usr/share/falco/plugins
   to: /usr/share/falco/plugins
@@ -105,11 +101,11 @@ shell:
   - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/jemalloc.cmake
   - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/openssl.cmake
   - sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" cmake/modules/cares.cmake
-  - sed -i "s|https://download.falco.org|http://{{ $.DistroPackagesProxy }}/repository/download-falco-org|g" cmake/modules/rules.cmake  
+  - sed -i "s|https://download.falco.org|http://{{ $.DistroPackagesProxy }}/repository/download-falco-org|g" cmake/modules/rules.cmake
   {{- end }}
   - mkdir -p /src/build
   - cd /src/build
-  - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DRIVER=OFF -DCPACK_GENERATOR=TGZ -DBUILD_BPF=OFF -DBUILD_FALCO_MODERN_BPF=ON -DBUILD_WARNINGS_AS_ERRORS=OFF -DFALCO_VERSION={{ $falcoVersion }} -DUSE_BUNDLED_DEPS=ON /src
+  - cmake -DUSE_JEMALLOC=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DRIVER=OFF -DCPACK_GENERATOR=TGZ -DBUILD_BPF=OFF -DBUILD_FALCO_MODERN_BPF=ON -DBUILD_WARNINGS_AS_ERRORS=OFF -DFALCO_VERSION={{ $falcoVersion }} -DUSE_BUNDLED_DEPS=ON /src
   # fix build tbb lib on altlinux (redefine FORTIFY_SOURCE)
   - sed -i 's|cd /src/build/tbb-prefix/src/tbb && /usr/bin/cmake -E touch /src/build/tbb-prefix/src/tbb-stamp/tbb-configure|&\n\tsed -i "s\|-D_FORTIFY_SOURCE=2\|-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2\|g" /src/build/tbb-prefix/src/tbb/src/tbb/CMakeFiles/tbb.dir/flags.make|' CMakeFiles/tbb.dir/build.make
   {{- if $.DistroPackagesProxy }}
@@ -118,9 +114,9 @@ shell:
     for f in `grep -lari 'URL "https://github.com'`; do
       sed -i "s|https://github.com|http://{{ $.DistroPackagesProxy }}/repository/github-com|g" $f
     done
-  - sed -i "s|https://download.falco.org|http://{{ $.DistroPackagesProxy }}/repository/download-falco-org|g" falcosecurity-libs-repo/falcosecurity-libs-prefix/src/falcosecurity-libs/cmake/modules/container_plugin.cmake 
+  - sed -i "s|https://download.falco.org|http://{{ $.DistroPackagesProxy }}/repository/download-falco-org|g" falcosecurity-libs-repo/falcosecurity-libs-prefix/src/falcosecurity-libs/cmake/modules/container_plugin.cmake
   - find . -maxdepth 1 -type d ! -name "falcosecurity-libs-repo" ! -name "." -print0 | xargs -0 rm -rf
-  - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DRIVER=OFF -DCPACK_GENERATOR=TGZ -DBUILD_BPF=OFF -DBUILD_FALCO_MODERN_BPF=ON -DBUILD_WARNINGS_AS_ERRORS=OFF -DFALCO_VERSION={{ $falcoVersion }} -DUSE_BUNDLED_DEPS=ON -DFORCE_UPDATE_DEPS=ON /src
+  - cmake -DUSE_JEMALLOC=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DRIVER=OFF -DCPACK_GENERATOR=TGZ -DBUILD_BPF=OFF -DBUILD_FALCO_MODERN_BPF=ON -DBUILD_WARNINGS_AS_ERRORS=OFF -DFALCO_VERSION={{ $falcoVersion }} -DUSE_BUNDLED_DEPS=ON -DFORCE_UPDATE_DEPS=ON /src
   - sed -i 's|cd /src/build/tbb-prefix/src/tbb && /usr/bin/cmake -E touch /src/build/tbb-prefix/src/tbb-stamp/tbb-configure|&\n\tsed -i "s\|-D_FORTIFY_SOURCE=2\|-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2\|g" /src/build/tbb-prefix/src/tbb/src/tbb/CMakeFiles/tbb.dir/flags.make|' CMakeFiles/tbb.dir/build.make
   {{- end }}
   - make falco -j ${BUILD_THREADS}


### PR DESCRIPTION
## Description
Compile falco without jemalloc (with stdlib allocator)

## Why do we need it, and what problem does it solve?
jemalloc does not return memory if there is plenty on the host, which leads to the memory growth and looks like a memory leak (which is not but it doesn't metter)
<img width="1101" height="356" alt="image" src="https://github.com/user-attachments/assets/ec12b14a-7db4-442d-b656-301ae21dc9b0" />

By compiling falco with the USE_JEMALLOC=Off we can improve the memory profile

## Why do we need it in the patch release (if we do)?

This is a user-facing problem that leads to higher resource consumption and looks like a bug

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: fix
summary: Improve memory footprint by switching to the stdlib memory allocator instead of jemalloc
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
