### PR TITLE
docs[istio] update alliance.ingressGateway.advertise example in ModuleConfig

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -82,7 +82,7 @@ properties:
               - ee
               - cse-pro
             default: []
-            x-examples: [[{"ip": "172.16.0.5", "port": 15443}]]
+            x-examples: [[{"address": "172.16.0.5", "port": 15443}]]
             items:
               type: object
               required: ["address", "port"]


### PR DESCRIPTION
## Description

Fix the `alliance.ingressGateway.advertise` example in `istio` ModuleConfig.

## Changelog entries

```changes
section: docs
type: chore
summary: Fix the `alliance.ingressGateway.advertise` example in `istio` ModuleConfig.
impact_level: low
```
