### PR TITLE
[dhctl] Enhance resource creation timeout message

### DIFF
--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -36,7 +36,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
-var ErrNotAllResourcesCreated = fmt.Errorf("Not all resources were creatated")
+var ErrNotAllResourcesCreated = fmt.Errorf("not all resources were created")
 
 // apiResourceListGetter discovery and cache APIResources list for group version kind
 type apiResourceListGetter struct {
@@ -341,6 +341,15 @@ func CreateResourcesLoop(ctx context.Context, kubeCl *client.KubernetesClient, r
 
 		select {
 		case <-endChannel:
+			if len(resources) > 0 {
+				return fmt.Errorf(
+					"creating resources timed out after %s: resources cannot become ready. "+
+						"This could be due to lack of worker nodes in the cluster. "+
+						"Add at least one worker node or remove taints from master nodes (for single-node cluster) ",
+					app.ResourcesTimeout,
+				)
+			}
+
 			return fmt.Errorf("creating resources failed after %s waiting", app.ResourcesTimeout)
 		case <-ticker.C:
 		}


### PR DESCRIPTION
## Description
Enhanced error messages when resource creation times out in dhctl. When dhctl fails to create resources within the timeout period, it now provides a clear, user-friendly message explicitly stating that this is not an installation failure and explaining the necessary next steps.

## Why do we need it, and what problem does it solve?
In reality, this timeout is expected behavior when certain resources require worker nodes that haven't been created yet. The new error message explicitly indicates that the installation is proceeding normally, and the user only needs to add a worker node or remove taints from master nodes to continue the process.


## Why do we need it in the patch release (if we do)?
Not necessarily.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature 
summary: Added clearer error messages when resource creation times out
impact: Improved user experience when dhctl cannot create resources due to missing worker nodes
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
