### PR TITLE
[node-manager] fix reset of GracefulShutdownPostpone condition at start

### DIFF
--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/nodecondition/graceful_shutdown_postpone.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/nodecondition/graceful_shutdown_postpone.go
@@ -66,7 +66,8 @@ func uncordonOnStart(nodeName string) error {
 	}
 
 	// hold cordon if inhibitor is already in shutdown state
-	if podArePresentCondition.Status == "True" &&
+	if podArePresentCondition != nil &&
+		podArePresentCondition.Status == "True" &&
 		podArePresentCondition.Type == GracefulShutdownPostponeType &&
 		podArePresentCondition.Reason == ReasonPodsArePresent {
 		return nil

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/nodecondition/graceful_shutdown_postpone.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/nodecondition/graceful_shutdown_postpone.go
@@ -79,7 +79,8 @@ func uncordonOnStart(nodeName string) error {
 	}
 
 	// wait until node is ready
-	if nodeNotReadyCondition.Status == "False" &&
+	if nodeNotReadyCondition != nil &&
+		nodeNotReadyCondition.Status == "False" &&
 		nodeNotReadyCondition.Type == "Ready" &&
 		nodeNotReadyCondition.Reason == "KubeletNotReady" {
 		return fmt.Errorf("node %q is not ready", nodeName)

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/kubernetes/condition.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/kubernetes/condition.go
@@ -16,13 +16,14 @@ type Condition struct {
 }
 
 func ConditionFromJSON(condition []byte) (*Condition, error) {
-	var conditionJSON Condition
-	if string(condition) != "''" {
-		err := json.Unmarshal(condition, &conditionJSON)
-		if err != nil {
-			return nil, fmt.Errorf("condition json unmarshal: %w", err)
-		}
+	if len(condition) == 0 || condition[0] != '{' {
+		return nil, fmt.Errorf("expect condition as JSON object, got: %s", string(condition))
 	}
 
+	var conditionJSON Condition
+	err := json.Unmarshal(condition, &conditionJSON)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal condition JSON object: %w (%s)", err, string(condition))
+	}
 	return &conditionJSON, nil
 }

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/kubernetes/condition.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/kubernetes/condition.go
@@ -16,7 +16,11 @@ type Condition struct {
 }
 
 func ConditionFromJSON(condition []byte) (*Condition, error) {
-	if len(condition) == 0 || condition[0] != '{' {
+	if len(condition) == 0 {
+		return nil, nil
+	}
+
+	if condition[0] != '{' {
 		return nil, fmt.Errorf("expect condition as JSON object, got: %s", string(condition))
 	}
 

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/kubernetes/kubectl.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/kubernetes/kubectl.go
@@ -111,7 +111,7 @@ func (k *Kubectl) GetCondition(nodeName, reason string) (*Condition, error) {
 }
 
 func (k *Kubectl) getCondition(nodeName, reason string) ([]byte, error) {
-	jsonPath := fmt.Sprintf(`jsonpath='{.status.conditions[?(@.reason=="%s")]}'`, reason)
+	jsonPath := fmt.Sprintf(`jsonpath={.status.conditions[?(@.reason=="%s")]}`, reason)
 	cmd := k.cmd("get", "node", nodeName, "-o", jsonPath)
 	return cmd.Output()
 }


### PR DESCRIPTION
## Description

Single quotes in arguments are dropped in bash, but are passed as-is in Go. Unmarshal in  ConditionFromJSON can't parse quoted JSON objects.


## Why do we need it, and what problem does it solve?

In some scenarios, condition GracefulShutdownPostpone may still present during Node startup. This PR fixes parsing problem in this situation.

Error from logs:

```
Jul 28 08:53:58 node-03 systemd[1]: Started Shutdown inhibitor to allow manual Pod eviction.
...
Jul 28 08:53:58 node-03 d8-shutdown-inhibitor[98271]: Stop all tasks...
...
Jul 28 08:53:59 node-03 d8-shutdown-inhibitor[98271]: Stop app...
Jul 28 08:53:59 node-03 d8-shutdown-inhibitor[98271]: Application stopped
Jul 28 08:53:59 node-03 d8-shutdown-inhibitor[98271]: ERROR: nodeConditionSetter patch Node to set condition: condition json unmarshal: invalid character '\'' looking for beginning of value
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: fix reset of GracefulShutdownPostpone condition at Node startup
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
