### PR TITLE
[node-manager] usage Instance in update_approval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ bin/crane: bin ## Install crane deps for update-patchversion script.
 
 bin/trdl: bin
 	@if ! command -v werf >/dev/null 2>&1; then \
-		curl -sSfL https://tuf.trdl.dev/targets/releases/0.6.3/$(TRDL_PLATFORM)-$(TRDL_ARCH)/bin/trdl -o bin/trdl; \
+		curl -sSfL https://tuf.trdl.dev/targets/releases/0.7.0/$(TRDL_PLATFORM)-$(TRDL_ARCH)/bin/trdl -o bin/trdl; \
 		chmod +x bin/trdl; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -300,16 +300,20 @@ bin/crane: bin ## Install crane deps for update-patchversion script.
 	curl -sSfL https://github.com/google/go-containerregistry/releases/download/v0.10.0/go-containerregistry_$(OS_NAME)_$(CRANE_ARCH).tar.gz | tar -xzf - crane && mv crane bin/crane && chmod +x bin/crane
 
 bin/trdl: bin
-	curl -sSfL https://tuf.trdl.dev/targets/releases/0.6.3/$(TRDL_PLATFORM)-$(TRDL_ARCH)/bin/trdl -o bin/trdl
-	chmod +x bin/trdl
+	@if ! command -v werf >/dev/null 2>&1; then \
+		curl -sSfL https://tuf.trdl.dev/targets/releases/0.6.3/$(TRDL_PLATFORM)-$(TRDL_ARCH)/bin/trdl -o bin/trdl; \
+		chmod +x bin/trdl; \
+	fi
 
 bin/werf: bin bin/trdl ## Install werf for images-digests generator.
-	@bash -c 'trdl --home-dir bin/.trdl add werf https://tuf.werf.io 1 b7ff6bcbe598e072a86d595a3621924c8612c7e6dc6a82e919abe89707d7e3f468e616b5635630680dd1e98fc362ae5051728406700e6274c5ed1ad92bea52a2'
-	@if command -v bin/werf >/dev/null 2>&1; then \
-		trdl --home-dir bin/.trdl --no-self-update=true update --in-background werf 2 alpha; \
-	else \
-		trdl --home-dir bin/.trdl --no-self-update=true update werf 2 alpha; \
-		ln -sf $$(bin/trdl --home-dir bin/.trdl bin-path werf 2 alpha | sed 's|^.*/bin/\(.trdl.*\)|\1/werf|') bin/werf; \
+	@if ! command -v werf >/dev/null 2>&1; then \
+		bash -c 'trdl --home-dir bin/.trdl add werf https://tuf.werf.io 1 b7ff6bcbe598e072a86d595a3621924c8612c7e6dc6a82e919abe89707d7e3f468e616b5635630680dd1e98fc362ae5051728406700e6274c5ed1ad92bea52a2'; \
+		if command -v bin/werf >/dev/null 2>&1; then \
+			trdl --home-dir bin/.trdl --no-self-update=true update --in-background werf 2 alpha; \
+		else \
+			trdl --home-dir bin/.trdl --no-self-update=true update werf 2 alpha; \
+			ln -sf $$(bin/trdl --home-dir bin/.trdl bin-path werf 2 alpha | sed 's|^.*/bin/\(.trdl.*\)|\1/werf|') bin/werf; \
+		fi; \
 	fi
 
 bin/gh: bin ## Install gh cli.

