### PR TITLE
[user-authn] Hotfix USER CR ValidatingAdmissionPolicy oldObject == null

### DIFF
--- a/modules/150-user-authn/templates/validation.yaml
+++ b/modules/150-user-authn/templates/validation.yaml
@@ -44,7 +44,7 @@ spec:
         operations:  ["CREATE", "UPDATE"]
         resources:   ["users"]
   validations:
-    - expression: "object.spec.password == oldObject.spec.password"
+    - expression: "oldObject == null || object.spec.password == oldObject.spec.password"
       message: "password policy is enabled, user password field cannot be changed manually"
 ---
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}


### PR DESCRIPTION
## Description
Fix the `ValidatingAdmissionPolicy` for the `User` CR by updating the validation expression.  
Now the rule checks:  

```rego
oldObject == null || object.spec.password == oldObject.spec.password
```  

This ensures that validation passes on `CREATE` (where `oldObject` is `null`) and still enforces password immutability on `UPDATE`.  

## Why do we need it, and what problem does it solve?
Previously, the policy tried to compare `object.spec.password` with `oldObject.spec.password` even during `CREATE` operations, where `oldObject` does not exist.  
As a result, creating new `User` resources failed.  
With this fix, user creation works correctly, while password immutability is still enforced for updates.  

## Why do we need it in the patch release (if we do)?
Yes, because the bug directly prevents creating `User` resources in clusters with password policy enabled.  
This is a functional regression and must be fixed in the nearest patch release.  

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: user-authn
type: fix
summary: Fix `ValidatingAdmissionPolicy` for `User` CR to skip password check on create
impact: Fixes a bug where creating new User resources failed due to missing oldObject in validation; password immutability is still enforced on update
impact_level: high
```
