### PR TITLE
[docs] Move network-policy-engine module to the network section in the sidebar

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -972,7 +972,6 @@ entries:
                         en: Custom Resources
                         ru: Custom Resources
                       url: /modules/metallb/cr.html
-
         - title:
             en: Other modules
             ru: Другие модули
@@ -1017,6 +1016,23 @@ entries:
                     en: Configuration
                     ru: Настройки
                   url: /modules/network-gateway/configuration.html
+            - title:
+                en: network-policy-engine
+                ru: network-policy-engine
+              moduleName: network-policy-engine
+              folders:
+                - title:
+                    en: Description
+                    ru: Описание
+                  url: /modules/network-policy-engine/
+                - title:
+                    en: Examples
+                    ru: Примеры
+                  url: /modules/network-policy-engine/examples.html
+                - title:
+                    en: Configuration
+                    ru: Настройки
+                  url: /modules/network-policy-engine/configuration.html
             - title:
                 en: service-with-healthchecks
                 ru: service-with-healthchecks
@@ -1595,23 +1611,6 @@ entries:
                     en: FAQ
                     ru: FAQ
                   url: /modules/cert-manager/faq.html
-            - title:
-                en: network-policy-engine
-                ru: network-policy-engine
-              moduleName: network-policy-engine
-              folders:
-                - title:
-                    en: Description
-                    ru: Описание
-                  url: /modules/network-policy-engine/
-                - title:
-                    en: Examples
-                    ru: Примеры
-                  url: /modules/network-policy-engine/examples.html
-                - title:
-                    en: Configuration
-                    ru: Настройки
-                  url: /modules/network-policy-engine/configuration.html
             - title:
                 en: operator-trivy
                 ru: operator-trivy


### PR DESCRIPTION
## Description
Move network-policy-engine module to the network section in the sidebar.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Move network-policy-engine module to the network section in the sidebar.
impact_level: low
```
