### PR TITLE
[cni-cilium] fixed conversion type bug in discovery cni exclusive hook

### DIFF
--- a/modules/021-cni-cilium/hooks/discovery_cni_exclusive.go
+++ b/modules/021-cni-cilium/hooks/discovery_cni_exclusive.go
@@ -69,7 +69,7 @@ func discoveryIsExclusiveCNIPluginEnabled(input *go_hook.HookInput) error {
 		input.Values.Set("cniCilium.internal.exclusiveCNIPlugin", false)
 	} else {
 		eCNIP := input.Values.Get("cniCilium.exclusiveCNIPlugin")
-		input.Values.Set("cniCilium.internal.exclusiveCNIPlugin", eCNIP)
+		input.Values.Set("cniCilium.internal.exclusiveCNIPlugin", eCNIP.Bool())
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed conversion type bug in discovery cni exclusive hook.

(fix for https://github.com/deckhouse/deckhouse/pull/14627).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Unable to render Cilium agent configuration map correctly.
## Why do we need it in the patch release (if we do)?

Some setups face problem:
```
Queue '/modules/cni-cilium/set-exclusive': length 1, status: 'sleep after fail for 32s (19s left of 32s delay)'

 1. ModuleHookRun:/modules/cni-cilium/set-exclusive:kubernetes:021-cni-cilium/hooks/discovery_cni_exclusive.go:sdn-cni-daemonset:OperatorStartup:failures 71:8 errors occurred:
        * cannot apply values patch for module values
        * cniCilium.internal.exclusiveCNIPlugin must be of type boolean: "object"
        * cniCilium.internal.exclusiveCNIPlugin.Num is a forbidden property
        * cniCilium.internal.exclusiveCNIPlugin.Index is a forbidden property
        * cniCilium.internal.exclusiveCNIPlugin.Indexes is a forbidden property
        * cniCilium.internal.exclusiveCNIPlugin.Type is a forbidden property
        * cniCilium.internal.exclusiveCNIPlugin.Raw is a forbidden property
        * cniCilium.internal.exclusiveCNIPlugin.Str is a forbidden property
```

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: [cni-cilium]
type: fix
summary: Fixed conversion type bug in discovery cni exclusive hook.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
