### PR TITLE
[extended-monitoring] Exclude PVCs with block mode from space/inodes monitoring

### DIFF
--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/persistent-volume-claim.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/persistent-volume-claim.yaml
@@ -20,7 +20,7 @@
         (
           label_replace((kube_persistentvolume_is_local==0)^0, "volumename", "$1", "persistentvolume", "(.*)")
           * on (volumename) group_right()
-          kube_persistentvolumeclaim_info{job="kube-state-metrics"}
+          kube_persistentvolumeclaim_info{job="kube-state-metrics", volumemode!="Block"}
         )
       )
     for: 5m
@@ -62,7 +62,7 @@
         (
           label_replace((kube_persistentvolume_is_local==0)^0, "volumename", "$1", "persistentvolume", "(.*)")
           * on (volumename) group_right()
-          kube_persistentvolumeclaim_info{job="kube-state-metrics"}
+          kube_persistentvolumeclaim_info{job="kube-state-metrics", volumemode!="Block"}
         )
       )
     for: 5m
@@ -104,7 +104,7 @@
         (
           label_replace((kube_persistentvolume_is_local==0)^0, "volumename", "$1", "persistentvolume", "(.*)")
           * on (volumename) group_right()
-          kube_persistentvolumeclaim_info{job="kube-state-metrics"}
+          kube_persistentvolumeclaim_info{job="kube-state-metrics", volumemode!="Block"}
         )
       )
     for: 5m
@@ -146,7 +146,7 @@
         (
           label_replace((kube_persistentvolume_is_local==0)^0, "volumename", "$1", "persistentvolume", "(.*)")
           * on (volumename) group_right()
-          kube_persistentvolumeclaim_info{job="kube-state-metrics"}
+          kube_persistentvolumeclaim_info{job="kube-state-metrics", volumemode!="Block"}
         )
       )
     for: 2m


### PR DESCRIPTION
## Description
Most CSIs provide reports of device metrics that are eventually exported by the kubelet. In the extended-monitoring module, we rely on the `kubelet_volume_stats_available_bytes` and `kubelet_volume_stats_capacity_bytes` metrics to calculate usage in percentage and emit alerts when the usage exceeds a certain threshold.

## Why do we need it, and what problem does it solve?
For the PersistentVolumes with `volumeMode: Block`, most CSI reports zero as the available bytes, as it cannot be determined. In this case, the Prometheus rule in the module gives 100% usage and emits a meaningless alert.

It's OK to exclude PVs with the `volumeMode: Block` from the monitoring

## Why do we need it in the patch release (if we do)?
It can wait for the next release

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: extended-monitoring
type: fix
summary: Exclude PVCs with block volume mode from space and inodes monitoring. 
impact: free space monitoring for the PVCs in the Block volumeMode is meaningless and will be disabled
impact_level: default
```