### PR TITLE
[ci][docs] Add more environments for deployment documentation

### DIFF
--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -199,6 +199,15 @@ steps:
   {!{- $urlRu = "deckhouse.ru" -}!}
   {!{- $kubeConfig = "${{ secrets.KUBECONFIG_BASE64_PROD_25 }}" -}!}
   {!{- $dcName = "prod-25" -}!}
+{!{- else if eq $env "test2" }!}
+  {!{- $url = "deckhouse.2.test.flant.com" -}!}
+  {!{- $urlRu = "deckhouse.ru.2.test.flant.com" -}!}
+{!{- else if eq $env "test3" }!}
+  {!{- $url = "deckhouse.3.test.flant.com" -}!}
+  {!{- $urlRu = "deckhouse.ru.3.test.flant.com" -}!}
+{!{- else if eq $env "test4" }!}
+  {!{- $url = "deckhouse.4.test.flant.com" -}!}
+  {!{- $urlRu = "deckhouse.ru.4.test.flant.com" -}!}
 {!{- end -}!}
 
 # <template: deploy_doc_template>
@@ -236,6 +245,15 @@ steps:
   {!{- $urlRu = "deckhouse.ru" -}!}
   {!{- $kubeConfig = "${{ secrets.KUBECONFIG_BASE64_PROD_25 }}" -}!}
   {!{- $dcName = "prod-25" -}!}
+{!{- else if eq $env "test2" }!}
+  {!{- $url = "deckhouse.2.test.flant.com" -}!}
+  {!{- $urlRu = "deckhouse.ru.2.test.flant.com" -}!}
+{!{- else if eq $env "test3" }!}
+  {!{- $url = "deckhouse.3.test.flant.com" -}!}
+  {!{- $urlRu = "deckhouse.ru.3.test.flant.com" -}!}
+{!{- else if eq $env "test4" }!}
+  {!{- $url = "deckhouse.4.test.flant.com" -}!}
+  {!{- $urlRu = "deckhouse.ru.4.test.flant.com" -}!}
 {!{- end -}!}
 
 {!{- $siteDomainMap := printf "{\"en\" : \"%s\", \"ru\" : \"%s\"}" $url $urlRu -}!}

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -41,7 +41,7 @@ const {
   renderJobStatusOneLine,
   renderJobStatusSeparate,
   renderWorkflowStatusFinal,
-  releaseIssueHeader
+  releaseIssueHeader, renderDocumentationComments
 } = require('./comments');
 
 const { buildFailedE2eTestAdditionalInfo } = require('./e2e/cleanup');
