### PR TITLE
[cloud-provider-vsphere] ignore ept_rvi_mode and hv_mode

### DIFF
--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
@@ -199,6 +199,8 @@ resource "vsphere_virtual_machine" "master" {
       disk,
       vapp,
       firmware,
+      ept_rvi_mode,
+      hv_mode,
     ]
   }
 

--- a/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
+++ b/ee/se-plus/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
@@ -171,6 +171,8 @@ resource "vsphere_virtual_machine" "node" {
       disk,
       vapp,
       firmware,
+      ept_rvi_mode,
+      hv_mode,
     ]
   }
   wait_for_guest_net_routable = false


### PR DESCRIPTION
## Description
This PR adds `ept_rvi_mode` and `hv_mode` values of TF resource `vsphere_virtual_machine` to `ignore_changes` list

## Why do we need it, and what problem does it solve?
```
+ ept_rvi_mode                            = "automatic"
2025-07-31T10:24:58Z - [INFO] - │ │ │       + hv_mode                                 = "hvAuto"
```
See https://github.com/vmware/terraform-provider-vsphere/issues/1902

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: ignore ept_rvi_mode and hv_mode
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
