### PR TITLE
[dashboard] add user-authz requirement

### DIFF
--- a/modules/500-dashboard/enabled
+++ b/modules/500-dashboard/enabled
@@ -32,11 +32,6 @@ function __main__() {
     return
   fi
 
-  if values::array_has global.enabledModules "user-authn" ; then
-    echo "true" > "$MODULE_ENABLED_RESULT"
-    return
-  fi
-
   if values::has dashboard.auth.externalAuthentication.authSignInURL && \
      values::has dashboard.auth.externalAuthentication.authURL ; then
     echo "true" > "$MODULE_ENABLED_RESULT"

--- a/modules/500-dashboard/enabled
+++ b/modules/500-dashboard/enabled
@@ -32,12 +32,6 @@ function __main__() {
     return
   fi
 
-  if ! values::array_has global.enabledModules "user-authz" ; then
-    echo "false" > "$MODULE_ENABLED_RESULT"
-    echo "'user-authz' module needs to be enabled." > "$MODULE_ENABLED_REASON"
-    return
-  fi
-
   if values::array_has global.enabledModules "user-authn" ; then
     echo "true" > "$MODULE_ENABLED_RESULT"
     return

--- a/modules/500-dashboard/module.yaml
+++ b/modules/500-dashboard/module.yaml
@@ -4,4 +4,5 @@ subsystems:
   - observability
 namespace: d8-dashboard
 requirements:
+  user-authz: ">= 0.0.0"
   deckhouse: ">= 1.68"


### PR DESCRIPTION
## Description
It adds ```user-authz``` requirement for the module ```dashboard```.

## Why do we need it, and what problem does it solve?
After removing weight, all non critical modules have the 'same' weight, which may cause the script to be unaware of whether ```user-authz``` has been enabled.

For example:
```
root@paksashvili-master-0:~# k get module dashboard -owide
NAME        WEIGHT   STAGE        RELEASE CHANNEL   SOURCE     VERSION                PHASE        ENABLED   DISABLED MESSAGE                                                         READY
dashboard   900      Deprecated   Stable            Embedded   v1.73.0-main+9bde9c9   Downloaded   False     turned off by enabled script: 'user-authz' module needs to be enabled.   False
root@paksashvili-master-0:~# k get module user-authz
NAME         STAGE                  SOURCE     PHASE   ENABLED   READY
user-authz   General Availability   Embedded   Ready   True      True
```

After:
```
root@paksashvili-master-0:~# k get module dashboard -owide
NAME        WEIGHT   STAGE        RELEASE CHANNEL   SOURCE     VERSION                   PHASE         ENABLED   DISABLED MESSAGE   READY
dashboard   900      Deprecated   Stable            Embedded   v1.73.0-pr15204+38bcb8f   Reconciling   True                         False
root@paksashvili-master-0:~# k get module user-authz
NAME         STAGE                  SOURCE     PHASE         ENABLED   READY
user-authz   General Availability   Embedded   Reconciling   True      False
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dashboard
type: fix
summary: Add user-authz requirement
impact_level: low
```
