### PR TITLE
[runtime-audit-engine] Disable falco VPA until memory leak is fixed

### DIFF
--- a/ee/modules/650-runtime-audit-engine/template_tests/module_test.go
+++ b/ee/modules/650-runtime-audit-engine/template_tests/module_test.go
@@ -67,73 +67,80 @@ resourcesRequests:
 		})
 	})
 
-	Context("With VPA mode set", func() {
-		BeforeEach(func() {
-			hec.ValuesSetFromYaml("runtimeAuditEngine", `
-debugLogging: false
-internal:
-  webhookCertificate:
-    ca: ABC
-    crt: ABC
-    key: ABC
-resourcesRequests:
-  mode: VPA
-  static:
-    cpu: 5m
-    memory: 4Mi
-  vpa:
-    cpu:
-      max: 500m
-      min: 50m
-    memory:
-      max: 2048Mi
-      min: 64Mi
-    mode: Initial
-`)
-			hec.HelmRender()
-		})
-		It("Should add desired objects", func() {
-			Expect(hec.RenderError).ShouldNot(HaveOccurred())
-
-			testD := hec.KubernetesResource("DaemonSet", "d8-runtime-audit-engine", "runtime-audit-engine")
-			Expect(testD.Exists()).To(BeTrue())
-			Expect(testD.Field("spec.template.spec.containers.0.resources.requests").String()).To(MatchYAML(`
-ephemeral-storage: 50Mi
-`))
-
-			manVPA := hec.KubernetesResource("VerticalPodAutoscaler", "d8-runtime-audit-engine", "runtime-audit-engine")
-			Expect(manVPA.Exists()).To(BeTrue())
-			Expect(manVPA.Field("spec.updatePolicy.updateMode").String()).To(Equal("Initial"))
-			Expect(manVPA.Field("spec.resourcePolicy.containerPolicies").String()).To(MatchYAML(`
-- containerName: falco
-  controlledValues: RequestsAndLimits
-  maxAllowed:
-    cpu: 500m
-    memory: 2048Mi
-  minAllowed:
-    cpu: 50m
-    memory: 64Mi
-- containerName: falcosidekick
-  maxAllowed:
-    cpu: 100m
-    memory: 300Mi
-  minAllowed:
-    cpu: 5m
-    memory: 10Mi
-- containerName: rules-loader
-  maxAllowed:
-    cpu: 100m
-    memory: 300Mi
-  minAllowed:
-    cpu: 10m
-    memory: 25Mi
-- containerName: kube-rbac-proxy
-  maxAllowed:
-    cpu: 20m
-    memory: 25Mi
-  minAllowed:
-    cpu: 10m
-    memory: 25Mi`))
-		})
-	})
+	//	Context("With VPA mode set", func() {
+	//		BeforeEach(func() {
+	//			hec.ValuesSetFromYaml("runtimeAuditEngine", `
+	//
+	// debugLogging: false
+	// internal:
+	//
+	//	webhookCertificate:
+	//	  ca: ABC
+	//	  crt: ABC
+	//	  key: ABC
+	//
+	// resourcesRequests:
+	//
+	//	mode: VPA
+	//	static:
+	//	  cpu: 5m
+	//	  memory: 4Mi
+	//	vpa:
+	//	  cpu:
+	//	    max: 500m
+	//	    min: 50m
+	//	  memory:
+	//	    max: 2048Mi
+	//	    min: 64Mi
+	//	  mode: Initial
+	//
+	// `)
+	//
+	//		hec.HelmRender()
+	//	})
+	//	It("Should add desired objects", func() {
+	//		Expect(hec.RenderError).ShouldNot(HaveOccurred())
+	//
+	//		testD := hec.KubernetesResource("DaemonSet", "d8-runtime-audit-engine", "runtime-audit-engine")
+	//		Expect(testD.Exists()).To(BeTrue())
+	//		Expect(testD.Field("spec.template.spec.containers.0.resources.requests").String()).To(MatchYAML(`
+	//
+	// ephemeral-storage: 50Mi
+	// `))
+	//
+	//	manVPA := hec.KubernetesResource("VerticalPodAutoscaler", "d8-runtime-audit-engine", "runtime-audit-engine")
+	//	Expect(manVPA.Exists()).To(BeTrue())
+	//	Expect(manVPA.Field("spec.updatePolicy.updateMode").String()).To(Equal("Initial"))
+	//	Expect(manVPA.Field("spec.resourcePolicy.containerPolicies").String()).To(MatchYAML(`
+	//   - containerName: falco
+	//     controlledValues: RequestsAndLimits
+	//     maxAllowed:
+	//     cpu: 500m
+	//     memory: 2048Mi
+	//     minAllowed:
+	//     cpu: 50m
+	//     memory: 64Mi
+	//   - containerName: falcosidekick
+	//     maxAllowed:
+	//     cpu: 100m
+	//     memory: 300Mi
+	//     minAllowed:
+	//     cpu: 5m
+	//     memory: 10Mi
+	//   - containerName: rules-loader
+	//     maxAllowed:
+	//     cpu: 100m
+	//     memory: 300Mi
+	//     minAllowed:
+	//     cpu: 10m
+	//     memory: 25Mi
+	//   - containerName: kube-rbac-proxy
+	//     maxAllowed:
+	//     cpu: 20m
+	//     memory: 25Mi
+	//     minAllowed:
+	//     cpu: 10m
+	//     memory: 25Mi`))
+	//     })
+	//     })
 })

