### PR TITLE
[docs][getting-started] Fix sudo -i command in GS pages

### DIFF
--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -233,7 +233,7 @@ Next, you will need to create an Ingress controller, a user to access the web in
   <p>Apply it using the following command on the <strong>master node</strong>:</p>
 <div markdown="1">
 ```shell
-sudo -i d8 k create -f ingress-nginx-controller.yml
+sudo -i d8 k create -f $PWD/ingress-nginx-controller.yml
 ```
 </div>
 
@@ -265,7 +265,7 @@ controller-nginx-r6hxc                     3/3     Running   0          5m
 <p>Apply it using the following command on the <strong>master node</strong>:</p>
 <div markdown="1">
 ```shell
-sudo -i d8 k create -f user.yml
+sudo -i d8 k create -f $PWD/user.yml
 ```
 </div>
 </li>

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -242,7 +242,7 @@ kruise-controller-manager-7dfcbdc549-b4wk7   3/3     Running   0           15m
 
 <div markdown="1">
 ```shell
-sudo -i d8 k create -f ingress-nginx-controller.yml
+sudo -i d8 k create -f $PWD/ingress-nginx-controller.yml
 ```
 </div>
 
@@ -273,7 +273,7 @@ controller-nginx-r6hxc                     3/3     Running   0          5m
 <p>Примените его, выполнив на <strong>master-узле</strong> следующую команду:</p>
 <div markdown="1">
 ```shell
-sudo -i d8 k create -f user.yml
+sudo -i d8 k create -f $PWD/user.yml
 ```
 </div>
 </li>

--- a/docs/site/_includes/getting_started/dvp/global/STEP_USER.md
+++ b/docs/site/_includes/getting_started/dvp/global/STEP_USER.md
@@ -13,7 +13,7 @@ Create a user to access the cluster web interfaces:
 <li><p>Apply it using the following command on the <strong>master node</strong>:</p>
 <div markdown="1">
 ```shell
-sudo -i d8 k create -f user.yml
+sudo -i d8 k create -f $PWD/user.yml
 ```
 </div>
 </li>

--- a/docs/site/_includes/getting_started/dvp/global/STEP_USER_RU.md
+++ b/docs/site/_includes/getting_started/dvp/global/STEP_USER_RU.md
@@ -13,7 +13,7 @@
 <li><p>Примените его, выполнив на <strong>master-узле</strong> следующую команду:</p>
 <div markdown="1">
 ```shell
-sudo -i d8 k create -f user.yml
+sudo -i d8 k create -f $PWD/user.yml
 ```
 </div>
 </li>

--- a/docs/site/_includes/getting_started/stronghold/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/stronghold/bm/STEP_FINALIZE.md
@@ -232,7 +232,7 @@ Next, you will need to create an Ingress controller, a user to access the web in
   <p>Apply it using the following command on the <strong>master node</strong>:</p>
 {% snippetcut %}
 ```shell
-sudo -i d8 k create -f ingress-nginx-controller.yml
+sudo -i d8 k create -f $PWD/ingress-nginx-controller.yml
 ```
 {% endsnippetcut %}
 
@@ -262,7 +262,7 @@ controller-nginx-r6hxc                     3/3     Running   0          5m
 <p>Apply it using the following command on the <strong>master node</strong>:</p>
 {% snippetcut %}
 ```shell
-sudo -i d8 k create -f user.yml
+sudo -i d8 k create -f $PWD/user.yml
 ```
 {% endsnippetcut %}
 </li>

--- a/docs/site/_includes/getting_started/stronghold/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/stronghold/bm/STEP_FINALIZE_RU.md
@@ -241,7 +241,7 @@ kruise-controller-manager-7dfcbdc549-b4wk7   3/3     Running   0           15m
 <p>Примените его, выполнив на <strong>master-узле</strong> следующую команду:</p>
 {% snippetcut %}
 ```shell
-sudo -i d8 k create -f ingress-nginx-controller.yml
+sudo -i d8 k create -f $PWD/ingress-nginx-controller.yml
 ```
 {% endsnippetcut %}
 
@@ -271,7 +271,7 @@ controller-nginx-r6hxc                     3/3     Running   0          5m
 <p>Примените его, выполнив на <strong>master-узле</strong> следующую команду:</p>
 {% snippetcut %}
 ```shell
-sudo -i d8 k create -f user.yml
+sudo -i d8 k create -f $PWD/user.yml
 ```
 {% endsnippetcut %}
 </li>


### PR DESCRIPTION
## Description

This pull request updates the documentation to clarify file paths when applying Kubernetes manifests, ensuring that commands explicitly reference files in the current working directory. This change is applied consistently across both English and Russian documentation for multiple deployment scenarios.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: |
  Fixed `sudo -i` command in GS pages.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
