### PR TITLE
[cert-manager] delete challenges and secrets with `background` propagation policy

### DIFF
--- a/modules/101-cert-manager/hooks/create_registry_secret_for_solver.go
+++ b/modules/101-cert-manager/hooks/create_registry_secret_for_solver.go
@@ -235,7 +235,9 @@ func handleChallenge(input *go_hook.HookInput) error {
 			continue
 		}
 
-		input.PatchCollector.Delete("v1", "Secret", ns, solverSecretName)
+		// NOTE: This deletion is async because synchronous deletion might hang.
+		// Kubernetes GC will handle the actual cleanup.
+		input.PatchCollector.DeleteInBackground("v1", "Secret", ns, solverSecretName)
 	}
 
 	// gc SA's
@@ -245,7 +247,9 @@ func handleChallenge(input *go_hook.HookInput) error {
 			continue
 		}
 
-		input.PatchCollector.Delete("v1", "ServiceAccount", ns, solverServiceAccountName)
+		// NOTE: This deletion is async because synchronous deletion might hang.
+		// Kubernetes GC will handle the actual cleanup.
+		input.PatchCollector.DeleteInBackground("v1", "ServiceAccount", ns, solverServiceAccountName)
 	}
 
 	return nil


### PR DESCRIPTION
## Description
Sometimes cert-manager secrets and service accounts get stuck during deletion

## Why do we need it, and what problem does it solve?
The hook responsible for cleaning up completed ACME challenge dependencies deletes the related secret and service account synchronously, so when it gets stuck, it causes a bunch of problems

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cert-manager
type: fix
summary: clean up ACME challenge with `background` propagation policy
impact_level: low
```

