### PR TITLE
[docs] Replace WEITH to STAGE in information about module

### DIFF
--- a/docs/documentation/pages/admin/configuration/access/authentication/EXTERNAL_AUTHENTICATION_PROVIDERS.md
+++ b/docs/documentation/pages/admin/configuration/access/authentication/EXTERNAL_AUTHENTICATION_PROVIDERS.md
@@ -57,8 +57,8 @@ If the parameter is not specified, no group-based filtering will be applied.
    Example output:
 
    ```console
-   NAME         STAGE   SOURCE     PHASE   ENABLED   READY
-   user-authn           Embedded   Ready   True      True
+   NAME         STAGE   SOURCE     PHASE       ENABLED   READY
+   user-authn           Embedded   Available   True      True
    ```
 
    Enable the module via CL:

--- a/docs/documentation/pages/admin/configuration/access/authentication/EXTERNAL_AUTHENTICATION_PROVIDERS.md
+++ b/docs/documentation/pages/admin/configuration/access/authentication/EXTERNAL_AUTHENTICATION_PROVIDERS.md
@@ -57,8 +57,8 @@ If the parameter is not specified, no group-based filtering will be applied.
    Example output:
 
    ```console
-   NAME         WEIGHT   SOURCE     PHASE   ENABLED   READY
-   user-authn   150      Embedded   Ready   True      True
+   NAME         STAGE   SOURCE     PHASE   ENABLED   READY
+   user-authn           Embedded   Ready   True      True
    ```
 
    Enable the module via CL:

--- a/docs/documentation/pages/admin/configuration/access/authentication/EXTERNAL_AUTHENTICATION_PROVIDERS_RU.md
+++ b/docs/documentation/pages/admin/configuration/access/authentication/EXTERNAL_AUTHENTICATION_PROVIDERS_RU.md
@@ -53,8 +53,8 @@ DKP поддерживает подключение следующих внеш�
    Пример вывода:
 
    ```console
-   NAME         WEIGHT   SOURCE     PHASE   ENABLED   READY
-   user-authn   150      Embedded   Ready   True      True
+   NAME         STAGE   SOURCE     PHASE   ENABLED   READY
+   user-authn           Embedded   Ready   True      True
    ```
 
    Включите модуль через CLI:

--- a/docs/documentation/pages/admin/configuration/access/authentication/EXTERNAL_AUTHENTICATION_PROVIDERS_RU.md
+++ b/docs/documentation/pages/admin/configuration/access/authentication/EXTERNAL_AUTHENTICATION_PROVIDERS_RU.md
@@ -53,8 +53,8 @@ DKP поддерживает подключение следующих внеш�
    Пример вывода:
 
    ```console
-   NAME         STAGE   SOURCE     PHASE   ENABLED   READY
-   user-authn           Embedded   Ready   True      True
+   NAME         STAGE   SOURCE     PHASE       ENABLED   READY
+   user-authn           Embedded   Available   True      True
    ```
 
    Включите модуль через CLI:

--- a/docs/documentation/pages/admin/configuration/storage/external/NFS.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/NFS.md
@@ -32,8 +32,8 @@ d8 k get module csi-nfs -w
 In the output, you should see information about the `csi-nfs` module:
 
 ```console
-NAME      WEIGHT   STATE     SOURCE     STAGE   STATUS
-csi-nfs   910      Enabled   Embedded           Ready
+NAME      STAGE   STATE     SOURCE     STAGE   STATUS
+csi-nfs           Enabled   Embedded           Ready
 ```
 
 ## Creating a StorageClass

--- a/docs/documentation/pages/admin/configuration/storage/external/NFS.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/NFS.md
@@ -32,8 +32,8 @@ d8 k get module csi-nfs -w
 In the output, you should see information about the `csi-nfs` module:
 
 ```console
-NAME      STAGE   STATE     SOURCE     STAGE   STATUS
-csi-nfs           Enabled   Embedded           Ready
+NAME      STAGE   STATE     SOURCE     STATUS
+csi-nfs           Enabled   Embedded   Ready
 ```
 
 ## Creating a StorageClass

