### PR TITLE
[docs] Change d8 d command to d8 dk in the documentation

### DIFF
--- a/docs/documentation/pages/DECKHOUSE-CLI.md
+++ b/docs/documentation/pages/DECKHOUSE-CLI.md
@@ -9,13 +9,13 @@ Deckhouse CLI is a command line interface for cluster management created by the 
 On the command line, the utility can be invoked using the `d8` alias. All the commands are grouped by their function:
 
 {% alert level="info" %}
-The `d8 k` and `d8 mirror` command groups are not available for Community Edition (CE) and Basic Edition (BE).
+The `d8 dk` and `d8 mirror` command groups are not available for Community Edition (CE) and Basic Edition (BE).
 {% endalert %}
 
 * `d8 k` — the `kubectl` command family.  
     For example, `d8 k get pods` is the same as `kubectl get pods`.
 * `d8 dk` — the range of delivery-related commands (see the `werf` tool).  
-    For example, you can run `d8 k plan --repo registry.deckhouse.io` instead of `werf plan --repo registry.deckhouse.io`.
+    For example, you can run `d8 dk plan --repo registry.deckhouse.io` instead of `werf plan --repo registry.deckhouse.io`.
 
 * `d8 mirror` — the range of commands that allow you to copy DKP distribution images to a private container registry (previously the `dhctl mirror` tool was used for this purpose).
   For example, you can run `d8 mirror pull -l <LICENSE> <TAR-BUNDLE-PATH>` instead of `dhctl mirror --license <LICENSE> --images-bundle-path <TAR-BUNDLE-PATH>`.

--- a/docs/documentation/pages/DECKHOUSE-CLI.md
+++ b/docs/documentation/pages/DECKHOUSE-CLI.md
@@ -9,13 +9,13 @@ Deckhouse CLI is a command line interface for cluster management created by the 
 On the command line, the utility can be invoked using the `d8` alias. All the commands are grouped by their function:
 
 {% alert level="info" %}
-The `d8 d` and `d8 mirror` command groups are not available for Community Edition (CE) and Basic Edition (BE).
+The `d8 k` and `d8 mirror` command groups are not available for Community Edition (CE) and Basic Edition (BE).
 {% endalert %}
 
 * `d8 k` — the `kubectl` command family.  
     For example, `d8 k get pods` is the same as `kubectl get pods`.
 * `d8 dk` — the range of delivery-related commands (see the `werf` tool).  
-    For example, you can run `d8 d plan --repo registry.deckhouse.io` instead of `werf plan --repo registry.deckhouse.io`.
+    For example, you can run `d8 k plan --repo registry.deckhouse.io` instead of `werf plan --repo registry.deckhouse.io`.
 
 * `d8 mirror` — the range of commands that allow you to copy DKP distribution images to a private container registry (previously the `dhctl mirror` tool was used for this purpose).
   For example, you can run `d8 mirror pull -l <LICENSE> <TAR-BUNDLE-PATH>` instead of `dhctl mirror --license <LICENSE> --images-bundle-path <TAR-BUNDLE-PATH>`.

--- a/docs/documentation/pages/DECKHOUSE-CLI_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-CLI_RU.md
@@ -10,7 +10,7 @@ Deckhouse CLI — это интерфейс командной строки дл
 В командной строке к утилите можно обратиться как `d8`. Все команды сгруппированы по функциям:
 
 {% alert level="info" %}
-Группы команд `d8 d` и `d8 mirror` недоступны для Community Edition (CE) и Basic Edition (BE).
+Группы команд `d8 k` и `d8 mirror` недоступны для Community Edition (CE) и Basic Edition (BE).
 {% endalert %}
 
 * `d8 k` — команды, которые в кластерах Kubernetes выполняет `kubectl`.  

--- a/docs/documentation/pages/DECKHOUSE-CLI_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-CLI_RU.md
@@ -10,7 +10,7 @@ Deckhouse CLI — это интерфейс командной строки дл
 В командной строке к утилите можно обратиться как `d8`. Все команды сгруппированы по функциям:
 
 {% alert level="info" %}
-Группы команд `d8 k` и `d8 mirror` недоступны для Community Edition (CE) и Basic Edition (BE).
+Группы команд `d8 dk` и `d8 mirror` недоступны для Community Edition (CE) и Basic Edition (BE).
 {% endalert %}
 
 * `d8 k` — команды, которые в кластерах Kubernetes выполняет `kubectl`.  

