### PR TITLE
[cloud-provider-vcd] Fix Template Org catalog querying

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager-legacy/patches/002-go-mod.patch
+++ b/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager-legacy/patches/002-go-mod.patch
@@ -1,8 +1,15 @@
 diff --git a/go.mod b/go.mod
-index 770e3105..4fffa0fc 100644
+index 770e3105..1a9dff9e 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -19,7 +19,7 @@ require (
+@@ -13,13 +13,13 @@ require (
+ 	github.com/onsi/gomega v1.27.4
+ 	github.com/pkg/errors v0.9.1
+ 	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20231207231939-203ccc98e915
+-	github.com/vmware/go-vcloud-director/v2 v2.15.0
++	github.com/vmware/go-vcloud-director/v2 v2.21.0
+ 	go.uber.org/zap v1.24.0
+ 	gopkg.in/yaml.v2 v2.4.0
  	k8s.io/api v0.26.1
  	k8s.io/apimachinery v0.26.1
  	k8s.io/client-go v0.26.1
@@ -41,20 +48,27 @@ index 770e3105..4fffa0fc 100644
  	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
  	google.golang.org/appengine v1.6.7 // indirect
  	google.golang.org/protobuf v1.30.0 // indirect
-@@ -99,7 +99,7 @@ require (
+@@ -99,7 +99,6 @@ require (
  	k8s.io/apiextensions-apiserver v0.26.1 // indirect
  	k8s.io/cluster-bootstrap v0.25.0 // indirect
  	k8s.io/component-base v0.26.1 // indirect
 -	k8s.io/klog/v2 v2.80.1 // indirect
-+	k8s.io/klog v1.0.0 // indirect
  	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
  	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
  	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 diff --git a/go.sum b/go.sum
-index b51e9874..4ded511f 100644
+index b51e9874..25740034 100644
 --- a/go.sum
 +++ b/go.sum
-@@ -207,8 +207,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
+@@ -135,7 +135,6 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
+ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+ github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+-github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+ github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+ github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+ github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
+@@ -207,8 +206,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
  github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
  github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
  github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -65,7 +79,36 @@ index b51e9874..4ded511f 100644
  github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
  github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
  github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-@@ -488,8 +488,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
+@@ -248,7 +247,6 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
+ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
+ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+-github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+ github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+ github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+ github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
+@@ -291,7 +289,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
+ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+ github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+ github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+@@ -445,10 +442,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
+ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+-github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20231207231939-203ccc98e915 h1:Leq2NJgGnhqL54Nn20tmR7KYF3vYJA6VoB4kSI63Xzw=
+-github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20231207231939-203ccc98e915/go.mod h1:ycVcmrTXBth/M8TSOe6iTeMI4jRy3lIK8QPhROZyuQU=
+-github.com/vmware/go-vcloud-director/v2 v2.15.0 h1:idQ9NsHLr2dOSLBC8KIdBMq7XOvPiWmfxgWNaf580mk=
+-github.com/vmware/go-vcloud-director/v2 v2.15.0/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
++github.com/vmware/go-vcloud-director/v2 v2.21.0 h1:zIONrJpM+Fj+rDyXmsRfMAn1sP5WAP87USL0T9GS4DY=
++github.com/vmware/go-vcloud-director/v2 v2.21.0/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
+ github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+ github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+@@ -488,8 +483,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
  golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
  golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
  golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
@@ -76,7 +119,7 @@ index b51e9874..4ded511f 100644
  golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
-@@ -563,8 +563,8 @@ golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su
+@@ -563,8 +558,8 @@ golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su
  golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
  golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
  golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
@@ -87,7 +130,7 @@ index b51e9874..4ded511f 100644
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
  golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-@@ -638,13 +638,13 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
+@@ -638,13 +633,13 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
  golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -105,7 +148,7 @@ index b51e9874..4ded511f 100644
  golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-@@ -654,8 +654,8 @@ golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+@@ -654,8 +649,8 @@ golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
  golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
  golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
  golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
@@ -116,7 +159,7 @@ index b51e9874..4ded511f 100644
  golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
  golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
  golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-@@ -709,8 +709,8 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
+@@ -709,8 +704,8 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
  golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
  golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
  golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
@@ -127,3 +170,12 @@ index b51e9874..4ded511f 100644
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+@@ -854,8 +849,6 @@ k8s.io/cluster-bootstrap v0.25.0 h1:KJ2/r0dV+bLfTK5EBobAVKvjGel3N4Qqh3bvnzh9qPk=
+ k8s.io/cluster-bootstrap v0.25.0/go.mod h1:x/TCtY3EiuR/rODkA3SvVQT3uSssQLf9cXcmSjdDTe0=
+ k8s.io/component-base v0.26.1 h1:4ahudpeQXHZL5kko+iDHqLj/FSGAEUnSVO0EBbgDd+4=
+ k8s.io/component-base v0.26.1/go.mod h1:VHrLR0b58oC035w6YQiBSbtsf0ThuSwXP+p5dD/kAWU=
+-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
+-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+ k8s.io/klog/v2 v2.80.1 h1:atnLQ121W371wYYFawwYx1aEY2eUfs4l3J72wtgAwV4=
+ k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
+ k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 h1:+70TFaan3hfJzs+7VK2o+OGxg8HsuBr/5f6tVAjDu6E=

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/patches/005-add-vapptemplate-search-by-org.patch
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/patches/005-add-vapptemplate-search-by-org.patch
@@ -1,43 +1,65 @@
-Subject: [PATCH] Add support for searching vAppTemplates in a given org
----
-Index: pkg/vcdsdk/vapp.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
+diff --git a/go.mod b/go.mod
+index 30b2a020..30d9ebf6 100644
+--- a/go.mod
++++ b/go.mod
+@@ -13,7 +13,7 @@ require (
+ 	github.com/peterhellberg/link v1.1.0
+ 	github.com/sethvargo/go-password v0.2.0
+ 	github.com/stretchr/testify v1.7.0
+-	github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3
++	github.com/vmware/go-vcloud-director/v2 v2.21.0
+ 	golang.org/x/oauth2 v0.7.0
+ 	gopkg.in/yaml.v2 v2.4.0
+ 	gopkg.in/yaml.v3 v3.0.0
+diff --git a/go.sum b/go.sum
+index 81ccc4ab..84082e69 100644
+--- a/go.sum
++++ b/go.sum
+@@ -435,8 +435,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
+ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=
+ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+-github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3 h1:VJolXzgomaRPrgzSr0EduuUtJIJEf5RdoLbktZFQqIc=
+-github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
++github.com/vmware/go-vcloud-director/v2 v2.21.0 h1:zIONrJpM+Fj+rDyXmsRfMAn1sP5WAP87USL0T9GS4DY=
++github.com/vmware/go-vcloud-director/v2 v2.21.0/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
+ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
+ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 diff --git a/pkg/vcdsdk/vapp.go b/pkg/vcdsdk/vapp.go
---- a/pkg/vcdsdk/vapp.go	(revision afb0bc63f9449b402122f210ae218cde81b80633)
-+++ b/pkg/vcdsdk/vapp.go	(date 1747234304160)
-@@ -531,7 +531,7 @@
+index d5ad922b..e6f6e552 100644
+--- a/pkg/vcdsdk/vapp.go
++++ b/pkg/vcdsdk/vapp.go
+@@ -531,7 +531,7 @@ func (vdc *VdcManager) SetVmExtraConfigKeyValue(vm *govcd.VM, key string, value
  // AddNewMultipleVM will create vmNum VMs in parallel, including recompose VApp of all VMs settings,
  // power on VMs and join the cluster with hardcoded script
  func (vdc *VdcManager) AddNewMultipleVM(vapp *govcd.VApp, vmNamePrefix string, vmNum int,
 -	catalogName string, templateName string, placementPolicyName string, computePolicyName string,
 +	catalogName string, templateName string, templateOrg string, placementPolicyName string, computePolicyName string,
  	storageProfileName string, guestCustScript string, acceptAllEulas bool, powerOn bool) (govcd.Task, error) {
-
+ 
  	klog.V(3).Infof("start adding %d VMs\n", vmNum)
-@@ -541,15 +541,29 @@
+@@ -541,15 +541,29 @@ func (vdc *VdcManager) AddNewMultipleVM(vapp *govcd.VApp, vmNamePrefix string, v
  		return govcd.Task{}, fmt.Errorf("error creating orgManager: [%v]", err)
  	}
-
+ 
 -	catalog, err := orgManager.GetCatalogByName(catalogName)
 -	if err != nil {
 -		return govcd.Task{}, fmt.Errorf("unable to find catalog [%s] in org [%s]: [%v]",
 -			catalogName, vdc.OrgName, err)
 -	}
 +	var vAppTemplateList []*types.QueryResultVappTemplateType
-+
+ 
+-	vAppTemplateList, err := catalog.QueryVappTemplateList()
+-	if err != nil {
+-		return govcd.Task{}, fmt.Errorf("unable to query templates of catalog [%s]: [%v]", catalogName, err)
 +	if templateOrg == "" {
 +		catalog, err := orgManager.GetCatalogByName(catalogName)
 +		if err != nil {
 +			return govcd.Task{}, fmt.Errorf("unable to find catalog [%s] in org [%s]: [%v]",
 +				catalogName, vdc.OrgName, err)
 +		}
-
--	vAppTemplateList, err := catalog.QueryVappTemplateList()
--	if err != nil {
--		return govcd.Task{}, fmt.Errorf("unable to query templates of catalog [%s]: [%v]", catalogName, err)
++
 +		vAppTemplateList, err = catalog.QueryVappTemplateList()
 +		if err != nil {
 +			return govcd.Task{}, fmt.Errorf("unable to query templates of catalog [%s]: [%v]", catalogName, err)
@@ -53,65 +75,65 @@ diff --git a/pkg/vcdsdk/vapp.go b/pkg/vcdsdk/vapp.go
 +			return govcd.Task{}, fmt.Errorf("unable to query templates of catalog [%s]: [%v]", catalogName, err)
 +		}
  	}
-
+ 
  	var queryVAppTemplate *types.QueryResultVappTemplateType
-@@ -808,7 +822,7 @@
+@@ -808,7 +822,7 @@ func (vdc *VdcManager) AddNewMultipleVM(vapp *govcd.VApp, vmNamePrefix string, v
  }
-
+ 
  func (vdc *VdcManager) AddNewTkgVM(vmNamePrefix string, VAppName string, vmNum int,
 -	catalogName string, templateName string, placementPolicyName string, computePolicyName string,
 +	catalogName string, templateName string, templateOrg string, placementPolicyName string, computePolicyName string,
  	storageProfileName string, powerOn bool) error {
-
+ 
  	// In TKG >= 1.6.0, there is a missing file at /etc/cloud/cloud.cfg.d/
-@@ -824,7 +838,7 @@
+@@ -824,7 +838,7 @@ cat > /etc/cloud/cloud.cfg.d/98-cse-vmware-datasource.cfg <<EOF
  datasource_list: [ "VMware" ]
  EOF`
-
+ 
 -	err := vdc.AddNewVM(vmNamePrefix, VAppName, vmNum, catalogName, templateName, placementPolicyName,
 +	err := vdc.AddNewVM(vmNamePrefix, VAppName, vmNum, catalogName, templateName, templateOrg, placementPolicyName,
  		computePolicyName, storageProfileName, guestCustScript, powerOn)
  	if err != nil {
  		return fmt.Errorf("error for adding TKG VM to vApp[%s]: [%v]", VAppName, err)
-@@ -833,7 +847,7 @@
+@@ -833,7 +847,7 @@ EOF`
  }
-
+ 
  func (vdc *VdcManager) AddNewVM(vmNamePrefix string, VAppName string, vmNum int,
 -	catalogName string, templateName string, placementPolicyName string, computePolicyName string,
 +	catalogName string, templateName string, templateOrg string, placementPolicyName string, computePolicyName string,
  	storageProfileName string, guestCustScript string, powerOn bool) error {
-
+ 
  	if vdc.Vdc == nil {
-@@ -846,20 +860,34 @@
+@@ -846,20 +860,34 @@ func (vdc *VdcManager) AddNewVM(vmNamePrefix string, VAppName string, vmNum int,
  			VAppName, vdc.VdcName, err)
  	}
-
+ 
 -	orgManager, err := NewOrgManager(vdc.Client, vdc.Client.ClusterOrgName)
 -	if err != nil {
 -		return fmt.Errorf("error creating an orgManager object: [%v]", err)
 -	}
 +	var vAppTemplateList []*types.QueryResultVappTemplateType
-+
-+	if templateOrg == "" {
-+		orgManager, err := NewOrgManager(vdc.Client, vdc.Client.ClusterOrgName)
-+		if err != nil {
-+			return fmt.Errorf("error creating an orgManager object: [%v]", err)
-+		}
-
+ 
 -	catalog, err := orgManager.GetCatalogByName(catalogName)
 -	if err != nil {
 -		return fmt.Errorf("unable to find catalog [%s] in org [%s]: [%v]",
 -			catalogName, vdc.OrgName, err)
 -	}
++	if templateOrg == "" {
++		orgManager, err := NewOrgManager(vdc.Client, vdc.Client.ClusterOrgName)
++		if err != nil {
++			return fmt.Errorf("error creating an orgManager object: [%v]", err)
++		}
+ 
+-	vAppTemplateList, err := catalog.QueryVappTemplateList()
+-	if err != nil {
+-		return fmt.Errorf("unable to query templates of catalog [%s]: [%v]", catalogName, err)
 +		catalog, err := orgManager.GetCatalogByName(catalogName)
 +		if err != nil {
 +			return fmt.Errorf("unable to find catalog [%s] in org [%s]: [%v]",
 +				catalogName, vdc.OrgName, err)
 +		}
-
--	vAppTemplateList, err := catalog.QueryVappTemplateList()
--	if err != nil {
--		return fmt.Errorf("unable to query templates of catalog [%s]: [%v]", catalogName, err)
++
 +		vAppTemplateList, err = catalog.QueryVappTemplateList()
 +		if err != nil {
 +			return fmt.Errorf("unable to query templates of catalog [%s]: [%v]", catalogName, err)
@@ -127,33 +149,52 @@ diff --git a/pkg/vcdsdk/vapp.go b/pkg/vcdsdk/vapp.go
 +			return fmt.Errorf("unable to query templates of catalog [%s]: [%v]", catalogName, err)
 +		}
  	}
-
+ 
  	var queryVAppTemplate *types.QueryResultVappTemplateType
-@@ -893,7 +921,7 @@
+@@ -893,7 +921,7 @@ func (vdc *VdcManager) AddNewVM(vmNamePrefix string, VAppName string, vmNum int,
  			queryVAppTemplate.HREF, err)
  	}
-
+ 
 -	_, err = vdc.AddNewMultipleVM(vApp, vmNamePrefix, vmNum, catalogName, templateName, placementPolicyName,
 +	_, err = vdc.AddNewMultipleVM(vApp, vmNamePrefix, vmNum, catalogName, templateName, templateOrg, placementPolicyName,
  		computePolicyName, storageProfileName, guestCustScript, true, powerOn)
  	if err != nil {
  		return fmt.Errorf(
-@@ -904,6 +932,20 @@
+@@ -904,6 +932,39 @@ func (vdc *VdcManager) AddNewVM(vmNamePrefix string, VAppName string, vmNum int,
  	return nil
  }
-
-+func (vdc *VdcManager) getCatalog(catalogName string, orgName string) (*govcd.Catalog, error) {
-+	org, err := vdc.Client.VCDClient.GetAdminOrgByName(orgName)
-+	if err != nil {
-+		return nil, fmt.Errorf("unable to get org [%s]: [%v]", orgName, err)
+ 
++func (vdc *VdcManager) getCatalog(catalogName string, orgName string) (*govcd.AdminCatalog, error) {
++	tenantContext := govcd.TenantContext{}
++	if vdc.Client.VCDClient.Client.IsSysAdmin {
++		org, err := vdc.Client.VCDClient.GetAdminOrgByName(orgName)
++		if err != nil {
++			return nil, fmt.Errorf("[getCatalogFromResource] error retrieving org %s: %s", orgName, err)
++		}
++		tenantContext.OrgId = org.AdminOrg.ID
++		tenantContext.OrgName = orgName
 +	}
-+
-+	catalog, err := org.GetCatalogByNameOrId(catalogName, false)
++	catalogRecords, err := vdc.Client.VCDClient.Client.QueryCatalogRecords(catalogName, tenantContext)
 +	if err != nil {
-+		return nil, fmt.Errorf("unable to get catalog [%s]: [%v]", catalogName, err)
++		return nil, fmt.Errorf("[getCatalogFromResource] error retrieving catalog records for catalog %s: %s", catalogName, err)
 +	}
-+
-+	return catalog, nil
++	var catalogRecord *types.CatalogRecord
++	var orgNames []string
++	for _, cr := range catalogRecords {
++		orgNames = append(orgNames, cr.OrgName)
++		if cr.OrgName == orgName {
++			catalogRecord = cr
++			break
++		}
++	}
++	if catalogRecord == nil {
++		message := fmt.Sprintf("no records found for catalog '%s' in org '%s'", catalogName, orgName)
++		if len(orgNames) > 0 {
++			message = fmt.Sprintf("%s\nThere are catalogs with the same name in other orgs: %v", message, orgNames)
++		}
++		return nil, fmt.Errorf(message)
++	}
++	return vdc.Client.VCDClient.Client.GetAdminCatalogByHref(catalogRecord.HREF)
 +}
 +
  func (vdc *VdcManager) DeleteVM(VAppName, vmName string) error {

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/patches/README.md
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/patches/README.md
@@ -6,20 +6,62 @@ This patch is for our case when we want to have a static Nodes in the cluster, m
 
 ### 001-ignore-static-nodes.patch
 
-TODO
+Files:
+
+- pkg/ccm/instances.go
+
+Changes:
+
+- Ignore static nodes in providerID
 
 ### 002-add-vapptemplate-search-by-vapptemplate-id.patch
 
-TODO
+Files:
+
+- pkg/vcdsdk/vapp.go
+
+Changes:
+
+- Add ability to search vApp template by id
 
 ### 003-go-mod.patch
 
-Update dependencies
+Files:
+
+- go.mod
+- go.sum
+
+Changes:
+
+- Update dependencies
 
 ### 004-klog.patch
 
-Update klog to klog/v2 in other files
+Files:
+
+- cmd/ccm/main.go
+- pkg/ccm/cloud.go
+- pkg/ccm/loadbalancer.go
+- pkg/ccm/vminfocache.go
+- pkg/config/cloudconfig.go
+- pkg/cpisdk/rde.go
+- pkg/testingsdk/k8sclient.go
+- pkg/vcdsdk/auth.go
+- pkg/vcdsdk/client.go
+- pkg/vcdsdk/defined_entity.go
+- pkg/vcdsdk/gateway.go
+- pkg/vcdsdk/ipam.go
+
+Changes:
+
+- Update klog to klog/v2 in other files
 
 ### 005-add-vapptemplate-search-by-org.patch
 
-Add support for searching vAppTemplates in a given org
+Files:
+
+- pkg/vcdsdk/vapp.go
+
+Changes:
+
+- Add support for searching vAppTemplates in a given org

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/patches/README.md
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/patches/README.md
@@ -61,6 +61,8 @@ Changes:
 Files:
 
 - pkg/vcdsdk/vapp.go
+- go.mod
+- go.sum
 
 Changes:
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`getCatalog()` failed to retrieve VM templates from organization catalogs lacking direct permissions.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Implemented indirect catalog access path

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: Fix fetching VM templates from organization catalogs without direct access to organizastion
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
