### PR TITLE
[docs] Fix pagination in guides filter

### DIFF
--- a/docs/site/assets/js/filter.js
+++ b/docs/site/assets/js/filter.js
@@ -1,7 +1,62 @@
 $(document).ready(function () {
-  const filterCheckboxes = document.querySelector('.filter__checkboxes');
   const articles = document.querySelectorAll('.button-tile');
+  const moreButton = document.querySelector('.tile__pagination');
+  const filterCheckboxes = document.querySelector('.filter__checkboxes');
   const resetButton = document.querySelector('.reset-check');
+  const itemsPerPage = 12;
+  let filteredArticles = [];
+  let count = 0;
+
+  function hideAllItems() {
+    articles.forEach(article => article.style.display = 'none');
+  }
+
+  function showItems() {
+    const end = Math.min(count + itemsPerPage, filteredArticles.length);
+
+    for(let i = count; i < end; i++) {
+        filteredArticles[i].style.display = 'flex';
+    }
+
+    count = end;
+
+    if(count >= filteredArticles.length) {
+      moreButton.style.display = 'none';
+    } else {
+      moreButton.style.display = 'flex';
+    }
+  }
+
+  function initializeArticlePagination(articlesToPagination) {
+    filteredArticles = articlesToPagination;
+    count = 0;
+    hideAllItems();
+
+    if(filteredArticles.length <= itemsPerPage) {
+      filteredArticles.forEach(list => list.style.display = 'flex');
+      moreButton.style.display = 'none';
+    } else {
+      showItems();
+    }
+  }
+
+  function filterArticles() {
+    const checkboxesChecked = filterCheckboxes.querySelectorAll('input[type="checkbox"]:checked');
+    const selectedTags = Array.from(checkboxesChecked).map(checkbox => checkbox.value);
+
+    const filtered = Array.from(articles).filter(article => {
+      const tagElement = Array.from(article.querySelectorAll('.button-tile__tags .sidebar__badge--container .sidebar__badge_v2')).map(tag => tag.textContent);
+      return selectedTags.length === 0 || selectedTags.every(tag => tagElement.includes(tag));
+    })
+
+    initializeArticlePagination(filtered);
+
+    if (checkboxesChecked.length > 0) {
+      resetButton.classList.add('active');
+    } else {
+      resetButton.classList.remove('active');
+    }
+  }
 
   function getTags() {
     const tags = new Set();
@@ -28,23 +83,6 @@ $(document).ready(function () {
     filterCheckboxes.appendChild(label);
   }
 
-  function filterArticles() {
-    const checkboxesChecked = filterCheckboxes.querySelectorAll('input[type="checkbox"]:checked');
-    const selectedTags = Array.from(checkboxesChecked).map(checkbox => checkbox.value);
-    articles.forEach(article => {
-      const tagElement = Array.from(article.querySelectorAll('.button-tile__tags .sidebar__badge--container .sidebar__badge_v2')).map(tag => tag.textContent);
-
-      const shouldShow = selectedTags.length === 0 || selectedTags.every(tag => tagElement.includes(tag));
-      article.style.display = shouldShow ? 'flex' : 'none';
-    });
-
-    if (checkboxesChecked.length > 0) {
-      resetButton.classList.add('active');
-    } else {
-      resetButton.classList.remove('active');
-    }
-  }
-
   function createFilters() {
     const tags = getTags();
     tags.forEach(tag => {
@@ -54,6 +92,10 @@ $(document).ready(function () {
     filterCheckboxes.querySelectorAll('input[type="checkbox"]').forEach(checkbox => checkbox.addEventListener('change', filterArticles));
   }
 
+  createFilters();
+  initializeArticlePagination(Array.from(articles));
+  moreButton.addEventListener('click', showItems);
+
   resetButton.addEventListener('click', () => {
     const checkboxes = filterCheckboxes.querySelectorAll('input[type="checkbox"]');
     checkboxes.forEach(checkbox => {
@@ -61,7 +103,4 @@ $(document).ready(function () {
     });
     filterArticles();
   })
-
-  createFilters();
-  filterArticles();
 })

--- a/docs/site/assets/js/tile.js
+++ b/docs/site/assets/js/tile.js
@@ -20,39 +20,3 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     });
 })
-
-document.addEventListener('DOMContentLoaded', function () {
-  const items = document.querySelectorAll('.button-tile');
-  const button = document.querySelector('.tile__pagination');
-  const itemsPerPage = 12;
-  let count = 0;
-
-  function hideAllItems() {
-    items.forEach(item => item.style.display = 'none');
-  }
-
-  function showItems() {
-    const end = Math.min(count + itemsPerPage, items.length);
-
-    for(let i = 0; i < end; i++) {
-        items[i].style.display = 'flex';
-    }
-
-    count = end;
-
-    if(count >= items.length) {
-        button.style.display = 'none';
-    }
-  }
-
-  if(items.length < itemsPerPage) {
-    button.style.display = 'none';
-  }
-
-  hideAllItems()
-  showItems();
-
-  button.addEventListener('click', () => {
-    showItems();
-  });
-})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix pagination in guides filter.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix pagination in guides.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