--- a/docs/documentation/pages/admin/configuration/storage/external/NFS.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/NFS.md
@@ -32,8 +32,8 @@ d8 k get module csi-nfs -w
 In the output, you should see information about the `csi-nfs` module:
 
 ```console
-NAME      STAGE   STATE     SOURCE     STATUS
-csi-nfs           Enabled   Embedded   Ready
+NAME      STAGE   SOURCE    PHASE       ENABLED    READY
+csi-nfs           Embedded  Available   True       True
 ```
 
 ## Creating a StorageClass

--- a/docs/documentation/pages/admin/configuration/storage/external/NFS_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/NFS_RU.md
@@ -33,8 +33,8 @@ d8 k get module csi-nfs -w
 В результате будет выведена информация о модуле `csi-nfs`:
 
 ```console
-NAME      STAGE   STATE     SOURCE     STATUS
-csi-nfs           Enabled   Embedded   Ready
+NAME      STAGE   SOURCE    PHASE       ENABLED    READY
+csi-nfs           Embedded  Available   True       True
 ```
 
 ## Создание StorageClass

--- a/docs/documentation/pages/admin/configuration/storage/external/NFS_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/NFS_RU.md
@@ -33,8 +33,8 @@ d8 k get module csi-nfs -w
 В результате будет выведена информация о модуле `csi-nfs`:
 
 ```console
-NAME      STAGE   STATE     SOURCE     STAGE   STATUS
-csi-nfs           Enabled   Embedded           Ready
+NAME      STAGE   STATE     SOURCE     STATUS
+csi-nfs           Enabled   Embedded   Ready
 ```
 
 ## Создание StorageClass

--- a/docs/documentation/pages/admin/configuration/storage/external/NFS_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/NFS_RU.md
@@ -33,8 +33,8 @@ d8 k get module csi-nfs -w
 В результате будет выведена информация о модуле `csi-nfs`:
 
 ```console
-NAME      WEIGHT   STATE     SOURCE     STAGE   STATUS
-csi-nfs   910      Enabled   Embedded           Ready
+NAME      STAGE   STATE     SOURCE     STAGE   STATUS
+csi-nfs           Enabled   Embedded           Ready
 ```
 
 ## Создание StorageClass

--- a/docs/documentation/pages/admin/configuration/storage/external/YADRO.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/YADRO.md
@@ -33,8 +33,8 @@ d8 k get module csi-yadro-tatlin-unified -w
 In the output, you should see information about the module:
 
 ```console
-NAME                       STAGE   STATE     SOURCE     STAGE   STATUS
-csi-yadro-tatlin-unified           Enabled   Embedded           Ready
+NAME                       STAGE   STATE     SOURCE     STATUS
+csi-yadro-tatlin-unified           Enabled   Embedded   Ready
 ```
 
 ## Connect to the TATLIN.UNIFIED storage system

--- a/docs/documentation/pages/admin/configuration/storage/external/YADRO.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/YADRO.md
@@ -33,8 +33,8 @@ d8 k get module csi-yadro-tatlin-unified -w
 In the output, you should see information about the module:
 
 ```console
-NAME                       WEIGHT   STATE     SOURCE     STAGE   STATUS
-csi-yadro-tatlin-unified   910      Enabled   Embedded           Ready
+NAME                       STAGE   STATE     SOURCE     STAGE   STATUS
+csi-yadro-tatlin-unified           Enabled   Embedded           Ready
 ```
 
 ## Connect to the TATLIN.UNIFIED storage system

--- a/docs/documentation/pages/admin/configuration/storage/external/YADRO.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/YADRO.md
@@ -33,8 +33,8 @@ d8 k get module csi-yadro-tatlin-unified -w
 In the output, you should see information about the module:
 
 ```console
-NAME                       STAGE   STATE     SOURCE     STATUS
-csi-yadro-tatlin-unified           Enabled   Embedded   Ready
+NAME                       STAGE   SOURCE    PHASE       ENABLED    READY
+si-yadro-tatlin-unified            Embedded  Available   True       True
 ```
 
 ## Connect to the TATLIN.UNIFIED storage system

