### PR TITLE
[deckhouse-controller] ignore migrate module if disabled

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_deckhouse_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_deckhouse_release.go
@@ -78,7 +78,7 @@ func validateDeckhouseReleaseApproval(
 	}
 
 	// If the DeckhouseRelease is not approved, allow it
-	if !dr.Approved {
+	if !dr.GetManuallyApproved() {
 		return allowResult(nil)
 	}
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_deckhouse_release_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_deckhouse_release_test.go
@@ -102,6 +102,28 @@ func createModuleSource(name string, modules []string) *v1alpha1.ModuleSource {
 	}
 }
 
+func createModuleConfig(name string) *v1alpha1.ModuleConfig {
+	return &v1alpha1.ModuleConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1alpha1.ModuleConfigSpec{
+			Enabled: &[]bool{true}[0],
+		},
+	}
+}
+
+func createDisabledModuleConfig(name string) *v1alpha1.ModuleConfig {
+	return &v1alpha1.ModuleConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1alpha1.ModuleConfigSpec{
+			Enabled: &[]bool{false}[0],
+		},
+	}
+}
+
 func createAdmissionReview(operation string, obj, oldObj interface{}) *admissionv1.AdmissionReview {
 	review := &admissionv1.AdmissionReview{
 		TypeMeta: metav1.TypeMeta{
@@ -190,10 +212,12 @@ func TestDeckhouseReleaseValidationHandler(t *testing.T) {
 		},
 		{
 			name:           "allow approved release with migrated modules found",
-			enabledModules: []string{"module1", "module2"},
+			enabledModules: []string{"module1", "module2", "migrated-module1", "migrated-module2"},
 			kubernetesObjs: []client.Object{
 				createClusterConfigSecret("1.28.0"),
-				createModuleSource("source1", []string{"migrated-module1", "migrated-module2"}),
+				createModuleConfig("migrated-module1"),
+				createModuleConfig("migrated-module2"),
+				createModuleSource("test-source", []string{"migrated-module1", "migrated-module2"}),
 			},
 			operation: "CREATE",
 			release: createDeckhouseRelease("test-release", true, map[string]string{
@@ -227,6 +251,119 @@ func TestDeckhouseReleaseValidationHandler(t *testing.T) {
 			}),
 			wantAllowed: true,
 			description: "Approved releases with whitespace-only migrated modules should be allowed",
+		},
+		{
+			name:           "allow when migrated module is disabled in ModuleConfig",
+			enabledModules: []string{"module1"},
+			kubernetesObjs: []client.Object{
+				createClusterConfigSecret("1.28.0"),
+				createDisabledModuleConfig("disabled-module"),
+			},
+			operation: "CREATE",
+			release: createDeckhouseRelease("test-release", true, map[string]string{
+				"migratedModules": "disabled-module",
+			}),
+			wantAllowed: true,
+			wantMessage: "",
+			description: "Releases with migrated modules that are disabled in ModuleConfig should be allowed (ModuleConfig presence is sufficient)",
+		},
+		{
+			name:           "allow when one migrated module is enabled and another is disabled (both present in ModuleConfig)",
+			enabledModules: []string{"enabled-module"},
+			kubernetesObjs: []client.Object{
+				createClusterConfigSecret("1.28.0"),
+				createModuleConfig("enabled-module"),
+				createDisabledModuleConfig("disabled-module"),
+			},
+			operation: "CREATE",
+			release: createDeckhouseRelease("test-release", true, map[string]string{
+				"migratedModules": "enabled-module, disabled-module",
+			}),
+			wantAllowed: false,
+			wantMessage: "requirements not met",
+			description: "Releases with mixed enabled/disabled migrated modules should be rejected (enabled module not found in ModuleSource)",
+		},
+		{
+			name:           "reject when migrated module is not found in ModuleSource",
+			enabledModules: []string{"cert-manager", "prometheus", "dashboard"},
+			kubernetesObjs: []client.Object{
+				createClusterConfigSecret("1.28.0"),
+				createModuleConfig("cert-manager"),
+				createModuleConfig("prometheus"),
+				createModuleSource("test-source", []string{"cert-manager", "prometheus"}),
+			},
+			operation: "CREATE",
+			release: createDeckhouseRelease("test-release", true, map[string]string{
+				"migratedModules": "cert-manager, prometheus, non-enabled-module",
+			}),
+			wantAllowed: false,
+			wantMessage: "requirements not met",
+			description: "Releases with migrated modules that are not found in ModuleSource and not disabled in MC should be rejected",
+		},
+		{
+			name:           "allow when ModuleConfig exists disabled and not in source",
+			enabledModules: []string{"module-x"},
+			kubernetesObjs: []client.Object{
+				createClusterConfigSecret("1.28.0"),
+				createDisabledModuleConfig("module-x"),
+				createModuleSource("src", []string{}),
+			},
+			operation:   "CREATE",
+			release:     createDeckhouseRelease("test-release", true, map[string]string{"migratedModules": "module-x"}),
+			wantAllowed: true,
+			description: "ModuleConfig disabled bypasses ModuleSource",
+		},
+		{
+			name:           "reject when ModuleConfig exists enabled and not in source",
+			enabledModules: []string{"module-y"},
+			kubernetesObjs: []client.Object{
+				createClusterConfigSecret("1.28.0"),
+				createModuleConfig("module-y"),
+				createModuleSource("src", []string{}),
+			},
+			operation:   "CREATE",
+			release:     createDeckhouseRelease("test-release", true, map[string]string{"migratedModules": "module-y"}),
+			wantAllowed: false,
+			wantMessage: "requirements not met",
+			description: "Enabled ModuleConfig requires ModuleSource",
+		},
+		{
+			name:           "reject when ModuleConfig exists enabled and exists in ModuleSource",
+			enabledModules: []string{"module-z"},
+			kubernetesObjs: []client.Object{
+				createClusterConfigSecret("1.28.0"),
+				createModuleConfig("module-z"),
+				createModuleSource("src", []string{"module-z"}),
+			},
+			operation:   "CREATE",
+			release:     createDeckhouseRelease("test-release", true, map[string]string{"migratedModules": "module-z"}),
+			wantAllowed: true,
+			description: "Enabled ModuleConfig with presence in ModuleSource",
+		},
+		{
+			name:           "allow when no in ModuleConfig and exists in ModuleSource",
+			enabledModules: []string{"module-a1"},
+			kubernetesObjs: []client.Object{
+				createClusterConfigSecret("1.28.0"),
+				createModuleSource("src", []string{"module-a1"}),
+			},
+			operation:   "CREATE",
+			release:     createDeckhouseRelease("test-release", true, map[string]string{"migratedModules": "module-a1"}),
+			wantAllowed: true,
+			description: "Absent ModuleConfig falls back to ModuleSource and passes",
+		},
+		{
+			name:           "reject when no in ModuleConfig and not in ModuleSource",
+			enabledModules: []string{"module-a2"},
+			kubernetesObjs: []client.Object{
+				createClusterConfigSecret("1.28.0"),
+				createModuleSource("src", []string{}),
+			},
+			operation:   "CREATE",
+			release:     createDeckhouseRelease("test-release", true, map[string]string{"migratedModules": "module-a2"}),
+			wantAllowed: false,
+			wantMessage: "requirements not met",
+			description: "Absent ModuleConfig and absence in ModuleSource rejects",
 		},
 	}
 
@@ -326,11 +463,13 @@ func TestDeckhouseReleaseValidation_RequirementsCoverage(t *testing.T) {
 			release: createDeckhouseRelease("test-release", true, map[string]string{
 				"migratedModules": "module-a, module-b , module-c",
 			}),
-			enabledModules: []string{"module1"},
+			enabledModules: []string{"module-a", "module-b", "module-c"},
 			kubernetesObjs: []client.Object{
 				createClusterConfigSecret("1.28.0"),
-				createModuleSource("source1", []string{"module-a", "module-b"}),
-				createModuleSource("source2", []string{"module-c"}),
+				createModuleConfig("module-a"),
+				createModuleConfig("module-b"),
+				createModuleConfig("module-c"),
+				createModuleSource("test-source", []string{"module-a", "module-b", "module-c"}),
 			},
 			wantAllowed: true,
 			description: "DeckhouseRelease with complex migratedModules should be allowed when all modules exist",
@@ -343,7 +482,7 @@ func TestDeckhouseReleaseValidation_RequirementsCoverage(t *testing.T) {
 			enabledModules: []string{"module1"},
 			kubernetesObjs: []client.Object{
 				createClusterConfigSecret("1.28.0"),
-				createModuleSource("source1", []string{"available-module"}),
+				createModuleConfig("available-module"),
 			},
 			wantAllowed: false,
 			description: "DeckhouseRelease with partially available migratedModules should be rejected",

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-module-not-enabled.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-module-not-enabled.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.49.0
+  resourceVersion: "999"
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.50.0
+  resourceVersion: "1000"
+spec:
+  requirements:
+    migratedModules: non-enabled-module
+  version: v1.50.0
+status:
+  approved: false
+  message: migrated module "non-enabled-module" not found in any ModuleSource registry
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: deckhouse
+  namespace: d8-system
+  resourceVersion: "999"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+        name: deckhouse
+        resources: {}
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-empty-migrated-modules.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-empty-migrated-modules.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.49.0
+  resourceVersion: "1000"
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Superseded
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "true"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  name: v1.50.0
+  resourceVersion: "1001"
+spec:
+  requirements:
+    migratedModules: ""
+  version: v1.50.0
+status:
+  approved: false
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: deckhouse
+  namespace: d8-system
+  resourceVersion: "1000"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - image: my.registry.com/deckhouse:v1.50.0
+        name: deckhouse
+        resources: {}
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-disabled-not-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-disabled-not-in-source.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.49.0
+  resourceVersion: "1000"
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Superseded
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "true"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  name: v1.50.0
+  resourceVersion: "1001"
+spec:
+  requirements:
+    migratedModules: disabled-module
+  version: v1.50.0
+status:
+  approved: false
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: deckhouse
+  namespace: d8-system
+  resourceVersion: "1000"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - image: my.registry.com/deckhouse:v1.50.0
+        name: deckhouse
+        resources: {}
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-enabled-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-enabled-in-source.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.49.0
+  resourceVersion: "1000"
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Superseded
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "true"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  name: v1.50.0
+  resourceVersion: "1001"
+spec:
+  requirements:
+    migratedModules: test-module-1
+  version: v1.50.0
+status:
+  approved: false
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: deckhouse
+  namespace: d8-system
+  resourceVersion: "1000"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - image: my.registry.com/deckhouse:v1.50.0
+        name: deckhouse
+        resources: {}
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-enabled-not-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-enabled-not-in-source.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.49.0
+  resourceVersion: "999"
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.50.0
+  resourceVersion: "1000"
+spec:
+  requirements:
+    migratedModules: enabled-module-not-found
+  version: v1.50.0
+status:
+  approved: false
+  message: migrated module "enabled-module-not-found" not found in any ModuleSource registry
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: deckhouse
+  namespace: d8-system
+  resourceVersion: "999"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+        name: deckhouse
+        resources: {}
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-module-missing.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-module-missing.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.49.0
+  resourceVersion: "999"
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.50.0
+  resourceVersion: "1000"
+spec:
+  requirements:
+    migratedModules: test-module-1, test-module-missing
+  version: v1.50.0
+status:
+  approved: false
+  message: migrated module "test-module-missing" not found in any ModuleSource registry
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: deckhouse
+  namespace: d8-system
+  resourceVersion: "999"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+        name: deckhouse
+        resources: {}
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-module-pull-error.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-module-pull-error.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.49.0
+  resourceVersion: "999"
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.50.0
+  resourceVersion: "1000"
+spec:
+  requirements:
+    migratedModules: test-module-1
+  version: v1.50.0
+status:
+  approved: false
+  message: migrated module "test-module-1" not found in any ModuleSource registry
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: deckhouse
+  namespace: d8-system
+  resourceVersion: "999"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+        name: deckhouse
+        resources: {}
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-modules-available.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-modules-available.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.49.0
+  resourceVersion: "1000"
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Superseded
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "true"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  name: v1.50.0
+  resourceVersion: "1001"
+spec:
+  requirements:
+    migratedModules: test-module-1, test-module-2
+  version: v1.50.0
+status:
+  approved: false
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: deckhouse
+  namespace: d8-system
+  resourceVersion: "1000"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - image: my.registry.com/deckhouse:v1.50.0
+        name: deckhouse
+        resources: {}
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-no-migrated-modules.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-no-migrated-modules.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.49.0
+  resourceVersion: "1000"
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Superseded
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "true"
+    release.deckhouse.io/notified: "false"
+  creationTimestamp: null
+  name: v1.50.0
+  resourceVersion: "1001"
+spec:
+  version: v1.50.0
+status:
+  approved: false
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: deckhouse
+  namespace: d8-system
+  resourceVersion: "1000"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - image: my.registry.com/deckhouse:v1.50.0
+        name: deckhouse
+        resources: {}
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-module-not-enabled.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-module-not-enabled.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.49.0
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.50.0
+spec:
+  version: v1.50.0
+  requirements:
+    migratedModules: "non-enabled-module"
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: deckhouse
+spec:
+  registry:
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  modulesCount: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deckhouse
+  namespace: d8-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  template:
+    metadata:
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - name: deckhouse
+        image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-empty-migrated-modules.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-empty-migrated-modules.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.49.0
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.50.0
+spec:
+  version: v1.50.0
+  requirements:
+    migratedModules: ""
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: deckhouse
+spec:
+  registry:
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  modulesCount: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deckhouse
+  namespace: d8-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  template:
+    metadata:
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - name: deckhouse
+        image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-mc-disabled-not-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-mc-disabled-not-in-source.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.49.0
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.50.0
+spec:
+  version: v1.50.0
+  requirements:
+    migratedModules: "disabled-module"
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: deckhouse
+spec:
+  registry:
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  modulesCount: 0
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: disabled-module
+spec:
+  enabled: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deckhouse
+  namespace: d8-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  template:
+    metadata:
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - name: deckhouse
+        image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+status:
+  replicas: 1
+  readyReplicas: 1
+
+

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-mc-enabled-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-mc-enabled-in-source.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.49.0
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.50.0
+spec:
+  version: v1.50.0
+  requirements:
+    migratedModules: "test-module-1"
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: source-1
+spec:
+  registry:
+    repo: registry1.example.com/modules
+    scheme: HTTPS
+status:
+  modules:
+    - name: other-module
+  modulesCount: 1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: test-module-1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: test-module-1
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: source-2
+spec:
+  registry:
+    repo: registry2.example.com/modules
+    scheme: HTTPS
+status:
+  modules:
+    - name: test-module-1
+  modulesCount: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deckhouse
+  namespace: d8-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  template:
+    metadata:
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - name: deckhouse
+        image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-mc-enabled-not-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-mc-enabled-not-in-source.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.49.0
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.50.0
+spec:
+  version: v1.50.0
+  requirements:
+    migratedModules: "enabled-module-not-found"
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: deckhouse
+spec:
+  registry:
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  modulesCount: 0
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: enabled-module-not-found
+spec:
+  enabled: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deckhouse
+  namespace: d8-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  template:
+    metadata:
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - name: deckhouse
+        image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-module-missing.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-module-missing.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.49.0
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.50.0
+spec:
+  version: v1.50.0
+  requirements:
+    migratedModules: "test-module-1, test-module-missing"
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: deckhouse
+spec:
+  registry:
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  modules:
+    - name: test-module-1
+  modulesCount: 1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: test-module-1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: test-module-1
+spec:
+  enabled: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deckhouse
+  namespace: d8-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  template:
+    metadata:
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - name: deckhouse
+        image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-module-pull-error.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-module-pull-error.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.49.0
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.50.0
+spec:
+  version: v1.50.0
+  requirements:
+    migratedModules: "test-module-1"
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: deckhouse
+spec:
+  registry:
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  modules:
+    - name: test-module-1
+      error: "failed to pull module"
+  modulesCount: 1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: test-module-1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: test-module-1
+spec:
+  enabled: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deckhouse
+  namespace: d8-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  template:
+    metadata:
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - name: deckhouse
+        image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-modules-available.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-modules-available.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.49.0
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.50.0
+spec:
+  version: v1.50.0
+  requirements:
+    migratedModules: "test-module-1, test-module-2"
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: deckhouse
+spec:
+  registry:
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  modules:
+    - name: test-module-1
+    - name: test-module-2
+  modulesCount: 2
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: test-module-1
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: test-module-1
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: test-module-2
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: test-module-2
+spec:
+  enabled: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deckhouse
+  namespace: d8-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  template:
+    metadata:
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - name: deckhouse
+        image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-no-migrated-modules.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-no-migrated-modules.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.49.0
+spec:
+  version: v1.49.0
+status:
+  approved: true
+  message: ""
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.50.0
+spec:
+  version: v1.50.0
+  requirements: {}
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: deckhouse
+spec:
+  registry:
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  modulesCount: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deckhouse
+  namespace: d8-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deckhouse
+  template:
+    metadata:
+      labels:
+        app: deckhouse
+    spec:
+      containers:
+      - name: deckhouse
+        image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
+++ b/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
@@ -406,7 +406,6 @@ func (c *migratedModulesCheck) GetName() string {
 
 func (c *migratedModulesCheck) Verify(ctx context.Context, dr *v1alpha1.DeckhouseRelease) error {
 	c.metricStorage.Grouped().ExpireGroupMetrics(metrics.MigratedModuleNotFoundGroup)
-
 	requirements := dr.GetRequirements()
 	migratedModules, exists := requirements[MigratedModulesRequirementFieldName]
 	if !exists || migratedModules == "" {
@@ -428,23 +427,41 @@ func (c *migratedModulesCheck) Verify(ctx context.Context, dr *v1alpha1.Deckhous
 
 	c.logger.Debug("checking migrated modules", slog.Any("modules", modules))
 
+	// Fetch ModuleConfigs and ModuleSources
+	mcList := &v1alpha1.ModuleConfigList{}
+	if err := c.k8sclient.List(ctx, mcList); err != nil {
+		return fmt.Errorf("failed to list ModuleConfigs: %w", err)
+	}
+
 	moduleSources := &v1alpha1.ModuleSourceList{}
 	if err := c.k8sclient.List(ctx, moduleSources); err != nil {
 		return fmt.Errorf("failed to list ModuleSources: %w", err)
 	}
 
 	for _, moduleName := range modules {
-		found := false
+		foundMS := false
+		foundMC := false
+		// Check if module exists in ModuleConfig and is disabled
+		for _, mc := range mcList.Items {
+			if mc.Name == moduleName && !mc.IsEnabled() {
+				c.logger.Debug("migrated module is disabled in ModuleConfig", slog.String("module", moduleName))
+				foundMC = true
+			}
+		}
+		if foundMC {
+			continue
+		}
 
+		// If module is not in ModuleConfig or is enabled, check ModuleSource
 		for _, source := range moduleSources.Items {
 			if c.isModuleAvailableInSource(moduleName, &source) {
-				found = true
+				foundMS = true
 				c.logger.Debug("migrated module found in source", slog.String("module", moduleName), slog.String("sourceName", source.Name))
 				break
 			}
 		}
 
-		if !found {
+		if !foundMS {
 			c.logger.Warn("migrated module not found in any ModuleSource registry", slog.String("module", moduleName))
 			c.setMigratedModuleNotFoundAlert(moduleName)
 
@@ -452,7 +469,7 @@ func (c *migratedModulesCheck) Verify(ctx context.Context, dr *v1alpha1.Deckhous
 		}
 	}
 
-	c.logger.Debug("all migrated modules found in registries")
+	c.logger.Debug("all migrated modules validation passed")
 
 	return nil
 }


### PR DESCRIPTION
## Description
Backport: https://github.com/deckhouse/deckhouse/pull/15145

This PR modifies the DeckhouseRelease controller to properly handle migrated modules validation. Previously, the system would ignore disabled migrated modules during release validation. Now, the system explicitly rejects DeckhouseRelease objects that specify disabled modules in their `migratedModules` requirement, as migration cannot occur for disabled modules.

The changes include:

- Updated `MigratedModulesCheck` logic in `requirements_checker.go` to skip checks if we have module, but it's disabled.

- Added comprehensive test coverage for both validation and controller packages

- Renamed test cases to follow consistent naming convention (matching YAML file names without extension)

- Fix for manual aprove in `validate_deckhouse_release.go`

Tests:
Both with `requirements: "module-module"`

Before:

Cases:
1. No `ModuleSource`. Module enable/disabled/Null

```

❯ kubectl get ms

NAME        COUNT   STATUS        SYNC   MSG
#Nothing   
...
❯ kubectl get mc
module-test      false     1         59m
❯ kubectl get deckhousereleases.deckhouse.io
NAME      PHASE     TRANSITIONTIME   MESSAGE
v1.71.0   Pending   5s               migrated module "module-test" not found in any ModuleSource registry
v1.72.0   Pending   5s               awaiting for v1.71.0 release to be deployed
v1.73.0   Pending   5s               awaiting for v1.71.0 release to be deployed
...
❯ kubectl get mc
module-test      true      1         60m
❯ kubectl get deckhousereleases.deckhouse.io
NAME      PHASE     TRANSITIONTIME   MESSAGE
v1.71.0   Pending   4s               migrated module "module-test" not found in any ModuleSource registry
v1.72.0   Pending   4s               awaiting for v1.71.0 release to be deployed
v1.73.0   Pending   3s               awaiting for v1.71.0 release to be deployed
```
2. Have ModuleSource. Module enabled/disabled/Null

```
❯ kubectl get ms
NAME               COUNT   STATUS        SYNC   MSG
dev-test   10      Active        111s   

❯ kubectl get deckhousereleases.deckhouse.io
NAME      PHASE      TRANSITIONTIME   MESSAGE
v1.71.0   Skipped    6m34s            
v1.72.0   Skipped    6m34s            
v1.73.0   Deployed
```

After:
Cases:
1. No ModuleSource. Module disabled

```
❯ kubectl get ms
NAME        COUNT   STATUS        SYNC   MSG
#Nothing

❯ kubectl get mc
module-test      false     1         67m

❯ kubectl get deckhousereleases.deckhouse.io
NAME      PHASE      TRANSITIONTIME   MESSAGE
v1.71.0   Skipped    6m34s            
v1.72.0   Skipped    6m34s            
v1.73.0   Deployed
```

2. No ModuleSource. Module Enabled/Null

```
❯ kubectl get ms
NAME        COUNT   STATUS        SYNC   MSG
#Nothing

❯ kubectl get mc
module-test      true     1         67m

❯ kubectl get deckhousereleases.deckhouse.io
NAME      PHASE     TRANSITIONTIME   MESSAGE
v1.71.0   Pending   4s               migrated module "sinelnikov-test" not found in any ModuleSource registry
v1.72.0   Pending   4s               awaiting for v1.71.0 release to be deployed
v1.73.0   Pending   4s               awaiting for v1.71.0 release to be deployed
```
3. Have ModuleSource. Module enabled/disabled/Null

```
❯ kubectl get ms
NAME               COUNT   STATUS        SYNC   MSG
dev-test   10      Active        111s   

❯ kubectl get deckhousereleases.deckhouse.io 
NAME      PHASE      TRANSITIONTIME   MESSAGE
v1.71.0   Skipped    6s               
v1.72.0   Skipped    29s              
v1.73.0   Deployed
```

**Critical Impact**: This change affects the DeckhouseRelease validation process but does not cause any restarts of critical cluster components. It only prevents invalid releases from being deployed.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
The previous implementation had a logical flaw where disabled migrated modules were silently ignored during release validation. This could lead to situations where:

1. **Inconsistent State**: A release could be approved even when it specified migration of modules that are not enabled in the cluster

2. **Silent Failures**: Users wouldn't be aware that their release requirements couldn't be met

The fix ensures that:

- **Consistent Validation**: All migrated modules must be either available in ModuleSource registries, or disabled in the cluster

This change improves the reliability and predictability of the Deckhouse upgrade process by enforcing proper validation of migrated module requirements before allowing release deployment.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

<!---
## Why do we need it in the patch release (if we do)?
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: ignore migrate module if disabled
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
