### PR TITLE
[docs] Fix relative links in multitenancy-manager module

### DIFF
--- a/modules/160-multitenancy-manager/docs/README.md
+++ b/modules/160-multitenancy-manager/docs/README.md
@@ -22,7 +22,7 @@ The configuration capabilities of `Namespace` do not fully meet modern developme
 The functionality of projects allows addressing these issues.
 
 {% alert level="warning" %}
-The `secret-copier` module [cannot be used together](../secret-copier/) with `multitenancy-manager` module.
+The `secret-copier` module [cannot be used together](./secret-copier/) with `multitenancy-manager` module.
 {% endalert %}
 
 ## Advantages of the module
@@ -48,13 +48,13 @@ The module works only within the limits below:
 ### Creating a project
 
 To create projects, the following [Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) are used:
-* [ProjectTemplate](cr.html#projecttemplate) — a resource that describes the project template. It defines a list of resources to be created in the project and a schema for parameters that can be passed when creating the project;
-* [Project](cr.html#project) — a resource that describes a specific project.
+* [ProjectTemplate](./multitenancy-manager/cr.html#projecttemplate) — a resource that describes the project template. It defines a list of resources to be created in the project and a schema for parameters that can be passed when creating the project;
+* [Project](./multitenancy-manager/cr.html#project) — a resource that describes a specific project.
 
-When creating a [Project](cr.html#project) resource from a specific [ProjectTemplate](cr.html#projecttemplate), the following happens:
-1. The [parameters](cr.html#project-v1alpha2-spec-parameters) passed are validated against the OpenAPI specification (the [openAPI](cr.html#projecttemplate-v1alpha1-spec-parametersschema) field of [ProjectTemplate](cr.html#projecttemplate));
-1. Rendering of the [resources template](cr.html#projecttemplate-v1alpha1-spec-resourcestemplate) is performed using [Helm](https://helm.sh/docs/). Values for rendering are taken from the [parameters](cr.html#projecttemplate-v1alpha1-spec-parametersschema) field of the [Project](cr.html#project) resource;
-1. A `Namespace` is created with a name matching the name of [Project](cr.html#project);
+When creating a [Project](./multitenancy-manager/cr.html#project) resource from a specific [ProjectTemplate](./multitenancy-manager/cr.html#projecttemplate), the following happens:
+1. The [parameters](./multitenancy-manager/cr.html#project-v1alpha2-spec-parameters) passed are validated against the OpenAPI specification (the [openAPI](./multitenancy-manager/cr.html#projecttemplate-v1alpha1-spec-parametersschema) field of [ProjectTemplate](./multitenancy-manager/cr.html#projecttemplate));
+1. Rendering of the [resources template](./multitenancy-manager/cr.html#projecttemplate-v1alpha1-spec-resourcestemplate) is performed using [Helm](https://helm.sh/docs/). Values for rendering are taken from the [parameters](./multitenancy-manager/cr.html#projecttemplate-v1alpha1-spec-parametersschema) field of the [Project](./multitenancy-manager/cr.html#project) resource;
+1. A `Namespace` is created with a name matching the name of [Project](./multitenancy-manager/cr.html#project);
 1. All resources described in the template are created in sequence.
 
 > **Attention!** When changing the project template, all created projects will be updated according to the new template.

--- a/modules/160-multitenancy-manager/docs/README_RU.md
+++ b/modules/160-multitenancy-manager/docs/README_RU.md
@@ -25,7 +25,7 @@ description: Мультитенантность и проекты в Kubernetes.
 Функционал проектов позволяет решить эти проблемы.
 
 {% alert level="warning" %}
-Модуль `secret-copier` [не может использоваться совместно](../secret-copier/) с модулем `multitenancy-manager`.
+Модуль `secret-copier` [не может использоваться совместно](./secret-copier/) с модулем `multitenancy-manager`.
 {% endalert %}
 
 ## Преимущества модуля
@@ -54,14 +54,14 @@ description: Мультитенантность и проекты в Kubernetes.
 
 Для создания проекта используются [ресурсы](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/):
 
-* [ProjectTemplate](cr.html#projecttemplate) — ресурс, который описывает шаблон проекта. При помощи него задается список ресурсов, которые будут созданы в проекте, а также схема параметров, которые можно передать при создании проекта;
-* [Project](cr.html#project) — ресурс, который описывает конкретный проект.
+* [ProjectTemplate](./multitenancy-manager/cr.html#projecttemplate) — ресурс, который описывает шаблон проекта. При помощи него задается список ресурсов, которые будут созданы в проекте, а также схема параметров, которые можно передать при создании проекта;
+* [Project](./multitenancy-manager/cr.html#project) — ресурс, который описывает конкретный проект.
 
-При создании ресурса [Project](cr.html#project) из определенного [ProjectTemplate](cr.html#projecttemplate) происходит следующее:
+При создании ресурса [Project](./multitenancy-manager/cr.html#project) из определенного [ProjectTemplate](./multitenancy-manager/cr.html#projecttemplate) происходит следующее:
 
-1. Переданные [параметры](cr.html#project-v1alpha2-spec-parameters) валидируются по OpenAPI-спецификации (параметр [openAPI](cr.html#projecttemplate-v1alpha1-spec-parametersschema) ресурса [ProjectTemplate](cr.html#projecttemplate));
-1. Выполняется рендеринг [шаблона для ресурсов](cr.html#projecttemplate-v1alpha1-spec-resourcestemplate) с помощью [Helm](https://helm.sh/docs/). Значения для рендеринга берутся из параметра [parameters](cr.html#project-v1alpha2-spec-parameters) ресурса [Project](cr.html#project);
-1. Cоздается `Namespace` с именем, которое совпадает c именем [Project](cr.html#project);
+1. Переданные [параметры](./multitenancy-manager/cr.html#project-v1alpha2-spec-parameters) валидируются по OpenAPI-спецификации (параметр [openAPI](./multitenancy-manager/cr.html#projecttemplate-v1alpha1-spec-parametersschema) ресурса [ProjectTemplate](./multitenancy-manager/cr.html#projecttemplate));
+1. Выполняется рендеринг [шаблона для ресурсов](./multitenancy-manager/cr.html#projecttemplate-v1alpha1-spec-resourcestemplate) с помощью [Helm](https://helm.sh/docs/). Значения для рендеринга берутся из параметра [parameters](./multitenancy-manager/cr.html#project-v1alpha2-spec-parameters) ресурса [Project](./multitenancy-manager/cr.html#project);
+1. Cоздается `Namespace` с именем, которое совпадает c именем [Project](./multitenancy-manager/cr.html#project);
 1. По очереди создаются все ресурсы, описанные в шаблоне.
 
 > **Внимание!** При изменении шаблона проекта, все созданные проекты будут обновлены в соответствии с новым шаблоном.


### PR DESCRIPTION
## Description
Fix relative links in the multitenancy-manager module documentation.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Fix relative links in the multitenancy-manager module documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
