### PR TITLE
[cni-cilium] some fixes to the process of upgrading cilium to version 1.17

### DIFF
--- a/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
+++ b/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
@@ -44,8 +44,8 @@ spec:
     fi
 
     # If the safe-agent-updater pod does not exist, there is nothing to do
-    if sau_pod_count="$(crictl pods --namespace d8-cni-cilium --label app=safe-agent-updater -o json | \
-        jq -er '.items | length')"; [[ "${sau_pod_count}" == "0" ]]; then
+    if sau_pod_count="$(/opt/deckhouse/bin/crictl pods --namespace d8-cni-cilium --label app=safe-agent-updater -o json | \
+        jq -er '.items | length == 0')"; then
       bb-log-info "There is no safe-agent-updater pod on the node."
       exit 0
     fi

--- a/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
+++ b/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cilium-1-17-migration.sh
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 spec:
-  weight: 72
+  weight: 98
   nodeGroups: ["*"]
   bundles: ["*"]
   content: |
@@ -39,10 +39,16 @@ spec:
       exit 0
     fi
 
+    attempt=0
     until
       is_migration_required="$(bb-kubectl --kubeconfig $kubeconfig get node $(bb-d8-node-name) -o json | \
       jq -er '.metadata.annotations."network.deckhouse.io/cilium-1-17-migration-disruptive-update-required"')";
     do
+      attempt=$(( attempt + 1 ))
+      if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
+          bb-log-error "ERROR: Failed to get annotation 'network.deckhouse.io/cilium-1-17-migration-disruptive-update-required' from our Node. Retry limit is over."
+          exit 1
+      fi
       bb-log-info "Waiting until the safe-agent-updater calculates the need for an disruptive-update and annotates the node."
       sleep 10
     done

--- a/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
+++ b/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
@@ -24,19 +24,56 @@ spec:
 
     # cilium-agent image hash: {{ include "helm_lib_module_image" (list . "agentDistroless") }}
 
+    desired_sau_ds_generation={{ include "agent_daemonset_template" (list . "undefined") | sha256sum | quote }}
+
     # If there is no kubelet.conf than node is not bootstrapped and there is nothing to do
     kubeconfig="/etc/kubernetes/kubelet.conf"
     if [ ! -f "$kubeconfig" ]; then
       exit 0
     fi
 
+    # If it is the first bashible run, there is nothing to do
     if [[ "${FIRST_BASHIBLE_RUN}" == "yes" ]]; then
       exit 0
     fi
 
+    # If the migration has already succeeded, there is nothing to do
     if bb-kubectl --kubeconfig $kubeconfig get node $(bb-d8-node-name) -o json | \
-          jq -e '.metadata.annotations | has("network.deckhouse.io/cilium-1-17-migration-succeeded")' >/dev/null; then
+        jq -e '.metadata.annotations | has("network.deckhouse.io/cilium-1-17-migration-succeeded")' >/dev/null; then
       exit 0
+    fi
+
+    # If the safe-agent-updater pod does not exist, there is nothing to do
+    if sau_pod_count="$(crictl pods --namespace d8-cni-cilium --label app=safe-agent-updater -o json | \
+        jq -er '.items | length')"; [[ "${sau_pod_count}" == "0" ]]; then
+      bb-log-info "There is no safe-agent-updater pod on the node."
+      exit 0
+    fi
+
+    attempt=0
+    until
+      sau_pod_count="$(crictl pods --namespace d8-cni-cilium --label app=safe-agent-updater -o json | \
+      jq -er '.items | length')"; \
+      [[ "${sau_pod_count}" == "1" ]];
+    do
+      attempt=$(( attempt + 1 ))
+      if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
+          bb-log-error "ERROR: Failed to wait until only one safe-agent-updater pod stays on the node. Retry limit is over."
+          exit 1
+      fi
+      bb-log-info "Waiting until there is only one safe-agent-updater pods on the node."
+      sleep 10
+    done
+
+    sau_pod_name="$(crictl pods --namespace d8-cni-cilium --label app=safe-agent-updater -o json | \
+      jq -er '.items[0].metadata.name')";
+
+    if ! current_sau_ds_generation="$(crictl pods --name ${sau_pod_name} -o json | \
+      jq -er '.items[0].annotations."safe-agent-updater-daemonset-generation"')" || \
+      [[ "${current_sau_ds_generation}" != "${desired_sau_ds_generation}" ]];
+    then
+      bb-kubectl --kubeconfig $kubeconfig delete pod -n d8-cni-cilium -l app=safe-agent-updater \
+        --field-selector spec.nodeName=$(bb-d8-node-name)
     fi
 
     attempt=0

--- a/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
+++ b/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
@@ -67,9 +67,8 @@ spec:
     sau_pod_name="$(/opt/deckhouse/bin/crictl pods --namespace d8-cni-cilium --label app=safe-agent-updater -o json | \
       jq -er '.items[0].metadata.name')";
 
-    if ! current_sau_ds_generation="$(/opt/deckhouse/bin/crictl pods --name ${sau_pod_name} -o json | \
-      jq -er '.items[0].annotations."safe-agent-updater-daemonset-generation"')" || \
-      [[ "${current_sau_ds_generation}" != "${desired_sau_ds_generation}" ]];
+    if /opt/deckhouse/bin/crictl pods --name ${sau_pod_name} -o json | \
+      jq --arg desired_sau_ds_generation "$desired_sau_ds_generation" -e '.items[0].annotations."safe-agent-updater-daemonset-generation" != $desired_sau_ds_generation' > /dev/null;
     then
       bb-kubectl --kubeconfig $kubeconfig delete pod -n d8-cni-cilium -l app=safe-agent-updater \
         --field-selector spec.nodeName=$(bb-d8-node-name)

