### PR TITLE
[deckhouse-controller] check lowercased scheme in ChangeRegistry function

### DIFF
--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
@@ -79,6 +79,8 @@ func ChangeRegistry(newRegistry, username, password, caFile, newDeckhouseImageTa
 		return err
 	}
 
+	// !! Convert scheme to lowercase to avoid case-sensitive issues
+	scheme = strings.ToLower(scheme)
 	nameOpts := newNameOptions(scheme)
 	newRepo, err := name.NewRepository(strings.TrimRight(newRegistry, "/"), nameOpts...)
 	if err != nil {

--- a/deckhouse-controller/pkg/helpers/register.go
+++ b/deckhouse-controller/pkg/helpers/register.go
@@ -45,7 +45,7 @@ func DefineHelperCommands(kpApp *kingpin.Application, logger *log.Logger) {
 		password := changeRegistryCommand.Flag("password", "Password/token for registry user.").String()
 		caFile := changeRegistryCommand.Flag("ca-file", "Path to registry CA.").ExistingFile()
 
-		scheme := changeRegistryCommand.Flag("scheme", "Used scheme while connecting to registry, http or https.").String()
+		scheme := changeRegistryCommand.Flag("scheme", `Used scheme while connecting to registry, "http" or "https".`).String()
 		dryRun := changeRegistryCommand.Flag("dry-run", "Don't change deckhouse resources, only print them.").Default("false").Bool()
 
 		newImageTag := changeRegistryCommand.Flag("new-deckhouse-tag", "New tag that will be used for deckhouse deployment image (by default current tag from deckhouse deployment will be used).").String()

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -781,7 +781,7 @@ To switch the Deckhouse cluster to using a third-party registry, follow these st
       --user=USER          User with pull access to registry.
       --password=PASSWORD  Password/token for registry user.
       --ca-file=CA-FILE    Path to registry CA.
-      --scheme=SCHEME      Used scheme while connecting to registry, http or https.
+      --scheme=SCHEME      Used scheme while connecting to registry, "http" or "https".
       --dry-run            Don't change deckhouse resources, only print them.
       --new-deckhouse-tag=NEW-DECKHOUSE-TAG
                           New tag that will be used for deckhouse deployment image (by default

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -784,7 +784,7 @@ echo "$MYRESULTSTRING"
       --user=USER          User with pull access to registry.
       --password=PASSWORD  Password/token for registry user.
       --ca-file=CA-FILE    Path to registry CA.
-      --scheme=SCHEME      Used scheme while connecting to registry, http or https.
+      --scheme=SCHEME      Used scheme while connecting to registry, "http" or "https".
       --dry-run            Don't change deckhouse resources, only print them.
       --new-deckhouse-tag=NEW-DECKHOUSE-TAG
                           New tag that will be used for deckhouse deployment image (by default


### PR DESCRIPTION
## Description

When using the registry change functionality, errors sometimes occur due to incorrect schema input. Bringing the schema to lowercase will solve this problem.

We also made changes to the documentation and flag description by enclosing the protocol enums in quotation marks.

## Why do we need it, and what problem does it solve?

For correct use of schema values in the registry address

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: chore
summary: check lowercased scheme in ChangeRegistry function
impact_level: default
```
