### PR TITLE
[docs][kube-dns] Update FAQ

### DIFF
--- a/modules/042-kube-dns/docs/FAQ.md
+++ b/modules/042-kube-dns/docs/FAQ.md
@@ -3,7 +3,7 @@ title: "The kube-dns module: FAQ"
 search: DNS, domain, clusterdomain
 ---
 
-## How do I replace the cluster domain with minimal downtime?
+## How to change cluster domain with minimal downtime?
 
 Add a new domain and retain the previous one. To do this, modify the configuration parameters:
 
@@ -56,21 +56,50 @@ Add a new domain and retain the previous one. To do this, modify the configurati
    ```
 
 1. Wait until the `kube-apiserver` has restarted.
-1. Replace the previous `clusterDomain` with the new one. To do this, execute the command:
+
+   ```bash
+   kubectl -n kube-system get pods -l component=kube-apiserver
+   ```
+
+1. Replace the previous `clusterDomain` with the new one. Run this command to edit cluster configuration:
 
    ```bash
    d8 platform edit cluster-configuration
    ```
+   
+1. Restart deckhouse pods:
 
-**Important!** If your Kubernetes version is 1.20 and higher, your controllers in the cluster use [advanced ServiceAccount tokens](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) to work with API server. Those tokens have extra fields `iss:` and `aud:` that contain `clusterDomain` (e.g. `"iss": "https://kubernetes.default.svc.cluster.local"`). After changing the clusterDomain, the API server will start issuing tokens with the new service-account-issuer, but thanks to the configuration of additionalAPIAudiences and additionalAPIIssuers, the apiserver will continue to accept the old tokens.
+   ```bash
+   kubectl -n d8-system rollout restart deployment deckhouse
+   ```
+
+{% alert level="warning" %}
+
+**Important!** In kubernetes, controllers in the cluster use [advanced ServiceAccount tokens](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) to interact with API server. These tokens have extra fields `iss:` and `aud:` that contain `clusterDomain` (e.g. `"iss": "https://kubernetes.default.svc.cluster.local"`). After changing the clusterDomain, the API server will start issuing tokens with the new service-account-issuer, but thanks to the configuration of additionalAPIAudiences and additionalAPIIssuers, the apiserver will continue to accept the old tokens.
 After 48 minutes (80% of 3607 seconds), Kubernetes will begin to refresh the issued tokens, and the new service-account-issuer will be used for the updated tokens. After 90 minutes (3607 seconds plus a short buffer) following the kube-apiserver restart, you can remove the serviceAccount configuration from the control-plane-manager configuration.
+
+{% endalert %}
+
+{% alert level="warning" %}
+
+**Important!** In case you need to remove old domain from `clusterDomainAliases` in moduleconfig kube-dns, recreation of all pods in cluster is required, so new pods will have correct search domain in `/etc/resolv.conf` file. This will lead to service downtime until pods are restarted.
+
+```bash
+kubectl delete pods --all-namespaces --all
+```
+
+{% endalert %}
+
+{% alert level="warning" %}
 
 **Important!** If you use [istio](../../modules/istio/) module, you have to restart all the application pods under istio control after changing `clusterDomain`.
 
+{% endalert %}
+
 ## How to Increase the Number of kube-dns pods?
 
-Deckhouse distributes kube-dns pods based on the following principles. It searches for nodes with the labels node-role.deckhouse.io/ and node-role.kubernetes.io/, then applies the following rules:
+Deckhouse distributes kube-dns pods based on the following principles. It searches for nodes with the labels `node-role.deckhouse.io/` and `node-role.kubernetes.io/`, then applies the following rules:
 
-* If there are nodes with the kube-dns role in the cluster, the number of replicas is calculated as the sum of these nodes and the master nodes.
-* If kube-dns nodes are absent, the system searches for nodes with the system role, and the number of replicas is then determined as the sum of system nodes and master nodes.
+* If there are nodes with the `kube-dns` role in the cluster, the number of replicas is calculated as the sum of these nodes and the master nodes, but not more than masters count plus 2.
+* If kube-dns nodes are absent, the system searches for nodes with the `system` role, and the number of replicas is then determined as the sum of system nodes and master nodes, but not more than masters count plus 2.
 * If only master nodes are present in the cluster, the number of kube-dns replicas will be equal to the number of masters.

--- a/modules/042-kube-dns/docs/FAQ_RU.md
+++ b/modules/042-kube-dns/docs/FAQ_RU.md
@@ -55,22 +55,51 @@ search: DNS, domain, домен, clusterdomain
          - <новый clusterDomain>
    ```
 
