### PR TITLE
[cloud-provider-huaweicloud] Make huawei autoscaler "scale from zero" 

### DIFF
--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
@@ -39,8 +39,8 @@ secrets:
   value: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}
 shell:
   install:
-  - export VERSION="v0.5.0"
-  - export VERSION_COMMON="v0.5.0"
+  - export VERSION="feature/autoscaler-huawei"
+  - export VERSION_COMMON="feature/autoscaler-huawei"
   - git clone --depth 1 --branch ${VERSION} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/cloud-data-discoverer.git /src
   - git clone --depth 1 --branch ${VERSION_COMMON} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/huaweicloud-common.git /src/huaweicloud-common
   - mv /deckhouse/go_lib /src

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
@@ -39,8 +39,8 @@ secrets:
   value: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}
 shell:
   install:
-  - export VERSION="feature/autoscaler-huawei"
-  - export VERSION_COMMON="feature/autoscaler-huawei"
+  - export VERSION="feature/huawei-autoscaler"
+  - export VERSION_COMMON="feature/huawei-autoscaler"
   - git clone --depth 1 --branch ${VERSION} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/cloud-data-discoverer.git /src
   - git clone --depth 1 --branch ${VERSION_COMMON} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/huaweicloud-common.git /src/huaweicloud-common
   - mv /deckhouse/go_lib /src

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
@@ -39,8 +39,8 @@ secrets:
   value: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}
 shell:
   install:
-  - export VERSION="feature/huawei-autoscaler"
-  - export VERSION_COMMON="feature/huawei-autoscaler"
+  - export VERSION="v0.6.0"
+  - export VERSION_COMMON="v0.6.0"
   - git clone --depth 1 --branch ${VERSION} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/cloud-data-discoverer.git /src
   - git clone --depth 1 --branch ${VERSION_COMMON} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/huaweicloud-common.git /src/huaweicloud-common
   - mv /deckhouse/go_lib /src


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Adds discovery logic so Cluster Autoscaler can create nodes starts with zero replicas

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Huawei clusters can not autoscale from zero.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-huaweicloud
type: feature
summary: discovery logic so Cluster Autoscaler can create nodes starts with zero replicas
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
