### PR TITLE
[cloud-provider-huaweicloud] Add missing volumeTypeMap property for nodeGroups

### DIFF
--- a/ee/candi/cloud-providers/huaweicloud/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/huaweicloud/openapi/cluster_configuration.yaml
@@ -218,6 +218,17 @@ apiVersions:
                 Partial contents of the fields.
               properties:
                 <<: *instanceClassProperties
+            volumeTypeMap:
+              description: |
+                A dictionary of disk types for storing Kubernetes configuration files.
+
+                Format of dictionary elements: `<AVAILABILITY ZONE>: <DISK TYPE>` (see the example).
+
+                If the `rootDiskSize` parameter is specified, the same disk type will be used for the VM's boot drive.
+
+                We recommend using the fastest disks provided by the provider in all cases.
+
+                If the value specified in `replicas` exceeds the number of elements in the dictionary, the master nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then master-0, master-2, master-4 will have the `fast-eu-1a` disk type, while master-1, master-3 will have the `fast-eu-1b` disk type.
       layout:
         description: |
           The layout name.

--- a/ee/modules/030-cloud-provider-huaweicloud/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/openapi/values.yaml
@@ -24,41 +24,41 @@ properties:
         x-doc-search: |
           ProviderClusterConfiguration
         x-examples:
-        - apiVersion: deckhouse.io/v1
-          kind: HuaweiCloudClusterConfiguration
-          layout: Standard
-          sshPublicKey: "<SSH_PUBLIC_KEY>"
-          zones:
-            - eu-3a
-          standard:
-            externalNetworkName: "external-network"
-          provider:
-            domainName: '<DOMAIN_NAME>'
-            region: 'eu-3'
-            accessKey: '<USERNAME>'
-            secretKey: '<PASSWORD>'
-          masterNodeGroup:
-            replicas: 1
-            instanceClass:
-              rootDiskSize: 50
-              imageName: "debian-11-genericcloud-amd64-20220911-1135"
-          nodeGroups:
-            - name: front
-              replicas: 2
+          - apiVersion: deckhouse.io/v1
+            kind: HuaweiCloudClusterConfiguration
+            layout: Standard
+            sshPublicKey: "<SSH_PUBLIC_KEY>"
+            zones:
+              - eu-3a
+            standard:
+              externalNetworkName: "external-network"
+            provider:
+              domainName: '<DOMAIN_NAME>'
+              region: 'eu-3'
+              accessKey: '<USERNAME>'
+              secretKey: '<PASSWORD>'
+            masterNodeGroup:
+              replicas: 1
               instanceClass:
-                flavorName: m1.large
-                imageName: "debian-11-genericcloud-amd64-20220911-1135"
                 rootDiskSize: 50
-                configDrive: false
-                floatingIPPools:
-                  - public
-                  - shared
-                additionalSecurityGroups:
-                  - sec_group_1
-                  - sec_group_2
-              zones:
-                - eu-1a
-                - eu-1b
+                imageName: "debian-11-genericcloud-amd64-20220911-1135"
+            nodeGroups:
+              - name: front
+                replicas: 2
+                instanceClass:
+                  flavorName: m1.large
+                  imageName: "debian-11-genericcloud-amd64-20220911-1135"
+                  rootDiskSize: 50
+                  configDrive: false
+                  floatingIPPools:
+                    - public
+                    - shared
+                  additionalSecurityGroups:
+                    - sec_group_1
+                    - sec_group_2
+                zones:
+                  - eu-1a
+                  - eu-1b
         required: [apiVersion, kind, layout, provider, sshPublicKey, masterNodeGroup]
         properties:
           apiVersion:
@@ -69,7 +69,8 @@ properties:
             enum: [HuaweiCloudClusterConfiguration]
           sshPublicKey:
             type: string
-            description: A public key for accessing nodes.
+            description: |
+              A public key for accessing nodes.
           zones:
             type: array
             items:
@@ -77,16 +78,17 @@ properties:
             minItems: 1
             uniqueItems: true
             description: |
-              The globally restricted set of zones the cloud provider works with.
+              The globally restricted set of zones that this cloud provider works with.
             x-doc-required: false
           masterNodeGroup:
-            type: object
-            additionalProperties: false
-            required: [replicas, instanceClass, volumeTypeMap]
             description: |
               The definition of a NodeGroup for master nodes.
 
-              > For the changes to take effect, run `dhctl converge` after modifying the parameters of this section.
+              > For the changes to take effect, run `dhctl converge` after modifying the parameters of the `masterNodeGroup` section.
+            x-doc-required: true
+            x-unsafe-rules: [updateMasterImage]
+            additionalProperties: false
+            required: [replicas, instanceClass, volumeTypeMap]
             properties:
               replicas:
                 type: integer
@@ -96,7 +98,7 @@ properties:
                 x-unsafe-rules: [updateReplicas]
               instanceClass:
                 description: |
