### PR TITLE
[dhctl] Fix connection string

### DIFF
--- a/dhctl/pkg/system/node/session/session.go
+++ b/dhctl/pkg/system/node/session/session.go
@@ -244,8 +244,8 @@ func (s *Session) String() string {
 		builder.WriteString(s.host)
 	}
 
-	if s.Port != "" {
-		builder.WriteString(fmt.Sprintf(":%s", s.Port))
+	if s.Port != "" && s.Port != "22" {
+		builder.WriteString(fmt.Sprintf(" -p %s", s.Port))
 	}
 
 	return builder.String()


### PR DESCRIPTION
## Description

Fix SSH connection string shown by bootstraping process

## Why do we need it, and what problem does it solve?

If any SSH port set, connection string shows not correctly and user cannot just copy and paste it to connect to first master host


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix SSH connection string.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
