### PR TITLE
[istio] fixed metadata exporter template

### DIFF
--- a/ee/modules/110-istio/templates/alliance/metadata-exporter/deployment.yaml
+++ b/ee/modules/110-istio/templates/alliance/metadata-exporter/deployment.yaml
@@ -100,6 +100,6 @@ spec:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
   {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
-            {{- include "metadata_discovery_resources" . | nindent 12 }}
+            {{- include "metadata_exporter_resources" . | nindent 12 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
There is a typo in the metadata exporter's template - the metadata_exporter_resources macro must be used instead of metadata_discovery_resources.
If the vertical-pod-autoscaler module is disabled, the istio module fails to render with the error:
```
 1. ConvergeModules:main:::Operator-Startup

Queue 'parallel_queue_10': length 1, status: 'sleep after fail for 32s (24s left of 32s delay)'

 1. ModuleRun:parallel_queue_10:istio:doStartup:OperatorStartup:failures 18:run helm install: template: istio/templates/alliance/metadata-exporter/deployment.yaml:103:16: executing "istio/templates/alliance/metadata-exporter/deployment.yaml" at <include "metadata_discovery_resources" .>: error calling include: template: no template "metadata_discovery_resources" associated with template "gotpl"

Use --debug flag to render out invalid YAML

```
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It fixes the aforementioned typo in the macro's name.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Fixed istio metadata exporter's template to use a valid resource definition macro.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
