### PR TITLE
[ci] Disable e2e blocking for non-PR jobs

### DIFF
--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -120,9 +120,8 @@ block-until-image-is-not-ready:
           if (context.eventName === 'pull_request') {
             branchName = context.payload.pull_request.head.ref;
             prNum = context.payload.pull_request.number;
-          } else if (context.eventName === 'workflow_dispatch') {
-            branchName = context.payload.inputs.ci_commit_ref_name;
-            prNum = context.payload.inputs.issue_number;
+          } else {
+            return true;
           }
 
           if (!branchName) {

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -64,9 +64,8 @@ jobs:
             if (context.eventName === 'pull_request') {
               branchName = context.payload.pull_request.head.ref;
               prNum = context.payload.pull_request.number;
-            } else if (context.eventName === 'workflow_dispatch') {
-              branchName = context.payload.inputs.ci_commit_ref_name;
-              prNum = context.payload.inputs.issue_number;
+            } else {
+              return true;
             }
 
             if (!branchName) {

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -192,9 +192,8 @@ jobs:
             if (context.eventName === 'pull_request') {
               branchName = context.payload.pull_request.head.ref;
               prNum = context.payload.pull_request.number;
-            } else if (context.eventName === 'workflow_dispatch') {
-              branchName = context.payload.inputs.ci_commit_ref_name;
-              prNum = context.payload.inputs.issue_number;
+            } else {
+              return true;
             }
 
             if (!branchName) {

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -192,9 +192,8 @@ jobs:
             if (context.eventName === 'pull_request') {
               branchName = context.payload.pull_request.head.ref;
               prNum = context.payload.pull_request.number;
-            } else if (context.eventName === 'workflow_dispatch') {
-              branchName = context.payload.inputs.ci_commit_ref_name;
-              prNum = context.payload.inputs.issue_number;
+            } else {
+              return true;
             }
 
             if (!branchName) {

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -192,9 +192,8 @@ jobs:
             if (context.eventName === 'pull_request') {
               branchName = context.payload.pull_request.head.ref;
               prNum = context.payload.pull_request.number;
-            } else if (context.eventName === 'workflow_dispatch') {
-              branchName = context.payload.inputs.ci_commit_ref_name;
-              prNum = context.payload.inputs.issue_number;
+            } else {
+              return true;
             }
 
             if (!branchName) {

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -192,9 +192,8 @@ jobs:
             if (context.eventName === 'pull_request') {
               branchName = context.payload.pull_request.head.ref;
               prNum = context.payload.pull_request.number;
-            } else if (context.eventName === 'workflow_dispatch') {
-              branchName = context.payload.inputs.ci_commit_ref_name;
-              prNum = context.payload.inputs.issue_number;
+            } else {
+              return true;
             }
 
             if (!branchName) {

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -192,9 +192,8 @@ jobs:
             if (context.eventName === 'pull_request') {
               branchName = context.payload.pull_request.head.ref;
               prNum = context.payload.pull_request.number;
-            } else if (context.eventName === 'workflow_dispatch') {
-              branchName = context.payload.inputs.ci_commit_ref_name;
-              prNum = context.payload.inputs.issue_number;
+            } else {
+              return true;
             }
 
             if (!branchName) {

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -192,9 +192,8 @@ jobs:
             if (context.eventName === 'pull_request') {
               branchName = context.payload.pull_request.head.ref;
               prNum = context.payload.pull_request.number;
-            } else if (context.eventName === 'workflow_dispatch') {
-              branchName = context.payload.inputs.ci_commit_ref_name;
-              prNum = context.payload.inputs.issue_number;
+            } else {
+              return true;
             }
 
             if (!branchName) {

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -192,9 +192,8 @@ jobs:
             if (context.eventName === 'pull_request') {
               branchName = context.payload.pull_request.head.ref;
               prNum = context.payload.pull_request.number;
-            } else if (context.eventName === 'workflow_dispatch') {
-              branchName = context.payload.inputs.ci_commit_ref_name;
-              prNum = context.payload.inputs.issue_number;
+            } else {
+              return true;
             }
 
             if (!branchName) {

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -192,9 +192,8 @@ jobs:
             if (context.eventName === 'pull_request') {
               branchName = context.payload.pull_request.head.ref;
               prNum = context.payload.pull_request.number;
-            } else if (context.eventName === 'workflow_dispatch') {
-              branchName = context.payload.inputs.ci_commit_ref_name;
-              prNum = context.payload.inputs.issue_number;
+            } else {
+              return true;
             }
 
             if (!branchName) {

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -192,9 +192,8 @@ jobs:
             if (context.eventName === 'pull_request') {
               branchName = context.payload.pull_request.head.ref;
               prNum = context.payload.pull_request.number;
-            } else if (context.eventName === 'workflow_dispatch') {
-              branchName = context.payload.inputs.ci_commit_ref_name;
-              prNum = context.payload.inputs.issue_number;
+            } else {
+              return true;
             }
 
             if (!branchName) {


### PR DESCRIPTION
## Description
Disable e2e blocking for non-PR jobs.

## Why do we need it, and what problem does it solve?
Blocking for release branch tests if incorrect and should be disabled.

## Why do we need it in the patch release (if we do)?
Blocks pre-release tests.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Disable e2e blocking for non-PR jobs.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
