### PR TITLE
[cni] Add new logic to merge the parameters from the moduleConfig CNI and d8-cni-configuration secret.

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -752,17 +752,25 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        Steps to troubleshoot:
+        This happened because there were several sources for configuring CNI parameters in the cluster, and ModuleConfig did not have the highest priority previously.
 
-        1. Find the desired settings in the ConfigMap `d8-system/desired-cni-moduleconfig` by running the following command:
+        To resolve this issue, the following steps should be taken:
+
+        1. Find the ConfigMap `d8-system/desired-cni-moduleconfig` in the cluster, which contains the actual ModuleConfig settings.
 
            ```bash
            d8 k -n d8-system get configmap desired-cni-moduleconfig -o yaml
            ```
 
-        1. Update the conflicting settings in the CNI `{{ $labels.cni }}` ModuleConfig to match the desired configuration.
+        2. Apply this prepared ModuleConfig to the cluster. This will not cause any actual reconfigurations in the cluster and is completely safe.
+
+        3. Once the parameters in "ModuleConfig" match those used in the cluster:
+             - this alert will be resolved,
+             - and the priority of the sources for configuring CNI will change, and ModuleConfig will become the main source.
+
+        4. After that, you can add the desired parameters to the ModuleConfig CNI and they will be applied immediately.
       summary: |
-        Settings in the secret d8-cni-configuration conflict with the ModuleConfig.
+        The parameters specified in ModuleConfig of {{ $labels.cni }} do not match the ones that are actually being used in the cluster.
       severity: "5"
       markupFormat: markdown
     - name: D8ControlPlaneManagerPodNotRunning

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -766,7 +766,7 @@ alerts:
 
         3. Once the parameters in "ModuleConfig" match those used in the cluster:
              - this alert will be resolved,
-             - and the priority of the sources for configuring CNI will change, and ModuleConfig will become the main source.
+             - and the priority of the sources for configuring CNI will change, and ModuleConfig will become the main source of truth.
 
         4. After that, you can add the desired parameters to the ModuleConfig CNI and they will be applied immediately.
       summary: |

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.ru.yml.standard.other.inc
@@ -62,6 +62,7 @@ spec:
   enabled: true
   settings:
     bpfLBMode: SNAT
+    masqueradeMode: BPF
     tunnelMode: VXLAN
 ---
 # [<en>] Global Deckhouse settings.

--- a/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_vk/partials/config.yml.standard.other.inc
@@ -62,6 +62,7 @@ spec:
   enabled: true
   settings:
     bpfLBMode: SNAT
+    masqueradeMode: BPF
     tunnelMode: VXLAN
 ---
 # [<en>] Global Deckhouse settings.

--- a/modules/021-cni-cilium/hooks/check_cni_configuration.go
+++ b/modules/021-cni-cilium/hooks/check_cni_configuration.go
@@ -149,10 +149,6 @@ func applyCNIMCFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert object to moduleconfig: %v", err)
 	}
-	// ignore only explicitly disabled modules.
-	if mc.Spec.Enabled != nil && !*mc.Spec.Enabled {
-		return nil, nil
-	}
 
 	return mc, nil
 }
@@ -281,7 +277,7 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 	}
 
 	// If MC exist, but is explicitly disabled, it means that CNI is in the process of disabling, there is nothing to do.
-	if len(cniModuleConfigs) != 0 && cniModuleConfigs[0].Spec.Enabled == nil || !*cniModuleConfigs[0].Spec.Enabled {
+	if cniModuleConfigs[0].Spec.Enabled != nil && !*cniModuleConfigs[0].Spec.Enabled {
 		return nil
 	}
 
@@ -350,7 +346,7 @@ func annotateSecret(input *go_hook.HookInput) {
 			},
 		},
 	}
-	input.PatchCollector.PatchWithMerge(secretPatch, "v1", "Secret", "kube-system", "d8-cluster-configuration")
+	input.PatchCollector.PatchWithMerge(secretPatch, "v1", "Secret", "kube-system", "d8-cni-configuration")
 }
 
 func createDesiredModuleConfig(input *go_hook.HookInput, desiredCNIModuleConfig *v1alpha1.ModuleConfig) {

--- a/modules/021-cni-cilium/hooks/check_cni_configuration.go
+++ b/modules/021-cni-cilium/hooks/check_cni_configuration.go
@@ -312,8 +312,8 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 		return nil
 	}
 
-	// Let's check what was created earlier: MC or Secret.
-	if cniSecret.CreationTimestamp.After(cniModuleConfigs[0].CreationTimestamp.Time) {
+	// Let's check what was created earlier: MC(+10m) or Secret.
+	if cniSecret.CreationTimestamp.After(cniModuleConfigs[0].CreationTimestamp.Time.Add(10 * time.Minute)) {
 		annotateSecret(input)
 		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
 		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)

--- a/modules/021-cni-cilium/hooks/check_cni_configuration.go
+++ b/modules/021-cni-cilium/hooks/check_cni_configuration.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
@@ -38,12 +39,15 @@ import (
 )
 
 const (
-	cniConfigurationSettledKey = "cniConfigurationSettled"
-	checkCNIConfigMetricName   = "cniMisconfigured"
-	checkCNIConfigMetricGroup  = "d8_check_cni_conf"
-	desiredCNIModuleConfigName = "desired-cni-moduleconfig"
-	cni                        = "cilium"
-	cniName                    = "cni-" + cni
+	cniConfigurationSettledKey        = "cniConfigurationSettled"
+	checkCNIConfigMetricName          = "cniMisconfigured"
+	checkCNIConfigMetricGroup         = "d8_check_cni_conf"
+	desiredCNIModuleConfigName        = "desired-cni-moduleconfig"
+	cni                               = "cilium"
+	cniName                           = "cni-" + cni
+	cniConfigurationIsNotSettled      = true
+	cniConfigurationIsSettled         = false
+	cniConfigSourcePriorityAnnotation = "network.deckhouse.io/cni-configuration-source-priority"
 )
 
 type flannelConfigStruct struct {
@@ -56,9 +60,10 @@ type ciliumConfigStruct struct {
 }
 
 type cniSecretStruct struct {
-	CNI     string
-	Flannel flannelConfigStruct
-	Cilium  ciliumConfigStruct
+	CniConfigSourcePriorityFlagExists bool
+	CNI                               string
+	Flannel                           flannelConfigStruct
+	Cilium                            ciliumConfigStruct
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -92,7 +97,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func applyCNIConfigurationFromSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	// Return nil if
-	// error occurred while json parse
+	// an error occurred while JSON parse
 	// or d8-cni-configuration secret does not contain key "cni"
 	// or value of key "cni" not in [cni-cilium, cni-flannel, cni-simple-bridge]
 	secret := &v1.Secret{}
@@ -101,9 +106,13 @@ func applyCNIConfigurationFromSecretFilter(obj *unstructured.Unstructured) (go_h
 		return nil, fmt.Errorf("cannot convert incoming object to Secret: %v", err)
 	}
 	cniSecret := cniSecretStruct{}
+	// Check if the secret has the annotation "network.deckhouse.io/cni-configuration-source-priority"
+	_, exists := secret.Annotations[cniConfigSourcePriorityAnnotation]
+	cniSecret.CniConfigSourcePriorityFlagExists = exists
+
 	cniBytes, ok := secret.Data["cni"]
 	if !ok {
-		// d8-cni-configuration secret does not contain "cni" field
+		// d8-cni-configuration secret does not contain the "cni" field
 		return nil, nil
 	}
 	cniSecret.CNI = string(cniBytes)
@@ -140,15 +149,181 @@ func applyCNIMCFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert object to moduleconfig: %v", err)
 	}
-	if mc.Spec.Enabled == nil || !*mc.Spec.Enabled {
+	// ignore only explicitly disabled modules.
+	if mc.Spec.Enabled != nil && !*mc.Spec.Enabled {
 		return nil, nil
 	}
 
 	return mc, nil
 }
 
-func setCNIMiscMetricAndReq(input *go_hook.HookInput, miss bool) {
-	switch miss {
+func checkCni(_ context.Context, input *go_hook.HookInput) error {
+	// Clear a metrics and reqKey
+	input.MetricsCollector.Expire(checkCNIConfigMetricGroup)
+	requirements.RemoveValue(cniConfigurationSettledKey)
+
+	// Get existing secret.
+	cniSecrets, err := sdkobjectpatch.UnmarshalToStruct[cniSecretStruct](input.Snapshots, "cni_configuration_secret")
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal cni_configuration_secret snapshot: %w", err)
+	}
+
+	// If secret does not exist, then we are already using a new logic de facto: the parameters in the MC have priority.
+	// So there is nothing to do.
+	if len(cniSecrets) == 0 {
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If the secret has the annotation "network.deckhouse.io/cni-configuration-source-priority", so there is nothing to do.
+	if cniSecrets[0].CniConfigSourcePriorityFlagExists {
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If secret does not contain config for current cni, then we are already using a new logic de facto: the parameters in the MC have priority.
+	// - add an annotation to the secret
+	cniSecret := cniSecrets[0]
+	if cniSecret.CNI != cni {
+		annotateSecret(input)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// Get existing MC.
+	cniModuleConfigs, err := sdkobjectpatch.UnmarshalToStruct[v1alpha1.ModuleConfig](input.Snapshots, "deckhouse_cni_mc")
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal deckhouse_cni_mc snapshot: %w", err)
+	}
+
+	// Prepare a template for the desiredCNIModuleConfig, which is empty and explicitly enabled.
+	desiredCNIModuleConfig := &v1alpha1.ModuleConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ModuleConfig",
+			APIVersion: "deckhouse.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cniName,
+		},
+		Spec: v1alpha1.ModuleConfigSpec{
+			Enabled:  ptr.To(true),
+			Version:  1,
+			Settings: v1alpha1.SettingsValues{},
+		},
+	}
+	// If the MC exists, use its Settings to generate the desired MC.
+	if len(cniModuleConfigs) != 0 {
+		cniModuleConfig := cniModuleConfigs[0]
+		desiredCNIModuleConfig.Spec.Settings = cniModuleConfig.DeepCopy().Spec.Settings
+	}
+	// Generate the desired CNIModuleConfig based on existing secret and MC and compare them at the same time.
+	// Skip if in the secret key "cilium" does not exist or empty.
+	secretMatchesMc := true
+	if cniSecret.Cilium != (ciliumConfigStruct{}) {
+		switch cniSecret.Cilium.Mode {
+		case "VXLAN":
+			value, ok := input.ConfigValues.GetOk("cniCilium.tunnelMode")
+			if !ok || value.String() != "VXLAN" {
+				desiredCNIModuleConfig.Spec.Settings["tunnelMode"] = "VXLAN"
+				secretMatchesMc = false
+			}
+		case "Direct":
+			value, ok := input.ConfigValues.GetOk("cniCilium.tunnelMode")
+			if !ok || value.String() != "Disabled" {
+				desiredCNIModuleConfig.Spec.Settings["tunnelMode"] = "Disabled"
+				secretMatchesMc = false
+			}
+		case "DirectWithNodeRoutes":
+			value, ok := input.ConfigValues.GetOk("cniCilium.tunnelMode")
+			if !ok || value.String() != "Disabled" {
+				desiredCNIModuleConfig.Spec.Settings["tunnelMode"] = "Disabled"
+				secretMatchesMc = false
+			}
+			value, ok = input.ConfigValues.GetOk("cniCilium.createNodeRoutes")
+			if !ok || !value.Bool() {
+				desiredCNIModuleConfig.Spec.Settings["createNodeRoutes"] = true
+				secretMatchesMc = false
+			}
+		default:
+			input.Logger.Warn("An unknown cilium mode was specified in the d8-cni-configuration secret, so the default cni mode will be used instead.", slog.String("specified mode", cniSecret.Cilium.Mode))
+		}
+
+		switch cniSecret.Cilium.MasqueradeMode {
+		case "Netfilter", "BPF":
+			value, ok := input.ConfigValues.GetOk("cniCilium.masqueradeMode")
+			if !ok || value.String() != cniSecret.Cilium.MasqueradeMode {
+				desiredCNIModuleConfig.Spec.Settings["masqueradeMode"] = cniSecret.Cilium.MasqueradeMode
+				secretMatchesMc = false
+			}
+		case "":
+			value, ok := input.ConfigValues.GetOk("cniCilium.masqueradeMode")
+			if !ok || value.String() != "BPF" {
+				desiredCNIModuleConfig.Spec.Settings["masqueradeMode"] = "BPF"
+				secretMatchesMc = false
+			}
+		default:
+			input.Logger.Warn("An unknown cilium masqueradeMode was specified in the d8-cni-configuration secret, so the default cni masqueradeMode will be used instead.", slog.String("specified masqueradeMode", cniSecret.Cilium.Mode))
+		}
+	}
+
+	// If MC does not exist, then we should
+	// - add an annotation to the secret (to activate new_logic)
+	// - create the desired MC, which was generated based on the secret.
+	if len(cniModuleConfigs) == 0 {
+		annotateSecret(input)
+		createDesiredModuleConfig(input, desiredCNIModuleConfig)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If MC exist, but is explicitly disabled, it means that CNI is in the process of disabling, there is nothing to do.
+	if len(cniModuleConfigs) != 0 && cniModuleConfigs[0].Spec.Enabled == nil || !*cniModuleConfigs[0].Spec.Enabled {
+		return nil
+	}
+
+	if cniModuleConfigs[0].Spec.Enabled == nil {
+		secretMatchesMc = false
+	}
+
+	// If the secret matches MC, then we should
+	// - add an annotation to the secret (to activate new_logic)
+	if secretMatchesMc {
+		annotateSecret(input)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// Let's check if the cluster has already been bootstrapped.
+	clusterIsBootstrapped := input.Values.Get("global.clusterIsBootstrapped").Bool()
+
+	// If the cluster is not yet bootstrapped, then we should
+	// - add an annotation to the secret (to activate new_logic)
+	if !clusterIsBootstrapped {
+		annotateSecret(input)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If the cluster is already bootstrapped, then we should
+	// - generate desired MC based on secret
+	// - create cm based on desired MC
+	// - fire alert
+	err = createConfigMapWithDesiredModuleConfig(input, desiredCNIModuleConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create config map with desired module config: %w", err)
+	}
+	setMetricAndRequirementsValue(input, cniConfigurationIsNotSettled)
+	return nil
+}
+
+func setMetricAndRequirementsValue(input *go_hook.HookInput, isCniMisconfigured bool) {
+	switch isCniMisconfigured {
 	// misconfigure detected
 	case true:
 		input.MetricsCollector.Set(checkCNIConfigMetricName, 1,
@@ -167,141 +342,39 @@ func setCNIMiscMetricAndReq(input *go_hook.HookInput, miss bool) {
 	}
 }
 
-func checkCni(_ context.Context, input *go_hook.HookInput) error {
-	// Clear a metrics and reqKey
-	input.MetricsCollector.Expire(checkCNIConfigMetricGroup)
-	requirements.RemoveValue(cniConfigurationSettledKey)
-	needUpdateMC := false
-	cniSecrets, err := sdkobjectpatch.UnmarshalToStruct[cniSecretStruct](input.Snapshots, "cni_configuration_secret")
+func annotateSecret(input *go_hook.HookInput) {
+	secretPatch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				"network.deckhouse.io/cni-configuration-source-priority": "ModuleConfig",
+			},
+		},
+	}
+	input.PatchCollector.PatchWithMerge(secretPatch, "v1", "Secret", "kube-system", "d8-cluster-configuration")
+}
+
+func createDesiredModuleConfig(input *go_hook.HookInput, desiredCNIModuleConfig *v1alpha1.ModuleConfig) {
+	input.PatchCollector.CreateOrUpdate(desiredCNIModuleConfig)
+}
+
+func createConfigMapWithDesiredModuleConfig(input *go_hook.HookInput, desiredCNIModuleConfig *v1alpha1.ModuleConfig) error {
+	desiredCNIModuleConfigYAML, err := yaml.Marshal(*desiredCNIModuleConfig)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal cni_configuration_secret snapshot: %w", err)
+		return fmt.Errorf("cannot marshal desired CNI moduleConfig, err: %w", err)
 	}
-
-	// Let's check secret.
-	// Secret d8-cni-configuration does not exist or exist but contain nil.
-	// This means that the current CNI module is enabled and configured via mc, nothing to do.
-	if len(cniSecrets) == 0 {
-		setCNIMiscMetricAndReq(input, false)
-		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-		return nil
-	}
-
-	// Secret d8-cni-configuration exist but key "cni" does not equal "cilium".
-	// This means that the current CNI module is enabled and configured via mc, nothing to do.
-	cniSecret := cniSecrets[0]
-	if cniSecret.CNI != cni {
-		setCNIMiscMetricAndReq(input, false)
-		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-		return nil
-	}
-
-	// Secret d8-cni-configuration exist, key "cni" eq "cilium".
-
-	// Prepare desiredCNIModuleConfig
-	desiredCNIModuleConfig := &v1alpha1.ModuleConfig{
+	data := map[string]string{cniName + "-mc.yaml": string(desiredCNIModuleConfigYAML)}
+	cm := &v1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "ModuleConfig",
-			APIVersion: "deckhouse.io/v1alpha1",
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: cniName,
+			Name:      desiredCNIModuleConfigName,
+			Namespace: "d8-system",
 		},
-		Spec: v1alpha1.ModuleConfigSpec{
-			Enabled:  ptr.To(true),
-			Version:  1,
-			Settings: v1alpha1.SettingsValues{},
-		},
+		Data: data,
 	}
-	cniModuleConfigs, err := sdkobjectpatch.UnmarshalToStruct[v1alpha1.ModuleConfig](input.Snapshots, "deckhouse_cni_mc")
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal deckhouse_cni_mc snapshot: %w", err)
-	}
-	// Let's check what mc exist and explicitly enabled.
-	if len(cniModuleConfigs) == 0 {
-		needUpdateMC = true
-	} else {
-		cniModuleConfig := cniModuleConfigs[0]
-		desiredCNIModuleConfig.Spec.Settings = cniModuleConfig.DeepCopy().Spec.Settings
-	}
-
-	// Skip comparison if in secret d8-cni-configuration key "cilium" does not exist or empty.
-	if cniSecret.Cilium != (ciliumConfigStruct{}) {
-		// Secret d8-cni-configuration exist, key "cni" eq "cilium" and key "cilium" does not empty.
-		// Let's compare secret with module configuration.
-		switch cniSecret.Cilium.Mode {
-		case "VXLAN":
-			value, ok := input.ConfigValues.GetOk("cniCilium.tunnelMode")
-			if !ok || value.String() != "VXLAN" {
-				desiredCNIModuleConfig.Spec.Settings["tunnelMode"] = "VXLAN"
-				needUpdateMC = true
-			}
-		case "Direct":
-			value, ok := input.ConfigValues.GetOk("cniCilium.tunnelMode")
-			if !ok || value.String() != "Disabled" {
-				desiredCNIModuleConfig.Spec.Settings["tunnelMode"] = "Disabled"
-				needUpdateMC = true
-			}
-		case "DirectWithNodeRoutes":
-			value, ok := input.ConfigValues.GetOk("cniCilium.tunnelMode")
-			if !ok || value.String() != "Disabled" {
-				desiredCNIModuleConfig.Spec.Settings["tunnelMode"] = "Disabled"
-				needUpdateMC = true
-			}
-			value, ok = input.ConfigValues.GetOk("cniCilium.createNodeRoutes")
-			if !ok || !value.Bool() {
-				desiredCNIModuleConfig.Spec.Settings["createNodeRoutes"] = true
-				needUpdateMC = true
-			}
-		default:
-			setCNIMiscMetricAndReq(input, true)
-			input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-			return fmt.Errorf("unknown cilium mode %s", cniSecret.Cilium.Mode)
-		}
-		switch cniSecret.Cilium.MasqueradeMode {
-		case "Netfilter", "BPF":
-			value, ok := input.ConfigValues.GetOk("cniCilium.masqueradeMode")
-			if !ok || value.String() != cniSecret.Cilium.MasqueradeMode {
-				desiredCNIModuleConfig.Spec.Settings["masqueradeMode"] = cniSecret.Cilium.MasqueradeMode
-				needUpdateMC = true
-			}
-		case "":
-			value, ok := input.ConfigValues.GetOk("cniCilium.masqueradeMode")
-			if !ok || value.String() != "BPF" {
-				desiredCNIModuleConfig.Spec.Settings["masqueradeMode"] = "BPF"
-				needUpdateMC = true
-			}
-		default:
-			setCNIMiscMetricAndReq(input, true)
-			input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-			return fmt.Errorf("unknown cilium masquerade mode %s", cniSecret.Cilium.MasqueradeMode)
-		}
-	}
-
-	if needUpdateMC {
-		desiredCNIModuleConfigYAML, err := yaml.Marshal(*desiredCNIModuleConfig)
-		if err != nil {
-			return fmt.Errorf("cannot marshal desired CNI moduleConfig, err: %w", err)
-		}
-		data := map[string]string{cniName + "-mc.yaml": string(desiredCNIModuleConfigYAML)}
-		cm := &v1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "ConfigMap",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      desiredCNIModuleConfigName,
-				Namespace: "d8-system",
-			},
-			Data: data,
-		}
-		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-		input.PatchCollector.CreateOrUpdate(cm)
-		setCNIMiscMetricAndReq(input, true)
-		return nil
-	}
-
-	// All configuration settled, nothing to do.
-	setCNIMiscMetricAndReq(input, false)
 	input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+	input.PatchCollector.CreateOrUpdate(cm)
 	return nil
 }

--- a/modules/021-cni-cilium/hooks/check_cni_configuration.go
+++ b/modules/021-cni-cilium/hooks/check_cni_configuration.go
@@ -223,31 +223,31 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 	}
 	// Generate the desired CNIModuleConfig based on existing secret and MC and compare them at the same time.
 	// Skip if in the secret key "cilium" does not exist or empty.
