### PR TITLE
[docs][user-authn] Correction of KeyCloak documentation in d8-user-authn

### DIFF
--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -181,11 +181,11 @@ spec:
 {% alert level="warning" %}
 If KeyCloak does not use Email account confirmation, to use it as an Identity Provider, you need to delete the Email verified mapping in the [Client scopes tab](https://www.keycloak.org/docs/latest/server_admin/#_client_scopes_linking) ("Client Scopes" → "Email" → "Mappers"). This is necessary for the correct processing of the true value of the [`insecureSkipEmailVerified`](cr.html#dexprovider-v1-spec-oidc-insecureskipemailverified) field and the correct granting of rights to unverified users.
 
-If it is not possible to edit or delete the `Email verified` mapping, then you need to create a separate `Client scopes` `email_dkp` and add two mappings there:
+If it is not possible to edit or delete the `Email verified` mapping, then you need to create a separate `Client scopes`with the name, for example, `email_dkp` and add two mappings there:
 - `email`: «Client Scopes» → «email_dkp» → «Add mapper» → «From predefined mappers» → «email»
 - `email verified`: «Client Scopes» → «email_dkp» → «Add mapper» → «By configuration» → «Hardcoded claim», where you need to specify the following fields: «Name: email verified», «Token Claim Name: emailVerified», «Claim value: true», «Claim JSON Type: boolean». In the client registered for the DKP cluster in `Clients`, it is necessary to change the `Client scopes` `email` to `email_dkp`.
 
-You also need to specify the `insecureSkipEmailVerified: true` field in `dexProvider` and correct the name of the `Client scope` in `.spec.oidc.scopes` to `email_dkp`, as in the example:
+You also need to specify the `insecureSkipEmailVerified: true` field in `dexProvider` and replace the `Client scope` name of the `email` with `email_dkp` in the `.spec.oidc.scopes` field, as in the example:
 ```yaml
     scopes:
       - openid

--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -178,22 +178,30 @@ spec:
       - groups
 ```
 
-{% alert level="warning" %}
-If KeyCloak does not use Email account confirmation, to use it as an Identity Provider, you need to delete the Email verified mapping in the [Client scopes tab](https://www.keycloak.org/docs/latest/server_admin/#_client_scopes_linking) ("Client Scopes" → "Email" → "Mappers"). This is necessary for the correct processing of the true value of the [`insecureSkipEmailVerified`](cr.html#dexprovider-v1-spec-oidc-insecureskipemailverified) field and the correct granting of rights to unverified users.
+If email verification is not enabled in KeyCloak, to properly use it as an identity provider, adjust the [`Client Scopes`](https://www.keycloak.org/docs/latest/server_admin/#_client_scopes_linking) settings in one of the following ways:
 
-If it is not possible to edit or delete the `Email verified` mapping, then you need to create a separate `Client scopes`with the name, for example, `email_dkp` and add two mappings there:
-- `email`: «Client Scopes» → «email_dkp» → «Add mapper» → «From predefined mappers» → «email»
-- `email verified`: «Client Scopes» → «email_dkp» → «Add mapper» → «By configuration» → «Hardcoded claim», where you need to specify the following fields: «Name: email verified», «Token Claim Name: emailVerified», «Claim value: true», «Claim JSON Type: boolean». In the client registered for the DKP cluster in `Clients`, it is necessary to change the `Client scopes` `email` to `email_dkp`.
+* Delete the `Email verified` mapping ("Client Scopes" → "Email" → "Mappers").
+  This is required for proper processing of the [`insecureSkipEmailVerified`](cr.html#dexprovider-v1-spec-oidc-insecureskipemailverified) field when it's set to `true` and for correct permission assignment to users with unverified emails.
 
-You also need to specify the `insecureSkipEmailVerified: true` field in `dexProvider` and replace the `Client scope` name of the `email` with `email_dkp` in the `.spec.oidc.scopes` field, as in the example:
-```yaml
-    scopes:
-      - openid
-      - profile
-      - email_dkp
-      - groups
-```
-{% endalert %}
+* If you can't modify or delete the `Email verified` mapping, create a new Client Scope named `email_dkp` (or any other name) and add two mappings:
+  * `email`: "Client Scopes" → `email_dkp` → "Add mapper" → "From predefined mappers" → `email`.
+  * `email verified`: "Client Scopes" → `email_dkp` → "Add mapper" → "By configuration" → "Hardcoded claim". Specify the following fields:
+    * "Name": `email verified`
+    * "Token Claim Name": `emailVerified`
+    * "Claim value": `true`
+    * "Claim JSON Type": `boolean`
+
+  After that, in the client registered for the DKP cluster in "Clients", change `Client scopes` from `email` to `email_dkp`.
+
+  In the DexProvider resource, specify `insecureSkipEmailVerified: true` and in the `.spec.oidc.scopes` field, change the Client Scope name to `email_dkp` following the example:
+  
+  ```yaml
+      scopes:
+        - openid
+        - profile
+        - email_dkp
+        - groups
+  ```
 
 #### Okta
 

--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -179,7 +179,20 @@ spec:
 ```
 
 {% alert level="warning" %}
-When using Keycloak as an Identity Provider, remove the `Email verified` mapping in the [Client scopes tab](https://www.keycloak.org/docs/latest/server_admin/#_client_scopes_linking) ("Client Scopes" → "Email" → "Mappers"). This is necessary for correct processing of `true` value of [`insecureSkipEmailVerified`](cr.html#dexprovider-v1-spec-oidc-insecureskipemailverified) field  and to grant permissions to unverified users.
+If KeyCloak does not use Email account confirmation, to use it as an Identity Provider, you need to delete the Email verified mapping in the [Client scopes tab](https://www.keycloak.org/docs/latest/server_admin/#_client_scopes_linking) ("Client Scopes" → "Email" → "Mappers"). This is necessary for the correct processing of the true value of the [`insecureSkipEmailVerified`](cr.html#dexprovider-v1-spec-oidc-insecureskipemailverified) field and the correct granting of rights to unverified users.
+
+If it is not possible to edit or delete the `Email verified` mapping, then you need to create a separate `Client scopes` `email_dkp` and add two mappings there:
+- `email`: «Client Scopes» → «email_dkp» → «Add mapper» → «From predefined mappers» → «email»
+- `email verified`: «Client Scopes» → «email_dkp» → «Add mapper» → «By configuration» → «Hardcoded claim», where you need to specify the following fields: «Name: email verified», «Token Claim Name: emailVerified», «Claim value: true», «Claim JSON Type: boolean». In the client registered for the DKP cluster in `Clients`, it is necessary to change the `Client scopes` `email` to `email_dkp`.
+
+You also need to specify the `insecureSkipEmailVerified: true` field in `dexProvider` and correct the name of the `Client scope` in `.spec.oidc.scopes` to `email_dkp`, as in the example:
+```yaml
+    scopes:
+      - openid
+      - profile
+      - email_dkp
+      - groups
+```
 {% endalert %}
 
 #### Okta

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -186,11 +186,11 @@ spec:
 {% alert level="warning" %}
 В случае, если в KeyCloak не используется подтверждение учетных записей по Email, для использования его как `Identity Provider`, нужно [во вкладке Client scopes](https://www.keycloak.org/docs/latest/server_admin/#_client_scopes_linking) удалить маппинг `Email verified` («Client Scopes» → «Email» → «Mappers»). Это необходимо для корректной обработки значения `true` поля [`insecureSkipEmailVerified`](cr.html#dexprovider-v1-spec-oidc-insecureskipemailverified) и правильной выдачи прав неверифицированным пользователям.
 
-Если нет возможности редактировать или удалить маппинг `Email verified`, то необходимо создать отдельный `Client scopes` `email_dkp` и добавить туда два маппинга:
+Если нет возможности редактировать или удалить маппинг `Email verified`, то необходимо создать отдельный `Client scope` c именем, например, `email_dkp` и добавить туда два маппинга:
 - `email`: «Client Scopes» → «email_dkp» → «Add mapper» → «From predefined mappers» → «email»
 - `email verified`: «Client Scopes» → «email_dkp» → «Add mapper» → «By configuration» → «Hardcoded claim», где нужно указать следующие поля: «Name: email verified», «Token Claim Name: emailVerified», «Claim value: true», «Claim JSON Type: boolean». В зарегистрированном для кластера DKP клиенте в `Clients` необходимо поменять `Client scopes` `email` на `email_dkp`. 
 
-Также необходимо указать в `dexProvider` поле `insecureSkipEmailVerified: true` и поправить в `.spec.oidc.scopes` название `Client scope` на `email_dkp`, как в примере:
+Также необходимо указать в `dexProvider` поле `insecureSkipEmailVerified: true` и заменить в `.spec.oidc.scopes` название `Client scope` `email` на `email_dkp`, как в примере:
 ```yaml
     scopes:
       - openid

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -184,7 +184,20 @@ spec:
 ```
 
 {% alert level="warning" %}
-При использовании Keycloak, как Identity Provider [во вкладке Client scopes](https://www.keycloak.org/docs/latest/server_admin/#_client_scopes_linking) удалите маппинг `Email verified` («Client Scopes» → «Email» → «Mappers»). Это необходимо для корректной обработки значения `true` поля [`insecureSkipEmailVerified`](cr.html#dexprovider-v1-spec-oidc-insecureskipemailverified) и правильной выдачи прав неверифицированным пользователям.
+В случае, если в KeyCloak не используется подтверждение учетных записей по Email, для использования его как `Identity Provider`, нужно [во вкладке Client scopes](https://www.keycloak.org/docs/latest/server_admin/#_client_scopes_linking) удалить маппинг `Email verified` («Client Scopes» → «Email» → «Mappers»). Это необходимо для корректной обработки значения `true` поля [`insecureSkipEmailVerified`](cr.html#dexprovider-v1-spec-oidc-insecureskipemailverified) и правильной выдачи прав неверифицированным пользователям.
+
+Если нет возможности редактировать или удалить маппинг `Email verified`, то необходимо создать отдельный `Client scopes` `email_dkp` и добавить туда два маппинга:
+- `email`: «Client Scopes» → «email_dkp» → «Add mapper» → «From predefined mappers» → «email»
+- `email verified`: «Client Scopes» → «email_dkp» → «Add mapper» → «By configuration» → «Hardcoded claim», где нужно указать следующие поля: «Name: email verified», «Token Claim Name: emailVerified», «Claim value: true», «Claim JSON Type: boolean». В зарегистрированном для кластера DKP клиенте в `Clients` необходимо поменять `Client scopes` `email` на `email_dkp`. 
+
+Также необходимо указать в `dexProvider` поле `insecureSkipEmailVerified: true` и поправить в `.spec.oidc.scopes` название `Client scope` на `email_dkp`, как в примере:
+```yaml
+    scopes:
+      - openid
+      - profile
+      - email_dkp
+      - groups
+```
 {% endalert %}
 
 #### Okta

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -183,22 +183,30 @@ spec:
       - groups
 ```
 
-{% alert level="warning" %}
-В случае, если в KeyCloak не используется подтверждение учетных записей по Email, для использования его как `Identity Provider`, нужно [во вкладке Client scopes](https://www.keycloak.org/docs/latest/server_admin/#_client_scopes_linking) удалить маппинг `Email verified` («Client Scopes» → «Email» → «Mappers»). Это необходимо для корректной обработки значения `true` поля [`insecureSkipEmailVerified`](cr.html#dexprovider-v1-spec-oidc-insecureskipemailverified) и правильной выдачи прав неверифицированным пользователям.
+Если в KeyCloak не используется подтверждение учетных записей по email, для корректной работы с ним в качестве провайдера аутентификации внесите изменения в настройку [`Client scopes`](https://www.keycloak.org/docs/latest/server_admin/#_client_scopes_linking) одним из следующих способов:
 
-Если нет возможности редактировать или удалить маппинг `Email verified`, то необходимо создать отдельный `Client scope` c именем, например, `email_dkp` и добавить туда два маппинга:
-- `email`: «Client Scopes» → «email_dkp» → «Add mapper» → «From predefined mappers» → «email»
-- `email verified`: «Client Scopes» → «email_dkp» → «Add mapper» → «By configuration» → «Hardcoded claim», где нужно указать следующие поля: «Name: email verified», «Token Claim Name: emailVerified», «Claim value: true», «Claim JSON Type: boolean». В зарегистрированном для кластера DKP клиенте в `Clients` необходимо поменять `Client scopes` `email` на `email_dkp`. 
+* Удалите маппинг `Email verified` («Client Scopes» → «Email» → «Mappers»).
+  Это необходимо для корректной обработки значения `true` в поле [`insecureSkipEmailVerified`](cr.html#dexprovider-v1-spec-oidc-insecureskipemailverified) и правильной выдачи прав пользователям с неподтвержденным email.
 
-Также необходимо указать в `dexProvider` поле `insecureSkipEmailVerified: true` и заменить в `.spec.oidc.scopes` название `Client scope` `email` на `email_dkp`, как в примере:
-```yaml
-    scopes:
-      - openid
-      - profile
-      - email_dkp
-      - groups
-```
-{% endalert %}
+* Если отредактировать или удалить маппинг `Email verified` невозможно, создайте отдельный Client Scope с именем `email_dkp` (или любым другим) и добавьте в него два маппинга:
+  * `email`: «Client Scopes» → `email_dkp` → «Add mapper» → «From predefined mappers» → `email`;
+  * `email verified`: «Client Scopes» → `email_dkp` → «Add mapper» → «By configuration» → «Hardcoded claim». Укажите следующие поля:
+    * «Name»: `email verified`;
+    * «Token Claim Name»: `emailVerified`;
+    * «Claim value»: `true`;
+    * «Claim JSON Type»: `boolean`.
+  
+  После этого в клиенте, зарегистрированном для кластера DKP, в разделе «Clients» для `Client scopes` замените значение `email` на `email_dkp`.
+
+  В ресурсе DexProvider укажите параметр `insecureSkipEmailVerified: true` и в поле `.spec.oidc.scopes` замените название Client Scope на `email_dkp`, следуя примеру:
+
+  ```yaml
+      scopes:
+        - openid
+        - profile
+        - email_dkp
+        - groups
+  ```
 
 #### Okta
 


### PR DESCRIPTION
## Description
Information about KeyCloak settings has been added in case email verification is not used.

## Why do we need it, and what problem does it solve?
Some users cannot change KeyCloak settings and delete the `email_verified` mapping. To bypass email verification, a method was proposed with the configuration of `client scopes` `email`.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Added information about configuring KeyCloak, which does not use email verification.

```changes
section: docs
type: fix
summary: Correction of KeyCloak documentation in d8-user-authn
impact: Users will know how to configure KeyCloak and dexProvider to get user rights in dashboard and console.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