--- a/docs/documentation/pages/admin/configuration/storage/external/YADRO_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/YADRO_RU.md
@@ -34,8 +34,8 @@ d8 k get module csi-yadro-tatlin-unified -w
 В результате будет выведена информация о модуле:
 
 ```console
-NAME                       STAGE   STATE     SOURCE     STATUS
-csi-yadro-tatlin-unified           Enabled   Embedded   Ready
+NAME                       STAGE   SOURCE    PHASE       ENABLED    READY
+si-yadro-tatlin-unified            Embedded  Available   True       True
 ```
 
 ## Подключение к системе хранения данных TATLIN.UNIFIED

--- a/docs/documentation/pages/admin/configuration/storage/external/YADRO_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/YADRO_RU.md
@@ -34,8 +34,8 @@ d8 k get module csi-yadro-tatlin-unified -w
 В результате будет выведена информация о модуле:
 
 ```console
-NAME                       STAGE   STATE     SOURCE     STAGE   STATUS
-csi-yadro-tatlin-unified           Enabled   Embedded           Ready
+NAME                       STAGE   STATE     SOURCE     STATUS
+csi-yadro-tatlin-unified           Enabled   Embedded   Ready
 ```
 
 ## Подключение к системе хранения данных TATLIN.UNIFIED

--- a/docs/documentation/pages/admin/configuration/storage/external/YADRO_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/YADRO_RU.md
@@ -34,8 +34,8 @@ d8 k get module csi-yadro-tatlin-unified -w
 В результате будет выведена информация о модуле:
 
 ```console
-NAME                       WEIGHT   STATE     SOURCE     STAGE   STATUS
-csi-yadro-tatlin-unified   910      Enabled   Embedded           Ready
+NAME                       STAGE   STATE     SOURCE     STAGE   STATUS
+csi-yadro-tatlin-unified           Enabled   Embedded           Ready
 ```
 
 ## Подключение к системе хранения данных TATLIN.UNIFIED

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL.md
@@ -32,8 +32,8 @@ d8 k get modules sds-node-configurator -w
 In the output, you should see information about the `sds-node-configurator` module:
 
 ```console
-NAME                    WEIGHT   STATE     SOURCE      STAGE   STATUS
-sds-node-configurator   900      Enabled   deckhouse           Ready
+NAME                    STAGE   STATE     SOURCE      STAGE   STATUS
+sds-node-configurator           Enabled   deckhouse           Ready
 ```
 
 Then, to enable the `sds-local-volume` module with default settings, run the following command:
@@ -59,8 +59,8 @@ d8 k get modules sds-local-volume -w
 In the output, you should see information about the state of the `sds-local-volume` module:
 
 ```console
-NAME               WEIGHT   STATE     SOURCE     STAGE   STATUS
-sds-local-volume   920      Enabled   Embedded           Ready
+NAME               STAGE   STATE     SOURCE     STAGE   STATUS
+sds-local-volume           Enabled   Embedded           Ready
 ```
 
 To verify that all pods in the `d8-sds-local-volume` and `d8-sds-node-configurator` namespaces are in the `Running` or `Completed` state and are deployed on all nodes where LVM resources are planned to be used, use the following commands:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL.md
@@ -32,8 +32,8 @@ d8 k get modules sds-node-configurator -w
 In the output, you should see information about the `sds-node-configurator` module:
 
 ```console
-NAME                    STAGE   STATE     SOURCE      STAGE   STATUS
-sds-node-configurator           Enabled   deckhouse           Ready
+NAME                    STAGE   STATE     SOURCE      STATUS
+sds-node-configurator           Enabled   deckhouse   Ready
 ```
 
 Then, to enable the `sds-local-volume` module with default settings, run the following command:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL.md
@@ -59,8 +59,8 @@ d8 k get modules sds-local-volume -w
 In the output, you should see information about the state of the `sds-local-volume` module:
 
 ```console
-NAME               STAGE   STATE     SOURCE     STAGE   STATUS
-sds-local-volume           Enabled   Embedded           Ready
+NAME               STAGE   STATE     SOURCE     STATUS
+sds-local-volume           Enabled   Embedded   Ready
 ```
 
 To verify that all pods in the `d8-sds-local-volume` and `d8-sds-node-configurator` namespaces are in the `Running` or `Completed` state and are deployed on all nodes where LVM resources are planned to be used, use the following commands:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL.md
