### PR TITLE
[docs][getting started][cloud-provider-vkcloud] Enable cni-cilium module

### DIFF
--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.other.inc
@@ -49,6 +49,21 @@ spec:
     releaseChannel: Stable
     logLevel: Info
 ---
+# [<en>] Turn on cni-cilium module.
+# [<en>] https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/cni-cilium/
+# [<ru>] Включение модуля cni-cilium.
+# [<ru>] https://deckhouse.ru/products/kubernetes-platform/documentation/v1/modules/cni-cilium/
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cni-cilium
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bpfLBMode: SNAT
+    tunnelMode: VXLAN
+---
 # [<en>] Global Deckhouse settings.
 # [<en>] https://deckhouse.ru/products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#parameters
 # [<ru>] Глобальные настройки Deckhouse.

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.other.inc
@@ -54,7 +54,6 @@ spec:
 # [<ru>] Включение модуля cni-cilium.
 # [<ru>] https://deckhouse.ru/products/kubernetes-platform/documentation/v1/modules/cni-cilium/
 apiVersion: deckhouse.io/v1alpha1
-apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: cni-cilium


### PR DESCRIPTION
## Description
Enabled cni-cilium module in the getting started for VK Cloud.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: chore
summary: Enabled cni-cilium module in the getting started for VK Cloud.
impact_level: low
```