-                  Partial contents of the fields of the [HuaweiCloudInstanceClass](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/cloud-provider-huaweicloud/cr.html#huaweicloudinstanceclass).
+                  Partial contents of the fields of the [HuaweiCloudInstanceClass](./cr.html#huaweicloudinstanceclass).
                 type: object
                 required: [flavorName, imageName]
                 additionalProperties: false
@@ -105,18 +107,10 @@ properties:
                     type: string
                     description: |
                       The flavor of Huawei Cloud servers.
-
-                      To get a list of all available flavors, run the following command: `huaweicloud flavor list`.
-
-                      For all non-master nodes, it's recommended that you use a flavor that includes a local disk. If the cloud provider supports local disks, they're usually faster and cheaper. The disadvantage of using such a flavor is the inability to migrate nodes between hypervisors.
-
-                      Example of the flavor creation command: `huaweicloud flavor create c4m8d50 --ram 8192 --disk 50 --vcpus 4`
                     x-doc-required: true
                   imageName: &instanceClassImageName
                     description: |
                       The image to use while provisioning Huawei Cloud servers.
-
-                      To get a list of available images, run the following command: `huaweicloud image list`.
 
                       For the list of operating systems and specific versions supported by Deckhouse, refer to [Supported Kubernetes and OS versions](https://deckhouse.io/products/kubernetes-platform/documentation/v1/supported_versions.html) (take into account the Deckhouse version you use).
                     type: string
@@ -126,6 +120,8 @@ properties:
                       The size of a root disk in gigabytes.
 
                       This parameter also affects the type of a root disk.
+                    example: 50
+                    default: 50
                     type: integer
                   etcdDiskSizeGb:
                     description: |
@@ -144,10 +140,6 @@ properties:
                   We recommend using the fastest disks provided by the provider in all cases.
 
                   If the value specified in `replicas` exceeds the number of elements in the dictionary, the master nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then master-0, master-2, master-4 will have the `fast-eu-1a` disk type, while master-1, master-3 will have the `fast-eu-1b` disk type.
-
-                  Useful commands:
-                  - `openstack availability zone list`: Get a list of availability zones.
-                  - `openstack volume type list`: Get a list of volume types.
                 x-examples:
                   - eu-1a: fast-eu-1a
                     eu-1b: fast-eu-1b
@@ -160,11 +152,11 @@ properties:
                 type: object
                 description: |
                   The ServerGroup object groups instances together. The instances in the group are placed on the same hypervisor (affinity) or different hypervisors (anti-affinity). This allows you to increase the fault tolerance of the cluster.
-                required: [ policy ]
+                required: [policy]
                 properties:
                   policy:
                     type: string
-                    enum: [ AntiAffinity ]
+                    enum: [AntiAffinity]
                     description: |
                       The policy that determines how instances are distributed among hypervisors.
 
@@ -172,7 +164,7 @@ properties:
           nodeGroups:
             type: array
             description: |
-              An array of additional NodeGroups for creating static nodes (for example, for dedicated front nodes or gateways).
+              An array of additional NodeGroups for creating static nodes (e.g., for dedicated front nodes or gateways).
             items:
               type: object
               required: [name, replicas, instanceClass]
@@ -192,12 +184,14 @@ properties:
                     labels:
                       type: object
                       description: |
-                        A list of labels to attach to cluster resources.
+                        A list of labels to attach to all cluster resources, if they support it.
 
                         The same as the [`metadata.labels` standard field](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta).
+
+                        If you change a label on a running cluster, recreate all virtual machines after the changes come into effect.
                       x-examples:
-                      - environment: production
-                        app: warp-drive-ai
+                        - environment: production
+                          app: warp-drive-ai
                       additionalProperties:
                         type: string
                     annotations:
@@ -205,7 +199,7 @@ properties:
                       description: |
                         The same as the [`metadata.annotations` standard field](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta).
                       x-examples:
-                      - ai.fleet.com/discombobulate: "true"
+                        - ai.fleet.com/discombobulate: "true"
                       additionalProperties:
                         type: string
                     taints:
@@ -215,9 +209,9 @@ properties:
 
                         > Available fields: `effect`, `key`, and `values`.
                       x-examples:
-                      - - effect: NoExecute
-                          key: ship-class
-                          value: frigate
+                        - - effect: NoExecute
+                            key: ship-class
+                            value: frigate
                       items:
                         type: object
                         properties:
@@ -233,53 +227,64 @@ properties:
                   additionalProperties: false
                   required: [flavorName, imageName]
                   description: |
-                    Partial contents of the fields of the [HuaweiCloudInstanceClass](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/cloud-provider-huaweicloud/cr.html#huaweicloudinstanceclass).
+                    Partial contents of the fields.
                   properties:
-                    <<: *instanceClassProperties
+                    !!merge <<: *instanceClassProperties
+                volumeTypeMap:
+                  description: |
+                    A dictionary of disk types for storing Kubernetes configuration files.
+
+                    Format of dictionary elements: `<AVAILABILITY ZONE>: <DISK TYPE>` (see the example).
+
+                    If the `rootDiskSize` parameter is specified, the same disk type will be used for the VM's boot drive.
+
+                    We recommend using the fastest disks provided by the provider in all cases.
+
+                    If the value specified in `replicas` exceeds the number of elements in the dictionary, the master nodes whose number exceeds the length of the dictionary get the values starting from the beginning of the dictionary. For example, if `replicas: 5`, then master-0, master-2, master-4 will have the `fast-eu-1a` disk type, while master-1, master-3 will have the `fast-eu-1b` disk type.
           layout:
-            type: string
             description: |
               The layout name.
 
-              For details about possible provider layouts, refer to [Layouts](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/cloud-provider-huaweicloud/layouts.html).
+              For details about possible provider layouts, refer to [Layouts](./layouts.html).
+            type: string
             x-unsafe: true
           standard:
             type: object
             description: |
-              Settings for the [`Standard` layout](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/cloud-provider-huaweicloud/layouts.html#standard).
+              Settings for the [`Standard` layout](./layouts.html#standard).
             additionalProperties: false
             required: [internalNetworkCIDR]
             properties:
               internalNetworkCIDR: &internalNetworkCIDR
                 description: |
-                  The routing for the internal cluster node network.
+                  Routing for the internal cluster node network.
                 type: string
                 pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
                 x-unsafe: true
               internalNetworkDNSServers:
                 description: |
-                  A list of addresses of the recursive DNSs of the internal cluster node network.
+                  A list of addresses of the recursive DNSs for the internal cluster node network.
                 type: array
                 items:
                   type: string
                   pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
               internalNetworkSecurity: &internalNetworkSecurity
                 description: |
-                  Defines whether [SecurityGroups](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/cloud-provider-huaweicloud/faq.html#how-to-check-whether-the-provider-supports-securitygroups) must be configured for the internal network ports.
+                  Defines whether [SecurityGroups](./cr.html#huaweicloudinstanceclass-v1-spec-securitygroups) must be configured for the internal network ports.
                 type: boolean
                 default: true
               enableEIP:
                 description: |
-                    Enable Elastic IP for the master nodes.
+                  Enable Elastic IP for the master nodes.
                 type: boolean
                 pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$'
                 x-unsafe: true
           vpcPeering:
             type: object
             description: |
-              Settings for the [`Standard` layout](./layouts.html#standard).
+              Settings for the [`VpcPeering` layout](./layouts.html#vpcpeering).
             additionalProperties: false
-            required: [ internalNetworkCIDR ]
+            required: [internalNetworkCIDR]
             properties:
               internalNetworkCIDR: &internalNetworkCIDR
                 description: |
@@ -305,9 +310,9 @@ properties:
                 type: string
           provider:
             description: |
-              Contains [Huawei Cloud API connection settings](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/cloud-provider-huaweicloud/environment.html).
+              Huawei Cloud API [connection settings](./environment.html).
 
-              These settings match the ones in the `connection` field of the [cloud-provider-huaweicloud](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/cloud-provider-huaweicloud/configuration.html#parameters) module.
+              These settings match the ones in the `connection` field of the [cloud-provider-huaweicloud](./configuration.html) module.
             type: object
             additionalProperties: false
             required: [cloud, region, accessKey, secretKey]
@@ -324,11 +329,11 @@ properties:
               accessKey:
                 type: string
                 description: |
-                  The Huawei Cloud access key to use.
+                  The Huawei Cloud access key.
               secretKey:
                 type: string
                 description: |
-                  The Huawei Cloud secret key to use.
+                  The Huawei Cloud secret key.
               insecure:
                 type: boolean
                 description: |
@@ -352,26 +357,26 @@ properties:
       providerDiscoveryData:
         type: object
         additionalProperties: false
-        required: [ apiVersion, kind ]
+        required: [apiVersion, kind]
         x-examples:
-        - apiVersion: deckhouse.io/v1
-          kind: HuaweiCloudDiscoveryData
-          layout: Standard
-          zones:
-            - eu-3a
-          instances:
-            vpcIPv4SubnetId: "00000000-0000-0000-0000-000000000000"
-          volumeTypes:
-          - id: "00000000-0000-0000-0000-000000000000"
-            name: "ssd"
-            isPublic: true
+          - apiVersion: deckhouse.io/v1
+            kind: HuaweiCloudDiscoveryData
+            layout: Standard
+            zones:
+              - eu-3a
+            instances:
+              vpcIPv4SubnetId: "00000000-0000-0000-0000-000000000000"
+            volumeTypes:
+              - id: "00000000-0000-0000-0000-000000000000"
+                name: "ssd"
+                isPublic: true
         properties:
           apiVersion:
             type: string
-            enum: [ deckhouse.io/v1 ]
+            enum: [deckhouse.io/v1]
           kind:
             type: string
-            enum: [ HuaweiCloudDiscoveryData ]
+            enum: [HuaweiCloudDiscoveryData]
           layout:
             type: string
             enum: [Standard, VpcPeering]


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add missing volumeTypeMap property for nodeGroups.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Currently, it is impossible to create a CloudPermanent node due to a configuration error.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi, cloud-provider-huaweicloud
type: fix
summary: Add missing volumeTypeMap property for nodeGroups.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
