### PR TITLE
[common] Disable tag "i-was-a-digest" when crane pull image by digest.

### DIFF
--- a/modules/000-common/images/crane/werf.inc.yaml
+++ b/modules/000-common/images/crane/werf.inc.yaml
@@ -11,6 +11,9 @@ import:
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 fromImage: builder/golang-alpine
 final: false
+secrets:
+- id: SOURCE_REPO
+  value: {{ .SOURCE_REPO }}      
 shell:
   beforeInstall:
   {{- include "alpine packages proxy" . | nindent 2 }}

--- a/modules/007-registrypackages/images/kubernetes-api-proxy/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubernetes-api-proxy/werf.inc.yaml
@@ -45,3 +45,10 @@ mount:
 shell:
   setup:
   - /crane pull $IMAGE_REPO@$IMAGE_DIGEST /kubernetes-api-proxy.tar
+  - mkdir /tmp/kubernetes-api-proxy
+  - tar -xf /kubernetes-api-proxy.tar -C /tmp/kubernetes-api-proxy
+  - cd /tmp/kubernetes-api-proxy
+  - sed -i 's/"RepoTags":\["[^"]*"\]/"RepoTags":[]/' manifest.json
+  - rm /kubernetes-api-proxy.tar
+  - tar -cvf /kubernetes-api-proxy.tar ./
+  - rm -rf /tmp/kubernetes-api-proxy

--- a/modules/007-registrypackages/images/pause/werf.inc.yaml
+++ b/modules/007-registrypackages/images/pause/werf.inc.yaml
@@ -50,5 +50,5 @@ shell:
   - cd /tmp/pause
   - sed -i 's/"RepoTags":\["[^"]*"\]/"RepoTags":[]/' manifest.json
   - rm /pause.tar
-  - tar -cvf /pause ./
+  - tar -cvf /pause.tar ./
   - rm -rf /tmp/pause    

--- a/modules/007-registrypackages/images/pause/werf.inc.yaml
+++ b/modules/007-registrypackages/images/pause/werf.inc.yaml
@@ -45,3 +45,10 @@ mount:
 shell:
   setup:
   - /crane pull $PAUSE_IMAGE_REPO@$PAUSE_IMAGE_DIGEST /pause.tar
+  - mkdir /tmp/pause
+  - tar -xf /pause.tar -C /tmp/pause
+  - cd /tmp/pause
+  - sed -i 's/"RepoTags":\["[^"]*"\]/"RepoTags":[]/' manifest.json
+  - rm /pause.tar
+  - tar -cvf /pause ./
+  - rm -rf /tmp/pause    


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
this pr allow disable crane issue with tag "i-was-a-digest" with dev-registry.deckhouse.io when pull image artifact.
ex.
```
werf.yaml
dependencies:
- image: control-plane-manager/kubernetes-api-proxy
  before: setup
  imports:
  - type: ImageDigest
    targetEnv: IMAGE_DIGEST
  - type: ImageRepo
    targetEnv: IMAGE_REPO
...
shell:
  setup:
  - /crane pull $IMAGE_REPO@$IMAGE_DIGEST $param /kubernetes-api-proxy.tar
...

/kubernetes-api-proxy # cat manifest.json
..."RepoTags":["dev-registry.deckhouse.io/sys/deckhouse-oss:i-was-a-digest"],"Layers":...
```
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this pr resolve issues when images pulled from private repos have tag "i-was-a-digest" with "dev-registry.deckhouse.io"
```
kubectl get no -oyaml
...
before
images:
- names:
  - deckhouse.local/images:kubernetes-api-proxy
  - dev-registry.deckhouse.io/sys/deckhouse-oss:i-was-a-digest
 ...
after
images:
- names:
  - deckhouse.local/images:kubernetes-api-proxy
```


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: fix
summary: delete tag "i-was-a-digest"
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
