### PR TITLE
[cloud-provider-zvirt] Add zvirt cloud provider support to CSE release.

### DIFF
--- a/.werf/werf-modules.yaml
+++ b/.werf/werf-modules.yaml
@@ -65,6 +65,7 @@
       {{- $_ := set $ctx "SVACE_ANALYZE_HOST" $Root.SVACE_ANALYZE_HOST }}
       {{- $_ := set $ctx "SVACE_ANALYZE_SSH_USER" $Root.SVACE_ANALYZE_SSH_USER }}
       {{- $_ := set $ctx "Commit" $Root.Commit }}  
+      {{- $_ := set $ctx "gitPrefix" $Root.gitPrefix }}
 ---
 {{ include "module_image_template" $ctx }}
   {{- range $ImageYamlMainfest := regexSplit "\n?---[ \t]*\n" (include "module_image_template" $ctx) -1 }}

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/werf.inc.yaml
@@ -24,7 +24,7 @@ git:
       - go.mod
       - go.sum
       - "**/*.go"
-- add: /go_lib/cloud-data
+- add: {{ .gitPrefix }}/go_lib/cloud-data
   to: /src/go_lib/cloud-data
   excludePaths:
     - "**/*.md"
@@ -34,7 +34,7 @@ git:
       - go.mod
       - go.sum
       - "**/*.go"
-- add: /pkg/log
+- add: {{ .gitPrefix }}/pkg/log
   to: /src/pkg/log
   excludePaths:
     - "**/*.md"

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/zvirt-csi-driver/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/zvirt-csi-driver/werf.inc.yaml
@@ -81,7 +81,7 @@ final: false
 fromImage: common/relocate-artifact
 shell:
   beforeInstall:
-    - apt-get update -y
-    - apt-get install -y e2fsprogs xfsprogs btrfs-progs nfs-utils parted nvme udev
+  {{- include "alt packages proxy" . | nindent 2 }}
+  - apt-get install -y e2fsprogs xfsprogs btrfs-progs nfs-utils parted nvme udev
   install:
     - /binary_replace.sh -i "{{ $csiBinaries }}" -o /relocate

--- a/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
@@ -96,6 +96,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
+  {{- include "alpine packages proxy" . | nindent 2 }}          
   - apk add --no-cache openssh-client
   - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
   install:
@@ -121,6 +122,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
+  {{- include "alpine packages proxy" . | nindent 2 }}
   - apk add --no-cache openssh-client
   - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
   install:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
this mr allow to bootstrap CSE release on cloud provider zvirt.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-zvirt
type: feature
summary: zvirt cloud provider to cse. 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
