### PR TITLE
[multitenancy-manager] Fix networkpolicy description typo in templates

### DIFF
--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
@@ -89,7 +89,7 @@ spec:
         networkPolicy:
           description: |
             NotRestricted — Allow all traffic by default.
-            Restricted — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
+            Isolated — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
           enum:
             - Isolated
             - NotRestricted

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/template.yaml
@@ -90,7 +90,7 @@ spec:
         networkPolicy:
           description: |
             NotRestricted — Allow all traffic by default.
-            Restricted — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
+            Isolated — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
           enum:
             - Isolated
             - NotRestricted
@@ -306,17 +306,17 @@ spec:
       - rule:
           name: Drop and execute new binary in container in {{ .projectName }} project
           condition: >
-            spawned_process 
-            and container 
-            and proc.is_exe_upper_layer=true 
-            {{ with .parameters.allowedUIDs }} 
-            and user.uid > {{ .min }} 
-            and user.uid < {{ .max }} 
-            {{ end }} 
-            {{ with .parameters.allowedGIDs }} 
-            and group.gid >= {{ .min }} 
-            and group.gid <= {{ .max }} 
-            {{ end }} 
+            spawned_process
+            and container
+            and proc.is_exe_upper_layer=true
+            {{ with .parameters.allowedUIDs }}
+            and user.uid > {{ .min }}
+            and user.uid < {{ .max }}
+            {{ end }}
+            {{ with .parameters.allowedGIDs }}
+            and group.gid >= {{ .min }}
+            and group.gid <= {{ .max }}
+            {{ end }}
             and k8s.ns.name={{ .projectName }}
           desc: Detect if an executable not belonging to the base image of a container is being executed. The drop and execute pattern can be observed very often after an attacker gained an initial foothold. is_exe_upper_layer filter field only applies for container runtimes that use overlayfs as union mount filesystem.
           output: |

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/template.yaml
@@ -89,7 +89,7 @@ spec:
         networkPolicy:
           description: |
             NotRestricted — Allow all traffic by default.
-            Restricted — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
+            Isolated — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
           enum:
             - Isolated
             - NotRestricted
@@ -356,17 +356,17 @@ spec:
       - rule:
           name: Drop and execute new binary in container in {{ .projectName }} project
           condition: >
-            spawned_process 
-            and container 
-            and proc.is_exe_upper_layer=true 
-            {{ with .parameters.allowedUIDs }} 
-            and user.uid > {{ .min }} 
-            and user.uid < {{ .max }} 
-            {{ end }} 
-            {{ with .parameters.allowedGIDs }} 
-            and group.gid >= {{ .min }} 
-            and group.gid <= {{ .max }} 
-            {{ end }} 
+            spawned_process
+            and container
+            and proc.is_exe_upper_layer=true
+            {{ with .parameters.allowedUIDs }}
+            and user.uid > {{ .min }}
+            and user.uid < {{ .max }}
+            {{ end }}
+            {{ with .parameters.allowedGIDs }}
+            and group.gid >= {{ .min }}
+            and group.gid <= {{ .max }}
+            {{ end }}
             and k8s.ns.name={{ .projectName }}
           desc: Detect if an executable not belonging to the base image of a container is being executed. The drop and execute pattern can be observed very often after an attacker gained an initial foothold. is_exe_upper_layer filter field only applies for container runtimes that use overlayfs as union mount filesystem.
           output: |

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
@@ -89,7 +89,7 @@ spec:
         networkPolicy:
           description: |
             NotRestricted — Allow all traffic by default.
-            Restricted — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
+            Isolated — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
           enum:
             - Isolated
             - NotRestricted

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml
@@ -90,7 +90,7 @@ spec:
         networkPolicy:
           description: |
             NotRestricted — Allow all traffic by default.
-            Restricted — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
+            Isolated — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
           enum:
             - Isolated
             - NotRestricted

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml
@@ -90,7 +90,7 @@ spec:
         networkPolicy:
           description: |
             NotRestricted — Allow all traffic by default.
-            Restricted — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
+            Isolated — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
           enum:
             - Isolated
             - NotRestricted
@@ -357,17 +357,17 @@ spec:
       - rule:
           name: Drop and execute new binary in container in {{ .projectName }} project
           condition: >
-            spawned_process 
-            and container 
-            and proc.is_exe_upper_layer=true 
-            {{ with .parameters.allowedUIDs }} 
-            and user.uid > {{ .min }} 
-            and user.uid < {{ .max }} 
-            {{ end }} 
-            {{ with .parameters.allowedGIDs }} 
-            and group.gid >= {{ .min }} 
-            and group.gid <= {{ .max }} 
-            {{ end }} 
+            spawned_process
+            and container
+            and proc.is_exe_upper_layer=true
+            {{ with .parameters.allowedUIDs }}
+            and user.uid > {{ .min }}
+            and user.uid < {{ .max }}
+            {{ end }}
+            {{ with .parameters.allowedGIDs }}
+            and group.gid >= {{ .min }}
+            and group.gid <= {{ .max }}
+            {{ end }}
             and k8s.ns.name={{ .projectName }}
           desc: Detect if an executable not belonging to the base image of a container is being executed. The drop and execute pattern can be observed very often after an attacker gained an initial foothold. is_exe_upper_layer filter field only applies for container runtimes that use overlayfs as union mount filesystem.
           output: |

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml
@@ -90,7 +90,7 @@ spec:
         networkPolicy:
           description: |
             NotRestricted — Allow all traffic by default.
-            Restricted — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
+            Isolated — Deny all traffic by default except namespaced traffic, dns, prometheus metrics scraping and ingress-nginx.
           enum:
             - Isolated
             - NotRestricted
@@ -306,17 +306,17 @@ spec:
       - rule:
           name: Drop and execute new binary in container in {{ .projectName }} project
           condition: >
-            spawned_process 
-            and container 
-            and proc.is_exe_upper_layer=true 
-            {{ with .parameters.allowedUIDs }} 
-            and user.uid > {{ .min }} 
-            and user.uid < {{ .max }} 
-            {{ end }} 
-            {{ with .parameters.allowedGIDs }} 
-            and group.gid >= {{ .min }} 
-            and group.gid <= {{ .max }} 
-            {{ end }} 
+            spawned_process
+            and container
+            and proc.is_exe_upper_layer=true
+            {{ with .parameters.allowedUIDs }}
+            and user.uid > {{ .min }}
+            and user.uid < {{ .max }}
+            {{ end }}
+            {{ with .parameters.allowedGIDs }}
+            and group.gid >= {{ .min }}
+            and group.gid <= {{ .max }}
+            {{ end }}
             and k8s.ns.name={{ .projectName }}
           desc: Detect if an executable not belonging to the base image of a container is being executed. The drop and execute pattern can be observed very often after an attacker gained an initial foothold. is_exe_upper_layer filter field only applies for container runtimes that use overlayfs as union mount filesystem.
           output: |


### PR DESCRIPTION
## Description
Change `Restricted` to `Isolated` in network policy toggle description to match enums.

## Why do we need it, and what problem does it solve?
Typo

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: multitenancy-manager
type: chore
summary: Fix networkpolicy description typo in templates
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
