### PR TITLE
[deckhouse] remove module weight constraint

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/types/definition.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/types/definition.go
@@ -148,10 +148,6 @@ type ModuleDescriptions struct {
 }
 
 func (d *Definition) Validate(values addonutils.Values, logger *log.Logger) error {
-	if d.Weight < 900 || d.Weight > 999 {
-		return errors.New("external module weight must be between 900 and 999")
-	}
-
 	if d.Path == "" {
 		return errors.New("cannot validate module without path. Path is required to load openapi specs")
 	}


### PR DESCRIPTION
## Description
It remove weight constraints for modules

## Why do we need it, and what problem does it solve?
Critical modules have weight less than 900

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Remove module weight constraints.
```
