### PR TITLE
[docs] Added information about disk size in the Yandex documentation

### DIFF
--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -130,7 +130,7 @@ apiVersions:
               diskType: &instanceClassDiskType
                 type: string
                 description: |
-                  Yandex Compute Instance disk type.
+                  Yandex Compute Instance disk type. Size of `network-ssd-nonreplicated` and `network-ssd-io-m3` disks must be a multiple of 93 GB.
                 example: network-ssd-io-m3
                 x-doc-default: network-ssd
                 enum: [ network-ssd, network-ssd-io-m3, network-ssd-nonreplicated ]

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -54,7 +54,7 @@ apiVersions:
                   Размер диска у инстансов. Значение указывается в `ГиБ`.
               diskType:
                 description: |
-                  Тип диска у создаваемых инстансов.
+                  Тип диска у создаваемых инстансов. Размер дисков `network-ssd-nonreplicated` и `network-ssd-io-m3` должен быть кратен 93 GB.
               etcdDiskSizeGb:
                 description: |
                   Размер диска для etcd. Значение указывается в `ГиБ`.

--- a/candi/cloud-providers/yandex/openapi/doc-ru-instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-instance_class.yaml
@@ -39,6 +39,8 @@ spec:
                   description: |
                     Тип диска у виртуальных машин.
 
+                    Размер дисков `network-ssd-nonreplicated` и `network-ssd-io-m3` должен быть кратен 93 GB.
+
                     Подробнее о возможных типах дисков можно узнать в [документации провайдера](https://cloud.yandex.com/docs/compute/concepts/disk#disks_types).
                 diskSizeGB:
                   description: |
@@ -98,10 +100,10 @@ spec:
                 diskType:
                   description: |
                     Тип диска у виртуальных машин.
+                    
+                    Размер дисков `network-ssd-nonreplicated` и `network-ssd-io-m3` должен быть кратен 93 GB.
 
                     Подробнее о возможных типах дисков можно узнать в [документации провайдера](https://cloud.yandex.com/docs/compute/concepts/disk#disks_types).
-
-                    Размер дисков `network-ssd-nonreplicated` и `network-ssd-io-m3` должен быть кратен 93 GB.
                 diskSizeGB:
                   description: |
                     Размер диска у виртуальных машин. Значение указывается в `ГиБ`.

--- a/candi/cloud-providers/yandex/openapi/instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/instance_class.yaml
@@ -74,6 +74,8 @@ spec:
                   description: |
                     Instance disk type.
 
+                    Size of `network-ssd-nonreplicated` and `network-ssd-io-m3` disks must be a multiple of 93 GB.
+
                     For more information about possible disk types, read the [provider's documentation](https://cloud.yandex.com/en-ru/docs/compute/concepts/disk#disks_types).
                   x-doc-examples: ["network-hdd"]
                   x-doc-default: "network-hdd"


### PR DESCRIPTION
## Description
Added information about disk size in the Yandex documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary:Added information about disk size in the Yandex documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
