### PR TITLE
[control-plane-manager] Add different api version for `apiserver.config.k8s.io` depends kube version

### DIFF
--- a/candi/control-plane-kubeadm/v1beta3/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta3/config.yaml.tpl
@@ -6,6 +6,7 @@ https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 {{- if semverCompare "< 1.30" .clusterConfiguration.kubernetesVersion }}
     {{- $featureGates = list $featureGates "ValidatingAdmissionPolicy=true" | join "," }}
     {{- $featureGates = list $featureGates "AdmissionWebhookMatchConditions=true" | join "," }}
+    {{- $featureGates = list $featureGates "StructuredAuthenticationConfiguration=true" | join "," }}
 {{- end }}
 
 apiVersion: kubeadm.k8s.io/v1beta3
@@ -105,15 +106,6 @@ apiServer:
   {{- else }}
     bind-address: "0.0.0.0"
   {{- end }}
-  {{- if .apiserver.oidcCA }}
-    oidc-ca-file: /etc/kubernetes/deckhouse/extra-files/oidc-ca.crt
-  {{- end }}
-  {{- if .apiserver.oidcIssuerURL }}
-    oidc-client-id: kubernetes
-    oidc-groups-claim: groups
-    oidc-username-claim: email
-    oidc-issuer-url: {{ .apiserver.oidcIssuerURL }}
-  {{- end }}
   {{ if .apiserver.webhookURL }}
     authorization-mode: Node,Webhook,RBAC
     authorization-webhook-config-file: /etc/kubernetes/deckhouse/extra-files/webhook-config.yaml
@@ -146,7 +138,10 @@ apiServer:
     profiling: "false"
     request-timeout: "60s"
     tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
-  {{- if hasKey .apiserver "certSANs" }}
+    {{- if .apiserver.oidcIssuerURL }}
+    authentication-config: /etc/kubernetes/deckhouse/extra-files/authentication-config.yaml
+    {{- end }}
+    {{- if hasKey .apiserver "certSANs" }}
   certSANs:
     {{- range $san := .apiserver.certSANs }}
   - {{ $san | quote }}

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -801,7 +801,7 @@ resources:
 				err = yaml.Unmarshal(authConfig, &config)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(config.APIVersion).To(Equal("apiserver.config.k8s.io/v1alpha1"))
-				Expect(config.JWT[0].Issuer.DiscoveryURL).To(Equal("https://dex.d8-user-authn.svc.cluster.local/.well-known/openid-configuration"))
+				Expect(config.JWT[0].Issuer.DiscoveryURL).Should(BeEmpty())
 				Expect(config.JWT[0].Issuer.URL).To(Equal("https://dex.example.com"))
 				Expect(config.JWT[0].Issuer.CertificateAuthority).To(Equal("-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n    \n"))
 			})

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -780,6 +780,7 @@ resources:
 				var config AuthenticationConfigurationV1beta1
 				err = yaml.Unmarshal(authConfig, &config)
 				Expect(err).ShouldNot(HaveOccurred())
+				Expect(config.APIVersion).To(Equal("apiserver.config.k8s.io/v1beta1"))
 				Expect(config.JWT[0].Issuer.DiscoveryURL).To(Equal("https://dex.d8-user-authn.svc.cluster.local/.well-known/openid-configuration"))
 				Expect(config.JWT[0].Issuer.URL).To(Equal("https://dex.example.com"))
 				Expect(config.JWT[0].Issuer.CertificateAuthority).To(Equal("-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n    \n"))
@@ -799,6 +800,7 @@ resources:
 				var config AuthenticationConfigurationV1beta1
 				err = yaml.Unmarshal(authConfig, &config)
 				Expect(err).ShouldNot(HaveOccurred())
+				Expect(config.APIVersion).To(Equal("apiserver.config.k8s.io/v1alpha1"))
 				Expect(config.JWT[0].Issuer.DiscoveryURL).To(Equal("https://dex.d8-user-authn.svc.cluster.local/.well-known/openid-configuration"))
 				Expect(config.JWT[0].Issuer.URL).To(Equal("https://dex.example.com"))
 				Expect(config.JWT[0].Issuer.CertificateAuthority).To(Equal("-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n    \n"))
@@ -818,6 +820,7 @@ resources:
 				var config AuthenticationConfigurationV1beta1
 				err = yaml.Unmarshal(authConfig, &config)
 				Expect(err).ShouldNot(HaveOccurred())
