### PR TITLE
[docs] Update table with revision comparison

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -108,6 +108,13 @@
     "external": "true",
     "path": "/products/kubernetes-platform/modules/csi-ceph/stable/"
   },
+  "csi-netapp": {
+    "editions": [
+      "ee"
+    ],
+    "external": "true",
+    "path": "/products/kubernetes-platform/modules/csi-netapp/stable/"
+  },
   "csi-hpe": {
     "editions": [
       "ee"
@@ -181,13 +188,6 @@
         "ru": "Ограничение на&nbsp;использование федерации и&nbsp;мультикластерной конфигурации"
       }
     }
-  },
-  "managed-postgres": {
-    "editions": [
-      "ee"
-    ],
-    "external": "true",
-    "path": "/products/kubernetes-platform/modules/managed-postgres/stable/"
   },
   "metallb": {
     "editionMinimumAvailable": "se",
@@ -317,6 +317,23 @@
     ],
     "external": "true",
     "path": "/products/kubernetes-platform/modules/snapshot-controller/stable/"
+  },
+  "static-routing-manager": {
+    "editions": [
+      "ee"
+    ],
+    "external": "true",
+    "path": "/products/kubernetes-platform/modules/static-routing-manager/stable/"
+  },
+  "storage-volume-data-manager": {
+    "editions": [
+      "se",
+      "se-plus",
+      "ee",
+      "cse-pro"
+    ],
+    "external": "true",
+    "path": "/products/kubernetes-platform/modules/storage-volume-data-manager/stable/"
   },
   "stronghold (CE)": {
     "editions": [


### PR DESCRIPTION
## Description

This pull request updates the `modules-addition.json` file to reflect changes in available modules for the Kubernetes platform documentation. The most important changes include the addition of new modules and the removal of an existing module.

**Module additions:**

* Added the `csi-netapp` module, available for the `ee` edition, with an external path to its documentation.
* Added the `static-routing-manager` module, available for the `ee` edition, with an external path.
* Added the `storage-volume-data-manager` module, available for multiple editions (`se`, `se-plus`, `ee`, `cse-pro`), with an external path.

**Module removal:**

* Removed the `managed-postgres` module and its documentation reference for the `ee` edition.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Updated table with revision comparison.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
