### PR TITLE
[node-manager] Upgrade CAPI manager. Increase and add leader elect timeouts

### DIFF
--- a/modules/040-node-manager/images/capi-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/capi-controller-manager/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "1.10.4" }}
+{{- $version := "1.10.6" }}
 ---
 image: {{ .ModuleName }}/capi-controller-manager
 fromImage: common/distroless

--- a/modules/040-node-manager/images/caps-controller-manager/src/cmd/main.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/cmd/main.go
@@ -68,6 +68,9 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var syncPeriod time.Duration
+	var leaderElectionLeaseDuration time.Duration
+	var leaderElectionRenewDeadline time.Duration
+	var leaderElectionRetryPeriod time.Duration
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -75,6 +78,15 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Minute, "The minimum interval at which watched resources are reconciled (e.g. 15m).")
+	flag.DurationVar(&leaderElectionLeaseDuration, "leader-elect-lease-duration", 15*time.Second,
+		"Interval at which non-leader candidates will wait to force acquire leadership (duration string)")
+
+	flag.DurationVar(&leaderElectionRenewDeadline, "leader-elect-renew-deadline", 10*time.Second,
+		"Duration that the leading controller manager will retry refreshing leadership before giving up (duration string)")
+
+	flag.DurationVar(&leaderElectionRetryPeriod, "leader-elect-retry-period", 2*time.Second,
+		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
+
 	flag.Parse()
 
 	if err := v1.ValidateAndApply(logOptions, nil); err != nil {
@@ -90,6 +102,9 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "controller-leader-election-caps",
+		LeaseDuration:          &leaderElectionLeaseDuration,
+		RenewDeadline:          &leaderElectionRenewDeadline,
+		RetryPeriod:            &leaderElectionRetryPeriod,
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
@@ -83,6 +83,10 @@ spec:
         - /capi-controller-manager
         args:
         - --leader-elect
+        # Todo remove after rewrite caps
+        - --leader-elect-lease-duration=3m
+        - --leader-elect-renew-deadline=2m50s
+        - --leader-elect-retry-period=5s
         - --diagnostics-address=127.0.0.1:4211
         - --insecure-diagnostics
         - --feature-gates=MachinePool=true,ClusterResourceSet=false,ClusterTopology=false,RuntimeSDK=false

--- a/modules/040-node-manager/templates/caps-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/caps-controller-manager/deployment.yaml
@@ -88,6 +88,10 @@ spec:
             readOnly: true
         args:
           - "--leader-elect"
+          # Todo remove after rewrite caps
+          - "--leader-elect-lease-duration=3m"
+          - "--leader-elect-renew-deadline=2m50s"
+          - "--leader-elect-retry-period=5s"
           - "--sync-period=1m"
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Description
Upgrade patch version of CAPI manager due to logic fixes and fix cve's.

Increase leader elect leases timeout in CAPI manager.

Add leader elect leases timeout in CAPS manager.

## Why do we need it, and what problem does it solve?
We have some incorrect logical solution when caps crashes due bootstrap node.
We will fix it in 1.73 version.
Probably from version 1.71 (where we upgrade etcd to 3.6) etcd increase restart timeout and we have multiple restarts of CAPI and CAPS controllers when renew lease due to bootstrap cluster and we do not continue of bootstrap static nodes.
As temporary solution we add lease duration timeouts to CAPS and set and increase lease duration for CAPI.

<img width="2218" height="652" alt="image" src="https://github.com/user-attachments/assets/d93317ee-1a52-41be-8a30-a7546188727e" />


## Why do we need it in the patch release (if we do)?

Probably from version 1.71 (where we upgrade etcd to 3.6) etcd increase restart timeout and we have multiple restarts of CAPI and CAPS controllers when renew lease due to bootstrap cluster and we do not continue of bootstrap static nodes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Add and increase lease duration timeouts to CAPS.
impact_level: default
---
section: node-manager
type: fix
summary: Upgrade CAPI version and increase lease duration timeouts.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
