### PR TITLE
[prometheus] Fix initContainer securityContext indent

### DIFF
--- a/modules/300-prometheus/templates/prometheus/_helpers.tpl
+++ b/modules/300-prometheus/templates/prometheus/_helpers.tpl
@@ -8,15 +8,15 @@
 {{- define "prometheus_init_containers" -}}
 {{- $ctx := index . 0 }}
 {{- $volume := index . 1 }}
-{{- if hasKey .Values.global.modulesImages.digests "prompp" }}
+{{- if hasKey $ctx.Values.global.modulesImages.digests "prompp" }}
 initContainers:
 - name: prompptool
-  image: {{ include "helm_lib_module_image" (list (include "prompp_context" . | fromYaml) "prompptool") }}
+  image: {{ include "helm_lib_module_image" (list (include "prompp_context" $ctx | fromYaml) "prompptool") }}
   command:
   - /bin/prompptool
   - "--working-dir=/prometheus"
   - "--verbose"
-  {{- if (.Values.global.enabledModules | has "prompp") }}
+  {{- if ($ctx.Values.global.enabledModules | has "prompp") }}
   - "walvanilla"
   {{- else }}
   - "walpp"
@@ -25,8 +25,9 @@ initContainers:
   - name: {{ $volume }}
     mountPath: /prometheus
     subPath: prometheus-db
