### PR TITLE
[tools] add Deckhouse version requirements to multiple module configurations

### DIFF
--- a/modules/038-registry/module.yaml
+++ b/modules/038-registry/module.yaml
@@ -10,3 +10,5 @@ namespace: d8-system
 disable:
   confirmation: true
   message: "Disabling this module will completely stop normal operation of the Deckhouse Kubernetes Platform."
+requirements:
+  deckhouse: ">= 1.68"

--- a/modules/038-registry/module.yaml
+++ b/modules/038-registry/module.yaml
@@ -11,4 +11,4 @@ disable:
   confirmation: true
   message: "Disabling this module will completely stop normal operation of the Deckhouse Kubernetes Platform."
 requirements:
-  deckhouse: ">= 1.68"
+  deckhouse: ">= 1.71"

--- a/modules/200-operator-prometheus/module.yaml
+++ b/modules/200-operator-prometheus/module.yaml
@@ -8,3 +8,5 @@ description: |
 descriptions:
   en: |
     This module installs the prometheus operator for creating Prometheus installations
+requirements:
+  deckhouse: ">= 1.68"

--- a/modules/300-prometheus/module.yaml
+++ b/modules/300-prometheus/module.yaml
@@ -12,3 +12,4 @@ descriptions:
 requirements:
   modules:
     operator-prometheus: ">= 0.0.0"
+  deckhouse: ">= 1.68"

--- a/modules/301-prometheus-metrics-adapter/module.yaml
+++ b/modules/301-prometheus-metrics-adapter/module.yaml
@@ -7,3 +7,4 @@ namespace: d8-monitoring
 requirements:
   modules:
     prometheus: ">= 0.0.0"
+  deckhouse: ">= 1.68"

--- a/modules/303-prometheus-pushgateway/module.yaml
+++ b/modules/303-prometheus-pushgateway/module.yaml
@@ -7,3 +7,4 @@ namespace: kube-prometheus-pushgateway
 requirements:
   modules:
     prometheus: ">= 0.0.0"
+  deckhouse: ">= 1.68"

--- a/modules/340-extended-monitoring/module.yaml
+++ b/modules/340-extended-monitoring/module.yaml
@@ -7,3 +7,4 @@ namespace: d8-monitoring
 requirements:
   modules:
     prometheus: ">= 0.0.0"
+  deckhouse: ">= 1.68"

--- a/modules/340-monitoring-custom/module.yaml
+++ b/modules/340-monitoring-custom/module.yaml
@@ -7,3 +7,4 @@ namespace: d8-monitoring
 requirements:
   modules:
     prometheus: ">= 0.0.0"
+  deckhouse: ">= 1.68"

--- a/modules/340-monitoring-deckhouse/module.yaml
+++ b/modules/340-monitoring-deckhouse/module.yaml
@@ -7,3 +7,4 @@ namespace: d8-monitoring
 requirements:
   modules:
     prometheus: ">= 0.0.0"
+  deckhouse: ">= 1.68"

--- a/modules/340-monitoring-kubernetes-control-plane/module.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/module.yaml
@@ -8,3 +8,4 @@ requirements:
   modules:
     prometheus: ">= 0.0.0"
     control-plane-manager: ">= 0.0.0"
+  deckhouse: ">= 1.68"

--- a/modules/340-monitoring-kubernetes/module.yaml
+++ b/modules/340-monitoring-kubernetes/module.yaml
@@ -7,3 +7,4 @@ namespace: d8-monitoring
 requirements:
   modules:
     prometheus: ">= 0.0.0"
+  deckhouse: ">= 1.68"

--- a/modules/340-monitoring-ping/module.yaml
+++ b/modules/340-monitoring-ping/module.yaml
@@ -9,3 +9,4 @@ requirements:
     # node-exporter is required for this module to work because the exporter stores metrics as a text file on a node,
     # which then be read by a node-exporter
     monitoring-kubernetes: ">= 0.0.0"
+  deckhouse: ">= 1.68"

--- a/modules/460-log-shipper/module.yaml
+++ b/modules/460-log-shipper/module.yaml
@@ -8,3 +8,5 @@ description: |
 descriptions:
   en: |
     Collecting logs in the Kubernetes cluster
+requirements:
+  deckhouse: ">= 1.68"

--- a/modules/462-loki/module.yaml
+++ b/modules/462-loki/module.yaml
@@ -3,3 +3,5 @@ stage: "Experimental"
 subsystems:
   - infrastructure
 namespace: d8-monitoring
+requirements:
+  deckhouse: ">= 1.68"

--- a/modules/500-cilium-hubble/module.yaml
+++ b/modules/500-cilium-hubble/module.yaml
@@ -4,9 +4,10 @@ subsystems:
   - networking
 namespace: d8-cni-cilium
 description: |
-    The cilium-hubble module
+  The cilium-hubble module
 descriptions:
   en: The cilium-hubble module
 requirements:
   modules:
-    cni-cilium: '>= 0.0.0'
+    cni-cilium: ">= 0.0.0"
+  deckhouse: ">= 1.68"

--- a/modules/500-okmeter/module.yaml
+++ b/modules/500-okmeter/module.yaml
@@ -3,3 +3,5 @@ stage: "General Availability"
 subsystems:
   - observability
 namespace: d8-okmeter
+requirements:
+  deckhouse: ">= 1.68"


### PR DESCRIPTION
## Description

Modules should use requirements with deckhouse version when used stage properties

## Why do we need it, and what problem does it solve?

fix lint on deckhouse build

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: fix
summary: add Deckhouse version requirements to multiple module configurations
impact_level: low
```