-	secretMatchesMc := true
+	secretMatchesMC := true
 	if cniSecret.Cilium != (ciliumConfigStruct{}) {
 		switch cniSecret.Cilium.Mode {
 		case "VXLAN":
 			value, ok := input.ConfigValues.GetOk("cniCilium.tunnelMode")
 			if !ok || value.String() != "VXLAN" {
 				desiredCNIModuleConfig.Spec.Settings["tunnelMode"] = "VXLAN"
-				secretMatchesMc = false
+				secretMatchesMC = false
 			}
 		case "Direct":
 			value, ok := input.ConfigValues.GetOk("cniCilium.tunnelMode")
 			if !ok || value.String() != "Disabled" {
 				desiredCNIModuleConfig.Spec.Settings["tunnelMode"] = "Disabled"
-				secretMatchesMc = false
+				secretMatchesMC = false
 			}
 		case "DirectWithNodeRoutes":
 			value, ok := input.ConfigValues.GetOk("cniCilium.tunnelMode")
 			if !ok || value.String() != "Disabled" {
 				desiredCNIModuleConfig.Spec.Settings["tunnelMode"] = "Disabled"
-				secretMatchesMc = false
+				secretMatchesMC = false
 			}
 			value, ok = input.ConfigValues.GetOk("cniCilium.createNodeRoutes")
 			if !ok || !value.Bool() {
 				desiredCNIModuleConfig.Spec.Settings["createNodeRoutes"] = true
-				secretMatchesMc = false
+				secretMatchesMC = false
 			}
 		default:
 			input.Logger.Warn("An unknown cilium mode was specified in the d8-cni-configuration secret, so the default cni mode will be used instead.", slog.String("specified mode", cniSecret.Cilium.Mode))
@@ -258,13 +258,13 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 			value, ok := input.ConfigValues.GetOk("cniCilium.masqueradeMode")
 			if !ok || value.String() != cniSecret.Cilium.MasqueradeMode {
 				desiredCNIModuleConfig.Spec.Settings["masqueradeMode"] = cniSecret.Cilium.MasqueradeMode
-				secretMatchesMc = false
+				secretMatchesMC = false
 			}
 		case "":
 			value, ok := input.ConfigValues.GetOk("cniCilium.masqueradeMode")
 			if !ok || value.String() != "BPF" {
 				desiredCNIModuleConfig.Spec.Settings["masqueradeMode"] = "BPF"
-				secretMatchesMc = false
+				secretMatchesMC = false
 			}
 		default:
 			input.Logger.Warn("An unknown cilium masqueradeMode was specified in the d8-cni-configuration secret, so the default cni masqueradeMode will be used instead.", slog.String("specified masqueradeMode", cniSecret.Cilium.Mode))
@@ -288,12 +288,12 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 	}
 
 	if cniModuleConfigs[0].Spec.Enabled == nil {
-		secretMatchesMc = false
+		secretMatchesMC = false
 	}
 
 	// If the secret matches MC, then we should
 	// - add an annotation to the secret (to activate new_logic)
-	if secretMatchesMc {
+	if secretMatchesMC {
 		annotateSecret(input)
 		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
 		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)

--- a/modules/021-cni-cilium/hooks/check_cni_configuration_test.go
+++ b/modules/021-cni-cilium/hooks/check_cni_configuration_test.go
@@ -172,7 +172,6 @@ data:
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
-
 		})
 
 		It("Should execute successfully, set req=true and metric=0 and should not create desired mc", func() {
@@ -223,7 +222,6 @@ data:
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
-
 		})
 
 		It("Should execute successfully, set req=true and metric=0 and create MC directly", func() {
@@ -254,7 +252,6 @@ data:
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
-
 		})
 
 		It("Should execute successfully and do nothing", func() {
@@ -381,7 +378,6 @@ data:
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
-
 		})
 
 		It("Should execute successfully, set req=false and metric=1 and create desired mc", func() {
@@ -535,7 +531,6 @@ status:
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
-
 		})
 
 		It("Should execute successfully with warnings, set req=true and metric=0 and should not create desired mc", func() {

--- a/modules/021-cni-cilium/hooks/check_cni_configuration_test.go
+++ b/modules/021-cni-cilium/hooks/check_cni_configuration_test.go
@@ -81,7 +81,7 @@ data:
 	f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
 	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
 
-	cniSecretYAML := func(cniName, data string) string {
+	cniSecretYAML := func(cniName, data string, creationTime *time.Time, annotations map[string]string) string {
 		secretData := make(map[string][]byte)
 		secretData["cni"] = []byte(cniName)
 		if data != "" {
@@ -93,38 +93,19 @@ data:
 				Kind:       "Secret",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "d8-cni-configuration",
-				Namespace: "kube-system",
+				Name:        "d8-cni-configuration",
+				Namespace:   "kube-system",
+				Annotations: annotations,
 			},
 			Data: secretData,
+		}
+		if creationTime != nil {
+			s.ObjectMeta.CreationTimestamp = metav1.NewTime(*creationTime)
 		}
 		marshaled, _ := yaml.Marshal(s)
 		return string(marshaled)
 	}
-	cniSecretWithAnnotationYAML := func(cniName, data string) string {
-		secretData := make(map[string][]byte)
-		secretData["cni"] = []byte(cniName)
-		if data != "" {
-			secretData[cniName] = []byte(data)
-		}
-		s := &v1core.Secret{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "Secret",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "d8-cni-configuration",
-				Namespace: "kube-system",
-				Annotations: map[string]string{
-					"network.deckhouse.io/cni-configuration-source-priority": "ModuleConfig",
-				},
-			},
-			Data: secretData,
-		}
-		marshaled, _ := yaml.Marshal(s)
-		return string(marshaled)
-	}
-	cniMCYAML := func(cniName string, enabled *bool, settings v1alpha1.SettingsValues) string {
+	cniMCYAML := func(cniName string, enabled *bool, settings v1alpha1.SettingsValues, creationTime *time.Time) string {
 		mc := &v1alpha1.ModuleConfig{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "deckhouse.io/v1alpha1",
@@ -140,6 +121,9 @@ data:
 				Settings: settings,
 				Enabled:  enabled,
 			},
+		}
+		if creationTime != nil {
+			mc.ObjectMeta.CreationTimestamp = metav1.NewTime(*creationTime)
 		}
 		marshaled, _ := yaml.Marshal(mc)
 		return string(marshaled)
@@ -168,7 +152,7 @@ data:
 	Context("Cluster has cni secret but key `cni` does not equal `cilium`", func() {
 		BeforeEach(func() {
 			resources := []string{
-				cniSecretYAML(anotherCni, ""),
+				cniSecretYAML(anotherCni, "", nil, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -193,7 +177,9 @@ data:
 	Context("Cluster has cni secret with priority annotation", func() {
 		BeforeEach(func() {
 			resources := []string{
-				cniSecretWithAnnotationYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "BPF"}`),
+				cniSecretYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "BPF"}`, nil, map[string]string{
+					"network.deckhouse.io/cni-configuration-source-priority": "ModuleConfig",
+				}),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -218,7 +204,7 @@ data:
 	Context("Cluster has cni secret, key `cni` eq `cilium`, but cni MC does not exist", func() {
 		BeforeEach(func() {
 			resources := []string{
-				cniSecretYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "BPF"}`),
+				cniSecretYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "BPF"}`, nil, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -247,8 +233,8 @@ data:
 			requirements.RemoveValue(cniConfigurationSettledKey)
 			f.ValuesSet("global.clusterIsBootstrapped", true)
 			resources := []string{
-				cniSecretYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "BPF"}`),
-				cniMCYAML(cniName, ptr.To(false), v1alpha1.SettingsValues{}),
+				cniSecretYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "BPF"}`, nil, nil),
+				cniMCYAML(cniName, ptr.To(false), v1alpha1.SettingsValues{}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -274,11 +260,11 @@ data:
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			f.ConfigValuesSet("cniCilium.masqueradeMode", "BPF")
 			resources := []string{
-				cniSecretYAML(cni, `{"mode": "Direct", "masqueradeMode": "Netfilter"}`),
+				cniSecretYAML(cni, `{"mode": "Direct", "masqueradeMode": "Netfilter"}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"tunnelMode":     "VXLAN",
 					"masqueradeMode": "BPF",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -305,11 +291,11 @@ data:
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			f.ConfigValuesSet("cniCilium.masqueradeMode", "BPF")
 			resources := []string{
-				cniSecretYAML(cni, ``),
+				cniSecretYAML(cni, ``, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"tunnelMode":     "VXLAN",
 					"masqueradeMode": "BPF",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -336,11 +322,11 @@ data:
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			f.ConfigValuesSet("cniCilium.masqueradeMode", "BPF")
 			resources := []string{
-				cniSecretYAML(cni, `{}`),
+				cniSecretYAML(cni, `{}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"tunnelMode":     "VXLAN",
 					"masqueradeMode": "BPF",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -369,12 +355,12 @@ data:
 			f.ConfigValuesSet("cniCilium.bpfLBMode", "SNAT")
 			f.ConfigValuesSet("cniCilium.debugLogging", true)
 			resources := []string{
-				cniSecretYAML(cni, `{"mode": "DirectWithNodeRoutes", "masqueradeMode": "Netfilter"}`),
+				cniSecretYAML(cni, `{"mode": "DirectWithNodeRoutes", "masqueradeMode": "Netfilter"}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"tunnelMode":   "VXLAN",
 					"bpfLBMode":    "SNAT",
 					"debugLogging": true,
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -421,11 +407,11 @@ status:
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			f.ConfigValuesSet("cniCilium.bpfLBMode", "SNAT")
 			resources := []string{
-				cniSecretYAML(cni, `{"mode": "DirectWithNodeRoutes"}`),
+				cniSecretYAML(cni, `{"mode": "DirectWithNodeRoutes"}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"tunnelMode": "VXLAN",
 					"bpfLBMode":  "SNAT",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -472,11 +458,11 @@ status:
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			f.ConfigValuesSet("cniCilium.bpfLBMode", "SNAT")
 			resources := []string{
-				cniSecretYAML(cni, `{"mode": "DirectWithNodeRoutes"}`),
+				cniSecretYAML(cni, `{"mode": "DirectWithNodeRoutes"}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"tunnelMode": "VXLAN",
 					"bpfLBMode":  "SNAT",
-				}),
+				}, nil),
 				foreignDesiredCM,
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
@@ -523,11 +509,11 @@ status:
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			f.ConfigValuesSet("cniCilium.bpfLBMode", "SNAT")
 			resources := []string{
-				cniSecretYAML(cni, `{"mode": "UnknownMode", "masqueradeMode": "UnknownMasqueradeMode"}`),
+				cniSecretYAML(cni, `{"mode": "UnknownMode", "masqueradeMode": "UnknownMasqueradeMode"}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"tunnelMode": "VXLAN",
 					"bpfLBMode":  "SNAT",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -556,11 +542,11 @@ status:
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			f.ConfigValuesSet("cniCilium.masqueradeMode", "BPF")
 			resources := []string{
-				cniSecretYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "BPF"}`),
+				cniSecretYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "BPF"}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"tunnelMode":     "VXLAN",
 					"masqueradeMode": "BPF",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -584,25 +570,12 @@ status:
 
 	Context("Cluster has cni secret with annotation having non-standard priority value", func() {
 		BeforeEach(func() {
-			secretData := make(map[string][]byte)
-			secretData["cni"] = []byte(cni)
-			secretData[cni] = []byte(`{"mode": "VXLAN", "masqueradeMode": "BPF"}`)
-			s := &v1core.Secret{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "Secret",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "d8-cni-configuration",
-					Namespace: "kube-system",
-					Annotations: map[string]string{
-						"network.deckhouse.io/cni-configuration-source-priority": "CustomValue",
-					},
-				},
-				Data: secretData,
+			resources := []string{
+				cniSecretYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "BPF"}`, nil, map[string]string{
+					"network.deckhouse.io/cni-configuration-source-priority": "CustomValue",
+				}),
 			}
-			marshaled, _ := yaml.Marshal(s)
-			f.KubeStateSet(string(marshaled))
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
@@ -627,10 +600,10 @@ status:
 			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			resources := []string{
-				cniSecretYAML(cni, `{"mode": "Direct", "masqueradeMode": "BPF"}`),
+				cniSecretYAML(cni, `{"mode": "Direct", "masqueradeMode": "BPF"}`, nil, nil),
 				cniMCYAML(cniName, nil, v1alpha1.SettingsValues{
 					"tunnelMode": "VXLAN",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -657,48 +630,15 @@ status:
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			f.ConfigValuesSet("cniCilium.masqueradeMode", "BPF")
 
-			// Create MC first (earlier timestamp)
-			mc := &v1alpha1.ModuleConfig{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "deckhouse.io/v1alpha1",
-					Kind:       "ModuleConfig",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              cniName,
-					CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)),
-				},
-				Spec: v1alpha1.ModuleConfigSpec{
-					Version: 1,
-					Settings: v1alpha1.SettingsValues{
-						"tunnelMode":     "VXLAN",
-						"masqueradeMode": "BPF",
-					},
-					Enabled: ptr.To(true),
-				},
-			}
-			mcYAML, _ := yaml.Marshal(mc)
-
-			// Create secret later (later timestamp)
-			secretData := make(map[string][]byte)
-			secretData["cni"] = []byte(cni)
-			secretData[cni] = []byte(`{"mode": "Direct", "masqueradeMode": "Netfilter"}`)
-			secret := &v1core.Secret{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "Secret",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "d8-cni-configuration",
-					Namespace:         "kube-system",
-					CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 2, 12, 0, 0, 0, time.UTC)), // 1 day later
-				},
-				Data: secretData,
-			}
-			secretYAML, _ := yaml.Marshal(secret)
+			mcTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)     // earlier timestamp
+			secretTime := time.Date(2023, 1, 2, 12, 0, 0, 0, time.UTC) // 1 day later
 
 			resources := []string{
-				string(secretYAML),
-				string(mcYAML),
+				cniSecretYAML(cni, `{"mode": "Direct", "masqueradeMode": "Netfilter"}`, &secretTime, nil),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"tunnelMode":     "VXLAN",
+					"masqueradeMode": "BPF",
+				}, &mcTime),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -717,6 +657,164 @@ status:
 			Expect(secret.Exists()).To(BeTrue())
 			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
 			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
+		})
+	})
+
+	Context("Cluster is bootstrapped, has cni secret(with mismatched configuration) created just within 10 minutes after MC, so Secret takes priority", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
+			f.ConfigValuesSet("cniCilium.masqueradeMode", "BPF")
+
+			mcTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+			secretTime := time.Date(2023, 1, 1, 12, 5, 0, 0, time.UTC) // 5 minutes later
+
+			resources := []string{
+				cniSecretYAML(cni, `{"mode": "Direct", "masqueradeMode": "Netfilter"}`, &secretTime, nil),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"tunnelMode":     "VXLAN",
+					"masqueradeMode": "BPF",
+				}, &mcTime),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=false and metric=1 and create desired mc (secret created within 10min after MC)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("false"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 1.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", "desired-cni-moduleconfig")
+			Expect(cm.Exists()).To(BeTrue())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Cluster is bootstrapped, has cni secret(with mismatched configuration) created exactly 10 minutes after MC, so Secret takes priority", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
+			f.ConfigValuesSet("cniCilium.masqueradeMode", "BPF")
+
+			mcTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+			secretTime := time.Date(2023, 1, 1, 12, 10, 0, 0, time.UTC) // exactly 10 minutes later
+
+			resources := []string{
+				cniSecretYAML(cni, `{"mode": "Direct", "masqueradeMode": "Netfilter"}`, &secretTime, nil),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"tunnelMode":     "VXLAN",
+					"masqueradeMode": "BPF",
+				}, &mcTime),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=false and metric=1 and create desired mc (secret created exactly 10min after MC)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("false"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 1.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", "desired-cni-moduleconfig")
+			Expect(cm.Exists()).To(BeTrue())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Cluster is bootstrapped, has cni secret(with mismatched configuration) created just after 10 minutes threshold, so MC takes priority", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
+			f.ConfigValuesSet("cniCilium.masqueradeMode", "BPF")
+
+			mcTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+			secretTime := time.Date(2023, 1, 1, 12, 10, 1, 0, time.UTC) // 10 minutes and 1 second later
+
+			resources := []string{
+				cniSecretYAML(cni, `{"mode": "Direct", "masqueradeMode": "Netfilter"}`, &secretTime, nil),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"tunnelMode":     "VXLAN",
+					"masqueradeMode": "BPF",
+				}, &mcTime),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=true and metric=0 and should not create desired mc (secret created after 10min threshold)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("true"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", "desired-cni-moduleconfig")
+			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
+		})
+	})
+
+	Context("Cluster is bootstrapped, has cni secret(with mismatched configuration) created much earlier than MC, so Secret takes priority", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
+			f.ConfigValuesSet("cniCilium.masqueradeMode", "BPF")
+
+			secretTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC) // 1 day earlier
+			mcTime := time.Date(2023, 1, 2, 12, 0, 0, 0, time.UTC)     // 1 day later
+
+			resources := []string{
+				cniSecretYAML(cni, `{"mode": "Direct", "masqueradeMode": "Netfilter"}`, &secretTime, nil),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"tunnelMode":     "VXLAN",
+					"masqueradeMode": "BPF",
+				}, &mcTime),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=false and metric=1 and create desired mc (secret created much earlier than MC)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("false"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 1.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", "desired-cni-moduleconfig")
+			Expect(cm.Exists()).To(BeTrue())
+			Expect(cm.Field(`data.cni-cilium-mc\.yaml`).Exists()).To(BeTrue())
+			Expect(cm.Field(`data.cni-cilium-mc\.yaml`).String()).To(MatchYAML(`
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  creationTimestamp: null
+  name: cni-cilium
+spec:
+  enabled: true
+  settings:
+    tunnelMode: Disabled
+    masqueradeMode: Netfilter
+  version: 1
+status:
+  message: ""
+  version: ""
+`))
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
 		})
 	})
 })

--- a/modules/021-cni-cilium/hooks/check_cni_configuration_test.go
+++ b/modules/021-cni-cilium/hooks/check_cni_configuration_test.go
@@ -403,7 +403,7 @@ status:
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			f.ConfigValuesSet("cniCilium.bpfLBMode", "SNAT")
 			resources := []string{
-				cniSecretYAML(cni, `{"mode": "DirectWithNodeRutes", "masqueradeMode": "Netfilter"}`),
+				cniSecretYAML(cni, `{"mode": "DirectWithNodeRoutes", "masqueradeMode": "Netfilter"}`),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"tunnelMode": "VXLAN",
 					"bpfLBMode":  "SNAT",
@@ -423,7 +423,7 @@ status:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 1.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
-			Expect(f.GoHookError.Error()).Should(ContainSubstring(`unknown cilium mode DirectWithNodeRutes`))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`unknown cilium mode DirectWithNodeRoutes`))
 		})
 	})
 

