### PR TITLE
Trivy license scan 

### DIFF
--- a/.github/scripts/cve_scan.sh
+++ b/.github/scripts/cve_scan.sh
@@ -65,13 +65,13 @@ send_report() {
     -F "verified=true" \
     -F "scan_type=Trivy Scan" \
     -F "close_old_findings=true" \
-    -F "do_not_reactivate=true" \
+    -F "do_not_reactivate=false" \
     -F "push_to_jira=false" \
     -F "file=@${2}" \
-    -F "product_type_name=Deckhouse images" \
+    -F "product_type_name=DKP" \
     -F "product_name=Deckhouse" \
     -F "scan_date=${date_iso}" \
-    -F "engagement_name=${1}: Deckhouse Images" \
+    -F "engagement_name=${1}" \
     -F "service=${MODULE_NAME} / ${IMAGE_NAME}" \
     -F "group_by=component_name+component_version" \
     -F "deduplication_on_engagement=false" \


### PR DESCRIPTION
## Description
Added trivy license scan for Deckhouse images

## Why do we need it, and what problem does it solve?
We need to scan Deckhouse images for bad license

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Trivy license scan 
impact: none
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
