### PR TITLE
[deckhouse] operator-trivy hook new param AllowEmptyDir

### DIFF
--- a/ee/modules/500-operator-trivy/hooks/storage_class_change.go
+++ b/ee/modules/500-operator-trivy/hooks/storage_class_change.go
@@ -14,4 +14,5 @@ var _ = storage_class_change.RegisterHook(storage_class_change.Args{
 	LabelSelectorValue: "trivy-server",
 	ObjectKind:         "StatefulSet",
 	ObjectName:         "trivy-server",
+	AllowEmptyDir:      true,
 })

--- a/go_lib/hooks/storage_class_change/hook.go
+++ b/go_lib/hooks/storage_class_change/hook.go
@@ -48,6 +48,7 @@ type Args struct {
 	ObjectName                    string `json:"objectName"`
 	InternalValuesSubPath         string `json:"internalValuesSubPath,omitempty"`
 	D8ConfigStorageClassParamName string `json:"d8ConfigStorageClassParamName,omitempty"`
+	AllowEmptyDir                 bool   `json:"allowEmptyDir,omitempty"`
 
 	// if return value is false - hook will stop its execution
 	// if return value is true - hook will continue
@@ -230,7 +231,9 @@ func calculateEffectiveStorageClass(input *go_hook.HookInput, args Args, current
 	emptydirUsageMetricValue := 0.0
 	if len(effectiveStorageClass) == 0 || effectiveStorageClass == "false" {
 		input.Values.Set(internalValuesPath, false)
-		emptydirUsageMetricValue = 1.0
+		if !args.AllowEmptyDir {
+			emptydirUsageMetricValue = 1.0
+		}
 	} else {
 		input.Values.Set(internalValuesPath, effectiveStorageClass)
 	}

--- a/modules/000-common/hooks/storage_class_change_test.go
+++ b/modules/000-common/hooks/storage_class_change_test.go
@@ -189,6 +189,17 @@ spec:
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("common.internal.testSubPath.effectiveStorageClass").String()).To(Equal("false"))
 		})
+
+		It("Should set d8_emptydir_usage metric to 1 (because AllowEmptyDir is not set)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.MetricsCollector.CollectedMetrics()).To(HaveLen(1))
+
+			metric := f.MetricsCollector.CollectedMetrics()[0]
+			Expect(metric.Name).To(Equal("d8_emptydir_usage"))
+			Expect(*metric.Value).To(Equal(float64(1)))
+			Expect(metric.Labels["namespace"]).To(Equal("d8-module-name"))
+			Expect(metric.Labels["module_name"]).To(Equal("common"))
+		})
 	})
 
 })


### PR DESCRIPTION
## Description
Added ability to allow emptyDir usage for specific modules without generating `DeckhouseModuleUseEmptyDir` alert.

## Why do we need it, and what problem does it solve?
**Problem:** operator-trivy sends `DeckhouseModuleUseEmptyDir` alert when using emptyDir, even though emptyDir usage is correct and safe for this module.

**Solution:** Added `AllowEmptyDir` flag that allows modules to explicitly permit emptyDir usage without generating false positive alerts.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: feature
summary: Fix false positive DeckhouseModuleUseEmptyDir alert for operator-trivy
impact_level: low
```