--- a/modules/021-cni-cilium/hooks/check_cni_configuration_test.go
+++ b/modules/021-cni-cilium/hooks/check_cni_configuration_test.go
@@ -159,6 +159,8 @@ data:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeFalse())
 		})
 	})
 
@@ -181,6 +183,10 @@ data:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 
@@ -202,6 +208,10 @@ data:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 
@@ -226,6 +236,10 @@ data:
 			Expect(cm.Exists()).To(BeFalse())
 			mc := f.KubernetesResource("ModuleConfig", "", cniName)
 			Expect(mc.Exists()).To(BeTrue())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 
@@ -250,6 +264,9 @@ data:
 			Expect(len(f.MetricsCollector.CollectedMetrics())).To(Equal(1)) // only expire
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
 		})
 	})
 
@@ -278,6 +295,10 @@ data:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 
@@ -305,6 +326,10 @@ data:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 
@@ -332,6 +357,10 @@ data:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 
@@ -383,6 +412,9 @@ status:
   message: ""
   version: ""
 `))
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
 		})
 	})
 
@@ -431,6 +463,9 @@ status:
   message: ""
   version: ""
 `))
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
 		})
 	})
 
@@ -479,6 +514,9 @@ status:
   message: ""
   version: ""
 `))
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
 		})
 	})
 
@@ -510,6 +548,10 @@ status:
 			Expect(cm.Exists()).To(BeFalse())
 			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("unknown cilium mode"))
 			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("unknown cilium masqueradeMode"))
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 
@@ -537,6 +579,79 @@ status:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
+		})
+	})
+
+	Context("Cluster has cni secret with annotation having non-standard priority value", func() {
+		BeforeEach(func() {
+			secretData := make(map[string][]byte)
+			secretData["cni"] = []byte(cni)
+			secretData[cni] = []byte(`{"mode": "VXLAN", "masqueradeMode": "BPF"}`)
+			s := &v1core.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "d8-cni-configuration",
+					Namespace: "kube-system",
+					Annotations: map[string]string{
+						"network.deckhouse.io/cni-configuration-source-priority": "CustomValue",
+					},
+				},
+				Data: secretData,
+			}
+			marshaled, _ := yaml.Marshal(s)
+			f.KubeStateSet(string(marshaled))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=true and metric=0 and should not create desired mc", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("true"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
+			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("CustomValue"))
+		})
+	})
+
+	Context("Cluster has cni secret, MC enabled=nil (implicitly enabled)", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
+			resources := []string{
+				cniSecretYAML(cni, `{"mode": "Direct", "masqueradeMode": "BPF"}`),
+				cniMCYAML(cniName, nil, v1alpha1.SettingsValues{
+					"tunnelMode": "VXLAN",
+				}),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should detect mismatch, set req=false and metric=1 and create desired mc", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("false"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 1.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
+			Expect(cm.Exists()).To(BeTrue())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
 		})
 	})
 })

--- a/modules/021-cni-cilium/hooks/set_cilium_mode.go
+++ b/modules/021-cni-cilium/hooks/set_cilium_mode.go
@@ -162,7 +162,7 @@ func setCiliumMode(_ context.Context, input *go_hook.HookInput) error {
 
 		return nil
 	case "SecretExistsAndMCHasPriority":
-		// Secret and MC exists, and MC has priority (new logic); merging priority: MC > Secret > Default
+		// Secret and MC exist, and MC has priority (new logic); merging priority: MC > Secret > Default
 
 		// masqueradeMode
 		if value, ok := cniModuleConfigs[0].Spec.Settings["masqueradeMode"]; ok && value != nil {
@@ -192,7 +192,7 @@ func setCiliumMode(_ context.Context, input *go_hook.HookInput) error {
 				input.Values.Set("cniCilium.internal.mode", "Direct")
 			}
 		}
-		//createNodeRoutes
+		// createNodeRoutes
 		if value, ok := cniModuleConfigs[0].Spec.Settings["createNodeRoutes"]; ok && value != nil {
 			if value.(bool) {
 				input.Values.Set("cniCilium.internal.mode", "DirectWithNodeRoutes")
@@ -227,7 +227,7 @@ func setCiliumMode(_ context.Context, input *go_hook.HookInput) error {
 				input.Values.Set("cniCilium.internal.mode", "Direct")
 			}
 		}
-		//createNodeRoutes
+		// createNodeRoutes
 		if value, ok := input.ConfigValues.GetOk("cniCilium.createNodeRoutes"); ok && value.Bool() {
 			input.Values.Set("cniCilium.internal.mode", "DirectWithNodeRoutes")
 		}
@@ -242,5 +242,5 @@ func setCiliumMode(_ context.Context, input *go_hook.HookInput) error {
 
 	// default_mode = Direct
 	// default_masqueradeMode = BPF
-	return nil
+	// return nil
 }

--- a/modules/021-cni-cilium/hooks/set_cilium_mode.go
+++ b/modules/021-cni-cilium/hooks/set_cilium_mode.go
@@ -27,8 +27,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 )
 
 type CiliumConfigStruct struct {
@@ -131,17 +132,18 @@ func setCiliumMode(_ context.Context, input *go_hook.HookInput) error {
 	typeOfMergingCNIParameters := "SecretNotExists"
 
 	if len(cniConfigurationSecrets) > 0 {
-		if len(cniModuleConfigs) == 0 {
+		switch {
+		case len(cniModuleConfigs) == 0:
 			typeOfMergingCNIParameters = "SecretExistsAndHasPriority"
-		} else if cniConfigurationSecrets[0].DesiredCniConfigSourcePriorityFlagExists {
+		case cniConfigurationSecrets[0].DesiredCniConfigSourcePriorityFlagExists:
 			if cniConfigurationSecrets[0].DesiredCniConfigSourcePriority == "ModuleConfig" {
 				typeOfMergingCNIParameters = "SecretExistsAndMCHasPriority"
 			} else {
 				typeOfMergingCNIParameters = "SecretExistsAndHasPriority"
 			}
-		} else if clusterIsBootstrapped {
+		case clusterIsBootstrapped:
 			typeOfMergingCNIParameters = "SecretExistsAndHasPriority"
-		} else {
+		default:
 			typeOfMergingCNIParameters = "SecretExistsAndMCHasPriority"
 		}
 	}

--- a/modules/021-cni-cilium/hooks/set_cilium_mode.go
+++ b/modules/021-cni-cilium/hooks/set_cilium_mode.go
@@ -36,9 +36,9 @@ type CiliumConfigStruct struct {
 }
 
 type resultStruct struct {
-	desiredCniConfigSourcePriorityFlagExists bool
-	desiredCniConfigSourcePriority           string
-	cniConfigFromSecret                      CiliumConfigStruct
+	DesiredCniConfigSourcePriorityFlagExists bool
+	DesiredCniConfigSourcePriority           string
+	CniConfigFromSecret                      CiliumConfigStruct
 }
 
 func applyCNIConfigurationSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -68,9 +68,9 @@ func applyCNIConfigurationSecretFilter(obj *unstructured.Unstructured) (go_hook.
 	cniConfigSourcePriority, cniConfigSourcePriorityFlagExists = secret.Annotations[cniConfigSourcePriorityAnnotation]
 
 	return resultStruct{
-		desiredCniConfigSourcePriorityFlagExists: cniConfigSourcePriorityFlagExists,
-		desiredCniConfigSourcePriority:           cniConfigSourcePriority,
-		cniConfigFromSecret:                      ciliumConfig,
+		DesiredCniConfigSourcePriorityFlagExists: cniConfigSourcePriorityFlagExists,
+		DesiredCniConfigSourcePriority:           cniConfigSourcePriority,
+		CniConfigFromSecret:                      ciliumConfig,
 	}, nil
 }
 
@@ -105,8 +105,8 @@ func setCiliumMode(_ context.Context, input *go_hook.HookInput) error {
 
 	cniConfigSourcePriority := "ModuleConfig"
 	if len(cniConfigurationSecrets) > 0 {
-		if cniConfigurationSecrets[0].desiredCniConfigSourcePriorityFlagExists {
-			if cniConfigurationSecrets[0].desiredCniConfigSourcePriority != "ModuleConfig" {
+		if cniConfigurationSecrets[0].DesiredCniConfigSourcePriorityFlagExists {
+			if cniConfigurationSecrets[0].DesiredCniConfigSourcePriority != "ModuleConfig" {
 				cniConfigSourcePriority = "Secret"
 			}
 		} else if clusterIsBootstrapped {
@@ -117,7 +117,7 @@ func setCiliumMode(_ context.Context, input *go_hook.HookInput) error {
 
 	switch cniConfigSourcePriority {
 	case "Secret":
-		ciliumConfig := cniConfigurationSecrets[0].cniConfigFromSecret
+		ciliumConfig := cniConfigurationSecrets[0].CniConfigFromSecret
 		if ciliumConfig.Mode != "" {
 			input.Values.Set("cniCilium.internal.mode", ciliumConfig.Mode)
 		}

--- a/modules/021-cni-cilium/hooks/set_cilium_mode.go
+++ b/modules/021-cni-cilium/hooks/set_cilium_mode.go
@@ -221,7 +221,6 @@ func setCiliumMode(_ context.Context, input *go_hook.HookInput) error {
 			switch value.String() {
 			case "VXLAN":
 				input.Values.Set("cniCilium.internal.mode", "VXLAN")
-				// ???
 				return nil
 			case "Disabled":
 				// to recover the default value if it was discovered before

--- a/modules/021-cni-cilium/hooks/set_cilium_mode_test.go
+++ b/modules/021-cni-cilium/hooks/set_cilium_mode_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration is present, but cni != `cilium`", func() {
+	Context("Secret is present, but cni != `cilium`", func() {
 		BeforeEach(func() {
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
 			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
@@ -122,7 +122,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration is present, cni == `cilium`, but cilium field is not set", func() {
+	Context("Secret is present, cni == `cilium`, but cilium field is not set", func() {
 		BeforeEach(func() {
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
 			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
@@ -140,7 +140,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration is present, cni = `cilium`, cilium mode = VXLAN", func() {
+	Context("Secret is present, cni == `cilium`, cilium mode == VXLAN", func() {
 		BeforeEach(func() {
 			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
@@ -159,7 +159,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration is present, cni = `cilium`, cilium mode = DirectWithNodeRoutes, masqueradeMode = Netfilter", func() {
+	Context("Secret is present, cni == `cilium`, cilium mode == DirectWithNodeRoutes, masqueradeMode == Netfilter", func() {
 		BeforeEach(func() {
 			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
@@ -179,7 +179,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration is absent, tunnelMode set to `VXLAN`", func() {
+	Context("Secret is absent, MC is present: tunnelMode set to `VXLAN`", func() {
 		BeforeEach(func() {
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
@@ -200,7 +200,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration is absent, masqueradeMode set to `Netfilter`", func() {
+	Context("Secret is absent, MC is present: masqueradeMode set to `Netfilter`, tunnelMode set to `VXLAN`", func() {
 		BeforeEach(func() {
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			f.ConfigValuesSet("cniCilium.masqueradeMode", "Netfilter")
@@ -223,7 +223,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration is absent, tunnelMode set to `Disabled`, but previously the mode was discovered to `VXLAN`", func() {
+	Context("Secret is absent, MC is present: tunnelMode set to `Disabled`, but previously the mode was discovered to `VXLAN`", func() {
 		BeforeEach(func() {
 			f.ConfigValuesSet("cniCilium.tunnelMode", "Disabled")
 			f.ValuesSet("cniCilium.internal.mode", "VXLAN")
@@ -242,7 +242,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration is absent, createNodeRoutes set to `true`", func() {
+	Context("Secret is absent, MC is present: createNodeRoutes set to `true`", func() {
 		BeforeEach(func() {
 			f.ConfigValuesSet("cniCilium.createNodeRoutes", true)
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
@@ -263,7 +263,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration is absent, createNodeRoutes set to `false`", func() {
+	Context("Secret is absent, MC is present: createNodeRoutes set to `false`", func() {
 		BeforeEach(func() {
 			f.ConfigValuesSet("cniCilium.createNodeRoutes", false)
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
@@ -284,7 +284,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration is absent, config parameters is absent, but cloud provider = Static", func() {
+	Context("Static, Secret is absent, MC is absent", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global.clusterConfiguration", []byte(`
 apiVersion: deckhouse.io/v1
