### PR TITLE
[istio] Fixed metrics port for operator 1.25>=

### DIFF
--- a/modules/110-istio/templates/operator/deployment.yaml
+++ b/modules/110-istio/templates/operator/deployment.yaml
@@ -109,9 +109,14 @@ spec:
   {{- end }}
 
         ports:
+        {{- if or (hasPrefix "1.21" $fullVersion) (hasPrefix "1.19" $fullVersion) }}
         - containerPort: 8383
           name: http-metrics
-          protocol: TCP
+        {{- else}}
+        - containerPort: 8443
+          name: https-metrics
+        {{- end }}
+        protocol: TCP
         env:
           - name: WATCH_NAMESPACE
             value: d8-{{ $.Chart.Name }}

--- a/modules/110-istio/templates/operator/deployment.yaml
+++ b/modules/110-istio/templates/operator/deployment.yaml
@@ -116,7 +116,7 @@ spec:
         - containerPort: 8383
           name: http-metrics
         {{- end }}
-        protocol: TCP
+          protocol: TCP
         env:
           - name: WATCH_NAMESPACE
             value: d8-{{ $.Chart.Name }}

--- a/modules/110-istio/templates/operator/deployment.yaml
+++ b/modules/110-istio/templates/operator/deployment.yaml
@@ -109,12 +109,12 @@ spec:
   {{- end }}
 
         ports:
-        {{- if or (hasPrefix "1.21" $fullVersion) (hasPrefix "1.19" $fullVersion) }}
-        - containerPort: 8383
-          name: http-metrics
-        {{- else}}
+        {{- if (hasPrefix "1.25" $fullVersion) }}
         - containerPort: 8443
           name: https-metrics
+        {{- else}}
+        - containerPort: 8383
+          name: http-metrics
         {{- end }}
         protocol: TCP
         env:

--- a/modules/110-istio/templates/operator/podmonitor.yaml
+++ b/modules/110-istio/templates/operator/podmonitor.yaml
@@ -1,6 +1,7 @@
 {{- if (.Values.global.enabledModules | has "operator-prometheus") }}
   {{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
     {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
+    {{- $fullVersion := get $versionInfo "fullVersion" }}
     {{- $revision := get $versionInfo "revision" }}
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/modules/110-istio/templates/operator/podmonitor.yaml
+++ b/modules/110-istio/templates/operator/podmonitor.yaml
@@ -1,6 +1,7 @@
 {{- if (.Values.global.enabledModules | has "operator-prometheus") }}
   {{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
     {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
+    {{- $fullVersion := get $versionInfo "fullVersion" }}
     {{- $revision := get $versionInfo "revision" }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -18,14 +19,18 @@ spec:
     matchNames:
     - d8-{{ $.Chart.Name }}
   podMetricsEndpoints:
+    {{- if or (hasPrefix "1.21" $fullVersion) (hasPrefix "1.19" $fullVersion) }}
   - port: http-metrics
     scheme: http
-    #scheme: https # TODO https://github.com/deckhouse/deckhouse/issues/1487
-    #bearerTokenSecret:
-    #  name: "prometheus-token"
-    #  key: "token"
-    #tlsConfig:
-    #  insecureSkipVerify: true
+    {{- else}}
+  - port: https-metrics
+    scheme: https
+  - bearerTokenSecret:
+      key: token
+      name: prometheus-token
+    tlsConfig:
+      insecureSkipVerify: true
+    {{- end }}
     relabelings:
     - targetLabel: job
       replacement: istio-operator

--- a/modules/110-istio/templates/operator/podmonitor.yaml
+++ b/modules/110-istio/templates/operator/podmonitor.yaml
@@ -25,7 +25,7 @@ spec:
     {{- else}}
   - port: https-metrics
     scheme: https
-  - bearerTokenSecret:
+    bearerTokenSecret:
       key: token
       name: prometheus-token
     tlsConfig:

--- a/modules/110-istio/templates/operator/podmonitor.yaml
+++ b/modules/110-istio/templates/operator/podmonitor.yaml
@@ -1,7 +1,6 @@
 {{- if (.Values.global.enabledModules | has "operator-prometheus") }}
   {{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
     {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
-    {{- $fullVersion := get $versionInfo "fullVersion" }}
     {{- $revision := get $versionInfo "revision" }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -19,10 +18,7 @@ spec:
     matchNames:
     - d8-{{ $.Chart.Name }}
   podMetricsEndpoints:
-    {{- if or (hasPrefix "1.21" $fullVersion) (hasPrefix "1.19" $fullVersion) }}
-  - port: http-metrics
-    scheme: http
-    {{- else}}
+    {{- if (hasPrefix "1.25" $fullVersion) }}
   - port: https-metrics
     scheme: https
     bearerTokenSecret:
@@ -30,6 +26,9 @@ spec:
       name: prometheus-token
     tlsConfig: # TODO https://github.com/deckhouse/deckhouse/issues/1487
       insecureSkipVerify: true
+    {{- else}}
+  - port: http-metrics
+    scheme: http
     {{- end }}
     relabelings:
     - targetLabel: job

--- a/modules/110-istio/templates/operator/podmonitor.yaml
+++ b/modules/110-istio/templates/operator/podmonitor.yaml
@@ -1,7 +1,6 @@
 {{- if (.Values.global.enabledModules | has "operator-prometheus") }}
   {{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
     {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
-    {{- $fullVersion := get $versionInfo "fullVersion" }}
     {{- $revision := get $versionInfo "revision" }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -19,7 +18,7 @@ spec:
     matchNames:
     - d8-{{ $.Chart.Name }}
   podMetricsEndpoints:
-    {{- if (hasPrefix "1.25" $fullVersion) }}
+    {{- if eq $version "1.25" }}
   - port: https-metrics
     scheme: https
     bearerTokenSecret:

--- a/modules/110-istio/templates/operator/podmonitor.yaml
+++ b/modules/110-istio/templates/operator/podmonitor.yaml
@@ -28,7 +28,7 @@ spec:
     bearerTokenSecret:
       key: token
       name: prometheus-token
-    tlsConfig:
+    tlsConfig: # TODO https://github.com/deckhouse/deckhouse/issues/1487
       insecureSkipVerify: true
     {{- end }}
     relabelings:


### PR DESCRIPTION
## Description
Added https 8443 metrics port to podmonitor deployment and istio operator 1.25 and newer deployment.
Certificate issue still persists, hence `insecureSkipVerify: true` https://github.com/deckhouse/deckhouse/issues/1487

## Why do we need it, and what problem does it solve?
We were getting `TargetDown` alert on Istio operator 1.25. It's happened because the port has changed.

## Why do we need it in the patch release (if we do)?
Metrics about Istio Operator 1.25 will be collected correctly and the `TargetDown` error will disappear.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fixed metrics port for operator 1.25 and newer
impact_level: default
```