### PR TITLE
backport [cloud-provider-dvp] fix logic of work with disks and coreFraction validation #14284

### DIFF
--- a/candi/cloud-providers/dvp/openapi/cloud_discovery_data.yaml
+++ b/candi/cloud-providers/dvp/openapi/cloud_discovery_data.yaml
@@ -32,6 +32,12 @@ apiVersions:
             properties:
               name:
                 type: string
+              volumeBindingMode:
+                type: string
+              reclaimPolicy:
+                type: string
+              allowVolumeExpansion:
+                type: boolean
               isEnabled:
                 type: boolean
               isDefault:

--- a/candi/cloud-providers/dvp/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/dvp/openapi/cluster_configuration.yaml
@@ -160,7 +160,7 @@ apiVersions:
                         coreFraction:
                           type: string
                           default: "100%"
-                          enum: ["5%", "10%", "25%", "50%", "100%"]
+                          pattern: ^100%$|^[1-9][0-9]?%$
                           description: |
                             Guaranteed share of CPU that will be allocated to the virtual machine.
                           example: "100%"

--- a/candi/cloud-providers/dvp/openapi/instance_class.yaml
+++ b/candi/cloud-providers/dvp/openapi/instance_class.yaml
@@ -44,7 +44,7 @@ spec:
                         coreFraction:
                           type: string
                           default: "100%"
-                          enum: ["5%", "10%", "25%", "50%", "100%"]
+                          pattern: ^100%$|^[1-9][0-9]?%$
                           description: |
                             Guaranteed share of CPU fraction that will be allocated to the virtual machine.
                           x-doc-example: "100%"

--- a/candi/cloud-providers/dvp/terraform-modules/kubernetes-data-disk/main.tf
+++ b/candi/cloud-providers/dvp/terraform-modules/kubernetes-data-disk/main.tf
@@ -29,11 +29,6 @@ resource "kubernetes_manifest" "kubernetes-data-disk" {
       )
     }
   }
-  wait {
-    fields = {
-      "status.phase" = "Ready"
-    }
-  }
   timeouts {
     create = var.timeouts.create
     update = var.timeouts.update

--- a/candi/cloud-providers/dvp/terraform-modules/master/outputs.tf
+++ b/candi/cloud-providers/dvp/terraform-modules/master/outputs.tf
@@ -22,6 +22,6 @@ output "node_internal_ip_address" {
 
 output "kubernetes_data_device_path" {
   # vd-${disk-name}
-  value = "/dev/disk/by-id/scsi-SQEMU_QEMU_HARDDISK_${var.kubernetes_data_disk.md5_id}"
+  value = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_${var.kubernetes_data_disk.md5_id}"
 }
 

--- a/candi/cloud-providers/dvp/terraform-modules/root-disk/main.tf
+++ b/candi/cloud-providers/dvp/terraform-modules/root-disk/main.tf
@@ -36,11 +36,6 @@ resource "kubernetes_manifest" "root-disk" {
       )
     }
   }