@@ -307,7 +307,7 @@ serviceSubnetCIDR: 10.232.0.0/16
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration is absent, config parameters is absent, but cloud provider != Static", func() {
+	Context("Not Static, Secret is absent, MC is absent", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global.clusterConfiguration", []byte(`
 apiVersion: deckhouse.io/v1
@@ -334,7 +334,7 @@ serviceSubnetCIDR: 10.232.0.0/16
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration is absent, cloud provider = Static, tunnelMode = VXLAN and masqueradeMode = Netfilter are configured", func() {
+	Context("Static, Secret is absent, MC is present: tunnelMode == VXLAN and masqueradeMode == Netfilter", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global.clusterConfiguration", []byte(`
 apiVersion: deckhouse.io/v1
@@ -365,7 +365,65 @@ serviceSubnetCIDR: 10.232.0.0/16
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration with annotation network.deckhouse.io/cni-configuration-source-priority=ModuleConfig, cilium mode = VXLAN", func() {
+	Context("Static, Secret is absent, MC is present: tunnelMode == VXLAN", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.clusterConfiguration", []byte(`
+apiVersion: deckhouse.io/v1
+clusterType: Static
+kind: ClusterConfiguration
+kubernetesVersion: "Automatic"
+podSubnetCIDR: 10.231.0.0/16
+serviceSubnetCIDR: 10.232.0.0/16
+`))
+			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
+			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
+			resources := []string{
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"tunnelMode": "VXLAN",
+				}, nil),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+		It("hook should run successfully, cilium mode should be `VXLAN`", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("VXLAN"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
+		})
+	})
+
+	Context("Static, Secret is absent, MC is present: createNodeRoutes == false", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.clusterConfiguration", []byte(`
+apiVersion: deckhouse.io/v1
+clusterType: Static
+kind: ClusterConfiguration
+kubernetesVersion: "Automatic"
+podSubnetCIDR: 10.231.0.0/16
+serviceSubnetCIDR: 10.232.0.0/16
+`))
+			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
+			f.ConfigValuesSet("cniCilium.createNodeRoutes", false)
+			resources := []string{
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"createNodeRoutes": false,
+				}, nil),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+		It("hook should run successfully, cilium mode should be `DirectWithNodeRoutes`", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("DirectWithNodeRoutes"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
+		})
+	})
+
+	Context("Secret is present, MC is present and has priority", func() {
 		BeforeEach(func() {
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
 			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
@@ -391,7 +449,7 @@ serviceSubnetCIDR: 10.232.0.0/16
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration with annotation network.deckhouse.io/cni-configuration-source-priority=Secret, cilium mode = VXLAN", func() {
+	Context("Secret is present and has priority, MC is present", func() {
 		BeforeEach(func() {
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
 			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
@@ -417,115 +475,7 @@ serviceSubnetCIDR: 10.232.0.0/16
 		})
 	})
 
-	Context("kube-system/d8-cni-configuration without annotation, cluster is not bootstrapped", func() {
-		BeforeEach(func() {
-			f.ValuesSet("global.clusterIsBootstrapped", false)
-			f.ValuesSet("cniCilium.internal.mode", "Direct")
-			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
-			f.ConfigValuesSet("cniCilium.tunnelMode", "Disabled")
-			f.ConfigValuesSet("cniCilium.createNodeRoutes", true)
-			resources := []string{
-				cniSecretYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "Netfilter"}`, nil, nil),
-				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
-					"tunnelMode":       "Disabled",
-					"createNodeRoutes": true,
-				}, nil),
-			}
-			f.KubeStateSet(strings.Join(resources, "\n---\n"))
-			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
-			f.RunHook()
-		})
-		It("hook should run successfully, cilium mode should be from MC (DirectWithNodeRoutes), not secret", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("DirectWithNodeRoutes"))
-			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("Netfilter"))
-		})
-	})
-
-	Context("kube-system/d8-cni-configuration without annotation, cluster is bootstrapped", func() {
-		BeforeEach(func() {
-			f.ValuesSet("global.clusterIsBootstrapped", true)
-			f.ValuesSet("cniCilium.internal.mode", "Direct")
-			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
-			f.ConfigValuesSet("cniCilium.tunnelMode", "Disabled")
-			f.ConfigValuesSet("cniCilium.createNodeRoutes", true)
-			resources := []string{
-				cniSecretYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "Netfilter"}`, nil, nil),
-				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
-					"tunnelMode":       "Disabled",
-					"createNodeRoutes": true,
-				}, nil),
-			}
-			f.KubeStateSet(strings.Join(resources, "\n---\n"))
-			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
-			f.RunHook()
-		})
-		It("hook should run successfully, cilium mode should be from secret (VXLAN), not MC", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("VXLAN"))
-			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("Netfilter"))
-		})
-	})
-
-	Context("Static cluster with tunnelMode VXLAN configured (priority test)", func() {
-		BeforeEach(func() {
-			f.ValuesSetFromYaml("global.clusterConfiguration", []byte(`
-apiVersion: deckhouse.io/v1
-clusterType: Static
-kind: ClusterConfiguration
-kubernetesVersion: "Automatic"
-podSubnetCIDR: 10.231.0.0/16
-serviceSubnetCIDR: 10.232.0.0/16
-`))
-			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
-			f.ValuesSet("cniCilium.internal.mode", "Direct")
-			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
-			resources := []string{
-				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
-					"tunnelMode": "VXLAN",
-				}, nil),
-			}
-			f.KubeStateSet(strings.Join(resources, "\n---\n"))
-			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
-			f.RunHook()
-		})
-		It("tunnelMode VXLAN should take priority over Static cluster default", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("VXLAN"))
-			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
-		})
-	})
-
-	Context("Static cluster with createNodeRoutes false (should not override default)", func() {
-		BeforeEach(func() {
-			f.ValuesSetFromYaml("global.clusterConfiguration", []byte(`
-apiVersion: deckhouse.io/v1
-clusterType: Static
-kind: ClusterConfiguration
-kubernetesVersion: "Automatic"
-podSubnetCIDR: 10.231.0.0/16
-serviceSubnetCIDR: 10.232.0.0/16
-`))
-			f.ConfigValuesSet("cniCilium.createNodeRoutes", false)
-			f.ValuesSet("cniCilium.internal.mode", "Direct")
-			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
-			resources := []string{
-				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
-					"createNodeRoutes": false,
-				}, nil),
-			}
-			f.KubeStateSet(strings.Join(resources, "\n---\n"))
-			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
-			f.RunHook()
-		})
-		It("Static cluster type takes priority over createNodeRoutes false", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("DirectWithNodeRoutes"))
-			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
-		})
-	})
-
-	Context("Priority annotation with value Secret", func() {
+	Context("Secret is present and has priority, MC is present 2", func() {
 		BeforeEach(func() {
 			f.ValuesSet("cniCilium.internal.mode", "VXLAN")
 			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
@@ -551,7 +501,7 @@ serviceSubnetCIDR: 10.232.0.0/16
 		})
 	})
 
-	Context("Priority annotation with non-standard value", func() {
+	Context("Secret is present and has priority, MC is present 3", func() {
 		BeforeEach(func() {
 			f.ValuesSet("cniCilium.internal.mode", "VXLAN")
 			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
@@ -573,6 +523,56 @@ serviceSubnetCIDR: 10.232.0.0/16
 		It("should treat non-ModuleConfig value as Secret priority", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("Direct"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("Netfilter"))
+		})
+	})
+
+	Context("Secret and MC are present, priority annotation is absent, cluster is not bootstrapped", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", false)
+			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
+			f.ConfigValuesSet("cniCilium.tunnelMode", "Disabled")
+			f.ConfigValuesSet("cniCilium.createNodeRoutes", true)
+			resources := []string{
+				cniSecretYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "Netfilter"}`, nil, nil),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"tunnelMode":       "Disabled",
+					"createNodeRoutes": true,
+				}, nil),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+		It("hook should run successfully, cilium mode should be from MC (DirectWithNodeRoutes), masqueradeMode from secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("DirectWithNodeRoutes"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("Netfilter"))
+		})
+	})
+
+	Context("Secret and MC are present, priority annotation is absent, cluster is bootstrapped", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
+			f.ConfigValuesSet("cniCilium.tunnelMode", "Disabled")
+			f.ConfigValuesSet("cniCilium.createNodeRoutes", true)
+			resources := []string{
+				cniSecretYAML(cni, `{"mode": "VXLAN", "masqueradeMode": "Netfilter"}`, nil, nil),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"tunnelMode":       "Disabled",
+					"createNodeRoutes": true,
+				}, nil),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+		It("hook should run successfully, cilium mode should be from secret (VXLAN), not MC", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("VXLAN"))
 			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("Netfilter"))
 		})
 	})

--- a/modules/021-cni-cilium/hooks/set_cilium_mode_test.go
+++ b/modules/021-cni-cilium/hooks/set_cilium_mode_test.go
@@ -28,7 +28,15 @@ import (
 )
 
 var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
