### PR TITLE
[ci] Temporarily disable DCGM module build

### DIFF
--- a/ee/modules/040-node-manager/images/nvidia-dcgm-exporter/werf.inc.yaml
+++ b/ee/modules/040-node-manager/images/nvidia-dcgm-exporter/werf.inc.yaml
@@ -56,6 +56,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
+final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /ldconf/

--- a/ee/modules/040-node-manager/images/nvidia-dcgm/werf.inc.yaml
+++ b/ee/modules/040-node-manager/images/nvidia-dcgm/werf.inc.yaml
@@ -188,6 +188,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
+final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /out/

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -353,8 +353,6 @@ var DefaultImagesDigests = map[string]interface{}{
 		"fencingAgent":             "imageHash-nodeManager-fencingAgent",
 		"machineControllerManager": "imageHash-nodeManager-machineControllerManager",
 		"nodeFeatureDiscovery":     "imageHash-nodeManager-nodeFeatureDiscovery",
-		"nvidiaDcgm":               "imageHash-nodeManager-nvidiaDcgm",
-		"nvidiaDcgmExporter":       "imageHash-nodeManager-nvidiaDcgmExporter",
 		"nvidiaDevicePlugin":       "imageHash-nodeManager-nvidiaDevicePlugin",
 		"nvidiaMigManager129":      "imageHash-nodeManager-nvidiaMigManager129",
 		"nvidiaMigManager130":      "imageHash-nodeManager-nvidiaMigManager130",


### PR DESCRIPTION
## Description
Temporarily disable DCGM module build.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Temporarily disable DCGM module
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
