### PR TITLE
[docs] Use delete-emptydir-data node drain flag

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -5808,7 +5808,7 @@ alerts:
         1. To drain the Node and grant the update approval, run the following command:
 
            ```shell
-           d8 k drain {{ $labels.node }} --delete-emptydir-data=true --ignore-daemonsets=true --force=true &&
+           d8 k drain {{ $labels.node }} --delete-emptydir-data --ignore-daemonsets --force=true &&
              d8 k annotate node {{ $labels.node }} update.node.deckhouse.io/disruption-approved=
            ```
 

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/ADDING_NODE_RU.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/ADDING_NODE_RU.md
@@ -287,7 +287,7 @@ bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-w
 1. Удалите узел из кластера Kubernetes:
 
    ```shell
-   d8 k drain <node> --ignore-daemonsets --delete-emptydir-data=true
+   d8 k drain <node> --ignore-daemonsets --delete-emptydir-data
    d8 k delete node <node>
    ```
 

--- a/docs/site/pages/stronghold/documentation/admin/removing/REMOVING.md
+++ b/docs/site/pages/stronghold/documentation/admin/removing/REMOVING.md
@@ -7,18 +7,18 @@ To delete a cluster, several steps need to be followed:
 
 1. Remove all additional nodes from the cluster:
 
-   1.1. Remove the node from the Kubernetes cluster:
+   1. Remove the node from the Kubernetes cluster:
 
-   ```shell
-   d8 k drain <node> --ignore-daemonsets --delete-emptydir-data=true
-   d8 k delete node <node>
-   ```
+      ```shell
+      d8 k drain <node> --ignore-daemonsets --delete-emptydir-data
+      d8 k delete node <node>
+      ```
 
-   1.2. Run the cleanup script on the node:
+   1. Run the cleanup script on the node:
 
-   ```shell
-   bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing
-   ```
+      ```shell
+      bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing
+      ```
 
 1. Check the release channel set in the cluster. To do this, run the command:
 

--- a/docs/site/pages/stronghold/documentation/admin/removing/REMOVING_RU.md
+++ b/docs/site/pages/stronghold/documentation/admin/removing/REMOVING_RU.md
@@ -8,18 +8,18 @@ lang: ru
 
 1. Удалите из кластера все узлы кроме master-узлов:
 
-   1.1. Удалите узел из кластера Kubernetes:
+   1. Удалите узел из кластера Kubernetes:
 
-     ```shell
-     d8 k drain <node> --ignore-daemonsets --delete-emptydir-data=true
-     d8 k delete node <node>
-     ```
+      ```shell
+      d8 k drain <node> --ignore-daemonsets --delete-emptydir-data
+      d8 k delete node <node>
+      ```
 
-    1.2. Запустите на узле скрипт очистки:
+   1. Запустите на узле скрипт очистки:
 
-     ```shell
-     bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing
-     ```
+      ```shell
+      bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing
+      ```
 
 1. Узнайте канал обновления, заданный в кластере:
 

--- a/docs/site/pages/virtualization-platform/documentation/admin/removing/REMOVING.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/removing/REMOVING.md
@@ -7,18 +7,18 @@ To delete a cluster, several steps need to be followed:
 
 1. Remove all additional nodes from the cluster:
 
-   1.1. Remove the node from the Kubernetes cluster:
+   1. Remove the node from the Kubernetes cluster:
 
-   ```shell
-   d8 k drain <node> --ignore-daemonsets --delete-emptydir-data=true
-   d8 k delete node <node>
-   ```
+      ```shell
+      d8 k drain <node> --ignore-daemonsets --delete-emptydir-data
+      d8 k delete node <node>
+      ```
 
-   1.2. Run the cleanup script on the node:
+   1. Run the cleanup script on the node:
 
-   ```shell
-   bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing
-   ```
+      ```shell
+      bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing
+      ```
 
 1. Check the release channel set in the cluster. To do this, run the command:
 

--- a/docs/site/pages/virtualization-platform/documentation/admin/removing/REMOVING_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/removing/REMOVING_RU.md
@@ -8,18 +8,18 @@ lang: ru
 
 1. Удалите из кластера все узлы кроме master-узлов:
 
-   1.1. Удалите узел из кластера Kubernetes:
+   1. Удалите узел из кластера Kubernetes:
 
-     ```shell
-     d8 k drain <node> --ignore-daemonsets --delete-emptydir-data=true
-     d8 k delete node <node>
-     ```
+      ```shell
+      d8 k drain <node> --ignore-daemonsets --delete-emptydir-data
+      d8 k delete node <node>
+      ```
 
-    1.2. Запустите на узле скрипт очистки:
+   1. Запустите на узле скрипт очистки:
 
-     ```shell
-     bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing
-     ```
+      ```shell
+      bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing
+      ```
 
 1. Узнайте канал обновления, заданный в кластере:
 

--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -290,7 +290,7 @@ Evict resources from the node and remove the node from LINSTOR/DRBD using the [i
 1. Delete the node from the Kubernetes cluster:
 
    ```shell
-   d8 k drain <node> --ignore-daemonsets --delete-emptydir-data=true
+   d8 k drain <node> --ignore-daemonsets --delete-emptydir-data
    d8 k delete node <node>
    ```
 

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -281,7 +281,7 @@ d8 k label node <node_name> node-role.kubernetes.io/<old_node_group_name>-
 
    ```shell
    d8 k drain <node> 
-   d8 k drain <node> --ignore-daemonsets --delete-emptydir-data=true 
+   d8 k drain <node> --ignore-daemonsets --delete-emptydir-data
    d8 k delete pods --all-namespaces --field-selector spec.nodeName=<node> --force 
    d8 k delete node <node>
    ```

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -197,7 +197,7 @@
         1. To drain the Node and grant the update approval, run the following command:
 
            ```shell
-           d8 k drain {{ $labels.node }} --delete-emptydir-data=true --ignore-daemonsets=true --force=true &&
+           d8 k drain {{ $labels.node }} --delete-emptydir-data --ignore-daemonsets --force=true &&
              d8 k annotate node {{ $labels.node }} update.node.deckhouse.io/disruption-approved=
            ```
 


### PR DESCRIPTION
## Description
Updates alerts documentation to follow recommended `--delete-emptydir-data=true` during node drain instead of the deprecated `--delete-local-data=true`

## Why do we need it, and what problem does it solve?
- Get us ready for `--delete-local-data=true` drain option in `NodeRequiresDisruptionApprovalForUpdate` alert documentation to be removed from future k8s releases
- Eliminates `--delete-local-data=true` deprecation warning when following the alert instructions to drain nodes

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: |
  Updated node drain documentation with the recommended `--delete-emptydir-data=true` option.
impact_level: low
```
