### PR TITLE
[dhctl] Fix tunnel string in preflight checks

### DIFF
--- a/dhctl/pkg/app/app.go
+++ b/dhctl/pkg/app/app.go
@@ -52,7 +52,7 @@ var (
 	ConfigPaths = make([]string, 0)
 	SanityCheck = false
 	LoggerType  = "pretty"
-	IsDebug     = true
+	IsDebug     = false
 
 	DoNotWriteDebugLogFile = false
 	DebugLogFilePath       = ""

--- a/dhctl/pkg/app/app.go
+++ b/dhctl/pkg/app/app.go
@@ -36,9 +36,9 @@ const (
 )
 
 var (
-	deckhouseDir             = "/deckhouse"
-	VersionFile              = deckhouseDir + "/version"
-	EditionFile              = deckhouseDir + "/edition"
+	deckhouseDir = "/deckhouse"
+	VersionFile  = deckhouseDir + "/version"
+	EditionFile  = deckhouseDir + "/edition"
 )
 
 var TmpDirName = filepath.Join(os.TempDir(), "dhctl")
@@ -52,7 +52,7 @@ var (
 	ConfigPaths = make([]string, 0)
 	SanityCheck = false
 	LoggerType  = "pretty"
-	IsDebug     = false
+	IsDebug     = true
 
 	DoNotWriteDebugLogFile = false
 	DebugLogFilePath       = ""

--- a/dhctl/pkg/preflight/common.go
+++ b/dhctl/pkg/preflight/common.go
@@ -47,7 +47,7 @@ func setupSSHTunnelToProxyAddr(sshCl node.SSHClient, proxyUrl *url.URL) (node.Tu
 			port = "443"
 		}
 	}
-	tunnel := strings.Join([]string{ProxyTunnelPort, proxyUrl.Hostname(), port}, ":")
+	tunnel := strings.Join([]string{proxyUrl.Hostname(), port, "127.0.0.1", ProxyTunnelPort}, ":")
 	log.DebugF("tunnel string: %s", tunnel)
 	tun := sshCl.Tunnel(tunnel)
 	err := tun.Up()

--- a/dhctl/pkg/system/node/gossh/file.go
+++ b/dhctl/pkg/system/node/gossh/file.go
@@ -64,6 +64,7 @@ func (f *SSHFile) Upload(ctx context.Context, srcPath, remotePath string) error 
 		if rType == "DIR" {
 			remotePath = remotePath + "/" + filepath.Base(srcPath)
 		}
+		log.DebugF("starting upload local %s to remote %s\n", srcPath, remotePath)
 
 		if err := scpClient.CopyFile(ctx, localFile, remotePath, "0755"); err != nil {
 			return fmt.Errorf("failed to copy file to remote host: %w", err)
@@ -203,6 +204,8 @@ func getRemoteFileStat(client *ssh.Client, remoteFilePath string) (string, error
 
 	command := fmt.Sprint("stat -c %F " + remoteFilePath)
 	output, err := session.CombinedOutput(command)
+
+	log.DebugF("remote path %s is %s\n", remoteFilePath, output)
 
 	if strings.TrimSpace(string(output)) == "directory" {
 		return "DIR", nil

--- a/dhctl/pkg/system/node/gossh/file.go
+++ b/dhctl/pkg/system/node/gossh/file.go
@@ -196,13 +196,17 @@ func (f *SSHFile) DownloadBytes(ctx context.Context, remotePath string) ([]byte,
 }
 
 func getRemoteFileStat(client *ssh.Client, remoteFilePath string) (string, error) {
+	if remoteFilePath == "." {
+		return "DIR", nil
+	}
+
 	session, err := client.NewSession()
 	if err != nil {
 		return "", fmt.Errorf("failed to create session: %w", err)
 	}
 	defer session.Close()
 
-	command := fmt.Sprint("stat -c %F " + remoteFilePath)
+	command := fmt.Sprint("LC_ALL=en_US.utf8 stat -c %F " + remoteFilePath)
 	output, err := session.CombinedOutput(command)
 
 	log.DebugF("remote path %s is %s\n", remoteFilePath, output)


### PR DESCRIPTION
## Description

Fix tunnel string in preflight checks

## Why do we need it, and what problem does it solve?

Preflight check `Checking if Cloud API is accessible through proxy` fails in case of wrong tunnel string. We should fix it.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix tunnel string in preflight checks.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
