### PR TITLE
[cloud-provider-vsphere] bump tf provider version to 2.14.2

### DIFF
--- a/candi/terraform_versions.yml
+++ b/candi/terraform_versions.yml
@@ -102,7 +102,7 @@ vsphere:
   namespace: hashicorp
   cloudName: vSphere
   type: vsphere
-  version: 2.0.2
+  version: 2.14.2
   artifact: terraform-provider-vsphere
   artifactBinary: terraform-provider-vsphere
   destinationBinary: terraform-provider-vsphere

--- a/candi/terraform_versions.yml
+++ b/candi/terraform_versions.yml
@@ -99,7 +99,7 @@ ovirt:
   useOpentofu: true
 
 vsphere:
-  namespace: hashicorp
+  namespace: vmware
   cloudName: vSphere
   type: vsphere
   version: 2.14.2

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/versions.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/versions.tf
@@ -4,8 +4,8 @@
 terraform {
   required_providers {
     vsphere = {
-      source = "hashicorp/vsphere"
-      version = "2.0.2"
+      source = "vmware/vsphere"
+      version = "2.14.2"
     }
   }
   required_version = ">= 0.13"

--- a/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
+++ b/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
@@ -13,13 +13,12 @@ import:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
 fromImage: common/src-artifact
-fromCacheVersion: "2025-02-05.03"
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
 shell:
   install:
-  - git clone --depth 1 --branch v{{ .TF.vsphere.version }}-flant.2 $(cat /run/secrets/SOURCE_REPO)/deckhouse/3p-terraform-provider-vsphere.git /src
+  - git clone --depth 1 --branch v{{ .TF.vsphere.version }}-flant.2 $(cat /run/secrets/SOURCE_REPO)/vmware/terraform-provider-vsphere.git /src
   - cd /src
   - rm -rf vendor
   - rm -rf .git

--- a/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
+++ b/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
@@ -18,7 +18,7 @@ secrets:
   value: {{ .SOURCE_REPO }}
 shell:
   install:
-  - git clone --depth 1 --branch v{{ .TF.vsphere.version }}-flant.2 $(cat /run/secrets/SOURCE_REPO)/vmware/terraform-provider-vsphere.git /src
+  - git clone --depth 1 --branch v{{ .TF.vsphere.version }} $(cat /run/secrets/SOURCE_REPO)/vmware/terraform-provider-vsphere.git /src
   - cd /src
   - rm -rf vendor
   - rm -rf .git
@@ -40,6 +40,6 @@ shell:
   install:
     - export GOPROXY=$(cat /run/secrets/GOPROXY)
     - cd /src
-    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -extldflags \"-static\" -X github.com/hashicorp/terraform-provider-vsphere/version.ProviderVersion={{ .TF.vsphere.version }}" -o /terraform-provider-vsphere
+    - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -extldflags \"-static\" -X github.com/vmware/terraform-provider-vsphere/version.ProviderVersion={{ .TF.vsphere.version }}" -o /terraform-provider-vsphere
     - chmod -R 755 /terraform-provider-vsphere
     - chown 64535:64535 /terraform-provider-vsphere


### PR DESCRIPTION
## Description
This PR upgrades vSphere Terraform provider.

## Why do we need it, and what problem does it solve?
```
+ ept_rvi_mode                            = "automatic"
2025-07-31T10:24:58Z - [INFO] - │ │ │       + hv_mode                                 = "hvAuto"
```
See https://github.com/vmware/terraform-provider-vsphere/issues/1902

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: bump vsphere tf provider version to 2.14.2
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