-	f := HookExecutionConfigInit(`{"cniCilium":{"internal":{}}}`, "")
+
+	const (
+		initValuesString       = `{"cniCilium":{"internal": {}}}`
+		initConfigValuesString = `{"cniCilium":{}}`
+	)
+
+	f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
+
 	Context("fresh cluster", func() {
 		BeforeEach(func() {
 			f.KubeStateSet("")

--- a/modules/035-cni-flannel/hooks/check_cni_configuration.go
+++ b/modules/035-cni-flannel/hooks/check_cni_configuration.go
@@ -290,8 +290,8 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 		return nil
 	}
 
-	// Let's check what was created earlier: MC or Secret.
-	if cniSecret.CreationTimestamp.After(cniModuleConfigs[0].CreationTimestamp.Time) {
+	// Let's check what was created earlier: MC(+10m) or Secret.
+	if cniSecret.CreationTimestamp.After(cniModuleConfigs[0].CreationTimestamp.Time.Add(10 * time.Minute)) {
 		annotateSecret(input)
 		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
 		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)

--- a/modules/035-cni-flannel/hooks/check_cni_configuration.go
+++ b/modules/035-cni-flannel/hooks/check_cni_configuration.go
@@ -223,26 +223,26 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 	}
 	// Generate the desired CNIModuleConfig based on existing secret and MC and compare them at the same time.
 	// Skip if in the secret key "flannel" does not exist or empty.
-	secretMatchesMc := true
+	secretMatchesMC := true
 	if cniSecret.Flannel != (flannelConfigStruct{}) {
 		switch cniSecret.Flannel.PodNetworkMode {
 		case "host-gw":
 			value, ok := input.ConfigValues.GetOk("cniFlannel.podNetworkMode")
 			if !ok || value.String() != "HostGW" {
 				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = "HostGW"
-				secretMatchesMc = false
+				secretMatchesMC = false
 			}
 		case "vxlan":
 			value, ok := input.ConfigValues.GetOk("cniFlannel.podNetworkMode")
 			if !ok || value.String() != "VXLAN" {
 				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = "VXLAN"
-				secretMatchesMc = false
+				secretMatchesMC = false
 			}
 		case "":
 			value, ok := input.ConfigValues.GetOk("cniFlannel.podNetworkMode")
 			if !ok || value.String() != "HostGW" {
 				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = "HostGW"
-				secretMatchesMc = false
+				secretMatchesMC = false
 			}
 		default:
 			input.Logger.Warn("An unknown flannel podNetworkMode was specified in the d8-cni-configuration secret, so the default cni podNetworkMode will be used instead.", slog.String("specified podNetworkMode", cniSecret.Flannel.PodNetworkMode))
@@ -266,12 +266,12 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 	}
 
 	if cniModuleConfigs[0].Spec.Enabled == nil {
-		secretMatchesMc = false
+		secretMatchesMC = false
 	}
 
 	// If the secret matches MC, then we should
 	// - add an annotation to the secret (to activate new_logic)
-	if secretMatchesMc {
+	if secretMatchesMC {
 		annotateSecret(input)
 		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
 		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)

--- a/modules/035-cni-flannel/hooks/check_cni_configuration.go
+++ b/modules/035-cni-flannel/hooks/check_cni_configuration.go
@@ -149,10 +149,6 @@ func applyCNIMCFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert object to moduleconfig: %v", err)
 	}
-	// ignore only explicitly disabled modules.
-	if mc.Spec.Enabled != nil && !*mc.Spec.Enabled {
-		return nil, nil
-	}
 
 	return mc, nil
 }
@@ -259,7 +255,7 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 	}
 
 	// If MC exist, but is explicitly disabled, it means that CNI is in the process of disabling, there is nothing to do.
-	if len(cniModuleConfigs) != 0 && cniModuleConfigs[0].Spec.Enabled == nil || !*cniModuleConfigs[0].Spec.Enabled {
+	if cniModuleConfigs[0].Spec.Enabled != nil && !*cniModuleConfigs[0].Spec.Enabled {
 		return nil
 	}
 
@@ -328,7 +324,7 @@ func annotateSecret(input *go_hook.HookInput) {
 			},
 		},
 	}
-	input.PatchCollector.PatchWithMerge(secretPatch, "v1", "Secret", "kube-system", "d8-cluster-configuration")
+	input.PatchCollector.PatchWithMerge(secretPatch, "v1", "Secret", "kube-system", "d8-cni-configuration")
 }
 
 func createDesiredModuleConfig(input *go_hook.HookInput, desiredCNIModuleConfig *v1alpha1.ModuleConfig) {

--- a/modules/035-cni-flannel/hooks/check_cni_configuration.go
+++ b/modules/035-cni-flannel/hooks/check_cni_configuration.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
@@ -60,6 +61,7 @@ type ciliumConfigStruct struct {
 }
 
 type cniSecretStruct struct {
+	CreationTimestamp                 time.Time
 	CniConfigSourcePriorityFlagExists bool
 	CNI                               string
 	Flannel                           flannelConfigStruct
@@ -106,6 +108,10 @@ func applyCNIConfigurationFromSecretFilter(obj *unstructured.Unstructured) (go_h
 		return nil, fmt.Errorf("cannot convert incoming object to Secret: %v", err)
 	}
 	cniSecret := cniSecretStruct{}
+
+	// get creation timestamp from secret
+	cniSecret.CreationTimestamp = secret.CreationTimestamp.Time
+
 	// Check if the secret has the annotation "network.deckhouse.io/cni-configuration-source-priority"
 	_, exists := secret.Annotations[cniConfigSourcePriorityAnnotation]
 	cniSecret.CniConfigSourcePriorityFlagExists = exists
@@ -284,7 +290,15 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 		return nil
 	}
 
-	// If the cluster is already bootstrapped, then we should
+	// Let's check what was created earlier: MC or Secret.
+	if cniSecret.CreationTimestamp.After(cniModuleConfigs[0].CreationTimestamp.Time) {
+		annotateSecret(input)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If the cluster is already bootstrapped and the secret was created earlier than MC, then we should
 	// - generate desired MC based on secret
 	// - create cm based on desired MC
 	// - fire alert

--- a/modules/035-cni-flannel/hooks/check_cni_configuration.go
+++ b/modules/035-cni-flannel/hooks/check_cni_configuration.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
@@ -38,12 +39,15 @@ import (
 )
 
 const (
-	cniConfigurationSettledKey = "cniConfigurationSettled"
-	checkCNIConfigMetricName   = "cniMisconfigured"
-	checkCNIConfigMetricGroup  = "d8_check_cni_conf"
-	desiredCNIModuleConfigName = "desired-cni-moduleconfig"
-	cni                        = "flannel"
-	cniName                    = "cni-" + cni
+	cniConfigurationSettledKey        = "cniConfigurationSettled"
+	checkCNIConfigMetricName          = "cniMisconfigured"
+	checkCNIConfigMetricGroup         = "d8_check_cni_conf"
+	desiredCNIModuleConfigName        = "desired-cni-moduleconfig"
+	cni                               = "flannel"
+	cniName                           = "cni-" + cni
+	cniConfigurationIsNotSettled      = true
+	cniConfigurationIsSettled         = false
+	cniConfigSourcePriorityAnnotation = "network.deckhouse.io/cni-configuration-source-priority"
 )
 
 type flannelConfigStruct struct {
@@ -56,9 +60,10 @@ type ciliumConfigStruct struct {
 }
 
 type cniSecretStruct struct {
-	CNI     string
-	Flannel flannelConfigStruct
-	Cilium  ciliumConfigStruct
+	CniConfigSourcePriorityFlagExists bool
+	CNI                               string
+	Flannel                           flannelConfigStruct
+	Cilium                            ciliumConfigStruct
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -92,7 +97,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func applyCNIConfigurationFromSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	// Return nil if
-	// error occurred while json parse
+	// an error occurred while JSON parse
 	// or d8-cni-configuration secret does not contain key "cni"
 	// or value of key "cni" not in [cni-cilium, cni-flannel, cni-simple-bridge]
 	secret := &v1.Secret{}
@@ -101,9 +106,13 @@ func applyCNIConfigurationFromSecretFilter(obj *unstructured.Unstructured) (go_h
 		return nil, fmt.Errorf("cannot convert incoming object to Secret: %v", err)
 	}
 	cniSecret := cniSecretStruct{}
+	// Check if the secret has the annotation "network.deckhouse.io/cni-configuration-source-priority"
+	_, exists := secret.Annotations[cniConfigSourcePriorityAnnotation]
+	cniSecret.CniConfigSourcePriorityFlagExists = exists
+
 	cniBytes, ok := secret.Data["cni"]
 	if !ok {
-		// d8-cni-configuration secret does not contain "cni" field
+		// d8-cni-configuration secret does not contain the "cni" field
 		return nil, nil
 	}
 	cniSecret.CNI = string(cniBytes)
@@ -140,15 +149,159 @@ func applyCNIMCFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert object to moduleconfig: %v", err)
 	}
-	if mc.Spec.Enabled == nil || !*mc.Spec.Enabled {
+	// ignore only explicitly disabled modules.
+	if mc.Spec.Enabled != nil && !*mc.Spec.Enabled {
 		return nil, nil
 	}
 
 	return mc, nil
 }
 
-func setCNIMiscMetricAndReq(input *go_hook.HookInput, miss bool) {
-	switch miss {
+func checkCni(_ context.Context, input *go_hook.HookInput) error {
+	// Clear a metrics and reqKey
+	input.MetricsCollector.Expire(checkCNIConfigMetricGroup)
+	requirements.RemoveValue(cniConfigurationSettledKey)
+
+	// Get existing secret.
+	cniSecrets, err := sdkobjectpatch.UnmarshalToStruct[cniSecretStruct](input.Snapshots, "cni_configuration_secret")
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal cni_configuration_secret snapshot: %w", err)
+	}
+
+	// If secret does not exist, then we are already using a new logic de facto: the parameters in the MC have priority.
+	// So there is nothing to do.
+	if len(cniSecrets) == 0 {
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If the secret has the annotation "network.deckhouse.io/cni-configuration-source-priority", so there is nothing to do.
+	if cniSecrets[0].CniConfigSourcePriorityFlagExists {
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If secret does not contain config for current cni, then we are already using a new logic de facto: the parameters in the MC have priority.
+	// - add an annotation to the secret
+	cniSecret := cniSecrets[0]
+	if cniSecret.CNI != cni {
+		annotateSecret(input)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// Get existing MC.
+	cniModuleConfigs, err := sdkobjectpatch.UnmarshalToStruct[v1alpha1.ModuleConfig](input.Snapshots, "deckhouse_cni_mc")
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal deckhouse_cni_mc snapshot: %w", err)
+	}
+
+	// Prepare a template for the desiredCNIModuleConfig, which is empty and explicitly enabled.
+	desiredCNIModuleConfig := &v1alpha1.ModuleConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ModuleConfig",
+			APIVersion: "deckhouse.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cniName,
+		},
+		Spec: v1alpha1.ModuleConfigSpec{
+			Enabled:  ptr.To(true),
+			Version:  1,
+			Settings: v1alpha1.SettingsValues{},
+		},
+	}
+	// If the MC exists, use its Settings to generate the desired MC.
+	if len(cniModuleConfigs) != 0 {
+		cniModuleConfig := cniModuleConfigs[0]
+		desiredCNIModuleConfig.Spec.Settings = cniModuleConfig.DeepCopy().Spec.Settings
+	}
+	// Generate the desired CNIModuleConfig based on existing secret and MC and compare them at the same time.
+	// Skip if in the secret key "flannel" does not exist or empty.
+	secretMatchesMc := true
+	if cniSecret.Flannel != (flannelConfigStruct{}) {
+		switch cniSecret.Flannel.PodNetworkMode {
+		case "host-gw":
+			value, ok := input.ConfigValues.GetOk("cniFlannel.podNetworkMode")
+			if !ok || value.String() != "HostGW" {
+				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = "HostGW"
+				secretMatchesMc = false
+			}
+		case "vxlan":
+			value, ok := input.ConfigValues.GetOk("cniFlannel.podNetworkMode")
+			if !ok || value.String() != "VXLAN" {
+				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = "VXLAN"
+				secretMatchesMc = false
+			}
+		case "":
+			value, ok := input.ConfigValues.GetOk("cniFlannel.podNetworkMode")
+			if !ok || value.String() != "HostGW" {
+				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = "HostGW"
+				secretMatchesMc = false
+			}
+		default:
+			input.Logger.Warn("An unknown flannel podNetworkMode was specified in the d8-cni-configuration secret, so the default cni podNetworkMode will be used instead.", slog.String("specified podNetworkMode", cniSecret.Flannel.PodNetworkMode))
+		}
+	}
+
+	// If MC does not exist, then we should
+	// - add an annotation to the secret (to activate new_logic)
+	// - create the desired MC, which was generated based on the secret.
+	if len(cniModuleConfigs) == 0 {
+		annotateSecret(input)
+		createDesiredModuleConfig(input, desiredCNIModuleConfig)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If MC exist, but is explicitly disabled, it means that CNI is in the process of disabling, there is nothing to do.
+	if len(cniModuleConfigs) != 0 && cniModuleConfigs[0].Spec.Enabled == nil || !*cniModuleConfigs[0].Spec.Enabled {
+		return nil
+	}
+
+	if cniModuleConfigs[0].Spec.Enabled == nil {
+		secretMatchesMc = false
+	}
+
+	// If the secret matches MC, then we should
+	// - add an annotation to the secret (to activate new_logic)
+	if secretMatchesMc {
+		annotateSecret(input)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// Let's check if the cluster has already been bootstrapped.
+	clusterIsBootstrapped := input.Values.Get("global.clusterIsBootstrapped").Bool()
+
+	// If the cluster is not yet bootstrapped, then we should
+	// - add an annotation to the secret (to activate new_logic)
+	if !clusterIsBootstrapped {
+		annotateSecret(input)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If the cluster is already bootstrapped, then we should
+	// - generate desired MC based on secret
+	// - create cm based on desired MC
+	// - fire alert
+	err = createConfigMapWithDesiredModuleConfig(input, desiredCNIModuleConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create config map with desired module config: %w", err)
+	}
+	setMetricAndRequirementsValue(input, cniConfigurationIsNotSettled)
+	return nil
+}
+
+func setMetricAndRequirementsValue(input *go_hook.HookInput, isCniMisconfigured bool) {
+	switch isCniMisconfigured {
 	// misconfigure detected
 	case true:
 		input.MetricsCollector.Set(checkCNIConfigMetricName, 1,
@@ -167,121 +320,39 @@ func setCNIMiscMetricAndReq(input *go_hook.HookInput, miss bool) {
 	}
 }
 
-func checkCni(_ context.Context, input *go_hook.HookInput) error {
-	// Clear a metrics and reqKey
-	input.MetricsCollector.Expire(checkCNIConfigMetricGroup)
-	requirements.RemoveValue(cniConfigurationSettledKey)
-	needUpdateMC := false
+func annotateSecret(input *go_hook.HookInput) {
+	secretPatch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				"network.deckhouse.io/cni-configuration-source-priority": "ModuleConfig",
+			},
+		},
+	}
+	input.PatchCollector.PatchWithMerge(secretPatch, "v1", "Secret", "kube-system", "d8-cluster-configuration")
+}
 
-	cniSecrets, err := sdkobjectpatch.UnmarshalToStruct[cniSecretStruct](input.Snapshots, "cni_configuration_secret")
+func createDesiredModuleConfig(input *go_hook.HookInput, desiredCNIModuleConfig *v1alpha1.ModuleConfig) {
+	input.PatchCollector.CreateOrUpdate(desiredCNIModuleConfig)
+}
+
+func createConfigMapWithDesiredModuleConfig(input *go_hook.HookInput, desiredCNIModuleConfig *v1alpha1.ModuleConfig) error {
+	desiredCNIModuleConfigYAML, err := yaml.Marshal(*desiredCNIModuleConfig)
 	if err != nil {
-		setCNIMiscMetricAndReq(input, false)
-		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-		return nil
+		return fmt.Errorf("cannot marshal desired CNI moduleConfig, err: %w", err)
 	}
-	// Let's check secret.
-	// Secret d8-cni-configuration does not exist or exist but contain nil.
-	// This means that the current CNI module is enabled and configured via mc, nothing to do.
-	if len(cniSecrets) == 0 {
-		setCNIMiscMetricAndReq(input, false)
-		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-		return nil
-	}
-
-	// Secret d8-cni-configuration exist but key "cni" does not equal "flannel".
-	// This means that the current CNI module is enabled and configured via mc, nothing to do.
-	cniSecret := cniSecrets[0]
-	if cniSecret.CNI != cni {
-		setCNIMiscMetricAndReq(input, false)
-		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-		return nil
-	}
-
-	// Secret d8-cni-configuration exist, key "cni" eq "flannel".
-
-	// Prepare desiredCNIModuleConfig
-	desiredCNIModuleConfig := &v1alpha1.ModuleConfig{
+	data := map[string]string{cniName + "-mc.yaml": string(desiredCNIModuleConfigYAML)}
+	cm := &v1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "ModuleConfig",
-			APIVersion: "deckhouse.io/v1alpha1",
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: cniName,
+			Name:      desiredCNIModuleConfigName,
+			Namespace: "d8-system",
 		},
-		Spec: v1alpha1.ModuleConfigSpec{
-			Enabled:  ptr.To(true),
-			Version:  1,
-			Settings: v1alpha1.SettingsValues{},
-		},
+		Data: data,
 	}
-
-	deckhouseCniMCs, err := sdkobjectpatch.UnmarshalToStruct[v1alpha1.ModuleConfig](input.Snapshots, "deckhouse_cni_mc")
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal deckhouse_cni_mc snapshot: %w", err)
-	}
-	// Let's check what mc exist and explicitly enabled.
-	if len(deckhouseCniMCs) == 0 {
-		needUpdateMC = true
-	} else {
-		cniModuleConfig := deckhouseCniMCs[0]
-		desiredCNIModuleConfig.Spec.Settings = cniModuleConfig.DeepCopy().Spec.Settings
-	}
-
-	// Skip comparison if in secret d8-cni-configuration key "flannel" does not exist or empty.
-	if cniSecret.Flannel != (flannelConfigStruct{}) {
-		// Secret d8-cni-configuration exist, key "cni" eq "flannel" and key "flannel" does not empty.
-		// Let's compare secret with module configuration.
-		switch cniSecret.Flannel.PodNetworkMode {
-		case "host-gw":
-			value, ok := input.ConfigValues.GetOk("cniFlannel.podNetworkMode")
-			if !ok || value.String() != "HostGW" {
-				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = "HostGW"
-				needUpdateMC = true
-			}
-		case "vxlan":
-			value, ok := input.ConfigValues.GetOk("cniFlannel.podNetworkMode")
-			if !ok || value.String() != "VXLAN" {
-				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = "VXLAN"
-				needUpdateMC = true
-			}
-		case "":
-			value, ok := input.ConfigValues.GetOk("cniFlannel.podNetworkMode")
-			if !ok || value.String() != "HostGW" {
-				desiredCNIModuleConfig.Spec.Settings["podNetworkMode"] = "HostGW"
-				needUpdateMC = true
-			}
-		default:
-			setCNIMiscMetricAndReq(input, true)
-			input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-			return fmt.Errorf("unknown flannel podNetworkMode %s", cniSecret.Flannel.PodNetworkMode)
-		}
-	}
-
-	if needUpdateMC {
-		desiredCNIModuleConfigYAML, err := yaml.Marshal(*desiredCNIModuleConfig)
-		if err != nil {
-			return fmt.Errorf("cannot marshal desired CNI moduleConfig, err: %w", err)
-		}
-		data := map[string]string{cniName + "-mc.yaml": string(desiredCNIModuleConfigYAML)}
-		cm := &v1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "ConfigMap",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      desiredCNIModuleConfigName,
-				Namespace: "d8-system",
-			},
-			Data: data,
-		}
-		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-		input.PatchCollector.CreateOrUpdate(cm)
-		setCNIMiscMetricAndReq(input, true)
-		return nil
-	}
-
-	// All configuration settled, nothing to do.
-	setCNIMiscMetricAndReq(input, false)
 	input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+	input.PatchCollector.CreateOrUpdate(cm)
 	return nil
 }

--- a/modules/035-cni-flannel/hooks/check_cni_configuration_test.go
+++ b/modules/035-cni-flannel/hooks/check_cni_configuration_test.go
@@ -73,22 +73,6 @@ data:
     status:
       message: ""
       version: ""
-  cni-cilium-mc.yaml: |
-    apiVersion: deckhouse.io/v1alpha1
-    kind: ModuleConfig
-    metadata:
-      creationTimestamp: null
-      name: cni-cilium
-    spec:
-      enabled: true
-      settings:
-        masqueradeMode: BPF
-        tunnelMode: VXLAN
-        debugLogging: true
-      version: 1
-    status:
-      message: ""
-      version: ""
 `
 	)
 	f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
@@ -108,6 +92,29 @@ data:
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "d8-cni-configuration",
 				Namespace: "kube-system",
+			},
+			Data: secretData,
+		}
+		marshaled, _ := yaml.Marshal(s)
+		return string(marshaled)
+	}
+	cniSecretWithAnnotationYAML := func(cniName, data string) string {
+		secretData := make(map[string][]byte)
+		secretData["cni"] = []byte(cniName)
+		if data != "" {
+			secretData[cniName] = []byte(data)
+		}
+		s := &v1core.Secret{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Secret",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "d8-cni-configuration",
+				Namespace: "kube-system",
+				Annotations: map[string]string{
+					"network.deckhouse.io/cni-configuration-source-priority": "ModuleConfig",
+				},
 			},
 			Data: secretData,
 		}
@@ -150,6 +157,8 @@ data:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeFalse())
 		})
 	})
 
@@ -171,10 +180,39 @@ data:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 
-	Context("Cluster has cni secret, key `cni` eq `flannel`, but cni MC does not exist or it not explicitly enabled", func() {
+	Context("Cluster has cni secret with priority annotation", func() {
+		BeforeEach(func() {
+			resources := []string{
+				cniSecretWithAnnotationYAML(cni, `{"podNetworkMode": "vxlan"}`),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=true and metric=0 and should not create desired mc", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("true"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
+			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
+		})
+	})
+
+	Context("Cluster has cni secret, key `cni` eq `flannel`, but cni MC does not exist", func() {
 		BeforeEach(func() {
 			resources := []string{
 				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`),
@@ -184,30 +222,76 @@ data:
 			f.RunHook()
 		})
 
-		It("Should execute successfully, set req=false and metric=1 and create desired mc", func() {
+		It("Should execute successfully, set req=true and metric=0 and create MC directly", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			value, exists := requirements.GetValue(cniConfigurationSettledKey)
 			Expect(exists).To(BeTrue())
-			Expect(value).To(BeEquivalentTo("false"))
-			checkMetric(f.MetricsCollector.CollectedMetrics(), 1.0)
+			Expect(value).To(BeEquivalentTo("true"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
-			Expect(cm.Exists()).To(BeTrue())
-			Expect(cm.Field(`data.cni-flannel-mc\.yaml`).Exists()).To(BeTrue())
-			Expect(cm.Field(`data.cni-flannel-mc\.yaml`).String()).To(MatchYAML(`
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  creationTimestamp: null
-  name: cni-flannel
-spec:
-  enabled: true
-  settings:
-    podNetworkMode: VXLAN
-  version: 1
-status:
-  message: ""
-  version: ""
-`))
+			Expect(cm.Exists()).To(BeFalse())
+			mc := f.KubernetesResource("ModuleConfig", "", cniName)
+			Expect(mc.Exists()).To(BeTrue())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
+		})
+	})
+
+	Context("Cluster has cni secret, key `cni` eq `flannel`, MC exists but explicitly disabled", func() {
+		BeforeEach(func() {
+			requirements.RemoveValue(cniConfigurationSettledKey)
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			resources := []string{
+				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`),
+				cniMCYAML(cniName, ptr.To(false), v1alpha1.SettingsValues{}),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully and do nothing", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			_, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeFalse())
+			Expect(len(f.MetricsCollector.CollectedMetrics())).To(Equal(1)) // only expire
+			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
+			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Cluster is not bootstrapped and has cni secret with mismatched configuration", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", false)
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
+			resources := []string{
+				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"podNetworkMode": "VXLAN",
+				}),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=true and metric=0 and should not create desired mc", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("true"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
+			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 
@@ -233,6 +317,10 @@ status:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 
@@ -258,11 +346,16 @@ status:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 
-	Context("Cluster has cni secret, key `cni` eq `flannel`, cni MC exist and enabled, secret key `flannel` exist and not empty but some parameters misconfigured 1", func() {
+	Context("Cluster is bootstrapped, has cni secret, key `cni` eq `flannel`, cni MC exist and enabled, secret key `flannel` exist and not empty but some parameters misconfigured 1", func() {
 		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 			resources := []string{
 				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`),
@@ -299,11 +392,17 @@ status:
   message: ""
   version: ""
 `))
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
 		})
 	})
 
-	Context("Cluster has cni secret, key `cni` eq `flannel`, cni MC exist and enabled, secret key `flannel` exist and not empty but some parameters misconfigured 2. And foreign desiredCNIModuleConfig exist", func() {
+	// space for easy compare
+
+	Context("Cluster is bootstrapped, has cni secret, key `cni` eq `flannel`, cni MC exist and enabled, secret key `flannel` exist and not empty but some parameters misconfigured 2. And foreign desiredCNIModuleConfig exist", func() {
 		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "HostGW")
 			resources := []string{
 				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`),
@@ -341,14 +440,18 @@ status:
   message: ""
   version: ""
 `))
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
 		})
 	})
 
-	Context("Cluster has cni secret, key `cni` eq `flannel`, cni MC exist and enabled, secret key `flannel` exist and not empty but some parameters has unexpected value", func() {
+	Context("Cluster is bootstrapped, has cni secret, key `cni` eq `flannel`, cni MC exist and enabled, secret key `flannel` exist and not empty but some parameters has unexpected value", func() {
 		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "HostGW"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "UnknownMode"}`),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"podNetworkMode": "VXLAN",
 				}),
@@ -358,15 +461,19 @@ status:
 			f.RunHook()
 		})
 
