### PR TITLE
[deckhouse-controller] Fix/backport 1 71 module config ensure

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -469,10 +469,10 @@ func (r *reconciler) disableModule(ctx context.Context, module *v1alpha1.Module)
 			module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleManager, "", "")
 			module.SetConditionFalse(v1alpha1.ModuleConditionIsReady, v1alpha1.ModuleReasonNotInstalled, v1alpha1.ModuleMessageNotInstalled)
 		default:
-			module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleConfig, "", "")
 			module.SetConditionFalse(v1alpha1.ModuleConditionIsReady, v1alpha1.ModuleReasonDisabled, v1alpha1.ModuleMessageDisabled)
 		}
 
+		module.SetConditionFalse(v1alpha1.ModuleConditionEnabledByModuleConfig, "", "")
 		module.SetConditionUnknown(v1alpha1.ModuleConditionLastReleaseDeployed, "", "")
 
 		return true

--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
@@ -167,10 +167,17 @@ func (md *ModuleDownloader) DownloadReleaseImageInfoByVersion(ctx context.Contex
 		slog.String("module_version", moduleVersion),
 	)
 
-	def, err := md.fetchModuleDefinitionFromImage(moduleName, releaseImageInfo.Image)
+	// fetch module image
+	img, err := md.fetchImage(moduleName, moduleVersion)
+	if err != nil {
+		return nil, fmt.Errorf("fetch image: %w", err)
+	}
+
+	def, err := md.fetchModuleDefinitionFromModuleImage(moduleName, img)
 	if err != nil {
 		return nil, fmt.Errorf("fetch module definition: %w", err)
 	}
+
 	res.ModuleDefinition = def
 
 	return res, nil
@@ -431,7 +438,7 @@ func (md *ModuleDownloader) fetchModuleDefinitionFromFS(name, path string) *modu
 	return def
 }
 
-func (md *ModuleDownloader) fetchModuleDefinitionFromImage(moduleName string, img crv1.Image) (*moduletypes.Definition, error) {
+func (md *ModuleDownloader) fetchModuleDefinitionFromModuleImage(moduleName string, img crv1.Image) (*moduletypes.Definition, error) {
 	def := &moduletypes.Definition{
 		Name:   moduleName,
 		Weight: defaultModuleWeight,
@@ -439,22 +446,23 @@ func (md *ModuleDownloader) fetchModuleDefinitionFromImage(moduleName string, im
 
 	rc, err := cr.Extract(img)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("extract: %w", err)
 	}
 	defer rc.Close()
 
-	buf := bytes.NewBuffer(nil)
-
-	if err = untarModuleDefinition(rc, buf); err != nil {
-		return def, err
+	rr := &moduleReader{
+		moduleReader: bytes.NewBuffer(nil),
 	}
 
-	if buf.Len() == 0 {
-		return def, nil
+	if err = rr.untarMetadata(rc); err != nil {
+		return def, fmt.Errorf("untar metadata: %w", err)
 	}
 
-	if err = yaml.NewDecoder(buf).Decode(def); err != nil {
-		return def, err
+	if rr.moduleReader.Len() > 0 {
+		err = yaml.NewDecoder(rr.moduleReader).Decode(def)
+		if err != nil {
+			return nil, fmt.Errorf("yaml decode: %w", err)
+		}
 	}
 
 	return def, nil
@@ -513,7 +521,11 @@ func (md *ModuleDownloader) fetchModuleReleaseMetadata(ctx context.Context, img 
 	return meta, err
 }
 
-func untarModuleDefinition(rc io.ReadCloser, rw io.Writer) error {
+type moduleReader struct {
+	moduleReader *bytes.Buffer
+}
+
+func (rr *moduleReader) untarMetadata(rc io.ReadCloser) error {
 	tr := tar.NewReader(rc)
 	for {
 		hdr, err := tr.Next()
@@ -521,22 +533,25 @@ func untarModuleDefinition(rc io.ReadCloser, rw io.Writer) error {
 			// end of archive
 			return nil
 		}
+
 		if err != nil {
 			return err
 		}
+
 		if strings.HasPrefix(hdr.Name, ".werf") {
 			continue
 		}
 
-		switch hdr.Name {
+		switch strings.ToLower(hdr.Name) {
 		case "module.yaml":
-			_, err = io.Copy(rw, tr)
+			_, err := io.Copy(rr.moduleReader, tr)
 			if err != nil {
 				return err
 			}
-			return nil
 
+			return nil
 		default:
+
 			continue
 		}
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Backport: https://github.com/deckhouse/deckhouse/pull/15199

Fixed fallback module definition downloading.
Fixed behavior when module config is disabled - module receives DisabledModuleConfig status

#### Before
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: Module
metadata:
  name: s-p-test
status:
  conditions:
  - lastProbeTime: "2025-08-26T14:06:24Z"
    lastTransitionTime: "2025-08-26T14:06:24Z"
    status: "False"
    type: EnabledByModuleManager
  - lastProbeTime: "2025-08-26T14:06:25Z"
    lastTransitionTime: "2025-08-26T14:06:24Z"
    message: downloading
    reason: Downloading
    status: "False"
    type: IsReady
  phase: Downloading
```

#### After
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: Module
metadata:
  name: s-p-test
status:
  conditions:
  - lastProbeTime: "2025-08-26T16:15:14Z"
    lastTransitionTime: "2025-08-26T16:15:14Z"
    status: "False"
    type: EnabledByModuleConfig
  - lastProbeTime: "2025-08-26T16:18:55Z"
    lastTransitionTime: "2025-08-26T16:15:14Z"
    message: not installed
    reason: NotInstalled
    status: "False"
    type: IsReady
  - lastProbeTime: "2025-08-26T16:18:55Z"
    lastTransitionTime: "2025-08-26T16:18:55Z"
    status: "False"
    type: EnabledByModuleManager
  phase: Available
```


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: fix module config ensure
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
