### PR TITLE
[extended-monitoring] Add 'device' label to NodeUsage alerts

### DIFF
--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/node.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/node.yaml
@@ -3,7 +3,7 @@
   - alert: NodeDiskBytesUsage
     expr: |
       (
-        max by (node, mountpoint) (
+        max by (node, mountpoint, device) (
           (node_filesystem_size_bytes - node_filesystem_avail_bytes)
           /
           node_filesystem_size_bytes
@@ -46,7 +46,7 @@
   - alert: NodeDiskBytesUsage
     expr: |
       (
-        max by (node, mountpoint) (
+        max by (node, mountpoint, device) (
           (node_filesystem_size_bytes - node_filesystem_avail_bytes)
           /
           node_filesystem_size_bytes
@@ -89,7 +89,7 @@
   - alert: NodeDiskInodesUsage
     expr: |
       (
-        max by (node, mountpoint) (
+        max by (node, mountpoint, device) (
           (node_filesystem_files - node_filesystem_files_free)
           /
           node_filesystem_files
@@ -117,7 +117,7 @@
   - alert: NodeDiskInodesUsage
     expr: |
       (
-        max by (node, mountpoint) (
+        max by (node, mountpoint, device) (
           (node_filesystem_files - node_filesystem_files_free)
           /
           node_filesystem_files


### PR DESCRIPTION
## Description

Fixed Prometheus alert expressions in the extended monitoring module to include the device label. The alert annotations were referencing {{$labels.device}} but the expressions were not preserving this label in their max by clauses, causing the device information to be unavailable in alert messages.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: fix 
summary:  Fix device label missing in NodeDiskBytesUsage and NodeDiskInodesUsage
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
