### PR TITLE
Restore diff and ps to the deckhouse-controller

### DIFF
--- a/.werf/defines/base.tmpl
+++ b/.werf/defines/base.tmpl
@@ -262,8 +262,8 @@ import:
   to: /usr/bin/diff
   before: install
 - image: tools/procps
-  add: /usr/bin/ps
-  to: /usr/bin/ps
+  add: /bin/ps
+  to: /bin/ps
   before: install
 shell:
   install:

--- a/.werf/defines/base.tmpl
+++ b/.werf/defines/base.tmpl
@@ -141,6 +141,7 @@ import:
   - usr/bin/cut
   - usr/bin/date
   - usr/bin/dd
+  - usr/bin/diff
   - usr/bin/df
   - usr/bin/dir
   - usr/bin/dircolors
@@ -180,6 +181,7 @@ import:
   - usr/bin/paste
   - usr/bin/pathchk
   - usr/bin/pinky
+  - usr/bin/ps
   - usr/bin/pr
   - usr/bin/printenv
   - usr/bin/printf

--- a/.werf/defines/base.tmpl
+++ b/.werf/defines/base.tmpl
@@ -141,7 +141,6 @@ import:
   - usr/bin/cut
   - usr/bin/date
   - usr/bin/dd
-  - usr/bin/diff
   - usr/bin/df
   - usr/bin/dir
   - usr/bin/dircolors
@@ -181,7 +180,6 @@ import:
   - usr/bin/paste
   - usr/bin/pathchk
   - usr/bin/pinky
-  - usr/bin/ps
   - usr/bin/pr
   - usr/bin/printenv
   - usr/bin/printf
@@ -258,6 +256,14 @@ import:
 - image: tools/util-linux
   add: /usr/bin/rev
   to: /usr/bin/rev
+  before: install
+- image: tools/diffutils
+  add: /usr/bin/diff
+  to: /usr/bin/diff
+  before: install
+- image: tools/procps
+  add: /usr/bin/ps
+  to: /usr/bin/ps
   before: install
 shell:
   install:


### PR DESCRIPTION
## Description
Restore `diff` and `ps` binaries to the deckhouse

## Why do we need it, and what problem does it solve?
These binaries are used by deckhouse.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Restore binaries.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
