### PR TITLE
[tools] update dmt to v0.1.33

### DIFF
--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-DMT_VERSION=0.1.32
+DMT_VERSION=0.1.33
 
 function install_dmt() {
   platform_name=$(uname -m)


### PR DESCRIPTION
## Description

update dmt to v0.1.33

## Why do we need it, and what problem does it solve?

added new linters

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: chore
summary: update dmt to v0.1.33
impact_level: low
```
