### PR TITLE
[cni-cilium] Workaround for the problem of reaching the bpf complexity limit.

### DIFF
--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{ include "helm_lib_module_labels" (list .) | nindent 2 }}
 data:
+  # A workaround for reaching the complexity limit.
+  # This option disables expose "policy verdict log" events to Cilium monitor and Hubble.
+  # This option can only be useful if "policyAuditMode" is enabled.
+  bpf-events-policy-verdict-enabled: "false"
   # For CiliumNetworkPolicy and NetworkPolicy
   policy-cidr-match-mode: "nodes"
   # For CiliumNetworkPolicy


### PR DESCRIPTION
## Description

Disabled the generation of "policy verdict log" events, which could only be used to check network policies in policyAuditMode mode.

## Why do we need it, and what problem does it solve?

In some specific clusters, after upgrading `D8` to version `1.71`, we encountered a problem where the bpf programs generated and used by cilium could not be loaded into the kernel because they exceeded the complexity limit. 
_The bpf verifier calculates the total number of instructions for each bpf program and compares it to the specified limit._

Disabling the `bpf-events-policy-verdict-enabled` option reduces the number of instructions by approximately 3 times.

## Why do we need it in the patch release (if we do)?

If this problem occurs, it can cause the rest of the BPF programs and maps to fail to load into the kernel and update, preventing the cluster from functioning normally.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Workaround for the problem of reaching the bpf complexity limit.
impact: The Cilium agents will be restarted, and the "policy verdict log" events, which could be used to check network policies in policyAuditMode, will no longer be generated.
impact_level: default
```