### PR TITLE
[tools] bump dmt version to 0.1.32

### DIFF
--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-DMT_VERSION=0.1.31
+DMT_VERSION=0.1.32
 
 function install_dmt() {
   platform_name=$(uname -m)


### PR DESCRIPTION
## Description

Bump dmt version to 0.1.32

## Why do we need it, and what problem does it solve?

Added new linters

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: chore
summary: bump dmt version to 0.1.32
impact_level: low
```
