### PR TITLE
[docs] Minor updates in nfsstorageclass documentation

### DIFF
--- a/docs/documentation/_data/storage/crds/doc-ru-nfsstorageclass.yaml
+++ b/docs/documentation/_data/storage/crds/doc-ru-nfsstorageclass.yaml
@@ -54,12 +54,14 @@ spec:
                     Права для chmod, которые будут применены к субдиректории тома в NFS-разделе
                 reclaimPolicy:
                   description: |
-                    Режим поведения при удалении PVC:
-                    - `Delete` — при удалении PVC будет удален PV и данные на NFS-сервере;
-                    - `Retain` — при удалении PVC не будут удалены PV и данные на NFS-сервере, требуют ручного удаления пользователем.
+                    Задаёт режим поведения при удалении PersistentVolumeClaim (PVC). Допустимые значения:
+                    - `Delete` — при удалении PVC также удаляется связанный PersistentVolume (PV) и соответствующие данные на NFS-сервере.
+                    - `Retain` — при удалении PVC связанные PersistentVolume и данные на NFS-сервере не удаляются и требуют ручного удаления пользователем. Подробнее [в документации Kubernetes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming).
                 volumeBindingMode:
                   description: |
-                    Режим создания тома. Может быть Immediate (запрос при создании PVC) или WaitForFirstConsumer (до появления первого Pod).
+                    Задаёт режим создания тома. Допустимые значения:
+                    - `Immediate` — том создаётся сразу после создания PVC.
+                    - `WaitForFirstConsumer` — том создаётся только при первом использовании PVC со стороны пода. Подробнее [в документации Kubernetes](https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode).
                 workloadNodes:
                   type: object
                   minProperties: 1

--- a/docs/documentation/_data/storage/crds/nfsstorageclass.yaml
+++ b/docs/documentation/_data/storage/crds/nfsstorageclass.yaml
@@ -143,9 +143,9 @@ spec:
                     - rule: self == oldSelf
                       message: Value is immutable.
                   description: |
-                    The StorageClass's reclaim policy:
-                    - `Delete` — if the Persistent Volume Claim is deleted, deletes the Persistent Volume and its associated storage as well;
-                    - `Retain` — if the Persistent Volume Claim is deleted, remains the Persistent Volume and its associated storage.
+                    Defines the behavior when a PersistentVolumeClaim (PVC) is deleted. Two values are allowed:
+                    - `Delete` — when the PVC is deleted, the associated PersistentVolume (PV) and corresponding data on the NFS server are also deleted.
+                    - `Retain` — when the PVC is deleted, the associated PersistentVolume and data on the NFS server are not deleted and require manual removal by the user. See more in [the Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming).
                   enum:
                     - Delete
                     - Retain
@@ -155,7 +155,9 @@ spec:
                     - rule: self == oldSelf
                       message: Value is immutable.
                   description: |
-                    The StorageClass's volume binding mode. Might be Immediate or WaitForFirstConsumer.
+                    Defines the volume binding mode. The following values are allowed:
+                    - `Immediate` — the volume is provisioned immediately after the PersistentVolumeClaim (PVC) is created.
+                    - `WaitForFirstConsumer` — the volume is provisioned only when the PVC is first used by a pod. See more in [the Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode).
                   enum:
                     - Immediate
                     - WaitForFirstConsumer


### PR DESCRIPTION
## Description
Added info about nfsstorageclass in documentation.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Added info about nfsstorageclass in documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
