### PR TITLE
[dhctl] Master IPs preserve state

### DIFF
--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -69,7 +69,7 @@ func (b *ClusterBootstrapper) initSSHClient() error {
 	sshClient := wrapper.Client()
 
 	if len(sshClient.Session().AvailableHosts()) == 0 {
-		mastersIPs, err := GetMasterHostsIPs()
+		mastersIPs, err := state.GetMasterHostsIPs(cache.Global())
 		if err != nil {
 			log.ErrorF("Can not load available ssh hosts: %v\n", err)
 			return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -452,7 +452,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 			deckhouseInstallConfig.NodesInfrastructureState[masterNodeName] = masterOutputs.InfrastructureState
 
 			masterAddressesForSSH[masterNodeName] = masterOutputs.MasterIPForSSH
-			SaveMasterHostsToCache(masterAddressesForSSH)
+			state.SaveMasterHostsToCache(stateCache, masterAddressesForSSH)
 			return nil
 		})
 		if err != nil {
@@ -475,7 +475,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 				SaveBastionHostToCache(sshClient.Session().BastionHost)
 			}
 
-			SaveMasterHostsToCache(map[string]string{
+			state.SaveMasterHostsToCache(stateCache, map[string]string{
 				"first-master": sshClient.Session().Host(),
 			})
 		}
@@ -623,7 +623,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 	if !b.DisableBootstrapClearCache {
 		_ = log.Process("bootstrap", "Clear cache", func() error {
 			cache.Global().CleanWithExceptions(
-				MasterHostsCacheKey,
+				state.MasterHostsCacheKey,
 				ManifestCreatedInClusterCacheKey,
 				BastionHostCacheKey,
 				PostBootstrapResultCacheKey,
@@ -698,7 +698,7 @@ func generateClusterUUID(stateCache state.Cache) (string, error) {
 }
 
 func bootstrapAdditionalNodesForCloudCluster(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, masterAddressesForSSH map[string]string, infrastructureContext *infrastructure.Context) error {
-	if err := BootstrapAdditionalMasterNodes(ctx, kubeCl, metaConfig, masterAddressesForSSH, infrastructureContext); err != nil {
+	if err := BootstrapAdditionalMasterNodes(ctx, kubeCl, metaConfig, masterAddressesForSSH, infrastructureContext, cache.Global()); err != nil {
 		return err
 	}
 

--- a/dhctl/pkg/server/pkg/helper/ssh_client.go
+++ b/dhctl/pkg/server/pkg/helper/ssh_client.go
@@ -22,9 +22,10 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/util"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/util/callback"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
@@ -60,7 +61,7 @@ func CreateSSHClient(config *config.ConnectionConfig) (node.SSHClient, func() er
 			sshHosts = append(sshHosts, session.Host{Host: h.Host, Name: h.Host})
 		}
 	} else {
-		mastersIPs, err := bootstrap.GetMasterHostsIPs()
+		mastersIPs, err := state.GetMasterHostsIPs(cache.Global())
 		if err != nil {
 			return nil, cleanuper.AsFunc(), err
 		}

--- a/dhctl/pkg/state/hosts.go
+++ b/dhctl/pkg/state/hosts.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"sort"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
+)
+
+const (
+	MasterHostsCacheKey = "cluster-hosts"
+)
+
+func SaveMasterHostsToCache(cache Cache, hosts map[string]string) {
+	if err := cache.SaveStruct(MasterHostsCacheKey, hosts); err != nil {
+		log.WarnF("Cannot save ssh hosts %v\n", err)
+	}
+}
+
+func GetMasterHostsIPs(cache Cache) ([]session.Host, error) {
+	var hosts map[string]string
+	err := cache.LoadStruct(MasterHostsCacheKey, &hosts)
+	if err != nil {
+		return nil, err
+	}
+	mastersIPs := make([]session.Host, 0, len(hosts))
+	for name, ip := range hosts {
+		mastersIPs = append(mastersIPs, session.Host{Host: ip, Name: name})
+	}
+
+	sort.Sort(session.SortByName(mastersIPs))
+
+	return mastersIPs, nil
+}


### PR DESCRIPTION
## Description

- Refactor SaveMasterHostsToCache
- Update state when master IPs are added/deleted
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

To make state more predictable and avoid any further issues
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

You don't
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [+] The code is covered by unit tests.
- [+] e2e tests passed.
- [+] Documentation updated according to the changes.
- [+] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: save new master IPs and remove them when they are deleted
impact_level: low
```
