### PR TITLE
[cni-cilium] add prometheus metric for maximum bpf instruction complexity

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/014-kernel-verifier-stat.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/014-kernel-verifier-stat.patch
@@ -1,0 +1,430 @@
+From 53cc5e23f992b898d19607e0c93375f23ae765a2 Mon Sep 17 00:00:00 2001
+From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
+Date: Fri, 8 Aug 2025 17:14:53 +0300
+Subject: [PATCH] kernel verifier stat
+
+Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
+---
+ pkg/bpf/collection.go |  18 +++
+ pkg/metrics/bpf.go    | 278 +++++++++++++++++++++++++++++++++---------
+ 2 files changed, 237 insertions(+), 59 deletions(-)
+
+diff --git a/pkg/bpf/collection.go b/pkg/bpf/collection.go
+index 26ab24a523..d961daea68 100644
+--- a/pkg/bpf/collection.go
++++ b/pkg/bpf/collection.go
+@@ -10,8 +10,11 @@ import (
+ 	"os"
+ 	"strings"
+ 
++	"github.com/cilium/coverbee/pkg/verifierlog"
++
+ 	"github.com/cilium/ebpf"
+ 	"github.com/cilium/ebpf/asm"
++	"github.com/sirupsen/logrus"
+ 
+ 	"github.com/cilium/cilium/pkg/maps/callsmap"
+ )
+@@ -309,9 +312,24 @@ func LoadCollection(spec *ebpf.CollectionSpec, opts *CollectionOptions) (*ebpf.C
+ 	// Collection. ebpf-go will reject maps with pins it doesn't recognize.
+ 	toReplace := consumePinReplace(spec)
+ 
++	if !opts.CollectionOptions.Programs.LogDisabled && opts.CollectionOptions.Programs.LogLevel == 0 {
++		opts.CollectionOptions.Programs.LogLevel = ebpf.LogLevelStats
++	}
++
+ 	// Attempt to load the Collection.
+ 	coll, err := ebpf.NewCollectionWithOptions(spec, opts.CollectionOptions)
+ 
++	if err == nil {
++		for _, prog := range coll.Programs {
++			log.WithFields(logrus.Fields{
++				"progInfo": prog.String(),
++			}).Debug("BPF program details")
++			for _, line := range verifierlog.ParseVerifierLog(prog.VerifierLog) {
++				log.Debug("Kernel verifier stat: ", line)
++			}
++		}
++	}
++
+ 	// Collect key names of maps that are not compatible with their pinned
+ 	// counterparts and remove their pinning flags.
+ 	if errors.Is(err, ebpf.ErrMapIncompatible) {
+diff --git a/pkg/metrics/bpf.go b/pkg/metrics/bpf.go
+index a44e151959..186181c3c7 100644
+--- a/pkg/metrics/bpf.go
++++ b/pkg/metrics/bpf.go
+@@ -4,39 +4,69 @@
+ package metrics
+ 
+ import (
+-	"context"
+-	"encoding/json"
++	"bufio"
++	"bytes"
++	"errors"
+ 	"fmt"
+-	"os/exec"
+-	"slices"
++	"io"
++	"os"
+ 	"strings"
+ 
+ 	"github.com/prometheus/client_golang/prometheus"
+ 	"github.com/sirupsen/logrus"
+ 	"golang.org/x/sync/singleflight"
+ 
+-	"github.com/cilium/cilium/pkg/time"
++	"github.com/cilium/cilium/pkg/version"
++	"github.com/cilium/cilium/pkg/versioncheck"
++	"github.com/cilium/ebpf"
++	"golang.org/x/sys/unix"
+ )
+ 
+ type bpfCollector struct {
+ 	sfg singleflight.Group
+ 
+-	bpfMapsCount      *prometheus.Desc
+-	bpfMapsMemory     *prometheus.Desc
+-	bpfProgramsCount  *prometheus.Desc
+-	bpfProgramsMemory *prometheus.Desc
++	bpfMapsCount          *prometheus.Desc
++	bpfMapsMemory         *prometheus.Desc
++	bpfProgramsCount      *prometheus.Desc
++	bpfProgramsMemory     *prometheus.Desc
++	bpfProgramsComplexity *prometheus.Desc
+ }
+ 
+ type bpfUsage struct {
+-	ids                   []uint64
+-	virtualMemoryMaxBytes float64
++	count                 uint32
++	virtualMemoryMaxBytes uint32
+ }
+ 
+-func (bu bpfUsage) count() float64 {
+-	return float64(len(bu.ids))
++func isVerifierComplexitySupported() string {
++	minVersion := "5.16"
++
++	v, err := versioncheck.Version(minVersion)
++	if err != nil {
++		return "Cannot parse minimum kernel version — this metric may not be supported"
++	}
++
++	kv, err := version.GetKernelVersion()
++	if err != nil {
++		return "Cannot determine current kernel version — this metric may not be supported"
++	}
++
++	if kv.LT(v) {
++		return fmt.Sprintf(
++			"Kernel verifier complexity metric is not available: running kernel %v < required %v",
++			kv, minVersion,
++		)
++	}
++
++	return ""
+ }
+ 
+ func newbpfCollector() *bpfCollector {
++	metricInfo := "Maximum number of verified instructions among loaded BPF programs."
++	metricDescription := isVerifierComplexitySupported()
++	if len(metricDescription) > 0 {
++		metricInfo = metricInfo + " " + metricDescription
++	}
++
+ 	return &bpfCollector{
+ 		bpfMapsCount: prometheus.NewDesc(
+ 			prometheus.BuildFQName(Namespace, "", "bpf_maps"),
+@@ -58,6 +88,11 @@ func newbpfCollector() *bpfCollector {
+ 			"BPF programs kernel max memory usage size in bytes.",
+ 			nil, nil,
+ 		),
++		bpfProgramsComplexity: prometheus.NewDesc(
++			prometheus.BuildFQName(Namespace, "", "bpf_progs_complexity_max_verified_insts"),
++			metricInfo,
++			nil, nil,
++		),
+ 	}
+ }
+ 
+@@ -65,79 +100,198 @@ func (s *bpfCollector) Describe(ch chan<- *prometheus.Desc) {
+ 	prometheus.DescribeByCollect(s, ch)
+ }
+ 
+-type memoryEntry struct {
+-	ID           uint64 `json:"id"`
+-	Name         string `json:"name"`
+-	BytesMemlock uint64 `json:"bytes_memlock"`
+-
+-	// (returned only for programs)
+-	MapIDs []uint64 `json:"map_ids"`
++func findFirstNumber(data []byte, start int) int {
++	n := len(data)
++	for start < n {
++		c := data[start]
++		switch {
++		case c >= '0' && c <= '9':
++			return start
++		default:
++			start++
++		}
++	}
++	return -1
+ }
+ 
+-func getBPFUsage(typ string, filter func(memoryEntry) bool) (bpfUsage, error) {
+-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+-	defer cancel()
+-	cmd := exec.CommandContext(ctx, "bpftool", "-j", typ, "show")
+-	out, err := cmd.Output()
++func getBpfMemory(fd int) (uint32, error) {
++	path := fmt.Sprintf("/proc/self/fdinfo/%d", fd)
++	f, err := os.Open(path)
+ 	if err != nil {
+-		return bpfUsage{}, fmt.Errorf("unable to get bpftool output: %w", err)
++		return 0, err
+ 	}
++	defer f.Close()
+ 
+-	var (
+-		memoryEntries []memoryEntry
+-		usage         bpfUsage
+-	)
++	reader := bufio.NewReaderSize(f, 512)
++	for {
++		data, _, err := reader.ReadLine()
++		if err != nil {
++			if err == io.EOF {
++				return 0, fmt.Errorf("memlock key not found in %s", path)
++			}
++			return 0, err
++		}
+ 
+-	err = json.Unmarshal(out, &memoryEntries)
+-	if err != nil {
+-		return usage, fmt.Errorf("unable to unmarshal bpftool output: %w", err)
++		key := []byte("memlock:")
++		idx := bytes.Index(data, key)
++		if idx == -1 {
++			continue
++		}
++
++		valueIdx := findFirstNumber(data, idx+len(key))
++		if valueIdx == -1 {
++			return 0, fmt.Errorf("memlock value not found")
++		}
++
++		valBytes := data[valueIdx:]
++		var val uint32
++		for _, c := range valBytes {
++			if c < '0' || c > '9' {
++				break
++			}
++			val = val*10 + uint32(c-'0')
++		}
++		return uint32(val), nil
+ 	}
++}
++
++func getCiliumMapsStats() (mapIDs map[ebpf.MapID]struct{}, memorySum uint32, count uint32, err error) {
++	mapIDs = make(map[ebpf.MapID]struct{}, 256)
++	var startID ebpf.MapID = 0
++	for {
++		nextID, err := ebpf.MapGetNextID(startID)
++		if err != nil {
++			if errors.Is(err, unix.ENOENT) {
++				break
++			}
++			return nil, 0, 0, fmt.Errorf("failed to get next map ID after %d: %w", startID, err)
++		}
+ 
+-	for _, entry := range memoryEntries {
+-		if !filter(entry) {
++		startID = nextID
++		m, err := ebpf.NewMapFromID(nextID)
++		if err != nil {
+ 			continue
+ 		}
+ 
+-		usage.ids = append(usage.ids, entry.ID)
+-		usage.virtualMemoryMaxBytes += float64(entry.BytesMemlock)
++		info, err := m.Info()
++		if err != nil {
++			m.Close()
++			continue
++		}
++
++		if !strings.HasPrefix(info.Name, "cilium_") {
++			m.Close()
++			continue
++		}
++
++		mapMemory, err := getBpfMemory(int(m.FD()))
++		m.Close()
++		if err != nil {
++			continue
++		}
++
++		mapIDs[nextID] = struct{}{}
++		count++
++		memorySum += mapMemory
+ 	}
++	return mapIDs, memorySum, count, nil
++}
++
++func getCiliumProgsStats(ciliumMapIDs map[ebpf.MapID]struct{}) (maxComplexity uint32, memorySum uint32, count uint32, err error) {
++	var startID ebpf.ProgramID = 0
++	for {
++		nextID, err := ebpf.ProgramGetNextID(startID)
++		if err != nil {
++			if errors.Is(err, os.ErrNotExist) {
++				break
++			}
++			return 0, 0, 0, fmt.Errorf("failed to get next program ID: %v", err)
++		}
++
++		startID = nextID
++		prog, err := ebpf.NewProgramFromID(nextID)
++		if err != nil {
++			continue
++		}
++
++		info, err := prog.Info()
++		if err != nil {
++			prog.Close()
++			continue
++		}
++
++		mapIDs, ok := info.MapIDs()
++		if !ok {
++			prog.Close()
++			continue
++		}
+ 
+-	return usage, nil
++		usesCiliumMap := false
++		for _, mapID := range mapIDs {
++			if _, ok := ciliumMapIDs[mapID]; ok {
++				usesCiliumMap = true
++				break
++			}
++		}
++		if !usesCiliumMap {
++			prog.Close()
++			continue
++		}
++
++		progMemory, err := getBpfMemory(int(prog.FD()))
++		prog.Close()
++		if err != nil {
++			continue
++		}
++
++		insts, valid := info.VerifiedInstructions()
++		if valid && insts > maxComplexity {
++			maxComplexity = insts
++		}
++
++		count++
++		memorySum += progMemory
++	}
++	return maxComplexity, memorySum, count, nil
+ }
+ 
+ func (s *bpfCollector) Collect(ch chan<- prometheus.Metric) {
+ 	type bpfUsageResults struct {
+-		maps     bpfUsage
+-		programs bpfUsage
++		maps          bpfUsage
++		programs      bpfUsage
++		maxComplexity uint32
+ 	}
+ 
+ 	// Avoid querying BPF multiple times concurrently, if it happens, additional callers will wait for the
+ 	// first one to finish and reuse its resulting values.
+ 	results, err, _ := s.sfg.Do("collect", func() (interface{}, error) {
+ 		var (
+-			results = bpfUsageResults{}
+-			err     error
++			results                                 = bpfUsageResults{}
++			mapIDs                                  map[ebpf.MapID]struct{}
++			mapMemorySum, mapCount                  uint32
++			maxComplexity, progMemorySum, progCount uint32
++			err                                     error
+ 		)
+ 
+-		if results.maps, err = getBPFUsage("map", func(entry memoryEntry) bool {
+-			// Filter on maps prefixed with cilium_
+-			return strings.HasPrefix(entry.Name, "cilium_")
+-		}); err != nil {
++		if mapIDs, mapMemorySum, mapCount, err = getCiliumMapsStats(); err != nil {
+ 			return results, err
+ 		}
+ 
+-		if results.programs, err = getBPFUsage("prog", func(entry memoryEntry) bool {
+-			// Filter on programs related to cilium maps
+-			for i := 0; i < len(entry.MapIDs); i++ {
+-				if slices.Contains(results.maps.ids, entry.MapIDs[i]) {
+-					return true
+-				}
+-			}
+-			return false
+-		}); err != nil {
++		if maxComplexity, progMemorySum, progCount, err = getCiliumProgsStats(mapIDs); err != nil {
+ 			return results, err
+ 		}
+ 
++		results = bpfUsageResults{
++			maps: bpfUsage{
++				count:                 mapCount,
++				virtualMemoryMaxBytes: mapMemorySum,
++			},
++			programs: bpfUsage{
++				count:                 progCount,
++				virtualMemoryMaxBytes: progMemorySum,
++			},
++			maxComplexity: maxComplexity,
++		}
+ 		return results, nil
+ 	})
+ 
+@@ -149,24 +303,30 @@ func (s *bpfCollector) Collect(ch chan<- prometheus.Metric) {
+ 	ch <- prometheus.MustNewConstMetric(
+ 		s.bpfMapsCount,
+ 		prometheus.GaugeValue,
+-		results.(bpfUsageResults).maps.count(),
++		float64(results.(bpfUsageResults).maps.count),
+ 	)
+ 
+ 	ch <- prometheus.MustNewConstMetric(
+ 		s.bpfMapsMemory,
+ 		prometheus.GaugeValue,
+-		results.(bpfUsageResults).maps.virtualMemoryMaxBytes,
++		float64(results.(bpfUsageResults).maps.virtualMemoryMaxBytes),
+ 	)
+ 
+ 	ch <- prometheus.MustNewConstMetric(
+ 		s.bpfProgramsCount,
+ 		prometheus.GaugeValue,
+-		results.(bpfUsageResults).programs.count(),
++		float64(results.(bpfUsageResults).programs.count),
+ 	)
+ 
+ 	ch <- prometheus.MustNewConstMetric(
+ 		s.bpfProgramsMemory,
+ 		prometheus.GaugeValue,
+-		results.(bpfUsageResults).programs.virtualMemoryMaxBytes,
++		float64(results.(bpfUsageResults).programs.virtualMemoryMaxBytes),
++	)
++
++	ch <- prometheus.MustNewConstMetric(
++		s.bpfProgramsComplexity,
++		prometheus.GaugeValue,
++		float64(results.(bpfUsageResults).maxComplexity),
+ 	)
+ }
+-- 
+2.34.1
+

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -68,3 +68,7 @@ Added an implementation of the Least Connections load balancing algorithm.
 ## 013-ignore-egress-gateway-inactual-warning.patch
 
 Ignore error when using IPv4 address for egress gateway other than assigned
+
+## 014-kernel-verifier-stat.patch
+
+Added kernel verifer statistics in logs and prometeus metric as max bpf program complexity


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add Prometheus metric `bpf_progs_complexity_max_verified_insts ` for maximum BPF instruction complexity among loaded programs.

Metric is available with kernel >= 5.16.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This PR introduces a new Prometheus metric that reports the maximum instruction complexity among all loaded BPF programs managed by Cilium. The metric provides observability into how complex the currently loaded BPF programs are, which can help operators identify potential performance or verification issues early after upgrades or configuration changes.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: feature
summary: Added Prometheus metric `bpf_progs_complexity_max_verified_insts ` for maximum BPF instruction complexity (available with kernel >= 5.16).
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
