### PR TITLE
[candi] kubectl-exec makes a direct request to the control plane if the proxy is unavailable

### DIFF
--- a/candi/bashible/bashbooster/61_proxy.sh.tpl
+++ b/candi/bashible/bashbooster/61_proxy.sh.tpl
@@ -1,3 +1,4 @@
+{{- /*
 # Copyright 2024 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
 bb-set-proxy() {
 {{- if .proxy }}

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -26,10 +26,33 @@ set -Eeo pipefail
 `
 (index (splitList "\n---\n" $bbnn) 0)) . | nindent 0 }}
 
-
-function kubectl_exec() {
-  kubectl --request-timeout 60s --kubeconfig=/etc/kubernetes/kubelet.conf ${@}
+bb-kubectl-exec() {
+  local kubeconfig="/etc/kubernetes/kubelet.conf"
+  local args=""
+{{ if eq .runType "Normal" }}
+  local kube_server
+  kube_server=$(kubectl --kubeconfig="$kubeconfig" config view -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null)
+  if [[ -n "$kube_server" ]]; then
+    host=$(echo "$kube_server" | sed -E 's#https?://([^:/]+).*#\1#')
+    port=$(echo "$kube_server" | sed -E 's#https?://[^:/]+:([0-9]+).*#\1#')
+    # checking local kubernetes-api-proxy availability
+    if ! (echo > /dev/tcp/"$host"/"$port") 2>/dev/null; then
+      for server in {{ .normal.apiserverEndpoints | join " " }}; do
+        host=$(echo "$server" | cut -d: -f1)
+        port=$(echo "$server" | cut -d: -f2)
+        # select the first available control plane
+        if (echo > /dev/tcp/"$host"/"$port") 2>/dev/null; then
+          args="--server=https://$server"
+          break
+        fi
+      done
+    fi
+  fi
+{{ end }}
+  kubectl --request-timeout 60s --kubeconfig=$kubeconfig $args ${@}
 }
+# make the function available in $step
+export -f bb-kubectl-exec
 
 function bb-event-error-create() {
     # This function is used for creating event in the default namespace with reference of
@@ -47,7 +70,7 @@ function bb-event-error-create() {
     nodeName=$(bb-d8-node-name)
     eventLog="/var/lib/bashible/step.log"
     if type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf ; then
-      kubectl_exec apply -f - <<EOF || true
+      bb-kubectl-exec apply -f - <<EOF || true
           apiVersion: events.k8s.io/v1
           kind: Event
           metadata:
@@ -72,7 +95,7 @@ function bb-event-info-create() {
     eventName="$(echo -n "$(bb-d8-node-name)")-$1"
     nodeName="$(bb-d8-node-name)"
     if type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf ; then
-      kubectl_exec apply -f - <<EOF || true
+      bb-kubectl-exec apply -f - <<EOF || true
           apiVersion: events.k8s.io/v1
           kind: Event
           metadata:
@@ -96,7 +119,7 @@ EOF
 function annotate_node() {
   echo "Annotate node $(bb-d8-node-name) with annotation ${@}"
   attempt=0
-  until error=$(kubectl_exec annotate node $(bb-d8-node-name) --overwrite ${@} 2>&1); do
+  until error=$(bb-kubectl-exec annotate node $(bb-d8-node-name) --overwrite ${@} 2>&1); do
     attempt=$(( attempt + 1 ))
     if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
       >&2 echo "ERROR: Failed to annotate node $(bb-d8-node-name) with annotation ${@} after ${MAX_RETRIES} retries. Last error from kubectl: ${error}"
@@ -117,7 +140,7 @@ function get_secret() {
 
   if type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf ; then
     attempt=0
-    until kubectl_exec -n d8-cloud-instance-manager get secret "$secret" -o json; do
+    until bb-kubectl-exec -n d8-cloud-instance-manager get secret "$secret" -o json; do
       attempt=$(( attempt + 1 ))
       if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
         >&2 echo "ERROR: Failed to get secret $secret with kubectl --kubeconfig=/etc/kubernetes/kubelet.conf"
@@ -154,7 +177,7 @@ function get_bundle() {
 
   if type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf ; then
     attempt=0
-    until kubectl_exec get "$resource" "$name" -o json; do
+    until bb-kubectl-exec get "$resource" "$name" -o json; do
       attempt=$(( attempt + 1 ))
       if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
         >&2 echo "ERROR: Failed to get $resource $name with kubectl --kubeconfig=/etc/kubernetes/kubelet.conf"
@@ -211,7 +234,7 @@ function main() {
   export D8_NODE_HOSTNAME=$(bb-d8-node-name)
 
   if type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf ; then
-    if tmp="$(kubectl_exec get node $(bb-d8-node-name) -o json | jq -r '.metadata.labels."node.deckhouse.io/group"')" ; then
+    if tmp="$(bb-kubectl-exec get node $(bb-d8-node-name) -o json | jq -r '.metadata.labels."node.deckhouse.io/group"')" ; then
       NODE_GROUP="$tmp"
       if [ "${NODE_GROUP}" == "null" ] ; then
         >&2 echo "failed to get node group. Forgot set label 'node.deckhouse.io/group'"
@@ -249,7 +272,7 @@ function main() {
 
 {{ if eq .runType "Normal" }}
   if type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf ; then
-      REBOOT_ANNOTATION="$( kubectl_exec get no "$D8_NODE_HOSTNAME" -o json |jq -r '.metadata.annotations."update.node.deckhouse.io/reboot"' )"
+      REBOOT_ANNOTATION="$( bb-kubectl-exec get no "$D8_NODE_HOSTNAME" -o json |jq -r '.metadata.annotations."update.node.deckhouse.io/reboot"' )"
     else
       REBOOT_ANNOTATION=null
   fi

--- a/candi/bashible/bb_node_name.sh.tpl
+++ b/candi/bashible/bb_node_name.sh.tpl
@@ -1,3 +1,4 @@
+{{- /*
 # Copyright 2025 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
 {{- define "bb-d8-node-name" -}}
 bb-d8-node-name() {

--- a/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl
+++ b/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function kubectl_exec() {
-  kubectl --request-timeout 60s --kubeconfig=/etc/kubernetes/kubelet.conf ${@}
-}
-
 MIN_KERNEL="5.8"
 MIN_SYSTEMD="244"
 MAX_RETRIES=10
@@ -57,16 +53,16 @@ function set_labels() {
 
   while true; do
     if (( unsupported )); then
-      kubectl_exec label node "$(bb-d8-node-name)" --overwrite "node.deckhouse.io/containerd-v2-unsupported="
+      bb-kubectl-exec label node "$(bb-d8-node-name)" --overwrite "node.deckhouse.io/containerd-v2-unsupported="
     else
-      kubectl_exec label node "$(bb-d8-node-name)" --overwrite "node.deckhouse.io/containerd-v2-unsupported-"
+      bb-kubectl-exec label node "$(bb-d8-node-name)" --overwrite "node.deckhouse.io/containerd-v2-unsupported-"
     fi
     local label_status=$?
 
     if [[ -n $errs ]]; then
-      kubectl_exec annotate node "$(bb-d8-node-name)" --overwrite "node.deckhouse.io/containerd-v2-err=$errs"
+      bb-kubectl-exec annotate node "$(bb-d8-node-name)" --overwrite "node.deckhouse.io/containerd-v2-err=$errs"
     else
-      kubectl_exec annotate node "$(bb-d8-node-name)" --overwrite "node.deckhouse.io/containerd-v2-err-"
+      bb-kubectl-exec annotate node "$(bb-d8-node-name)" --overwrite "node.deckhouse.io/containerd-v2-err-"
     fi
     local annotate_status=$?
 

--- a/candi/bashible/common-steps/all/001_configure_kubernetes_api_proxy.sh.tpl
+++ b/candi/bashible/common-steps/all/001_configure_kubernetes_api_proxy.sh.tpl
@@ -57,3 +57,8 @@ EOF
 if [[ ! -f /etc/kubernetes/kubernetes-api-proxy/nginx.conf ]]; then
   cp /etc/kubernetes/kubernetes-api-proxy/nginx_new.conf /etc/kubernetes/kubernetes-api-proxy/nginx.conf
 fi
+
+chown -R 0:64535 /etc/kubernetes/kubernetes-api-proxy
+chmod g+s /etc/kubernetes/kubernetes-api-proxy
+chmod 750 /etc/kubernetes/kubernetes-api-proxy
+chmod 640 /etc/kubernetes/kubernetes-api-proxy/*

--- a/candi/bashible/common-steps/all/098_update_node_annotations.sh.tpl
+++ b/candi/bashible/common-steps/all/098_update_node_annotations.sh.tpl
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function kubectl_exec() {
-  kubectl --request-timeout 60s --kubeconfig=/etc/kubernetes/kubelet.conf ${@}
-}
-
 {{- if hasKey .nodeGroup "staticInstances" }}
 if [[ -f /var/lib/bashible/node-spec-provider-id ]]; then
-  PROVIDER_ID="$( kubectl_exec get no $(bb-d8-node-name) -o json | jq -r '.spec.providerID' )"
+  PROVIDER_ID="$( bb-kubectl-exec get no $(bb-d8-node-name) -o json | jq -r '.spec.providerID' )"
 
   if [[ "${PROVIDER_ID}" == "static://" ]]; then
-    kubectl_exec annotate node $(bb-d8-node-name) node.deckhouse.io/provider-id="$(cat /var/lib/bashible/node-spec-provider-id)"
+    bb-kubectl-exec annotate node $(bb-d8-node-name) node.deckhouse.io/provider-id="$(cat /var/lib/bashible/node-spec-provider-id)"
   fi
 fi
 {{- end }}
@@ -30,4 +26,4 @@ fi
   This annotation is required by the registry module to track which 
   version of the registry configuration is currently applied on the node.
 */}}
