### PR TITLE
[chore] add svace build for modules

### DIFF
--- a/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falco/werf.inc.yaml
@@ -53,7 +53,7 @@ shell:
   - rm -rf /src/falcoctl/.git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-falcoctl-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -67,13 +67,20 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
+{{- if eq $.SVACE_ENABLED "true" }}
+  - apt-get update
+  - apt-get install -y make bash
+{{- else }}
   {{- include "alpine packages proxy" . | nindent 2 }}
   - apk add --no-cache make bash
+{{- end }}
   install:
   - cd /src
   - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
   - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
-  - RELEASE="$(cat RELEASE)" COMMIT="$(cat COMMIT)" make falcoctl
+  - export RELEASE="$(cat RELEASE)" COMMIT="$(cat COMMIT)"
+  - |
+    {{- include "image-build.build" (set $ "BuildCommand" `make falcoctl`) | indent 6 }}
   - mkdir -p /out
   - cp falcoctl /out
   - chown 64535:64535 /out/falcoctl

--- a/ee/modules/650-runtime-audit-engine/images/falcosidekick/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/falcosidekick/werf.inc.yaml
@@ -34,7 +34,7 @@ shell:
   - rm -rf /src/.git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
 final: false
 mount:
 {{ include "mount points for golang builds" . }}
@@ -48,12 +48,19 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
+{{- if eq $.SVACE_ENABLED "true" }}
+  - apt-get update
+  - apt-get install -y make bash
+{{- else }}
   {{- include "alpine packages proxy" . | nindent 2 }}
   - apk add --no-cache openssh-client make bash
+{{- end }}
   - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
   install:
   - cd /src
   - export GOPROXY=$(cat /run/secrets/GOPROXY) GOOS=linux GOARCH=amd64 CGO_ENABLED=0
-  - DIFF="" GIT_VERSION="$(cat GIT_VERSION)" GIT_HASH="$(cat GIT_HASH)" SOURCE_DATE_EPOCH="$(cat SOURCE_DATE_EPOCH)" make falcosidekick
+  - export DIFF="" GIT_VERSION="$(cat GIT_VERSION)" GIT_HASH="$(cat GIT_HASH)" SOURCE_DATE_EPOCH="$(cat SOURCE_DATE_EPOCH)" 
+  - |
+    {{- include "image-build.build" (set $ "BuildCommand" `make falcosidekick`) | indent 6 }}
   - chown -R 64535:64535 falcosidekick
   - chmod 0755 falcosidekick

--- a/ee/modules/650-runtime-audit-engine/images/k8s-metacollector/werf.inc.yaml
+++ b/ee/modules/650-runtime-audit-engine/images/k8s-metacollector/werf.inc.yaml
@@ -31,7 +31,7 @@ shell:
   - rm -rf .git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
 final: false
 mount:
 {{ include "mount points for golang builds" . }}
@@ -45,11 +45,18 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
+{{- if eq $.SVACE_ENABLED "true" }}
+  - apt-get update
+  - apt-get install -y make bash
+{{- else }}
   {{- include "alpine packages proxy" . | nindent 2 }}
   - apk add --no-cache make bash
+{{- end }}
   install:
   - cd /src
   - export GOPROXY=$(cat /run/secrets/GOPROXY) GOOS=linux GOARCH=amd64 CGO_ENABLED=0
-  - RELEASE="$(cat GIT_VERSION)" COMMIT="$(cat GIT_HASH)" make build
+  - export RELEASE="$(cat GIT_VERSION)" COMMIT="$(cat GIT_HASH)"
+  - |
+    {{- include "image-build.build" (set $ "BuildCommand" `make build`) | indent 6 }}
   - chown 64535:64535 manager
   - chmod 0755 manager


### PR DESCRIPTION
## Description
add new modules for svace analyze
- `runtimeAuditEngine/falco`
- `runtimeAuditEngine/falcosidekick`
- `runtimeAuditEngine/k8s-metacollector`

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: add new modules to svace analyze
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
