### PR TITLE
[deckhouse-controller] use remote.Get for checking module release from registry

### DIFF
--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
@@ -333,15 +333,9 @@ func updateImageRepoForContainers(containers []v1.Container, newRepository strin
 }
 
 func checkImageExists(imageRef name.Reference, opts []remote.Option) error {
-	img, err := remote.Image(imageRef, opts...)
-	if err != nil {
-		return err
-	}
-
-	if _, err := img.Digest(); err != nil {
-		return err
-	}
-	return nil
+	// Use remote.Get for efficient image existence check without downloading the image
+	_, err := remote.Get(imageRef, opts...)
+	return err
 }
 
 // checkBearerSupport func checks that registry accepts bearer token authentification.

--- a/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scanner/registry-scaner.go
+++ b/docs/site/backends/registry-modules-watcher/internal/backends/pkg/registry-scanner/registry-scaner.go
@@ -31,6 +31,7 @@ import (
 type Client interface {
 	Name() string
 	ReleaseImage(ctx context.Context, moduleName, releaseChannel string) (v1.Image, error)
+	ReleaseDigest(ctx context.Context, moduleName, releaseChannel string) (string, error)
 	Image(ctx context.Context, moduleName, version string) (v1.Image, error)
 	ListTags(ctx context.Context, moduleName string) ([]string, error)
 	Modules(ctx context.Context) ([]string, error)

--- a/go_lib/dependency/cr/cache.go
+++ b/go_lib/dependency/cr/cache.go
@@ -164,9 +164,20 @@ func (c *imageCache) evictOldestImage() {
 }
 
 // shouldCacheTag determines if a tag should be cached based on registry path
-// Caches ALL tags from release directories (path contains "/release")
-// Does NOT cache anything outside release directories
+// Caches ALL tags from:
+// - release directories (path contains "/release")
+// - dev registry (dev-registry.deckhouse.io)
+// Does NOT cache anything else
 func shouldCacheTag(registryURL, tag string) bool {
-	// Must be in a release directory
-	return strings.Contains(registryURL, "/release")
+	// Cache ALL tags from release directories
+	if strings.Contains(registryURL, "/release") {
+		return true
+	}
+	
+	// Cache dev images from dev-registry.deckhouse.io
+	if strings.Contains(registryURL, "dev-registry.deckhouse.io") {
+		return true
+	}
+	
+	return false
 }

--- a/go_lib/dependency/cr/cache.go
+++ b/go_lib/dependency/cr/cache.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2025 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -173,11 +173,11 @@ func shouldCacheTag(registryURL, tag string) bool {
 	if strings.Contains(registryURL, "/release") {
 		return true
 	}
-	
+
 	// Cache dev images from dev-registry.deckhouse.io
 	if strings.Contains(registryURL, "dev-registry.deckhouse.io") {
 		return true
 	}
-	
+
 	return false
 }

--- a/go_lib/dependency/cr/cache.go
+++ b/go_lib/dependency/cr/cache.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cr
+
+import (
+	"regexp"
+	"sync"
+	"time"
+
+	crv1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+const (
+	// Default maximum number of entries in each cache map
+	defaultMaxCacheSize = 1000
+)
+
+// cacheEntry holds cached data with timestamp for LRU eviction
+type cacheEntry struct {
+	value     any
+	timestamp time.Time
+}
+
+// imageCache provides thread-safe caching for container registry operations
+// with size limits to prevent memory leaks
+type imageCache struct {
+	mu         sync.RWMutex
+	digests    map[string]*cacheEntry // tag -> digest mapping
+	images     map[string]*cacheEntry // digest -> image mapping
+	maxSize    int
+}
+
+// newImageCache creates a new image cache instance
+func newImageCache() *imageCache {
+	return &imageCache{
+		digests: make(map[string]*cacheEntry),
+		images:  make(map[string]*cacheEntry),
+		maxSize: defaultMaxCacheSize,
+	}
+}
+
+// getDigest retrieves cached digest for a given tag
+func (c *imageCache) getDigest(tag string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, exists := c.digests[tag]
+	if !exists {
+		return "", false
+	}
+	// Update timestamp for LRU
+	entry.timestamp = time.Now()
+	return entry.value.(string), true
+}
+
+// setDigest stores digest for a given tag in cache
+func (c *imageCache) setDigest(tag, digest string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	
+	// Evict old entries if cache is full
+	if len(c.digests) >= c.maxSize {
+		c.evictOldestDigest()
+	}
+	
+	c.digests[tag] = &cacheEntry{
+		value:     digest,
+		timestamp: time.Now(),
+	}
+}
+
+// getImage retrieves cached image for a given digest
+func (c *imageCache) getImage(digest string) (crv1.Image, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, exists := c.images[digest]
+	if !exists {
+		return nil, false
+	}
+	// Update timestamp for LRU
+	entry.timestamp = time.Now()
+	return entry.value.(crv1.Image), true
+}
+
+// setImage stores image for a given digest in cache
+func (c *imageCache) setImage(digest string, image crv1.Image) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	
+	// Evict old entries if cache is full
+	if len(c.images) >= c.maxSize {
+		c.evictOldestImage()
+	}
+	
+	c.images[digest] = &cacheEntry{
+		value:     image,
+		timestamp: time.Now(),
+	}
+}
+
+// clear removes all cached data
+func (c *imageCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.digests = make(map[string]*cacheEntry)
+	c.images = make(map[string]*cacheEntry)
+}
+
+// evictOldestDigest removes the oldest digest entry from cache
+// Must be called with lock held
+func (c *imageCache) evictOldestDigest() {
+	if len(c.digests) == 0 {
+		return
+	}
+	
+	var oldestKey string
+	var oldestTime time.Time
+	first := true
+	
+	for key, entry := range c.digests {
+		if first || entry.timestamp.Before(oldestTime) {
+			oldestKey = key
+			oldestTime = entry.timestamp
+			first = false
+		}
+	}
+	
+	delete(c.digests, oldestKey)
+}
+
+// evictOldestImage removes the oldest image entry from cache
+// Must be called with lock held
+func (c *imageCache) evictOldestImage() {
+	if len(c.images) == 0 {
+		return
+	}
+	
+	var oldestKey string
+	var oldestTime time.Time
+	first := true
+	
+	for key, entry := range c.images {
+		if first || entry.timestamp.Before(oldestTime) {
+			oldestKey = key
+			oldestTime = entry.timestamp
+			first = false
+		}
+	}
+	
+	delete(c.images, oldestKey)
+}
+
+// versionPattern is compiled once for better performance
+var versionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+(?:-[\w\.-]+)?(?:\+[\w\.-]+)?$`)
+
+// isVersionedTag checks if tag contains semantic version
+// Returns true for tags like "v1.2.3", "1.0.0", "v2.1.0-alpha", "1.0.0+build.1"
+func isVersionedTag(tag string) bool {
+	return versionPattern.MatchString(tag)
+}

--- a/go_lib/dependency/cr/cache_test.go
+++ b/go_lib/dependency/cr/cache_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2025 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go_lib/dependency/cr/cache_test.go
+++ b/go_lib/dependency/cr/cache_test.go
@@ -133,6 +133,30 @@ func TestShouldCacheTag(t *testing.T) {
 			tag:         "v1.2.3",
 			want:        false,
 		},
+		{
+			name:        "cache dev image from dev-registry.deckhouse.io",
+			registryURL: "dev-registry.deckhouse.io/sys/deckhouse-oss",
+			tag:         "v1.49.0",
+			want:        true,
+		},
+		{
+			name:        "cache dev image with main tag",
+			registryURL: "dev-registry.deckhouse.io/sys/deckhouse-oss",
+			tag:         "main",
+			want:        true,
+		},
+		{
+			name:        "cache dev image with custom tag",
+			registryURL: "dev-registry.deckhouse.io/deckhouse/modules",
+			tag:         "feature-branch",
+			want:        true,
+		},
+		{
+			name:        "do not cache non-dev non-release registry",
+			registryURL: "other-registry.example.com/deckhouse",
+			tag:         "v1.0.0",
+			want:        false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/go_lib/dependency/cr/cache_test.go
+++ b/go_lib/dependency/cr/cache_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cr
+
+import "testing"
+
+func TestShouldCacheTag(t *testing.T) {
+	tests := []struct {
+		name        string
+		registryURL string
+		tag         string
+		want        bool
+	}{
+		{
+			name:        "cache versioned tag in release directory",
+			registryURL: "registry.example.com/deckhouse/release",
+			tag:         "v1.2.3",
+			want:        true,
+		},
+		{
+			name:        "cache stable channel in release directory",
+			registryURL: "registry.example.com/deckhouse/release",
+			tag:         "stable",
+			want:        true,
+		},
+		{
+			name:        "cache alpha channel in release directory",
+			registryURL: "registry.example.com/deckhouse/release",
+			tag:         "alpha",
+			want:        true,
+		},
+		{
+			name:        "cache beta channel in release directory",
+			registryURL: "registry.example.com/deckhouse/release",
+			tag:         "beta",
+			want:        true,
+		},
+		{
+			name:        "cache latest tag in release directory",
+			registryURL: "registry.example.com/deckhouse/release",
+			tag:         "latest",
+			want:        true,
+		},
+		{
+			name:        "cache main channel in release directory",
+			registryURL: "registry.example.com/deckhouse/release",
+			tag:         "main",
+			want:        true,
+		},
+		{
+			name:        "cache master channel in release directory",
+			registryURL: "registry.example.com/deckhouse/release",
+			tag:         "master",
+			want:        true,
+		},
+		{
+			name:        "cache any tag in release directory",
+			registryURL: "registry.example.com/deckhouse/release",
+			tag:         "custom-tag",
+			want:        true,
+		},
+		{
+			name:        "do not cache versioned tag outside release directory",
+			registryURL: "registry.example.com/deckhouse/dev",
+			tag:         "v1.2.3",
+			want:        false,
+		},
+		{
+			name:        "do not cache stable channel outside release directory",
+			registryURL: "registry.example.com/deckhouse",
+			tag:         "stable",
+			want:        false,
+		},
+		{
+			name:        "do not cache any tag outside release directory",
+			registryURL: "registry.example.com/deckhouse",
+			tag:         "latest",
+			want:        false,
+		},
+		{
+			name:        "cache in release-channel directory",
+			registryURL: "registry.example.com/deckhouse/release-channel",
+			tag:         "stable",
+			want:        true,
+		},
+		{
+			name:        "cache version in release-channel directory",
+			registryURL: "registry.example.com/deckhouse/release-channel",
+			tag:         "v1.60.0",
+			want:        true,
+		},
+		{
+			name:        "cache module versioned tag in release directory",
+			registryURL: "registry.example.com/moduleName/release",
+			tag:         "v1.0.0",
+			want:        true,
+		},
+		{
+			name:        "cache module stable tag in release directory",
+			registryURL: "registry.example.com/moduleName/release",
+			tag:         "stable",
+			want:        true,
+		},
+		{
+			name:        "do not cache module versioned tag outside release directory",
+			registryURL: "registry.example.com/moduleName",
+			tag:         "v1.0.0",
+			want:        false,
+		},
+		{
+			name:        "do not cache module stable tag outside release directory",
+			registryURL: "registry.example.com/moduleName",
+			tag:         "stable",
+			want:        false,
+		},
+		{
+			name:        "do not cache if no release in path",
+			registryURL: "registry.example.com/deckhouse/staging",
+			tag:         "v1.2.3",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldCacheTag(tt.registryURL, tt.tag)
+			if got != tt.want {
+				t.Errorf("shouldCacheTag(%q, %q) = %v, want %v", tt.registryURL, tt.tag, got, tt.want)
+			}
+		})
+	}
+}

--- a/go_lib/dependency/cr/cr.go
+++ b/go_lib/dependency/cr/cr.go
@@ -104,7 +104,7 @@ func NewClient(repo string, options ...Option) (Client, error) {
 }
 
 func (r *client) Image(ctx context.Context, tag string) (crv1.Image, error) {
-	shouldCache := isVersionedTag(tag)
+	shouldCache := shouldCacheTag(r.registryURL, tag)
 
 	if shouldCache {
 		// Check if digest is cached
@@ -232,7 +232,7 @@ func (r *client) ListTags(ctx context.Context) ([]string, error) {
 }
 
 func (r *client) Digest(ctx context.Context, tag string) (string, error) {
-	shouldCache := isVersionedTag(tag)
+	shouldCache := shouldCacheTag(r.registryURL, tag)
 
 	if shouldCache {
 		// Check if digest is cached

--- a/go_lib/dependency/cr/cr_test.go
+++ b/go_lib/dependency/cr/cr_test.go
@@ -539,7 +539,7 @@ func TestClient_Digest(t *testing.T) {
 
 	manifest, err := testImage.Manifest()
 	require.NoError(t, err)
-	
+
 	testDigest := manifest.Config.Digest.String()
 
 	registryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -621,7 +621,7 @@ func TestClient_ImageExists(t *testing.T) {
 
 	manifest, err := testImage.Manifest()
 	require.NoError(t, err)
-	
+
 	testDigest := manifest.Config.Digest.String()
 
 	registryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -677,7 +677,7 @@ func TestClient_ClearCache(t *testing.T) {
 
 	manifest, err := testImage.Manifest()
 	require.NoError(t, err)
-	
+
 	testDigest := manifest.Config.Digest.String()
 
 	registryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tools/regcopy/main.go
+++ b/tools/regcopy/main.go
@@ -86,12 +86,15 @@ func main() {
 			log.Fatal(err)
 		}
 
-		remoteImage, err := remote.Image(remoteRef)
+		// Get digest efficiently without downloading the full image
+		descriptor, err := remote.Get(remoteRef)
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		digest, err := remoteImage.Digest()
+		digest := descriptor.Digest
+		
+		// Now fetch the image for processing
+		remoteImage, err := remote.Image(remoteRef)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -105,15 +108,12 @@ func main() {
 			log.Fatal(err)
 		}
 
-		resultImage, err := remote.Image(newRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+		// Get result digest efficiently without downloading the full image
+		resultDescriptor, err := remote.Get(newRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		resultDigest, err := resultImage.Digest()
-		if err != nil {
-			log.Fatal(err)
-		}
+		resultDigest := resultDescriptor.Digest
 
 		log.Printf("sucessfully copied \"%s@%s\" -> \"%s@%s\"", remoteRef.String(), digest, newRef.String(), resultDigest)
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: feature
summary: use remote.Get for checking module release from registry
impact_level: default
```
