### PR TITLE
[cni-cilium]  fixed egress gateway reselection for case node hard reset

### DIFF
--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateway_stale_node_label_cleaner_test.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateway_stale_node_label_cleaner_test.go
@@ -174,6 +174,10 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: egress_label_cleaner", func(
 			Expect(f.KubernetesGlobalResource("Node", "frontend-4").Field("metadata.labels").Map()).ToNot(HaveKey("egress-gateway.network.deckhouse.io/active-for-egg-dev"))
 			Expect(f.KubernetesGlobalResource("Node", "frontend-4").Field("metadata.labels").Map()).ToNot(HaveKey("egress-gateway.network.deckhouse.io/active-for-egg-prod"))
 			Expect(f.KubernetesGlobalResource("Node", "frontend-4").Field("metadata.labels").Map()).ToNot(HaveKey("egress-gateway.network.deckhouse.io/member"))
+
+			Expect(f.KubernetesGlobalResource("CiliumNode", "frontend-4").Field("metadata.labels").Map()).ToNot(HaveKey("egress-gateway.network.deckhouse.io/active-for-egg-dev"))
+			Expect(f.KubernetesGlobalResource("CiliumNode", "frontend-4").Field("metadata.labels").Map()).ToNot(HaveKey("egress-gateway.network.deckhouse.io/active-for-egg-prod"))
+			Expect(f.KubernetesGlobalResource("CiliumNode", "frontend-4").Field("metadata.labels").Map()).ToNot(HaveKey("egress-gateway.network.deckhouse.io/member"))
 		})
 	})
 })

--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateway_stale_node_label_cleaner_test.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateway_stale_node_label_cleaner_test.go
@@ -42,6 +42,15 @@ spec:
   podCIDR: 10.111.1.0/24
   podCIDRs:
     - 10.111.1.0/24
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-1
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    egress-gateway.network.deckhouse.io/active-for-egg-dev: ""
+    node-role: egress
 `
 
 var nodeWithoutNodeRoleButWithLabels = `
@@ -57,6 +66,14 @@ spec:
   podCIDR: 10.111.2.0/24
   podCIDRs:
     - 10.111.2.0/24
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-2
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    egress-gateway.network.deckhouse.io/active-for-egg-dev: ""
 `
 
 var nodeWithoutNodeRoleWithoutLabels = `
@@ -69,6 +86,11 @@ spec:
   podCIDR: 10.111.3.0/24
   podCIDRs:
     - 10.111.3.0/24
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-3
 `
 
 var nodeWithMultipleActiveLabels = `

--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateway_stale_node_label_cleaner_test.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateway_stale_node_label_cleaner_test.go
@@ -107,6 +107,15 @@ spec:
   podCIDR: 10.111.4.0/24
   podCIDRs:
     - 10.111.4.0/24
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-4
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    egress-gateway.network.deckhouse.io/active-for-egg-dev: ""
+    egress-gateway.network.deckhouse.io/active-for-egg-prod: ""
 `
 
 var _ = Describe("Modules :: cni-cilium :: hooks :: egress_label_cleaner", func() {

--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateway_stale_node_label_cleaner_test.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateway_stale_node_label_cleaner_test.go
@@ -90,6 +90,7 @@ spec:
 var _ = Describe("Modules :: cni-cilium :: hooks :: egress_label_cleaner", func() {
 	f := HookExecutionConfigInit(`{}`, `{}`)
 	f.RegisterCRD("network.deckhouse.io", "v1alpha1", "EgressGateway", false)
+	f.RegisterCRD("cilium.io", "v2", "CiliumNode", false)
 
 	Context("Node with correct NodeSelector and labels", func() {
 		BeforeEach(func() {

--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery.go
@@ -510,8 +510,7 @@ func removeLabels(labels []string) func(obj *unstructured.Unstructured) (*unstru
 
 func processAddingLabels(input *go_hook.HookInput, nodeToLabel map[string][]string) {
 	for keyName, labels := range nodeToLabel {
-		doLabels := appendLabels(labels)
-		input.PatchCollector.PatchWithMutatingFunc(doLabels, "v1", "Node", "", keyName)
+		input.PatchCollector.PatchWithMutatingFunc(appendLabels(labels), "v1", "Node", "", keyName)
 	}
 }
 

--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
@@ -246,6 +246,31 @@ spec:
   podCIDRs:
   - 10.111.3.0/24
 ---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-1
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    egress-gateway.network.deckhouse.io/active-for-egg-dev: ""
+    node-role: egress
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-2
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    node-role: egress
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-3
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    node-role: egress
+---
 apiVersion: v1
 kind: Pod
 metadata:

--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
@@ -16,6 +16,7 @@ var _ = Describe("cni-cilium :: hooks :: egress_discovery ::", func() {
 	f := HookExecutionConfigInit(`{"cniCilium":{"internal": {"egressGatewaysMap": {}}}}`, "")
 	f.RegisterCRD("network.deckhouse.io", "v1alpha1", "EgressGateway", false)
 	f.RegisterCRD("internal.network.deckhouse.io", "v1alpha1", "SDNInternalEgressGatewayInstance", false)
+	f.RegisterCRD("cilium.io", "v2", "CiliumNode", false)
 
 	Context("Fresh cluster", func() {
 		BeforeEach(func() {

--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
@@ -381,6 +381,10 @@ status:
 {"node-role": "egress"}
 `))
 
