### PR TITLE
fix DEFECTDOJO_URL

### DIFF
--- a/.github/scripts/python/compare_cve_between_releases.py
+++ b/.github/scripts/python/compare_cve_between_releases.py
@@ -108,7 +108,7 @@ def get_defectdojo_findings(version_tag):
             "limit": limit,
             "offset": offset,
         }
-        response = requests.get(f"{DD_URL}/api/v2/findings/", headers=HEADERS, params=params)
+        response = requests.get(f"https://{DD_URL}/api/v2/findings/", headers=HEADERS, params=params)
         response.raise_for_status()
         data = response.json()
         results = data.get("results", [])


### PR DESCRIPTION
## Description

Fixed a bug in `compare_cve_between_releases.py` where missing `https://` in `DEFECTDOJO_URL` caused a `MissingSchema` error.  
Now the script adds the scheme automatically if it's not present.

No impact on cluster components.

## Why do we need it, and what problem does it solve?

Previously, the script failed if `DEFECTDOJO_URL` was set without a scheme.  
This fix ensures stable behavior even with incomplete URLs.

Tested in [this run](https://github.com/deckhouse/deckhouse/actions/runs/16572998823/job/46870064834).


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix 
summary: fix DEFECTDOJO_URL
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
