### PR TITLE
Exclude d8ShutdownInhibitor image from rootless scan

### DIFF
--- a/tools/cve/check-non-root.sh
+++ b/tools/cve/check-non-root.sh
@@ -38,10 +38,17 @@ declare -A allowed_components=(
 declare -A skip_components=(
   ["registrypackages"]="skip"
 )
+declare -A skip_components_images=(
+  ["d8ShutdownInhibitor"]="skip"
+)
 # Function to get skip components
 function get_skip_components() {
   local component=$1
   echo "${skip_components[$component]:-"none"}"
+}
+function get_skip_components_images() {
+  local image=$1
+  echo "${skip_components_images[$image]:-"none"}"
 }
 
 # Function to check allowed components
@@ -99,7 +106,7 @@ function __main__() {
     MODULE_NAME=$(jq -rc '.key' <<< "$module")
     if [[ $(get_skip_components "$MODULE_NAME") == "skip" ]]; then
           echo "=============================================="
-          echo "🛰 Module: $MODULE_NAME skip"
+          echo "🛰 Module: $MODULE_NAME skipped due to validation exclude"
           continue
     fi
     echo "=============================================="
@@ -109,6 +116,11 @@ function __main__() {
       IMAGE_NAME=$(jq -rc '.key' <<< "$module_image")
       if [[ "$IMAGE_NAME" == "trivy" ]]; then
         continue
+      fi
+      if [[ $(get_skip_components_images "$IMAGE_NAME") == "skip" ]]; then
+            echo "=============================================="
+            echo "🛰 Image: $IMAGE_NAME skipped due to validation exclude"
+            continue
       fi
       echo "----------------------------------------------"
       echo "👾 Image: $IMAGE_NAME"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Need to exclude d8ShutdownInhibitor image from rootless scan

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Validation constantly fails with false positive result due to d8ShutdownInhibitor should be excluded

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: chore
summary: Exclude d8ShutdownInhibitor image from rootless scan
impact: none
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
