### PR TITLE
[ingress-nginx] fix opentelemetry missing library and shrink ingress-nginx controller image

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -209,7 +209,7 @@ shell:
   {{- include "alt packages proxy" . | nindent 2 }}
   - apt-get -y install ca-certificates curl libxml2-devel libyajl libyajl-devel libmaxminddb libmaxminddb-devel iptables iptables-nft nfs-utils conntrack-tools glibc-gconv-modules libgrpc++-devel libgrpc++ libbrotli-devel libpcre-devel
   setup:
-  - cp -R /usr/lib64 /chroot/usr/lib64
+  - cp -R /usr/lib64/* /chroot/usr/lib64/
   - ln -s /usr/local/nginx/sbin/nginx /sbin/nginx
   - adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
   - |
@@ -219,6 +219,7 @@ shell:
       /chroot/usr/local/nginx
       /chroot/usr/share
       /chroot/usr/bin
+      /chroot/usr/lib/locale
       /chroot/etc/ingress-controller
       /chroot/etc/ingress-controller/ssl
       /chroot/etc/ingress-controller/auth
@@ -320,6 +321,7 @@ shell:
   - export LUA_PATH="/usr/local/share/luajit-2.1/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/lib/lua/?.lua;;"
   - export LUA_CPATH="/usr/local/lib/lua/?/?.so;/usr/local/lib/lua/?.so;;"
   - cp -R /src/rootfs/etc/* /chroot/etc
+  - cp -a /usr/lib/locale/* /chroot/usr/lib/locale/
   - rm -rf /src/rootfs/etc/
   - ln -s /usr/local/nginx/sbin/nginx /sbin/nginx
   - adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
@@ -353,15 +355,17 @@ shell:
   - mknod -m 0666 /chroot/dev/ptmx c 5 2
   - mknod -m 0666 /chroot/dev/zero c 1 5
   - mknod -m 0666 /chroot/dev/tty c 5 0
-  - echo -e "/lib\n/lib64\n/usr/local/lib\n/usr/local/lib64\n/etc/nginx/modules" > /etc/ld.so.conf.d/local.conf
+  - echo -e "/lib\n/lib64\n/usr/local/lib\n/usr/local/lib64\n/usr/lib64\n/etc/nginx/modules" > /etc/ld.so.conf.d/local.conf
   - ldconfig
 # Create ld.so.cache inside chroot
   - cp -a /etc/ld.so.conf* /chroot/etc/ && ldconfig -r /chroot
 # remove ruby from libs because it has cve's but not using in image
 # ruby install with grpc-plugins packet it needs for building nginx
   - rm -rf /chroot/usr/lib64/ruby
-# remove owasp-modsecurity-crs/util bash scripts cve
+# remove owasp-modsecurity-crs/util because of bash scripts cve
   - rm -rf /chroot/etc/nginx/owasp-modsecurity-crs
+# takes ~1GB
+  - rm -rf /chroot/usr/lib64/locale
 imageSpec:
   config:
     workingDir: /

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -355,7 +355,7 @@ shell:
   - mknod -m 0666 /chroot/dev/ptmx c 5 2
   - mknod -m 0666 /chroot/dev/zero c 1 5
   - mknod -m 0666 /chroot/dev/tty c 5 0
-  - echo -e "/lib\n/lib64\n/usr/local/lib\n/usr/local/lib64\n/usr/lib64\n/etc/nginx/modules" > /etc/ld.so.conf.d/local.conf
+  - echo -e "/lib\n/lib64\n/usr/local/lib\n/usr/local/lib64\n/etc/nginx/modules" > /etc/ld.so.conf.d/local.conf
   - ldconfig
 # Create ld.so.cache inside chroot
   - cp -a /etc/ld.so.conf* /chroot/etc/ && ldconfig -r /chroot

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -3,7 +3,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 fromImage: common/src-artifact
-fromCacheVersion: "2025-07-10"
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -244,6 +244,8 @@ shell:
   - cp -a /usr/local/lib /chroot/usr/local/
   - cp -a /usr/local/share/lua* /chroot/usr/local/share/
   - cp -a /usr/local/lib64 /chroot/usr/local/
+  # override old opentelemtry libs with new ones
+  - cp -a /usr/local/lib64/libopentelemetry* /chroot/lib64/
   - cp -a /usr/local/modsecurity/bin /chroot/usr/local/modsecurity/
   - cp -a /usr/local/modsecurity/lib/libmodsecurity.* /chroot/usr/lib64/
   - cp -a /usr/local/nginx /chroot/usr/local/
@@ -326,7 +328,7 @@ shell:
   - mknod -m 0666 /chroot/dev/ptmx c 5 2
   - mknod -m 0666 /chroot/dev/zero c 1 5
   - mknod -m 0666 /chroot/dev/tty c 5 0
-  - echo -e "/lib\n/lib64\n/usr/local/lib\n/usr/local/lib64\n/usr/lib64\n/etc/nginx/modules" > /etc/ld.so.conf.d/local.conf
+  - echo -e "/lib\n/lib64\n/usr/local/lib\n/usr/local/lib64\n/etc/nginx/modules" > /etc/ld.so.conf.d/local.conf
   - ldconfig
 # Create ld.so.cache inside chroot
   - cp -a /etc/ld.so.conf* /chroot/etc/ && ldconfig -r /chroot

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -180,7 +180,7 @@ shell:
   {{- include "alt packages proxy" . | nindent 2 }}
   - apt-get -y install ca-certificates curl libxml2-devel libyajl libyajl-devel libmaxminddb libmaxminddb-devel iptables iptables-nft nfs-utils conntrack-tools glibc-gconv-modules libgrpc++-devel libgrpc++ libbrotli-devel libpcre-devel
   setup:
-  - cp -R /usr/lib64 /chroot/usr/lib64
+  - cp -R /usr/lib64/* /chroot/usr/lib64/
   - ln -s /usr/local/nginx/sbin/nginx /sbin/nginx
   - adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
   - |
@@ -251,8 +251,6 @@ shell:
   - chown www-data:www-data /chroot/etc
   - cp -R /src/rootfs/etc/* /chroot/etc
   - rm -rf /src/rootfs/etc
-  # takes ~1GB
-  - rm -rf /chroot/usr/lib64/locale
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/alt-p11-artifact
@@ -335,6 +333,8 @@ shell:
 # remove ruby from libs because it has cve's but not using in image
 # ruby install with grpc-plugins packet it needs for building nginx
   - rm -rf /chroot/usr/lib64/ruby
+  # takes ~1GB
+  - rm -rf /chroot/usr/lib64/locale
 imageSpec:
   config:
     workingDir: /

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -333,6 +333,8 @@ shell:
 # remove ruby from libs because it has cve's but not using in image
 # ruby install with grpc-plugins packet it needs for building nginx
   - rm -rf /chroot/usr/lib64/ruby
+# remove owasp-modsecurity-crs/util because of bash scripts cve
+  - rm -rf /chroot/etc/nginx/owasp-modsecurity-crs
   # takes ~1GB
   - rm -rf /chroot/usr/lib64/locale
 imageSpec:

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -3,7 +3,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 fromImage: common/src-artifact
-fromCacheVersion: "2025-07-10"
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -191,6 +190,7 @@ shell:
       /chroot/usr/local/nginx
       /chroot/usr/share
       /chroot/usr/bin
+      /chroot/usr/lib/locale
       /chroot/etc/ingress-controller
       /chroot/etc/ingress-controller/ssl
       /chroot/etc/ingress-controller/auth
@@ -223,6 +223,7 @@ shell:
   - cp -a /usr/bin/curl /chroot/usr/bin/curl
   - cp -a /lib64/* /chroot/lib64/
   - rm -rf /chroot/lib64/apt /chroot/lib64/debug /chroot/lib64/games
+  - cp -a /usr/lib/locale/* /chroot/usr/lib/locale/
   - cp -a /usr/lib64/libcurl* /chroot/usr/lib64/
   - cp -a /usr/lib64/libstdc++* /chroot/usr/lib64/
   - cp -a /usr/lib64/libbrotli* /chroot/usr/lib64/
@@ -250,6 +251,8 @@ shell:
   - chown www-data:www-data /chroot/etc
   - cp -R /src/rootfs/etc/* /chroot/etc
   - rm -rf /src/rootfs/etc
+  # takes ~1GB
+  - rm -rf /chroot/usr/lib64/locale
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/alt-p11-artifact

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -223,7 +223,6 @@ shell:
   - cp -a /usr/bin/curl /chroot/usr/bin/curl
   - cp -a /lib64/* /chroot/lib64/
   - rm -rf /chroot/lib64/apt /chroot/lib64/debug /chroot/lib64/games
-  - cp -a /usr/lib/locale/* /chroot/usr/lib/locale/
   - cp -a /usr/lib64/libcurl* /chroot/usr/lib64/
   - cp -a /usr/lib64/libstdc++* /chroot/usr/lib64/
   - cp -a /usr/lib64/libbrotli* /chroot/usr/lib64/
@@ -293,6 +292,7 @@ shell:
   - export LUA_PATH="/usr/local/share/luajit-2.1/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/lib/lua/?.lua;;"
   - export LUA_CPATH="/usr/local/lib/lua/?/?.so;/usr/local/lib/lua/?.so;;"
   - cp -R /src/rootfs/etc/* /chroot/etc
+  - cp -a /usr/lib/locale/* /chroot/usr/lib/locale/
   - rm -rf /src/rootfs/etc/
   - ln -s /usr/local/nginx/sbin/nginx /sbin/nginx
   - adduser -r -U -u 101 -d /usr/local/nginx -s /sbin/nologin -c www-data www-data
@@ -326,7 +326,7 @@ shell:
   - mknod -m 0666 /chroot/dev/ptmx c 5 2
   - mknod -m 0666 /chroot/dev/zero c 1 5
   - mknod -m 0666 /chroot/dev/tty c 5 0
-  - echo -e "/lib\n/lib64\n/usr/local/lib\n/usr/local/lib64\n/etc/nginx/modules" > /etc/ld.so.conf.d/local.conf
+  - echo -e "/lib\n/lib64\n/usr/local/lib\n/usr/local/lib64\n/usr/lib64\n/etc/nginx/modules" > /etc/ld.so.conf.d/local.conf
   - ldconfig
 # Create ld.so.cache inside chroot
   - cp -a /etc/ld.so.conf* /chroot/etc/ && ldconfig -r /chroot


### PR DESCRIPTION
## Description
The following changes are introduced:

- The size of the ingress-nginx controller image is reduced by deleting extra locale data from the /chroot/usr/lib64/locale directory (it took approximately 1GB of disk space);

- The missing library
```
nginx: [emerg] dlopen() "/etc/nginx/modules/otel_ngx_module.so" failed (libupb_wire_lib.so.45: cannot open shared object file: No such file or directory)
``` 
issue was fixed.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

It fixes the missing opentelemetry library issue.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: The missing opentelemetry libraries issue is fixed.
impact: The pods of Ingress Nginx controllers of 1.10 and 1.12 versions will be restated.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
