### PR TITLE
[monitoring-kubernetes] Add tier=cluster label

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node.yaml
@@ -1,7 +1,7 @@
 - name: kubernetes.node
   rules:
   - alert: CPUStealHigh
-    expr: max by (node) (irate(node_cpu_seconds_total{mode="steal"}[30m]) * 100) > 10
+    expr: max by (node) (irate(node_cpu_seconds_total{mode="steal", tier="cluster"}[30m]) * 100) > 10
     for: 30m
     labels:
       severity_level: "4"
@@ -46,7 +46,7 @@
         3. Verify that the kubelet is running on node `{{ $labels.node }}`.
 
   - alert: NodeConntrackTableFull
-    expr: max by (node) ( node_nf_conntrack_entries / node_nf_conntrack_entries_limit * 100 > 70 )
+    expr: max by (node) ( node_nf_conntrack_entries{tier="cluster"} / node_nf_conntrack_entries_limit{tier="cluster"} * 100 > 70 )
     for: 5m
     labels:
       severity_level: "4"
@@ -65,7 +65,7 @@
         To identify the source of excessive `conntrack` entries, use Okmeter or Grafana dashboards.
 
   - alert: NodeConntrackTableFull
-    expr: max by (node) ( node_nf_conntrack_entries / node_nf_conntrack_entries_limit * 100 > 95 )
+    expr: max by (node) ( node_nf_conntrack_entries{tier="cluster"} / node_nf_conntrack_entries_limit{tier="cluster"} * 100 > 95 )
     for: 1m
     labels:
       severity_level: "3"
@@ -114,9 +114,9 @@
 
   - alert: NodeSUnreclaimBytesUsageHigh
     expr: |
-      max by (node) (predict_linear(node_memory_SUnreclaim_bytes[2h], 43200) > node_memory_MemTotal_bytes * 0.25)
+      max by (node) (predict_linear(node_memory_SUnreclaim_bytes{tier="cluster"}[2h], 43200) > node_memory_MemTotal_bytes{tier="cluster"} * 0.25)
       and
-      max by (node) (node_memory_SUnreclaim_bytes > node_memory_MemTotal_bytes * 0.1)
+      max by (node) (node_memory_SUnreclaim_bytes{tier="cluster"} > node_memory_MemTotal_bytes{tier="cluster"} * 0.1)
     for: 20m
     labels:
       severity_level: "4"
@@ -144,7 +144,7 @@
         For further details, refer to the [issue](https://github.com/deckhouse/deckhouse/issues/2152).
 
   - alert: NodeTCPMemoryExhaust
-    expr: max by (node) (node_sockstat_TCP_mem_bytes > node_sysctl_net_ipv4_tcp_mem{index="2"} * 4096 * 0.90)
+    expr: max by (node) (node_sockstat_TCP_mem_bytes{tier="cluster"} > node_sysctl_net_ipv4_tcp_mem{index="2", tier="cluster"} * 4096 * 0.90)
     for: 1m
     labels:
       severity_level: "6"


### PR DESCRIPTION
## Description
 Add `tier=cluster` label

## Why do we need it, and what problem does it solve?
If Prometheus has metrics from node-exporter outside the cluster (for example, collected via an external service), the alert description for `NodeConntrackTableFull` does not include the `node` field.

## Why do we need it in the patch release (if we do)?
Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: fix
summary: Add `tier=cluster` label
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
