### PR TITLE
[dhctl] Improve wrong ssh key passphrase handling

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -44,7 +44,11 @@ func DefineBootstrapInstallDeckhouseCommand(cmd *kingpin.CmdClause) *kingpin.Cmd
 			if app.SSHLegacyMode {
 				sshClient = clissh.NewClientFromFlags()
 			} else {
-				sshClient = gossh.NewClientFromFlags()
+				var err error
+				sshClient, err = gossh.NewClientFromFlags()
+				if err != nil {
+					return err
+				}
 			}
 		}
 
@@ -98,7 +102,11 @@ func DefineCreateResourcesCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			if app.SSHLegacyMode {
 				sshClient = clissh.NewClientFromFlags()
 			} else {
-				sshClient = gossh.NewClientFromFlags()
+				var err error
+				sshClient, err = gossh.NewClientFromFlags()
+				if err != nil {
+					return err
+				}
 			}
 		}
 
@@ -124,7 +132,11 @@ func DefineBootstrapAbortCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		if app.SSHLegacyMode {
 			sshClient = clissh.NewClientFromFlags()
 		} else {
-			sshClient = gossh.NewClientFromFlags()
+			var err error
+			sshClient, err = gossh.NewClientFromFlags()
+			if err != nil {
+				return err
+			}
 		}
 		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
 			NodeInterface: ssh.NewNodeInterfaceWrapper(sshClient),

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -73,7 +73,11 @@ func DefineDestroyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		if app.SSHLegacyMode {
 			sshClient = clissh.NewClientFromFlags()
 		} else {
-			sshClient = gossh.NewClientFromFlags()
+			var err error
+			sshClient, err = gossh.NewClientFromFlags()
+			if err != nil {
+				return err
+			}
 		}
 		err := sshClient.Start()
 		if err != nil {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -210,7 +210,11 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 			if app.SSHLegacyMode {
 				sshClient = clissh.NewClientFromFlags()
 			} else {
-				sshClient = gossh.NewClientFromFlags()
+				var err error
+				sshClient, err = gossh.NewClientFromFlags()
+				if err != nil {
+					return err
+				}
 			}
 
 			if metaConfig.IsStatic() {

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy.go
@@ -101,7 +101,11 @@ func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, 
 		if app.SSHLegacyMode {
 			sshClient = clissh.NewClientFromFlags()
 		} else {
-			sshClient = gossh.NewClientFromFlags()
+			var err error
+			sshClient, err = gossh.NewClientFromFlags()
+			if err != nil {
+				return false, err
+			}
 		}
 
 	}

--- a/dhctl/pkg/system/node/ssh/privatekeys.go
+++ b/dhctl/pkg/system/node/ssh/privatekeys.go
@@ -58,19 +58,36 @@ func GetPrivateKeys(keyPath string) (*session.AgentPrivateKey, error) {
 		var passphraseMissingError *ssh.PassphraseMissingError
 		switch {
 		case errors.As(err, &passphraseMissingError):
-			if len(passphrase) == 0 {
-				passphraseFromStdin, err := terminal.AskPassword(
-					fmt.Sprintf("Enter passphrase for ssh key %q: ", keyPath),
-				)
-				if err != nil {
-					return nil, fmt.Errorf("getting passphrase for ssh key %q: %w", keyPath, err)
+			attempt := 0
+			for {
+				if attempt == 5 {
+					return nil, fmt.Errorf("too many attempts for ssh private key passphrase")
 				}
-				passphrase = passphraseFromStdin
+				passphrase, err = askPassword(keyPath)
+				if err != nil {
+					return nil, err
+				}
+				_, err = ssh.ParseRawPrivateKeyWithPassphrase(keyData, passphrase)
+				if err == nil {
+					break
+				}
+				attempt++
 			}
+
 		default:
 			return nil, fmt.Errorf("parsing private key %q: %w", keyPath, err)
 		}
 	}
 
 	return &session.AgentPrivateKey{Key: keyPath, Passphrase: string(passphrase)}, nil
+}
+
+func askPassword(path string) ([]byte, error) {
+	passphraseFromStdin, err := terminal.AskPassword(
+		fmt.Sprintf("Enter passphrase for ssh key %q: ", path),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("getting passphrase for ssh key %q: %w", path, err)
+	}
+	return passphraseFromStdin, nil
 }


### PR DESCRIPTION
## Description

Add logic for re-prompt ssh key passphrase and handle error.

## Why do we need it, and what problem does it solve?

If user put a wrong ssh key passphrase, operations continues as usual, but ssh client fails to start. We should re-ask passphrase if it's wrong and don't start operation if ssh key cannot be parsed.

## Why do we need it in the patch release (if we do)?

Version since 1.72 affected

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Add logic for re-prompt ssh key passphrase and handle error.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
