### PR TITLE
[candi] fix ExecStartPre in d8-shutdown-inhibitor.service

### DIFF
--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/scripts/d8-shutdown-inhibitor.service
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/scripts/d8-shutdown-inhibitor.service
@@ -6,7 +6,7 @@ After=network-online.target kubelet.service containerd-deckhouse.service
 
 [Service]
 Environment="PATH=/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
-ExecStartPre=/bin/bash -c 'until echo >/dev/tcp/127.0.0.1/6445; do sleep 1; done'
+ExecStartPre=/bin/bash -c 'until /opt/deckhouse/bin/nc -z 127.0.0.1 6445; do sleep 1; done'
 ExecStart=/opt/deckhouse/bin/d8-shutdown-inhibitor
 Restart=always
 StartLimitInterval=0


### PR DESCRIPTION
## Description

follow https://github.com/deckhouse/deckhouse/pull/14622
Changed ExecStartPre in d8-shutdown-inhibitor.service


## Why do we need it, and what problem does it solve?

In some operating systems, echo >/dev/tcp/127.0.0.1/6445 does not work.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Changed ExecStartPre in d8-shutdown-inhibitor.service
impact:
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