-  {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 2 }}
+  {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" $ctx | nindent 2 }}
   resources:
     requests:
       {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/modules/300-prometheus/templates/prometheus/_helpers.tpl
+++ b/modules/300-prometheus/templates/prometheus/_helpers.tpl
@@ -6,6 +6,8 @@
 {{- end }}
 
 {{- define "prometheus_init_containers" -}}
+{{- $ctx := index . 0 }}
+{{- $volume := index . 1 }}
 {{- if hasKey .Values.global.modulesImages.digests "prompp" }}
   initContainers:
   - name: prompptool
@@ -20,7 +22,7 @@
     - "walpp"
     {{- end }}
     volumeMounts:
-    - name: prometheus-main-db
+    - name: {{ $volume }}
       mountPath: /prometheus
       subPath: prometheus-db
     {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 4 }}

--- a/modules/300-prometheus/templates/prometheus/_helpers.tpl
+++ b/modules/300-prometheus/templates/prometheus/_helpers.tpl
@@ -9,24 +9,24 @@
 {{- $ctx := index . 0 }}
 {{- $volume := index . 1 }}
 {{- if hasKey .Values.global.modulesImages.digests "prompp" }}
-  initContainers:
-  - name: prompptool
-    image: {{ include "helm_lib_module_image" (list (include "prompp_context" . | fromYaml) "prompptool") }}
-    command:
-    - /bin/prompptool
-    - "--working-dir=/prometheus"
-    - "--verbose"
-    {{- if (.Values.global.enabledModules | has "prompp") }}
-    - "walvanilla"
-    {{- else }}
-    - "walpp"
-    {{- end }}
-    volumeMounts:
-    - name: {{ $volume }}
-      mountPath: /prometheus
-      subPath: prometheus-db
-    {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 4 }}
-    resources:
-      requests:
-        {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
+initContainers:
+- name: prompptool
+  image: {{ include "helm_lib_module_image" (list (include "prompp_context" . | fromYaml) "prompptool") }}
+  command:
+  - /bin/prompptool
+  - "--working-dir=/prometheus"
+  - "--verbose"
+  {{- if (.Values.global.enabledModules | has "prompp") }}
+  - "walvanilla"
+  {{- else }}
+  - "walpp"
+  {{- end }}
+  volumeMounts:
+  - name: {{ $volume }}
+    mountPath: /prometheus
+    subPath: prometheus-db
+  {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 2 }}
+  resources:
+    requests:
+      {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 6 }}
 {{- end }}

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -66,7 +66,7 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
-  {{- include "prometheus_init_containers" . }}
+  {{- include "prometheus_init_containers" (list . "prometheus-longterm-db" }}
   containers:
   - name: prometheus
     startupProbe:

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -66,7 +66,7 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
-  {{- include "prometheus_init_containers" (list . "prometheus-longterm-db") }}
+  {{- include "prometheus_init_containers" (list . "prometheus-longterm-db") | nindent 2 }}
   containers:
   - name: prometheus
     startupProbe:

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -8,13 +8,6 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
-{{- define "prompp-context" -}}
-{{- $values := deepCopy .Values | merge dict }}
-{{- $_ := set $values.global.modulesImages.registry "base" (printf "%s/modules/prompp" .Values.global.modulesImages.registry.base) }}
-{{- $ctx := dict "Chart" (dict "Name" "prompp") "Values" $values }}
-{{- $ctx | toYaml }}
-{{- end }}
-
 {{- if .Values.prometheus.longtermRetentionDays }}
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
@@ -73,33 +66,7 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
-{{- if hasKey .Values.global.modulesImages.digests "prompp" }}
-  initContainers:
-  - name: prompptool
-    image: {{ include "helm_lib_module_image" (list (include "prompp-context" . | fromYaml) "prompptool") }}
-    command:
-    - /bin/prompptool
-    - "--working-dir=/prometheus"
-    - "--verbose"
-    {{- if (.Values.global.enabledModules | has "prompp") }}
-    - "walvanilla"
-    {{- else }}
-    - "walpp"
-    {{- end }}
-    volumeMounts:
-    - name: prometheus-longterm-db
-      mountPath: /prometheus
-      subPath: prometheus-db
-      securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-          - ALL
-        readOnlyRootFilesystem: true
-    resources:
-      requests:
-        {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-{{- end }}
+  {{- include "prometheus_init_containers" . }}
   containers:
   - name: prometheus
     startupProbe:

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -52,7 +52,7 @@ spec:
   retention: {{ .Values.prometheus.longtermRetentionDays }}d
   retentionSize: {{ .Values.prometheus.internal.prometheusLongterm.retentionGigabytes }}GB
 {{- if (.Values.global.enabledModules | has "prompp") }}
-  image: {{ include "helm_lib_module_image" (list (include "prompp-context" . | fromYaml) "prompp") }}
+  image: {{ include "helm_lib_module_image" (list (include "prompp_context" . | fromYaml) "prompp") }}
   version: v2.53.2
 {{- else }}
   image: {{ include "helm_lib_module_image" (list . "prometheus") }}

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -66,7 +66,7 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
-  {{- include "prometheus_init_containers" (list . "prometheus-longterm-db" }}
+  {{- include "prometheus_init_containers" (list . "prometheus-longterm-db") }}
   containers:
   - name: prometheus
     startupProbe:

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -101,7 +101,7 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
-  {{- include "prometheus_init_containers" . | nindent 2 }}
+  {{- include "prometheus_init_containers" (list . "prometheus-main-db") | nindent 2 }}
   containers:
   - name: prometheus
     startupProbe:

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -82,7 +82,7 @@ spec:
   retention: {{ .Values.prometheus.retentionDays }}d
   retentionSize: {{ .Values.prometheus.internal.prometheusMain.retentionGigabytes }}GB
 {{- if (.Values.global.enabledModules | has "prompp") }}
-  image: {{ include "helm_lib_module_image" (list (include "prompp-context" . | fromYaml) "prompp") }}
+  image: {{ include "helm_lib_module_image" (list (include "prompp_context" . | fromYaml) "prompp") }}
   version: v2.53.2
 {{- else }}
   image: {{ include "helm_lib_module_image" (list . "prometheus") }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -39,13 +39,6 @@ memory: 25Mi
 {{- sub ($now | unixEpoch) ($now |  date_modify (printf "-%s" $duration) | unixEpoch) }}
 {{- end }}
 
-{{- define "prompp-context" -}}
-{{- $values := deepCopy .Values | merge dict }}
-{{- $_ := set $values.global.modulesImages.registry "base" (printf "%s/modules/prompp" .Values.global.modulesImages.registry.base) }}
-{{- $ctx := dict "Chart" (dict "Name" "prompp") "Values" $values }}
-{{- $ctx | toYaml }}
-{{- end }}
-
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -108,33 +101,7 @@ spec:
   additionalArgs:
     - name: scrape.timestamp-tolerance
       value: 10ms
-{{- if hasKey .Values.global.modulesImages.digests "prompp" }}
-  initContainers:
-  - name: prompptool
-    image: {{ include "helm_lib_module_image" (list (include "prompp-context" . | fromYaml) "prompptool") }}
-    command:
-    - /bin/prompptool
-    - "--working-dir=/prometheus"
-    - "--verbose"
-    {{- if (.Values.global.enabledModules | has "prompp") }}
-    - "walvanilla"
-    {{- else }}
-    - "walpp"
-    {{- end }}
-    volumeMounts:
-    - name: prometheus-main-db
-      mountPath: /prometheus
-      subPath: prometheus-db
-      securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-          - ALL
-        readOnlyRootFilesystem: true
-    resources:
-      requests:
-        {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-{{- end }}
+  {{- include "prometheus_init_containers" . | nindent 2 }}
   containers:
   - name: prometheus
     startupProbe:


### PR DESCRIPTION
## Description
This PR fixes a misindentation in the securityContext of the initContainer, which resulted in an invalid resource manifest. Because of this, Prometheus configuration changes might not have been applied.
## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?
Yes. This issue affects virtually all clusters

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: fix
summary: fix securityContext indentation in the Prometheus main and longterm resources
impact: main and longterm Prometheuses will be rollout-restarted
impact_level: default
```
