### PR TITLE
[user-authn] add groups cycle validation

### DIFF
--- a/modules/150-user-authn/webhooks/validating/group.py
+++ b/modules/150-user-authn/webhooks/validating/group.py
@@ -16,7 +16,6 @@
 
 from typing import Optional, Self
 
-import dotmap
 from deckhouse import hook
 from dotmap import DotMap
 
@@ -190,7 +189,7 @@ class GroupTree(list[Group]):
         self.extend(groups)
 
     @classmethod
-    def from_binding_context(cls, target_group: dotmap.DotMap, all_groups: dotmap.DotMap):
+    def from_binding_context(cls, target_group: DotMap, all_groups: DotMap):
         """
         Build a GroupTree from a binding context (target group + all known groups).
 

--- a/modules/150-user-authn/webhooks/validating/group_cycle_test.py
+++ b/modules/150-user-authn/webhooks/validating/group_cycle_test.py
@@ -1,0 +1,469 @@
+#!/usr/bin/python3
+
+# Copyright 2024 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import unittest
+
+from deckhouse import hook, tests
+from dotmap import DotMap
+
+from group import main
+
+
+def _prepare_validation_binding_context(binding_context_json, new_spec: dict) -> DotMap:
+    ctx_dict = json.loads(binding_context_json)
+    ctx = DotMap(ctx_dict)
+    ctx.review.request.object.spec = new_spec
+    return ctx
+
+
+def _prepare_update_binding_context(new_spec: dict) -> DotMap:
+    binding_context_json = """
+{
+    "binding": "groups-unique.deckhouse.io",
+    "review": {
+        "request": {
+            "uid": "8af60184-b30b-4b90-a33e-0c190f10e96d",
+            "kind": {
+                "group": "deckhouse.io",
+                "version": "v1alpha1",
+                "kind": "Group"
+            },
+            "resource": {
+                "group": "deckhouse.io",
+                "version": "v1alpha1",
+                "resource": "groups"
+            },
+            "requestKind": {
+                "group": "deckhouse.io",
+                "version": "v1alpha1",
+                "kind": "Group"
+            },
+            "requestResource": {
+                "group": "deckhouse.io",
+                "version": "v1alpha1",
+                "resource": "groups"
+            },
+            "name": "candi-admins",
+            "operation": "UPDATE",
+            "userInfo": {
+                "username": "kubernetes-admin",
+                "groups": [
+                    "system:masters",
+                    "system:authenticated"
+                ]
+            },
+            "object": {
+                "apiVersion": "deckhouse.io/v1alpha1",
+                "kind": "Group",
+                "metadata": {
+                    "creationTimestamp": "2023-07-17T13:40:39Z",
+                    "generation": 3,
+                    "managedFields": [
+                        {
+                            "apiVersion": "deckhouse.io/v1alpha1",
+                            "fieldsType": "FieldsV1",
+                            "fieldsV1": {
+                                "f:spec": {
+                                    ".": {},
+                                    "f:name": {}
+                                }
+                            },
+                            "manager": "deckhouse-controller",
+                            "operation": "Update",
+                            "time": "2023-07-17T13:40:39Z"
+                        },
+                        {
+                            "apiVersion": "deckhouse.io/v1alpha1",
+                            "fieldsType": "FieldsV1",
+                            "fieldsV1": {
+                                "f:spec": {
+                                    "f:members": {}
+                                }
+                            },
+                            "manager": "kubectl-edit",
+                            "operation": "Update",
+                            "time": "2024-11-21T14:44:35Z"
+                        }
+                    ],
+                    "name": "group-1",
+                    "resourceVersion": "1184522270",
+                    "uid": "7820c68b-6423-49f0-b97f-b7e314e23c0b"
+                },
+                "spec": {}
+            },
+            "oldObject": {
+                "apiVersion": "deckhouse.io/v1alpha1",
+                "kind": "Group",
+                "metadata": {
+                    "creationTimestamp": "2023-07-17T13:40:39Z",
+                    "generation": 2,
+                    "managedFields": [
+                        {
+                            "apiVersion": "deckhouse.io/v1alpha1",
+                            "fieldsType": "FieldsV1",
+                            "fieldsV1": {
+                                "f:spec": {
+                                    ".": {},
+                                    "f:name": {}
+                                }
+                            },
+                            "manager": "deckhouse-controller",
+                            "operation": "Update",
+                            "time": "2023-07-17T13:40:39Z"
+                        },
+                        {
+                            "apiVersion": "deckhouse.io/v1alpha1",
+                            "fieldsType": "FieldsV1",
+                            "fieldsV1": {
+                                "f:spec": {
+                                    "f:members": {}
+                                }
+                            },
+                            "manager": "kubectl-edit",
+                            "operation": "Update",
+                            "time": "2024-11-20T14:00:21Z"
+                        }
+                    ],
+                    "name": "candi-admins",
+                    "resourceVersion": "1184522270",
+                    "uid": "7820c68b-6423-49f0-b97f-b7e314e23c0b"
+                },
+                "spec": {
+                    "members": [
+                        {
+                            "kind": "User",
+                            "name": "superadmin"
+                        },
+                        {
+                            "kind": "Group",
+                            "name": "none-exists"
+                        }
+                    ],
+                    "name": "candi-admins"
+                }
+            },
+            "dryRun": false,
+            "options": {
+                "kind": "UpdateOptions",
+                "apiVersion": "meta.k8s.io/v1",
+                "fieldManager": "kubectl-edit",
+                "fieldValidation": "Strict"
+            }
+        }
+    },
+    "snapshots": {
+        "groups": [
+            {
+                "filterResult": {
+                    "groupName": "group-1",
+                    "members": [
+                        {
+                            "kind": "User",
+                            "name": "superadmin"
+                        }
+                    ],
+                    "name": "group-1"
+                }
+            },
+            {
+                "filterResult": {
+                    "groupName": "group-2",
+                    "members": [
+                        {
+                            "kind": "User",
+                            "name": "test"
+                        },
+                        {
+                            "kind": "Group",
+                            "name": "group-1"
+                        }
+                    ],
+                    "name": "group-2"
+                }
+            }
+        ],
+        "users": [
+            {
+                "filterResult": {
+                    "userName": "superadmin"
+                }
+            },
+            {
+                "filterResult": {
+                    "userName": "test"
+                }
+            }
+        ]
+    },
+    "type": "Validating"
+}
+"""
+    return _prepare_validation_binding_context(binding_context_json, new_spec)
+
+
+def _prepare_create_binding_context(new_spec: dict) -> DotMap:
+    binding_context_json = """
+{
+    "binding": "groups-unique.deckhouse.io",
+    "review": {
+        "request": {
+            "uid": "adedd292-0be9-476b-b2fa-8286053a1b1b",
+            "kind": {
+                "group": "deckhouse.io",
+                "version": "v1alpha1",
+                "kind": "Group"
+            },
+            "resource": {
+                "group": "deckhouse.io",
+                "version": "v1alpha1",
+                "resource": "groups"
+            },
+            "requestKind": {
+                "group": "deckhouse.io",
+                "version": "v1alpha1",
+                "kind": "Group"
+            },
+            "requestResource": {
+                "group": "deckhouse.io",
+                "version": "v1alpha1",
+                "resource": "groups"
+            },
+            "name": "new",
+            "operation": "CREATE",
+            "userInfo": {
+                "username": "kubernetes-admin",
+                "groups": [
+                    "system:masters",
+                    "system:authenticated"
+                ]
+            },
+            "object": {
+                "apiVersion": "deckhouse.io/v1alpha1",
+                "kind": "Group",
+                "metadata": {
+                    "creationTimestamp": "2024-11-22T08:00:33Z",
+                    "generation": 1,
+                    "managedFields": [
+                        {
+                            "apiVersion": "deckhouse.io/v1alpha1",
+                            "fieldsType": "FieldsV1",
+                            "fieldsV1": {
+                                "f:spec": {
+                                    ".": {},
+                                    "f:members": {},
+                                    "f:name": {}
+                                }
+                            },
+                            "manager": "kubectl-create",
+                            "operation": "Update",
+                            "time": "2024-11-22T08:00:33Z"
+                        }
+                    ],
+                    "name": "new",
+                    "uid": "f43bdc3f-61a2-4957-ae5a-241972717118"
+                },
+                "spec": {}
+            },
+            "oldObject": null,
+            "dryRun": false,
+            "options": {
+                "kind": "CreateOptions",
+                "apiVersion": "meta.k8s.io/v1",
+                "fieldManager": "kubectl-create",
+                "fieldValidation": "Strict"
+            }
+        }
+    },
+    "snapshots": {
+        "groups": [
+            {
+                "filterResult": {
+                    "groupName": "group-1",
+                    "members": [
+                        {
+                            "kind": "User",
+                            "name": "superadmin"
+                        },
+                        {
+                            "kind": "Group",
+                            "name": "group-2"
+                        },
+                        {
+                            "kind": "Group",
+                            "name": "new-group"
+                        }
+                    ],
+                    "name": "group-1"
+                }
+            },
+            {
+                "filterResult": {
+                    "groupName": "group-2",
+                    "members": [
+                        {
+                            "kind": "User",
+                            "name": "test"
+                        },
+                        {
+                            "kind": "Group",
+                            "name": "new-group"
+                        }
+                    ],
+                    "name": "group-2"
+                }
+            },
+            {
+                "filterResult": {
+                    "groupName": "group-3",
+                    "members": [
+                        {
+                            "kind": "User",
+                            "name": "test"
+                        },
+                        {
+                            "kind": "Group",
+                            "name": "new-group"
+                        }
+                    ],
+                    "name": "group-3"
+                }
+            }
+        ],
+        "users": [
+            {
+                "filterResult": {
+                    "userName": "superadmin"
+                }
+            },
+            {
+                "filterResult": {
+                    "userName": "test"
+                }
+            }
+        ]
+    },
+    "type": "Validating"
+}
+"""
+    return _prepare_validation_binding_context(binding_context_json, new_spec)
+
+
+class TestGroupCycleValidationWebhook(unittest.TestCase):
+    def test_create_group_should_fail_with_cycle_detected(self):
+        ctx = _prepare_create_binding_context({
+            "members": [
+                {
+                    "kind": "User",
+                    "name": "test"
+                },
+                {
+                    "kind": "Group",
+                    "name": "group-2"
+                }
+            ],
+            "name": "new-group"
+        })
+        out = hook.testrun(main, [ctx])
+        err_msg = (f'Invalid group hierarchy: cycle detected! Path: groups.deckhouse.io("group-1" -> "group-2" -> '
+                   '"new-group" -> "group-2"). Groups must form a tree without circular references.')
+        tests.assert_validation_deny(self, out, err_msg)
+
+    def test_create_group_should_fail_with_cycle_detected_2(self):
+        ctx = _prepare_create_binding_context({
+            "members": [
+                {
+                    "kind": "User",
+                    "name": "test"
+                },
+                {
+                    "kind": "Group",
+                    "name": "new-group"
+                }
+            ],
+            "name": "new-group"
+        })
+        out = hook.testrun(main, [ctx])
+        err_msg = (f'Invalid group hierarchy: cycle detected! Path: groups.deckhouse.io("group-1" -> "group-2" -> '
+                   '"new-group" -> "new-group"). Groups must form a tree without circular references.')
+        tests.assert_validation_deny(self, out, err_msg)
+
+    def test_update_group_should_fail_with_cycle_detected(self):
+        ctx = _prepare_update_binding_context({
+            "members": [
+                {
+                    "kind": "User",
+                    "name": "superadmin"
+                },
+                {
+                    "kind": "Group",
+                    "name": "group-2"
+                },
+                {
+                    "kind": "User",
+                    "name": "not-exists"
+                }
+            ],
+            "name": "group-1"
+        })
+        out = hook.testrun(main, [ctx])
+        err_msg = (f'Invalid group hierarchy: cycle detected! Path: groups.deckhouse.io("group-1" -> "group-2" -> '
+                   '"group-1"). Groups must form a tree without circular references.')
+        tests.assert_validation_deny(self, out, err_msg)
+
+    def test_update_group_should_fail_with_cycle_detected_2(self):
+        ctx = _prepare_update_binding_context({
+            "members": [
+                {
+                    "kind": "User",
+                    "name": "superadmin"
+                },
+                {
+                    "kind": "Group",
+                    "name": "group-1"
+                },
+                {
+                    "kind": "User",
+                    "name": "not-exists"
+                }
+            ],
+            "name": "group-1"
+        })
+        out = hook.testrun(main, [ctx])
+        err_msg = (f'Invalid group hierarchy: cycle detected! Path: groups.deckhouse.io("group-2" -> "group-1" -> '
+                   '"group-1"). Groups must form a tree without circular references.')
+        tests.assert_validation_deny(self, out, err_msg)
+
+    def test_should_create_group(self):
+        ctx = _prepare_create_binding_context({
+            "members": [
+                {
+                    "kind": "User",
+                    "name": "test"
+                },
+                {
+                    "kind": "Group",
+                    "name": "some-none-exists-group"
+                }
+            ],
+            "name": "new-group"
+        })
+        out = hook.testrun(main, [ctx])
+        tests.assert_validation_allowed(self, out, None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/modules/150-user-authn/webhooks/validating/group_test.py
+++ b/modules/150-user-authn/webhooks/validating/group_test.py
@@ -512,7 +512,7 @@ class TestGroupValidationWebhook(unittest.TestCase):
                 },
                 {
                     "kind": "Group",
-                    "name": "candi-admins"
+                    "name": "candi-admins-2"
                 }
             ],
             "name": "candi-admins"


### PR DESCRIPTION
## Description
Add `Group` validation webhook which detects recursive loops in nested group's hierarchy.


## Why do we need it, and what problem does it solve?
Users can create `Groups` with  potentially cycled nested subgroups relations, resulting in infinite loops when resolving dependent subgroups. Example stack trace is shown below.

```
{"level":"info","msg":"Binding contexts from tasks. Tasks are dropped from queue","count":2,"filteredCount":1,"queueName":"/modules/user-authn","tasks":"are combined and compacted to 1 contexts","time":"2025-08-19T12:52:17Z"}
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc029790340 stack=[0xc029790000, 0xc049790000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x3b60fb9?, 0x200000008?})
    /usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0xc001815e90 sp=0xc001815e60 pc=0x479dc8
runtime.newstack()
    /usr/local/go/src/runtime/stack.go:1107 +0x5bb fp=0xc001815fc8 sp=0xc001815e90 pc=0x45de5b
runtime.morestack()
    /usr/local/go/src/runtime/asm_amd64.s:621 +0x7a fp=0xc001815fd0 sp=0xc001815fc8 pc=0x48085a

goroutine 7978 gp=0xc005bf7180 m=30 mp=0xc001800008 [running]:
github.com/deckhouse/deckhouse/modules/150-user-authn/hooks.makeUserGroupsMap({0xc004d0f530, 0x1, 0x1}, {0xc00511c700, 0xc}, {0xc004d0f560, 0x1, 0x1}, 0xc04978e460)
    /deckhouse/modules/150-user-authn/hooks/get_dex_user_crds.go:218 +0x5fe fp=0xc029790350 sp=0xc029790348 pc=0x2b3b3fe
github.com/deckhouse/deckhouse/modules/150-user-authn/hooks.makeUserGroupsMap({0xc004d0f530, 0x1, 0x1}, {0xc00511c700, 0xc}, {0xc004d0f560, 0x1, 0x1}, 0xc04978e460)
    /deckhouse/modules/150-user-authn/hooks/get_dex_user_crds.go:245 +0x4a7 fp=0xc029790420 sp=0xc029790350 pc=0x2b3b2a7
github.com/deckhouse/deckhouse/modules/150-user-authn/hooks.makeUserGroupsMap({0xc004d0f530, 0x1, 0x1}, {0xc00511c700, 0xc}, {0xc004d0f560, 0x1, 0x1}, 0xc04978e460)
    /deckhouse/modules/150-user-authn/hooks/get_dex_user_crds.go:245 +0x4a7 fp=0xc0297904f0 sp=0xc029790420 pc=0x2b3b2a7
github.com/deckhouse/deckhouse/modules/150-user-authn/hooks.makeUserGroupsMap({0xc004d0f530, 0x1, 0x1}, {0xc00511c700, 0xc}, {0xc004d0f560, 0x1, 0x1}, 0xc04978e460)
    /deckhouse/modules/150-user-authn/hooks/get_dex_user_crds.go:245 +0x4a7 fp=0xc0297905c0 sp=0xc0297904f0 pc=0x2b3b2a7
github.com/deckhouse/deckhouse/modules/150-user-authn/hooks.makeUserGroupsMap({0xc004d0f530, 0x1, 0x1}, {0xc00511c700, 0xc}, {0xc004d0f560, 0x1, 0x1}, 0xc04978e460)
    /deckhouse/modules/150-user-authn/hooks/get_dex_user_crds.go:245 +0x4a7 fp=0xc029790690 sp=0xc0297905c0 pc=0x2b3b2a7
github.com/deckhouse/deckhouse/modules/150-user-authn/hooks.makeUserGroupsMap({0xc004d0f530, 0x1, 0x1}, {0xc00511c700, 0xc}, {0xc004d0f560, 0x1, 0x1}, 0xc04978e460)
    /deckhouse/modules/150-user-authn/hooks/get_dex_user_crds.go:245 +0x4a7 fp=0xc029790760 sp=0xc029790690 pc=0x2b3b2a7
github.com/deckhouse/deckhouse/modules/150-user-authn/hooks.makeUserGroupsMap({0xc004d0f530, 0x1, 0x1}, {0xc00511c700, 0xc}, {0xc004d0f560, 0x1, 0x1}, 0xc04978e460)
```

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: user-authn
type: fix
summary: "User now can't create groups with  recursive loops in nested group's hierarchy"
impact_level: default
```
