### PR TITLE
[docs] Add Release Notes 1.72 at documentation

### DIFF
--- a/docs/documentation/_includes/release-notes/RELEASE-NOTES.md
+++ b/docs/documentation/_includes/release-notes/RELEASE-NOTES.md
@@ -32,7 +32,7 @@
 
 The following DKP components have been updated:
 
-- Kubernetes Control Plane: 1.30.14, 1.31.11, 1.32.7, 1.33.3
+- Kubernetes control plane: 1.30.14, 1.31.11, 1.32.7, 1.33.3
 - `cloud-provider-huaweicloud cloud-data-discoverer`: v0.6.0
 - `node-manager capi-controller-manager`: 1.10.4
 

--- a/docs/documentation/_includes/release-notes/RELEASE-NOTES_RU.md
+++ b/docs/documentation/_includes/release-notes/RELEASE-NOTES_RU.md
@@ -32,7 +32,7 @@
 
 Обновлены следующие компоненты DKP:
 
-- Kubernetes Control Plane: 1.30.14, 1.31.11, 1.32.7, 1.33.3
+- Kubernetes control plane: 1.30.14, 1.31.11, 1.32.7, 1.33.3
 - `cloud-provider-huaweicloud cloud-data-discoverer`: v0.6.0
 - `node-manager capi-controller-manager`: 1.10.4
 


### PR DESCRIPTION
## Description
Added Release Notes 1.72 at documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Added DKP 1.72 Release Notes.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