-1. Дождитесь перезапуска `kube-apiserver`.
+1. Дождитесь перезапуска `kube-apiserver`:
+
+   ```bash
+   kubectl -n kube-system get pods -l component=kube-apiserver
+   ```
+
 1. Поменяйте `clusterDomain` на новый. Для этого выполните команду:
 
    ```bash
    d8 platform edit cluster-configuration
    ```
+   
+1. Перезапустите поды deckhouse:
 
-**Важно!** Если версия вашего Kubernetes 1.20 и выше, контроллеры для работы с API-server гарантированно используют [расширенные токены для ServiceAccount'ов](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection). Это означает, что каждый такой токен содержит дополнительные поля `iss:` и `aud:`, которые включают в себя старый `clusterDomain` (например, `"iss": "https://kubernetes.default.svc.cluster.local"`).
-При смене `clusterDomain` API-server начнет выдавать токены с новым `service-account-issuer`, но благодаря произведенной конфигурации `additionalAPIAudiences` и `additionalAPIIssuers` по-прежнему будет принимать старые токены. По истечении 48 минут (80% от 3607 секунд) Kubernetes начнет обновлять выпущенные токены, при обновлении будет использован новый `service-account-issuer`. Через 90 минут (3607 секунд и немного больше) после перезагрузки kube-apiserver можете удалить конфигурацию `serviceAccount` из конфигурации `control-plane-manager`.
+   ```bash
+   kubectl -n d8-system rollout restart deployment deckhouse
+   ```
+
+{% alert level="warning" %}
+
+**Важно!** В Kubernetes, контроллеры используют [расширенные токены для ServiceAccount'ов](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) для работы с API-server. Это означает, что каждый такой токен содержит дополнительные поля `iss:` и `aud:`, которые включают в себя старый `clusterDomain` (например, `"iss": "https://kubernetes.default.svc.cluster.local"`).
+При смене `clusterDomain` API-server начнет выдавать токены с новым `service-account-issuer`, но благодаря произведенной конфигурации `additionalAPIAudiences` и `additionalAPIIssuers` по-прежнему будет принимать старые токены. По истечении 48 минут (80% от 3607 секунд) Kubernetes начнет обновлять выпущенные токены, при обновлении будет использован новый `service-account-issuer`. Через 90 минут (3607 секунд и дополнительный буфер) после перезагрузки kube-apiserver можете удалить конфигурацию `serviceAccount` из конфигурации `control-plane-manager`.
+
+{% endalert %}
+
+{% alert level="warning" %}
+
+**Важно!** Если необходимо убрать старый домен из `clusterDomainAliases` в moduleconfig kube-dns, необходимо пересоздать все поды в кластере, чтобы они запустились с новым search domain в `/etc/resolv.conf`. Это приведет к недоступности сервисов кластера, пока поды не перезапустятся.
+
+```bash
+kubectl delete pods --all-namespaces --all
+```
+
+{% endalert %}
+
+{% alert level="warning" %}
 
 **Важно!** Если вы используете модуль [istio](../../modules/istio/), после смены `clusterDomain` обязательно потребуется рестарт всех прикладных подов под управлением Istio.
 
+{% endalert %}
+
 ## Как увеличить количество подов kube-dns?
 
-Deckhouse распределяет поды kube-dns по следующему принципу: выполняется поиск узлов с метками node-role.deckhouse.io/ и node-role.kubernetes.io/, затем применяются следующие правила:
+Deckhouse распределяет поды kube-dns по следующему принципу: выполняется поиск узлов с метками `node-role.deckhouse.io/` и `node-role.kubernetes.io/`, затем применяются следующие правила:
 
-* Если в кластере есть узлы с ролью kube-dns, количество реплик вычисляется как сумма таких узлов и мастеров.
-* Если узлы kube-dns отсутствуют, производится поиск узлов с ролью system, и тогда количество реплик определяется как сумма system-узлов и мастеров.
+* Если в кластере есть узлы с ролью `kube-dns`, количество реплик вычисляется как сумма таких узлов и мастеров, но не больше чем количество мастеров + 2.
+* Если узлы kube-dns отсутствуют, производится поиск узлов с ролью `system`, и тогда количество реплик определяется как сумма system-узлов и мастеров, но не больше чем количество мастеров + 2.
 * Если в кластере присутствуют только мастер-узлы, количество реплик kube-dns будет равно числу мастеров.


### PR DESCRIPTION
## Description
- Updates to "How to change cluster domain" regarding old `resolv.conf` in pods.
- Updates to kube-dns replicas section regarding replicas limit.
- General markup cleanup.

## Why do we need it, and what problem does it solve?
Guide on changing cluster domain wraised some questions.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: kube-dns
type: chore
summary: Update kube-dns FAQ page in docs.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
