### PR TITLE
[istio] reduce RAM for regenerate multicluster JWT token

### DIFF
--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -100,6 +100,7 @@ func applyMulticlusterMergeFilter(obj *unstructured.Unstructured) (go_hook.Filte
 	var apiHost string
 	var networkName string
 	var p *eeCrd.AlliancePublicMetadata
+	var apiJWT string
 
 	if multicluster.Status.MetadataCache.Private != nil {
 		if multicluster.Status.MetadataCache.Private.IngressGateways != nil {
@@ -107,6 +108,17 @@ func applyMulticlusterMergeFilter(obj *unstructured.Unstructured) (go_hook.Filte
 		}
 		apiHost = multicluster.Status.MetadataCache.Private.APIHost
 		networkName = multicluster.Status.MetadataCache.Private.NetworkName
+
+		// Check if we have an existing valid JWT
+		if multicluster.Status.MetadataCache.Private.APIJWT != "" {
+			// Validate the existing JWT
+			isValid, _, err := jwt.IsJWTValid(multicluster.Status.MetadataCache.Private.APIJWT)
+			if err == nil && isValid {
+				// Use existing JWT if it's still valid
+				apiJWT = multicluster.Status.MetadataCache.Private.APIJWT
+			}
+			// If JWT is invalid or expired, apiJWT will remain empty and will be generated later
+		}
 	}
 	if multicluster.Status.MetadataCache.Public != nil {
 		p = multicluster.Status.MetadataCache.Public
@@ -120,6 +132,7 @@ func applyMulticlusterMergeFilter(obj *unstructured.Unstructured) (go_hook.Filte
 		EnableIngressGateway: multicluster.Spec.EnableIngressGateway,
 		APIHost:              apiHost,
 		NetworkName:          networkName,
+		APIJWT:               apiJWT, // This will be empty if no valid JWT exists
 		IngressGateways:      igs,
 		Public:               p,
 	}, nil
@@ -223,12 +236,21 @@ multiclustersLoop:
 			"sub":   input.Values.Get("global.discovery.clusterUUID").String(),
 			"scope": "api",
 		}
-		// until the bug won't be solved https://github.com/istio/istio/issues/37925
-		// multiclusterInfo.APIJWT, err = jwt.GenerateJWT(privKey, claims, time.Hour*25)
-		multiclusterInfo.APIJWT, err = jwt.GenerateJWT(privKey, claims, time.Hour*24*366)
-		if err != nil {
-			input.Logger.Warn("can't generate auth token for remote api of IstioMulticluster", slog.String("name", multiclusterInfo.Name), log.Err(err))
-			continue multiclustersLoop
+
+		// Check if we already have a valid JWT from the filter function
+		if multiclusterInfo.APIJWT != "" {
+			input.Logger.Info("using existing valid JWT from CRD status", slog.String("name", multiclusterInfo.Name))
+		} else {
+			// Generate new JWT if none exists or if the existing one is invalid/expired
+			// until the bug won't be solved https://github.com/istio/istio/issues/37925
+			// multiclusterInfo.APIJWT, err = jwt.GenerateJWT(privKey, claims, time.Hour*25)
+			multiclusterInfo.APIJWT, err = jwt.GenerateJWT(privKey, claims, time.Hour*24*366)
+			if err != nil {
+				input.Logger.Warn("can't generate auth token for remote api of IstioMulticluster", slog.String("name", multiclusterInfo.Name), log.Err(err))
+				continue multiclustersLoop
+			}
+
+			input.Logger.Info("generated new JWT", slog.String("name", multiclusterInfo.Name))
 		}
 
 		multiclusterInfo.Public = nil

--- a/ee/modules/110-istio/hooks/ee/lib/crd/istiomulticluster.go
+++ b/ee/modules/110-istio/hooks/ee/lib/crd/istiomulticluster.go
@@ -42,6 +42,8 @@ type MulticlusterPrivateMetadata struct {
 	IngressGateways *[]MulticlusterIngressGateways `json:"ingressGateways"`
 	APIHost         string                         `json:"apiHost,omitempty"`
 	NetworkName     string                         `json:"networkName,omitempty"`
+	APIJWT          string                         `json:"apiJWT,omitempty"`
+	JWTExpiryTime   string                         `json:"jwtExpiryTime,omitempty"`
 }
 
 type MulticlusterIngressGateways struct {

--- a/ee/modules/110-istio/hooks/ee/multicluster_discovery.go
+++ b/ee/modules/110-istio/hooks/ee/multicluster_discovery.go
@@ -169,6 +169,8 @@ func multiclusterDiscovery(input *go_hook.HookInput, dc dependency.Container) er
 
 		// TODO Make independent public and private fetch?
 		privKey := []byte(input.Values.Get("istio.internal.remoteAuthnKeypair.priv").String())
+
+		// Generate JWT for private metadata endpoint (short-lived)
 		claims := map[string]string{
 			"iss":   "d8-istio",
 			"aud":   publicMetadata.ClusterUUID,
@@ -181,6 +183,26 @@ func multiclusterDiscovery(input *go_hook.HookInput, dc dependency.Container) er
 			multiclusterInfo.SetMetricMetadataEndpointError(input.MetricsCollector, multiclusterInfo.PrivateMetadataEndpoint, 1)
 			continue
 		}
+
+		// Generate long-lived JWT for API access (stored in CRD status)
+		apiClaims := map[string]string{
+			"iss":   "d8-istio",
+			"aud":   publicMetadata.ClusterUUID,
+			"sub":   input.Values.Get("global.discovery.clusterUUID").String(),
+			"scope": "api",
+		}
+		apiJWT, err := jwt.GenerateJWT(privKey, apiClaims, time.Hour*24*366) // 1 year
+		if err != nil {
+			input.Logger.Warn("can't generate API JWT for IstioMulticluster", slog.String("name", multiclusterInfo.Name), log.Err(err))
+			continue
+		}
+
+		// Add JWT to private metadata
+		privateMetadata.APIJWT = apiJWT
+		privateMetadata.JWTExpiryTime = time.Now().Add(time.Hour * 24 * 366).Format(time.RFC3339)
+
+		input.Logger.Info("generated API JWT for multicluster", slog.String("name", multiclusterInfo.Name), slog.String("expires_at", privateMetadata.JWTExpiryTime))
+
 		bodyBytes, statusCode, err = lib.HTTPGet(dc.GetHTTPClient(httpOption...), multiclusterInfo.PrivateMetadataEndpoint, bearerToken)
 		if err != nil {
 			input.Logger.Warn("cannot fetch private metadata endpoint for IstioMulticluster", slog.String("endpoint", multiclusterInfo.PrivateMetadataEndpoint), slog.String("name", multiclusterInfo.Name), log.Err(err))

--- a/go_lib/jwt/gen.go
+++ b/go_lib/jwt/gen.go
@@ -25,6 +25,50 @@ import (
 
 type payloadMap map[string]interface{}
 
+// JWTClaims represents the standard JWT claims
+type JWTClaims struct {
+	Iss   string `json:"iss"`
+	Aud   string `json:"aud"`
+	Sub   string `json:"sub"`
+	Scope string `json:"scope"`
+	Nbf   int64  `json:"nbf"`
+	Exp   int64  `json:"exp"`
+}
+
+// IsJWTValid checks if a JWT token is valid and not expired
+func IsJWTValid(tokenString string) (bool, *JWTClaims, error) {
+	if tokenString == "" {
+		return false, nil, nil
+	}
+
+	// Parse the JWT token
+	token, err := jose.ParseSigned(tokenString)
+	if err != nil {
+		return false, nil, err
+	}
+
+	// Extract the payload (we don't need to verify signature for expiration check)
+	payload := token.UnsafePayloadWithoutVerification()
+
+	var claims JWTClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return false, nil, err
+	}
+
+	// Check if token is expired
+	now := time.Now().UTC().Unix()
+	if claims.Exp <= now {
+		return false, &claims, nil
+	}
+
+	// Check if token is not yet valid (nbf)
+	if claims.Nbf > now {
+		return false, &claims, nil
+	}
+
+	return true, &claims, nil
+}
+
 func GenerateJWT(privKeyPEMBytes []byte, claims map[string]string, ttl time.Duration) (string, error) {
 	keyBlock, _ := pem.Decode(privKeyPEMBytes)
 	key, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: fix
summary: Reduce RAM for regenerate multicluster JWT token
impact: With frequent regeneration of the JWT token, RAM consumption increased
impact_level: default
```