### PR TITLE
[docs] Edit info about restore etcd objects

### DIFF
--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -581,7 +581,7 @@ CronJob `kube-system/d8-etcd-backup-*` is automatically started at 00:00 UTC+0. 
 Starting with Deckhouse Kubernetes Platform v1.65, a new `d8 backup etcd` tool is available for taking snapshots of etcd state.
 
 ```bash
-d8 backup etcd --kubeconfig $KUBECONFIG ./etcd-backup.snapshot
+d8 backup etcd ./etcd-backup.snapshot
 ```
 
 #### Using bash (Deckhouse Kubernetes Platform v1.64 and older)

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -746,6 +746,12 @@ In the example below, `etcd-backup.snapshot` is a [etcd shapshot](#how-to-manual
 
 Following actions are performed on a master node, to which `etcd snapshot` file and `auger` tool were copied:
 
+1. Set the correct access permissions for the backup file:
+
+   ```shell
+   chmod 644 etcd-backup.snapshot
+   ```
+
 1. Set full path for snapshot file and for the tool into environmental variables:
 
    ```shell
@@ -770,10 +776,11 @@ Following actions are performed on a master node, to which `etcd snapshot` file 
        - operator: Exists
        initContainers:
        - command:
-         - etcdctl
+         - etcdutl
          - snapshot
          - restore
          - "/tmp/etcd-snapshot"
+         - --data-dir=/default.etcd
          image: $(kubectl -n kube-system get pod -l component=etcd -o jsonpath="{.items[*].spec.containers[*].image}" | cut -f 1 -d ' ')
          imagePullPolicy: IfNotPresent
          name: etcd-snapshot-restore

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -784,7 +784,7 @@ Following actions are performed on a master node, to which `etcd snapshot` file 
          image: $(kubectl -n kube-system get pod -l component=etcd -o jsonpath="{.items[*].spec.containers[*].image}" | cut -f 1 -d ' ')
          imagePullPolicy: IfNotPresent
          name: etcd-snapshot-restore
-         # Раскоментируйте фрагмент ниже, чтобы задать лимиты для контейнера, если ресурсов узла недостаточно для его запуска
+         # Uncomment the fragment below to set limits for the container if the node does not have enough resources to run it.
          # resources:
          #   requests:
          #     ephemeral-storage: "200Mi"
@@ -808,7 +808,7 @@ Following actions are performed on a master node, to which `etcd snapshot` file 
        volumes:
        - name: etcddir
          emptyDir: {}
-         # Use the snippet below instead of emptyDir: {} to set limits for the container if the node's resources are insufficient to run it
+         # Use the snippet below instead of emptyDir: {} to set limits for the container if the node's resources are insufficient to run it.
          # emptyDir:
          #  sizeLimit: 500Mi
        - name: etcd-snapshot

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -784,6 +784,12 @@ Following actions are performed on a master node, to which `etcd snapshot` file 
          image: $(kubectl -n kube-system get pod -l component=etcd -o jsonpath="{.items[*].spec.containers[*].image}" | cut -f 1 -d ' ')
          imagePullPolicy: IfNotPresent
          name: etcd-snapshot-restore
+         # Раскоментируйте фрагмент ниже, чтобы задать лимиты для контейнера, если ресурсов узла недостаточно для его запуска
+         # resources:
+         #   requests:
+         #     ephemeral-storage: "200Mi"
+         #   limits:
+         #     ephemeral-storage: "500Mi"
          volumeMounts:
          - name: etcddir
            mountPath: /default.etcd
@@ -802,6 +808,9 @@ Following actions are performed on a master node, to which `etcd snapshot` file 
        volumes:
        - name: etcddir
          emptyDir: {}
+         # Use the snippet below instead of emptyDir: {} to set limits for the container if the node's resources are insufficient to run it
+         # emptyDir:
+         #  sizeLimit: 500Mi
        - name: etcd-snapshot
          hostPath:
            path: $SNAPSHOT

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -561,7 +561,7 @@ spec:
 Начиная с релиза Deckhouse Kubernetes Platform v1.65, стала доступна утилита `d8 backup etcd`, которая предназначена для быстрого создания снимков состояния etcd.
 
 ```bash
-d8 backup etcd --kubeconfig $KUBECONFIG ./etcd-backup.snapshot
+d8 backup etcd ./etcd-backup.snapshot
 ```
 
 #### Используя bash (Deckhouse Kubernetes Platform v1.64 и старше)

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -767,7 +767,7 @@ rm -r ./kubernetes ./etcd-backup.snapshot
          image: $(kubectl -n kube-system get pod -l component=etcd -o jsonpath="{.items[*].spec.containers[*].image}" | cut -f 1 -d ' ')
          imagePullPolicy: IfNotPresent
          name: etcd-snapshot-restore
-         # Раскоментируйте фрагмент ниже, чтобы задать лимиты для контейнера, если ресурсов узла недостаточно для его запуска
+         # Раскоментируйте фрагмент ниже, чтобы задать лимиты для контейнера, если ресурсов узла недостаточно для его запуска.
          # resources:
          #   requests:
          #     ephemeral-storage: "200Mi"
@@ -791,7 +791,7 @@ rm -r ./kubernetes ./etcd-backup.snapshot
        volumes:
        - name: etcddir
          emptyDir: {}
-         # Используйте фрагмент ниже вместо emptyDir: {}, чтобы задать лимиты для контейнера, если ресурсов узла недостаточно для его запуска
+         # Используйте фрагмент ниже вместо emptyDir: {}, чтобы задать лимиты для контейнера, если ресурсов узла недостаточно для его запуска.
          # emptyDir:
          #  sizeLimit: 500Mi
        - name: etcd-snapshot

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -767,6 +767,12 @@ rm -r ./kubernetes ./etcd-backup.snapshot
          image: $(kubectl -n kube-system get pod -l component=etcd -o jsonpath="{.items[*].spec.containers[*].image}" | cut -f 1 -d ' ')
          imagePullPolicy: IfNotPresent
          name: etcd-snapshot-restore
+         # Раскоментируйте фрагмент ниже, чтобы задать лимиты для контейнера, если ресурсов узла недостаточно для его запуска
+         # resources:
+         #   requests:
+         #     ephemeral-storage: "200Mi"
+         #   limits:
+         #     ephemeral-storage: "500Mi"
          volumeMounts:
          - name: etcddir
            mountPath: /default.etcd
@@ -785,6 +791,9 @@ rm -r ./kubernetes ./etcd-backup.snapshot
        volumes:
        - name: etcddir
          emptyDir: {}
+         # Используйте фрагмент ниже вместо emptyDir: {}, чтобы задать лимиты для контейнера, если ресурсов узла недостаточно для его запуска
+         # emptyDir:
+         #  sizeLimit: 500Mi
        - name: etcd-snapshot
          hostPath:
            path: $SNAPSHOT

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -728,6 +728,12 @@ rm -r ./kubernetes ./etcd-backup.snapshot
 
 Данные действия выполняются на master-узле в кластере, на который предварительно был загружен файл `snapshot` и утилита `auger`:
 
+1. Установите корректные права доступа для файла с резервной копией:
+
+   ```shell
+   chmod 644 etcd-backup.snapshot
+   ```
+
 1. Установите полный путь до `snapshot` и до утилиты в переменных окружения:
 
    ```shell
@@ -753,10 +759,11 @@ rm -r ./kubernetes ./etcd-backup.snapshot
        - operator: Exists
        initContainers:
        - command:
-         - etcdctl
+         - etcdutl
          - snapshot
          - restore
          - "/tmp/etcd-snapshot"
+         - --data-dir=/default.etcd
          image: $(kubectl -n kube-system get pod -l component=etcd -o jsonpath="{.items[*].spec.containers[*].image}" | cut -f 1 -d ' ')
          imagePullPolicy: IfNotPresent
          name: etcd-snapshot-restore


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Edit steps to restore objects from an etcd backup.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Edited steps to restore objects from an etcd backup.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
