### PR TITLE
[deckhouse] dont ensure mrs of disabled modules

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
@@ -259,6 +259,16 @@ func (m *Module) ConditionStatus(condName string) bool {
 	return false
 }
 
+func (m *Module) ConditionUnknown(condName string) bool {
+	for _, cond := range m.Status.Conditions {
+		if cond.Type == condName {
+			return cond.Status == corev1.ConditionUnknown
+		}
+	}
+
+	return false
+}
+
 type ConditionOption func(opts *ConditionSettings)
 
 func WithTimer(fn func() time.Time) func(opts *ConditionSettings) {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
@@ -250,19 +250,10 @@ func isEnabledInBundle(bundles []string, requested string) bool {
 	return false
 }
 
-func (m *Module) ConditionStatus(condName string) bool {
+func (m *Module) IsCondition(condName string, status corev1.ConditionStatus) bool {
 	for _, cond := range m.Status.Conditions {
 		if cond.Type == condName {
-			return cond.Status == corev1.ConditionTrue
-		}
-	}
-	return false
-}
-
-func (m *Module) ConditionUnknown(condName string) bool {
-	for _, cond := range m.Status.Conditions {
-		if cond.Type == condName {
-			return cond.Status == corev1.ConditionUnknown
+			return cond.Status == status
 		}
 	}
 

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -213,7 +213,7 @@ func NewDeckhouseController(
 		}
 
 		// set some version for the modules overridden by mpos
-		if module.ConditionStatus(v1alpha1.ModuleConditionIsOverridden) {
+		if module.IsCondition(v1alpha1.ModuleConditionIsOverridden, corev1.ConditionTrue) {
 			return "v2.0.0", nil
 		}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules"
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules/events"
 	"github.com/flant/shell-operator/pkg/metric"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
@@ -256,7 +257,7 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 
 	if !moduleConfig.IsEnabled() {
 		// delete all pending releases for EnabledByModuleConfig disabled modules
-		if module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+		if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionTrue) {
 			releases := new(v1alpha1.ModuleReleaseList)
 			selector := client.MatchingLabels{v1alpha1.ModuleReleaseLabelModule: module.Name}
 			if err := r.client.List(ctx, releases, selector); err != nil {
@@ -509,7 +510,7 @@ func (r *reconciler) removeFinalizer(ctx context.Context, config *v1alpha1.Modul
 func (r *reconciler) disableModule(ctx context.Context, module *v1alpha1.Module) error {
 	r.logger.Debug("disable the module", slog.String("module", module.Name))
 	return utils.UpdateStatus[*v1alpha1.Module](ctx, r.client, module, func(module *v1alpha1.Module) bool {
-		if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+		if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionFalse) {
 			return false
 		}
 
@@ -538,7 +539,7 @@ func (r *reconciler) disableModule(ctx context.Context, module *v1alpha1.Module)
 func (r *reconciler) enableModule(ctx context.Context, module *v1alpha1.Module) error {
 	r.logger.Debug("enable the module", slog.String("module", module.Name))
 	return utils.UpdateStatus[*v1alpha1.Module](ctx, r.client, module, func(module *v1alpha1.Module) bool {
-		if module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+		if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionTrue) {
 			return false
 		}
 		module.SetConditionTrue(v1alpha1.ModuleConditionEnabledByModuleConfig)

--- a/deckhouse-controller/pkg/controller/module-controllers/override/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/override/controller.go
@@ -28,6 +28,7 @@ import (
 	addonmodules "github.com/flant/addon-operator/pkg/module_manager/models/modules"
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	cp "github.com/otiai10/copy"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -188,7 +189,7 @@ func (r *reconciler) handleModuleOverride(ctx context.Context, mpo *v1alpha2.Mod
 	}
 
 	// module must be enabled
-	if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionFalse) {
 		r.log.Debug("module is disabled, skip it", slog.String("name", mpo.Name))
 		if mpo.Status.Message != v1alpha1.ModulePullOverrideMessageModuleDisabled {
 			mpo.Status.Message = v1alpha1.ModulePullOverrideMessageModuleDisabled

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -187,7 +187,7 @@ func (r *reconciler) needToEnsureRelease(
 		return false
 	}
 
-	if module.ConditionUnknown(v1alpha1.ModuleConditionEnabledByModuleManager) {
+	if module.ConditionUnknown(v1alpha1.ModuleConditionEnabledByModuleConfig) {
 		enabledByBundle := false
 		if meta.ModuleDefinition != nil {
 			enabledByBundle = meta.ModuleDefinition.Accessibility.IsEnabled(r.edition.Name, r.edition.Bundle)
@@ -200,9 +200,7 @@ func (r *reconciler) needToEnsureRelease(
 		if len(module.Properties.AvailableSources) > 1 && !source.IsDefault() {
 			return false
 		}
-	}
-
-	if module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+	} else if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
 		return false
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -25,6 +25,7 @@ import (
 	"slices"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -55,7 +56,7 @@ func (r *reconciler) cleanSourceInModule(ctx context.Context, sourceName, module
 			// delete modules without sources, it seems impossible, but just in case
 			if len(module.Properties.AvailableSources) == 0 {
 				// don`t delete enabled module
-				if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleManager) {
+				if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleManager, corev1.ConditionFalse) {
 					return r.client.Delete(ctx, module)
 				}
 				return nil
@@ -64,7 +65,7 @@ func (r *reconciler) cleanSourceInModule(ctx context.Context, sourceName, module
 			// delete modules with this source as the last source
 			if len(module.Properties.AvailableSources) == 1 && module.Properties.AvailableSources[0] == sourceName {
 				// don`t delete enabled module
-				if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleManager) {
+				if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleManager, corev1.ConditionFalse) {
 					return r.client.Delete(ctx, module)
 				}
 				module.Properties.AvailableSources = []string{}
@@ -187,7 +188,7 @@ func (r *reconciler) needToEnsureRelease(
 		return false
 	}
 
-	if module.ConditionUnknown(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionUnknown) {
 		enabledByBundle := false
 		if meta.ModuleDefinition != nil {
 			enabledByBundle = meta.ModuleDefinition.Accessibility.IsEnabled(r.edition.Name, r.edition.Bundle)
@@ -200,7 +201,7 @@ func (r *reconciler) needToEnsureRelease(
 		if len(module.Properties.AvailableSources) > 1 && !source.IsDefault() {
 			return false
 		}
-	} else if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+	} else if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionFalse) {
 		return false
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -187,20 +187,22 @@ func (r *reconciler) needToEnsureRelease(
 		return false
 	}
 
-	if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
-		return false
+	if module.ConditionUnknown(v1alpha1.ModuleConditionEnabledByModuleManager) {
+		enabledByBundle := false
+		if meta.ModuleDefinition != nil {
+			enabledByBundle = meta.ModuleDefinition.Accessibility.IsEnabled(r.edition.Name, r.edition.Bundle)
+		}
+
+		if !enabledByBundle {
+			return false
+		}
+
+		if len(module.Properties.AvailableSources) > 1 && !source.IsDefault() {
+			return false
+		}
 	}
 
-	enabledByBundle := false
-	if meta.ModuleDefinition != nil {
-		enabledByBundle = meta.ModuleDefinition.Accessibility.IsEnabled(r.edition.Name, r.edition.Bundle)
-	}
-
-	if !enabledByBundle {
-		return false
-	}
-
-	if len(module.Properties.AvailableSources) > 1 && !source.IsDefault() {
+	if module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
 		return false
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -187,20 +187,21 @@ func (r *reconciler) needToEnsureRelease(
 		return false
 	}
 
-	// check the module enabled
 	if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
-		enabledByBundle := false
-		if meta.ModuleDefinition != nil {
-			enabledByBundle = meta.ModuleDefinition.Accessibility.IsEnabled(r.edition.Name, r.edition.Bundle)
-		}
+		return false
+	}
 
-		if !enabledByBundle {
-			return false
-		}
+	enabledByBundle := false
+	if meta.ModuleDefinition != nil {
+		enabledByBundle = meta.ModuleDefinition.Accessibility.IsEnabled(r.edition.Name, r.edition.Bundle)
+	}
 
-		if len(module.Properties.AvailableSources) > 1 && !source.IsDefault() {
-			return false
-		}
+	if !enabledByBundle {
+		return false
+	}
+
+	if len(module.Properties.AvailableSources) > 1 && !source.IsDefault() {
+		return false
 	}
 
 	return sourceModule.Checksum != meta.Checksum || !releaseExists

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/proceed-enabled-modules-without-default.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/proceed-enabled-modules-without-default.yaml
@@ -48,6 +48,9 @@ properties:
     - test-source-1
 status:
   phase: Available
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "Unknown"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: Module

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/proceed-enabled-modules.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/proceed-enabled-modules.yaml
@@ -63,6 +63,9 @@ properties:
     - test-source-1
 status:
   phase: Available
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "Unknown"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: Module

--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -144,7 +145,7 @@ func (l *Loader) restoreAbsentModulesFromOverrides(ctx context.Context) error {
 		}
 
 		// module must be enabled
-		if !module.ConditionStatus(v1alpha1.ModuleConditionEnabledByModuleConfig) {
+		if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionFalse) {
 			l.logger.Info("module disabled, skip restoring module pull override process", slog.String("name", mpo.Name))
 			continue
 		}


### PR DESCRIPTION
## Description
It fixes ensuring mr process.

## Why do we need it, and what problem does it solve?
If a user disabled a module via its config, we should not ensure mr.

## Why do we need it in the patch release (if we do)?
Without it deckhouse may stuck in restarting loop 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Dont ensure releases of disabled modules.
impact_level: low
```