### PR TITLE
[user-authn] Fix CVE-2025-30204 CVE-2025-22868 CVE-2024-28180

### DIFF
--- a/modules/150-user-authn/images/dex-authenticator/patches/005-fix-cves.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/005-fix-cves.patch
@@ -1,0 +1,804 @@
+From 4ed8fd56526f573e2c9094d29c63a8da76156e2c Mon Sep 17 00:00:00 2001
+From: s10dev <s10.dev@yandex.com>
+Date: Wed, 27 Aug 2025 07:49:36 +0300
+Subject: [PATCH] fix CVE-2025-30204 CVE-2025-22868 CVE-2024-28180
+
+Signed-off-by: s10dev <s10.dev@yandex.com>
+---
+ CHANGELOG.md                                 |  2 +-
+ go.mod                                       | 23 +++---
+ go.sum                                       | 54 +++++++------
+ pkg/middleware/jwt_session_test.go           | 41 +++++-----
+ pkg/providers/oidc/provider_verifier_test.go | 28 +++----
+ pkg/providers/oidc/verifier_test.go          |  4 +-
+ pkg/sessions/persistence/ticket_test.go      |  4 +-
+ providers/adfs_test.go                       |  2 +-
+ providers/azure_test.go                      | 18 ++---
+ providers/logingov.go                        | 15 ++--
+ providers/logingov_test.go                   | 32 ++++----
+ providers/provider_data_test.go              | 80 ++++++++++----------
+ 12 files changed, 151 insertions(+), 152 deletions(-)
+
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index 7381590c..d9eef2e5 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -237,7 +237,7 @@ N/A
+ - [#1375](https://github.com/oauth2-proxy/oauth2-proxy/pull/1375) Added `--force-json-errors` flag (@bancek)
+ - [#1337](https://github.com/oauth2-proxy/oauth2-proxy/pull/1337) Changing user field type to text when using htpasswd (@pburgisser)
+ - [#1239](https://github.com/oauth2-proxy/oauth2-proxy/pull/1239) Base GitLab provider implementation on OIDCProvider (@NickMeves)
+-- [#1276](https://github.com/oauth2-proxy/oauth2-proxy/pull/1276) Update crypto and switched to new github.com/golang-jwt/jwt (@JVecsei)
++- [#1276](https://github.com/oauth2-proxy/oauth2-proxy/pull/1276) Update crypto and switched to new github.com/golang-jwt/jwt/v5 (@JVecsei)
+ - [#1264](https://github.com/oauth2-proxy/oauth2-proxy/pull/1264) Update go-oidc to v3 (@NickMeves)
+ - [#1233](https://github.com/oauth2-proxy/oauth2-proxy/pull/1233) Extend email-domain validation with sub-domain capability (@morarucostel)
+ - [#1060](https://github.com/oauth2-proxy/oauth2-proxy/pull/1060) Implement RewriteTarget to allow requests to be rewritten before proxying to upstream servers (@JoelSpeed)
+diff --git a/go.mod b/go.mod
+index 9bfa34cd..331584d4 100644
+--- a/go.mod
++++ b/go.mod
+@@ -13,13 +13,14 @@ require (
+ 	github.com/coreos/go-oidc/v3 v3.5.0
+ 	github.com/fsnotify/fsnotify v1.6.0
+ 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
+-	github.com/golang-jwt/jwt v3.2.2+incompatible
++	github.com/go-jose/go-jose/v4 v4.1.2
++	github.com/golang-jwt/jwt/v5 v5.3.0
+ 	github.com/google/uuid v1.3.0
+ 	github.com/gorilla/mux v1.8.0
+ 	github.com/justinas/alice v1.2.0
+ 	github.com/mbland/hmacauth v0.0.0-20170912233209-44256dfd4bfa
+ 	github.com/mitchellh/mapstructure v1.1.2
+-	github.com/oauth2-proxy/mockoidc v0.0.0-20220221072942-e3afe97dec43
++	github.com/oauth2-proxy/mockoidc v0.0.0-20240214162133-caebfff84d25
+ 	github.com/oauth2-proxy/tools/reference-gen v0.0.0-20210118095127-56ffd7384404
+ 	github.com/ohler55/ojg v1.14.5
+ 	github.com/onsi/ginkgo v1.16.5
+@@ -30,22 +31,20 @@ require (
+ 	github.com/spf13/cast v1.5.0
+ 	github.com/spf13/pflag v1.0.5
+ 	github.com/spf13/viper v1.6.3
+-	github.com/stretchr/testify v1.8.1
++	github.com/stretchr/testify v1.8.4
+ 	github.com/vmihailenco/msgpack/v5 v5.3.5
+-	golang.org/x/crypto v0.36.0
++	golang.org/x/crypto v0.39.0
+ 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
+ 	golang.org/x/net v0.38.0
+-	golang.org/x/oauth2 v0.10.0
+-	golang.org/x/sync v0.12.0
++	golang.org/x/oauth2 v0.27.0
++	golang.org/x/sync v0.15.0
+ 	google.golang.org/api v0.126.0
+ 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+-	gopkg.in/square/go-jose.v2 v2.6.0
+ 	k8s.io/apimachinery v0.26.2
+ )
+ 
+ require (
+-	cloud.google.com/go/compute v1.21.0 // indirect
+-	cloud.google.com/go/compute/metadata v0.2.3 // indirect
++	cloud.google.com/go/compute/metadata v0.3.0 // indirect
+ 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
+ 	github.com/beorn7/perks v1.0.1 // indirect
+ 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
+@@ -56,7 +55,7 @@ require (
+ 	github.com/go-logr/logr v1.2.3 // indirect
+ 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+ 	github.com/golang/protobuf v1.5.3 // indirect
+-	github.com/google/go-cmp v0.5.9 // indirect
++	github.com/google/go-cmp v0.6.0 // indirect
+ 	github.com/google/s2a-go v0.1.4 // indirect
+ 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
+ 	github.com/googleapis/gax-go/v2 v2.11.0 // indirect
+@@ -75,8 +74,8 @@ require (
+ 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+ 	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9 // indirect
+ 	go.opencensus.io v0.24.0 // indirect
+-	golang.org/x/sys v0.31.0 // indirect
+-	golang.org/x/text v0.23.0 // indirect
++	golang.org/x/sys v0.33.0 // indirect
++	golang.org/x/text v0.26.0 // indirect
+ 	google.golang.org/appengine v1.6.7 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
+ 	google.golang.org/grpc v1.58.3 // indirect
+diff --git a/go.sum b/go.sum
+index 5bfd1e8a..c3e3c674 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1,10 +1,8 @@
+ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+-cloud.google.com/go/compute v1.21.0 h1:JNBsyXVoOoNJtTQcnEY5uYpZIbeCTYIeDe0Xh1bySMk=
+-cloud.google.com/go/compute v1.21.0/go.mod h1:4tCnrn48xsqlwSAiLf1HXMQk8CONslYbdiEZc9FEIbM=
+ cloud.google.com/go/compute/metadata v0.2.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
+-cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
+-cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
++cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
++cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
+ github.com/Bose/minisentinel v0.0.0-20200130220412-917c5a9223bb h1:ZVN4Iat3runWOFLaBCDVU5a9X/XikSRBosye++6gojw=
+ github.com/Bose/minisentinel v0.0.0-20200130220412-917c5a9223bb/go.mod h1:WsAABbY4HQBgd3mGuG4KMNTbHJCPvx9IVBHzysbknss=
+ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+@@ -85,6 +83,8 @@ github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH
+ github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
+ github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
+ github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
++github.com/go-jose/go-jose/v4 v4.1.2 h1:TK/7NqRQZfgAh+Td8AlsrvtPoUyiHh0LqVvokh+1vHI=
++github.com/go-jose/go-jose/v4 v4.1.2/go.mod h1:22cg9HWM1pOlnRiY+9cQYJ9XHmya1bYW8OeDM6Ku6Oo=
+ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
+ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+@@ -98,8 +98,8 @@ github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEe
+ github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
+ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
++github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
++github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+ github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+@@ -132,11 +132,11 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
+ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+-github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
++github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
++github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+ github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+ github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
+@@ -199,8 +199,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
+ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+ github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+ github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+-github.com/oauth2-proxy/mockoidc v0.0.0-20220221072942-e3afe97dec43 h1:V9YiO92tYBmVgVcKhdxK6I4avJCefBM+0Db4WM2dank=
+-github.com/oauth2-proxy/mockoidc v0.0.0-20220221072942-e3afe97dec43/go.mod h1:rW25Kyd08Wdn3UVn0YBsDTSvReu0jqpmJKzxITPSjks=
++github.com/oauth2-proxy/mockoidc v0.0.0-20240214162133-caebfff84d25 h1:9bCMuD3TcnjeqjPT2gSlha4asp8NvgcFRYExCaikCxk=
++github.com/oauth2-proxy/mockoidc v0.0.0-20240214162133-caebfff84d25/go.mod h1:eDjgYHYDJbPLBLsyZ6qRaugP0mX8vePOhZ5id1fdzJw=
+ github.com/oauth2-proxy/tools/reference-gen v0.0.0-20210118095127-56ffd7384404 h1:ZpzR4Ou1nhldBG/vEzauoqyaUlofaUcLkv1C/gBK8ls=
+ github.com/oauth2-proxy/tools/reference-gen v0.0.0-20210118095127-56ffd7384404/go.mod h1:YpORG8zs14vNlpXvuHYnnDvWazIRaDk02MaY8lafqdI=
+ github.com/ohler55/ojg v1.14.5 h1:xCX2oyh/ZaoesbLH6fwVHStSJpk4o4eJs8ttXutzdg0=
+@@ -275,8 +275,9 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
+ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
++github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
++github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+ github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
+ github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
+@@ -307,11 +308,10 @@ golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8U
+ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+-golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+ golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+ golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
+-golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+-golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
++golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
++golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
+ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 h1:5llv2sWeaMSnA3w2kS57ouQQ4pudlXrR0dCgw51QK9o=
+ golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
+@@ -322,8 +322,8 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+ golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+-golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
+-golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
++golang.org/x/mod v0.25.0 h1:n7a+ZbQKQA/Ysbyb0/6IbB1H/X41mKgbhfv7AfG/44w=
++golang.org/x/mod v0.25.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
+ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+@@ -353,8 +353,8 @@ golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+ golang.org/x/oauth2 v0.3.0/go.mod h1:rQrIauxkUhJ6CuwEXwymO2/eh4xz2ZWF1nBkcxS+tGk=
+-golang.org/x/oauth2 v0.10.0 h1:zHCpF2Khkwy4mMB4bv0U37YtJdTGW8jI0glAApi0Kh8=
+-golang.org/x/oauth2 v0.10.0/go.mod h1:kTpgurOux7LqtuxjuyZa4Gj2gdezIt/jQtGnNFfypQI=
++golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
++golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -363,8 +363,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+-golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
++golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
++golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+@@ -389,8 +389,8 @@ golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
++golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
++golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+ golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
+@@ -407,8 +407,8 @@ golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+ golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+ golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+ golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
++golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
++golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
+ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+@@ -422,8 +422,8 @@ golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roY
+ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+ golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
+-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
+-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
++golang.org/x/tools v0.33.0 h1:4qz2S3zmRxbGIhDIAgjxvFutSvH5EfnsYrRBj0UI0bc=
++golang.org/x/tools v0.33.0/go.mod h1:CIJMaWEY88juyUfo7UbgPqbC8rU2OqfAV1h2Qp0oMYI=
+ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+@@ -482,8 +482,6 @@ gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+ gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+ gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
+ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+-gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
+-gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
+ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
+diff --git a/pkg/middleware/jwt_session_test.go b/pkg/middleware/jwt_session_test.go
+index 2d056a78..2a4af171 100644
+--- a/pkg/middleware/jwt_session_test.go
++++ b/pkg/middleware/jwt_session_test.go
+@@ -13,8 +13,9 @@ import (
+ 	"strings"
+ 	"time"
+ 
++	"github.com/golang-jwt/jwt/v5"
++
+ 	"github.com/coreos/go-oidc/v3/oidc"
+-	"github.com/golang-jwt/jwt"
+ 	middlewareapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/middleware"
+ 	sessionsapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+ 	. "github.com/onsi/ginkgo"
+@@ -401,7 +402,7 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
+ 		type idTokenClaims struct {
+ 			Email    string `json:"email,omitempty"`
+ 			Verified *bool  `json:"email_verified,omitempty"`
+-			jwt.StandardClaims
++			jwt.RegisteredClaims
+ 		}
+ 
+ 		type tokenToSessionTableInput struct {
+@@ -451,13 +452,13 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
+ 			},
+ 			Entry("with no email", tokenToSessionTableInput{
+ 				idToken: idTokenClaims{
+-					StandardClaims: jwt.StandardClaims{
+-						Audience:  "asdf1234",
+-						ExpiresAt: expiresFuture.Unix(),
+-						Id:        "id-some-id",
+-						IssuedAt:  time.Now().Unix(),
++					RegisteredClaims: jwt.RegisteredClaims{
++						Audience:  jwt.ClaimStrings{"asdf1234"},
++						ExpiresAt: jwt.NewNumericDate(expiresFuture),
++						ID:        "id-some-id",
++						IssuedAt:  jwt.NewNumericDate(time.Now()),
+ 						Issuer:    "https://issuer.example.com",
+-						NotBefore: 0,
++						NotBefore: jwt.NewNumericDate(time.Unix(0, 0)),
+ 						Subject:   "123456789",
+ 					},
+ 				},
+@@ -468,13 +469,13 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
+ 			}),
+ 			Entry("with a verified email", tokenToSessionTableInput{
+ 				idToken: idTokenClaims{
+-					StandardClaims: jwt.StandardClaims{
+-						Audience:  "asdf1234",
+-						ExpiresAt: expiresFuture.Unix(),
+-						Id:        "id-some-id",
+-						IssuedAt:  time.Now().Unix(),
++					RegisteredClaims: jwt.RegisteredClaims{
++						Audience:  jwt.ClaimStrings{"asdf1234"},
++						ExpiresAt: jwt.NewNumericDate(expiresFuture),
++						ID:        "id-some-id",
++						IssuedAt:  jwt.NewNumericDate(time.Now()),
+ 						Issuer:    "https://issuer.example.com",
+-						NotBefore: 0,
++						NotBefore: jwt.NewNumericDate(time.Unix(0, 0)),
+ 						Subject:   "123456789",
+ 					},
+ 					Email:    "foo@example.com",
+@@ -487,13 +488,13 @@ Nnc3a3lGVWFCNUMxQnNJcnJMTWxka1dFaHluYmI4Ongtb2F1dGgtYmFzaWM=`
+ 			}),
+ 			Entry("with a non-verified email", tokenToSessionTableInput{
+ 				idToken: idTokenClaims{
+-					StandardClaims: jwt.StandardClaims{
+-						Audience:  "asdf1234",
+-						ExpiresAt: expiresFuture.Unix(),
+-						Id:        "id-some-id",
+-						IssuedAt:  time.Now().Unix(),
++					RegisteredClaims: jwt.RegisteredClaims{
++						Audience:  jwt.ClaimStrings{"asdf1234"},
++						ExpiresAt: jwt.NewNumericDate(expiresFuture),
++						ID:        "id-some-id",
++						IssuedAt:  jwt.NewNumericDate(time.Now()),
+ 						Issuer:    "https://issuer.example.com",
+-						NotBefore: 0,
++						NotBefore: jwt.NewNumericDate(time.Unix(0, 0)),
+ 						Subject:   "123456789",
+ 					},
+ 					Email:    "foo@example.com",
+diff --git a/pkg/providers/oidc/provider_verifier_test.go b/pkg/providers/oidc/provider_verifier_test.go
+index 1b0c06e7..e3724891 100644
+--- a/pkg/providers/oidc/provider_verifier_test.go
++++ b/pkg/providers/oidc/provider_verifier_test.go
+@@ -4,7 +4,7 @@ import (
+ 	"context"
+ 	"time"
+ 
+-	"github.com/golang-jwt/jwt"
++	"github.com/golang-jwt/jwt/v5"
+ 	"github.com/oauth2-proxy/mockoidc"
+ 	. "github.com/onsi/ginkgo"
+ 	. "github.com/onsi/ginkgo/extensions/table"
+@@ -90,7 +90,7 @@ var _ = Describe("ProviderVerifier", func() {
+ 
+ 	type verifierTableInput struct {
+ 		modifyOpts    func(*ProviderVerifierOptions)
+-		modifyClaims  func(*jwt.StandardClaims)
++		modifyClaims  func(*jwt.RegisteredClaims)
+ 		expectedError string
+ 	}
+ 
+@@ -109,11 +109,11 @@ var _ = Describe("ProviderVerifier", func() {
+ 		Expect(err).ToNot(HaveOccurred())
+ 
+ 		now := time.Now()
+-		claims := jwt.StandardClaims{
+-			Audience:  m.Config().ClientID,
++		claims := jwt.RegisteredClaims{
++			Audience:  jwt.ClaimStrings{m.Config().ClientID},
+ 			Issuer:    m.Issuer(),
+-			ExpiresAt: now.Add(1 * time.Hour).Unix(),
+-			IssuedAt:  now.Unix(),
++			ExpiresAt: jwt.NewNumericDate(now.Add(1 * time.Hour)),
++			IssuedAt:  jwt.NewNumericDate(now),
+ 			Subject:   "user",
+ 		}
+ 		if in.modifyClaims != nil {
+@@ -136,8 +136,8 @@ var _ = Describe("ProviderVerifier", func() {
+ 	},
+ 		Entry("with the default opts and claims", &verifierTableInput{}),
+ 		Entry("when the audience is mismatched", &verifierTableInput{
+-			modifyClaims: func(j *jwt.StandardClaims) {
+-				j.Audience = "OtherClient"
++			modifyClaims: func(j *jwt.RegisteredClaims) {
++				j.Audience = jwt.ClaimStrings{"OtherClient"}
+ 			},
+ 			expectedError: "audience from claim aud with value [OtherClient] does not match with any of allowed audiences",
+ 		}),
+@@ -145,12 +145,12 @@ var _ = Describe("ProviderVerifier", func() {
+ 			modifyOpts: func(p *ProviderVerifierOptions) {
+ 				p.ExtraAudiences = []string{"ExtraIssuer"}
+ 			},
+-			modifyClaims: func(j *jwt.StandardClaims) {
+-				j.Audience = "ExtraIssuer"
++			modifyClaims: func(j *jwt.RegisteredClaims) {
++				j.Audience = jwt.ClaimStrings{"ExtraIssuer"}
+ 			},
+ 		}),
+ 		Entry("when the issuer is mismatched", &verifierTableInput{
+-			modifyClaims: func(j *jwt.StandardClaims) {
++			modifyClaims: func(j *jwt.RegisteredClaims) {
+ 				j.Issuer = "OtherIssuer"
+ 			},
+ 			expectedError: "failed to verify token: oidc: id token issued by a different provider",
+@@ -159,13 +159,13 @@ var _ = Describe("ProviderVerifier", func() {
+ 			modifyOpts: func(p *ProviderVerifierOptions) {
+ 				p.SkipIssuerVerification = true
+ 			},
+-			modifyClaims: func(j *jwt.StandardClaims) {
++			modifyClaims: func(j *jwt.RegisteredClaims) {
+ 				j.Issuer = "OtherIssuer"
+ 			},
+ 		}),
+ 		Entry("when the token has expired", &verifierTableInput{
+-			modifyClaims: func(j *jwt.StandardClaims) {
+-				j.ExpiresAt = time.Now().Add(-1 * time.Hour).Unix()
++			modifyClaims: func(j *jwt.RegisteredClaims) {
++				j.ExpiresAt = jwt.NewNumericDate(time.Now().Add(-1 * time.Hour))
+ 			},
+ 			expectedError: "failed to verify token: oidc: token is expired",
+ 		}),
+diff --git a/pkg/providers/oidc/verifier_test.go b/pkg/providers/oidc/verifier_test.go
+index c82de7af..98b8b5d9 100755
+--- a/pkg/providers/oidc/verifier_test.go
++++ b/pkg/providers/oidc/verifier_test.go
+@@ -8,9 +8,9 @@ import (
+ 	"fmt"
+ 
+ 	"github.com/coreos/go-oidc/v3/oidc"
++	"github.com/go-jose/go-jose/v4"
+ 	. "github.com/onsi/ginkgo"
+ 	. "github.com/onsi/gomega"
+-	"gopkg.in/square/go-jose.v2"
+ )
+ 
+ var _ = Describe("Verify", func() {
+@@ -200,7 +200,7 @@ type testVerifier struct {
+ }
+ 
+ func (t *testVerifier) VerifySignature(ctx context.Context, jwt string) ([]byte, error) {
+-	jws, err := jose.ParseSigned(jwt)
++	jws, err := jose.ParseSigned(jwt, []jose.SignatureAlgorithm{jose.RS256})
+ 	if err != nil {
+ 		return nil, fmt.Errorf("oidc: malformed jwt: %v", err)
+ 	}
+diff --git a/pkg/sessions/persistence/ticket_test.go b/pkg/sessions/persistence/ticket_test.go
+index 6b868b90..4f2f724b 100644
+--- a/pkg/sessions/persistence/ticket_test.go
++++ b/pkg/sessions/persistence/ticket_test.go
+@@ -27,11 +27,11 @@ var _ = Describe("Session Ticket Tests", func() {
+ 					enc := in.ticket.encodeTicket()
+ 					Expect(enc).To(Equal(in.encodedTicket))
+ 
+-					dec, err := decodeTicket(enc, in.ticket.options)
++					dec, _, err := decodeTicket(enc, in.ticket.options)
+ 					Expect(err).ToNot(HaveOccurred())
+ 					Expect(dec).To(Equal(in.ticket))
+ 				} else {
+-					_, err := decodeTicket(in.encodedTicket, nil)
++					_, _, err := decodeTicket(in.encodedTicket, nil)
+ 					Expect(err).To(MatchError(in.expectedError))
+ 				}
+ 			},
+diff --git a/providers/adfs_test.go b/providers/adfs_test.go
+index 355fd939..067d8872 100755
+--- a/providers/adfs_test.go
++++ b/providers/adfs_test.go
+@@ -12,7 +12,7 @@ import (
+ 	"strings"
+ 
+ 	"github.com/coreos/go-oidc/v3/oidc"
+-	"github.com/golang-jwt/jwt"
++	"github.com/golang-jwt/jwt/v5"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+ 	internaloidc "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/providers/oidc"
+diff --git a/providers/azure_test.go b/providers/azure_test.go
+index 27d70b88..46742042 100644
+--- a/providers/azure_test.go
++++ b/providers/azure_test.go
+@@ -14,7 +14,7 @@ import (
+ 	"time"
+ 
+ 	"github.com/coreos/go-oidc/v3/oidc"
+-	"github.com/golang-jwt/jwt"
++	"github.com/golang-jwt/jwt/v5"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+ 	internaloidc "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/providers/oidc"
+@@ -311,9 +311,9 @@ func TestAzureProviderRedeem(t *testing.T) {
+ 			if testCase.EmailFromIDToken != "" {
+ 				var err error
+ 				token := idTokenClaims{
+-					StandardClaims: jwt.StandardClaims{Audience: "cd6d4fae-f6a6-4a34-8454-2c6b598e9532"},
+-					Email:          testCase.EmailFromIDToken,
+-					Groups:         []string{"aa", "bb"},
++					RegisteredClaims: jwt.RegisteredClaims{Audience: jwt.ClaimStrings{"cd6d4fae-f6a6-4a34-8454-2c6b598e9532"}},
++					Email:            testCase.EmailFromIDToken,
++					Groups:           []string{"aa", "bb"},
+ 				}
+ 				idTokenString, err = newSignedTestIDToken(token)
+ 				assert.NoError(t, err)
+@@ -321,9 +321,9 @@ func TestAzureProviderRedeem(t *testing.T) {
+ 			if testCase.EmailFromAccessToken != "" {
+ 				var err error
+ 				token := idTokenClaims{
+-					StandardClaims: jwt.StandardClaims{Audience: "cd6d4fae-f6a6-4a34-8454-2c6b598e9532"},
+-					Email:          testCase.EmailFromAccessToken,
+-					Groups:         []string{"aa", "bb"},
++					RegisteredClaims: jwt.RegisteredClaims{Audience: jwt.ClaimStrings{"cd6d4fae-f6a6-4a34-8454-2c6b598e9532"}},
++					Email:            testCase.EmailFromAccessToken,
++					Groups:           []string{"aa", "bb"},
+ 				}
+ 				accessTokenString, err = newSignedTestIDToken(token)
+ 				assert.NoError(t, err)
+@@ -390,8 +390,8 @@ func TestAzureProviderRefresh(t *testing.T) {
+ 	subject := "foo"
+ 	idToken := idTokenClaims{
+ 		Email: email,
+-		StandardClaims: jwt.StandardClaims{
+-			Audience: "cd6d4fae-f6a6-4a34-8454-2c6b598e9532",
++		RegisteredClaims: jwt.RegisteredClaims{
++			Audience: jwt.ClaimStrings{"cd6d4fae-f6a6-4a34-8454-2c6b598e9532"},
+ 			Subject:  subject,
+ 		},
+ 	}
+diff --git a/providers/logingov.go b/providers/logingov.go
+index 2660b015..3c9c1073 100644
+--- a/providers/logingov.go
++++ b/providers/logingov.go
+@@ -12,11 +12,12 @@ import (
+ 	"os"
+ 	"time"
+ 
+-	"github.com/golang-jwt/jwt"
++	"github.com/golang-jwt/jwt/v5"
++
++	"github.com/go-jose/go-jose/v4"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/requests"
+-	"gopkg.in/square/go-jose.v2"
+ )
+ 
+ // LoginGovProvider represents an OIDC based Identity Provider
+@@ -146,7 +147,7 @@ type loginGovCustomClaims struct {
+ 	Birthdate     string `json:"birthdate"`
+ 	AtHash        string `json:"at_hash"`
+ 	CHash         string `json:"c_hash"`
+-	jwt.StandardClaims
++	jwt.Claims
+ }
+ 
+ // checkNonce checks the nonce in the id_token
+@@ -207,12 +208,12 @@ func (p *LoginGovProvider) Redeem(ctx context.Context, _, code, codeVerifier str
+ 		return nil, ErrMissingCode
+ 	}
+ 
+-	claims := &jwt.StandardClaims{
++	claims := &jwt.RegisteredClaims{
+ 		Issuer:    p.ClientID,
+ 		Subject:   p.ClientID,
+-		Audience:  p.RedeemURL.String(),
+-		ExpiresAt: time.Now().Add(5 * time.Minute).Unix(),
+-		Id:        randSeq(32),
++		Audience:  jwt.ClaimStrings{p.RedeemURL.String()},
++		ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
++		ID:        randSeq(32),
+ 	}
+ 	token := jwt.NewWithClaims(jwt.GetSigningMethod("RS256"), claims)
+ 	ss, err := token.SignedString(p.JWTKey)
+diff --git a/providers/logingov_test.go b/providers/logingov_test.go
+index 00fe8dcc..78bee724 100644
+--- a/providers/logingov_test.go
++++ b/providers/logingov_test.go
+@@ -15,11 +15,11 @@ import (
+ 	"testing"
+ 	"time"
+ 
+-	"github.com/golang-jwt/jwt"
++	"github.com/go-jose/go-jose/v4"
++	"github.com/golang-jwt/jwt/v5"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+ 	. "github.com/onsi/gomega"
+ 	"github.com/stretchr/testify/assert"
+-	"gopkg.in/square/go-jose.v2"
+ )
+ 
+ type MyKeyData struct {
+@@ -174,7 +174,7 @@ func TestLoginGovProviderSessionData(t *testing.T) {
+ 		Birthdate     string `json:"birthdate"`
+ 		AtHash        string `json:"at_hash"`
+ 		CHash         string `json:"c_hash"`
+-		jwt.StandardClaims
++		jwt.RegisteredClaims
+ 	}
+ 	claims := MyCustomClaims{
+ 		"http://idmanagement.gov/ns/assurance/loa/1",
+@@ -186,13 +186,13 @@ func TestLoginGovProviderSessionData(t *testing.T) {
+ 		"",
+ 		"",
+ 		"",
+-		jwt.StandardClaims{
+-			Audience:  "Audience",
+-			ExpiresAt: time.Now().Unix() + expiresIn,
+-			Id:        "foo",
+-			IssuedAt:  time.Now().Unix(),
++		jwt.RegisteredClaims{
++			Audience:  jwt.ClaimStrings{"Audience"},
++			ExpiresAt: jwt.NewNumericDate(time.Unix(time.Now().Unix()+expiresIn, 0)),
++			ID:        "foo",
++			IssuedAt:  jwt.NewNumericDate(time.Now()),
+ 			Issuer:    "https://idp.int.login.gov",
+-			NotBefore: time.Now().Unix() - 1,
++			NotBefore: jwt.NewNumericDate(time.Unix(time.Now().Unix()-1, 0)),
+ 			Subject:   "b2d2d115-1d7e-4579-b9d6-f8e84f4f56ca",
+ 		},
+ 	}
+@@ -268,7 +268,7 @@ func TestLoginGovProviderBadNonce(t *testing.T) {
+ 		Birthdate     string `json:"birthdate"`
+ 		AtHash        string `json:"at_hash"`
+ 		CHash         string `json:"c_hash"`
+-		jwt.StandardClaims
++		jwt.RegisteredClaims
+ 	}
+ 	claims := MyCustomClaims{
+ 		"http://idmanagement.gov/ns/assurance/loa/1",
+@@ -280,13 +280,13 @@ func TestLoginGovProviderBadNonce(t *testing.T) {
+ 		"",
+ 		"",
+ 		"",
+-		jwt.StandardClaims{
+-			Audience:  "Audience",
+-			ExpiresAt: time.Now().Unix() + expiresIn,
+-			Id:        "foo",
+-			IssuedAt:  time.Now().Unix(),
++		jwt.RegisteredClaims{
++			Audience:  jwt.ClaimStrings{"Audience"},
++			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(expiresIn) * time.Second)),
++			ID:        "foo",
++			IssuedAt:  jwt.NewNumericDate(time.Now()),
+ 			Issuer:    "https://idp.int.login.gov",
+-			NotBefore: time.Now().Unix() - 1,
++			NotBefore: jwt.NewNumericDate(time.Now().Add(-1 * time.Second)),
+ 			Subject:   "b2d2d115-1d7e-4579-b9d6-f8e84f4f56ca",
+ 		},
+ 	}
+diff --git a/providers/provider_data_test.go b/providers/provider_data_test.go
+index 838c061b..1ebe1ce9 100644
+--- a/providers/provider_data_test.go
++++ b/providers/provider_data_test.go
+@@ -13,11 +13,11 @@ import (
+ 	"testing"
+ 	"time"
+ 
++	"github.com/golang-jwt/jwt/v5"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
+ 	"github.com/stretchr/testify/assert"
+ 
+ 	"github.com/coreos/go-oidc/v3/oidc"
+-	"github.com/golang-jwt/jwt"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
+ 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/encryption"
+ 	internaloidc "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/providers/oidc"
+@@ -42,38 +42,38 @@ var (
+ 	verified   = true
+ 	unverified = false
+ 
+-	standardClaims = jwt.StandardClaims{
+-		Audience:  oidcClientID,
+-		ExpiresAt: time.Now().Add(time.Duration(5) * time.Minute).Unix(),
+-		Id:        "id-some-id",
+-		IssuedAt:  time.Now().Unix(),
++	registeredClaims = jwt.RegisteredClaims{
++		Audience:  jwt.ClaimStrings{oidcClientID},
++		ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
++		ID:        "id-some-id",
++		IssuedAt:  jwt.NewNumericDate(time.Now()),
+ 		Issuer:    oidcIssuer,
+-		NotBefore: 0,
++		NotBefore: jwt.NewNumericDate(time.Unix(0, 0)),
+ 		Subject:   "123456789",
+ 	}
+ 
+ 	defaultIDToken = idTokenClaims{
+-		Name:           "Jane Dobbs",
+-		Email:          "janed@me.com",
+-		Phone:          "+4798765432",
+-		Picture:        "http://mugbook.com/janed/me.jpg",
+-		Groups:         []string{"test:a", "test:b"},
+-		Roles:          []string{"test:c", "test:d"},
+-		Verified:       &verified,
+-		Nonce:          encryption.HashNonce([]byte(oidcNonce)),
+-		StandardClaims: standardClaims,
++		Name:             "Jane Dobbs",
++		Email:            "janed@me.com",
++		Phone:            "+4798765432",
++		Picture:          "http://mugbook.com/janed/me.jpg",
++		Groups:           []string{"test:a", "test:b"},
++		Roles:            []string{"test:c", "test:d"},
++		Verified:         &verified,
++		Nonce:            encryption.HashNonce([]byte(oidcNonce)),
++		RegisteredClaims: registeredClaims,
+ 	}
+ 
+ 	numericGroupsIDToken = idTokenClaims{
+-		Name:           "Jane Dobbs",
+-		Email:          "janed@me.com",
+-		Phone:          "+4798765432",
+-		Picture:        "http://mugbook.com/janed/me.jpg",
+-		Groups:         []interface{}{1, 2, 3},
+-		Roles:          []string{"test:c", "test:d"},
+-		Verified:       &verified,
+-		Nonce:          encryption.HashNonce([]byte(oidcNonce)),
+-		StandardClaims: standardClaims,
++		Name:             "Jane Dobbs",
++		Email:            "janed@me.com",
++		Phone:            "+4798765432",
++		Picture:          "http://mugbook.com/janed/me.jpg",
++		Groups:           []interface{}{1, 2, 3},
++		Roles:            []string{"test:c", "test:d"},
++		Verified:         &verified,
++		Nonce:            encryption.HashNonce([]byte(oidcNonce)),
++		RegisteredClaims: registeredClaims,
+ 	}
+ 
+ 	complexGroupsIDToken = idTokenClaims{
+@@ -89,24 +89,24 @@ var (
+ 			12345,
+ 			"Just::A::String",
+ 		},
+-		Roles:          []string{"test:simple", "test:roles"},
+-		Verified:       &verified,
+-		StandardClaims: standardClaims,
++		Roles:            []string{"test:simple", "test:roles"},
++		Verified:         &verified,
++		RegisteredClaims: registeredClaims,
+ 	}
+ 
+ 	unverifiedIDToken = idTokenClaims{
+-		Name:           "Mystery Man",
+-		Email:          "unverified@email.com",
+-		Phone:          "+4025205729",
+-		Picture:        "http://mugbook.com/unverified/email.jpg",
+-		Groups:         []string{"test:a", "test:b"},
+-		Roles:          []string{"test:c", "test:d"},
+-		Verified:       &unverified,
+-		StandardClaims: standardClaims,
++		Name:             "Mystery Man",
++		Email:            "unverified@email.com",
++		Phone:            "+4025205729",
++		Picture:          "http://mugbook.com/unverified/email.jpg",
++		Groups:           []string{"test:a", "test:b"},
++		Roles:            []string{"test:c", "test:d"},
++		Verified:         &unverified,
++		RegisteredClaims: registeredClaims,
+ 	}
+ 
+ 	minimalIDToken = idTokenClaims{
+-		StandardClaims: standardClaims,
++		RegisteredClaims: registeredClaims,
+ 	}
+ )
+ 
+@@ -119,7 +119,7 @@ type idTokenClaims struct {
+ 	Roles    interface{} `json:"roles,omitempty"`
+ 	Verified *bool       `json:"email_verified,omitempty"`
+ 	Nonce    string      `json:"nonce,omitempty"`
+-	jwt.StandardClaims
++	jwt.RegisteredClaims
+ }
+ 
+ type mockJWKS struct{}
+@@ -132,7 +132,7 @@ func (mockJWKS) VerifySignature(_ context.Context, jwt string) ([]byte, error) {
+ 
+ 	tokenClaims := &idTokenClaims{}
+ 	err = json.Unmarshal(decoded, tokenClaims)
+-	if err != nil || tokenClaims.Id == failureTokenID {
++	if err != nil || tokenClaims.ID == failureTokenID {
+ 		return nil, fmt.Errorf("the validation failed for subject [%v]", tokenClaims.Subject)
+ 	}
+ 
+@@ -156,7 +156,7 @@ func newTestOauth2Token() *oauth2.Token {
+ 
+ func TestProviderData_verifyIDToken(t *testing.T) {
+ 	failureIDToken := defaultIDToken
+-	failureIDToken.Id = failureTokenID
++	failureIDToken.ID = failureTokenID
+ 
+ 	testCases := map[string]struct {
+ 		IDToken       *idTokenClaims
+-- 
+2.39.5 (Apple Git-154)
+

--- a/modules/150-user-authn/images/dex-authenticator/patches/README.md
+++ b/modules/150-user-authn/images/dex-authenticator/patches/README.md
@@ -22,3 +22,7 @@ Migrate to a structured config (alpha config): https://oauth2-proxy.github.io/oa
 ### 004-add-redis-retries.patch
 
 Prevents oauth2-proxy from failing with exit 1 if Redis has not started in time. Adds a loop to retry sendRedisConnectionTest.
+
+### 005-fix-cves.patch
+
+Fixes CVE-2025-30204 CVE-2025-22868 CVE-2024-28180

--- a/modules/150-user-authn/images/dex/patches/009-oauth2-cve.patch
+++ b/modules/150-user-authn/images/dex/patches/009-oauth2-cve.patch
@@ -1,0 +1,29 @@
+diff --git a/go.mod b/go.mod
+index 7e5aaf0b..0617b93a 100644
+--- a/go.mod
++++ b/go.mod
+@@ -38,7 +38,7 @@ require (
+ 	golang.org/x/crypto v0.36.0
+ 	golang.org/x/exp v0.0.0-20221004215720-b9f4876ce741
+ 	golang.org/x/net v0.38.0
+-	golang.org/x/oauth2 v0.26.0
++	golang.org/x/oauth2 v0.27.0
+ 	google.golang.org/api v0.221.0
+ 	google.golang.org/grpc v1.70.0
+ 	google.golang.org/protobuf v1.36.5
+diff --git a/go.sum b/go.sum
+index 9b5665d5..ea354d63 100644
+--- a/go.sum
++++ b/go.sum
+@@ -283,6 +283,8 @@ golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+ golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+ golang.org/x/oauth2 v0.26.0 h1:afQXWNNaeC4nvZ0Ed9XvCCzXM6UHJG7iCg0W4fPqSBE=
+ golang.org/x/oauth2 v0.26.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
++golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
++golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-- 
+2.39.5 (Apple Git-154)
+

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -49,3 +49,6 @@ for local user accounts. The following features are added:
 This adds functionality to configure password policy duration fields with `day` units, such as: `1d`, `30d12h`, etc.
 This patch also includes refactored password complexity checks - making them much simpler.
 
+### 009-oauth2-cve.patch
+
+Fixes CVE-2025-22868

--- a/modules/150-user-authn/images/kubeconfig-generator/patches/003-fix-cves.patch
+++ b/modules/150-user-authn/images/kubeconfig-generator/patches/003-fix-cves.patch
@@ -1,0 +1,170 @@
+From e24ef44cc803e78ee56a149e4cdd5c5313b386d7 Mon Sep 17 00:00:00 2001
+From: s10dev <s10.dev@yandex.com>
+Date: Thu, 28 Aug 2025 18:37:30 +0300
+Subject: [PATCH] fix cve
+
+---
+ go.mod | 16 ++++++----------
+ go.sum | 35 ++++++++++++-----------------------
+ 2 files changed, 18 insertions(+), 33 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 51ccb62..0798cbc 100644
+--- a/go.mod
++++ b/go.mod
+@@ -5,16 +5,15 @@ go 1.23.0
+ toolchain go1.24.2
+ 
+ require (
+-	github.com/coreos/go-oidc v2.0.0+incompatible
++	github.com/coreos/go-oidc v2.4.0+incompatible
+ 	github.com/spf13/cast v1.3.0
+ 	github.com/spf13/cobra v0.0.5
+ 	github.com/spf13/viper v1.4.0
+-	golang.org/x/oauth2 v0.10.0
++	golang.org/x/oauth2 v0.28.0
+ )
+ 
+ require (
+ 	github.com/fsnotify/fsnotify v1.4.7 // indirect
+-	github.com/golang/protobuf v1.5.3 // indirect
+ 	github.com/google/go-cmp v0.6.0 // indirect
+ 	github.com/hashicorp/hcl v1.0.0 // indirect
+ 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+@@ -28,13 +27,10 @@ require (
+ 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+ 	github.com/spf13/pflag v1.0.3 // indirect
+ 	github.com/stretchr/testify v1.8.3 // indirect
+-	golang.org/x/crypto v0.36.0 // indirect
+-	golang.org/x/net v0.38.0 // indirect
+-	golang.org/x/sys v0.31.0 // indirect
+-	golang.org/x/text v0.23.0 // indirect
+-	google.golang.org/appengine v1.6.7 // indirect
+-	google.golang.org/protobuf v1.33.0 // indirect
++	golang.org/x/crypto v0.39.0 // indirect
++	golang.org/x/sys v0.33.0 // indirect
++	golang.org/x/text v0.26.0 // indirect
+ 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+-	gopkg.in/square/go-jose.v2 v2.3.1 // indirect
++	gopkg.in/go-jose/go-jose.v2 v2.6.3 // indirect
+ 	gopkg.in/yaml.v2 v2.2.8 // indirect
+ )
+diff --git a/go.sum b/go.sum
+index 877289b..e27cf27 100644
+--- a/go.sum
++++ b/go.sum
+@@ -57,8 +57,8 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
+ github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
+ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
+-github.com/coreos/go-oidc v2.0.0+incompatible h1:+RStIopZ8wooMx+Vs5Bt8zMXxV1ABl5LbakNExNmZIg=
+-github.com/coreos/go-oidc v2.0.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
++github.com/coreos/go-oidc v2.4.0+incompatible h1:xjdlhLWXcINyUJgLQ9I76g7osgC2goiL6JDXS6Fegjk=
++github.com/coreos/go-oidc v2.4.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
+ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+@@ -113,9 +113,6 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
+ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
+ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+-github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+@@ -127,7 +124,6 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
+ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
+@@ -263,8 +259,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+ golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+-golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+-golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
++golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
++golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
+ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
+@@ -332,8 +328,6 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
+ golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+@@ -343,8 +337,8 @@ golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ
+ golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+ golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+ golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+-golang.org/x/oauth2 v0.10.0 h1:zHCpF2Khkwy4mMB4bv0U37YtJdTGW8jI0glAApi0Kh8=
+-golang.org/x/oauth2 v0.10.0/go.mod h1:kTpgurOux7LqtuxjuyZa4Gj2gdezIt/jQtGnNFfypQI=
++golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
++golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -393,8 +387,8 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
+ golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
++golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
++golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+@@ -402,8 +396,8 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
+ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
++golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
++golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
+ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+@@ -484,7 +478,6 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
+ google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+ google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+ google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+-google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
+ google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+ google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
+@@ -549,19 +542,15 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
+ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
+ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
++gopkg.in/go-jose/go-jose.v2 v2.6.3 h1:nt80fvSDlhKWQgSWyHyy5CfmlQr+asih51R8PTWNKKs=
++gopkg.in/go-jose/go-jose.v2 v2.6.3/go.mod h1:zzZDPkNNw/c9IE7Z9jr11mBZQhKQTMzoEEIoEdZlFBI=
+ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+-gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
+-gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
+ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+-- 
+2.39.5 (Apple Git-154)
+

--- a/modules/150-user-authn/images/kubeconfig-generator/patches/README.md
+++ b/modules/150-user-authn/images/kubeconfig-generator/patches/README.md
@@ -7,3 +7,7 @@ Update dependencies
 ## 002-already_logged.patch
 
 patch
+
+### 003-fix-cves.patch
+
+Fixes CVE-2025-22868 CVE-2024-28180


### PR DESCRIPTION
## Description
Fix multiple security vulnerabilities in **user-authn** module:  
- CVE-2025-30204  
- CVE-2025-22868  
- CVE-2024-28180  

## Why do we need it, and what problem does it solve?
These CVEs affect authentication components and may lead to security risks if not patched.  
Fixing them ensures the cluster remains protected and compliant with security requirements.  

## Why do we need it in the patch release (if we do)?
Yes, because the changes address critical security vulnerabilities and should be delivered in the nearest patch release.  

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: user-authn
type: fix
summary: Fix CVE-2025-30204, CVE-2025-22868, and CVE-2024-28180 in the user-authn module
impact: Fixed multiple security vulnerabilities that could affect authentication components.
impact_level: high