+			Expect(f.KubernetesGlobalResource("CiliumNode", "frontend-1").Field("metadata.labels").String()).To(MatchJSON(`
+{"node-role": "egress"}
+`))
+
 			Expect(f.KubernetesGlobalResource("Node", "frontend-3").Field("metadata.labels").String()).To(MatchJSON(`
 {
 "egress-gateway.network.deckhouse.io/active-for-egg-dev": "",

--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
@@ -730,12 +730,21 @@ status:
 {
 "node-role": "egress"}
 `))
+			Expect(f.KubernetesGlobalResource("CiliumNode", "frontend-1").Field("metadata.labels").String()).To(MatchJSON(`
+{
+"node-role": "egress"}
+`))
+
 			Expect(f.KubernetesGlobalResource("Node", "frontend-2").Field("metadata.labels").String()).To(MatchJSON(`
 {
 "egress-gateway.network.deckhouse.io/member": "",
 "node-role": "egress"}
 `))
 			Expect(f.KubernetesGlobalResource("Node", "frontend-3").Field("metadata.labels").String()).To(MatchJSON(`
+{
+"node-role": "egress"}
+`))
+			Expect(f.KubernetesGlobalResource("CiliumNode", "frontend-3").Field("metadata.labels").String()).To(MatchJSON(`
 {
 "node-role": "egress"}
 `))

--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
@@ -444,6 +444,31 @@ spec:
   podCIDRs:
   - 10.111.3.0/24
 ---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-1
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    egress-gateway.network.deckhouse.io/active-for-egg-dev: ""
+    node-role: egress
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-2
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    node-role: egress
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-3
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    node-role: egress
+---
 apiVersion: v1
 kind: Pod
 metadata:

