### PR TITLE
[ingress-nginx] Disable some log messages

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/018-disable-error-logs.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/018-disable-error-logs.patch
@@ -1,0 +1,13 @@
+diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
+index 012f465bf..670405cf1 100644
+--- a/internal/ingress/controller/controller.go
++++ b/internal/ingress/controller/controller.go
+@@ -1110,7 +1110,7 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
+ 					_, port := upstreamServiceNameAndPort(path.Backend.Service)
+ 					endp, err := n.serviceEndpoints(svcKey, port.String())
+ 					if err != nil {
+-						klog.Warningf("Error obtaining Endpoints for Service %q: %v", svcKey, err)
++						// klog.Warningf("Error obtaining Endpoints for Service %q: %v", svcKey, err)
+ 						n.metricCollector.IncOrphanIngress(ing.Namespace, ing.Name, orphanMetricLabelNoService)
+ 						continue
+ 					}

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -67,7 +67,7 @@ Build nginx for controller on ALT Linux.
 
 Add HTTP/3 support.
 
-We have made two PRs in upstream to bump ingress-nginx image and to enable http3 module. 
+We have made two PRs in upstream to bump ingress-nginx image and to enable http3 module.
 But we did not add full support for http3 in upstream, because at that time OpenSSL did not fully support quic.
 
 Bump the image and enable http3 module: https://github.com/kubernetes/ingress-nginx/pull/11470
@@ -75,7 +75,7 @@ README about next steps for upstream: https://github.com/kubernetes/ingress-ngin
 
 README: https://github.com/kubernetes/ingress-nginx/blob/main/images/nginx/README.md
 
-When OpenSSL fully supports quic, the work can be continued. 
+When OpenSSL fully supports quic, the work can be continued.
 To add fully support - steps from the readme should be accomplished and after this the patch can be deleted.
 
 ### 012-new-metrics.patch
@@ -106,3 +106,7 @@ Added additional logging when downloading GeoIP databases from the MaxMind servi
 This patch ensures that when an invalid Ingress configuration is deleted, metric `nginx_ingress_controller_config_last_reload_successful` is set to 1.
 
 https://github.com/kubernetes/ingress-nginx/pull/13830
+
+### 018-disable-error-logs.patch
+
+Disabling log messages such as "Error obtaining Endpoints for Service...".

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -55,6 +55,7 @@ shell:
   - patch -p1 < /patches/015-validation-mode.patch
   - patch -p1 < /patches/016-verbose-maxmind-logs.patch
   - patch -p1 < /patches/017-fix-success-reload-metric.patch
+  - patch -p1 < /patches/018-disable-error-logs.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/014-balancer-lua.patch
   - patch -p1 < /patches/003-nginx-tmpl.patch

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/016-disable-error-logs.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/016-disable-error-logs.patch
@@ -1,0 +1,13 @@
+diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
+index 012f465bf..670405cf1 100644
+--- a/internal/ingress/controller/controller.go
++++ b/internal/ingress/controller/controller.go
+@@ -1110,7 +1110,7 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
+ 					_, port := upstreamServiceNameAndPort(path.Backend.Service)
+ 					endp, err := n.serviceEndpoints(svcKey, port.String())
+ 					if err != nil {
+-						klog.Warningf("Error obtaining Endpoints for Service %q: %v", svcKey, err)
++						// klog.Warningf("Error obtaining Endpoints for Service %q: %v", svcKey, err)
+ 						n.metricCollector.IncOrphanIngress(ing.Namespace, ing.Name, orphanMetricLabelNoService)
+ 						continue
+ 					}

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
@@ -93,3 +93,7 @@ Go mod patches for ingress-nginx-controller.
 This patch ensures that when an invalid Ingress configuration is deleted, metric `nginx_ingress_controller_config_last_reload_successful` is set to 1.
 
 https://github.com/kubernetes/ingress-nginx/pull/13830
+
+### 016-disable-error-logs.patch
+
+Disabling log messages such as "Error obtaining Endpoints for Service...".

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/015-disable-error-logs.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/015-disable-error-logs.patch
@@ -1,0 +1,13 @@
+diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
+index 012f465bf..670405cf1 100644
+--- a/internal/ingress/controller/controller.go
++++ b/internal/ingress/controller/controller.go
+@@ -1110,7 +1110,7 @@ func (n *NGINXController) createUpstreams(data []*ingress.Ingress, du *ingress.B
+ 					_, port := upstreamServiceNameAndPort(path.Backend.Service)
+ 					endp, err := n.serviceEndpoints(svcKey, port.String())
+ 					if err != nil {
+-						klog.Warningf("Error obtaining Endpoints for Service %q: %v", svcKey, err)
++						// klog.Warningf("Error obtaining Endpoints for Service %q: %v", svcKey, err)
+ 						n.metricCollector.IncOrphanIngress(ing.Namespace, ing.Name, orphanMetricLabelNoService)
+ 						continue
+ 					}

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/README.md
@@ -74,3 +74,7 @@ Added additional logging when downloading GeoIP databases from the MaxMind servi
 This patch ensures that when an invalid Ingress configuration is deleted, metric `nginx_ingress_controller_config_last_reload_successful` is set to 1.
 
 https://github.com/kubernetes/ingress-nginx/pull/13830
+
+### 015-disable-error-logs.patch
+
+Disabling log messages such as "Error obtaining Endpoints for Service...".

--- a/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
@@ -3,7 +3,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 fromImage: common/src-artifact
-fromCacheVersion: "2025-08-26"
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -65,6 +64,7 @@ shell:
   - patch -p1 < /patches/ingress-nginx/012-validation-mode.patch
   - patch -p1 < /patches/ingress-nginx/013-verbose-maxmind-logs.patch
   - patch -p1 < /patches/ingress-nginx/014-fix-success-reload-metric.patch
+  - patch -p1 < /patches/ingress-nginx/015-disable-error-logs.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/rootfs/001-balancer-lua.patch
   - patch -p1 < /patches/rootfs/002-nginx-tmpl.patch


### PR DESCRIPTION
## Description

Disable log messages like:

```log
W0828 11:09:05.372106       7 controller.go:1116] Error obtaining Endpoints for Service "d8-monitoring/grafana": no object matching key "d8-monitoring/grafana" in local store
W0828 11:09:05.372284       7 controller.go:1116] Error obtaining Endpoints for Service "d8-ingress-nginx/fakeservice": no object matching key "d8-ingress-nginx/fakeservice" in local store
```

How to verify:

```shell
kubectl -n d8-ingress-nginx logs controller-main-wvvh6 | grep "Error obtaining"
```

## Why do we need it, and what problem does it solve?

- These messages are of the Warning type, but they contain the word "Error", which many users perceive as an error that needs to be fixed.
- These messages are generated very frequently and clutter the log with unnecessary information.

## Checklist

- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: fix
summary: Disabled log messages such as `Error obtaining Endpoints for Service...`.
impact_level: default
```
