### PR TITLE
[docs] Add steps that patch secret and prevent the image pull fail

### DIFF
--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -1099,7 +1099,7 @@ To switch to `Unmanaged` mode, follow the [instruction](modules/registry/example
    ```shell
    DOCKER_CONFIG_JSON=$(echo -n "{\"auths\": {\"registry.deckhouse.io\": {\"username\": \"license-token\", \"password\": \"${LICENSE_TOKEN}\", \"auth\": \"${AUTH_STRING}\"}}}" | base64 -w 0)
    kubectl --as system:sudouser -n d8-cloud-instance-manager patch secret deckhouse-registry --type merge --patch="{\"data\":{\".dockerconfigjson\":\"$DOCKER_CONFIG_JSON\"}}"  
-   kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller helper change-registry --user=license-token --password=$LICENSE_TOKEN --new-deckhouse-tag=$DECKHOUSE_VERSION registry.deckhouse.ru/deckhouse/$NEW_EDITION
+   kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller helper change-registry --user=license-token --password=$LICENSE_TOKEN --new-deckhouse-tag=$DECKHOUSE_VERSION registry.deckhouse.io/deckhouse/$NEW_EDITION
    ```
 
    To switch to CE edition:

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -1097,7 +1097,10 @@ To switch to `Unmanaged` mode, follow the [instruction](modules/registry/example
    To switch to BE/SE/SE+/EE editions:
 
    ```shell
-   kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller helper change-registry --user=license-token --password=$LICENSE_TOKEN --new-deckhouse-tag=$DECKHOUSE_VERSION registry.deckhouse.io/deckhouse/$NEW_EDITION
+   DOCKER_CONFIG_JSON=$(echo -n "{\"auths\": {\"registry.deckhouse.io\": {\"username\": \"license-token\", \"password\": \"${LICENSE_TOKEN}\", \"auth\": \"${AUTH_STRING}\"}}}" | base64 -w 0)
+   kubectl -n d8-system exec -it deploy/deckhouse -- bash -c "
+   kubectl -n d8-system exec -it deploy/deckhouse -- bash -c " kubectl patch secret -n d8-cloud-instance-manager deckhouse-registry -p='{\"data\":{\".dockerconfigjson\":\"$DOCKER_CONFIG_JSON\"}}' "
+   kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller helper change-registry --user=license-token --password=$LICENSE_TOKEN --new-deckhouse-tag=$DECKHOUSE_VERSION registry.deckhouse.ru/deckhouse/$NEW_EDITION
    ```
 
    To switch to CE edition:

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -1098,8 +1098,7 @@ To switch to `Unmanaged` mode, follow the [instruction](modules/registry/example
 
    ```shell
    DOCKER_CONFIG_JSON=$(echo -n "{\"auths\": {\"registry.deckhouse.io\": {\"username\": \"license-token\", \"password\": \"${LICENSE_TOKEN}\", \"auth\": \"${AUTH_STRING}\"}}}" | base64 -w 0)
-   kubectl -n d8-system exec -it deploy/deckhouse -- bash -c "
-   kubectl -n d8-system exec -it deploy/deckhouse -- bash -c " kubectl patch secret -n d8-cloud-instance-manager deckhouse-registry -p='{\"data\":{\".dockerconfigjson\":\"$DOCKER_CONFIG_JSON\"}}' "
+   kubectl --as system:sudouser -n d8-cloud-instance-manager patch secret deckhouse-registry --type merge --patch="{\"data\":{\".dockerconfigjson\":\"$DOCKER_CONFIG_JSON\"}}"  
    kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller helper change-registry --user=license-token --password=$LICENSE_TOKEN --new-deckhouse-tag=$DECKHOUSE_VERSION registry.deckhouse.ru/deckhouse/$NEW_EDITION
    ```
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -1104,6 +1104,9 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
    Для переключения на BE/SE/SE+/EE издания:
 
    ```shell
+   DOCKER_CONFIG_JSON=$(echo -n "{\"auths\": {\"registry.deckhouse.io\": {\"username\": \"license-token\", \"password\": \"${LICENSE_TOKEN}\", \"auth\": \"${AUTH_STRING}\"}}}" | base64 -w 0)
+   kubectl -n d8-system exec -it deploy/deckhouse -- bash -c "
+   kubectl -n d8-system exec -it deploy/deckhouse -- bash -c " kubectl patch secret -n d8-cloud-instance-manager deckhouse-registry -p='{\"data\":{\".dockerconfigjson\":\"$DOCKER_CONFIG_JSON\"}}' "
    kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller helper change-registry --user=license-token --password=$LICENSE_TOKEN --new-deckhouse-tag=$DECKHOUSE_VERSION registry.deckhouse.ru/deckhouse/$NEW_EDITION
    ```
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -1105,8 +1105,7 @@ kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-con
 
    ```shell
    DOCKER_CONFIG_JSON=$(echo -n "{\"auths\": {\"registry.deckhouse.io\": {\"username\": \"license-token\", \"password\": \"${LICENSE_TOKEN}\", \"auth\": \"${AUTH_STRING}\"}}}" | base64 -w 0)
-   kubectl -n d8-system exec -it deploy/deckhouse -- bash -c "
-   kubectl -n d8-system exec -it deploy/deckhouse -- bash -c " kubectl patch secret -n d8-cloud-instance-manager deckhouse-registry -p='{\"data\":{\".dockerconfigjson\":\"$DOCKER_CONFIG_JSON\"}}' "
+   kubectl --as system:sudouser -n d8-cloud-instance-manager patch secret deckhouse-registry --type merge --patch="{\"data\":{\".dockerconfigjson\":\"$DOCKER_CONFIG_JSON\"}}"  
    kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller helper change-registry --user=license-token --password=$LICENSE_TOKEN --new-deckhouse-tag=$DECKHOUSE_VERSION registry.deckhouse.ru/deckhouse/$NEW_EDITION
    ```
 


### PR DESCRIPTION
## Description

Added steps how to patch secret before `deckhouse-controller helper change-registry`.


## Why do we need it, and what problem does it solve?

It solves problem with incorrect `.dockerconfigjson` after `deckhouse-controller helper change-registry`.


## Why do we need it in the patch release (if we do)?

<!---
Prevent errors during image pull while DH editions was changed.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Added steps that patch secret and prevented the image pull fail.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
