### PR TITLE
[cloud-provider-huaweicloud] Fix providerID format and exclude 127.0.0.0/8 in node IP selection

### DIFF
--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/004-fix_providerid_and_exclude_loopback_in_node_IP_selection.patch
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/004-fix_providerid_and_exclude_loopback_in_node_IP_selection.patch
@@ -1,0 +1,66 @@
+Subject: [PATCH] fix providerID format and exclude loopback subnet in node IP selection
+---
+Index: pkg/cloudprovider/huaweicloud/instances.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/cloudprovider/huaweicloud/instances.go b/pkg/cloudprovider/huaweicloud/instances.go
+--- a/pkg/cloudprovider/huaweicloud/instances.go	(revision 037c9107fd4a33aa924b5c7c55e9578cfc61aa01)
++++ b/pkg/cloudprovider/huaweicloud/instances.go	(revision ddb4621b8829edd32df8a0d83cd387c9a7a698c5)
+@@ -208,7 +208,7 @@
+ 		if err != nil {
+ 			return nil, err
+ 		}
+-		providerID = id
++		providerID = fmt.Sprintf("%s://%s", ProviderName, id)
+ 	}
+ 	instanceID, err := parseInstanceID(providerID)
+ 	if err != nil {
+Index: pkg/cloudprovider/huaweicloud/wrapper/ecs.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/cloudprovider/huaweicloud/wrapper/ecs.go b/pkg/cloudprovider/huaweicloud/wrapper/ecs.go
+--- a/pkg/cloudprovider/huaweicloud/wrapper/ecs.go	(revision 037c9107fd4a33aa924b5c7c55e9578cfc61aa01)
++++ b/pkg/cloudprovider/huaweicloud/wrapper/ecs.go	(revision ddb4621b8829edd32df8a0d83cd387c9a7a698c5)
+@@ -52,19 +52,27 @@
+ 	return rst, err
+ }
+ 
+-func (e *EcsClient) GetByNodeName(name string) (*model.ServerDetail, error) {
+-	privateIP := ""
++func getPrivateIPbyName(name string) string {
+ 	if net.ParseIP(name).To4() != nil {
+-		privateIP = name
+-	} else if ips := utils.LookupHost(name); len(ips) > 0 {
+-		for _, ip := range ips {
+-			if ip != "127.0.0.1" {
+-				privateIP = ip
+-				break
+-			}
+-		}
+-	}
++		return name
++	}
++
++	_, loopbackNet, _ := net.ParseCIDR("127.0.0.0/8")
++	ips, err := net.LookupIP(name)
++	if err != nil {
++		return ""
++	}
++
++	for _, ip := range ips {
++		if !loopbackNet.Contains(ip) {
++			return ip.String()
++		}
++	}
++	return ""
++}
+ 
++func (e *EcsClient) GetByNodeName(name string) (*model.ServerDetail, error) {
++	privateIP := getPrivateIPbyName(name)
+ 	if privateIP == "" {
+ 		klog.V(6).Infof("query ECS detail by name: %s", name)
+ 		return e.GetByName(name)

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/README.md
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/README.md
@@ -13,3 +13,7 @@ For each `Service`, two load balancers were provisioned: one with the correct cl
 ### 003-enterprise-project-id.patch
 
 Add support enterprise-project-id
+
+### 004-fix_providerid_and_exclude_loopback_in_node_IP_selection.patch
+
+Fix providerID format and exclude 127.0.0.0/8 in node IP selection


### PR DESCRIPTION
## Description
Fix providerID format and exclude 127.0.0.0/8 in node IP selection

## Why do we need it, and what problem does it solve?
Currently, only `127.0.0.1` is excluded from IP selection and host IP lookup fails if its `/etc/hosts` contains `127.0.1.1` entry

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-huaweicloud
type: fix
summary: fix providerID format and exclude 127.0.0.0/8 in node IP selection
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
