### PR TITLE
[candi] Import local images without oci.image.index manifest.

### DIFF
--- a/.werf/werf-modules.yaml
+++ b/.werf/werf-modules.yaml
@@ -59,6 +59,8 @@
       {{- $_ := set $ctx "DECKHOUSE_PRIVATE_REPO" $Root.DECKHOUSE_PRIVATE_REPO }}
       {{- $_ := set $ctx "DistroPackagesProxy" $Root.DistroPackagesProxy }}
       {{- $_ := set $ctx "CargoProxy" $Root.CargoProxy }}
+      {{- $_ := set $ctx "RegistryUser" $Root.RegistryUser }}
+      {{- $_ := set $ctx "RegistryPassword" $Root.RegistryPassword }}
 
       {{- $_ := set $ctx "ProjectName" (list $ctx.ModuleName $ctx.ImageName | join "/") }}
       {{- $_ := set $ctx "SVACE_ENABLED" $Root.SVACE_ENABLED }}

--- a/candi/bashible/common-steps/all/034_ctr_import_local_images.sh.tpl
+++ b/candi/bashible/common-steps/all/034_ctr_import_local_images.sh.tpl
@@ -21,7 +21,7 @@ ctr_import_image() {
   local image_name="$1"
   local image_path="$2"
 
-  ctr -n k8s.io images import --index-name "$image_name" "$image_path"
+  ctr -n k8s.io images import "$image_path"
   ctr -n k8s.io images label "$image_name" io.cri-containerd.pinned=pinned
 }
 
@@ -36,7 +36,7 @@ post-install-import() {
   fi
 
   if [[ "${PACKAGE}" == "kubernetes-api-proxy" ]]; then
-    ctr_import_image {{ $kubernetes_api_proxy_image }} "/opt/deckhouse/images/kubernetes-api-proxy.tar"
+    ctr_import_image "/opt/deckhouse/images/kubernetes-api-proxy.tar"
     return 0
   fi
 }

--- a/candi/bashible/common-steps/all/034_ctr_import_local_images.sh.tpl
+++ b/candi/bashible/common-steps/all/034_ctr_import_local_images.sh.tpl
@@ -36,7 +36,7 @@ post-install-import() {
   fi
 
   if [[ "${PACKAGE}" == "kubernetes-api-proxy" ]]; then
-    ctr_import_image "/opt/deckhouse/images/kubernetes-api-proxy.tar"
+    ctr_import_image {{ $kubernetes_api_proxy_image }} "/opt/deckhouse/images/kubernetes-api-proxy.tar"
     return 0
   fi
 }

--- a/candi/bashible/common-steps/all/051_pull_and_configure_kubernetes_api_proxy.sh.tpl
+++ b/candi/bashible/common-steps/all/051_pull_and_configure_kubernetes_api_proxy.sh.tpl
@@ -50,8 +50,11 @@ spec:
     volumeMounts:
     - mountPath: /etc/nginx/config
       name: kubernetes-api-proxy-conf
+      readOnly: true
     - mountPath: /tmp
       name: tmp
+    securityContext:
+      readOnlyRootFilesystem: true
   - name: kubernetes-api-proxy-reloader
     image: {{ $kubernetes_api_proxy_image }}
     imagePullPolicy: IfNotPresent
@@ -62,8 +65,11 @@ spec:
     volumeMounts:
     - mountPath: /etc/nginx/config
       name: kubernetes-api-proxy-conf
+      readOnly: true
     - mountPath: /tmp
       name: tmp
+    securityContext:
+      readOnlyRootFilesystem: true
   priorityClassName: system-node-critical
   priority: 2000001000
   volumes:

