### PR TITLE
[deckhouse] Fix new snapshot logic bag

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/discover.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/discover.go
@@ -169,12 +169,12 @@ func handleDiscoveryDataVolumeTypes(
 		}
 	}
 
-	storageClassSnapshots, err := sdkobjectpatch.UnmarshalToStruct[*storage.StorageClass](input.NewSnapshots, "storage_classes")
+	storageClassSnapshots, err := sdkobjectpatch.UnmarshalToStruct[storage.StorageClass](input.NewSnapshots, "storage_classes")
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal storage_classes snapshot: %w", err)
 	}
 
-	storageClassMap := make(map[string]*storage.StorageClass, len(storageClassSnapshots))
+	storageClassMap := make(map[string]storage.StorageClass, len(storageClassSnapshots))
 	for _, s := range storageClassSnapshots {
 		storageClassMap[s.Name] = s
 	}

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/discover.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/discover.go
@@ -174,9 +174,9 @@ func handleDiscoveryDataVolumeTypes(
 		return fmt.Errorf("failed to unmarshal storage_classes snapshot: %w", err)
 	}
 
-	storageClassMap := make(map[string]*storage.StorageClass, len(storageClassSnapshots))
+	storageClassMap := make(map[string]storage.StorageClass, len(storageClassSnapshots))
 	for _, s := range storageClassSnapshots {
-		storageClassMap[s.Name] = &s
+		storageClassMap[s.Name] = s
 	}
 
 	storageClasses := make([]storageClass, 0, len(storageClassStorageDomain))

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/discover.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/discover.go
@@ -174,9 +174,9 @@ func handleDiscoveryDataVolumeTypes(
 		return fmt.Errorf("failed to unmarshal storage_classes snapshot: %w", err)
 	}
 
-	storageClassMap := make(map[string]storage.StorageClass, len(storageClassSnapshots))
+	storageClassMap := make(map[string]*storage.StorageClass, len(storageClassSnapshots))
 	for _, s := range storageClassSnapshots {
-		storageClassMap[s.Name] = s
+		storageClassMap[s.Name] = &s
 	}
 
 	storageClasses := make([]storageClass, 0, len(storageClassStorageDomain))


### PR DESCRIPTION
## Description

Fix for [New Snapshot logic](https://github.com/deckhouse/deckhouse/pull/12513)

We must use non pointer generics for snapshots

## Why do we need it, and what problem does it solve?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: fix new snapshot logic bag
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