@@ -32,8 +32,8 @@ d8 k get modules sds-node-configurator -w
 In the output, you should see information about the `sds-node-configurator` module:
 
 ```console
-NAME                    STAGE   STATE     SOURCE      STATUS
-sds-node-configurator           Enabled   deckhouse   Ready
+NAME                    STAGE   SOURCE    PHASE       ENABLED    READY
+sds-node-configurator           Embedded  Available   True       True
 ```
 
 Then, to enable the `sds-local-volume` module with default settings, run the following command:
@@ -59,8 +59,8 @@ d8 k get modules sds-local-volume -w
 In the output, you should see information about the state of the `sds-local-volume` module:
 
 ```console
-NAME               STAGE   STATE     SOURCE     STATUS
-sds-local-volume           Enabled   Embedded   Ready
+NAME                  STAGE   SOURCE    PHASE       ENABLED    READY
+sds-local-volume              Embedded  Available   True       True
 ```
 
 To verify that all pods in the `d8-sds-local-volume` and `d8-sds-node-configurator` namespaces are in the `Running` or `Completed` state and are deployed on all nodes where LVM resources are planned to be used, use the following commands:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL_RU.md
@@ -33,8 +33,8 @@ d8 k get modules sds-node-configurator -w
 В результате будет выведена информация о модуле `sds-node-configurator`:
 
 ```console
-NAME                    WEIGHT   STATE     SOURCE      STAGE   STATUS
-sds-node-configurator   900      Enabled   deckhouse           Ready
+NAME                    STAGE   STATE     SOURCE      STAGE   STATUS
+sds-node-configurator           Enabled   deckhouse           Ready
 ```
 
 Затем, чтобы включить модуль `sds-local-volume` с настройками по умолчанию, выполните команду:
@@ -60,8 +60,8 @@ d8 k get modules sds-local-volume -w
 В результате будет выведена информация о модуле `sds-local-volume`:
 
 ```console
-NAME               WEIGHT   STATE     SOURCE     STAGE   STATUS
-sds-local-volume   920      Enabled   Embedded           Ready
+NAME               STAGE   STATE     SOURCE     STAGE   STATUS
+sds-local-volume           Enabled   Embedded           Ready
 ```
 
 Чтобы проверить, что в пространстве имен `d8-sds-local-volume` и `d8-sds-node-configurator` все поды в состоянии `Running` или `Completed` и запущены на всех узлах, где планируется использовать ресурсы LVM, используйте команды:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL_RU.md
@@ -33,8 +33,8 @@ d8 k get modules sds-node-configurator -w
 В результате будет выведена информация о модуле `sds-node-configurator`:
 
 ```console
-NAME                    STAGE   STATE     SOURCE      STATUS
-sds-node-configurator           Enabled   deckhouse   Ready
+NAME                    STAGE   SOURCE    PHASE       ENABLED    READY
+sds-node-configurator           Embedded  Available   True       True
 ```
 
 Затем, чтобы включить модуль `sds-local-volume` с настройками по умолчанию, выполните команду:
@@ -60,8 +60,8 @@ d8 k get modules sds-local-volume -w
 В результате будет выведена информация о модуле `sds-local-volume`:
 
 ```console
-NAME               STAGE   STATE     SOURCE     STATUS
-sds-local-volume           Enabled   Embedded   Ready
+NAME               STAGE   SOURCE    PHASE       ENABLED    READY
+sds-local-volume           Embedded  Available   True       True
 ```
 
 Чтобы проверить, что в пространстве имен `d8-sds-local-volume` и `d8-sds-node-configurator` все поды в состоянии `Running` или `Completed` и запущены на всех узлах, где планируется использовать ресурсы LVM, используйте команды:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL_RU.md
