### PR TITLE
[registry] FIx CVEs

### DIFF
--- a/modules/038-registry/images/docker-auth/werf.inc.yaml
+++ b/modules/038-registry/images/docker-auth/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "v1.13.0-deckhouse.0"}}
+{{- $version := "v1.14.0-deckhouse.0"}}
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
 fromImage: common/src-artifact

--- a/modules/038-registry/images/docker-distribution/werf.inc.yaml
+++ b/modules/038-registry/images/docker-distribution/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "v2.8.3-deckhouse.0"}}
+{{- $version := "v2.8.3-deckhouse.1"}}
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
 fromImage: common/src-artifact


### PR DESCRIPTION
## Description
Update module images to fix dependencies CVEs:
```
Component - registry/dockerAuth

auth_server (gobinary)
======================
Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 3, CRITICAL: 0)

┌─────────────────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│               Library               │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                            │
├─────────────────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/go-jose/go-jose/v3       │ CVE-2025-27144 │ MEDIUM   │ fixed  │ v3.0.3            │ 3.0.4         │ go-jose: Go JOSE's Parsing Vulnerable to Denial of Service │
│                                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-27144                 │
├─────────────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/prometheus/client_golang │ CVE-2022-21698 │ HIGH     │        │ v1.3.0            │ 1.11.1        │ prometheus/client_golang: Denial of service using          │
│                                     │                │          │        │                   │               │ InstrumentHandlerCounter                                   │
│                                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-21698                 │
├─────────────────────────────────────┼────────────────┤          │        ├───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto                 │ CVE-2025-22869 │          │        │ v0.31.0           │ 0.35.0        │ golang.org/x/crypto/ssh: Denial of Service in the Key      │
│                                     │                │          │        │                   │               │ Exchange of golang.org/x/crypto/ssh                        │
│                                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-22869                 │
├─────────────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ golang.org/x/net                    │ CVE-2025-22870 │ MEDIUM   │        │ v0.33.0           │ 0.36.0        │ golang.org/x/net/proxy: golang.org/x/net/http/httpproxy:   │
│                                     │                │          │        │                   │               │ HTTP Proxy bypass using IPv6 Zone IDs in golang.org/x/net  │
│                                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-22870                 │
│                                     ├────────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                                     │ CVE-2025-22872 │          │        │                   │ 0.38.0        │ golang.org/x/net/html: Incorrect Neutralization of Input   │
│                                     │                │          │        │                   │               │ During Web Page Generation in x/net in...                  │
│                                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-22872                 │
├─────────────────────────────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ golang.org/x/oauth2                 │ CVE-2025-22868 │ HIGH     │        │ v0.13.0           │ 0.27.0        │ golang.org/x/oauth2/jws: Unexpected memory consumption     │
│                                     │                │          │        │                   │               │ during token parsing in golang.org/x/oauth2/jws            │
│                                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-22868                 │
└─────────────────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
Component - registry/dockerDistribution

registry (gobinary)
===================
Total: 7 (UNKNOWN: 0, LOW: 1, MEDIUM: 3, HIGH: 3, CRITICAL: 0)

┌─────────────────────────────────────┬─────────────────────┬──────────┬──────────┬───────────────────────────────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│               Library               │    Vulnerability    │ Severity │  Status  │             Installed Version             │ Fixed Version │                            Title                            │
├─────────────────────────────────────┼─────────────────────┼──────────┼──────────┼───────────────────────────────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ github.com/aws/aws-sdk-go           │ CVE-2020-8911       │ MEDIUM   │ fixed    │ v1.14.30                                  │ 1.34.0        │ aws/aws-sdk-go: CBC padding oracle issue in AWS S3 Crypto   │
│                                     │                     │          │          │                                           │               │ SDK for golang...                                           │
│                                     │                     │          │          │                                           │               │ https://avd.aquasec.com/nvd/cve-2020-8911                   │
│                                     ├─────────────────────┤          │          │                                           │               ├─────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-2582       │          │          │                                           │               │ The AWS S3 Crypto SDK sends an unencrypted hash of the      │
│                                     │                     │          │          │                                           │               │ plaintext...                                                │
│                                     │                     │          │          │                                           │               │ https://avd.aquasec.com/nvd/cve-2022-2582                   │
│                                     ├─────────────────────┤          │          │                                           │               ├─────────────────────────────────────────────────────────────┤
│                                     │ GHSA-76wf-9vgp-pj7w │          │          │                                           │               │ Unencrypted md5 plaintext hash in metadata in AWS S3 Crypto │
│                                     │                     │          │          │                                           │               │ SDK for...                                                  │
│                                     │                     │          │          │                                           │               │ https://github.com/advisories/GHSA-76wf-9vgp-pj7w           │
│                                     ├─────────────────────┼──────────┤          │                                           │               ├─────────────────────────────────────────────────────────────┤
│                                     │ CVE-2020-8912       │ LOW      │          │                                           │               │ aws-sdk-go: In-band key negotiation issue in AWS S3 Crypto  │
│                                     │                     │          │          │                                           │               │ SDK for golang...                                           │
│                                     │                     │          │          │                                           │               │ https://avd.aquasec.com/nvd/cve-2020-8912                   │
├─────────────────────────────────────┼─────────────────────┼──────────┼──────────┼───────────────────────────────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ github.com/dgrijalva/jwt-go         │ CVE-2020-26160      │ HIGH     │ affected │ v3.2.0+incompatible                       │               │ jwt-go: access restriction bypass vulnerability             │
│                                     │                     │          │          │                                           │               │ https://avd.aquasec.com/nvd/cve-2020-26160                  │
├─────────────────────────────────────┼─────────────────────┤          ├──────────┼───────────────────────────────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ github.com/prometheus/client_golang │ CVE-2022-21698      │          │ fixed    │ v0.9.0-pre1.0.20180209125602-c332b6f63c06 │ 1.11.1        │ prometheus/client_golang: Denial of service using           │
│                                     │                     │          │          │                                           │               │ InstrumentHandlerCounter                                    │
│                                     │                     │          │          │                                           │               │ https://avd.aquasec.com/nvd/cve-2022-21698                  │
├─────────────────────────────────────┼─────────────────────┤          │          ├───────────────────────────────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto                 │ CVE-2025-22869      │          │          │ v0.32.0                                   │ 0.35.0        │ golang.org/x/crypto/ssh: Denial of Service in the Key       │
│                                     │                     │          │          │                                           │               │ Exchange of golang.org/x/crypto/ssh                         │
│                                     │                     │          │          │                                           │               │ https://avd.aquasec.com/nvd/cve-2025-22869                  │
└─────────────────────────────────────┴─────────────────────┴──────────┴──────────┴───────────────────────────────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry
type: chore
summary: "Fixed CVE's: CVE-2020-26160, CVE-2020-8911, CVE-2020-8912, CVE-2022-21698, CVE-2022-2582, CVE-2025-22868, CVE-2025-22869, CVE-2025-22870, CVE-2025-22872, CVE-2025-27144"
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