--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -393,7 +393,6 @@ func (ar *updateApprover) nodeUpToDate(input *go_hook.HookInput, node *updateApp
 func (ar *updateApprover) nodeDeleteRollingUpdate(input *go_hook.HookInput, node *updateApprovalNode) {
 	input.Logger.Info("Delete instances due to RollingUpdate strategy", slog.String("node", node.Name), slog.String("ng", node.NodeGroup))
 	input.PatchCollector.DeleteInBackground("deckhouse.io/v1alpha1", "Instance", "", node.Name)
-	input.PatchCollector.PatchWithMerge(RollingUpdatePatch, "v1", "Node", "", node.Name)
 	ar.finished = true
 }
 
@@ -446,13 +445,6 @@ type updateNodeGroup struct {
 }
 
 var (
-	RollingUpdatePatch = map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": map[string]interface{}{
-				"update.node.deckhouse.io/rolling-update": "controler",
-			},
-		},
-	}
 	approvedPatch = map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"annotations": map[string]interface{}{

--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -391,8 +391,8 @@ func (ar *updateApprover) nodeUpToDate(input *go_hook.HookInput, node *updateApp
 }
 
 func (ar *updateApprover) nodeDeleteRollingUpdate(input *go_hook.HookInput, node *updateApprovalNode) {
-	input.Logger.Info("Delete machine d8-cloud-instance-manager due to RollingUpdate strategy", slog.String("name", node.Name), slog.String("ng", node.NodeGroup))
-	input.PatchCollector.DeleteInBackground("machine.sapcloud.io/v1alpha1", "Machine", "d8-cloud-instance-manager", node.Name)
+	input.Logger.Info("Delete instances due to RollingUpdate strategy", slog.String("name", node.Name), slog.String("ng", node.NodeGroup))
+	input.PatchCollector.DeleteInBackground("deckhouse.io/v1alpha1", "Instance", "", node.Name)
 	ar.finished = true
 }
 

--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -391,8 +391,9 @@ func (ar *updateApprover) nodeUpToDate(input *go_hook.HookInput, node *updateApp
 }
 
 func (ar *updateApprover) nodeDeleteRollingUpdate(input *go_hook.HookInput, node *updateApprovalNode) {
-	input.Logger.Info("Delete instances due to RollingUpdate strategy", slog.String("name", node.Name), slog.String("ng", node.NodeGroup))
+	input.Logger.Info("Delete instances due to RollingUpdate strategy", slog.String("node", node.Name), slog.String("ng", node.NodeGroup))
 	input.PatchCollector.DeleteInBackground("deckhouse.io/v1alpha1", "Instance", "", node.Name)
+	input.PatchCollector.PatchWithMerge(RollingUpdatePatch, "v1", "Node", "", node.Name)
 	ar.finished = true
 }
 
@@ -445,6 +446,13 @@ type updateNodeGroup struct {
 }
 
 var (
+	RollingUpdatePatch = map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				"update.node.deckhouse.io/rolling-update": "controler",
+			},
+		},
+	}
 	approvedPatch = map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"annotations": map[string]interface{}{

--- a/modules/040-node-manager/hooks/update_approval_test.go
+++ b/modules/040-node-manager/hooks/update_approval_test.go
@@ -69,7 +69,7 @@ data:
 
 	f := HookExecutionConfigInit(`{"nodeManager":{"internal":{}}}`, `{}`)
 	f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
-	f.RegisterCRD("machine.sapcloud.io", "v1alpha1", "Machine", true)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "Instance", false)
 
 	Context("Empty cluster", func() {
 		BeforeEach(func() {
@@ -1103,21 +1103,20 @@ metadata:
     update.node.deckhouse.io/approved: ""
     update.node.deckhouse.io/rolling-update: ""
 ---
-apiVersion: machine.sapcloud.io/v1alpha1
-kind: Machine
+apiVersion: deckhouse.io/v1alpha1
+kind: Instance
 metadata:
   name: worker-1
-  namespace: d8-cloud-instance-manager
   labels:
-    node: worker-1
+    node.deckhouse.io/group: ng1
 `))
 				f.RunHook()
 			})
 
-			It("machine should be deleted", func() {
+			It("Instance should be deleted", func() {
 				Expect(f).To(ExecuteSuccessfully())
 
-				m := f.KubernetesResource("Machine", "d8-cloud-instance-manager", "worker-1")
+				m := f.KubernetesResource("Instance", "", "worker-1")
 				Expect(m.Exists()).To(BeFalse())
 			})
 		})
@@ -1156,21 +1155,20 @@ metadata:
     update.node.deckhouse.io/approved: ""
     update.node.deckhouse.io/rolling-update: ""
 ---
-apiVersion: machine.sapcloud.io/v1alpha1
-kind: Machine
+apiVersion: deckhouse.io/v1alpha1
+kind: Instance
 metadata:
   name: worker-1
-  namespace: d8-cloud-instance-manager
   labels:
-    node: worker-1
+    node.deckhouse.io/group: ng1
 `))
 				f.RunHook()
 			})
 
-			It("machine should be deleted", func() {
+			It("Instance should be deleted", func() {
 				Expect(f).To(ExecuteSuccessfully())
 
-				m := f.KubernetesResource("Machine", "d8-cloud-instance-manager", "worker-1")
+				m := f.KubernetesResource("Instance", "", "worker-1")
 				Expect(m.Exists()).To(BeFalse())
 			})
 		})
@@ -1209,21 +1207,20 @@ metadata:
     update.node.deckhouse.io/approved: ""
     update.node.deckhouse.io/rolling-update: ""
 ---
-apiVersion: machine.sapcloud.io/v1alpha1
-kind: Machine
+apiVersion: deckhouse.io/v1alpha1
+kind: Instance
 metadata:
   name: worker-1
-  namespace: d8-cloud-instance-manager
   labels:
-    node: worker-1
+    node.deckhouse.io/group: ng1
 `))
 				f.RunHook()
 			})
 
-			It("machine should be deleted", func() {
+			It("Instance should be deleted", func() {
 				Expect(f).To(ExecuteSuccessfully())
 
-				m := f.KubernetesResource("Machine", "d8-cloud-instance-manager", "worker-1")
+				m := f.KubernetesResource("Instance", "", "worker-1")
 				Expect(m.Exists()).To(BeTrue())
 			})
 		})


### PR DESCRIPTION
## Description
We redesigned it to use new node abstractions in clouds.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Using outdated node abstractions in clouds
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: usage Instance in update_approval
impact: 
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
