### PR TITLE
[deckhouse] remove bundle enum

### DIFF
--- a/deckhouse-controller/crds/module.yaml
+++ b/deckhouse-controller/crds/module.yaml
@@ -108,10 +108,6 @@ spec:
                             type: array
                             items:
                               type: string
-                              enum:
-                                - Default
-                                - Minimal
-                                - Managed
             status:
               type: object
               properties:


### PR DESCRIPTION
## Description
It removes bundle enum

## Why do we need it, and what problem does it solve?
We put bundles from a module definition - invalid bundle there causes crash module creating.

## Why do we need it in the patch release (if we do)?
Invalid bundle can crash module`s creating and deckhouse.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Remove bundle enum
impact_level: low
```