-  wait {
-    fields = {
-      "status.phase" = "Ready"
-    }
-  }
   timeouts {
     create = var.timeouts.create
     update = var.timeouts.update

--- a/go_lib/cloud-data/apis/v1/dvp_cloud_provider_discovery_data.go
+++ b/go_lib/cloud-data/apis/v1/dvp_cloud_provider_discovery_data.go
@@ -23,7 +23,10 @@ type DVPCloudProviderDiscoveryData struct {
 }
 
 type DVPStorageClass struct {
-	Name      string `json:"name,omitempty"`
-	IsEnabled bool   `json:"isEnabled,omitempty"`
-	IsDefault bool   `json:"isDefault,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	VolumeBindingMode    string `json:"volumeBindingMode,omitempty"`
+	ReclaimPolicy        string `json:"reclaimPolicy,omitempty"`
+	AllowVolumeExpansion bool   `json:"allowVolumeExpansion,omitempty"`
+	IsEnabled            bool   `json:"isEnabled,omitempty"`
+	IsDefault            bool   `json:"isDefault,omitempty"`
 }

--- a/modules/030-cloud-provider-dvp/crds/external/deckhousemachines.yaml
+++ b/modules/030-cloud-provider-dvp/crds/external/deckhousemachines.yaml
@@ -87,12 +87,7 @@ spec:
                       description: |-
                         Fraction is a guaranteed share of CPU time that will be allocated to the virtual machine.
                         Expressed as a percentage.
-                      enum:
-                        - 5%
-                        - 10%
-                        - 25%
-                        - 50%
-                        - 100%
+                      pattern: ^100%$|^[1-9][0-9]?%$
                       type: string
                   required:
                     - cores

--- a/modules/030-cloud-provider-dvp/crds/external/deckhousemachinetemplates.yaml
+++ b/modules/030-cloud-provider-dvp/crds/external/deckhousemachinetemplates.yaml
@@ -141,12 +141,7 @@ spec:
                               description: |-
                                 Fraction is a guaranteed share of CPU time that will be allocated to the virtual machine.
                                 Expressed as a percentage.
-                              enum:
-                                - 5%
-                                - 10%
-                                - 25%
-                                - 50%
-                                - 100%
+                              pattern: ^100%$|^[1-9][0-9]?%$
                               type: string
                           required:
                             - cores

--- a/modules/030-cloud-provider-dvp/hooks/discover.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover.go
@@ -27,8 +27,8 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
-	v1 "k8s.io/api/core/v1"
-	storage "k8s.io/api/storage/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -69,7 +69,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, handleCloudProviderDiscoveryDataSecret)
 
 func applyCloudProviderDiscoveryDataSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	secret := &v1.Secret{}
+	secret := &corev1.Secret{}
 	err := sdk.FromUnstructured(obj, secret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert kubernetes object: %v", err)
@@ -79,7 +79,7 @@ func applyCloudProviderDiscoveryDataSecretFilter(obj *unstructured.Unstructured)
 }
 
 func applyStorageClassFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	storageClass := &storage.StorageClass{}
+	storageClass := &storagev1.StorageClass{}
 	err := sdk.FromUnstructured(obj, storageClass)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert kubernetes object: %v", err)
@@ -98,26 +98,31 @@ func handleCloudProviderDiscoveryDataSecret(input *go_hook.HookInput) error {
 			return nil
 		}
 
-		storageClassesSnapshots := input.Snapshots["storage_classes"]
-
+		storageClassesSnapshots := input.NewSnapshots.Get("storage_classes")
 		storageClasses := make([]storageClass, 0, len(storageClassesSnapshots))
 
-		for _, storageClassSnapshot := range storageClassesSnapshots {
-			sc := storageClassSnapshot.(*storage.StorageClass)
-
-			storageClasses = append(storageClasses, storageClass{
-				Name:            sc.Name,
-				DVPStorageClass: sc.Parameters["dvpStorageClass"],
-			})
+		for storageClassSnapshot, err := range sdkobjectpatch.SnapshotIter[storagev1.StorageClass](storageClassesSnapshots) {
+			if err != nil {
+				return fmt.Errorf("failed to iterate over 'storage_classes' snapshots: %v", err)
+			}
+			storageClasses = append(storageClasses, storageClassToStorageClassValue(&storageClassSnapshot))
 		}
 		input.Logger.Info("Found DVP storage classes using StorageClass snapshots: %v", storageClasses)
 
 		setStorageClassesValues(input, storageClasses)
-
 		return nil
 	}
 
-	secret := input.Snapshots["cloud_provider_discovery_data"][0].(*v1.Secret)
+	secrets := input.NewSnapshots.Get("cloud_provider_discovery_data")
+	if len(secrets) == 0 {
+		return fmt.Errorf("'cloud_provider_discovery_data' snapshot is empty")
+	}
+
+	secret := new(corev1.Secret)
+	err := secrets[0].UnmarshalTo(secret)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal 'cloud_provider_discovery_data' snapshot: %w", err)
+	}
 
 	discoveryDataJSON := secret.Data["discovery-data.json"]
 
@@ -134,12 +139,12 @@ func handleCloudProviderDiscoveryDataSecret(input *go_hook.HookInput) error {
 
 	input.Values.Set("cloudProviderDvp.internal.providerDiscoveryData", discoveryData)
 
-	handleDiscoveryDataVolumeTypes(input, discoveryData.StorageClassList)
+	handleDiscoveryDataStorageClasses(input, discoveryData.StorageClassList)
 
 	return nil
 }
 
-func handleDiscoveryDataVolumeTypes(
+func handleDiscoveryDataStorageClasses(
 	input *go_hook.HookInput,
 	dvpStorageClassList []cloudDataV1.DVPStorageClass,
 ) {
@@ -153,9 +158,17 @@ func handleDiscoveryDataVolumeTypes(
 		dvpstorageClass[getStorageClassName(sc.Name)] = sc
 	}
 
-	classExcludes, ok := input.Values.GetOk("cloudProviderDvp.storageClass.exclude")
+	storageClasses := make([]storageClass, 0, len(dvpStorageClassList))
+	for _, snapshot := range input.Snapshots["storage_classes"] {
+		sc := snapshot.(*storagev1.StorageClass)
+		if _, ok := dvpstorageClass[sc.Name]; !ok {
+			storageClasses = append(storageClasses, storageClassToStorageClassValue(sc))
+		}
+	}
+
+	storageClassExcludes, ok := input.Values.GetOk("cloudProviderDvp.storageClass.exclude")
 	if ok {
-		for _, esc := range classExcludes.Array() {
+		for _, esc := range storageClassExcludes.Array() {
 			rg := regexp.MustCompile("^(" + esc.String() + ")$")
 			for class := range dvpstorageClass {
 				if rg.MatchString(class) {
@@ -165,17 +178,13 @@ func handleDiscoveryDataVolumeTypes(
 		}
 	}
 
-	storageClassSnapshots := make(map[string]*storage.StorageClass)
-	for _, snapshot := range input.Snapshots["storage_classes"] {
-		s := snapshot.(*storage.StorageClass)
-		storageClassSnapshots[s.Name] = s
-	}
-
-	storageClasses := make([]storageClass, 0, len(dvpStorageClassList))
-	for name, domain := range dvpstorageClass {
+	for name, sc := range dvpstorageClass {
 		sc := storageClass{
-			Name:            name,
-			DVPStorageClass: domain.Name,
+			Name:                 name,
+			DVPStorageClass:      sc.Name,
+			VolumeBindingMode:    sc.VolumeBindingMode,
+			ReclaimPolicy:        sc.ReclaimPolicy,
+			AllowVolumeExpansion: sc.AllowVolumeExpansion,
 		}
 		storageClasses = append(storageClasses, sc)
 	}
@@ -215,6 +224,34 @@ func setStorageClassesValues(input *go_hook.HookInput, storageClasses []storageC
 }
 
 type storageClass struct {
-	Name            string `json:"name"`
-	DVPStorageClass string `json:"dvpStorageClass"`
+	Name                 string `json:"name"`
+	DVPStorageClass      string `json:"dvpStorageClass"`
+	VolumeBindingMode    string `json:"volumeBindingMode"`
+	ReclaimPolicy        string `json:"reclaimPolicy"`
+	AllowVolumeExpansion bool   `json:"allowVolumeExpansion"`
+}
+
+func storageClassToStorageClassValue(sc *storagev1.StorageClass) storageClass {
+	volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+	if sc.VolumeBindingMode != nil {
+		volumeBindingMode = *sc.VolumeBindingMode
+	}
+
+	reclaimPolicy := corev1.PersistentVolumeReclaimDelete
+	if sc.ReclaimPolicy != nil {
+		reclaimPolicy = *sc.ReclaimPolicy
+	}
+
+	allowVolumeExpansion := false
+	if sc.AllowVolumeExpansion != nil {
+		allowVolumeExpansion = *sc.AllowVolumeExpansion
+	}
+
+	return storageClass{
+		Name:                 sc.Name,
+		DVPStorageClass:      sc.Parameters["dvpStorageClass"],
+		VolumeBindingMode:    string(volumeBindingMode),
+		ReclaimPolicy:        string(reclaimPolicy),
+		AllowVolumeExpansion: allowVolumeExpansion,
+	}
 }

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/api/v1alpha1/deckhousemachine_types.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/api/v1alpha1/deckhousemachine_types.go
@@ -48,7 +48,7 @@ type CPU struct {
 	// Fraction is a guaranteed share of CPU time that will be allocated to the VM.
 	// Expressed as percentage.
 	// +kubebuilder:default="100%"
-	// +kubebuilder:validation:Enum:={"5%", "10%", "25%", "50%", "100%"}
+	// +kubebuilder:validation:Pattern=`^100%$|^[1-9][0-9]?%$`
 	Fraction string `json:"cpuFraction"`
 }
 

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -403,17 +403,6 @@ func (r *DeckhouseMachineReconciler) createVM(
 		return nil, fmt.Errorf("Expected to find a cloud-init script in secret %s/%s", bootstrapDataSecret.Namespace, bootstrapDataSecret.Name)
 	}
 
-	// FIXME remove this user after testing
-	cloudInitScript = append(cloudInitScript, []byte(`
-ssh_pwauth: true
-users:
-- name: cloud
-  passwd: $6$rounds=4096$vln/.aPHBOI7BMYR$bBMkqQvuGs5Gyd/1H5DP4m9HjQSy.kgrxpaGEHwkX7KEFV8BS.HZWPitAtZ2Vd8ZqIZRqmlykRCagTgPejt1i.
-  shell: /bin/bash
-  sudo: ALL=(ALL) NOPASSWD:ALL
-  chpasswd: { expire: False }
-  lock_passwd: false`)...)
-
 	cloudInitSecretName := "cloud-init-" + dvpMachine.Name
 	if err := r.DVP.ComputeService.CreateCloudInitProvisioningSecret(ctx, cloudInitSecretName, cloudInitScript); err != nil {
 		return nil, fmt.Errorf("Cannot create cloud-init provisioning secret: %w", err)

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -92,11 +92,6 @@ func (d *DiskService) CreateDisk(ctx context.Context, diskName string, diskSize 
 		return nil, err
 	}
 
-	err = d.WaitDiskCreation(ctx, diskName)
-	if err != nil {
-		return nil, err
-	}
-
 	newDisk, err := d.GetDiskByName(ctx, diskName)
 	if err != nil {
 		return nil, err
@@ -135,11 +130,6 @@ func (d *DiskService) CreateDiskFromDataSource(
 
 	err := d.client.Create(ctx, &vmd)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
-		return nil, err
-	}
-
-	err = d.WaitDiskCreation(ctx, diskName)
-	if err != nil {
 		return nil, err
 	}
 

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
@@ -137,13 +137,8 @@ func (c *ControllerService) CreateVolume(
 		return nil, msg
 	}
 
-	diskCapacity, err := utils.ConvertStringQuantityToInt64(disk.Status.Capacity)
-	if err != nil {
-		klog.Error(err.Error())
-		return nil, err
-	}
 	result.Volume.VolumeId = disk.Name
-	result.Volume.CapacityBytes = diskCapacity
+	result.Volume.CapacityBytes = requiredSize
 	return result, nil
 }
 

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/identity.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/identity.go
@@ -83,7 +83,7 @@ func (i *IdentityService) GetPluginCapabilities(
 	}, nil
 }
 
-// Probe checks the state of the connection to ovirt-engine
+// Probe checks the state of the connection
 func (i *IdentityService) Probe(
 	ctx context.Context,
 	_ *csi.ProbeRequest,

--- a/modules/030-cloud-provider-dvp/openapi/values.yaml
+++ b/modules/030-cloud-provider-dvp/openapi/values.yaml
@@ -138,10 +138,10 @@ properties:
                           coreFraction:
                             type: string
                             default: "100%"
-                            enum: ["5%", "10%", "25%", "50%", "100%"]
+                            pattern: ^100%$|^[1-9][0-9]?%$
                             description: |
                               Guaranteed share of CPU that will be allocated to the VM. Specified as a percentage.
-                              Supported values: `5%`, `10%`, `25%`, `50%`, `100%`.
+                              Supported values: `1% - 100%`.
                             example: "100%"
                       memory:
                         type: object
@@ -465,6 +465,12 @@ properties:
               properties:
                 name:
                   type: string
+                volumeBindingMode:
+                  type: string
+                reclaimPolicy:
+                  type: string
+                allowVolumeExpansion:
+                  type: boolean
                 isEnabled:
                   type: boolean
                 IsDefault:
@@ -476,5 +482,11 @@ properties:
           properties:
             name:
               type: string
+            volumeBindingMode:
+              type: string
+            reclaimPolicy:
+              type: string
+            allowVolumeExpansion:
+              type: boolean
             dvpStorageClass:
               type: string

--- a/modules/030-cloud-provider-dvp/templates/csi/storage-classes.yaml
+++ b/modules/030-cloud-provider-dvp/templates/csi/storage-classes.yaml
@@ -7,9 +7,9 @@ metadata:
   {{- include "helm_lib_module_storage_class_annotations" (list $ $index $storageClass.name) | nindent 2 }}
   name: {{ $storageClass.name | quote }}
 provisioner: csi.dvp.deckhouse.io
-reclaimPolicy: Delete
-allowVolumeExpansion: true
-volumeBindingMode: WaitForFirstConsumer
+volumeBindingMode: {{ $storageClass.volumeBindingMode | quote }}
+reclaimPolicy: {{ $storageClass.reclaimPolicy | quote }}
+allowVolumeExpansion: {{ $storageClass.allowVolumeExpansion }}
 parameters:
   dvpStorageClass: {{ $storageClass.dvpStorageClass | quote }}
 {{- end }}


### PR DESCRIPTION
## Description
fix logic of work with disks and coreFraction validation
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Incorrect disk handling. Disk does not go to Ready status under certain conditions
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: fix logic of work with disks and coreFraction validation
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
