### PR TITLE
[docs] Add pod-reloader module to the comparison table

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -243,6 +243,17 @@
     "external": "true",
     "path": "/products/kubernetes-platform/modules/operator-argo/stable/"
   },
+  "pod-reloader": {
+    "editions": [
+      "ce",
+      "be",
+      "se",
+      "se-plus",
+      "ee"
+    ],
+    "external": "true",
+    "path": "/products/kubernetes-platform/modules/pod-reloader/stable/"
+  },
   "sds-local-volume": {
     "editions": [
       "ce",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -177,6 +177,17 @@
     "external": "true",
     "path": "/products/kubernetes-platform/modules/operator-argo/stable/"
   },
+  "pod-reloader": {
+    "editions": [
+      "ce",
+      "be",
+      "se",
+      "se-plus",
+      "ee"
+    ],
+    "external": "true",
+    "path": "/products/kubernetes-platform/modules/pod-reloader/stable/"
+  },
   "sds-local-volume": {
     "editions": [
       "ce",


### PR DESCRIPTION
## Description

Add pod-reloader module to the comparison table.

Ref: https://github.com/deckhouse/deckhouse/pull/14343/


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add pod-reloader module to the comparison table
impact_level: low
```
