### PR TITLE
[docs][log-shipper] Minor updates and fix linter

### DIFF
--- a/modules/460-log-shipper/docs/ADVANCED_USAGE.md
+++ b/modules/460-log-shipper/docs/ADVANCED_USAGE.md
@@ -26,12 +26,13 @@ Then in logs, you will find a lot of helpful information about HTTP requests, co
 To begin with, retrieve the list of pods on the desired node.
 
 ```bash
-kubectl -n d8-log-shipper get pods -o wide | grep $node
+d8 k -n d8-log-shipper get pods -o wide | grep $node
 ```
+
 Select the appropriate pod and execute commands directly from the container.
 
 ```bash
-kubectl -n d8-log-shipper exec $pod -c vector -- COMMAND_NAME
+d8 k -n d8-log-shipper exec $pod -c vector -- COMMAND_NAME
 ```
 
 All subsequent commands are assumed to be executed within the container.

--- a/modules/460-log-shipper/docs/ADVANCED_USAGE_RU.md
+++ b/modules/460-log-shipper/docs/ADVANCED_USAGE_RU.md
@@ -29,12 +29,13 @@ spec:
 Для начала получите список подов на желаемом узле.
 
 ```bash
-kubectl -n d8-log-shipper get pods -o wide | grep $node
+d8 k -n d8-log-shipper get pods -o wide | grep $node
 ```
 
 Выберите нужный под и выполните команды напрямую из контейнера.
+
 ```bash
-kubectl -n d8-log-shipper exec $pod -c vector -- ИМЯ_КОМАНДЫ
+d8 k -n d8-log-shipper exec $pod -c vector -- ИМЯ_КОМАНДЫ
 ```
 
 Все следующие команды предполагается запускать передавая их в контейнер.

--- a/modules/460-log-shipper/docs/FAQ.md
+++ b/modules/460-log-shipper/docs/FAQ.md
@@ -28,7 +28,7 @@ For example:
 - Get the `log-shipper-token` token from the `d8-log-shipper` namespace:
 
   ```bash
-  kubectl -n d8-log-shipper get secret log-shipper-token -o jsonpath='{.data.token}' | base64 -d
+  d8 k -n d8-log-shipper get secret log-shipper-token -o jsonpath='{.data.token}' | base64 -d
   ```
 
 - ClusterLogDestination resource with authorization:

--- a/modules/460-log-shipper/docs/FAQ_RU.md
+++ b/modules/460-log-shipper/docs/FAQ_RU.md
@@ -28,7 +28,7 @@ title: "The log-shipper module: FAQ"
 - Получите токен `log-shipper-token` из пространства имен `d8-log-shipper`:
 
   ```bash
-  kubectl -n d8-log-shipper get secret log-shipper-token -o jsonpath='{.data.token}' | base64 -d
+  d8 k -n d8-log-shipper get secret log-shipper-token -o jsonpath='{.data.token}' | base64 -d
   ```
 
 - Ресурс _ClusterLogDestination_ с авторизацией:


### PR DESCRIPTION
## Description
Updated the kubectl commands to use the d8 alias in the log-shipper documentation.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Minor updates and fix linter
impact_level: low
```