-		It("Should not execute successfully, should set req=false and metric=1 and should not create desired mc", func() {
-			Expect(f).NotTo(ExecuteSuccessfully())
+		It("Should execute successfully with warnings, set req=true and metric=0 and should not create desired mc", func() {
+			Expect(f).To(ExecuteSuccessfully())
 			value, exists := requirements.GetValue(cniConfigurationSettledKey)
 			Expect(exists).To(BeTrue())
-			Expect(value).To(BeEquivalentTo("false"))
-			checkMetric(f.MetricsCollector.CollectedMetrics(), 1.0)
+			Expect(value).To(BeEquivalentTo("true"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
-			Expect(f.GoHookError.Error()).Should(ContainSubstring(`unknown flannel podNetworkMode HostGW`))
+			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("unknown flannel podNetworkMode"))
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 
@@ -392,6 +499,79 @@ status:
 			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
 			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
 			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
+		})
+	})
+
+	Context("Cluster has cni secret with annotation having non-standard priority value", func() {
+		BeforeEach(func() {
+			secretData := make(map[string][]byte)
+			secretData["cni"] = []byte(cni)
+			secretData[cni] = []byte(`{"podNetworkMode": "vxlan"}`)
+			s := &v1core.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "d8-cni-configuration",
+					Namespace: "kube-system",
+					Annotations: map[string]string{
+						"network.deckhouse.io/cni-configuration-source-priority": "CustomValue",
+					},
+				},
+				Data: secretData,
+			}
+			marshaled, _ := yaml.Marshal(s)
+			f.KubeStateSet(string(marshaled))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=true and metric=0 and should not create desired mc", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("true"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
+			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("CustomValue"))
+		})
+	})
+
+	Context("Cluster has cni secret, MC enabled=nil (implicitly enabled)", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
+			resources := []string{
+				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`),
+				cniMCYAML(cniName, nil, v1alpha1.SettingsValues{
+					"podNetworkMode": "VXLAN",
+				}),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should detect mismatch, set req=false and metric=1 and create desired mc", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("false"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 1.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", desiredCNIModuleConfigName)
+			Expect(cm.Exists()).To(BeTrue())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
 		})
 	})
 })

--- a/modules/035-cni-flannel/hooks/check_cni_configuration_test.go
+++ b/modules/035-cni-flannel/hooks/check_cni_configuration_test.go
@@ -79,7 +79,7 @@ data:
 	f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
 	f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
 
-	cniSecretYAML := func(cniName, data string) string {
+	cniSecretYAML := func(cniName, data string, creationTime *time.Time, annotations map[string]string) string {
 		secretData := make(map[string][]byte)
 		secretData["cni"] = []byte(cniName)
 		if data != "" {
@@ -91,38 +91,19 @@ data:
 				Kind:       "Secret",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "d8-cni-configuration",
-				Namespace: "kube-system",
+				Name:        "d8-cni-configuration",
+				Namespace:   "kube-system",
+				Annotations: annotations,
 			},
 			Data: secretData,
+		}
+		if creationTime != nil {
+			s.ObjectMeta.CreationTimestamp = metav1.NewTime(*creationTime)
 		}
 		marshaled, _ := yaml.Marshal(s)
 		return string(marshaled)
 	}
-	cniSecretWithAnnotationYAML := func(cniName, data string) string {
-		secretData := make(map[string][]byte)
-		secretData["cni"] = []byte(cniName)
-		if data != "" {
-			secretData[cniName] = []byte(data)
-		}
-		s := &v1core.Secret{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "Secret",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "d8-cni-configuration",
-				Namespace: "kube-system",
-				Annotations: map[string]string{
-					"network.deckhouse.io/cni-configuration-source-priority": "ModuleConfig",
-				},
-			},
-			Data: secretData,
-		}
-		marshaled, _ := yaml.Marshal(s)
-		return string(marshaled)
-	}
-	cniMCYAML := func(cniName string, enabled *bool, settings v1alpha1.SettingsValues) string {
+	cniMCYAML := func(cniName string, enabled *bool, settings v1alpha1.SettingsValues, creationTime *time.Time) string {
 		mc := &v1alpha1.ModuleConfig{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "deckhouse.io/v1alpha1",
@@ -138,6 +119,9 @@ data:
 				Settings: settings,
 				Enabled:  enabled,
 			},
+		}
+		if creationTime != nil {
+			mc.ObjectMeta.CreationTimestamp = metav1.NewTime(*creationTime)
 		}
 		marshaled, _ := yaml.Marshal(mc)
 		return string(marshaled)
@@ -166,7 +150,7 @@ data:
 	Context("Cluster has cni secret but key `cni` does not equal `flannel`", func() {
 		BeforeEach(func() {
 			resources := []string{
-				cniSecretYAML(anotherCni, ""),
+				cniSecretYAML(anotherCni, "", nil, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -191,7 +175,9 @@ data:
 	Context("Cluster has cni secret with priority annotation", func() {
 		BeforeEach(func() {
 			resources := []string{
-				cniSecretWithAnnotationYAML(cni, `{"podNetworkMode": "vxlan"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`, nil, map[string]string{
+					"network.deckhouse.io/cni-configuration-source-priority": "ModuleConfig",
+				}),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -216,7 +202,7 @@ data:
 	Context("Cluster has cni secret, key `cni` eq `flannel`, but cni MC does not exist", func() {
 		BeforeEach(func() {
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`, nil, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -245,8 +231,8 @@ data:
 			requirements.RemoveValue(cniConfigurationSettledKey)
 			f.ValuesSet("global.clusterIsBootstrapped", true)
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`),
-				cniMCYAML(cniName, ptr.To(false), v1alpha1.SettingsValues{}),
+				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`, nil, nil),
+				cniMCYAML(cniName, ptr.To(false), v1alpha1.SettingsValues{}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -271,10 +257,10 @@ data:
 			f.ValuesSet("global.clusterIsBootstrapped", false)
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"podNetworkMode": "VXLAN",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -300,10 +286,10 @@ data:
 		BeforeEach(func() {
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 			resources := []string{
-				cniSecretYAML(cni, ``),
+				cniSecretYAML(cni, ``, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"podNetworkMode": "VXLAN",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -329,10 +315,10 @@ data:
 		BeforeEach(func() {
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 			resources := []string{
-				cniSecretYAML(cni, `{}`),
+				cniSecretYAML(cni, `{}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"podNetworkMode": "VXLAN",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -359,10 +345,10 @@ data:
 			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"podNetworkMode": "VXLAN",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -406,10 +392,10 @@ status:
 			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "HostGW")
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"podNetworkMode": "HostGW",
-				}),
+				}, nil),
 				foreignDesiredCM,
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
@@ -452,10 +438,10 @@ status:
 			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "UnknownMode"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "UnknownMode"}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"podNetworkMode": "VXLAN",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -482,10 +468,10 @@ status:
 		BeforeEach(func() {
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`, nil, nil),
 				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
 					"podNetworkMode": "VXLAN",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -509,25 +495,12 @@ status:
 
 	Context("Cluster has cni secret with annotation having non-standard priority value", func() {
 		BeforeEach(func() {
-			secretData := make(map[string][]byte)
-			secretData["cni"] = []byte(cni)
-			secretData[cni] = []byte(`{"podNetworkMode": "vxlan"}`)
-			s := &v1core.Secret{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "Secret",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "d8-cni-configuration",
-					Namespace: "kube-system",
-					Annotations: map[string]string{
-						"network.deckhouse.io/cni-configuration-source-priority": "CustomValue",
-					},
-				},
-				Data: secretData,
+			resources := []string{
+				cniSecretYAML(cni, `{"podNetworkMode": "vxlan"}`, nil, map[string]string{
+					"network.deckhouse.io/cni-configuration-source-priority": "CustomValue",
+				}),
 			}
-			marshaled, _ := yaml.Marshal(s)
-			f.KubeStateSet(string(marshaled))
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
@@ -552,10 +525,10 @@ status:
 			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 			resources := []string{
-				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`),
+				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`, nil, nil),
 				cniMCYAML(cniName, nil, v1alpha1.SettingsValues{
 					"podNetworkMode": "VXLAN",
-				}),
+				}, nil),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -581,47 +554,14 @@ status:
 			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
 
-			// Create MC first (earlier timestamp)
-			mc := &v1alpha1.ModuleConfig{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "deckhouse.io/v1alpha1",
-					Kind:       "ModuleConfig",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              cniName,
-					CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)),
-				},
-				Spec: v1alpha1.ModuleConfigSpec{
-					Version: 1,
-					Settings: v1alpha1.SettingsValues{
-						"podNetworkMode": "VXLAN",
-					},
-					Enabled: ptr.To(true),
-				},
-			}
-			mcYAML, _ := yaml.Marshal(mc)
-
-			// Create secret later (later timestamp)
-			secretData := make(map[string][]byte)
-			secretData["cni"] = []byte(cni)
-			secretData[cni] = []byte(`{"podNetworkMode": "host-gw"}`)
-			secret := &v1core.Secret{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "Secret",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "d8-cni-configuration",
-					Namespace:         "kube-system",
-					CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 2, 12, 0, 0, 0, time.UTC)), // 1 day later
-				},
-				Data: secretData,
-			}
-			secretYAML, _ := yaml.Marshal(secret)
+			mcTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)     // earlier timestamp
+			secretTime := time.Date(2023, 1, 2, 12, 0, 0, 0, time.UTC) // 1 day later
 
 			resources := []string{
-				string(secretYAML),
-				string(mcYAML),
+				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`, &secretTime, nil),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"podNetworkMode": "VXLAN",
+				}, &mcTime),
 			}
 			f.KubeStateSet(strings.Join(resources, "\n---\n"))
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
@@ -640,6 +580,155 @@ status:
 			Expect(secret.Exists()).To(BeTrue())
 			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
 			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
+		})
+	})
+
+	Context("Cluster is bootstrapped, has cni secret(with mismatched configuration) created just within 10 minutes after MC, so Secret takes priority", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
+
+			mcTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+			secretTime := time.Date(2023, 1, 1, 12, 5, 0, 0, time.UTC) // 5 minutes later
+
+			resources := []string{
+				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`, &secretTime, nil),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"podNetworkMode": "VXLAN",
+				}, &mcTime),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=false and metric=1 and create desired mc (secret created within 10min after MC)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("false"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 1.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", "desired-cni-moduleconfig")
+			Expect(cm.Exists()).To(BeTrue())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Cluster is bootstrapped, has cni secret(with mismatched configuration) created exactly 10 minutes after MC, so Secret takes priority", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
+
+			mcTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+			secretTime := time.Date(2023, 1, 1, 12, 10, 0, 0, time.UTC) // exactly 10 minutes later
+
+			resources := []string{
+				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`, &secretTime, nil),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"podNetworkMode": "VXLAN",
+				}, &mcTime),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=false and metric=1 and create desired mc (secret created exactly 10min after MC)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("false"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 1.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", "desired-cni-moduleconfig")
+			Expect(cm.Exists()).To(BeTrue())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Cluster is bootstrapped, has cni secret(with mismatched configuration) created just after 10 minutes threshold, so MC takes priority", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
+
+			mcTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+			secretTime := time.Date(2023, 1, 1, 12, 10, 1, 0, time.UTC) // 10 minutes and 1 second later
+
+			resources := []string{
+				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`, &secretTime, nil),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"podNetworkMode": "VXLAN",
+				}, &mcTime),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=true and metric=0 and should not create desired mc (secret created after 10min threshold)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("true"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", "desired-cni-moduleconfig")
+			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
+		})
+	})
+
+	Context("Cluster is bootstrapped, has cni secret(with mismatched configuration) created much earlier than MC, so Secret takes priority", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
+
+			secretTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC) // 1 day earlier
+			mcTime := time.Date(2023, 1, 2, 12, 0, 0, 0, time.UTC)     // 1 day later
+
+			resources := []string{
+				cniSecretYAML(cni, `{"podNetworkMode": "host-gw"}`, &secretTime, nil),
+				cniMCYAML(cniName, ptr.To(true), v1alpha1.SettingsValues{
+					"podNetworkMode": "VXLAN",
+				}, &mcTime),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=false and metric=1 and create desired mc (secret created much earlier than MC)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("false"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 1.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", "desired-cni-moduleconfig")
+			Expect(cm.Exists()).To(BeTrue())
+			Expect(cm.Field(`data.cni-flannel-mc\.yaml`).Exists()).To(BeTrue())
+			Expect(cm.Field(`data.cni-flannel-mc\.yaml`).String()).To(MatchYAML(`
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  creationTimestamp: null
+  name: cni-flannel
+spec:
+  enabled: true
+  settings:
+    podNetworkMode: HostGW
+  version: 1
+status:
+  message: ""
+  version: ""
+`))
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
 		})
 	})
 })

--- a/modules/035-cni-flannel/hooks/check_cni_configuration_test.go
+++ b/modules/035-cni-flannel/hooks/check_cni_configuration_test.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"strings"
+	"time"
 
 	"github.com/flant/shell-operator/pkg/metric_storage/operation"
 	. "github.com/onsi/ginkgo"
@@ -56,7 +57,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: desiredCNIModuleConfig
+  name: desired-cni-moduleconfig
   namespace: d8-system
 data:
   cni-flannel-mc.yaml: |
@@ -572,6 +573,73 @@ status:
 			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
 			Expect(secret.Exists()).To(BeTrue())
 			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Cluster is bootstrapped, has cni secret(with mismatched configuration) created after MC, so MC takes priority", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
+
+			// Create MC first (earlier timestamp)
+			mc := &v1alpha1.ModuleConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "deckhouse.io/v1alpha1",
+					Kind:       "ModuleConfig",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              cniName,
+					CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)),
+				},
+				Spec: v1alpha1.ModuleConfigSpec{
+					Version: 1,
+					Settings: v1alpha1.SettingsValues{
+						"podNetworkMode": "VXLAN",
+					},
+					Enabled: ptr.To(true),
+				},
+			}
+			mcYAML, _ := yaml.Marshal(mc)
+
+			// Create secret later (later timestamp)
+			secretData := make(map[string][]byte)
+			secretData["cni"] = []byte(cni)
+			secretData[cni] = []byte(`{"podNetworkMode": "host-gw"}`)
+			secret := &v1core.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "d8-cni-configuration",
+					Namespace:         "kube-system",
+					CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 2, 12, 0, 0, 0, time.UTC)), // 1 day later
+				},
+				Data: secretData,
+			}
+			secretYAML, _ := yaml.Marshal(secret)
+
+			resources := []string{
+				string(secretYAML),
+				string(mcYAML),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=true and metric=0 and should not create desired mc (secret created after MC)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("true"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", "desired-cni-moduleconfig")
+			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 })