--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
@@ -568,6 +568,11 @@ status:
 "egress-gateway.network.deckhouse.io/member": "",
 "node-role": "egress"}
 `))
+			Expect(f.KubernetesGlobalResource("CiliumNode", "frontend-1").Field("metadata.labels").String()).To(MatchJSON(`
+{
+"egress-gateway.network.deckhouse.io/member": "",
+"node-role": "egress"}
+`))
 
 			Expect(f.KubernetesGlobalResource("Node", "frontend-3").Field("metadata.labels").String()).To(MatchJSON(`
 {

--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
@@ -1304,6 +1304,23 @@ spec:
   podCIDRs:
   - 10.111.2.0/24
 ---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-1
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    egress-gateway.network.deckhouse.io/active-for-egg-dev: ""
+    node-role: egress
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-2
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    node-role: egress
+---
 apiVersion: v1
 kind: Pod
 metadata:

--- a/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
+++ b/ee/se-plus/modules/021-cni-cilium/hooks/ee/egressgateways_discovery_test.go
@@ -634,6 +634,31 @@ spec:
   podCIDRs:
   - 10.111.3.0/24
 ---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-1
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    egress-gateway.network.deckhouse.io/active-for-egg-dev: ""
+    node-role: egress
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-2
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    node-role: egress
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-3
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    node-role: egress
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -761,6 +786,31 @@ spec:
   podCIDR: 10.111.3.0/24
   podCIDRs:
   - 10.111.3.0/24
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-1
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    egress-gateway.network.deckhouse.io/active-for-egg-dev: ""
+    node-role: egress
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-2
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    node-role: egress
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-3
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    node-role: egress
 ---
 apiVersion: v1
 kind: Pod
@@ -927,6 +977,31 @@ spec:
   podCIDRs:
   - 10.111.3.0/24
 ---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-1
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    egress-gateway.network.deckhouse.io/active-for-egg-dev: ""
+    node-role: egress
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-2
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    node-role: egress
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-3
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    node-role: egress
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -1080,6 +1155,23 @@ spec:
   podCIDR: 10.111.2.0/24
   podCIDRs:
   - 10.111.2.0/24
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-1
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    egress-gateway.network.deckhouse.io/active-for-egg-dev: ""
+    node-role: egress
+---
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: frontend-2
+  labels:
+    egress-gateway.network.deckhouse.io/member: ""
+    node-role: egress
 ---
 apiVersion: v1
 kind: Pod

--- a/modules/021-cni-cilium/images/bin-cilium/patches/013-ignore-egress-gateway-inactual-warning.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/013-ignore-egress-gateway-inactual-warning.patch
@@ -1,28 +1,29 @@
-From 4cbd99a0e84f347757e6dd98ed45b9f29d278a49 Mon Sep 17 00:00:00 2001
+From 7a6ea2cb050e8f7c610f5290722be8a55bcae739 Mon Sep 17 00:00:00 2001
 From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 Date: Thu, 4 Sep 2025 13:18:30 +0300
 Subject: [PATCH] ignore egress gateway inactual warning
 
 Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
 ---
- pkg/egressgateway/policy.go | 4 ++++
- 1 file changed, 4 insertions(+)
+ pkg/egressgateway/policy.go | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/pkg/egressgateway/policy.go b/pkg/egressgateway/policy.go
-index 36e8e871ad..fcce9c6a03 100644
+index 36e8e871ad..dedd25f78b 100644
 --- a/pkg/egressgateway/policy.go
 +++ b/pkg/egressgateway/policy.go
-@@ -171,6 +171,10 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(gc *policyGatewayConfig)
+@@ -171,7 +171,10 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(gc *policyGatewayConfig)
  		gwc.egressIP = gc.egressIP
  		gwc.ifaceName, err = netdevice.GetIfaceWithIPv4Address(gc.egressIP)
  		if err != nil {
+-			return fmt.Errorf("failed to retrieve interface with egress IP: %w", err)
 +			expectedErr := fmt.Sprintf("no interface with %s IPv4 assigned to", gc.egressIP)
 +			if err.Error() != expectedErr {
 +				return fmt.Errorf("failed to retrieve interface with egress IP: %w", err)
 +			}
- 			return fmt.Errorf("failed to retrieve interface with egress IP: %w", err)
  		}
  	default:
+ 		// If the gateway config doesn't specify any egress IP or interface, use the
 -- 
 2.34.1
 

--- a/modules/021-cni-cilium/images/bin-cilium/patches/013-ignore-egress-gateway-inactual-warning.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/013-ignore-egress-gateway-inactual-warning.patch
@@ -1,0 +1,28 @@
+From 4cbd99a0e84f347757e6dd98ed45b9f29d278a49 Mon Sep 17 00:00:00 2001
+From: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
+Date: Thu, 4 Sep 2025 13:18:30 +0300
+Subject: [PATCH] ignore egress gateway inactual warning
+
+Signed-off-by: Dmitriy Andreychenko <dmitriy.andreychenko@flant.com>
+---
+ pkg/egressgateway/policy.go | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/pkg/egressgateway/policy.go b/pkg/egressgateway/policy.go
+index 36e8e871ad..fcce9c6a03 100644
+--- a/pkg/egressgateway/policy.go
++++ b/pkg/egressgateway/policy.go
+@@ -171,6 +171,10 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(gc *policyGatewayConfig)
+ 		gwc.egressIP = gc.egressIP
+ 		gwc.ifaceName, err = netdevice.GetIfaceWithIPv4Address(gc.egressIP)
+ 		if err != nil {
++			expectedErr := fmt.Sprintf("no interface with %s IPv4 assigned to", gc.egressIP)
++			if err.Error() != expectedErr {
++				return fmt.Errorf("failed to retrieve interface with egress IP: %w", err)
++			}
+ 			return fmt.Errorf("failed to retrieve interface with egress IP: %w", err)
+ 		}
+ 	default:
+-- 
+2.34.1
+

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -64,3 +64,7 @@ For HostPort pseudo-serivces always use random LB algo. When bpf-lb-algorithm-an
 ## 012-add-least-conn-lb-algorithm.patch
 
 Added an implementation of the Least Connections load balancing algorithm.
+
+## 013-ignore-egress-gateway-inactual-warning.patch
+
+Ignore error when using IPv4 address for egress gateway other than assigned


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
 Fixed egress gateway reselection for case node hard reset.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In the event of a hard reboot of a node in the cluster, a new egress gateway is not elected by cilium agents on other nodes. To fix this issue, we need to manually remove the labels from the ciliumnodes CR too in the hook.
## Why do we need it in the patch release (if we do)?

## Manual testing

1. Deploy debug app.

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: debug-pod-right
  namespace: right
  labels:
    app: debug-pod
spec:
  replicas: 1
  selector:
    matchLabels:
      app: debug-pod
  template:
    metadata:
      labels:
        # sidecar.istio.io/inject: "true"
        app: debug-pod
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: node-role.kubernetes.io/master
                    operator: Exists
              - matchExpressions:
                  - key: node-role.kubernetes.io/control-plane
                    operator: Exists
      tolerations:
        - key: "node-role.kubernetes.io/master"
          operator: "Exists"
          effect: "NoSchedule"
        - key: "node-role.kubernetes.io/control-plane"
          operator: "Exists"
          effect: "NoSchedule"
      containers:
        - name: debug-container
          image: nicolaka/netshoot:latest
          command: ["tail"]
          args: ["-f", "/dev/null"]
```

2. Deploy EgressGateway

```yaml
apiVersion: network.deckhouse.io/v1alpha1
kind: EgressGateway
metadata:
  name: egress-eth
spec:
  nodeSelector:
    node-role.deckhouse.io/egress: ""
  sourceIP:
    mode: PrimaryIPFromEgressGatewayNodeInterface
    primaryIPFromEgressGatewayNodeInterface:
      interfaceName: ens3
---
apiVersion: network.deckhouse.io/v1alpha1
kind: EgressGatewayPolicy
metadata:
  name: my-egressgw-policy-second
spec:
  destinationCIDRs:
  - 0.0.0.0/0
  egressGatewayName: egress-eth
  selectors:
  - podSelector:
      matchLabels:
        io.kubernetes.pod.namespace: right
```

3. Labaled worker node for egress traffic and check is working properly
<details>
<summary>Screenshot</summary>
<img width="1655" height="387" alt="image" src="https://github.com/user-attachments/assets/1f73c796-1f9d-438c-80a5-a56849054f6e" />
</details>

4. Labeled master node and simulate Power Off instruction on worker node, there must be no service label for EgressGateway.

```bash
echo b > /proc/sysrq-trigger
```
<details>
<summary>Screenshot</summary>
<img width="1886" height="671" alt="image" src="https://github.com/user-attachments/assets/9fa5a994-f9d2-407c-9cb5-5d319a8d2327" />
</details>

6. Check IP from debug pod

<details>
<summary>Screenshot</summary>
<img width="1193" height="107" alt="image" src="https://github.com/user-attachments/assets/9258b177-eddc-4c24-a25a-41dd356a0ed7" />
</details>





<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: fixed egress gateway reselection for case node hard reset
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
