### PR TITLE
[chore] add to svace analyze new modules

### DIFF
--- a/ee/be/modules/140-user-authz/images/webhook/werf.inc.yaml
+++ b/ee/be/modules/140-user-authz/images/webhook/werf.inc.yaml
@@ -31,7 +31,7 @@ git:
         - '**/go.sum'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-user-authz-webhook-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-user-authz-webhook-src-artifact

--- a/ee/be/modules/140-user-authz/images/webhook/werf.inc.yaml
+++ b/ee/be/modules/140-user-authz/images/webhook/werf.inc.yaml
@@ -31,7 +31,7 @@ git:
         - '**/go.sum'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-user-authz-webhook-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-user-authz-webhook-src-artifact
@@ -47,7 +47,8 @@ shell:
   install:
     - export GOPROXY=$(cat /run/secrets/GOPROXY) CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src
-    - go build -ldflags '-s -w' -o webhook ./cmd/webhook/main.go
+    - |
+      {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags '-s -w' -o webhook ./cmd/webhook/main.go`) | indent 6 }}
     - go build -ldflags '-s -w' -o healthcheck ./cmd/healthcheck/main.go
     - chown 64535:64535 webhook healthcheck
     - chmod 0700 webhook healthcheck

--- a/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
@@ -51,7 +51,7 @@ shell:
   - rm -rf .git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -67,6 +67,8 @@ shell:
   install:
   - export GOPROXY=$(cat /run/secrets/GOPROXY)
   - cd /src
-  - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /node-collector cmd/node-collector/main.go
+  - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+  - |
+    {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" -o /node-collector cmd/node-collector/main.go`) | indent 6 }}
   - chown root:root /node-collector
   - chmod 0700 /node-collector

--- a/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
@@ -51,7 +51,7 @@ shell:
   - rm -rf .git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/modules/500-operator-trivy/images/operator/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/operator/werf.inc.yaml
@@ -44,7 +44,7 @@ shell:
   - mkdir ./local && tar zxvf /bundle.tar.gz -C ./local
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/modules/500-operator-trivy/images/operator/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/operator/werf.inc.yaml
@@ -44,7 +44,7 @@ shell:
   - mkdir ./local && tar zxvf /bundle.tar.gz -C ./local
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -61,6 +61,8 @@ shell:
   - cd /src
   - ln -s ./trivy-db ./original-trivy-db
   - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
