### PR TITLE
[monitoring-kubernetes] Changed alert LoadBalancerServiceWithoutExternalIP description

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4864,7 +4864,7 @@ alerts:
         To list affected services, run the following command:
 
         ```bash
-        kubectl get svc -Ao json | jq -r '.items[] | select(.spec.type == "LoadBalancer") | select(.status.loadBalancer.ingress[0].ip == null) | "namespace: \(.metadata.namespace), name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
+        kubectl get svc -Ao json | jq -r '.items[] | select(.spec.type == "LoadBalancer") | select((.status.loadBalancer.ingress[0].ip == null) and (.status.loadBalancer.ingress[0].hostname == null)) | "namespace: \(.metadata.namespace), name: \(.metadata.name)"'
         ```
 
         Steps to troubleshoot:

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
@@ -17,7 +17,7 @@
           To list affected services, run the following command:
 
           ```bash
-          kubectl get svc -Ao json | jq -r '.items[] | select(.spec.type == "LoadBalancer") | select(.status.loadBalancer.ingress[0].ip == null) | "namespace: \(.metadata.namespace), name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
+          kubectl get svc -Ao json | jq -r '.items[] | select(.spec.type == "LoadBalancer") | select((.status.loadBalancer.ingress[0].ip == null) and (.status.loadBalancer.ingress[0].hostname == null)) | "namespace: \(.metadata.namespace), name: \(.metadata.name)"'
           ```
           
           Steps to troubleshoot:


### PR DESCRIPTION
## Description
This PR improves the alert description for LoadBalancerServiceWithoutExternalIP to provide clearer troubleshooting steps when a LoadBalancer service doesn't receive an external IP address or hostname.

## Why do we need it, and what problem does it solve?
Previously, the alert description only included a command that checked for missing IP addresses in LoadBalancer services. However, in some cloud environments like AWS, LoadBalancer services receive hostnames instead of IPs. The improved command now properly checks both fields (IP and hostname)

## Why do we need it in the patch release (if we do)?
Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: chore
summary: Improved alert LoadBalancerServiceWithoutExternalIP description
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
