### PR TITLE
[docs] Delete annotation from Yandex hybrid documentation

### DIFF
--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW.md
@@ -89,16 +89,6 @@ To create a hybrid cluster combining static nodes and nodes in Yandex Cloud, fol
 
 ### Setup steps
 
-1. Add an annotation to all existing static node groups (NodeGroup resources) exclude nodes from Cluster Autoscaler deletion:
-
-   ```yaml
-   metadata:
-    annotations:
-      cluster-autoscaler.kubernetes.io/scale-down-disabled: "true"
-   ```
-
-   This annotation prevents adding taints such as `ToBeDeletedByClusterAutoscaler` and `DeletionCandidateOfClusterAutoscaler` to nodes that are not managed by `machine-controller-manager` (e.g., `static` and `CloudPermanent`). [More info](https://github.com/deckhouse/deckhouse/issues/5252).
-
 1. Create a Service Account in the required Yandex Cloud folder:
 
    - Assign the `editor` role.

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW_RU.md
@@ -80,16 +80,6 @@ volumeBindingMode: WaitForFirstConsumer
 
 ### Шаги по настройке
 
-1. Добавьте аннотацию ко всем текущим группам статических узлов (ресурсам NodeGroup), чтобы исключить узлы из процесса удаления Cluster Autoscaler:
-
-   ```yaml
-   metadata:
-    annotations:
-      cluster-autoscaler.kubernetes.io/scale-down-disabled: "true"
-   ```
-
-   Эта аннотация предотвращает добавление taints типа `ToBeDeletedByClusterAutoscaler` и `DeletionCandidateOfClusterAutoscaler` к узлам, которые не управляются `machine-controller-manager` (например, `static` и `CloudPermanent`). [Подробнее](https://github.com/deckhouse/deckhouse/issues/5252).
-
 1. Создайте Service Account в нужном каталоге Yandex Cloud:
 
    - Назначьте роль `editor`.


### PR DESCRIPTION
## Description
Deleted annotation from Yandex hybrid documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Deleted annotation from Yandex hybrid documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