--- a/modules/007-registrypackages/images/kubernetes-api-proxy/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubernetes-api-proxy/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "08.04.25" }}
+{{- $version := "28.08.25" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: builder/scratch
@@ -29,6 +29,9 @@ import:
   add: /crane
   to: /crane
   before: setup
+- image: tools/jq
+  add: /usr/bin/jq
+  before: setup
 dependencies:
 - image: control-plane-manager/kubernetes-api-proxy
   before: setup
@@ -37,17 +40,17 @@ dependencies:
     targetEnv: IMAGE_DIGEST
   - type: ImageRepo
     targetEnv: IMAGE_REPO
-mount:
-- fromPath: ~/.docker
-  to: /root/.docker
+secrets:
+- id: REGISTRY_USER
+  value: {{ .RegistryUser }}
+- id: REGISTRY_PASSWORD
+  value: {{ .RegistryPassword }}
 shell:
   setup:
   - case "$IMAGE_REPO" in *.local/*) export param="--insecure" ;; esac
-  - /crane pull $IMAGE_REPO@$IMAGE_DIGEST $param /kubernetes-api-proxy.tar
-  - mkdir /tmp/kubernetes-api-proxy
-  - tar -xf /kubernetes-api-proxy.tar -C /tmp/kubernetes-api-proxy
-  - cd /tmp/kubernetes-api-proxy
-  - sed -i 's/"RepoTags":\["[^"]*"\]/"RepoTags":[]/' manifest.json
-  - rm /kubernetes-api-proxy.tar
-  - tar -cvf /kubernetes-api-proxy.tar ./
-  - rm -rf /tmp/kubernetes-api-proxy
+  - /crane auth login --password "$(cat /run/secrets/REGISTRY_PASSWORD)" --username "$(cat /run/secrets/REGISTRY_USER)" "${IMAGE_REPO%%/*}"
+  - /crane pull --format oci $IMAGE_REPO@$IMAGE_DIGEST $param /tmp/image
+  - rm -f ~/.docker/config.json
+  - jq '.manifests[0].annotations = {"org.opencontainers.image.ref.name":"deckhouse.local/images:kubernetes-api-proxy"}' /tmp/image/index.json > /tmp/index.updated.json && mv /tmp/index.updated.json /tmp/image/index.json
+  - tar -C /tmp/image -cf /kubernetes-api-proxy.tar .
+  - rm -rf /tmp/image

--- a/modules/007-registrypackages/images/pause/werf.inc.yaml
+++ b/modules/007-registrypackages/images/pause/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "08.04.25" }}
+{{- $version := "28.08.25" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: builder/scratch
@@ -29,6 +29,9 @@ import:
   add: /crane
   to: /crane
   before: setup
+- image: tools/jq
+  add: /usr/bin/jq
+  before: setup
 dependencies:
 - image: common/pause
   before: setup
@@ -37,17 +40,17 @@ dependencies:
     targetEnv: IMAGE_DIGEST
   - type: ImageRepo
     targetEnv: IMAGE_REPO
-mount:
-- fromPath: ~/.docker
-  to: /root/.docker
+secrets:
+- id: REGISTRY_USER
+  value: {{ .RegistryUser }}
+- id: REGISTRY_PASSWORD
+  value: {{ .RegistryPassword }}
 shell:
   setup:
   - case "$IMAGE_REPO" in *.local/*) export param="--insecure" ;; esac
-  - /crane pull $IMAGE_REPO@$IMAGE_DIGEST $param /pause.tar
-  - mkdir /tmp/pause
-  - tar -xf /pause.tar -C /tmp/pause
-  - cd /tmp/pause
-  - sed -i 's/"RepoTags":\["[^"]*"\]/"RepoTags":[]/' manifest.json
-  - rm /pause.tar
-  - tar -cvf /pause.tar ./
-  - rm -rf /tmp/pause
+  - /crane auth login --password "$(cat /run/secrets/REGISTRY_PASSWORD)" --username "$(cat /run/secrets/REGISTRY_USER)" "${IMAGE_REPO%%/*}"
+  - /crane pull --format oci $IMAGE_REPO@$IMAGE_DIGEST $param /tmp/image
+  - rm -f ~/.docker/config.json
+  - jq '.manifests[0].annotations = {"org.opencontainers.image.ref.name":"deckhouse.local/images:pause"}' /tmp/image/index.json > /tmp/index.updated.json && mv /tmp/index.updated.json /tmp/image/index.json
+  - tar -C /tmp/image -cf /pause.tar .
+  - rm -rf /tmp/image

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -12,6 +12,8 @@ config:
       - DISTRO_PACKAGES_PROXY
       - CARGO_PROXY
       - DECKHOUSE_PRIVATE_REPO
+      - REGISTRY_USER
+      - REGISTRY_PASSWORD
       - SVACE_ENABLED
       - SVACE_ANALYZE_HOST
       - SVACE_ANALYZE_SSH_USER
@@ -23,9 +25,10 @@ config:
       - CLOUD_PROVIDERS_SOURCE_REPO
       - CARGO_PROXY
       - DECKHOUSE_PRIVATE_REPO
+      - REGISTRY_USER
+      - REGISTRY_PASSWORD
   stapel:
     mount:
       allowBuildDir: true
       allowFromPaths:
         - ~/go-pkg-cache
-        - ~/.docker

--- a/werf.yaml
+++ b/werf.yaml
@@ -87,6 +87,10 @@ build:
 
 # goproxy  settings
 {{- $_ := set . "GOPROXY" (env "GOPROXY" "https://proxy.golang.org,direct") }}
+
+# registry auth
+{{- $_ := set . "RegistryUser" (env "REGISTRY_USER" "test") }}
+{{- $_ := set . "RegistryPassword" (env "REGISTRY_PASSWORD" "test") }}
 ---
 # render ssh-static
 {{ include "ssh_static_artifact" (dict "Images" .Images "SOURCE_REPO" .SOURCE_REPO "DistroPackagesProxy" .DistroPackagesProxy) }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Import local images(k8s-api-proxy and pause) without oci.image.index manifest.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

1. Import without `application/vnd.oci.image.index.v1+json ` 
2. Set image name and tag at the stage of creating the tar archive.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Import local images without oci.image.index manifest. 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
