### PR TITLE
[cloud-provider-huaweicloud] Add default CNI for huawei cloud provider

### DIFF
--- a/ee/modules/030-cloud-provider-huaweicloud/hooks/get_cni_secret.go
+++ b/ee/modules/030-cloud-provider-huaweicloud/hooks/get_cni_secret.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderHuaweicloud")

--- a/ee/modules/030-cloud-provider-huaweicloud/hooks/get_cni_secret.go
+++ b/ee/modules/030-cloud-provider-huaweicloud/hooks/get_cni_secret.go
@@ -1,14 +1,6 @@
 /*
-Copyright 2025 Flant JSC
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
 package hooks

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/cni.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/cni.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+{{- if hasKey .Values.cloudProviderDvp.internal "cniSecretData" }}
+  {{- .Values.cloudProviderDvp.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ b64enc "{\"mode\": \"VXLAN\"}" | quote }}
+{{- end }}

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/cni.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/cni.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 data:
-{{- if hasKey .Values.cloudProviderDvp.internal "cniSecretData" }}
-  {{- .Values.cloudProviderDvp.internal.cniSecretData | b64dec | nindent 2 }}
+{{- if hasKey .Values.cloudProviderHuaweicloud.internal "cniSecretData" }}
+  {{- .Values.cloudProviderHuaweicloud.internal.cniSecretData | b64dec | nindent 2 }}
 {{- else }}
   cni: {{ b64enc "cilium" | quote }}
   cilium: {{ b64enc "{\"mode\": \"VXLAN\"}" | quote }}


### PR DESCRIPTION
## Description
Add default CNI for huawei cloud provider

## Why do we need it, and what problem does it solve?
If no MC CNI specified run cni module by default

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-huaweicloud
type: feature
summary: If no MC CNI specified run cni module by default
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
