### PR TITLE
[docs-builder] Hugo config error handling

### DIFF
--- a/docs/site/backends/docs-builder/internal/docs/build.go
+++ b/docs/site/backends/docs-builder/internal/docs/build.go
@@ -68,7 +68,7 @@ func (svc *Service) buildHugo() error {
 			return nil
 		}
 
-		if moduleName, ok := getAssembleErrorPath(buildErr.Error()); ok {
+		if moduleName, ok := getModuleNameFromErrorPath(buildErr.Error()); ok {
 			paths := []string{
 				filepath.Join(svc.baseDir, contentDir, moduleName),
 				filepath.Join(svc.baseDir, modulesDir, moduleName),
@@ -100,7 +100,7 @@ func (svc *Service) removeModuleFromChannelMapping(moduleName string) error {
 	})
 }
 
-func getAssembleErrorPath(errorMessage string) (string, bool) {
+func getModuleNameFromErrorPath(errorMessage string) (string, bool) {
 	match := assembleErrorRegexp.FindStringSubmatch(errorMessage)
 	if len(match) == 6 {
 		// return only module name

--- a/docs/site/backends/docs-builder/internal/docs/build_test.go
+++ b/docs/site/backends/docs-builder/internal/docs/build_test.go
@@ -21,21 +21,21 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-func TestAssembleErrorRegexp(t *testing.T) {
+func TestModuleNameFromErrorPathRegexp(t *testing.T) {
 	input := "error building site: assemble: \"/app/hugo/content/modules/moduleName/BROKEN.md:1:1\": EOF looking for end YAML front matter delimiter"
 
-	path, ok := getAssembleErrorPath(input)
-	if !ok || path != "/app/hugo/content/modules/moduleName" {
-		t.Fatalf("unexpected path %q", path)
+	moduleName, ok := getModuleNameFromErrorPath(input)
+	if !ok || moduleName != "moduleName" {
+		t.Fatalf("unexpected module name %q", moduleName)
 	}
 }
 
-func TestAssembleErrorWithColorRegexp(t *testing.T) {
+func TestModuleNameFromErrorPathWithColorRegexp(t *testing.T) {
 	input := "error building site: assemble: \x1b[1;36m\"/app/hugo/content/modules/moduleName/BROKEN.md:1:1\"\x1b[0m: EOF looking for end YAML front matter delimiter"
 
-	path, ok := getAssembleErrorPath(input)
-	if !ok || path != "/app/hugo/content/modules/moduleName" {
-		t.Fatalf("unexpected path %q", path)
+	path, ok := getModuleNameFromErrorPath(input)
+	if !ok || path != "moduleName" {
+		t.Fatalf("unexpected module name %q", path)
 	}
 }
 

--- a/docs/site/backends/docs-builder/internal/docs/build_test.go
+++ b/docs/site/backends/docs-builder/internal/docs/build_test.go
@@ -33,9 +33,9 @@ func TestModuleNameFromErrorPathRegexp(t *testing.T) {
 func TestModuleNameFromErrorPathWithColorRegexp(t *testing.T) {
 	input := "error building site: assemble: \x1b[1;36m\"/app/hugo/content/modules/moduleName/BROKEN.md:1:1\"\x1b[0m: EOF looking for end YAML front matter delimiter"
 
-	path, ok := getModuleNameFromErrorPath(input)
-	if !ok || path != "moduleName" {
-		t.Fatalf("unexpected module name %q", path)
+	moduleName, ok := getModuleNameFromErrorPath(input)
+	if !ok || moduleName != "moduleName" {
+		t.Fatalf("unexpected module name %q", moduleName)
 	}
 }
 

--- a/docs/site/backends/docs-builder/pkg/hugo/commandeer.go
+++ b/docs/site/backends/docs-builder/pkg/hugo/commandeer.go
@@ -15,6 +15,7 @@
 package hugo
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	stdlog "log"
@@ -104,6 +105,19 @@ type commonConfig struct {
 	configs *allconfig.Configs
 	cfg     config.Provider
 	fs      *hugofs.Fs
+}
+
+func (c *commonConfig) validate() error {
+	if c == nil {
+		return errors.New("commonConfig is nil")
+	}
+	if c.fs == nil {
+		return errors.New("commonConfig: no fs provided")
+	}
+	if c.configs == nil {
+		return errors.New("commonConfig: no config provided")
+	}
+	return nil
 }
 
 // This is the root command.
@@ -264,13 +278,20 @@ func (c *command) ConfigFromProvider(key int32, cfg config.Provider) (*commonCon
 }
 
 func (c *command) HugFromConfig(conf *commonConfig) (*hugolib.HugoSites, error) {
+	if err := conf.validate(); err != nil {
+		return nil, err
+	}
 	h, _, err := c.hugoSites.GetOrCreate(c.configVersionID.Load(), func(key int32) (*hugolib.HugoSites, error) {
 		depsCfg := deps.DepsCfg{Configs: conf.configs, Fs: conf.fs, StdOut: c.hugologger.StdOut(), LogLevel: c.hugologger.Level()}
 		return hugolib.NewHugoSites(depsCfg)
 	})
+	if err != nil {
+		return nil, fmt.Errorf("HugFromConfig: %w", err)
+	}
+
 	h.Log = c.hugologger
 
-	return h, err
+	return h, nil
 }
 
 func duration(key string, d time.Duration) slog.Attr {

--- a/docs/site/backends/docs-builder/pkg/hugo/commandeer_test.go
+++ b/docs/site/backends/docs-builder/pkg/hugo/commandeer_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hugo
+
+import (
+	"github.com/gohugoio/hugo/common/loggers"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bep/lazycache"
+	"github.com/deckhouse/deckhouse/pkg/log"
+	"github.com/gohugoio/hugo/hugolib"
+)
+
+func TestHugFromConfig_ErrorHandling(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("HugFromConfig panicked when it should have returned an error: %v", r)
+		}
+	}()
+
+	cmd := &command{
+		configVersionID: atomic.Int32{},
+		hugoSites: lazycache.New(lazycache.Options[int32, *hugolib.HugoSites]{
+			MaxEntries: 1,
+		}),
+		flags:      Flags{},
+		logger:     log.NewNop(),
+		hugologger: loggers.NewDefault(),
+	}
+
+	// Invalid commonConfig that will cause NewHugoSites to fail
+	conf := &commonConfig{
+		configs: nil, // This will cause hugolib.NewHugoSites to return an error
+		fs:      nil,
+	}
+
+	result, err := cmd.HugFromConfig(conf)
+
+	// Error should be returned instead of panic
+	if err == nil {
+		t.Error("expected an error to be returned when configs are nil, but got nil error")
+	}
+
+	// Verify that the result is nil when there's an error
+	if result != nil {
+		t.Error("expected result to be nil when an error occurs, but got non-nil result")
+	}
+}


### PR DESCRIPTION
## Description
This PR fixes issue during calling HugFromConfig causing the panic. To get the panic it was enough to:
1) [docs/site/backends/docs-builder-template/layouts/baseof.html](https://github.com/deckhouse/deckhouse/blob/main/docs/site/backends/docs-builder-template/layouts/baseof.html) - edit this file and broke something (syntax or invalid variable name)
2) run server locally:
```
mkdir -p ~/test-docs-builder/{src,dst}

cp -r docs/site/backends/docs-builder-template/* ~/test-docs-builder/src/

go run main.go --src ~/test-docs-builder/src --dst ~/test-docs-builder/dst --address :8081
```
3) generate the docs:
```
curl -X POST http://localhost:8081/api/v1/build \
     -H "Content-Type: application/json" \
     -d '{}'
```

4) Ensure that there is no panic in logs after fix(previously it was)

## Why do we need it, and what problem does it solve?
With this fix I added nil pointer checks and error handling in HugFromConfig body.

## Why do we need it in the patch release (if we do)?
To avoid potential issue with panic.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs-builder
type: fix
summary: error handling to avoid panicking during HugFromConfig invocation
impact: more stable behavior
impact_level: default
```
