### PR TITLE
[node-local-dns] disable caching servfail

### DIFF
--- a/ee/be/modules/350-node-local-dns/templates/configmap.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
         denial 9984 5 5    # <cache size> <TTL max> <TTL min>
         prefetch 10 1m 25%
         serve_stale 1h immediate
+        servfail 0 # disable caching servfail
       }
       dynamicforward {
         namespace kube-system


### PR DESCRIPTION
## Description
The "servfail 0" option of the CoreDNS cache plugin is introduced in order to disable caching SERVFAIL responses as it can cause cache poisoning.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It was tested and proven that CoreDNS cache plugin with "serve_stale 1h immediate" option is subjected to poisoning when an upstream server returns a SERVFAIL response. Such a response would be staying in the cache and used in subsequent responses to clients for an hour due to an unknown CoreDNS issue related to updating cached negative responses.
Despite the fact that "serve_stale 1h verify" mode, for some reason, seems to be unaffected by the issue, it was decided to disable caching SERVFAIL responses at all.
 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-local-dns
type: chore
summary: Caching SERVFAIL responses is disabled.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