+				Expect(config.APIVersion).To(Equal("apiserver.config.k8s.io/v1beta1"))
 				Expect(config.JWT[0].Issuer.DiscoveryURL).To(Equal("https://dex.d8-user-authn.svc.cluster.local/.well-known/openid-configuration"))
 				Expect(config.JWT[0].Issuer.URL).To(Equal("https://dex.example.com"))
 				Expect(config.JWT[0].Issuer.CertificateAuthority).Should(BeEmpty())

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -299,6 +299,25 @@ apiserver:
       ...
       -----END CERTIFICATE-----
 `
+	const apiServerWithOidcFullKube129 = `
+internal:
+  admissionWebhookClientCertificateData:
+    cert: mock-cert
+    key: mock-key
+  effectiveKubernetesVersion: "1.29"
+  etcdServers:
+    - https://192.168.199.186:2379
+  pkiChecksum: checksum
+  rolloutEpoch: 1857
+  audit: {}
+apiserver:
+  authn:
+    oidcIssuerURL: https://dex.example.com
+    oidcCA: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+`
 	const apiServerWithOidcIssuerOnly = `
 internal:
   admissionWebhookClientCertificateData:
@@ -750,6 +769,25 @@ resources:
 		Context("apiserver oidc settings are set fully", func() {
 			BeforeEach(func() {
 				f.ValuesSetFromYaml("controlPlaneManager", apiServerWithOidcFull)
+				f.HelmRender()
+			})
+			It("for issuer[0] should bet set discoveryURL, URL and certificateAuthority", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				s := f.KubernetesResource("Secret", "kube-system", "d8-control-plane-manager-config")
+				Expect(s.Exists()).To(BeTrue())
+				authConfig, err := base64.StdEncoding.DecodeString(s.Field("data.extra-file-authentication-config\\.yaml").String())
+				Expect(err).ShouldNot(HaveOccurred())
+				var config AuthenticationConfigurationV1beta1
+				err = yaml.Unmarshal(authConfig, &config)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(config.JWT[0].Issuer.DiscoveryURL).To(Equal("https://dex.d8-user-authn.svc.cluster.local/.well-known/openid-configuration"))
+				Expect(config.JWT[0].Issuer.URL).To(Equal("https://dex.example.com"))
+				Expect(config.JWT[0].Issuer.CertificateAuthority).To(Equal("-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n    \n"))
+			})
+		})
+		Context("apiserver oidc settings are set fully and kubernetes 1.29", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("controlPlaneManager", apiServerWithOidcFullKube129)
 				f.HelmRender()
 			})
 			It("for issuer[0] should bet set discoveryURL, URL and certificateAuthority", func() {

--- a/modules/040-control-plane-manager/templates/_authentication_configuration.tpl
+++ b/modules/040-control-plane-manager/templates/_authentication_configuration.tpl
@@ -8,7 +8,9 @@ kind: AuthenticationConfiguration
 jwt:
 - issuer:
     url: {{ .apiserver.oidcIssuerURL }} 
+    {{- if semverCompare ">= 1.30" .clusterConfiguration.kubernetesVersion }}
     discoveryURL: https://dex.d8-user-authn.svc.{{.clusterConfiguration.clusterDomain }}/.well-known/openid-configuration
+    {{- end }}
     {{- if .apiserver.oidcCA }}
     certificateAuthority: |
       {{- .apiserver.oidcCA | nindent 6 }} 

--- a/modules/040-control-plane-manager/templates/_authentication_configuration.tpl
+++ b/modules/040-control-plane-manager/templates/_authentication_configuration.tpl
@@ -1,5 +1,9 @@
 {{- define "authenticationConfiguration" }}
+{{- if semverCompare "< 1.30" .clusterConfiguration.kubernetesVersion }}
+apiVersion: apiserver.config.k8s.io/v1alpha1
+{{- else }}
 apiVersion: apiserver.config.k8s.io/v1beta1
+{{- end }}
 kind: AuthenticationConfiguration
 jwt:
 - issuer:


### PR DESCRIPTION
## Description

When adding `AuthenticationConfiguration` in #14788, it was not taken into account that depending on the version of kubernetes, different versions of the api `apiserver.config.k8s.io` should be used.
This revision eliminates this problem

## Why do we need it, and what problem does it solve?
Improving code quality

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix 
summary: Add different api version for "apiserver.config.k8s.io" depends kube version
impact_level: low
```

