### PR TITLE
[docs] Add example at admission-policy-engine documentation

### DIFF
--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
@@ -19,7 +19,11 @@ Provide a configurable set of policies for modifying Kubernetes resources at the
 Allows you to modify the `Metadata` section of a resource.
 At the moment, Gatekeeper only allows **adding** `labels` and `annotations` objects. Modification of existing objects is not provided.
 
-An example of adding the label `owner` with the value `admin` in all namespaces:
+{% alert level="info" %}
+Using `*` in `spec.match.kinds` is not allowed. If `*` is specified, the mutation will not be applied. Instead, you must explicitly list the target resources (`kinds`) along with their corresponding `apiGroups`.
+{% endalert %}
+
+Example 1. Adding the `owner` label with the value `admin` to all namespaces:
 
 ```yaml
 apiVersion: mutations.gatekeeper.sh/v1
@@ -33,6 +37,26 @@ spec:
   parameters:
     assign:
       value: "admin"
+```
+
+Example 2. Adding a label in a specific namespace and only to selected resources:
+
+```yaml
+apiVersion: mutations.gatekeeper.sh/v1
+kind: AssignMetadata
+metadata:
+  name: set-labels-<your_namespace>
+spec:
+  match:
+    scope: Namespaced
+    namespaces: ["<your_namespace>"]
+    kinds:
+    - apiGroups: [""]
+      kinds: ["Pod"] # Запрещено использовать "*" .
+  location: "metadata.labels.<your_label_name>"
+  parameters:
+    assign:
+      value: <your_label_value>
 ```
 
 ### Assign

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR.md
@@ -52,7 +52,7 @@ spec:
     namespaces: ["<your_namespace>"]
     kinds:
     - apiGroups: [""]
-      kinds: ["Pod"] # Запрещено использовать "*" .
+      kinds: ["Pod"] # The use of "*" is not allowed.
   location: "metadata.labels.<your_label_name>"
   parameters:
     assign:

--- a/modules/015-admission-policy-engine/docs/GATEKEEPER-CR_RU.md
+++ b/modules/015-admission-policy-engine/docs/GATEKEEPER-CR_RU.md
@@ -19,7 +19,11 @@ title: "Модуль admission-policy-engine: Custom Resources (от Gatekeeper)
 Позволяет изменять секцию `Metadata` ресурса.  
 На данный момент сервисом Gatekeeper разрешено только **добавление** объектов `lables` и `annotations`. Изменение существующих объектов не предусмотрено.
 
-Пример добавления label `owner` со значением `admin` во всех пространствах имен:
+{% alert level="info" %}
+В `spec.match.kinds` запрещено использовать `*`. При указании `*` мутация не применяется. Вместо этого необходимо явно перечислять целевые ресурсы (`kinds`) и их `apiGroups`.
+{% endalert %}
+
+Пример 1. Добавление лейбла `owner` со значением `admin` во всех пространствах имён:
   
 ```yaml
 apiVersion: mutations.gatekeeper.sh/v1
@@ -33,6 +37,26 @@ spec:
   parameters:
     assign:
       value: "admin"
+```
+
+Пример 2. Добавление лейбла в конкретном пространстве имён и только на выбранные ресурсы:
+
+```yaml
+apiVersion: mutations.gatekeeper.sh/v1
+kind: AssignMetadata
+metadata:
+  name: set-labels-<your_namespace>
+spec:
+  match:
+    scope: Namespaced
+    namespaces: ["<your_namespace>"]
+    kinds:
+    - apiGroups: [""]
+      kinds: ["Pod"] # Запрещено использовать "*" .
+  location: "metadata.labels.<your_label_name>"
+  parameters:
+    assign:
+      value: <your_label_value>
 ```
 
 ### Assign


### PR DESCRIPTION
## Description
Added example at admission-policy-engine documentation.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Added example at admission-policy-engine documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
