### PR TITLE
[docs] Add preview badge status to sidebar plugin

### DIFF
--- a/docs/documentation/_plugins/custom_sidebar.rb
+++ b/docs/documentation/_plugins/custom_sidebar.rb
@@ -89,6 +89,8 @@ module Jekyll
                <span class='sidebar__badge_v2'
                      title="#{ @context.registers[:site].data['i18n']['features']["%s_long" % entry['featureStatus']][lang].gsub(/<\/?[^>]*>/, "").lstrip.sub(/\.$/, '')}">
                    #{case entry['featureStatus']
+                       when "preview"
+                           "Preview"
                        when "experimental"
                            "Exp"
                        when "deprecated"


### PR DESCRIPTION
## Description
Add support for displaying a "Preview" badge status in the custom sidebar plugin for documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add preview badge status to sidebar plugin.
impact_level: low
```