--- a/docs/site/pages/stronghold/reference/console-utilities/D8.md
+++ b/docs/site/pages/stronghold/reference/console-utilities/D8.md
@@ -11,13 +11,13 @@ Deckhouse CLI is a command line interface for cluster management created by the 
 On the command line, the utility can be invoked using the `d8` alias. All the commands are grouped by their function:
 
 {% alert level="info" %}
-The `d8 d` and `d8 mirror` command groups are not available for Community Edition (CE) and Basic Edition (BE).
+The `d8 k` and `d8 mirror` command groups are not available for Community Edition (CE) and Basic Edition (BE).
 {% endalert %}
 
 * `d8 k` — the `kubectl` command family.  
     For example, `d8 k get pods` is the same as `kubectl get pods`.
 * `d8 d` — the range of delivery-related commands (see the `werf` tool).  
-    For example, you can run `d8 d plan --repo registry.deckhouse.io` instead of `werf plan --repo registry.deckhouse.io`.
+    For example, you can run `d8 k plan --repo registry.deckhouse.io` instead of `werf plan --repo registry.deckhouse.io`.
 
 * `d8 mirror` — the range of commands that allow you to copy DKP distribution images to a private container registry (previously the `dhctl mirror` tool was used for this purpose).
   For example, you can run `d8 mirror pull -l <LICENSE> <TAR-BUNDLE-PATH>` instead of `dhctl mirror --license <LICENSE> --images-bundle-path <TAR-BUNDLE-PATH>`.

--- a/docs/site/pages/stronghold/reference/console-utilities/D8.md
+++ b/docs/site/pages/stronghold/reference/console-utilities/D8.md
@@ -11,13 +11,13 @@ Deckhouse CLI is a command line interface for cluster management created by the 
 On the command line, the utility can be invoked using the `d8` alias. All the commands are grouped by their function:
 
 {% alert level="info" %}
-The `d8 k` and `d8 mirror` command groups are not available for Community Edition (CE) and Basic Edition (BE).
+The `d8 dk` and `d8 mirror` command groups are not available for Community Edition (CE) and Basic Edition (BE).
 {% endalert %}
 
 * `d8 k` — the `kubectl` command family.  
     For example, `d8 k get pods` is the same as `kubectl get pods`.
 * `d8 d` — the range of delivery-related commands (see the `werf` tool).  
-    For example, you can run `d8 k plan --repo registry.deckhouse.io` instead of `werf plan --repo registry.deckhouse.io`.
+    For example, you can run `d8 dk plan --repo registry.deckhouse.io` instead of `werf plan --repo registry.deckhouse.io`.
 
 * `d8 mirror` — the range of commands that allow you to copy DKP distribution images to a private container registry (previously the `dhctl mirror` tool was used for this purpose).
   For example, you can run `d8 mirror pull -l <LICENSE> <TAR-BUNDLE-PATH>` instead of `dhctl mirror --license <LICENSE> --images-bundle-path <TAR-BUNDLE-PATH>`.

--- a/docs/site/pages/stronghold/reference/console-utilities/D8_RU.md
+++ b/docs/site/pages/stronghold/reference/console-utilities/D8_RU.md
@@ -12,7 +12,7 @@ Deckhouse CLI — это интерфейс командной строки дл
 В командной строке к утилите можно обратиться как `d8`. Все команды сгруппированы по функциям:
 
 {% alert level="info" %}
-Группы команд `d8 k` и `d8 mirror` недоступны для Community Edition (CE) и Basic Edition (BE).
+Группы команд `d8 dk` и `d8 mirror` недоступны для Community Edition (CE) и Basic Edition (BE).
 {% endalert %}
 
 * `d8 k` — команды, которые в кластерах Kubernetes выполняет `kubectl`.  

--- a/docs/site/pages/stronghold/reference/console-utilities/D8_RU.md
+++ b/docs/site/pages/stronghold/reference/console-utilities/D8_RU.md
@@ -12,7 +12,7 @@ Deckhouse CLI — это интерфейс командной строки дл
 В командной строке к утилите можно обратиться как `d8`. Все команды сгруппированы по функциям:
 
 {% alert level="info" %}
-Группы команд `d8 d` и `d8 mirror` недоступны для Community Edition (CE) и Basic Edition (BE).
+Группы команд `d8 k` и `d8 mirror` недоступны для Community Edition (CE) и Basic Edition (BE).
 {% endalert %}
 
 * `d8 k` — команды, которые в кластерах Kubernetes выполняет `kubectl`.  

--- a/docs/site/pages/virtualization-platform/reference/console-utilities/D8.md
+++ b/docs/site/pages/virtualization-platform/reference/console-utilities/D8.md
@@ -10,13 +10,13 @@ Deckhouse CLI is a command line interface for cluster management created by the 
 On the command line, the utility can be invoked using the `d8` alias. All the commands are grouped by their function:
 
 {% alert level="info" %}