@@ -60,8 +60,8 @@ d8 k get modules sds-local-volume -w
 В результате будет выведена информация о модуле `sds-local-volume`:
 
 ```console
-NAME               STAGE   STATE     SOURCE     STAGE   STATUS
-sds-local-volume           Enabled   Embedded           Ready
+NAME               STAGE   STATE     SOURCE     STATUS
+sds-local-volume           Enabled   Embedded   Ready
 ```
 
 Чтобы проверить, что в пространстве имен `d8-sds-local-volume` и `d8-sds-node-configurator` все поды в состоянии `Running` или `Completed` и запущены на всех узлах, где планируется использовать ресурсы LVM, используйте команды:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-local/LVM_LOCAL_RU.md
@@ -33,8 +33,8 @@ d8 k get modules sds-node-configurator -w
 В результате будет выведена информация о модуле `sds-node-configurator`:
 
 ```console
-NAME                    STAGE   STATE     SOURCE      STAGE   STATUS
-sds-node-configurator           Enabled   deckhouse           Ready
+NAME                    STAGE   STATE     SOURCE      STATUS
+sds-node-configurator           Enabled   deckhouse   Ready
 ```
 
 Затем, чтобы включить модуль `sds-local-volume` с настройками по умолчанию, выполните команду:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED.md
@@ -34,8 +34,8 @@ d8 k get modules sds-node-configurator -w
 In the output, you should see information about the `sds-node-configurator` module:
 
 ```console
-NAME                    WEIGHT   STATE     SOURCE      STAGE   STATUS
-sds-node-configurator   900      Enabled   deckhouse           Ready
+NAME                    STAGE   STATE     SOURCE      STAGE   STATUS
+sds-node-configurator           Enabled   deckhouse           Ready
 ```
 
 ### DRBD connection
@@ -65,8 +65,8 @@ d8 k get modules sds-replicated-volume -w
 In the output, you should see information about the `sds-replicated-volume` module:
 
 ```console
-NAME                    WEIGHT   STATE     SOURCE     STAGE   STATUS
-sds-replicated-volume   915      Enabled   Embedded           Ready
+NAME                    STAGE   STATE     SOURCE     STAGE   STATUS
+sds-replicated-volume           Enabled   Embedded           Ready
 ```
 
 To check that all pods in the `d8-sds-replicated-volume` and `d8-sds-node-configurator` namespaces are in the `Running` or `Completed` state and have been started on all nodes where DRBD resources are planned to be used, use the following commands:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED.md
@@ -34,8 +34,8 @@ d8 k get modules sds-node-configurator -w
 In the output, you should see information about the `sds-node-configurator` module:
 
 ```console
-NAME                    STAGE   STATE     SOURCE      STAGE   STATUS
-sds-node-configurator           Enabled   deckhouse           Ready
+NAME                    STAGE   STATE     SOURCE      STATUS
+sds-node-configurator           Enabled   deckhouse   Ready
 ```
 
 ### DRBD connection

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED.md
@@ -34,8 +34,8 @@ d8 k get modules sds-node-configurator -w
 In the output, you should see information about the `sds-node-configurator` module:
 
 ```console
-NAME                    STAGE   STATE     SOURCE      STATUS
-sds-node-configurator           Enabled   deckhouse   Ready
+NAME                       STAGE   SOURCE    PHASE       ENABLED    READY
+sds-node-configurator              Embedded  Available   True       True
 ```
 
 ### DRBD connection
@@ -65,8 +65,8 @@ d8 k get modules sds-replicated-volume -w
 In the output, you should see information about the `sds-replicated-volume` module:
 
 ```console
-NAME                    STAGE   STATE     SOURCE     STATUS
-sds-replicated-volume           Enabled   Embedded   Ready
+NAME                       STAGE   SOURCE    PHASE       ENABLED    READY
+sds-replicated-volume              Embedded  Available   True       True
 ```
 
 To check that all pods in the `d8-sds-replicated-volume` and `d8-sds-node-configurator` namespaces are in the `Running` or `Completed` state and have been started on all nodes where DRBD resources are planned to be used, use the following commands:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED.md
@@ -65,8 +65,8 @@ d8 k get modules sds-replicated-volume -w
 In the output, you should see information about the `sds-replicated-volume` module:
 
 ```console
-NAME                    STAGE   STATE     SOURCE     STAGE   STATUS
-sds-replicated-volume           Enabled   Embedded           Ready
+NAME                    STAGE   STATE     SOURCE     STATUS
+sds-replicated-volume           Enabled   Embedded   Ready
 ```
 
 To check that all pods in the `d8-sds-replicated-volume` and `d8-sds-node-configurator` namespaces are in the `Running` or `Completed` state and have been started on all nodes where DRBD resources are planned to be used, use the following commands:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED_RU.md
