### PR TITLE
[ingress-nginx] Fix NginxIngressDaemonSetReplicasUnavailable alert description

### DIFF
--- a/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
@@ -162,7 +162,7 @@
         List of unavailable pods:
 
         ```text
-        {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
+        {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_phase{namespace=\"%s\", phase!~\"Running|Succeeded\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
         ```
 
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
@@ -190,7 +190,7 @@
         List of unavailable pods:
 
         ```text
-        {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
+        {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_phase{namespace=\"%s\", phase!~\"Running|Succeeded\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
         ```
 
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.


### PR DESCRIPTION
## Description
This PR fixes the `NginxIngressDaemonSetReplicasUnavailable` alert.
In the alert query, the metric `kube_pod_status_ready` has been replaced with `kube_pod_status_phase{phase!~"Running|Succeeded"}`.
This change addresses the issue of the alert not correctly reflecting pods in non-ready states.

## Why do we need it, and what problem does it solve?
Previously, the alert relied on the `kube_pod_status_ready metric`, which did not account for pod states such as `Pending`. As a result, the alert could trigger even when there were no unavailable pods listed in its description, leading to confusion. This update ensures that all relevant pod states are considered, providing a more accurate alert status.

<img width="1713" height="564" alt="image" src="https://github.com/user-attachments/assets/4641f2ea-cb47-466d-9ab1-a48200001a83" />

## How to test these changes?
1. Create a copy of the Kruise DaemonSet controller in such a way that a pod cannot start and remains in the Pending state;
2. Wait for 5 minutes (the alert registration period);
3. Check the alert in the Prometheus console — the list of unavailable pods should now be populated and not empty.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: fix 
summary: fix NginxIngressDaemonSetReplicasUnavailable alert description
impact_level: low
```
