### PR TITLE
[docs] Fix description in global-hooks/conversions/v2

### DIFF
--- a/global-hooks/openapi/conversions/v2.yaml
+++ b/global-hooks/openapi/conversions/v2.yaml
@@ -7,5 +7,5 @@ conversions:
   - del(.modules.resourcesRequests.masterNode)
   - del(.modules.proxy)
 description:
-  ru: "Перенесите `storageClass` в `modules.storageClass`."
-  en: "Move `storageClass` to `modules.storageClass`."
+  ru: "Перенесите `storageClass` в `modules.storageClass`. Удалите свойства (если они есть): `modules.resourcesRequests.everyNode`, `modules.resourcesRequests.masterNode`, `modules.proxy`."
+  en: "Move `storageClass` to `modules.storageClass`. Remove properties (if they exist): `modules.resourcesRequests.everyNode`, `modules.resourcesRequests.masterNode`, `modules.proxy`."

--- a/global-hooks/openapi/conversions/v2.yaml
+++ b/global-hooks/openapi/conversions/v2.yaml
@@ -7,5 +7,5 @@ conversions:
   - del(.modules.resourcesRequests.masterNode)
   - del(.modules.proxy)
 description:
-  ru: "Перенесите `storageClass` в `modules.storageClass`. Удалите свойства (если они есть): `modules.resourcesRequests.everyNode`, `modules.resourcesRequests.masterNode`, `modules.proxy`."
-  en: "Move `storageClass` to `modules.storageClass`. Remove properties (if they exist): `modules.resourcesRequests.everyNode`, `modules.resourcesRequests.masterNode`, `modules.proxy`."
+  ru: "Перенесите `storageClass` в `modules.storageClass`. Удалите параметры `modules.resourcesRequests.everyNode`, `modules.resourcesRequests.masterNode` и `modules.proxy`."
+  en: "Move `storageClass` to `modules.storageClass`. Remove `modules.resourcesRequests.everyNode`, `modules.resourcesRequests.masterNode` and `modules.proxy` parameters."


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix description in global ModuleConfig conversion (add info about removing deprecated properties from ModuleConfig).

Relevant to #13573

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Update `global` ModuleConfig conversion from v1 to v2.
impact_level: low
```
