### PR TITLE
[docs] Fix broken links at DVP cloud provider documentation

### DIFF
--- a/candi/cloud-providers/dvp/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/dvp/openapi/cluster_configuration.yaml
@@ -134,7 +134,7 @@ apiVersions:
             instanceClass:
               type: object
               description: |
-                Configuration of the virtual machine and its disks for the created master node.
+                Configuration for the virtual machine's root disk.
               additionalProperties: false
               required: [virtualMachine, rootDisk, etcdDisk]
               properties:
@@ -432,7 +432,7 @@ apiVersions:
           description: |
             Layout name.
 
-            [Read more about possible provider layouts.](https://deckhouse.io/documentation/v1/modules/030-cloud-provider-dvp/layouts.html)
+            [Read more about possible provider layouts](../cloud-provider-dvp/layouts.html).
           enum: [Standard]
 
         region:
@@ -441,7 +441,7 @@ apiVersions:
             Region name.
 
             To use this setting, the `topology.kubernetes.io/region` label must be set on DVP nodes.
-            [Read more about topological labels.](https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesioregion).
+            [Read more about topological labels](https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesioregion).
 
             > To set the required label for a DVP node, follow the [NodeGroup documentation](https://deckhouse.io/documentation/v1/modules/040-node-manager/cr.html#nodegroup-v1-spec-nodetemplate-labels).
         zones:

--- a/candi/cloud-providers/dvp/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/dvp/openapi/doc-ru-cluster_configuration.yaml
@@ -180,15 +180,15 @@ apiVersions:
           description: |
             Название схемы размещения.
 
-            [Подробнее о возможных схемах размещения провайдера.](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/modules/cloud-provider-dvp/layouts.html).
+            [Подробнее о возможных схемах размещения провайдера](../cloud-provider-dvp/layouts.html).
         region:
           description: |
             Название региона.
 
             Чтобы использовать эту настройку, на узлах DVP должна быть установлена метка `topology.kubernetes.io/region`.
-            [Подробнее о топологических метках.](https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesioregion)
+            [Подробнее о топологических метках](https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesioregion)
 
-            > Чтобы установить требуемую метку для узла DVP, следуйте [документации по  NodeGroup](https://deckhouse.io/documentation/v1/modules/040-node-manager/cr.html#nodegroup-v1-spec-nodetemplate-labels).
+            > Чтобы установить требуемую метку для узла DVP, следуйте [документации по NodeGroup](https://deckhouse.io/documentation/v1/modules/040-node-manager/cr.html#nodegroup-v1-spec-nodetemplate-labels).
         zones:
           description: |
             Набор зон, в которых могут быть созданы узлы.


### PR DESCRIPTION
## Description
Fixed broken links at DVP cloud provider documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Fixed broken links at DVP cloud provider documentation.
impact_level: low
```
