### PR TITLE
[log-shipper] Fix ClusterLoggingConfig regex

### DIFF
--- a/modules/460-log-shipper/crds/cluster-logging-config.yaml
+++ b/modules/460-log-shipper/crds/cluster-logging-config.yaml
@@ -148,7 +148,7 @@ spec:
                                     type: array
                                     items:
                                       type: string
-                                      pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+                                      pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
                                       minLength: 1
                                       maxLength: 63
                     labelSelector:
@@ -211,7 +211,7 @@ spec:
                                 description: A label value.
                                 items:
                                   type: string
-                                  pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+                                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
                                   minLength: 1
                                   maxLength: 63
                 file:
@@ -570,7 +570,7 @@ spec:
                                     type: array
                                     items:
                                       type: string
-                                      pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+                                      pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
                                       minLength: 1
                                       maxLength: 63
                     labelSelector:
@@ -633,7 +633,7 @@ spec:
                                 description: A label value.
                                 items:
                                   type: string
-                                  pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+                                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
                                   minLength: 1
                                   maxLength: 63
                 file:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix [issue](https://github.com/deckhouse/deckhouse/issues/14248) `matchExpressions` values validation for `ClusterLoggingConfig` adding strict compliance
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Current validation `[a-z0-9]([-a-z0-9]*[a-z0-9])?` does not accurately validate values, and pass some wrong values
We get panic in deckhouse pod
`panic: values[0][kubernetes.io/metadata.name]: Invalid value: "Default*": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')`
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: fix
summary: Fix matchExpressions values validation for ClusterLoggingConfig
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