--- a/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
+++ b/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
@@ -26,14 +26,34 @@ spec:
 
     desired_sau_ds_generation={{ include "agent_daemonset_template" (list . "undefined") | sha256sum | quote }}
 
-    # If there is no kubelet.conf than node is not bootstrapped and there is nothing to do
-    kubeconfig="/etc/kubernetes/kubelet.conf"
-    if [ ! -f "$kubeconfig" ]; then
+    # If there is no cilium-cni binary on node than node is not bootstrapped and there is nothing to do
+    if [ ! -f "/opt/cni/bin/cilium-cni" ]; then
       exit 0
+    fi
+
+    # If the cilium-cni binary is the version 1.17.4 or higher, there is nothing to do
+    if ! out=$(/opt/cni/bin/cilium-cni VERSION 2>&1); then
+      bb-log-info "Failed to execute cilium-cni binary: $out"
+      exit 1
+    fi
+    version=$(echo "$out" | grep -oP 'Cilium\s+CNI\s+plugin\s+\K\d+\.\d+\.\d+')
+    major=$(echo "$version" | cut -d. -f1)
+    minor=$(echo "$version" | cut -d. -f2)
+    patch=$(echo "$version" | cut -d. -f3)
+
+    if [[ $major -gt 1 || ( $major -eq 1 && $minor -ge 17 ) ]]; then
+        echo "Cilium CNI plugin version is not less than 1.17: $version"
+        exit 0
     fi
 
     # If it is the first bashible run, there is nothing to do
     if [[ "${FIRST_BASHIBLE_RUN}" == "yes" ]]; then
+      exit 0
+    fi
+
+    # If there is no kubelet.conf than node is not bootstrapped and there is nothing to do
+    kubeconfig="/etc/kubernetes/kubelet.conf"
+    if [ ! -f "$kubeconfig" ]; then
       exit 0
     fi
 
@@ -94,10 +114,16 @@ spec:
 
     bb-deckhouse-get-disruptive-update-approval
 
+    attempt=0
     until
       bb-kubectl --kubeconfig $kubeconfig get node $(bb-d8-node-name) -o json | \
       jq -e '.metadata.annotations | has("network.deckhouse.io/cilium-1-17-migration-succeeded")' >/dev/null;
     do
+      attempt=$(( attempt + 1 ))
+      if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
+          bb-log-error "ERROR: Failed to wait until the safe-agent-updater completes the disruptive-update on our Node (can't get annotation 'network.deckhouse.io/cilium-1-17-migration-succeeded') . Retry limit is over."
+          exit 1
+      fi
       bb-log-info "Waiting until the safe-agent-updater completes the disruptive-update on node."
       sleep 10
     done

--- a/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
+++ b/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
@@ -44,17 +44,16 @@ spec:
     fi
 
     # If the safe-agent-updater pod does not exist, there is nothing to do
-    if sau_pod_count="$(/opt/deckhouse/bin/crictl pods --namespace d8-cni-cilium --label app=safe-agent-updater -o json | \
-        jq -er '.items | length == 0')"; then
+    if /opt/deckhouse/bin/crictl pods --namespace d8-cni-cilium --label app=safe-agent-updater -o json | \
+        jq -er '.items | length == 0' > /dev/null; then
       bb-log-info "There is no safe-agent-updater pod on the node."
       exit 0
     fi
 
     attempt=0
     until
-      sau_pod_count="$(crictl pods --namespace d8-cni-cilium --label app=safe-agent-updater -o json | \
-      jq -er '.items | length')"; \
-      [[ "${sau_pod_count}" == "1" ]];
+      /opt/deckhouse/bin/crictl pods --namespace d8-cni-cilium --label app=safe-agent-updater -o json | \
+        jq -er '.items | length == 1' > /dev/null;
     do
       attempt=$(( attempt + 1 ))
       if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
@@ -65,10 +64,10 @@ spec:
       sleep 10
     done
 
-    sau_pod_name="$(crictl pods --namespace d8-cni-cilium --label app=safe-agent-updater -o json | \
+    sau_pod_name="$(/opt/deckhouse/bin/crictl pods --namespace d8-cni-cilium --label app=safe-agent-updater -o json | \
       jq -er '.items[0].metadata.name')";
 
-    if ! current_sau_ds_generation="$(crictl pods --name ${sau_pod_name} -o json | \
+    if ! current_sau_ds_generation="$(/opt/deckhouse/bin/crictl pods --name ${sau_pod_name} -o json | \
       jq -er '.items[0].annotations."safe-agent-updater-daemonset-generation"')" || \
       [[ "${current_sau_ds_generation}" != "${desired_sau_ds_generation}" ]];
     then


### PR DESCRIPTION
## Description

- changed the startup order of NGC,
- added the maximum number of attempts to prevent an infinite loop,
- added a forced update of the `safe-agent-updater` pod on the nodes where the disruptive-update was starting.

## Why do we need it, and what problem does it solve?

- this NGC will wait indefinitely for the user to approve the update, blocking other "bashible" steps in the process.
- if a disruptive update was starting on a node where the `safe-agent-updater` pod was not already updated, the upgrade process would be stuck.

## Why do we need it in the patch release (if we do)?

This fix will improve the stability and reliability of bashible steps.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Fixed the infinite loop in the "cilium migration" bashible step and improved synchronization between bashible and safe-agent-updater.
impact_level: default 
```