--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -13,6 +13,27 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
+{{- define "disabled_vpa_spec" -}}
+  {{- $targetAPIVersion := index . 0 -}}  {{- /* Target API version */ -}}
+  {{- $targetKind       := index . 1 -}}  {{- /* Target Kind */ -}}
+  {{- $targetName       := index . 2 -}}  {{- /* Target Name */ -}}
+  {{- $configuration    := index . 3 -}}  {{- /* VPA resource configuration [example](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/istio/configuration.html#parameters-controlplane-resourcesmanagement) */ -}}
+
+targetRef:
+  apiVersion: {{ $targetAPIVersion }}
+  kind: {{ $targetKind }}
+  name: {{ $targetName }}
+  {{- if eq ($configuration.mode) "VPA" }}
+updatePolicy:
+  updateMode: "Off"
+resourcePolicy:
+  containerPolicies:
+  {{- else }}
+updatePolicy:
+  updateMode: "Off"
+  {{- end }}
+{{- end }}
+
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -22,7 +43,11 @@ metadata:
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
 spec:
-    {{- include "helm_lib_resources_management_vpa_spec"  (list "apps/v1" "DaemonSet" $.Chart.Name "falco" $.Values.runtimeAuditEngine.resourcesRequests ) | nindent 2}}
+    {{/* Disable falco VPA until memory leak in falco is fixed. Removing that also requires falco-leak-limit-range.y eaml to be removed.*/}}
+    {{/* Also, uncomment the test for VPA template rendering in template_tests/module_test.go */}}
+    {{/* {{- include "helm_lib_resources_management_vpa_spec"  (list "apps/v1" "DaemonSet" $.Chart.Name "falco" $.Values.runtimeAuditEngine.resourcesRequests) | nindent 2}} */}}
+    {{- include "disabled_vpa_spec"  (list "apps/v1" "DaemonSet" $.Chart.Name $.Values.runtimeAuditEngine.resourcesRequests) | nindent 2}}
+
     {{- if eq (.Values.runtimeAuditEngine.resourcesRequests.mode) "VPA" }}
     - containerName: "falcosidekick"
       minAllowed:

--- a/ee/modules/650-runtime-audit-engine/templates/falco-leak-limit-range.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/falco-leak-limit-range.yaml
@@ -1,3 +1,4 @@
+{{/*# If removing that, also restore the falco VPA in daemonset.yaml*/}}
 apiVersion: v1
 kind: LimitRange
 metadata:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Temporarily set `updateMode` for falco VPA to `Off` so that it does not try to go over 1Gi limit and interfere with memory limiting introduced in https://github.com/deckhouse/deckhouse/pull/14818

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This fixes falco daemonsets not being able to schedule due to VPA going crazy and constantly raising memory limits over the ceiling set with the LimitRange from https://github.com/deckhouse/deckhouse/pull/14818

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

See above ^

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: runtime-audit-engine
type: chore
summary: Disable VPA for Falco until it's memory leak is fixed
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
