### PR TITLE
[dhctl] Fix sudo with password

### DIFF
--- a/dhctl/pkg/system/node/gossh/command.go
+++ b/dhctl/pkg/system/node/gossh/command.go
@@ -296,8 +296,6 @@ func (c *SSHCommand) Run(ctx context.Context) error {
 		return err
 	}
 
-	// <-c.waitCh
-
 	c.Stop()
 
 	return c.WaitError()
@@ -532,7 +530,6 @@ func (c *SSHCommand) SetupStreamHandlers() (err error) {
 		return
 	}
 
-	// var stdoutReadPipe io.Reader
 	var stdoutHandlerWritePipe *os.File
 	var stdoutHandlerReadPipe *os.File
 	if c.out != nil || c.stdoutHandler != nil || len(c.Matchers) > 0 {
@@ -683,8 +680,6 @@ func (c *SSHCommand) readFromStreams(stdoutReadPipe io.Reader, stdoutHandlerWrit
 			continue
 		}
 
-		// log.DebugF("read: %s\n", string(buf))
-
 		m := 0
 		if !matchersDone {
 			for _, matcher := range c.Matchers {
@@ -715,12 +710,10 @@ func (c *SSHCommand) readFromStreams(stdoutReadPipe io.Reader, stdoutHandlerWrit
 			os.Stdout.Write(buf[m:n])
 		}
 		if c.out != nil && !isError {
-			// log.DebugF("write to out: %s\n", string(buf[:n]))
 			c.out.Write(buf[:n])
 		}
 
 		if c.err != nil && isError {
-			// log.DebugF("write to err: %s\n", string(buf[:n]))
 			c.err.Write(buf[:n])
 		}
 


### PR DESCRIPTION
## Description

Fix sudo with password behavior

## Why do we need it, and what problem does it solve?

Sudo with password was broken in gossh implementation, we should fix it

## Why do we need it in the patch release (if we do)?

Broken since 1.72

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix sudo with password behavior.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