-The `d8 d` and `d8 mirror` command groups are not available for Community Edition (CE) and Basic Edition (BE).
+The `d8 k` and `d8 mirror` command groups are not available for Community Edition (CE) and Basic Edition (BE).
 {% endalert %}
 
 * `d8 k` — the `kubectl` command family.  
     For example, `d8 k get pods` is the same as `kubectl get pods`.
 * `d8 d` — the range of delivery-related commands (see the `werf` tool).  
-    For example, you can run `d8 d plan --repo registry.deckhouse.io` instead of `werf plan --repo registry.deckhouse.io`.
+    For example, you can run `d8 k plan --repo registry.deckhouse.io` instead of `werf plan --repo registry.deckhouse.io`.
 
 * `d8 mirror` — the range of commands that allow you to copy DKP distribution images to a private container registry (previously the `dhctl mirror` tool was used for this purpose).
   For example, you can run `d8 mirror pull -l <LICENSE> <TAR-BUNDLE-PATH>` instead of `dhctl mirror --license <LICENSE> --images-bundle-path <TAR-BUNDLE-PATH>`.

--- a/docs/site/pages/virtualization-platform/reference/console-utilities/D8.md
+++ b/docs/site/pages/virtualization-platform/reference/console-utilities/D8.md
@@ -10,13 +10,13 @@ Deckhouse CLI is a command line interface for cluster management created by the 
 On the command line, the utility can be invoked using the `d8` alias. All the commands are grouped by their function:
 
 {% alert level="info" %}
-The `d8 k` and `d8 mirror` command groups are not available for Community Edition (CE) and Basic Edition (BE).
+The `d8 dk` and `d8 mirror` command groups are not available for Community Edition (CE) and Basic Edition (BE).
 {% endalert %}
 
 * `d8 k` — the `kubectl` command family.  
     For example, `d8 k get pods` is the same as `kubectl get pods`.
 * `d8 d` — the range of delivery-related commands (see the `werf` tool).  
-    For example, you can run `d8 k plan --repo registry.deckhouse.io` instead of `werf plan --repo registry.deckhouse.io`.
+    For example, you can run `d8 dk plan --repo registry.deckhouse.io` instead of `werf plan --repo registry.deckhouse.io`.
 
 * `d8 mirror` — the range of commands that allow you to copy DKP distribution images to a private container registry (previously the `dhctl mirror` tool was used for this purpose).
   For example, you can run `d8 mirror pull -l <LICENSE> <TAR-BUNDLE-PATH>` instead of `dhctl mirror --license <LICENSE> --images-bundle-path <TAR-BUNDLE-PATH>`.

--- a/docs/site/pages/virtualization-platform/reference/console-utilities/D8_RU.md
+++ b/docs/site/pages/virtualization-platform/reference/console-utilities/D8_RU.md
@@ -11,7 +11,7 @@ Deckhouse CLI — это интерфейс командной строки дл
 В командной строке к утилите можно обратиться как `d8`. Все команды сгруппированы по функциям:
 
 {% alert level="info" %}
-Группы команд `d8 d` и `d8 mirror` недоступны для Community Edition (CE) и Basic Edition (BE).
+Группы команд `d8 k` и `d8 mirror` недоступны для Community Edition (CE) и Basic Edition (BE).
 {% endalert %}
 
 * `d8 k` — команды, которые в кластерах Kubernetes выполняет `kubectl`.  

--- a/docs/site/pages/virtualization-platform/reference/console-utilities/D8_RU.md
+++ b/docs/site/pages/virtualization-platform/reference/console-utilities/D8_RU.md
@@ -11,7 +11,7 @@ Deckhouse CLI — это интерфейс командной строки дл
 В командной строке к утилите можно обратиться как `d8`. Все команды сгруппированы по функциям:
 
 {% alert level="info" %}
-Группы команд `d8 k` и `d8 mirror` недоступны для Community Edition (CE) и Basic Edition (BE).
+Группы команд `d8 dk` и `d8 mirror` недоступны для Community Edition (CE) и Basic Edition (BE).
 {% endalert %}
 
 * `d8 k` — команды, которые в кластерах Kubernetes выполняет `kubectl`.  


### PR DESCRIPTION
## Description
Replace `d8 d` command with `d8 dk` in the documentation.

## Changelog entries


```changes
section: docs
type: chore
summary: Replace `d8 d` command with `d8 dk` in the documentation.
impact_level: low
```