-kubectl_exec annotate node $(bb-d8-node-name) registry.deckhouse.io/version={{ .registry.version | quote }} --overwrite
+bb-kubectl-exec annotate node $(bb-d8-node-name) registry.deckhouse.io/version={{ .registry.version | quote }} --overwrite

--- a/candi/bashible/common-steps/all/098_update_node_labels.sh.tpl
+++ b/candi/bashible/common-steps/all/098_update_node_labels.sh.tpl
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function kubectl_exec() {
-  kubectl --request-timeout 60s --kubeconfig=/etc/kubernetes/kubelet.conf ${@}
-}
-
 check_python
 function fetch-local-labels() {
   cat - <<EOF | $python_binary
@@ -111,7 +107,7 @@ EOF
 LABEL_DIRECTORY_PATH=/var/lib/node_labels
 mkdir -p $LABEL_DIRECTORY_PATH
 
-LABELS_FROM_ANNOTATION="$( kubectl_exec get no $(bb-d8-node-name) -o json |jq -r '.metadata.annotations."node.deckhouse.io/last-applied-local-labels"' )"
+LABELS_FROM_ANNOTATION="$( bb-kubectl-exec get no $(bb-d8-node-name) -o json |jq -r '.metadata.annotations."node.deckhouse.io/last-applied-local-labels"' )"
 
 if [[ $LABELS_FROM_ANNOTATION == "null" ]]
   then
@@ -125,7 +121,7 @@ LABELS_ANNOTATION="$( fetch-local-labels "$LABEL_DIRECTORY_PATH" add "$LABELS_FR
 if [[ $LABLES_TO_REMOVE ]]
   then
     for label in $LABLES_TO_REMOVE; do
-        kubectl_exec label node $(bb-d8-node-name) "$label"
+        bb-kubectl-exec label node $(bb-d8-node-name) "$label"
     done
 fi
 
@@ -139,6 +135,6 @@ if [[ -z $LABELS ]]
     exit 0
   else
     # Apply labels to node
-    kubectl_exec label node $(bb-d8-node-name) "${LABELS}" --overwrite
+    bb-kubectl-exec label node $(bb-d8-node-name) "${LABELS}" --overwrite
     kubectl --request-timeout 60s --kubeconfig=/etc/kubernetes/kubelet.conf annotate node $(bb-d8-node-name) --overwrite node.deckhouse.io/last-applied-local-labels="${LABELS_ANNOTATION}"
 fi


### PR DESCRIPTION

## Description
bashible cannot restore node operation by applying a new node configuration if kubernetes-api-proxy cannot start.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
When kubernetes-api-proxy is not working, kubectl makes requests directly to the API server.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: kubectl-exec makes a direct request to the control plane if the proxy is unavailable
impact: 
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