-  - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /operator-trivy ./cmd/trivy-operator/main.go
+  - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+  - |
+    {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" -o /operator-trivy ./cmd/trivy-operator/main.go`) | indent 6 }}
   - chown 64535:64535 /operator-trivy
   - chmod 0700 /operator-trivy

--- a/ee/modules/500-operator-trivy/images/report-updater/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/report-updater/werf.inc.yaml
@@ -23,7 +23,7 @@ git:
     - '**/*'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -37,8 +37,9 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   install:
-  - export GOPROXY=$(cat /run/secrets/GOPROXY)
+  - export GOPROXY=$(cat /run/secrets/GOPROXY) GOOS=linux GOARCH=amd64 CGO_ENABLED=0
   - cd /src
-  - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /report-updater cmd/main.go
+  - |
+    {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" -o /report-updater cmd/main.go`) | indent 6 }}
   - chown 64535:64535 /report-updater
   - chmod 0700 /report-updater

--- a/ee/modules/500-operator-trivy/images/report-updater/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/report-updater/werf.inc.yaml
@@ -23,7 +23,7 @@ git:
     - '**/*'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
@@ -36,7 +36,7 @@ shell:
   - rm -rf /src/trivy/.git /src/trivy-db/.git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
@@ -36,7 +36,7 @@ shell:
   - rm -rf /src/trivy/.git /src/trivy-db/.git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -50,8 +50,9 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   install:
-  - export GOPROXY=$(cat /run/secrets/GOPROXY)
+  - export GOPROXY=$(cat /run/secrets/GOPROXY) GOOS=linux GOARCH=amd64 CGO_ENABLED=0
   - cd /src/trivy
-  - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /trivy ./cmd/trivy/main.go
+  - |
+    {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" -o /trivy ./cmd/trivy/main.go`) | indent 6 }}
   - chown 64535:64535 /trivy
   - chmod 0700 /trivy

--- a/modules/015-admission-policy-engine/images/gatekeeper/werf.inc.yaml
+++ b/modules/015-admission-policy-engine/images/gatekeeper/werf.inc.yaml
@@ -33,7 +33,7 @@ shell:
   - rm -rf .git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -49,6 +49,8 @@ shell:
   install:
   - cd /src
   - GOPROXY=$(cat /run/secrets/GOPROXY) go mod vendor
-  - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -mod vendor -ldflags="-s -w" -o /gatekeeper .
+  - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+  - |
+    {{- include "image-build.build" (set $ "BuildCommand" `go build -mod vendor -ldflags="-s -w" -o /gatekeeper .`) | indent 6 }}
   - chown 64535:64535 /gatekeeper
   - chmod 0700 /gatekeeper

--- a/modules/015-admission-policy-engine/images/gatekeeper/werf.inc.yaml
+++ b/modules/015-admission-policy-engine/images/gatekeeper/werf.inc.yaml
@@ -33,7 +33,7 @@ shell:
   - rm -rf .git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/300-prometheus/images/prometheus/werf.inc.yaml
+++ b/modules/300-prometheus/images/prometheus/werf.inc.yaml
@@ -83,7 +83,7 @@ shell:
   - go build -ldflags="-s -w" -o promu ./main.go
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 mount:
 {{ include "mount points for golang builds" . }}
@@ -104,7 +104,8 @@ shell:
   - export GOPROXY=$(cat /run/secrets/GOPROXY) CGO_ENABLED=0 GOOS=linux GOARCH=amd64
   - cd /src
   - go generate -tags plugins ./plugins
-  - /bin/promu build --prefix /src
+  - |
+    {{- include "image-build.build" (set $ "BuildCommand" `/bin/promu build --prefix /src`) | indent 6 }}
   - mkdir -p /empty
   - chown 64535:64535 /src/prometheus /src/promtool
   - chmod 0700 /src/prometheus /src/promtool

--- a/modules/300-prometheus/images/prometheus/werf.inc.yaml
+++ b/modules/300-prometheus/images/prometheus/werf.inc.yaml
@@ -1,4 +1,5 @@
 ---
+{{- $prometheusVersion := "v2.55.1" }}
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
@@ -54,8 +55,8 @@ secrets:
 shell:
   install:
   - git clone --depth 1 --branch v0.17.0 $(cat /run/secrets/SOURCE_REPO)/prometheus/promu.git /src/promu
-  - git clone --depth 1 --branch v2.55.1 $(cat /run/secrets/SOURCE_REPO)/prometheus/prometheus-deps.git /src/prometheus-deps
-  - git clone --depth 1 --branch v2.55.1 $(cat /run/secrets/SOURCE_REPO)/prometheus/prometheus.git /src/prometheus
+  - git clone --depth 1 --branch {{ $prometheusVersion }} $(cat /run/secrets/SOURCE_REPO)/prometheus/prometheus-deps.git /src/prometheus-deps
+  - git clone --depth 1 --branch {{ $prometheusVersion }} $(cat /run/secrets/SOURCE_REPO)/prometheus/prometheus.git /src/prometheus
   - cd /src/prometheus
   - git apply /patches/*.patch --verbose
   - rm -rf web/ui/*
@@ -83,7 +84,7 @@ shell:
   - go build -ldflags="-s -w" -o promu ./main.go
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
 final: false
 mount:
 {{ include "mount points for golang builds" . }}
@@ -102,10 +103,26 @@ secrets:
 shell:
   install:
   - export GOPROXY=$(cat /run/secrets/GOPROXY) CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+  - |
+    while IFS=':' read -r key value; do
+    if [[ -n $key && -n $value ]]; then
+        key_clean=$(echo "$key" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
+        value_clean=$(echo "$value" | sed 's/^ *//g')
+        export "PROMETHEUS_${key_clean}=${value_clean}"
+    fi
+    done < <(/bin/promu info)
+    export LDFLAGS="-X github.com/prometheus/common/version.Version=${PROMETHEUS_VERSION} \
+    -X github.com/prometheus/common/version.Revision=${PROMETHEUS_REVISION} \
+    -X github.com/prometheus/common/version.Branch=HEAD \
+    -X github.com/prometheus/common/version.BuildUser=root@unknown \
+    -X github.com/prometheus/common/version.BuildDate=$(date +%Y%m%d-%H:%M:%S) \
+    -extldflags '-static'"
+    export PROMETHEUS_TAGS="netgo,builtinassets,stringlabels"
   - cd /src
   - go generate -tags plugins ./plugins
   - |
-    {{- include "image-build.build" (set $ "BuildCommand" `/bin/promu build --prefix /src`) | indent 6 }}
+    {{- include "image-build.build" (set $ "BuildCommand" `go build -tags "${PROMETHEUS_TAGS}" -ldflags="${LDFLAGS}" -o prometheus ./cmd/prometheus`) | indent 6 }}
+  - go build -tags "${PROMETHEUS_TAGS}" -ldflags="${LDFLAGS}" -o promtool ./cmd/promtool
   - mkdir -p /empty
   - chown 64535:64535 /src/prometheus /src/promtool
   - chmod 0700 /src/prometheus /src/promtool

--- a/modules/462-loki/images/loki/werf.inc.yaml
+++ b/modules/462-loki/images/loki/werf.inc.yaml
@@ -20,7 +20,7 @@ shell:
     - rm -r .git vendor
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -36,7 +36,8 @@ shell:
     - cd /src
     - export CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - GOPROXY=$(cat /run/secrets/GOPROXY) go mod vendor
-    - go build -o loki ./cmd/loki
+    - |
+      {{- include "image-build.build" (set $ "BuildCommand" `go build -o loki ./cmd/loki`) | indent 6 }}
     - chown -R 64535:64535 /src/loki
     - chmod 0700 /src/loki
     - rm -rf vendor

--- a/modules/462-loki/images/loki/werf.inc.yaml
+++ b/modules/462-loki/images/loki/werf.inc.yaml
@@ -20,7 +20,7 @@ shell:
     - rm -r .git vendor
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact


### PR DESCRIPTION
## Description
add new modules for svace analyze
- `userAuthz/webhook`
- `operatorTrivy/node-collector`
- `operatorTrivy/operator`
- `operatorTrivy/report-updater`
- `operatorTrivy/trivy`
- `prometheus/prometheus`
- `admissionPolicyEngine/gatekeeper`
- `loki`

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: add new modules to svace analyze
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
