### PR TITLE
[docs] Fix alert level for modules with General Availability status

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/single.html
+++ b/docs/site/backends/docs-builder-template/layouts/single.html
@@ -27,10 +27,13 @@
         {{- end }}
 
         {{- if $moduleStatus }}
-          {{- if (T (printf "module_alert_%s_long" (replace (lower $moduleStatus) " " "_" ) )) }}
-            {{- partial "alert" ( dict "level" "warn" "content" (T (printf "module_alert_%s_long" (replace (lower $moduleStatus) " " "_" ) )) ) }}
+          {{- $statusKey := replace (lower $moduleStatus) " " "_" -}}
+          {{- if (T (printf "module_alert_%s_long" $statusKey )) }}
+             {{- $level := "warn" -}}
+             {{- if eq $statusKey "general_availability" }}{{ $level = "info" }}{{ end -}}
+             {{- partial "alert" ( dict "level" $level "content" (T (printf "module_alert_%s_long" $statusKey )) ) }}
           {{- end }}
-        {{- end }}
+       {{- end }}
 
         {{.Content}}
 


### PR DESCRIPTION
## Description
Fix alert level from warning to info for modules with General Availability status.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Fix alert level from warning to info for modules with General Availability status.
impact_level: low
```