--- a/modules/035-cni-flannel/hooks/set_pod_network_mode.go
+++ b/modules/035-cni-flannel/hooks/set_pod_network_mode.go
@@ -30,14 +30,14 @@ import (
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
-type FlannelConfig struct {
+type FlannelConfigStruct struct {
 	PodNetworkMode string `json:"podNetworkMode"`
 }
 
 type resultStruct struct {
 	desiredCniConfigSourcePriorityFlagExists bool
 	desiredCniConfigSourcePriority           string
-	cniConfigFromSecret                      FlannelConfig
+	cniConfigFromSecret                      FlannelConfigStruct
 }
 
 func applyCNIConfigurationSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -51,7 +51,7 @@ func applyCNIConfigurationSecretFilter(obj *unstructured.Unstructured) (go_hook.
 		return nil, nil
 	}
 
-	var flannelConfig FlannelConfig
+	var flannelConfig FlannelConfigStruct
 	flannelConfigJSON, ok := secret.Data["flannel"]
 	if !ok {
 		return nil, nil
@@ -99,7 +99,7 @@ func setPodNetworkMode(_ context.Context, input *go_hook.HookInput) error {
 
 	cniConfigurationSecrets, err := sdkobjectpatch.UnmarshalToStruct[resultStruct](input.Snapshots, "cni_configuration_secret")
 	if err != nil {
-		return fmt.Errorf("cannot unmarshal cni_configuration_secret to FlannelConfig: %w", err)
+		return fmt.Errorf("failed to unmarshal cni_configuration_secret snapshot: %w", err)
 	}
 
 	cniConfigSourcePriority := "ModuleConfig"

--- a/modules/035-cni-flannel/hooks/set_pod_network_mode.go
+++ b/modules/035-cni-flannel/hooks/set_pod_network_mode.go
@@ -35,9 +35,9 @@ type FlannelConfigStruct struct {
 }
 
 type resultStruct struct {
-	desiredCniConfigSourcePriorityFlagExists bool
-	desiredCniConfigSourcePriority           string
-	cniConfigFromSecret                      FlannelConfigStruct
+	DesiredCniConfigSourcePriorityFlagExists bool
+	DesiredCniConfigSourcePriority           string
+	CniConfigFromSecret                      FlannelConfigStruct
 }
 
 func applyCNIConfigurationSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -67,9 +67,9 @@ func applyCNIConfigurationSecretFilter(obj *unstructured.Unstructured) (go_hook.
 	cniConfigSourcePriority, cniConfigSourcePriorityFlagExists = secret.Annotations[cniConfigSourcePriorityAnnotation]
 
 	return resultStruct{
-		desiredCniConfigSourcePriorityFlagExists: cniConfigSourcePriorityFlagExists,
-		desiredCniConfigSourcePriority:           cniConfigSourcePriority,
-		cniConfigFromSecret:                      flannelConfig,
+		DesiredCniConfigSourcePriorityFlagExists: cniConfigSourcePriorityFlagExists,
+		DesiredCniConfigSourcePriority:           cniConfigSourcePriority,
+		CniConfigFromSecret:                      flannelConfig,
 	}, nil
 }
 
@@ -104,8 +104,8 @@ func setPodNetworkMode(_ context.Context, input *go_hook.HookInput) error {
 
 	cniConfigSourcePriority := "ModuleConfig"
 	if len(cniConfigurationSecrets) > 0 {
-		if cniConfigurationSecrets[0].desiredCniConfigSourcePriorityFlagExists {
-			if cniConfigurationSecrets[0].desiredCniConfigSourcePriority != "ModuleConfig" {
+		if cniConfigurationSecrets[0].DesiredCniConfigSourcePriorityFlagExists {
+			if cniConfigurationSecrets[0].DesiredCniConfigSourcePriority != "ModuleConfig" {
 				cniConfigSourcePriority = "Secret"
 			}
 		} else if clusterIsBootstrapped {
@@ -116,7 +116,7 @@ func setPodNetworkMode(_ context.Context, input *go_hook.HookInput) error {
 
 	switch cniConfigSourcePriority {
 	case "Secret":
-		flannelConfig := cniConfigurationSecrets[0].cniConfigFromSecret
+		flannelConfig := cniConfigurationSecrets[0].CniConfigFromSecret
 		if flannelConfig.PodNetworkMode != "" {
 			input.Values.Set("cniFlannel.internal.podNetworkMode", flannelConfig.PodNetworkMode)
 		}

--- a/modules/035-cni-flannel/hooks/set_pod_network_mode_test.go
+++ b/modules/035-cni-flannel/hooks/set_pod_network_mode_test.go
@@ -17,121 +17,256 @@ limitations under the License.
 package hooks
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = Describe("Modules :: cniFlannel :: hooks :: set_pod_network_mode ::", func() {
-	f := HookExecutionConfigInit(`{"cniFlannel":{"podNetworkMode":"HostGW", "internal":{}}}`, ``)
+var _ = Describe("Modules :: cni-flannel :: hooks :: set_pod_network_mode", func() {
+	f := HookExecutionConfigInit(`{"cniFlannel":{"internal":{}}}`, "")
 
-	state := `
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: d8-cni-configuration
-  namespace: kube-system
-data:
-  cni: Zmxhbm5lbA== # flannel
-  flannel: ICAgIHsKICAgICAgInBvZE5ldHdvcmtNb2RlIjogInZ4bGFuIgogICAgfQ== # {"podNetworkMode":"vxlan"}
-`
-
-	stateWithEmptyFlannelConfig := `
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: d8-cni-configuration
-  namespace: kube-system
-data:
-  cni: Zmxhbm5lbA== # flannel
-  flannel: e30= # {}
-`
-
-	stateWithoutFlannelConfig := `
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: d8-cni-configuration
-  namespace: kube-system
-data:
-  cni: Zmxhbm5lbA== # flannel
-`
-
-	Context("Empty cluster", func() {
+	Context("fresh cluster", func() {
 		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "host-gw")
 			f.RunHook()
 		})
-		It("Must be executed successfully", func() {
+		It("hook should run successfully, flannel mode should be `host-gw`", func() {
 			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("host-gw"))
 		})
 	})
 
-	Context("d8-cni-configuration", func() {
-		It("Must be executed successfully", func() {
-			By("podNetworkMode must be vxlan", func() {
-				f.BindingContexts.Set(f.KubeStateSet(state))
-				f.RunHook()
-				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("vxlan"))
-			})
+	Context("kube-system/d8-cni-configuration is present, but cni != `flannel`", func() {
+		cniSecret := generateCniConfigurationSecret("cilium", "")
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "host-gw")
+			f.RunHook()
 		})
-
-		It("Must be executed successfully", func() {
-			By("podNetworkMode must be vxlan, because secret has higher priority, than config", func() {
-				f.BindingContexts.Set(f.KubeStateSet(state))
-				f.ConfigValuesSet("cniFlannel.podNetworkMode", "HostGW")
-				f.RunHook()
-				Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("vxlan"))
-			})
-
-		})
-		It("Must be executed successfully", func() {
-			By("podNetworkMode must be host-gw", func() {
-				f.BindingContexts.Set(f.KubeStateSet(stateWithEmptyFlannelConfig))
-				f.RunHook()
-				Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("host-gw"))
-			})
-		})
-
-		It("Must be executed successfully", func() {
-			By("podNetworkMode must be host-gw", func() {
-				f.BindingContexts.Set(f.KubeStateSet(stateWithoutFlannelConfig))
-				f.RunHook()
-				Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("host-gw"))
-			})
-		})
-
-	})
-
-	// BeforeHelm without snapshots.
-	Context("BeforeHelm on empty cluster", func() {
-		It("Should use config values", func() {
-			By("podNetworkMode must be host-gw", func() {
-				f.ConfigValuesSet("cniFlannel.podNetworkMode", "HostGW")
-				f.BindingContexts.Set(f.GenerateBeforeHelmContext())
-				f.RunHook()
-				Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("host-gw"))
-			})
-
+		It("hook should run successfully, flannel mode should be `host-gw`", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("host-gw"))
 		})
 	})
 
-	// BeforeHelm without snapshot.
-	Context("BeforeHelm on cluster with Secret", func() {
-		It("Should use value from Secret", func() {
-			By("podNetworkMode must be vxlan", func() {
-				f.ConfigValuesSet("cniFlannel.podNetworkMode", "HostGW")
-				f.KubeStateSet(state)
-				f.BindingContexts.Set(f.GenerateBeforeHelmContext())
-				f.RunHook()
-				Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("vxlan"))
-			})
+	Context("kube-system/d8-cni-configuration is present, cni == `flannel`, but flannel field is not set", func() {
+		cniSecret := generateCniConfigurationSecret("flannel", "")
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "host-gw")
+			f.RunHook()
+		})
+		It("hook should run successfully, flannel mode should be `host-gw`", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("host-gw"))
 		})
 	})
 
+	Context("kube-system/d8-cni-configuration is present, cni = `flannel`, flannel mode = vxlan", func() {
+		cniSecret := generateCniConfigurationSecret("flannel", "vxlan")
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "host-gw")
+			f.RunHook()
+		})
+		It("hook should run successfully, flannel mode should be set to `vxlan`", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("vxlan"))
+		})
+	})
+
+	Context("kube-system/d8-cni-configuration is present, cni = `flannel`, flannel mode = host-gw", func() {
+		cniSecret := generateCniConfigurationSecret("flannel", "host-gw")
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "vxlan")
+			f.RunHook()
+		})
+		It("hook should run successfully, flannel mode should be set to `host-gw`", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("host-gw"))
+		})
+	})
+
+	Context("kube-system/d8-cni-configuration is absent, podNetworkMode set to `VXLAN`", func() {
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "host-gw")
+			f.RunHook()
+		})
+		It("hook should run successfully, mode should be changed to vxlan", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("vxlan"))
+		})
+	})
+
+	Context("kube-system/d8-cni-configuration is absent, podNetworkMode set to `HostGW`", func() {
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "HostGW")
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "vxlan")
+			f.RunHook()
+		})
+		It("hook should run successfully, mode should be changed to host-gw", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("host-gw"))
+		})
+	})
+
+	Context("kube-system/d8-cni-configuration with annotation network.deckhouse.io/cni-configuration-source-priority=ModuleConfig, flannel mode = vxlan", func() {
+		cniSecret := generateCniConfigurationSecretWithAnnotations("flannel", "vxlan", map[string]string{
+			"network.deckhouse.io/cni-configuration-source-priority": "ModuleConfig",
+		})
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "host-gw")
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "HostGW")
+			f.RunHook()
+		})
+		It("hook should run successfully, flannel mode should be `host-gw` from MC, not secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("host-gw"))
+		})
+	})
+
+	Context("kube-system/d8-cni-configuration with annotation network.deckhouse.io/cni-configuration-source-priority=Secret, flannel mode = vxlan", func() {
+		cniSecret := generateCniConfigurationSecretWithAnnotations("flannel", "vxlan", map[string]string{
+			"network.deckhouse.io/cni-configuration-source-priority": "Secret",
+		})
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "host-gw")
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "HostGW")
+			f.RunHook()
+		})
+		It("hook should run successfully, flannel mode should be `vxlan` from secret, not MC", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("vxlan"))
+		})
+	})
+
+	Context("kube-system/d8-cni-configuration without annotation, cluster is not bootstrapped", func() {
+		cniSecret := generateCniConfigurationSecret("flannel", "vxlan")
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("global.clusterIsBootstrapped", false)
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "host-gw")
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "HostGW")
+			f.RunHook()
+		})
+		It("hook should run successfully, flannel mode should be from MC (host-gw), not secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("host-gw"))
+		})
+	})
+
+	Context("kube-system/d8-cni-configuration without annotation, cluster is bootstrapped", func() {
+		cniSecret := generateCniConfigurationSecret("flannel", "vxlan")
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "host-gw")
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "HostGW")
+			f.RunHook()
+		})
+		It("hook should run successfully, flannel mode should be from secret (vxlan), not MC", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("vxlan"))
+		})
+	})
+
+	Context("Priority annotation with value Secret", func() {
+		cniSecret := generateCniConfigurationSecretWithAnnotations("flannel", "host-gw", map[string]string{
+			"network.deckhouse.io/cni-configuration-source-priority": "Secret",
+		})
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "vxlan")
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
+			f.RunHook()
+		})
+		It("should use secret values even when MC differs", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("host-gw"))
+		})
+	})
+
+	Context("Priority annotation with non-standard value", func() {
+		cniSecret := generateCniConfigurationSecretWithAnnotations("flannel", "host-gw", map[string]string{
+			"network.deckhouse.io/cni-configuration-source-priority": "CustomValue",
+		})
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("cniFlannel.internal.podNetworkMode", "vxlan")
+			f.ConfigValuesSet("cniFlannel.podNetworkMode", "VXLAN")
+			f.RunHook()
+		})
+		It("should treat non-ModuleConfig value as Secret priority", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniFlannel.internal.podNetworkMode").String()).To(Equal("host-gw"))
+		})
+	})
 })
+
+func generateCniConfigurationSecret(cni string, podNetworkMode string) string {
+	return generateCniConfigurationSecretWithAnnotations(cni, podNetworkMode, nil)
+}
+
+func generateCniConfigurationSecretWithAnnotations(cni string, podNetworkMode string, annotations map[string]string) string {
+	var (
+		secretTemplate = `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system`
+	)
+
+	if len(annotations) > 0 {
+		secretTemplate += "\n  annotations:"
+		for key, value := range annotations {
+			secretTemplate += fmt.Sprintf("\n    %s: %s", key, value)
+		}
+	}
+
+	secretTemplate += "\ntype: Opaque"
+
+	jsonByte, _ := generateJSONFlannelConf(podNetworkMode)
+	secretTemplate = fmt.Sprintf("%s\ndata:\n  cni: %s", secretTemplate, base64.StdEncoding.EncodeToString([]byte(cni)))
+	if podNetworkMode != "" {
+		secretTemplate = fmt.Sprintf("%s\n  flannel: %s", secretTemplate, base64.StdEncoding.EncodeToString(jsonByte))
+	}
+	return secretTemplate
+}
+
+func generateJSONFlannelConf(podNetworkMode string) ([]byte, error) {
+	var confMAP FlannelConfigStruct
+	if podNetworkMode != "" {
+		confMAP.PodNetworkMode = podNetworkMode
+	}
+
+	return json.Marshal(confMAP)
+}

--- a/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
+++ b/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
@@ -148,10 +148,6 @@ func applyCNIMCFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert object to moduleconfig: %v", err)
 	}
-	// ignore only explicitly disabled modules.
-	if mc.Spec.Enabled != nil && !*mc.Spec.Enabled {
-		return nil, nil
-	}
 
 	return mc, nil
 }
@@ -233,7 +229,7 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 	}
 
 	// If MC exist, but is explicitly disabled, it means that CNI is in the process of disabling, there is nothing to do.
-	if len(cniModuleConfigs) != 0 && cniModuleConfigs[0].Spec.Enabled == nil || !*cniModuleConfigs[0].Spec.Enabled {
+	if cniModuleConfigs[0].Spec.Enabled != nil && !*cniModuleConfigs[0].Spec.Enabled {
 		return nil
 	}
 
@@ -302,7 +298,7 @@ func annotateSecret(input *go_hook.HookInput) {
 			},
 		},
 	}
-	input.PatchCollector.PatchWithMerge(secretPatch, "v1", "Secret", "kube-system", "d8-cluster-configuration")
+	input.PatchCollector.PatchWithMerge(secretPatch, "v1", "Secret", "kube-system", "d8-cni-configuration")
 }
 
 func createDesiredModuleConfig(input *go_hook.HookInput, desiredCNIModuleConfig *v1alpha1.ModuleConfig) {

--- a/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
+++ b/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
@@ -264,8 +264,8 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 		return nil
 	}
 
-	// Let's check what was created earlier: MC or Secret.
-	if cniSecret.CreationTimestamp.After(cniModuleConfigs[0].CreationTimestamp.Time) {
+	// Let's check what was created earlier: MC(+10m) or Secret.
+	if cniSecret.CreationTimestamp.After(cniModuleConfigs[0].CreationTimestamp.Time.Add(10 * time.Minute)) {
 		annotateSecret(input)
 		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
 		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)

--- a/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
+++ b/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
@@ -59,6 +60,7 @@ type ciliumConfigStruct struct {
 }
 
 type cniSecretStruct struct {
+	CreationTimestamp                 time.Time
 	CniConfigSourcePriorityFlagExists bool
 	CNI                               string
 	Flannel                           flannelConfigStruct
@@ -105,6 +107,10 @@ func applyCNIConfigurationFromSecretFilter(obj *unstructured.Unstructured) (go_h
 		return nil, fmt.Errorf("cannot convert incoming object to Secret: %v", err)
 	}
 	cniSecret := cniSecretStruct{}
+
+	// get creation timestamp from secret
+	cniSecret.CreationTimestamp = secret.CreationTimestamp.Time
+
 	// Check if the secret has the annotation "network.deckhouse.io/cni-configuration-source-priority"
 	_, exists := secret.Annotations[cniConfigSourcePriorityAnnotation]
 	cniSecret.CniConfigSourcePriorityFlagExists = exists
@@ -258,7 +264,15 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 		return nil
 	}
 
-	// If the cluster is already bootstrapped, then we should
+	// Let's check what was created earlier: MC or Secret.
+	if cniSecret.CreationTimestamp.After(cniModuleConfigs[0].CreationTimestamp.Time) {
+		annotateSecret(input)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If the cluster is already bootstrapped and the secret was created earlier than MC, then we should
 	// - generate desired MC based on secret
 	// - create cm based on desired MC
 	// - fire alert

--- a/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
+++ b/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
@@ -221,7 +221,7 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 		desiredCNIModuleConfig.Spec.Settings = cniModuleConfig.DeepCopy().Spec.Settings
 	}
 	// Generate the desired CNIModuleConfig based on existing secret and MC and compare them at the same time.
-	secretMatchesMc := true
+	secretMatchesMC := true
 
 	// If MC does not exist, then we should
 	// - add an annotation to the secret (to activate new_logic)
@@ -240,12 +240,12 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 	}
 
 	if cniModuleConfigs[0].Spec.Enabled == nil {
-		secretMatchesMc = false
+		secretMatchesMC = false
 	}
 
 	// If the secret matches MC, then we should
 	// - add an annotation to the secret (to activate new_logic)
