### PR TITLE
[docs] Added information about using webhooks and notifications at new docs structure

### DIFF
--- a/docs/documentation/pages/admin/configuration/update/UPDATE-CONFIGURATION.md
+++ b/docs/documentation/pages/admin/configuration/update/UPDATE-CONFIGURATION.md
@@ -198,6 +198,62 @@ Manual approval of DKP updates is required in the following cases:
   d8 k annotate node ${NODE_1} update.node.deckhouse.io/disruption-approved=
   ```
 
+### Deckhouse update notifications
+
+In the `Auto` update mode, you can [configure](/modules/deckhouse/configuration.html#parameters-update-notification) a webhook call to receive a notification about an upcoming minor Deckhouse version update.
+
+In addition, notifications are generated not only for Deckhouse updates but also for updates of any modules, including their individual updates.  
+In some cases, the system may initiate the sending of multiple notifications at once (10–20 notifications) at approximately 15-second intervals.
+
+{% alert %}
+Notifications are available only in the `Auto` update mode; in the `Manual` mode they are not generated.
+{% endalert %}
+
+{% alert %}
+Specifying a webhook is optional: if the `update.notification.webhook` parameter is not set but the `update.notification.minimalNotificationTime` parameter is specified, the update will still be postponed for the specified period. In this case, the appearance of a [DeckhouseRelease](cr.html#deckhouserelease) resource in the cluster with the name of the new version can be considered the notification of its availability.
+{% endalert %}
+
+Notifications are sent only once for a specific update. If something goes wrong (for example, the webhook receives incorrect data), they will not be resent automatically. To resend the notification, you must delete the corresponding [DeckhouseRelease](cr.html#deckhouserelease) resource.
+
+Example of notification configuration:
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    update:
+      releaseChannel: Stable
+      mode: Auto
+      notification:
+        webhook: https://release-webhook.mydomain.com
+```
+
+After a new minor Deckhouse version appears on the selected update channel, but before it is applied in the cluster, a [POST request](/modules/deckhouse/configuration.html#parameters-update-notification-webhook) will be sent to the configured webhook address.
+
+The [minimalNotificationTime](/modules/deckhouse/configuration.html#parameters-update-notification-minimalnotificationtime) parameter allows you to postpone the update installation for the specified period, providing time to react to the notification while respecting update windows. If the webhook is unavailable, each failed attempt to send the notification will postpone the update by the same duration, which may lead to the update being deferred indefinitely.
+
+Example:
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    update:
+      releaseChannel: Stable
+      mode: Auto
+      notification:
+        webhook: https://release-webhook.mydomain.com
+        minimalNotificationTime: 8h
+```
+
 ## Update windows
 
 DKP allows you to define *update windows*, which are specific time intervals during which automatic updates are allowed.

--- a/docs/documentation/pages/admin/configuration/update/UPDATE-CONFIGURATION_RU.md
+++ b/docs/documentation/pages/admin/configuration/update/UPDATE-CONFIGURATION_RU.md
@@ -191,6 +191,62 @@ d8 k get deckhousereleases
   d8 k annotate node ${NODE_1} update.node.deckhouse.io/disruption-approved=
   ```
 
+### Оповещение об обновлении Deckhouse
+
+В режиме обновлений `Auto` можно [настроить](/modules/deckhouse/configuration.html#parameters-update-notification) вызов вебхука для получения оповещения о предстоящем обновлении минорной версии Deckhouse.
+
+Кроме того, оповещения формируются не только при обновлении Deckhouse, но и при обновлении любых модулей, включая их отдельные обновления.
+В отдельных случаях система может инициировать отправку нескольких оповещений одновременно (по 10–20 оповещений) с интервалом около 15 секунд.
+
+{% alert %}
+Оповещения доступны только в режиме обновлений `Auto`, в режиме `Manual` они не формируются.
+{% endalert %}
+
+{% alert %}
+Вебхук указывать не обязательно: если параметр `update.notification.webhook` не задан, но указано время в параметре `update.notification.minimalNotificationTime`, применение новой версии всё равно будет отложено на указанный период. В этом случае оповещением о появлении новой версии можно считать появление в кластере ресурса [DeckhouseRelease](cr.html#deckhouserelease) с именем новой версии.
+{% endalert %}
+
+Оповещения отправляются только один раз для конкретного обновления. Если что-то пошло не так (например, вебхук получил некорректные данные), повторная отправка автоматически не произойдёт. Чтобы отправить оповещение повторно, необходимо удалить соответствующий ресурс [DeckhouseRelease](cr.html#deckhouserelease).
+
+Пример настройки оповещения:
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    update:
+      releaseChannel: Stable
+      mode: Auto
+      notification:
+        webhook: https://release-webhook.mydomain.com
+```
+
+После появления новой минорной версии Deckhouse на используемом канале обновлений, но до момента применения ее в кластере на адрес вебхука будет выполнен [POST-запрос](/modules/deckhouse/configuration.html#parameters-update-notification-webhook).
+
+Параметр [minimalNotificationTime](/modules/deckhouse/configuration.html#parameters-update-notification-minimalnotificationtime) позволяет отложить установку обновления на заданный период, обеспечивая время для реакции на оповещение с учётом окон обновлений. Если при этом вебхук недоступен, каждая неудачная попытка отправки будет сдвигать время применения на ту же величину, что может привести к бесконечному откладыванию обновления.
+
+Пример:
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    update:
+      releaseChannel: Stable
+      mode: Auto
+      notification:
+        webhook: https://release-webhook.mydomain.com
+        minimalNotificationTime: 8h
+```
+
 ## Окна обновлений
 
 DKP позволяет задавать *окна обновлений* — временные интервалы,


### PR DESCRIPTION
## Description
Added information about using webhooks and notifications at new docs structure.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Added information about using webhooks and notifications at new docs structure.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
