### PR TITLE
[dhctl] Fix ssh command panic

### DIFF
--- a/dhctl/pkg/system/node/gossh/command.go
+++ b/dhctl/pkg/system/node/gossh/command.go
@@ -105,10 +105,6 @@ func NewSSHCommand(client *Client, name string, arg ...string) *SSHCommand {
 		return err
 	})
 
-	if err != nil {
-		panic(err)
-	}
-
 	return &SSHCommand{
 		// Executor: process.NewDefaultExecutor(sess.Run(cmd)),
 		sshClient: client,
@@ -174,6 +170,9 @@ func (c *SSHCommand) start() error {
 
 	command := c.cmd + " " + strings.Join(c.Args, " ")
 
+	if c.session == nil {
+		return fmt.Errorf("ssh session not started")
+	}
 	return c.session.Start(command)
 }
 
@@ -279,6 +278,10 @@ func (c *SSHCommand) ProcessWait() {
 func (c *SSHCommand) Run(ctx context.Context) error {
 	log.DebugF("executor: run '%s'\n", c.cmd)
 	c.Cmd(ctx)
+
+	if c.session == nil {
+		return fmt.Errorf("ssh session not started")
+	}
 	defer c.session.Close()
 
 	err := c.Start()
@@ -395,6 +398,9 @@ func (c *SSHCommand) Cmd(ctx context.Context) {
 
 func (c *SSHCommand) Output(ctx context.Context) ([]byte, []byte, error) {
 	c.Cmd(ctx)
+	if c.session == nil {
+		return nil, nil, fmt.Errorf("ssh session not started")
+	}
 	defer c.session.Close()
 
 	var o bytes.Buffer
@@ -424,6 +430,10 @@ func (w *singleWriter) Write(p []byte) (int, error) {
 
 func (c *SSHCommand) CombinedOutput(ctx context.Context) ([]byte, error) {
 	c.Cmd(ctx)
+	if c.session == nil {
+		return nil, fmt.Errorf("ssh session not started")
+	}
+
 	defer c.session.Close()
 
 	var o singleWriter


### PR DESCRIPTION
## Description

Fix panic by trying to start ssh session on not available host

## Why do we need it, and what problem does it solve?

Sometimes, if target host is unavailable, dhctl panics after 10 retries to start ssh session. We should avoid this panic behavior

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix panic by trying to start ssh session on unavailable host.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