@@ -35,8 +35,8 @@ d8 k get modules sds-node-configurator -w
 В результате будет выведена информация о модуле `sds-node-configurator`:
 
 ```console
-NAME                    STAGE   STATE     SOURCE      STAGE   STATUS
-sds-node-configurator           Enabled   deckhouse           Ready
+NAME                    STAGE   STATE     SOURCE      STATUS
+sds-node-configurator           Enabled   deckhouse   Ready
 ```
 
 ### Подключение DRBD

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED_RU.md
@@ -66,8 +66,8 @@ d8 k get modules sds-replicated-volume -w
 В результате будет выведена информация о модуле `sds-replicated-volume`:
 
 ```console
-NAME                    STAGE   STATE     SOURCE     STAGE   STATUS
-sds-replicated-volume           Enabled   Embedded           Ready
+NAME                    STAGE   STATE     SOURCE     STATUS
+sds-replicated-volume           Enabled   Embedded   Ready
 ```
 
 Чтобы проверить, что в пространстве имен `d8-sds-replicated-volume` и `d8-sds-node-configurator` все поды в состоянии `Running` или `Completed` и запущены на всех узлах, где планируется использовать ресурсы DRBD, можно использовать команды:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED_RU.md
@@ -35,8 +35,8 @@ d8 k get modules sds-node-configurator -w
 В результате будет выведена информация о модуле `sds-node-configurator`:
 
 ```console
-NAME                    STAGE   STATE     SOURCE      STATUS
-sds-node-configurator           Enabled   deckhouse   Ready
+NAME                       STAGE   SOURCE    PHASE       ENABLED    READY
+sds-node-configurator              Embedded  Available   True       True
 ```
 
 ### Подключение DRBD
@@ -66,8 +66,8 @@ d8 k get modules sds-replicated-volume -w
 В результате будет выведена информация о модуле `sds-replicated-volume`:
 
 ```console
-NAME                    STAGE   STATE     SOURCE     STATUS
-sds-replicated-volume           Enabled   Embedded   Ready
+NAME                       STAGE   SOURCE    PHASE       ENABLED    READY
+sds-replicated-volume              Embedded  Available   True       True
 ```
 
 Чтобы проверить, что в пространстве имен `d8-sds-replicated-volume` и `d8-sds-node-configurator` все поды в состоянии `Running` или `Completed` и запущены на всех узлах, где планируется использовать ресурсы DRBD, можно использовать команды:

--- a/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/sds/lvm-replicated/LVM_REPLICATED_RU.md
@@ -35,8 +35,8 @@ d8 k get modules sds-node-configurator -w
 В результате будет выведена информация о модуле `sds-node-configurator`:
 
 ```console
-NAME                    WEIGHT   STATE     SOURCE      STAGE   STATUS
-sds-node-configurator   900      Enabled   deckhouse           Ready
+NAME                    STAGE   STATE     SOURCE      STAGE   STATUS
+sds-node-configurator           Enabled   deckhouse           Ready
 ```
 
 ### Подключение DRBD
@@ -66,8 +66,8 @@ d8 k get modules sds-replicated-volume -w
 В результате будет выведена информация о модуле `sds-replicated-volume`:
 
 ```console
-NAME                    WEIGHT   STATE     SOURCE     STAGE   STATUS
-sds-replicated-volume   915      Enabled   Embedded           Ready
+NAME                    STAGE   STATE     SOURCE     STAGE   STATUS
+sds-replicated-volume           Enabled   Embedded           Ready
 ```
 
 Чтобы проверить, что в пространстве имен `d8-sds-replicated-volume` и `d8-sds-node-configurator` все поды в состоянии `Running` или `Completed` и запущены на всех узлах, где планируется использовать ресурсы DRBD, можно использовать команды:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

 Replace WEITH to STAGE in information about module.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Replace WEITH to STAGE in information about module.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