@@ -282,6 +282,10 @@ module.exports.updateCommentOnFinish = async ({
     }
   } else {
     comment = `${comment}\n${statusReport}`;
+  }
+
+  if (statusConfig.includes(',docs')) {
+    comment = `${comment}\n${renderDocumentationComments()}`;
   }
 
   const updateResponse = await github.rest.issues.updateComment({

--- a/.github/scripts/js/comments.js
+++ b/.github/scripts/js/comments.js
@@ -113,6 +113,11 @@ module.exports.renderWorkflowStatusFinal = (status, name, ref, build_url, starte
   return `${statusComment}${info}`;
 };
 
+module.exports.renderDocumentationComments = () => {
+  let statusComment = `\n<details><summary>Environment URLS</summary>\n<ul><li>Stage: <a href="https://deckhouse.stage.flant.com/products/kubernetes-platform/documentation/v1/">deckhouse.stage.flant.com</a></li><li>Test: <a href="https://deckhouse.test.flant.com/products/kubernetes-platform/documentation/v1/">deckhouse.test.flant.com</a></li><li>Test2: <a href="https://deckhouse.2.test.flant.com/products/kubernetes-platform/documentation/v1/">deckhouse.2.test.flant.com</a></li><li>Test3: <a href="https://deckhouse.3.test.flant.com/products/kubernetes-platform/documentation/v1/">deckhouse.3.test.flant.com</a></li><li>Test4: <a href="https://deckhouse.4.test.flant.com/products/kubernetes-platform/documentation/v1/">deckhouse.4.test.flant.com</a></li></ul></details>`;
+  return `${statusComment}`;
+};
+
 /**
  * Return a human-readable duration.
  *

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -72,6 +72,9 @@ const labels = {
 
   // Deploy documentation and site to test or stage.
   'deploy/web/test': { type: 'deploy-web', env: 'test' },
+  'deploy/web/test2': { type: 'deploy-web', env: 'test2' },
+  'deploy/web/test3': { type: 'deploy-web', env: 'test3' },
+  'deploy/web/test4': { type: 'deploy-web', env: 'test4' },
   'deploy/web/stage': { type: 'deploy-web', env: 'stage' },
 
   // Edition for build-and-test workflow

--- a/.github/workflow_templates/deploy-web.multi.yml
+++ b/.github/workflow_templates/deploy-web.multi.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{!{- range $env := slice "test" "stage" -}!}
+{!{- range $env := slice "test" "test2" "test3" "test4" "stage" -}!}
 {!{-   $ctx := dict "webEnv" $env }!}
 {!{-   $outFile := printf "deploy-web-%s.yml" $env }!}
 {!{-   $outPath := filepath.Join (getenv "OUTDIR") (toLower $outFile) }!}
@@ -93,6 +93,6 @@ jobs:
 {!{ tmpl.Exec "doc_version_template" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_doc_template" .webEnv | strings.Indent 6 }!}
 
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,final" $workflowName) | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,final,docs" $workflowName) | strings.Indent 6 }!}
 
 {!{ end -}!}

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -314,7 +314,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const statusConfig = 'job,final';
+            const statusConfig = 'job,final,docs';
             const name = 'Deploy web to stage';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);

--- a/.github/workflows/deploy-web-test2.yml
+++ b/.github/workflows/deploy-web-test2.yml
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Deploy web to test'
+name: 'Deploy web to test2'
 
 on:
   workflow_dispatch:
@@ -63,7 +63,7 @@ env:
 
 # Cancel in-progress jobs for the same tag/branch.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-test
+  group: ${{ github.workflow }}-${{ github.ref }}-test2
   cancel-in-progress: true
 
 jobs:
@@ -166,7 +166,7 @@ jobs:
         with:
           script: |
             const labelType = 'deploy-web';
-            const labelSubject = 'test';
+            const labelSubject = 'test2';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
@@ -204,7 +204,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'Deploy web to test';
+            const name = 'Deploy web to test2';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -252,23 +252,23 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: deploy_site_template>
-      - name: Deploy site to test
+      - name: Deploy site to test2
         uses: werf/actions/converge@v2
         with:
           version: ${{env.WERF_VERSION}}
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_DEV }}"
-          env: web-test
+          env: web-test2
         env:
           WERF_REPO: ${{ steps.check_dev_registry.outputs.web_registry_path }}
           WERF_DIR: "docs/site"
           WERF_RELEASE: "deckhouse-site"
-          WERF_NAMESPACE: deckhouse-web-test
+          WERF_NAMESPACE: deckhouse-web-test2
           WERF_SET_DOC_VERSION: "global.doc_version=${{ env.DOC_VERSION }}"
           WERF_SET_ACTIVE_RELEASE: "global.active_release=v1"
-          WERF_SET_URL: "global.url=deckhouse.test.flant.com"
-          WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.test.flant.com"
-          WERF_SET_WEB_ENV: "web.env=web-test"
-          WERF_SET_DOMAIN_MAP: "global.domain_map=eyJlbiIgOiAiZGVja2hvdXNlLnRlc3QuZmxhbnQuY29tIiwgInJ1IiA6ICJkZWNraG91c2UucnUudGVzdC5mbGFudC5jb20ifQ=="
+          WERF_SET_URL: "global.url=deckhouse.2.test.flant.com"
+          WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.2.test.flant.com"
+          WERF_SET_WEB_ENV: "web.env=web-test2"
+          WERF_SET_DOMAIN_MAP: "global.domain_map=eyJlbiIgOiAiZGVja2hvdXNlLjIudGVzdC5mbGFudC5jb20iLCAicnUiIDogImRlY2tob3VzZS5ydS4yLnRlc3QuZmxhbnQuY29tIn0="
           WERF_SET_DCNAME: "web.dc_name=dev"
           DOC_API_KEY: "${{secrets.DOC_API_KEY}}"
           DOC_API_URL: "${{vars.DOC_API_URL}}"
@@ -283,21 +283,21 @@ jobs:
           echo "DOC_VERSION=${CI_COMMIT_TAG:-latest}" >> $GITHUB_ENV
       # </template: doc_version_template>
       # <template: deploy_doc_template>
-      - name: Deploy documentation to test
+      - name: Deploy documentation to test2
         uses: werf/actions/converge@v2
         with:
           version: ${{env.WERF_VERSION}}
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_DEV }}"
-          env: web-test
+          env: web-test2
         env:
           WERF_REPO: ${{ steps.check_dev_registry.outputs.web_registry_path }}
           WERF_DIR: "docs/documentation"
           WERF_RELEASE: "deckhouse-doc-${{ env.DOC_VERSION }}"
-          WERF_NAMESPACE: deckhouse-web-test
+          WERF_NAMESPACE: deckhouse-web-test2
           WERF_SET_DOC_VERSION: "global.doc_version=${{ env.DOC_VERSION }}"
-          WERF_SET_URL: "global.url=deckhouse.test.flant.com"
-          WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.test.flant.com"
-          WERF_SET_WEB_ENV: "web.env=web-test"
+          WERF_SET_URL: "global.url=deckhouse.2.test.flant.com"
+          WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.2.test.flant.com"
+          WERF_SET_WEB_ENV: "web.env=web-test2"
           WERF_SET_DCNAME: "web.dc_name=dev"
       # </template: deploy_doc_template>
 
@@ -315,7 +315,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,final,docs';
-            const name = 'Deploy web to test';
+            const name = 'Deploy web to test2';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);

--- a/.github/workflows/deploy-web-test3.yml
+++ b/.github/workflows/deploy-web-test3.yml
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Deploy web to test'
+name: 'Deploy web to test3'
 
 on:
   workflow_dispatch:
@@ -63,7 +63,7 @@ env:
 
 # Cancel in-progress jobs for the same tag/branch.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-test
+  group: ${{ github.workflow }}-${{ github.ref }}-test3
   cancel-in-progress: true
 
 jobs:
@@ -166,7 +166,7 @@ jobs:
         with:
           script: |
             const labelType = 'deploy-web';
-            const labelSubject = 'test';
+            const labelSubject = 'test3';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
@@ -204,7 +204,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'Deploy web to test';
+            const name = 'Deploy web to test3';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -252,23 +252,23 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: deploy_site_template>
-      - name: Deploy site to test
+      - name: Deploy site to test3
         uses: werf/actions/converge@v2
         with:
           version: ${{env.WERF_VERSION}}
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_DEV }}"
-          env: web-test
+          env: web-test3
         env:
           WERF_REPO: ${{ steps.check_dev_registry.outputs.web_registry_path }}
           WERF_DIR: "docs/site"
           WERF_RELEASE: "deckhouse-site"
-          WERF_NAMESPACE: deckhouse-web-test
+          WERF_NAMESPACE: deckhouse-web-test3
           WERF_SET_DOC_VERSION: "global.doc_version=${{ env.DOC_VERSION }}"
           WERF_SET_ACTIVE_RELEASE: "global.active_release=v1"
-          WERF_SET_URL: "global.url=deckhouse.test.flant.com"
-          WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.test.flant.com"
-          WERF_SET_WEB_ENV: "web.env=web-test"
-          WERF_SET_DOMAIN_MAP: "global.domain_map=eyJlbiIgOiAiZGVja2hvdXNlLnRlc3QuZmxhbnQuY29tIiwgInJ1IiA6ICJkZWNraG91c2UucnUudGVzdC5mbGFudC5jb20ifQ=="
+          WERF_SET_URL: "global.url=deckhouse.3.test.flant.com"
+          WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.3.test.flant.com"
+          WERF_SET_WEB_ENV: "web.env=web-test3"
+          WERF_SET_DOMAIN_MAP: "global.domain_map=eyJlbiIgOiAiZGVja2hvdXNlLjMudGVzdC5mbGFudC5jb20iLCAicnUiIDogImRlY2tob3VzZS5ydS4zLnRlc3QuZmxhbnQuY29tIn0="
           WERF_SET_DCNAME: "web.dc_name=dev"
           DOC_API_KEY: "${{secrets.DOC_API_KEY}}"
           DOC_API_URL: "${{vars.DOC_API_URL}}"
@@ -283,21 +283,21 @@ jobs:
           echo "DOC_VERSION=${CI_COMMIT_TAG:-latest}" >> $GITHUB_ENV
       # </template: doc_version_template>
       # <template: deploy_doc_template>
-      - name: Deploy documentation to test
+      - name: Deploy documentation to test3
         uses: werf/actions/converge@v2
         with:
           version: ${{env.WERF_VERSION}}
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_DEV }}"
-          env: web-test
+          env: web-test3
         env:
           WERF_REPO: ${{ steps.check_dev_registry.outputs.web_registry_path }}
           WERF_DIR: "docs/documentation"
           WERF_RELEASE: "deckhouse-doc-${{ env.DOC_VERSION }}"
-          WERF_NAMESPACE: deckhouse-web-test
+          WERF_NAMESPACE: deckhouse-web-test3
           WERF_SET_DOC_VERSION: "global.doc_version=${{ env.DOC_VERSION }}"
-          WERF_SET_URL: "global.url=deckhouse.test.flant.com"
-          WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.test.flant.com"
-          WERF_SET_WEB_ENV: "web.env=web-test"
+          WERF_SET_URL: "global.url=deckhouse.3.test.flant.com"
+          WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.3.test.flant.com"
+          WERF_SET_WEB_ENV: "web.env=web-test3"
           WERF_SET_DCNAME: "web.dc_name=dev"
       # </template: deploy_doc_template>
 
@@ -315,7 +315,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,final,docs';
-            const name = 'Deploy web to test';
+            const name = 'Deploy web to test3';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);

--- a/.github/workflows/deploy-web-test4.yml
+++ b/.github/workflows/deploy-web-test4.yml
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Deploy web to test'
+name: 'Deploy web to test4'
 
 on:
   workflow_dispatch:
@@ -63,7 +63,7 @@ env:
 
 # Cancel in-progress jobs for the same tag/branch.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-test
+  group: ${{ github.workflow }}-${{ github.ref }}-test4
   cancel-in-progress: true
 
 jobs:
@@ -166,7 +166,7 @@ jobs:
         with:
           script: |
             const labelType = 'deploy-web';
-            const labelSubject = 'test';
+            const labelSubject = 'test4';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
@@ -204,7 +204,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           retries: 3
           script: |
-            const name = 'Deploy web to test';
+            const name = 'Deploy web to test4';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -252,23 +252,23 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: deploy_site_template>
-      - name: Deploy site to test
+      - name: Deploy site to test4
         uses: werf/actions/converge@v2
         with:
           version: ${{env.WERF_VERSION}}
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_DEV }}"
-          env: web-test
+          env: web-test4
         env:
           WERF_REPO: ${{ steps.check_dev_registry.outputs.web_registry_path }}
           WERF_DIR: "docs/site"
           WERF_RELEASE: "deckhouse-site"
-          WERF_NAMESPACE: deckhouse-web-test
+          WERF_NAMESPACE: deckhouse-web-test4
           WERF_SET_DOC_VERSION: "global.doc_version=${{ env.DOC_VERSION }}"
           WERF_SET_ACTIVE_RELEASE: "global.active_release=v1"
-          WERF_SET_URL: "global.url=deckhouse.test.flant.com"
-          WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.test.flant.com"
-          WERF_SET_WEB_ENV: "web.env=web-test"
-          WERF_SET_DOMAIN_MAP: "global.domain_map=eyJlbiIgOiAiZGVja2hvdXNlLnRlc3QuZmxhbnQuY29tIiwgInJ1IiA6ICJkZWNraG91c2UucnUudGVzdC5mbGFudC5jb20ifQ=="
+          WERF_SET_URL: "global.url=deckhouse.4.test.flant.com"
+          WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.4.test.flant.com"
+          WERF_SET_WEB_ENV: "web.env=web-test4"
+          WERF_SET_DOMAIN_MAP: "global.domain_map=eyJlbiIgOiAiZGVja2hvdXNlLjQudGVzdC5mbGFudC5jb20iLCAicnUiIDogImRlY2tob3VzZS5ydS40LnRlc3QuZmxhbnQuY29tIn0="
           WERF_SET_DCNAME: "web.dc_name=dev"
           DOC_API_KEY: "${{secrets.DOC_API_KEY}}"
           DOC_API_URL: "${{vars.DOC_API_URL}}"
@@ -283,21 +283,21 @@ jobs:
           echo "DOC_VERSION=${CI_COMMIT_TAG:-latest}" >> $GITHUB_ENV
       # </template: doc_version_template>
       # <template: deploy_doc_template>
-      - name: Deploy documentation to test
+      - name: Deploy documentation to test4
         uses: werf/actions/converge@v2
         with:
           version: ${{env.WERF_VERSION}}
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_DEV }}"
-          env: web-test
+          env: web-test4
         env:
           WERF_REPO: ${{ steps.check_dev_registry.outputs.web_registry_path }}
           WERF_DIR: "docs/documentation"
           WERF_RELEASE: "deckhouse-doc-${{ env.DOC_VERSION }}"
-          WERF_NAMESPACE: deckhouse-web-test
+          WERF_NAMESPACE: deckhouse-web-test4
           WERF_SET_DOC_VERSION: "global.doc_version=${{ env.DOC_VERSION }}"
-          WERF_SET_URL: "global.url=deckhouse.test.flant.com"
-          WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.test.flant.com"
-          WERF_SET_WEB_ENV: "web.env=web-test"
+          WERF_SET_URL: "global.url=deckhouse.4.test.flant.com"
+          WERF_SET_URL_RU: "global.url_ru=deckhouse.ru.4.test.flant.com"
+          WERF_SET_WEB_ENV: "web.env=web-test4"
           WERF_SET_DCNAME: "web.dc_name=dev"
       # </template: deploy_doc_template>
 
@@ -315,7 +315,7 @@ jobs:
           retries: 3
           script: |
             const statusConfig = 'job,final,docs';
-            const name = 'Deploy web to test';
+            const name = 'Deploy web to test4';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);


### PR DESCRIPTION
## Description
Add new environments: test2, test3, and test4 for deployment deployment.

Update corresponding workflow files and constants to reflect changes.

Use corresponding label: deploy/web/test[234]

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Add new environments for documentation deployment.
impact_level: low
```
