### PR TITLE
feat: suspend daily e2e tests

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -735,7 +735,7 @@ check_e2e_labels:
       if: {!{
             coll.Has $ctx "manualRun" |
             test.Ternary "inputs.autodelete||success()"
-            (has $commanderProviders $provider | test.Ternary "inputs.autodelete||success()" "always()")
+            (has $commanderProviders $provider | test.Ternary "success()" "always()")
           }!}
       id: cleanup_cluster
       timeout-minutes: 60

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -459,7 +459,7 @@ jobs:
             await waitPauseRemove();
 
       - name: Cleanup bootstrapped cluster
-        if: inputs.autodelete||success()
+        if: success()
         id: cleanup_cluster
         timeout-minutes: 60
         env:
@@ -1391,7 +1391,7 @@ jobs:
             await waitPauseRemove();
 
       - name: Cleanup bootstrapped cluster
-        if: inputs.autodelete||success()
+        if: success()
         id: cleanup_cluster
         timeout-minutes: 60
         env:
@@ -1793,7 +1793,7 @@ jobs:
             await waitPauseRemove();
 
       - name: Cleanup bootstrapped cluster
-        if: inputs.autodelete||success()
+        if: success()
         id: cleanup_cluster
         timeout-minutes: 60
         env:
@@ -2195,7 +2195,7 @@ jobs:
             await waitPauseRemove();
 
       - name: Cleanup bootstrapped cluster
-        if: inputs.autodelete||success()
+        if: success()
         id: cleanup_cluster
         timeout-minutes: 60
         env:
@@ -2593,7 +2593,7 @@ jobs:
             await waitPauseRemove();
 
       - name: Cleanup bootstrapped cluster
-        if: always()
+        if: success()
         id: cleanup_cluster
         timeout-minutes: 60
         env:
@@ -2993,7 +2993,7 @@ jobs:
             await waitPauseRemove();
 
       - name: Cleanup bootstrapped cluster
-        if: always()
+        if: success()
         id: cleanup_cluster
         timeout-minutes: 60
         env:
@@ -3884,7 +3884,7 @@ jobs:
             await waitPauseRemove();
 
       - name: Cleanup bootstrapped cluster
-        if: always()
+        if: success()
         id: cleanup_cluster
         timeout-minutes: 60
         env:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Now daily test results are deleted, which makes it difficult to debug problems
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Remove automatic deletion of daily e2e stands
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not related to release
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: feature
summary: Remove automatic deletion of daily e2e stands
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