-	if secretMatchesMc {
+	if secretMatchesMC {
 		annotateSecret(input)
 		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
 		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)

--- a/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
+++ b/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
@@ -66,7 +66,7 @@ type cniSecretStruct struct {
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnBeforeHelm: &go_hook.OrderedConfig{Order: 9}, // before set_cilium_mode.go
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 9}, // not essential, a copy-paste from cni-cilium module
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "cni_configuration_secret",

--- a/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
+++ b/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
@@ -66,7 +66,7 @@ type cniSecretStruct struct {
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnBeforeHelm: &go_hook.OrderedConfig{Order: 9},
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 9}, // before set_cilium_mode.go
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "cni_configuration_secret",

--- a/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
+++ b/modules/035-cni-simple-bridge/hooks/check_cni_configuration.go
@@ -38,12 +38,15 @@ import (
 )
 
 const (
-	cniConfigurationSettledKey = "cniConfigurationSettled"
-	checkCNIConfigMetricName   = "cniMisconfigured"
-	checkCNIConfigMetricGroup  = "d8_check_cni_conf"
-	desiredCNIModuleConfigName = "desired-cni-moduleconfig"
-	cni                        = "simple-bridge"
-	cniName                    = "cni-" + cni
+	cniConfigurationSettledKey        = "cniConfigurationSettled"
+	checkCNIConfigMetricName          = "cniMisconfigured"
+	checkCNIConfigMetricGroup         = "d8_check_cni_conf"
+	desiredCNIModuleConfigName        = "desired-cni-moduleconfig"
+	cni                               = "simple-bridge"
+	cniName                           = "cni-" + cni
+	cniConfigurationIsNotSettled      = true
+	cniConfigurationIsSettled         = false
+	cniConfigSourcePriorityAnnotation = "network.deckhouse.io/cni-configuration-source-priority"
 )
 
 type flannelConfigStruct struct {
@@ -56,9 +59,10 @@ type ciliumConfigStruct struct {
 }
 
 type cniSecretStruct struct {
-	CNI     string
-	Flannel flannelConfigStruct
-	Cilium  ciliumConfigStruct
+	CniConfigSourcePriorityFlagExists bool
+	CNI                               string
+	Flannel                           flannelConfigStruct
+	Cilium                            ciliumConfigStruct
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -92,7 +96,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func applyCNIConfigurationFromSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	// Return nil if
-	// error occurred while json parse
+	// an error occurred while JSON parse
 	// or d8-cni-configuration secret does not contain key "cni"
 	// or value of key "cni" not in [cni-cilium, cni-flannel, cni-simple-bridge]
 	secret := &v1.Secret{}
@@ -101,9 +105,13 @@ func applyCNIConfigurationFromSecretFilter(obj *unstructured.Unstructured) (go_h
 		return nil, fmt.Errorf("cannot convert incoming object to Secret: %v", err)
 	}
 	cniSecret := cniSecretStruct{}
+	// Check if the secret has the annotation "network.deckhouse.io/cni-configuration-source-priority"
+	_, exists := secret.Annotations[cniConfigSourcePriorityAnnotation]
+	cniSecret.CniConfigSourcePriorityFlagExists = exists
+
 	cniBytes, ok := secret.Data["cni"]
 	if !ok {
-		// d8-cni-configuration secret does not contain "cni" field
+		// d8-cni-configuration secret does not contain the "cni" field
 		return nil, nil
 	}
 	cniSecret.CNI = string(cniBytes)
@@ -140,15 +148,134 @@ func applyCNIMCFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert object to moduleconfig: %v", err)
 	}
-	if mc.Spec.Enabled == nil || !*mc.Spec.Enabled {
+	// ignore only explicitly disabled modules.
+	if mc.Spec.Enabled != nil && !*mc.Spec.Enabled {
 		return nil, nil
 	}
 
 	return mc, nil
 }
 
-func setCNIMiscMetricAndReq(input *go_hook.HookInput, miss bool) {
-	switch miss {
+func checkCni(_ context.Context, input *go_hook.HookInput) error {
+	// Clear a metrics and reqKey
+	input.MetricsCollector.Expire(checkCNIConfigMetricGroup)
+	requirements.RemoveValue(cniConfigurationSettledKey)
+
+	// Get existing secret.
+	cniSecrets, err := sdkobjectpatch.UnmarshalToStruct[cniSecretStruct](input.Snapshots, "cni_configuration_secret")
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal cni_configuration_secret snapshot: %w", err)
+	}
+
+	// If secret does not exist, then we are already using a new logic de facto: the parameters in the MC have priority.
+	// So there is nothing to do.
+	if len(cniSecrets) == 0 {
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If the secret has the annotation "network.deckhouse.io/cni-configuration-source-priority", so there is nothing to do.
+	if cniSecrets[0].CniConfigSourcePriorityFlagExists {
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If secret does not contain config for current cni, then we are already using a new logic de facto: the parameters in the MC have priority.
+	// - add an annotation to the secret
+	cniSecret := cniSecrets[0]
+	if cniSecret.CNI != cni {
+		annotateSecret(input)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// Get existing MC.
+	cniModuleConfigs, err := sdkobjectpatch.UnmarshalToStruct[v1alpha1.ModuleConfig](input.Snapshots, "deckhouse_cni_mc")
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal deckhouse_cni_mc snapshot: %w", err)
+	}
+
+	// Prepare a template for the desiredCNIModuleConfig, which is empty and explicitly enabled.
+	desiredCNIModuleConfig := &v1alpha1.ModuleConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ModuleConfig",
+			APIVersion: "deckhouse.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cniName,
+		},
+		Spec: v1alpha1.ModuleConfigSpec{
+			Enabled:  ptr.To(true),
+			Version:  1,
+			Settings: v1alpha1.SettingsValues{},
+		},
+	}
+	// If the MC exists, use its Settings to generate the desired MC.
+	if len(cniModuleConfigs) != 0 {
+		cniModuleConfig := cniModuleConfigs[0]
+		desiredCNIModuleConfig.Spec.Settings = cniModuleConfig.DeepCopy().Spec.Settings
+	}
+	// Generate the desired CNIModuleConfig based on existing secret and MC and compare them at the same time.
+	secretMatchesMc := true
+
+	// If MC does not exist, then we should
+	// - add an annotation to the secret (to activate new_logic)
+	// - create the desired MC, which was generated based on the secret.
+	if len(cniModuleConfigs) == 0 {
+		annotateSecret(input)
+		createDesiredModuleConfig(input, desiredCNIModuleConfig)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If MC exist, but is explicitly disabled, it means that CNI is in the process of disabling, there is nothing to do.
+	if len(cniModuleConfigs) != 0 && cniModuleConfigs[0].Spec.Enabled == nil || !*cniModuleConfigs[0].Spec.Enabled {
+		return nil
+	}
+
+	if cniModuleConfigs[0].Spec.Enabled == nil {
+		secretMatchesMc = false
+	}
+
+	// If the secret matches MC, then we should
+	// - add an annotation to the secret (to activate new_logic)
+	if secretMatchesMc {
+		annotateSecret(input)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// Let's check if the cluster has already been bootstrapped.
+	clusterIsBootstrapped := input.Values.Get("global.clusterIsBootstrapped").Bool()
+
+	// If the cluster is not yet bootstrapped, then we should
+	// - add an annotation to the secret (to activate new_logic)
+	if !clusterIsBootstrapped {
+		annotateSecret(input)
+		setMetricAndRequirementsValue(input, cniConfigurationIsSettled)
+		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+		return nil
+	}
+
+	// If the cluster is already bootstrapped, then we should
+	// - generate desired MC based on secret
+	// - create cm based on desired MC
+	// - fire alert
+	err = createConfigMapWithDesiredModuleConfig(input, desiredCNIModuleConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create config map with desired module config: %w", err)
+	}
+	setMetricAndRequirementsValue(input, cniConfigurationIsNotSettled)
+	return nil
+}
+
+func setMetricAndRequirementsValue(input *go_hook.HookInput, isCniMisconfigured bool) {
+	switch isCniMisconfigured {
 	// misconfigure detected
 	case true:
 		input.MetricsCollector.Set(checkCNIConfigMetricName, 1,
@@ -167,87 +294,39 @@ func setCNIMiscMetricAndReq(input *go_hook.HookInput, miss bool) {
 	}
 }
 
-func checkCni(_ context.Context, input *go_hook.HookInput) error {
-	// Clear metrics and reqKey
-	input.MetricsCollector.Expire(checkCNIConfigMetricGroup)
-	requirements.RemoveValue(cniConfigurationSettledKey)
-	needUpdateMC := false
+func annotateSecret(input *go_hook.HookInput) {
+	secretPatch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				"network.deckhouse.io/cni-configuration-source-priority": "ModuleConfig",
+			},
+		},
+	}
+	input.PatchCollector.PatchWithMerge(secretPatch, "v1", "Secret", "kube-system", "d8-cluster-configuration")
+}
 
-	cniSecrets, err := sdkobjectpatch.UnmarshalToStruct[cniSecretStruct](input.Snapshots, "cni_configuration_secret")
+func createDesiredModuleConfig(input *go_hook.HookInput, desiredCNIModuleConfig *v1alpha1.ModuleConfig) {
+	input.PatchCollector.CreateOrUpdate(desiredCNIModuleConfig)
+}
+
+func createConfigMapWithDesiredModuleConfig(input *go_hook.HookInput, desiredCNIModuleConfig *v1alpha1.ModuleConfig) error {
+	desiredCNIModuleConfigYAML, err := yaml.Marshal(*desiredCNIModuleConfig)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal cni_configuration_secret snapshot: %w", err)
+		return fmt.Errorf("cannot marshal desired CNI moduleConfig, err: %w", err)
 	}
-	// Let's check secret.
-	// Secret d8-cni-configuration does not exist or exist but contain nil.
-	// This means that the current CNI module is enabled and configured via mc, nothing to do.
-	if len(cniSecrets) == 0 {
-		setCNIMiscMetricAndReq(input, false)
-		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-		return nil
-	}
-
-	// Secret d8-cni-configuration exist but key "cni" does not equal "simple-bridge".
-	// This means that the current CNI module is enabled and configured via mc, nothing to do.
-	cniSecret := cniSecrets[0]
-	if cniSecret.CNI != cni {
-		setCNIMiscMetricAndReq(input, false)
-		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-		return nil
-	}
-	// Secret d8-cni-configuration exist, key "cni" eq "simple-bridge".
-
-	// Prepare desiredCNIModuleConfig
-	desiredCNIModuleConfig := &v1alpha1.ModuleConfig{
+	data := map[string]string{cniName + "-mc.yaml": string(desiredCNIModuleConfigYAML)}
+	cm := &v1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "ModuleConfig",
-			APIVersion: "deckhouse.io/v1alpha1",
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: cniName,
+			Name:      desiredCNIModuleConfigName,
+			Namespace: "d8-system",
 		},
-		Spec: v1alpha1.ModuleConfigSpec{
-			Enabled:  ptr.To(true),
-			Version:  1,
-			Settings: v1alpha1.SettingsValues{},
-		},
+		Data: data,
 	}
-
-	// Let's check what mc exist and explicitly enabled.
-	cniMCs, err := sdkobjectpatch.UnmarshalToStruct[v1alpha1.ModuleConfig](input.Snapshots, "deckhouse_cni_mc")
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal deckhouse_cni_mc snapshot: %w", err)
-	}
-	if len(cniMCs) == 0 {
-		needUpdateMC = true
-	} else {
-		desiredCNIModuleConfig.Spec.Settings = cniMCs[0].DeepCopy().Spec.Settings
-	}
-
-	if needUpdateMC {
-		desiredCNIModuleConfigYAML, err := yaml.Marshal(*desiredCNIModuleConfig)
-		if err != nil {
-			return fmt.Errorf("cannot marshal desired CNI moduleConfig, err: %w", err)
-		}
-		data := map[string]string{cniName + "-mc.yaml": string(desiredCNIModuleConfigYAML)}
-		cm := &v1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "ConfigMap",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      desiredCNIModuleConfigName,
-				Namespace: "d8-system",
-			},
-			Data: data,
-		}
-		input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
-		input.PatchCollector.CreateOrUpdate(cm)
-		setCNIMiscMetricAndReq(input, true)
-		return nil
-	}
-
-	// All configuration settled, nothing to do.
-	setCNIMiscMetricAndReq(input, false)
 	input.PatchCollector.Delete("v1", "ConfigMap", "d8-system", desiredCNIModuleConfigName)
+	input.PatchCollector.CreateOrUpdate(cm)
 	return nil
 }

--- a/modules/035-cni-simple-bridge/hooks/check_cni_configuration_test.go
+++ b/modules/035-cni-simple-bridge/hooks/check_cni_configuration_test.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"strings"
+	"time"
 
 	"github.com/flant/shell-operator/pkg/metric_storage/operation"
 	. "github.com/onsi/ginkgo"
@@ -56,7 +57,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: desiredCNIModuleConfig
+  name: desired-cni-moduleconfig
   namespace: d8-system
 data:
   cni-flannel-mc.yaml: |
@@ -449,6 +450,70 @@ data:
 			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
 			Expect(secret.Exists()).To(BeTrue())
 			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Cluster is bootstrapped, has cni secret created after MC, so MC takes priority", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
+
+			// Create MC first (earlier timestamp)
+			mc := &v1alpha1.ModuleConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "deckhouse.io/v1alpha1",
+					Kind:       "ModuleConfig",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              cniName,
+					CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)),
+				},
+				Spec: v1alpha1.ModuleConfigSpec{
+					Version:  1,
+					Settings: v1alpha1.SettingsValues{},
+					Enabled:  ptr.To(true),
+				},
+			}
+			mcYAML, _ := yaml.Marshal(mc)
+
+			// Create secret later (later timestamp)
+			secretData := make(map[string][]byte)
+			secretData["cni"] = []byte(cni)
+			secretData[cni] = []byte(``)
+			secret := &v1core.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "d8-cni-configuration",
+					Namespace:         "kube-system",
+					CreationTimestamp: metav1.NewTime(time.Date(2023, 1, 2, 12, 0, 0, 0, time.UTC)), // 1 day later
+				},
+				Data: secretData,
+			}
+			secretYAML, _ := yaml.Marshal(secret)
+
+			resources := []string{
+				string(secretYAML),
+				string(mcYAML),
+			}
+			f.KubeStateSet(strings.Join(resources, "\n---\n"))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should execute successfully, set req=true and metric=0 and should not create desired mc (secret created after MC)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("true"))
+			checkMetric(f.MetricsCollector.CollectedMetrics(), 0.0)
+			cm := f.KubernetesResource("ConfigMap", "d8-system", "desired-cni-moduleconfig")
+			Expect(cm.Exists()).To(BeFalse())
+			secret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations`).Exists()).To(BeTrue())
+			Expect(secret.Field(`metadata.annotations.network\.deckhouse\.io/cni-configuration-source-priority`).String()).To(Equal("ModuleConfig"))
 		})
 	})
 })

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/cni-checks.yaml
@@ -45,6 +45,6 @@
 
           3. Once the parameters in "ModuleConfig" match those used in the cluster:
                - this alert will be resolved,
-               - and the priority of the sources for configuring CNI will change, and ModuleConfig will become the main source.
+               - and the priority of the sources for configuring CNI will change, and ModuleConfig will become the main source of truth.
 
           4. After that, you can add the desired parameters to the ModuleConfig CNI and they will be applied immediately.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/cni-checks.yaml
@@ -29,15 +29,22 @@
         plk_protocol_version: "1"
         plk_create_group_if_not_exists__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         plk_grouped_by__d8_cni_check: D8CNIMisconfiguration,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-        summary: Settings in the secret `d8-cni-configuration` conflict with the ModuleConfig.
+        summary: The parameters specified in `ModuleConfig` of `{{ $labels.cni }}` do not match the ones that are actually being used in the cluster.
         description: |
-          Steps to troubleshoot:
+          This happened because there were several sources for configuring CNI parameters in the cluster, and ModuleConfig did not have the highest priority previously.
 
-          1. Find the desired settings in the ConfigMap `d8-system/desired-cni-moduleconfig` by running the following command:
+          To resolve this issue, the following steps should be taken:
+
+          1. Find the ConfigMap `d8-system/desired-cni-moduleconfig` in the cluster, which contains the actual ModuleConfig settings.
 
              ```bash
              d8 k -n d8-system get configmap desired-cni-moduleconfig -o yaml
              ```
 
-          1. Update the conflicting settings in the CNI `{{ $labels.cni }}` ModuleConfig to match the desired configuration.
+          2. Apply this prepared ModuleConfig to the cluster. This will not cause any actual reconfigurations in the cluster and is completely safe.
 
+          3. Once the parameters in "ModuleConfig" match those used in the cluster:
+               - this alert will be resolved,
+               - and the priority of the sources for configuring CNI will change, and ModuleConfig will become the main source.
+
+          4. After that, you can add the desired parameters to the ModuleConfig CNI and they will be applied immediately.


### PR DESCRIPTION
## Description

The following changes have been implemented:

- Cloud provider controllers will continue to generate the Secret d8-cni configuration. 
  - However, its purpose has slightly changed. These are now the recommended CNI settings for this provider by default.
- Parameters described in the ModuleConfig CNI take priority over those specified in the Secret d8-cni-configuration. 
  - Any parameter can now be redefined.
- A migration mechanism has been added to allow for a safe switch to the new logic.

## Why do we need it, and what problem does it solve?

There are two sources of parameters for configuring CNI in a cluster:
- the CNI ModuleConfig, which can be configured by the user,
- the d8-cni-configuration secret, which is created by a cloud provider controller.

The d8-cni-configuration secret always has priority over the ModuleConfig CNI parameters. As a result, some parameters may not be able to be redefined.


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: chore
summary: The new logic implemented where settings from the ModuleConfig take priority over the "d8-cni-configuration" secret.
impact_level: default
---
section: cni-flannel
type: chore
summary: The new logic implemented where settings from the ModuleConfig take priority over the "d8-cni-configuration" secret.
impact_level: default
---
section: cni-simple-bridge
type: chore
summary: The new logic implemented where settings from the ModuleConfig take priority over the "d8-cni-configuration" secret.
impact_level: default
```
