### PR TITLE
[docs] Replace kubectl to d8 k in alerts

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -31,13 +31,13 @@ alerts:
           1. Retrieve the certificate name from the Secret:
 
              ```bash
-             cert=$(kubectl get secret -n {{$labels.secret_namespace}} {{$labels.secret_name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
+             cert=$(d8 k get secret -n {{$labels.secret_namespace}} {{$labels.secret_name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
              ```
 
           2. Check the certificate status and investigate why it hasn't been updated:
 
              ```bash
-             kubectl describe cert -m {{$labels.secret_namespace}} "$cert"
+             d8 k describe cert -m {{$labels.secret_namespace}} "$cert"
              ```
       summary: |
         Certificate has expired.
@@ -58,13 +58,13 @@ alerts:
           1. Retrieve the certificate name from the Secret:
 
              ```bash
-             cert=$(kubectl get secret -n {{$labels.secret_namespace}} {{$labels.secret_name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
+             cert=$(d8 k get secret -n {{$labels.secret_namespace}} {{$labels.secret_name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
              ```
 
           2. Check the certificate status and investigate why it hasn't been updated:
 
              ```bash
-             kubectl describe cert -n {{$labels.secret_namespace}} "$cert"
+             d8 k describe cert -n {{$labels.secret_namespace}} "$cert"
              ```
       summary: |
         Certificate is expiring soon.
@@ -81,7 +81,7 @@ alerts:
         To check the certificate details, run the following command:
 
         ```shell
-        kubectl -n {{$labels.exported_namespace}} describe certificate {{$labels.name}}
+        d8 k -n {{$labels.exported_namespace}} describe certificate {{$labels.name}}
         ```
       summary: |
         Certificate {{$labels.exported_namespace}}/{{$labels.name}} is not provided.
@@ -98,7 +98,7 @@ alerts:
         To check the certificate details, run the following command:
 
         ```bash
-        kubectl -n <NAMESPACE> describe certificate <CERTIFICATE-NAME>
+        d8 k -n <NAMESPACE> describe certificate <CERTIFICATE-NAME>
         ```
       summary: |
         Certificate will expire soon.
@@ -115,7 +115,7 @@ alerts:
         This can affect certificate ordering and prolongation in the future. For details, check the cert-manager logs using the following command:
 
         ```bash
-        kubectl -n d8-cert-manager logs -l app=cert-manager -c cert-manager
+        d8 k -n d8-cert-manager logs -l app=cert-manager -c cert-manager
         ```
       summary: |
         Cert-manager couldn't order a certificate.
@@ -130,7 +130,7 @@ alerts:
         For details, refer to the logs of the agent:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}
+        d8 k -n {{ $labels.namespace }} logs {{ $labels.pod }}
         ```
       summary: |
         Over 50% of all known endpoints aren't ready in agent {{ $labels.namespace }}/{{ $labels.pod }}.
@@ -160,13 +160,13 @@ alerts:
         1. Check the logs of the agent:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}
+           d8 k -n {{ $labels.namespace }} logs {{ $labels.pod }}
            ```
 
         1. Verify the agent's health status:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} exec -ti {{ $labels.pod }} cilium-health status
+           d8 k -n {{ $labels.namespace }} exec -ti {{ $labels.pod }} cilium-health status
            ```
 
         1. Compare the metrics with those of a neighboring agent.
@@ -185,7 +185,7 @@ alerts:
         For details, refer to the logs of the agent:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}
+        d8 k -n {{ $labels.namespace }} logs {{ $labels.pod }}
         ```
       summary: |
         Agent {{ $labels.namespace }}/{{ $labels.pod }} fails to import policies.
@@ -200,7 +200,7 @@ alerts:
         For details, refer to the logs of the agent:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}
+        d8 k -n {{ $labels.namespace }} logs {{ $labels.pod }}
         ```
       summary: |
         Agent {{ $labels.namespace }}/{{ $labels.pod }} can't reach some of the node health endpoints.
@@ -326,19 +326,19 @@ alerts:
         1. Print the job details:
 
            ```bash
-           kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}
+           d8 k -n {{$labels.namespace}} describe job {{$labels.job_name}}
            ```
 
         1. Check the job status:
 
            ```bash
-           kubectl -n {{$labels.namespace}} get job {{$labels.job_name}}
+           d8 k -n {{$labels.namespace}} get job {{$labels.job_name}}
            ```
 
         1. Check the status of pods created by the job:
 
            ```bash
-           kubectl -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}
+           d8 k -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}
            ```
       summary: |
         Job {{$labels.namespace}}/{{$labels.job_name}} failed in CronJob {{$labels.namespace}}/{{$labels.owner_name}}.
@@ -374,19 +374,19 @@ alerts:
         1. Print the job details:
 
            ```bash
-           kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}
+           d8 k -n {{$labels.namespace}} describe job {{$labels.job_name}}
            ```
 
         1. Check the job status:
 
            ```bash
-           kubectl -n {{$labels.namespace}} get job {{$labels.job_name}}
+           d8 k -n {{$labels.namespace}} get job {{$labels.job_name}}
            ```
 
         1. Check the status of pods created by the job:
 
            ```bash
-           kubectl -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}
+           d8 k -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}
            ```
       summary: |
         Pods set in CronJob {{$labels.namespace}}/{{$labels.job_name}} haven't been created.
@@ -458,7 +458,7 @@ alerts:
         To list all PodMonitors in the Deckhouse namespace, run the following command:
 
         ```bash
-        kubectl get podmonitors --all-namespaces -l heritage!=deckhouse
+        d8 k get podmonitors --all-namespaces -l heritage!=deckhouse
         ```
 
         For more information on metric collection, refer to the [Prometheus module FAQ](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html).
@@ -479,7 +479,7 @@ alerts:
         To list all ServiceMonitors in the Deckhouse namespace, run the following command:
 
         ```bash
-        kubectl get servicemonitors --all-namespaces -l heritage!=deckhouse
+        d8 k get servicemonitors --all-namespaces -l heritage!=deckhouse
         ```
 
         For more information on metric collection, refer to the [Prometheus module FAQ](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html).
@@ -500,13 +500,13 @@ alerts:
         1. Verify that the module's components are up and running:
 
            ```bash
-           kubectl get pods -n d8-admission-policy-engine
+           d8 k get pods -n d8-admission-policy-engine
            ```
 
         2. Check logs for issues, such as missing constraint templates or incomplete CRD creation:
 
            ```bash
-           kubectl logs -n d8-system -lapp=deckhouse --tail=1000 | grep admission-policy-engine
+           d8 k logs -n d8-system -lapp=deckhouse --tail=1000 | grep admission-policy-engine
            ```
       summary: |
         Admission-policy-engine module hasn't been bootstrapped for 10 minutes.
@@ -523,7 +523,7 @@ alerts:
         To resolve the issue, check if the `bashible-apiserver` Pods are up-to-date and running:
 
         ```shell
-        kubectl -n d8-cloud-instance-manager get pods -l app=bashible-apiserver
+        d8 k -n d8-cloud-instance-manager get pods -l app=bashible-apiserver
         ```
       summary: |
         Bashible-apiserver has been locked for too long.
@@ -534,7 +534,7 @@ alerts:
       moduleUrl: 340-extended-monitoring
       module: extended-monitoring
       edition: ce
-      description: "Steps to resolve:\n\n1. Retrieve the deployment details:\n   \n   ```bash\n   kubectl -n d8-monitoring describe deploy x509-certificate-exporter\n   ```\n\n2. Check the pod status and investigate why it's not ready:\n\n   ```bash\n   kubectl -n d8-monitoring describe pod -l app=x509-certificate-exporter\n   ```\n"
+      description: "Steps to resolve:\n\n1. Retrieve the deployment details:\n   \n   ```bash\n   d8 k -n d8-monitoring describe deploy x509-certificate-exporter\n   ```\n\n2. Check the pod status and investigate why it's not ready:\n\n   ```bash\n   d8 k -n d8-monitoring describe pod -l app=x509-certificate-exporter\n   ```\n"
       summary: |
         The x509-certificate-exporter pod isn't ready.
       severity: "8"
@@ -544,7 +544,7 @@ alerts:
       moduleUrl: 340-extended-monitoring
       module: extended-monitoring
       edition: ce
-      description: "Steps to resolve:\n\n1. Retrieve the deployment details:\n   \n   ```bash\n   kubectl -n d8-monitoring describe deploy x509-certificate-exporter\n   ```\n\n2. Check the pod status and investigate why it's not running:\n\n   ```bash\n   kubectl -n d8-monitoring describe pod -l app=x509-certificate-exporter\n   ```\n"
+      description: "Steps to resolve:\n\n1. Retrieve the deployment details:\n   \n   ```bash\n   d8 k -n d8-monitoring describe deploy x509-certificate-exporter\n   ```\n\n2. Check the pod status and investigate why it's not running:\n\n   ```bash\n   d8 k -n d8-monitoring describe pod -l app=x509-certificate-exporter\n   ```\n"
       summary: |
         The x509-certificate-exporter pod isn't running.
       severity: "8"
@@ -560,13 +560,13 @@ alerts:
         - Check the pod status:
 
           ```bash
-          kubectl -n d8-monitoring get pod -l app=x509-certificate-exporter
+          d8 k -n d8-monitoring get pod -l app=x509-certificate-exporter
           ```
 
         - Check the pod logs:
 
           ```bash
-          kubectl -n d8-monitoring logs -l app=x509-certificate-exporter -c x509-certificate-exporter
+          d8 k -n d8-monitoring logs -l app=x509-certificate-exporter -c x509-certificate-exporter
           ```
       summary: |
         There is no x509-certificate-exporter target in Prometheus.
@@ -583,13 +583,13 @@ alerts:
         - Check the pod status:
 
           ```bash
-          kubectl -n d8-monitoring get pod -l app=x509-certificate-exporter
+          d8 k -n d8-monitoring get pod -l app=x509-certificate-exporter
           ```
 
         - Check the pod logs:
 
           ```bash
-          kubectl -n d8-monitoring logs -l app=x509-certificate-exporter -c x509-certificate-exporter
+          d8 k -n d8-monitoring logs -l app=x509-certificate-exporter -c x509-certificate-exporter
           ```
       summary: |
         Prometheus can't scrape x509-certificate-exporter metrics.
@@ -757,7 +757,7 @@ alerts:
         1. Find the desired settings in the ConfigMap `d8-system/desired-cni-moduleconfig` by running the following command:
 
            ```bash
-           kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml
+           d8 k -n d8-system get configmap desired-cni-moduleconfig -o yaml
            ```
 
         1. Update the conflicting settings in the CNI `{{ $labels.cni }}` ModuleConfig to match the desired configuration.
@@ -776,7 +776,7 @@ alerts:
         To resolve this issue, check the status of the `kube-system/d8-control-plane-manager` DaemonSet and its pods by running the following command:
 
         ```bash
-        kubectl -n kube-system get daemonset,pod --selector=app=d8-control-plane-manager
+        d8 k -n kube-system get daemonset,pod --selector=app=d8-control-plane-manager
         ```
       summary: |
         Controller pod isn't running on node {{ $labels.node }}.
@@ -795,7 +795,7 @@ alerts:
         To list all PrometheusRules in the Deckhouse namespace, run the following command:
 
         ```bash
-        kubectl get prometheusrules --all-namespaces -l heritage!=deckhouse
+        d8 k get prometheusrules --all-namespaces -l heritage!=deckhouse
         ```
 
         For details on adding alerts and recording rules, refer to the [Prometheus module FAQ](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html#how-do-i-add-alerts-andor-recording-rules).
@@ -808,7 +808,7 @@ alerts:
       moduleUrl: 340-monitoring-deckhouse
       module: monitoring-deckhouse
       edition: ce
-      description: "Deckhouse configuration contains errors.\n\nSteps to troubleshoot:\n\n1. Check Deckhouse logs by running the following command:\n\n   ```bash\n   kubectl -n d8-system logs -f -l app=deckhouse\n   ```\n\n1. Edit the Deckhouse global configuration:\n\n   ```bash\n   kubectl edit mc global\n   ```\n   \n   Or edit configuration of a specific module:\n\n   ```bash\n   kubectl edit mc <MODULE_NAME>\n   ```\n"
+      description: "Deckhouse configuration contains errors.\n\nSteps to troubleshoot:\n\n1. Check Deckhouse logs by running the following command:\n\n   ```bash\n   d8 k -n d8-system logs -f -l app=deckhouse\n   ```\n\n1. Edit the Deckhouse global configuration:\n\n   ```bash\n   d8 k edit mc global\n   ```\n   \n   Or edit configuration of a specific module:\n\n   ```bash\n   d8 k edit mc <MODULE_NAME>\n   ```\n"
       summary: |
         Deckhouse configuration is invalid.
       severity: "5"
@@ -822,7 +822,7 @@ alerts:
         To investigate the issue, check the logs by running the following command:
 
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
       summary: |
         Deckhouse is unable to delete the {{ $labels.module }} module.
@@ -837,7 +837,7 @@ alerts:
         To investigate the issue, check the logs by running the following command:
 
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
       summary: |
         Deckhouse is unable to discover modules.
@@ -852,7 +852,7 @@ alerts:
         To investigate the issue, check the logs by running the following command:
 
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
       summary: |
         Deckhouse is unable to run the {{ $labels.hook }} global hook.
@@ -867,7 +867,7 @@ alerts:
         To investigate the issue, check the logs by running the following command:
 
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
       summary: |
         Deckhouse is unable to start the {{ $labels.module }} module.
@@ -882,7 +882,7 @@ alerts:
         To investigate the issue, check the logs by running the following command:
 
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
       summary: |
         Deckhouse is unable to run the {{ $labels.module }}/{{ $labels.hook }} module hook.
@@ -922,7 +922,7 @@ alerts:
         To investigate the issue, check the logs by running the following command:
 
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
       summary: |
         The {{ $labels.hook }} Deckhouse global hook is crashing too frequently.
@@ -966,7 +966,7 @@ alerts:
         1. Check the current release channel used in the cluster:
 
            ```bash
-           kubectl -n d8-system  get deploy deckhouse -o json | jq '.spec.template.spec.containers[0].image' -r
+           d8 k -n d8-system  get deploy deckhouse -o json | jq '.spec.template.spec.containers[0].image' -r
            ```
 
         1. Subscribe to one of the regular release channels by adjusting the [`deckhouse` module configuration](https://deckhouse.io/products/kubernetes-platform/documentation/latest/modules/deckhouse/configuration.html#parameters-releasechannel).
@@ -985,7 +985,7 @@ alerts:
         To investigate the issue, check the logs by running the following command:
 
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
       summary: |
         The {{ $labels.module }}/{{ $labels.hook }} Deckhouse hook is crashing too frequently.
@@ -1002,7 +1002,7 @@ alerts:
         To resolve this issue, remove the label from the module release using the following command:
 
         ```bash
-        kubectl label mr {{ $labels.module_release }} modules.deckhouse.io/update-policy-
+        d8 k label mr {{ $labels.module_release }} modules.deckhouse.io/update-policy-
         ```
 
         A new suitable policy will be detected automatically.
@@ -1015,7 +1015,7 @@ alerts:
       moduleUrl: 340-monitoring-deckhouse
       module: monitoring-deckhouse
       edition: ce
-      description: "Initial config for module {{ $labels.module }} is not valid. \n\nYou can get more details via\n \n```bash\nkubectl get mr -l module={{ $labels.module }}\n```\n\nProvided error: {{ $labels.error }}\n"
+      description: "Initial config for module {{ $labels.module }} is not valid. \n\nYou can get more details via\n\n```bash\nd8 k get mr -l module={{ $labels.module }}\n```\n\nProvided error: {{ $labels.error }}\n"
       summary: |
         Module configuration failed for module {{ $labels.module }}.
       severity: "5"
@@ -1053,7 +1053,7 @@ alerts:
         To investigate the issue, check the logs by running the following command:
 
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
       summary: |
         Excessive Deckhouse restarts detected.
@@ -1070,7 +1070,7 @@ alerts:
         To investigate the issue, check the logs by running the following command:
 
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
       summary: |
         The {{ $labels.queue }} Deckhouse queue is stuck with {{ $value }} pending task(s).
@@ -1101,7 +1101,7 @@ alerts:
       moduleUrl: 340-monitoring-deckhouse
       module: monitoring-deckhouse
       edition: ce
-      description: "Deckhouse has detected an error in the client-go informer, possibly due to connection issues with the API server.\n\nSteps to investigate:\n\n1. Check Deckhouse logs for more information by running:\n\n   ```bash\n   kubectl -n d8-system logs deploy/deckhouse | grep error | grep -i watch\n   ```\n\n1. This alert attempts to detect a correlation between the faulty snapshot invalidation and API server connection errors, specifically for the `handle-node-template` hook in the `node-manager` module.\n   \n   To compare the snapshot with the actual node objects for this hook, run the following command:\n\n   ```bash\n   diff -u <(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'|sort) <(kubectl -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module snapshots node-manager -o json | jq '.\"040-node-manager/hooks/handle_node_templates.go\"' | jq '.nodes.snapshot[] | .filterResult.Name' -r | sort)\n   ```\n"
+      description: "Deckhouse has detected an error in the client-go informer, possibly due to connection issues with the API server.\n\nSteps to investigate:\n\n1. Check Deckhouse logs for more information by running:\n\n   ```bash\n   d8 k -n d8-system logs deploy/deckhouse | grep error | grep -i watch\n   ```\n\n1. This alert attempts to detect a correlation between the faulty snapshot invalidation and API server connection errors, specifically for the `handle-node-template` hook in the `node-manager` module.\n   \n   To compare the snapshot with the actual node objects for this hook, run the following command:\n\n   ```bash\n   diff -u <(d8 k get nodes -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'|sort) <(d8 k -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module snapshots node-manager -o json | jq '.\"040-node-manager/hooks/handle_node_templates.go\"' | jq '.nodes.snapshot[] | .filterResult.Name' -r | sort)\n   ```\n"
       summary: |
         Possible API server connection error in the client-go informer.
       severity: "5"
@@ -1127,7 +1127,7 @@ alerts:
         To resolve this issue, defragment the etcd database by running the following command:
 
         ```bash
-        kubectl -n kube-system exec -ti etcd-{{ $labels.node }} -- /usr/bin/etcdctl \
+        d8 k -n kube-system exec -ti etcd-{{ $labels.node }} -- /usr/bin/etcdctl \
           --cacert /etc/kubernetes/pki/etcd/ca.crt \
           --cert /etc/kubernetes/pki/etcd/ca.crt \
           --key /etc/kubernetes/pki/etcd/ca.key \
@@ -1280,7 +1280,7 @@ alerts:
         To resolve this issue and stop the alert, run the following command:
 
         ```bash
-        kubectl annotate moduleconfig {{ $labels.module }} modules.deckhouse.io/allow-disabling-
+        d8 k annotate moduleconfig {{ $labels.module }} modules.deckhouse.io/allow-disabling-
         ```
       summary: |
         The ModuleConfig annotation for allowing module disabling is set.
@@ -1297,7 +1297,7 @@ alerts:
         To investigate the issue, review the exporter's logs:
 
         ```bash
-        kubectl -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter
+        d8 k -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter
         ```
       summary: |
         The image-availability-exporter has crashed.
@@ -1316,13 +1316,13 @@ alerts:
         1. Retrieve the deployment details:
 
            ```bash
-           kubectl -n d8-monitoring describe deploy image-availability-exporter
+           d8 k -n d8-monitoring describe deploy image-availability-exporter
            ```
 
         2. Check the pod status and investigate why it isn't `Ready`:
 
            ```bash
-           kubectl -n d8-monitoring describe pod -l app=image-availability-exporter
+           d8 k -n d8-monitoring describe pod -l app=image-availability-exporter
            ```
       summary: |
         The image-availability-exporter pod is not ready.
@@ -1341,13 +1341,13 @@ alerts:
         1. Retrieve the deployment details:
 
            ```bash
-           kubectl -n d8-monitoring describe deploy image-availability-exporter
+           d8 k -n d8-monitoring describe deploy image-availability-exporter
            ```
 
         2. Check the pod status and investigate why it isn't running:
 
            ```bash
-           kubectl -n d8-monitoring describe pod -l app=image-availability-exporter
+           d8 k -n d8-monitoring describe pod -l app=image-availability-exporter
            ```
       summary: |
         The image-availability-exporter pod is not running.
@@ -1366,13 +1366,13 @@ alerts:
         1. Check the pod status:
 
            ```bash
-           kubectl -n d8-monitoring get pod -l app=image-availability-exporter
+           d8 k -n d8-monitoring get pod -l app=image-availability-exporter
            ```
 
         1. Check the pod logs:
 
            ```bash
-           kubectl -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter
+           d8 k -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter
            ```
       summary: |
         The image-availability-exporter target is missing from Prometheus.
@@ -1391,13 +1391,13 @@ alerts:
         1. Check the pod status:
 
            ```bash
-           kubectl -n d8-monitoring get pod -l app=image-availability-exporter
+           d8 k -n d8-monitoring get pod -l app=image-availability-exporter
            ```
 
         1. Check the pod logs:
 
            ```bash
-           kubectl -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter
+           d8 k -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter
            ```
       summary: |
         Prometheus can't scrape metrics of image-availability-exporter.
@@ -1417,10 +1417,10 @@ alerts:
         ### Namespace-wide configuration
         # `istio.io/rev=vXYZ`: Use a specific revision.
         # `istio-injection=enabled`: Use the global revision.
-        kubectl get ns {{$labels.namespace}} --show-labels
+        d8 k get ns {{$labels.namespace}} --show-labels
 
         ### Pod-wide configuration
-        kubectl -n {{$labels.namespace}} get pods -l istio.io/rev={{$labels.desired_revision}}
+        d8 k -n {{$labels.namespace}} get pods -l istio.io/rev={{$labels.desired_revision}}
         ```
       summary: |
         There are pods with Istio data plane version {{$labels.version}}, but desired version is {{$labels.desired_version}}.
@@ -1439,7 +1439,7 @@ alerts:
         To identify orphaned pods, run the following command:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} get pods -l 'service.istio.io/canonical-name' -o json | jq --arg revision {{ $labels.revision }} '.items[] | select(.metadata.annotations."sidecar.istio.io/status" // "{}" | fromjson | .revision == $revision) | .metadata.name'
+        d8 k -n {{ $labels.namespace }} get pods -l 'service.istio.io/canonical-name' -o json | jq --arg revision {{ $labels.revision }} '.items[] | select(.metadata.annotations."sidecar.istio.io/status" // "{}" | fromjson | .revision == $revision) | .metadata.name'
         ```
       summary: |
         The control plane version for pods with injected sidecars isn't installed.
@@ -1458,7 +1458,7 @@ alerts:
         To check the status of the control plane pods, run the following command:
 
         ```
-        kubectl get pods -n d8-istio -l istio.io/rev={{$labels.label_istio_io_rev}}
+        d8 k get pods -n d8-istio -l istio.io/rev={{$labels.label_istio_io_rev}}
         ```
       summary: |
         Additional control plane isn't working.
@@ -1476,7 +1476,7 @@ alerts:
 
         1. Restart affected pods and use the following PromQL query to get a full list:
 
-           ```promql
+           ```prometheus
            max by (namespace, dataplane_pod) (d8_istio_dataplane_metadata{full_version="{{$labels.full_version}}"})
            ```
 
@@ -1496,7 +1496,7 @@ alerts:
         To identify the affected pods, run the following command:
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pods -o json | jq -r --arg revision {{$labels.revision}} '.items[] | select(.metadata.annotations."sidecar.istio.io/status" // "{}" | fromjson | .revision == $revision) | .metadata.name'
+        d8 k -n {{$labels.namespace}} get pods -o json | jq -r --arg revision {{$labels.revision}} '.items[] | select(.metadata.annotations."sidecar.istio.io/status" // "{}" | fromjson | .revision == $revision) | .metadata.name'
         ```
       summary: |
         Detected pods with Istio sidecars but istio-injection isn't configured.
@@ -1533,10 +1533,10 @@ alerts:
         ### Namespace-wide configuration
         # `istio.io/rev=vXYZ`: Use a specific revision.
         # `istio-injection=enabled`: Use the global revision.
-        kubectl get ns {{$labels.namespace}} --show-labels
+        d8 k get ns {{$labels.namespace}} --show-labels
 
         ### Pod-wide configuration
-        kubectl -n {{$labels.namespace}} get pods -l istio.io/rev={{$labels.revision}}
+        d8 k -n {{$labels.namespace}} get pods -l istio.io/rev={{$labels.revision}}
         ```
       summary: |
         Desired control plane version isn't installed.
@@ -1561,7 +1561,7 @@ alerts:
         ```bash
         KEY="$(deckhouse-controller module values istio -o json | jq -r .internal.remoteAuthnKeypair.priv)"
         LOCAL_CLUSTER_UUID="$(deckhouse-controller module values -g istio -o json | jq -r .global.discovery.clusterUUID)"
-        REMOTE_CLUSTER_UUID="$(kubectl get istiofederation {{$labels.federation_name}} -o json | jq -r .status.metadataCache.public.clusterUUID)"
+        REMOTE_CLUSTER_UUID="$(d8 k get istiofederation {{$labels.federation_name}} -o json | jq -r .status.metadataCache.public.clusterUUID)"
         TOKEN="$(deckhouse-controller helper gen-jwt --private-key-path <(echo "$KEY") --claim iss=d8-istio --claim sub=$LOCAL_CLUSTER_UUID --claim aud=$REMOTE_CLUSTER_UUID --claim scope=private-federation --ttl 1h)"
         curl -H "Authorization: Bearer $TOKEN" {{$labels.endpoint}}
         ```
@@ -1582,7 +1582,7 @@ alerts:
         To check the status of the control plane pods, run the following command:
 
         ```bash
-        kubectl get pods -n d8-istio -l istio.io/rev={{$labels.label_istio_io_rev}}
+        d8 k get pods -n d8-istio -l istio.io/rev={{$labels.label_istio_io_rev}}
         ```
       summary: |
         Global control plane isn't working.
@@ -1607,7 +1607,7 @@ alerts:
         ```bash
         KEY="$(deckhouse-controller module values istio -o json | jq -r .internal.remoteAuthnKeypair.priv)"
         LOCAL_CLUSTER_UUID="$(deckhouse-controller module values -g istio -o json | jq -r .global.discovery.clusterUUID)"
-        REMOTE_CLUSTER_UUID="$(kubectl get istiomulticluster {{$labels.multicluster_name}} -o json | jq -r .status.metadataCache.public.clusterUUID)"
+        REMOTE_CLUSTER_UUID="$(d8 k get istiomulticluster {{$labels.multicluster_name}} -o json | jq -r .status.metadataCache.public.clusterUUID)"
         TOKEN="$(deckhouse-controller helper gen-jwt --private-key-path <(echo "$KEY") --claim iss=d8-istio --claim sub=$LOCAL_CLUSTER_UUID --claim aud=$REMOTE_CLUSTER_UUID --claim scope=private-multicluster --ttl 1h)"
         curl -H "Authorization: Bearer $TOKEN" {{$labels.endpoint}}
         ```
@@ -1644,7 +1644,7 @@ alerts:
         To investigate the issue, check the operator logs:
 
         ```bash
-        kubectl -n d8-istio logs -l app=operator,revision={{$labels.revision}}
+        d8 k -n d8-istio logs -l app=operator,revision={{$labels.revision}}
         ```
       summary: |
         The istio-operator is unable to reconcile Istio control plane setup.
@@ -1661,7 +1661,7 @@ alerts:
         To identify the affected pods, run the following command:
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pods -l '!service.istio.io/canonical-name' -o json | jq -r '.items[] | select(.metadata.annotations."sidecar.istio.io/inject" != "false") | .metadata.name'
+        d8 k -n {{$labels.namespace}} get pods -l '!service.istio.io/canonical-name' -o json | jq -r '.items[] | select(.metadata.annotations."sidecar.istio.io/inject" != "false") | .metadata.name'
         ```
       summary: |
         Detected pods without Istio sidecars but with istio-injection configured.
@@ -1712,7 +1712,7 @@ alerts:
         - Defragment the etcd database by running the following command:
 
           ```bash
-          kubectl -n kube-system exec -ti etcd-{{ $labels.node }} -- /usr/bin/etcdctl \
+          d8 k -n kube-system exec -ti etcd-{{ $labels.node }} -- /usr/bin/etcdctl \
             --cacert /etc/kubernetes/pki/etcd/ca.crt \
             --cert /etc/kubernetes/pki/etcd/ca.crt \
             --key /etc/kubernetes/pki/etcd/ca.key \
@@ -1773,7 +1773,7 @@ alerts:
         Example of applying an additional audit policy:
 
         ```bash
-        kubectl apply -f - <<EOF
+        d8 k apply -f - <<EOF
         apiVersion: v1
         kind: Secret
         metadata:
@@ -1817,19 +1817,19 @@ alerts:
         1. Check the state of the `d8-log-shipper/log-shipper-agent` DaemonSet:
 
            ```shell
-           kubectl -n d8-log-shipper get daemonsets --selector=app=log-shipper
+           d8 k -n d8-log-shipper get daemonsets --selector=app=log-shipper
            ```
 
         1. Check the state of the `d8-log-shipper/log-shipper-agent` pods:
 
            ```shell
-           kubectl -n d8-log-shipper get pods --selector=app=log-shipper-agent
+           d8 k -n d8-log-shipper get pods --selector=app=log-shipper-agent
            ```
 
         1. If you know where the DaemonSet should be scheduled, run the following command to identify the problematic nodes:
 
            ```shell
-           kubectl -n d8-log-shipper get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="log-shipper-agent")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+           d8 k -n d8-log-shipper get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="log-shipper-agent")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
            ```
       summary: |
         The log-shipper-agent pods can't be scheduled in the cluster.
@@ -1861,7 +1861,7 @@ alerts:
         To resolve this, check the pod logs or follow advanced instructions:
 
         ```bash
-        kubectl -n d8-log-shipper logs {{ $labels.host }}` -c vector
+        d8 k -n d8-log-shipper logs {{ $labels.host }}` -c vector
         ```
       summary: |
         The log-shipper-agent pods can't collect logs to {{ $labels.component_id }} on the {{ $labels.node }} node.
@@ -1880,7 +1880,7 @@ alerts:
         To resolve this, check the pod logs or follow advanced instructions:
 
         ```bash
-        kubectl -n d8-log-shipper logs {{ $labels.host }}` -c vector
+        d8 k -n d8-log-shipper logs {{ $labels.host }}` -c vector
         ```
       summary: |
         The log-shipper-agent pods can't send logs to {{ $labels.component_id }} on the {{ $labels.node }} node.
@@ -1897,7 +1897,7 @@ alerts:
         To resolve this, check the pod logs or follow advanced instructions:
 
         ```bash
-        kubectl -n d8-log-shipper get pods -o wide | grep {{ $labels.node }}
+        d8 k -n d8-log-shipper get pods -o wide | grep {{ $labels.node }}
         ```
       summary: |
         The log-shipper-agent pods are dropping logs to {{ $labels.component_id }} on the {{ $labels.node }} node.
@@ -2003,7 +2003,7 @@ alerts:
         Check the logs for details:
 
         ```bash
-        kubectl -n d8-metallb logs daemonset/speaker -c speaker
+        d8 k -n d8-metallb logs daemonset/speaker -c speaker
         ```
       summary: |
         MetalLB BGP session is down.
@@ -2020,7 +2020,7 @@ alerts:
         To find the cause of the issue, review the controller logs:
 
         ```bash
-        kubectl -n d8-metallb logs deploy/controller -c controller
+        d8 k -n d8-metallb logs deploy/controller -c controller
         ```
       summary: |
         The MetalLB configuration hasn't been loaded.
@@ -2037,7 +2037,7 @@ alerts:
         To find the cause of the issue, review the controller logs:
 
         ```bash
-        kubectl -n d8-metallb logs deploy/controller -c controller
+        d8 k -n d8-metallb logs deploy/controller -c controller
         ```
       summary: |
         MetalLB is running on a stale configuration.
@@ -2098,8 +2098,8 @@ alerts:
         To modify `quota-backend-bytes`, set the `controlPlaneManager.etcd.maxDbSize` parameter. Before setting a new value, check the current database usage on every control plane node by running:
 
         ```
-        for pod in $(kubectl get pod -n kube-system -l component=etcd,tier=control-plane -o name); do
-          kubectl -n kube-system exec -ti "$pod" -- /usr/bin/etcdctl \
+        for pod in $(d8 k get pod -n kube-system -l component=etcd,tier=control-plane -o name); do
+          d8 k -n kube-system exec -ti "$pod" -- /usr/bin/etcdctl \
             --cacert /etc/kubernetes/pki/etcd/ca.crt \
             --cert /etc/kubernetes/pki/etcd/ca.crt \
             --key /etc/kubernetes/pki/etcd/ca.key \
@@ -2144,19 +2144,19 @@ alerts:
         - Current Terraform version:
 
           ```shell
-          kubectl -n d8-system exec -it deployments/terraform-state-exporter -c exporter -- terraform version
+          d8 k -n d8-system exec -it deployments/terraform-state-exporter -c exporter -- terraform version
           ```
 
         - Version in the Terraform state:
 
           ```shell
-          kubectl -n d8-system get secret d8-cluster-terraform-state -o json | jq -r '.data["cluster-tf-state.json"] | @base64d | fromjson | .terraform_version'
+          d8 k -n d8-system get secret d8-cluster-terraform-state -o json | jq -r '.data["cluster-tf-state.json"] | @base64d | fromjson | .terraform_version'
           ```
 
         - Check for destructive changes:
 
           ```shell
-          kubectl exec -it deploy/terraform-state-exporter -n d8-system -- dhctl terraform check
+          d8 k exec -it deploy/terraform-state-exporter -n d8-system -- dhctl terraform check
           ```
 
         To resolve the issue and migrate to OpenTofu manually, follow these steps:
@@ -2185,7 +2185,7 @@ alerts:
         2. In the cluster, remove the `commander-agent` module using the following command:
 
            ```shell
-           kubectl delete mc commander-agent
+           d8 k delete mc commander-agent
            ```
 
         3. Using the `install` container with the previous major Deckhouse release (for example, `1.69.X`, while the cluster is now on `1.70.X`), run the following command to resolve all destructive changes in the cluster:
@@ -2214,19 +2214,19 @@ alerts:
         1. Check events associated with `kruise-controller-manager` in the `d8-ingress-nginx` namespace. Look for issues related to node failures or memory shortages (OOM events):
 
            ```bash
-           kubectl -n d8-ingress-nginx get events | grep kruise-controller-manager
+           d8 k -n d8-ingress-nginx get events | grep kruise-controller-manager
            ```
 
         2. Analyze the controller's pod descriptions to identify restarted containers and possible causes. Pay attention to exit codes and other details:
 
            ```bash
-           kubectl -n d8-ingress-nginx describe pod -lapp=kruise,control-plane=controller-manager
+           d8 k -n d8-ingress-nginx describe pod -lapp=kruise,control-plane=controller-manager
            ```
 
         3. In case the `kruise` container has restarted, get a list of relevant container logs to identify any meaningful errors:
 
            ```bash
-           kubectl -n d8-ingress-nginx logs -lapp=kruise,control-plane=controller-manager -c kruise
+           d8 k -n d8-ingress-nginx logs -lapp=kruise,control-plane=controller-manager -c kruise
            ```
       summary: |
         Too many Kruise controller restarts detected.
@@ -2254,7 +2254,7 @@ alerts:
 
         1. Get a list of affected nodes by running the following Prometheus query:
 
-           ```promql
+           ```prometheus
            kube_node_info{os_image=~"Ubuntu 18.04.*|Debian GNU/Linux 10.*|CentOS Linux 7.*"}
            ```
 
@@ -2324,13 +2324,13 @@ alerts:
         - Check the expected configuration checksum for the NodeGroup:
 
           ```shell
-          kubectl -n d8-cloud-instance-manager get secret configuration-checksums -o jsonpath={.data.{{ $labels.node_group }}} | base64 -d
+          d8 k -n d8-cloud-instance-manager get secret configuration-checksums -o jsonpath={.data.{{ $labels.node_group }}} | base64 -d
           ```
 
         - Check the current configuration checksum on the Node:
 
           ```shell
-          kubectl get node {{ $labels.node }} -o jsonpath='{.metadata.annotations.node\.deckhouse\.io/configuration-checksum}'
+          d8 k get node {{ $labels.node }} -o jsonpath='{.metadata.annotations.node\.deckhouse\.io/configuration-checksum}'
           ```
 
         - View Bashible logs on the Node:
@@ -2460,7 +2460,7 @@ alerts:
         To list all services labeled with `prometheus-custom-target`, run the following command:
 
         ```bash
-        kubectl get service --all-namespaces --show-labels | grep prometheus-custom-target
+        d8 k get service --all-namespaces --show-labels | grep prometheus-custom-target
         ```
 
         For more information on metric collection, refer to the [Prometheus module FAQ](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html).
@@ -2481,7 +2481,7 @@ alerts:
         To list all services labeled with `prometheus-target`, run the following command:
 
         ```bash
-        kubectl get service --all-namespaces --show-labels | grep prometheus-target
+        d8 k get service --all-namespaces --show-labels | grep prometheus-target
         ```
       summary: |
         Services with the prometheus-target label are being used for metric collection.
@@ -2562,13 +2562,13 @@ alerts:
         1. Analyze the Deployment details:
 
            ```shell
-           kubectl -n d8-operator-prometheus describe deployment prometheus-operator
+           d8 k -n d8-operator-prometheus describe deployment prometheus-operator
            ```
 
         2. Examine the Pod's to determine why it is not running:
 
            ```shell
-           kubectl -n d8-operator-prometheus describe pod -l app=prometheus-operator
+           d8 k -n d8-operator-prometheus describe pod -l app=prometheus-operator
            ```
       summary: |
         The prometheus-operator Pod is NOT Ready.
@@ -2589,13 +2589,13 @@ alerts:
         1. Analyze the Deployment details:
 
            ```shell
-           kubectl -n d8-operator-prometheus describe deployment prometheus-operator
+           d8 k -n d8-operator-prometheus describe deployment prometheus-operator
            ```
 
         2. Examine the Pod's to determine why it is not running:
 
            ```shell
-           kubectl -n d8-operator-prometheus describe pod -l app=prometheus-operator
+           d8 k -n d8-operator-prometheus describe pod -l app=prometheus-operator
            ```
       summary: |
         The prometheus-operator Pod is NOT Running.
@@ -2614,7 +2614,7 @@ alerts:
         To resolve the issue, analyze the Deployment details:
 
         ```shell
-        kubectl -n d8-operator-prometheus describe deployment prometheus-operator
+        d8 k -n d8-operator-prometheus describe deployment prometheus-operator
         ```
       summary: |
         Prometheus-operator target is missing in Prometheus.
@@ -2637,13 +2637,13 @@ alerts:
         1. Analyze the Deployment details:
 
            ```shell
-           kubectl -n d8-operator-prometheus describe deployment prometheus-operator
+           d8 k -n d8-operator-prometheus describe deployment prometheus-operator
            ```
 
         2. Examine the Pod's to determine why it is not running:
 
            ```shell
-           kubectl -n d8-operator-prometheus describe pod -l app=prometheus-operator
+           d8 k -n d8-operator-prometheus describe pod -l app=prometheus-operator
            ```
       summary: |
         Prometheus is unable to scrape prometheus-operator metrics.
@@ -2677,13 +2677,13 @@ alerts:
         1. Check the status of the DaemonSet `d8-runtime-audit-engine/runtime-audit-engine`:
 
            ```shell
-           kubectl -n d8-runtime-audit-engine get daemonset,pod --selector=app=runtime-audit-engine
+           d8 k -n d8-runtime-audit-engine get daemonset,pod --selector=app=runtime-audit-engine
            ```
 
         2. Get a list of nodes where Pods are not in the Ready state:
 
            ```shell
-           kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+           d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
            ```
       summary: |
         Runtime-audit-engine Pods cannot be scheduled.
@@ -2717,7 +2717,7 @@ alerts:
         To investigate the cause, check the PersistentVolumeClaim phase:
 
         ```shell
-        kubectl -n d8-upmeter get pvc {{ $labels.persistentvolumeclaim }}
+        d8 k -n d8-upmeter get pvc {{ $labels.persistentvolumeclaim }}
         ```
 
         If your cluster doesn't have a disk provisioning system,
@@ -3075,13 +3075,13 @@ alerts:
         - Check the DaemonSet status:
 
           ```shell
-          kubectl -n d8-upmeter get daemonset upmeter-agent -o json | jq .status
+          d8 k -n d8-upmeter get daemonset upmeter-agent -o json | jq .status
           ```
 
         - Check the Pod status:
 
           ```shell
-          kubectl -n d8-upmeter get pods -l app=upmeter-agent -o json | jq '.items[] | {(.metadata.name):.status}'
+          d8 k -n d8-upmeter get pods -l app=upmeter-agent -o json | jq '.items[] | {(.metadata.name):.status}'
           ```
       summary: |
         One or more upmeter-agent Pods are NOT Running.
@@ -3102,13 +3102,13 @@ alerts:
         1. Delete the PVC and restart the `upmeter` Pod:
 
            ```shell
-           kubectl -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0
+           d8 k -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0
            ```
 
         1. Check the status of the created PVC:
 
            ```shell
-           kubectl -n d8-upmeter get pvc
+           d8 k -n d8-upmeter get pvc
            ```
       summary: |
         Upmeter disk usage exceeds 80%.
@@ -3135,7 +3135,7 @@ alerts:
         1. Check the `upmeter-agent` logs:
 
            ```shell
-           kubectl -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "basic-functionality") | [.time, .level, .msg] | @tsv'
+           d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "basic-functionality") | [.time, .level, .msg] | @tsv'
            ```
 
         2. Ensure the control plane is operating normally.
@@ -3143,7 +3143,7 @@ alerts:
         3. Delete stale ConfigMaps manually:
 
            ```shell
-           kubectl -n d8-upmeter delete cm -l heritage=upmeter
+           d8 k -n d8-upmeter delete cm -l heritage=upmeter
            ```
       summary: |
         Garbage ConfigMaps from the basic probe are not being cleaned up.
@@ -3170,7 +3170,7 @@ alerts:
         1. Check the `upmeter-agent` logs:
 
            ```shell
-           kubectl -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "controller-manager") | [.time, .level, .msg] | @tsv'
+           d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "controller-manager") | [.time, .level, .msg] | @tsv'
            ```
 
         2. Ensure the control plane is operating normally. Pay close attention to `kube-controller-manager`.
@@ -3178,7 +3178,7 @@ alerts:
         3. Delete stale Deployments manually:
 
            ```shell
-           kubectl -n d8-upmeter delete deployment -l heritage=upmeter
+           d8 k -n d8-upmeter delete deployment -l heritage=upmeter
            ```
       summary: |
         Garbage Deployments from the controller-manager probe are not being cleaned up.
@@ -3189,7 +3189,7 @@ alerts:
       moduleUrl: 500-upmeter
       module: upmeter
       edition: ce
-      description: "The average number of probe-created namespaces per `upmeter-agent` Pod is {{ $value }}.\n\n`upmeter-agent` should automatically clean up namespaces created by the `control-plane/namespace` probe.  \nThere should not be more of these namespaces than there are master nodes (since `upmeter-agent` runs as a DaemonSet with a master `nodeSelector`), and they should be deleted within seconds.\n\nThis may indicate:\n\n- A problem with the `kube-apiserver`.\n- Stale namespaces left from older `upmeter-agent` Pods after an Upmeter update.\n\nTroubleshooting steps:\n\n1. Check `upmeter-agent` logs:\n\n   ```shell\n   kubectl -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group==\"control-plane\" and .probe == \"namespace\") | [.time, .level, .msg] | @tsv'\n   ```\n\n2. Ensure the control plane is operating normally.\n\n3. Delete stale namespaces manually:\n\n   ```shell\n   kubectl -n d8-upmeter delete ns -l heritage=upmeter\n   ```\n"
+      description: "The average number of probe-created namespaces per `upmeter-agent` Pod is {{ $value }}.\n\n`upmeter-agent` should automatically clean up namespaces created by the `control-plane/namespace` probe.  \nThere should not be more of these namespaces than there are master nodes (since `upmeter-agent` runs as a DaemonSet with a master `nodeSelector`), and they should be deleted within seconds.\n\nThis may indicate:\n\n- A problem with the `kube-apiserver`.\n- Stale namespaces left from older `upmeter-agent` Pods after an Upmeter update.\n\nTroubleshooting steps:\n\n1. Check `upmeter-agent` logs:\n\n   ```shell\n   d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group==\"control-plane\" and .probe == \"namespace\") | [.time, .level, .msg] | @tsv'\n   ```\n\n2. Ensure the control plane is operating normally.\n\n3. Delete stale namespaces manually:\n\n   ```shell\n   d8 k -n d8-upmeter delete ns -l heritage=upmeter\n   ```\n"
       summary: |
         Garbage namespaces from the namespace probe are not being cleaned up.
       severity: "9"
@@ -3199,7 +3199,7 @@ alerts:
       moduleUrl: 500-upmeter
       module: upmeter
       edition: ce
-      description: "The average number of probe Pods per `upmeter-agent` Pod is {{ $value }}.\n\n`upmeter-agent` should automatically clean up Pods created by the `control-plane/scheduler` probe.  \nThere should not be more of these Pods than there are master nodes (since `upmeter-agent` runs as a DaemonSet with a master `nodeSelector`), and they should be deleted within seconds.\n\nThis may indicate:\n\n- A problem with the `kube-apiserver`.\n- Stale Pods left from old `upmeter-agent` Pods after an Upmeter update.\n\nTroubleshooting steps:\n\n1. Check `upmeter-agent` logs:\n\n   ```shell\n   kubectl -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group==\"control-plane\" and .probe == \"scheduler\") | [.time, .level, .msg] | @tsv'\n   ```\n\n2. Ensure the control plane is operating normally.\n\n3. Delete stale Pods manually:\n\n   ```shell\n   kubectl -n d8-upmeter delete pods -l upmeter-probe=scheduler\n   ```\n"
+      description: "The average number of probe Pods per `upmeter-agent` Pod is {{ $value }}.\n\n`upmeter-agent` should automatically clean up Pods created by the `control-plane/scheduler` probe.  \nThere should not be more of these Pods than there are master nodes (since `upmeter-agent` runs as a DaemonSet with a master `nodeSelector`), and they should be deleted within seconds.\n\nThis may indicate:\n\n- A problem with the `kube-apiserver`.\n- Stale Pods left from old `upmeter-agent` Pods after an Upmeter update.\n\nTroubleshooting steps:\n\n1. Check `upmeter-agent` logs:\n\n   ```shell\n   d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group==\"control-plane\" and .probe == \"scheduler\") | [.time, .level, .msg] | @tsv'\n   ```\n\n2. Ensure the control plane is operating normally.\n\n3. Delete stale Pods manually:\n\n   ```shell\n   d8 k -n d8-upmeter delete pods -l upmeter-probe=scheduler\n   ```\n"
       summary: |
         Garbage Pods from the scheduler probe are not being cleaned up.
       severity: "9"
@@ -3226,7 +3226,7 @@ alerts:
         1. Check the `upmeter-agent` logs:
 
            ```shell
-           kubectl -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "controller-manager") | [.time, .level, .msg] | @tsv'
+           d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "controller-manager") | [.time, .level, .msg] | @tsv'
            ```
 
         2. Ensure the control plane is operating normally. Pay close attention to `kube-controller-manager`.
@@ -3234,7 +3234,7 @@ alerts:
         3. Delete stale Pods manually:
 
            ```shell
-           kubectl -n d8-upmeter delete pods -l upmeter-probe=controller-manager
+           d8 k -n d8-upmeter delete pods -l upmeter-probe=controller-manager
            ```
       summary: |
         Garbage Pods from the controller-manager probe are not being cleaned up.
@@ -3261,7 +3261,7 @@ alerts:
         1. Check `upmeter-agent` logs:
 
            ```shell
-           kubectl -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "cert-manager") | [.time, .level, .msg] | @tsv'
+           d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "cert-manager") | [.time, .level, .msg] | @tsv'
            ```
 
         2. Check that the control plane and `cert-manager` are operating normally.
@@ -3269,8 +3269,8 @@ alerts:
         3. Delete stale certificates and Secrets manually:
 
            ```shell
-           kubectl -n d8-upmeter delete certificate -l upmeter-probe=cert-manager
-           kubectl -n d8-upmeter get secret -ojson | jq -r '.items[] | .metadata.name' | grep upmeter-cm-probe | xargs -n 1 -- kubectl -n d8-upmeter delete secret
+           d8 k -n d8-upmeter delete certificate -l upmeter-probe=cert-manager
+           d8 k -n d8-upmeter get secret -ojson | jq -r '.items[] | .metadata.name' | grep upmeter-cm-probe | xargs -n 1 -- d8 k -n d8-upmeter delete secret
            ```
       summary: |
         Garbage Secrets from the cert-manager probe are not being cleaned up.
@@ -3300,7 +3300,7 @@ alerts:
         To investigate the cause, check the logs:
 
         ```shell
-        kubectl -n d8-upmeter logs -f upmeter-0 upmeter
+        d8 k -n d8-upmeter logs -f upmeter-0 upmeter
         ```
       summary: |
         Upmeter server is restarting too frequently.
@@ -3319,13 +3319,13 @@ alerts:
         - Check the StatefulSet status:
 
           ```shell
-          kubectl -n d8-upmeter get statefulset upmeter -o json | jq .status
+          d8 k -n d8-upmeter get statefulset upmeter -o json | jq .status
           ```
 
         - Check the Pod status:
 
           ```shell
-          kubectl -n d8-upmeter get pods upmeter-0 -o json | jq '.items[] | {(.metadata.name):.status}'
+          d8 k -n d8-upmeter get pods upmeter-0 -o json | jq '.items[] | {(.metadata.name):.status}'
           ```
       summary: |
         One or more Upmeter server Pods are NOT Running.
@@ -3351,7 +3351,7 @@ alerts:
         To list all the PVs, run the following command:
 
         ```shell
-        kubectl get pv | grep disk-smoke-mini
+        d8 k get pv | grep disk-smoke-mini
         ```
       summary: |
         Unnecessary smoke-mini PersistentVolumes detected in the cluster.
@@ -3372,7 +3372,7 @@ alerts:
         To view all `UpmeterHookProbe` objects, run the following command:
 
         ```shell
-        kubectl get upmeterhookprobes.deckhouse.io
+        d8 k get upmeterhookprobes.deckhouse.io
         ```
       summary: |
         Too many UpmeterHookProbe objects in the cluster.
@@ -3532,9 +3532,9 @@ alerts:
         Please, if possible, get the dumps for debugging purposes (it will take around 30 seconds):
 
         ```bash
-        curl -s "http://$(kubectl -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/heap" -o /tmp/heap.pprof
-        curl -s "http://$(kubectl -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/goroutine" -o /tmp/goroutine.pprof
-        curl -s "http://$(kubectl -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/profile?seconds=30" -o /tmp/cpu.pprof
+        curl -s "http://$(d8 k -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/heap" -o /tmp/heap.pprof
+        curl -s "http://$(d8 k -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/goroutine" -o /tmp/goroutine.pprof
+        curl -s "http://$(d8 k -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/profile?seconds=30" -o /tmp/cpu.pprof
         ```
 
         and send these files (/tmp/heap.pprof, /tmp/cpu.pprof and /tmp/goroutine.pprof) to the support team.
@@ -3556,7 +3556,7 @@ alerts:
         - There is a network issue preventing access to the registry.
 
         Please check:
-        1. ModuleSource configurations: `kubectl get modulesources`.
+        1. ModuleSource configurations: `d8 k get modulesources`.
         2. Registry accessibility and credentials.
         3. Module availability in the configured registries.
 
@@ -3564,14 +3564,14 @@ alerts:
 
         ```bash
         # Check ModuleSource status
-        kubectl get modulesources
+        d8 k get modulesources
 
         # Check available modules in all sources
-        kubectl -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get sources
-        kubectl -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get modules <source_name>
+        d8 k -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get sources
+        d8 k -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get modules <source_name>
 
         # Check Deckhouse logs for more details
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
       summary: |
         Migrated module {{ $labels.module_name }} not found in registry.
@@ -3641,13 +3641,13 @@ alerts:
         To check the details, run the following command:
 
         ```bash
-        kubectl describe DeckhouseRelease {{ $labels.name }}
+        d8 k describe DeckhouseRelease {{ $labels.name }}
         ```
 
         To approve the disruptive update, run the following command:
 
         ```bash
-        kubectl annotate DeckhouseRelease {{ $labels.name }} release.deckhouse.io/disruption-approved=true
+        d8 k annotate DeckhouseRelease {{ $labels.name }} release.deckhouse.io/disruption-approved=true
         ```
       summary: |
         Deckhouse release disruption approval required.
@@ -3664,7 +3664,7 @@ alerts:
         To check the details, run the following command:
 
         ```bash
-        kubectl describe DeckhouseRelease {{ $labels.name }}
+        d8 k describe DeckhouseRelease {{ $labels.name }}
         ```
       summary: |
         Deckhouse release requirements haven't been met.
@@ -3681,7 +3681,7 @@ alerts:
         To approve the release, run the following command:
 
         ```bash
-        kubectl patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'
+        d8 k patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'
         ```
       summary: |
         A new Deckhouse release is awaiting manual approval.
@@ -3698,7 +3698,7 @@ alerts:
         To approve the release, run the following command:
 
         ```bash
-        kubectl patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'
+        d8 k patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'
         ```
       summary: |
         A new Deckhouse release is awaiting manual approval.
@@ -3715,7 +3715,7 @@ alerts:
         To approve the release, run the following command:
 
         ```bash
-        kubectl patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'
+        d8 k patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'
         ```
       summary: |
         A new Deckhouse release is awaiting manual approval.
@@ -3732,7 +3732,7 @@ alerts:
         To check the notification webhook address, run the following command:
 
         ```bash
-        kubectl get mc deckhouse -o yaml
+        d8 k get mc deckhouse -o yaml
         ```
       summary: |
         Deckhouse release notification webhook hasn't been sent.
@@ -3984,13 +3984,13 @@ alerts:
         1. Print detailed information about the `extended-monitoring-exporter` deployment:
 
            ```bash
-           kubectl -n d8-monitoring describe deploy extended-monitoring-exporter
+           d8 k -n d8-monitoring describe deploy extended-monitoring-exporter
            ```
 
         2. Print detailed information about the pods associated with the `extended-monitoring-exporter`:
 
            ```bash
-           kubectl -n d8-monitoring describe pod -l app=extended-monitoring-exporter
+           d8 k -n d8-monitoring describe pod -l app=extended-monitoring-exporter
            ```
       summary: |
         Extended monitoring is unavailable.
@@ -4050,7 +4050,7 @@ alerts:
 
         To list all deprecated alert rules, use the following expression:
 
-        ```promql
+        ```prometheus
         sum by (dashboard, panel, alert_rule) (d8_grafana_dashboards_deprecated_alert_rule) > 0
         ```
 
@@ -4069,7 +4069,7 @@ alerts:
 
         To list all deprecated panel intervals, use the following expression:
 
-        ```promql
+        ```prometheus
         sum by (dashboard, panel, interval) (d8_grafana_dashboards_deprecated_interval) > 0
         ```
 
@@ -4088,7 +4088,7 @@ alerts:
 
         To list all potentially outdated plugins, use the following expression:
 
-        ```promql
+        ```prometheus
         sum by (dashboard, panel, plugin) (d8_grafana_dashboards_deprecated_plugin) > 0
         ```
 
@@ -4108,7 +4108,7 @@ alerts:
       description: |
         To list all affected resources, run the following Prometheus query:
 
-        ```promql
+        ```prometheus
         max by (helm_release_namespace, helm_release_name, helm_version, resource_namespace, resource_name, api_version, kind, k8s_version) (resource_versions_compatibility) == 1
         ```
 
@@ -4127,7 +4127,7 @@ alerts:
       description: |
         To list all affected resources, run the following Prometheus query:
 
-        ```promql
+        ```prometheus
         max by (helm_release_namespace, helm_release_name, helm_version, resource_namespace, resource_name, api_version, kind, k8s_version) (resource_versions_compatibility) == 2
         ```
 
@@ -4336,7 +4336,7 @@ alerts:
       description: |
         The etcd cluster has too few members, increasing the risk of failure if another member becomes unavailable.
         To resolve this issue, check the status of etcd Pods:
-        ```bash kubectl -n kube-system get pod -l component=etcd ```
+        ```bash d8 k -n kube-system get pod -l component=etcd ```
       summary: |
         Insufficient members in the etcd cluster.
       severity: "4"
@@ -4348,7 +4348,7 @@ alerts:
       edition: ce
       description: |
         To resolve this issue, check the status of the etcd Pods:
-        ```bash kubectl -n kube-system get pod -l component=etcd | grep {{ $labels.node }} ```
+        ```bash d8 k -n kube-system get pod -l component=etcd | grep {{ $labels.node }} ```
       summary: |
         The etcd cluster member running on node {{ $labels.node }} has lost the leader.
       severity: "4"
@@ -4363,13 +4363,13 @@ alerts:
         1. Check the status of the etcd Pods:
 
            ```bash
-           kubectl -n kube-system get pod -l component=etcd
+           d8 k -n kube-system get pod -l component=etcd
            ```
 
         1. Review Prometheus logs:
 
            ```bash
-           kubectl -n d8-monitoring logs -l app.kubernetes.io/name=prometheus -c prometheus
+           d8 k -n d8-monitoring logs -l app.kubernetes.io/name=prometheus -c prometheus
            ```
       summary: |
         There is no etcd target in Prometheus.
@@ -4385,13 +4385,13 @@ alerts:
         1. Check the status of the etcd Pods:
 
            ```bash
-           kubectl -n kube-system get pod -l component=etcd
+           d8 k -n kube-system get pod -l component=etcd
            ```
 
         1. Review Prometheus logs:
 
            ```bash
-           kubectl -n d8-monitoring logs -l app.kubernetes.io/name=prometheus -c prometheus
+           d8 k -n d8-monitoring logs -l app.kubernetes.io/name=prometheus -c prometheus
            ```
       summary: |
         Prometheus is unable to scrape etcd metrics.
@@ -4628,7 +4628,7 @@ alerts:
         To resolve the issue, review the container logs:
 
         ```bash
-        kubectl -n kube-system logs {{$labels.pod}}
+        d8 k -n kube-system logs {{$labels.pod}}
         ```
       summary: |
         Critical errors found in CoreDNS.
@@ -4647,19 +4647,19 @@ alerts:
         1. Check the DaemonSet's status:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} get ds {{ $labels.daemonset }}
+           d8 k -n {{ $labels.namespace }} get ds {{ $labels.daemonset }}
            ```
 
         2. Analyze the DaemonSet's description:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} describe ds {{ $labels.daemonset }}
+           d8 k -n {{ $labels.namespace }} describe ds {{ $labels.daemonset }}
            ```
 
         3. If the parameter `Number of Nodes Scheduled with Up-to-date Pods` does not match `Current Number of Nodes Scheduled`, check the DaemonSet's `updateStrategy`:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} get ds {{ $labels.daemonset }} -o json | jq '.spec.updateStrategy'
+           d8 k -n {{ $labels.namespace }} get ds {{ $labels.daemonset }} -o json | jq '.spec.updateStrategy'
            ```
 
            If `updateStrategy` is set to `OnDelete`, the DaemonSet is updated only when pods are deleted.
@@ -4684,7 +4684,7 @@ alerts:
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```
       summary: |
         No available replicas remaining in DaemonSet {{$labels.namespace}}/{{$labels.daemonset}}.
@@ -4710,7 +4710,7 @@ alerts:
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```
       summary: |
         The number of unavailable replicas in DaemonSet {{$labels.namespace}}/{{$labels.daemonset}} exceeds the threshold.
@@ -4829,13 +4829,13 @@ alerts:
         1. Check the `kube-state-metrics` pods:
 
            ```bash
-           kubectl -n d8-monitoring describe pod -l app=kube-state-metrics
+           d8 k -n d8-monitoring describe pod -l app=kube-state-metrics
            ```
 
         2. Check the deployment logs:
 
            ```bash
-           kubectl -n d8-monitoring describe deploy kube-state-metrics
+           d8 k -n d8-monitoring describe deploy kube-state-metrics
            ```
       summary: |
         Kube-state-metrics isn't working in the cluster.
@@ -4901,7 +4901,7 @@ alerts:
         To list affected services, run the following command:
 
         ```bash
-        kubectl get svc -Ao json | jq -r '.items[] | select(.spec.type == "LoadBalancer") | select(.status.loadBalancer.ingress[0].ip == null) | "namespace: \(.metadata.namespace), name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
+        d8 k get svc -Ao json | jq -r '.items[] | select(.spec.type == "LoadBalancer") | select(.status.loadBalancer.ingress[0].ip == null) | "namespace: \(.metadata.namespace), name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
         ```
 
         Steps to troubleshoot:
@@ -4952,7 +4952,7 @@ alerts:
         1. Delete it using the following command:
 
            ```bash
-           kubectl delete mc deckhouse-web
+           d8 k delete mc deckhouse-web
            ```
       summary: |
         Deprecated deckhouse-web ModuleConfig detected.
@@ -4982,13 +4982,13 @@ alerts:
         To specify the update policy in the module configuration, run the following command:
 
         ```bash
-        kubectl patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
+        d8 k patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
         ```
 
         After resolving all alerts related to the update policy `{{ $labels.updatePolicy }}`, clear the selector by running the following command:
 
         ```bash
-        kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
+        d8 k patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
         ```
       summary: |
         Module {{ $labels.moduleName }} is matched by the deprecated update policy {{ $labels.updatePolicy }}.
@@ -5005,7 +5005,7 @@ alerts:
         To switch the module back to normal mode, edit the corresponding ModuleConfig resource with the following command:
 
         ```bash
-        kubectl patch moduleconfig {{ $labels.moduleName }} --type=json -p='[{"op": "remove", "path": "/spec/maintenance"}]'
+        d8 k patch moduleconfig {{ $labels.moduleName }} --type=json -p='[{"op": "remove", "path": "/spec/maintenance"}]'
         ```
       summary: |
         Module {{ $labels.moduleName }} is running in maintenance mode.
@@ -5022,7 +5022,7 @@ alerts:
         To check the requirements, run the following command:
 
         ```bash
-        kubectl  get mr {{ $labels.name }} -o json | jq .spec.requirements
+        d8 k  get mr {{ $labels.name }} -o json | jq .spec.requirements
         ```
       summary: |
         A new release for module {{ $labels.moduleName }} has been blocked due to unmet requirements.
@@ -5040,7 +5040,7 @@ alerts:
         To approve the module release update, run the following command:
 
         ```bash
-        kubectl annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
+        d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```
       summary: |
         Module {{ $labels.moduleName }} is {{ $labels.versionLag }} or more minor versions behind the latest available release.
@@ -5058,7 +5058,7 @@ alerts:
         To approve the module release update, run the following command:
 
         ```bash
-        kubectl annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
+        d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```
       summary: |
         Module {{ $labels.moduleName }} is 2 minor versions behind the latest available release.
@@ -5076,7 +5076,7 @@ alerts:
         To approve the module release update, run the following command:
 
         ```bash
-        kubectl annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
+        d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```
       summary: |
         Module {{ $labels.moduleName }} is 1 minor version behind the latest available release.
@@ -5093,7 +5093,7 @@ alerts:
         To approve the module release, run the following command:
 
         ```bash
-        kubectl annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
+        d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```
       summary: |
         A new release for module {{ $labels.moduleName }} is awaiting manual approval.
@@ -5112,7 +5112,7 @@ alerts:
         1. Migrate the NAT instance. To get `providerClusterConfiguration.withNATInstance`, run the following command:
 
            ```bash
-           kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values -g cloud-provider-yandex -o json | jq -c | jq '.cloudProviderYandex.internal.providerClusterConfiguration.withNATInstance'
+           d8 k -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values -g cloud-provider-yandex -o json | jq -c | jq '.cloudProviderYandex.internal.providerClusterConfiguration.withNATInstance'
            ```
 
            - If you specified `withNATInstance.natInstanceInternalAddress` and/or `withNATInstance.internalSubnetID` in `providerClusterConfiguration`, remove them using the following command:
@@ -5136,8 +5136,8 @@ alerts:
            - Get the appropriate edition and version of Deckhouse:
 
              ```bash
-             DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}')
-             DH_EDITION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}' | tr '[:upper:]' '[:lower:]')
+             DH_VERSION=$(d8 k -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}')
+             DH_EDITION=$(d8 k -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}' | tr '[:upper:]' '[:lower:]')
              echo "DH_VERSION=$DH_VERSION DH_EDITION=$DH_EDITION"
              ```
 
@@ -5158,13 +5158,13 @@ alerts:
            - Get the route table name:
 
              ```bash
-             kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values -g cloud-provider-yandex -o json | jq -c | jq '.global.clusterConfiguration.cloud.prefix'
+             d8 k -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values -g cloud-provider-yandex -o json | jq -c | jq '.global.clusterConfiguration.cloud.prefix'
              ```
 
            - Get the NAT instance name:
 
              ```bash
-             kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values -g cloud-provider-yandex -o json | jq -c | jq '.cloudProviderYandex.internal.providerDiscoveryData.natInstanceName'
+             d8 k -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values -g cloud-provider-yandex -o json | jq -c | jq '.cloudProviderYandex.internal.providerDiscoveryData.natInstanceName'
              ```
 
            - Get the NAT instance internal IP address:
@@ -5195,13 +5195,13 @@ alerts:
         1. Check the controller logs:
 
            ```bash
-           kubectl -n {{ $labels.controller_namespace }} logs {{ $labels.controller_pod }} -c controller
+           d8 k -n {{ $labels.controller_namespace }} logs {{ $labels.controller_pod }} -c controller
            ```
 
         2. Find the most recently created Ingress in the cluster:
 
            ```bash
-           kubectl get ingress --all-namespaces --sort-by="metadata.creationTimestamp"
+           d8 k get ingress --all-namespaces --sort-by="metadata.creationTimestamp"
            ```
 
         3. Check for errors in the `configuration-snippet` or `server-snippet` annotations.
@@ -5222,13 +5222,13 @@ alerts:
         1. Check the DaemonSet's status:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} get ads {{ $labels.daemonset }}
+           d8 k -n {{ $labels.namespace }} get ads {{ $labels.daemonset }}
            ```
 
         2. Analyze the DaemonSet's description:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} describe ads {{ $labels.daemonset }}
+           d8 k -n {{ $labels.namespace }} describe ads {{ $labels.daemonset }}
            ```
 
         3. If the parameter `Number of Nodes Scheduled with Up-to-date Pods` does not match
@@ -5254,7 +5254,7 @@ alerts:
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```
       summary: |
         No available replicas remaining in NGINX Ingress DaemonSet {{$labels.namespace}}/{{$labels.daemonset}}.
@@ -5279,7 +5279,7 @@ alerts:
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```
       summary: |
         Some replicas of NGINX Ingress DaemonSet {{$labels.namespace}}/{{$labels.daemonset}} are unavailable.
@@ -5323,7 +5323,7 @@ alerts:
         To resolve the issue, check the Ingress controller's logs:
 
         ```bash
-        kubectl -n d8-ingress-nginx logs $(kubectl -n d8-ingress-nginx get pods -l app=controller,name={{ $labels.controller }} -o wide | grep {{ $labels.node }} | awk '{print $1}') -c protobuf-exporter
+        d8 k -n d8-ingress-nginx logs $(d8 k -n d8-ingress-nginx get pods -l app=controller,name={{ $labels.controller }} -o wide | grep {{ $labels.node }} | awk '{print $1}') -c protobuf-exporter
         ```
       summary: |
         The Ingress NGINX sidecar container with protobuf_exporter has {{ $labels.type }} errors.
@@ -5340,7 +5340,7 @@ alerts:
         To verify the certificate, run the following command:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
+        d8 k -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
         ```
 
         The site at `https://{{ $labels.host }}` is not accessible.
@@ -5359,7 +5359,7 @@ alerts:
         To verify the certificate, run the following command:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
+        d8 k -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
         ```
       summary: |
         Certificate is expiring soon.
@@ -5546,7 +5546,7 @@ alerts:
         1. Identify the nodes that need to be migrated by running the following command:
 
            ```bash
-           kubectl get node -l "topology.kubernetes.io/zone=ru-central1-c"
+           d8 k get node -l "topology.kubernetes.io/zone=ru-central1-c"
            ```
 
         2. Migrate your nodes, disks, and load balancers to one of the supported zones: `ru-central1-a`, `ru-central1-b`, or `ru-central1-d`. Refer to the [Yandex migration guide](https://cloud.yandex.com/en/docs/overview/concepts/zone-migration) for detailed instructions.
@@ -5727,7 +5727,7 @@ alerts:
       moduleUrl: 040-node-manager
       module: node-manager
       edition: ce
-      description: "Node `{{ $labels.node }}` in NodeGroup `{{ $labels.node_group }}` has detected a new update, received initial approval, and started the update.  \nHowever, it encountered a stage that may cause downtime and requires manual disruption approval, because the NodeGroup is configured with `disruptions.approvalMode: Manual`.\n\nTo resolve the issue, ensure the Node is ready for unsafe updates (drained) and grant disruption approval by annotating the Node with `update.node.deckhouse.io/disruption-approved=`.\n\n**Caution**:\n\n- Nodes in manual mode aren't drained automatically.\n- Do not drain master nodes.\n\n1. To drain the Node and grant the update approval, run the following command:\n\n   ```shell\n   kubectl drain {{ $labels.node }} --delete-local-data=true --ignore-daemonsets=true --force=true &&\n     kubectl annotate node {{ $labels.node }} update.node.deckhouse.io/disruption-approved=\n   ```\n\n2. Uncordon the Node once the update is complete and the annotation `update.node.deckhouse.io/approved` is removed:\n\n   ```shell\n   while kubectl get node {{ $labels.node }} -o json | jq -e '.metadata.annotations | has(\"update.node.deckhouse.io/approved\")' > /dev/null; do sleep 1; done\n   kubectl uncordon {{ $labels.node }}\n   ```\n\nIf the NodeGroup has multiple Nodes, repeat this process for each one, since only one Node is updated at a time.\nConsider temporarily switching to automatic disruption approval (`disruptions.approvalMode: Automatic`).\n"
+      description: "Node `{{ $labels.node }}` in NodeGroup `{{ $labels.node_group }}` has detected a new update, received initial approval, and started the update.  \nHowever, it encountered a stage that may cause downtime and requires manual disruption approval, because the NodeGroup is configured with `disruptions.approvalMode: Manual`.\n\nTo resolve the issue, ensure the Node is ready for unsafe updates (drained) and grant disruption approval by annotating the Node with `update.node.deckhouse.io/disruption-approved=`.\n\n**Caution**:\n\n- Nodes in manual mode aren't drained automatically.\n- Do not drain master nodes.\n\n1. To drain the Node and grant the update approval, run the following command:\n\n   ```shell\n   d8 k drain {{ $labels.node }} --delete-local-data=true --ignore-daemonsets=true --force=true &&\n     d8 k annotate node {{ $labels.node }} update.node.deckhouse.io/disruption-approved=\n   ```\n\n2. Uncordon the Node once the update is complete and the annotation `update.node.deckhouse.io/approved` is removed:\n\n   ```shell\n   while d8 k get node {{ $labels.node }} -o json | jq -e '.metadata.annotations | has(\"update.node.deckhouse.io/approved\")' > /dev/null; do sleep 1; done\n   d8 k uncordon {{ $labels.node }}\n   ```\n\nIf the NodeGroup has multiple Nodes, repeat this process for each one, since only one Node is updated at a time.\nConsider temporarily switching to automatic disruption approval (`disruptions.approvalMode: Automatic`).\n"
       summary: |
         Node {{ $labels.node }} requires disruption approval to proceed with the update.
       severity: "8"
@@ -5743,7 +5743,7 @@ alerts:
         To get more details, run the following:
 
         ```shell
-        kubectl -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=DrainFailed --sort-by='.metadata.creationTimestamp'
+        d8 k -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=DrainFailed --sort-by='.metadata.creationTimestamp'
         ```
 
         Error message: {{ $labels.message }}
@@ -5756,7 +5756,7 @@ alerts:
       moduleUrl: 040-node-manager
       module: node-manager
       edition: ce
-      description: "Node `{{ $labels.node }}` in NodeGroup `{{ $labels.node_group }}` has detected a new update, requested and received approval, started the update, and reached a step that could cause downtime.  \nIt is currently stuck in the draining process while waiting for automatic disruption approval.\n\nTo get more details, run the following:\n\n```shell\nkubectl -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=ScaleDown --sort-by='.metadata.creationTimestamp'\n```\n"
+      description: "Node `{{ $labels.node }}` in NodeGroup `{{ $labels.node_group }}` has detected a new update, requested and received approval, started the update, and reached a step that could cause downtime.  \nIt is currently stuck in the draining process while waiting for automatic disruption approval.\n\nTo get more details, run the following:\n\n```shell\nd8 k -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=ScaleDown --sort-by='.metadata.creationTimestamp'\n```\n"
       summary: |
         Node {{ $labels.node }} is stuck in draining.
       severity: "6"
@@ -5796,13 +5796,13 @@ alerts:
         1. Find the `node-exporter` Pod running on the affected node:
 
            ```bash
-           kubectl -n d8-monitoring get pod -l app=node-exporter -o json | jq -r ".items[] | select(.spec.nodeName==\"{{$labels.node}}\") | .metadata.name"
+           d8 k -n d8-monitoring get pod -l app=node-exporter -o json | jq -r ".items[] | select(.spec.nodeName==\"{{$labels.node}}\") | .metadata.name"
            ```
 
         2. Describe the `node-exporter` Pod:
 
            ```bash
-           kubectl -n d8-monitoring describe pod <POD_NAME>
+           d8 k -n d8-monitoring describe pod <POD_NAME>
            ```
 
         3. Verify that the kubelet is running on node `{{ $labels.node }}`.
@@ -5859,13 +5859,13 @@ alerts:
         - To cordon the node:
 
           ```bash
-          kubectl cordon {{ $labels.node }}
+          d8 k cordon {{ $labels.node }}
           ```
 
         - To drain the node (if draining has been running for more than 20 minutes):
 
           ```bash
-          kubectl drain {{ $labels.node }}
+          d8 k drain {{ $labels.node }}
           ```
 
         The was likely caused by the scheduled maintenance of that node.
@@ -5884,13 +5884,13 @@ alerts:
         1. Check if the chrony pod is running on the node by executing the following command:
 
            ```bash
-           kubectl -n d8-chrony --field-selector spec.nodeName="{{$labels.node}}" get pods
+           d8 k -n d8-chrony --field-selector spec.nodeName="{{$labels.node}}" get pods
            ```
 
         2. Verify the chrony daemon's status by executing the following command:
 
            ```bash
-           kubectl -n d8-chrony exec <POD_NAME> -- /opt/chrony-static/bin/chronyc sources
+           d8 k -n d8-chrony exec <POD_NAME> -- /opt/chrony-static/bin/chronyc sources
            ```
 
         3. Resolve the time synchronization issues:
@@ -5913,7 +5913,7 @@ alerts:
         Check the certificate information and make sure it actually expires:
 
         ```shell
-        kubectl -n d8-openvpn get secrets -l name="{{ $labels.client }}"  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+        d8 k -n d8-openvpn get secrets -l name="{{ $labels.client }}"  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
         ```
 
         Renew or delete the expired certificate.
@@ -5936,7 +5936,7 @@ alerts:
         View certificate details to display the exact expiration date:
 
         ```shell
-        kubectl -n d8-openvpn get secrets -l name={{ $labels.client }}  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+        d8 k -n d8-openvpn get secrets -l name={{ $labels.client }}  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
         ```
       summary: |
         OpenVPN client certificate expires for {{ $labels.client }} in less than 7 days.
@@ -5956,7 +5956,7 @@ alerts:
         View certificate details to display the exact expiration date:
 
         ```shell
-        kubectl -n d8-openvpn get secrets -l name={{ $labels.client }}  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+        d8 k -n d8-openvpn get secrets -l name={{ $labels.client }}  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
         ```
       summary: |
         OpenVPN client certificate expires for {{ $labels.client }} in less than 30 days.
@@ -5967,7 +5967,7 @@ alerts:
       moduleUrl: 500-openvpn
       module: openvpn
       edition: ce
-      description: "OpenVPN CA certificate renews automatically 1 days before expiration.  \nAutomatic rotation did not work.  \nCheck the module status or perform [manual rotation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/openvpn/faq.html#how-to-rotate-a-root-certificate-ca).\n\nView certificate details to display the exact expiration date:\n\n```shell\nkubectl -n d8-openvpn get secrets openvpn-pki-ca  -o jsonpath='{.data.tls\\.crt}' | base64 -d | openssl x509 -text -noout\n```       \n\nThe hook should rotate CA and server certificates before expiry."
+      description: "OpenVPN CA certificate renews automatically 1 days before expiration.  \nAutomatic rotation did not work.  \nCheck the module status or perform [manual rotation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/openvpn/faq.html#how-to-rotate-a-root-certificate-ca).\n\nView certificate details to display the exact expiration date:\n\n```shell\nd8 k -n d8-openvpn get secrets openvpn-pki-ca  -o jsonpath='{.data.tls\\.crt}' | base64 -d | openssl x509 -text -noout\n```       \n\nThe hook should rotate CA and server certificates before expiry."
       summary: |
         OpenVPN CA certificate has expired.
       severity: "4"
@@ -5977,7 +5977,7 @@ alerts:
       moduleUrl: 500-openvpn
       module: openvpn
       edition: ce
-      description: "\nOpenVPN CA certificate renews automatically 1 days before expiration.  \nAutomatic rotation did not work.  \nCheck the module status or perform [manual rotation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/openvpn/faq.html#how-to-rotate-a-root-certificate-ca).\n\nView certificate details to display the exact expiration date:\n\n```shell\nkubectl -n d8-openvpn get secrets openvpn-pki-ca  -o jsonpath='{.data.tls\\.crt}' | base64 -d | openssl x509 -text -noout\n```       \n\nThe hook should rotate CA and server certificates before expiry."
+      description: "\nOpenVPN CA certificate renews automatically 1 days before expiration.  \nAutomatic rotation did not work.  \nCheck the module status or perform [manual rotation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/openvpn/faq.html#how-to-rotate-a-root-certificate-ca).\n\nView certificate details to display the exact expiration date:\n\n```shell\nd8 k -n d8-openvpn get secrets openvpn-pki-ca  -o jsonpath='{.data.tls\\.crt}' | base64 -d | openssl x509 -text -noout\n```       \n\nThe hook should rotate CA and server certificates before expiry."
       summary: |
         OpenVPN CA certificate will expire tomorrow
       severity: "4"
@@ -5987,7 +5987,7 @@ alerts:
       moduleUrl: 500-openvpn
       module: openvpn
       edition: ce
-      description: "The OpenVPN CA certificate is set to expire in {{ $value }} days.\n\nRenew the CA certificate if necessary.\nAfter renewing the certificate, **you will need to reissue all client and server certificates**.\nCheck [the documentation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/openvpn/faq.html#how-to-rotate-a-root-certificate-ca) for details.\n\nView certificate details to display the exact expiration date:\n\n```shell\nkubectl -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\\.crt}' | base64 -d | openssl x509 -text -noout\n```               "
+      description: "The OpenVPN CA certificate is set to expire in {{ $value }} days.\n\nRenew the CA certificate if necessary.\nAfter renewing the certificate, **you will need to reissue all client and server certificates**.\nCheck [the documentation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/openvpn/faq.html#how-to-rotate-a-root-certificate-ca) for details.\n\nView certificate details to display the exact expiration date:\n\n```shell\nd8 k -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\\.crt}' | base64 -d | openssl x509 -text -noout\n```               "
       summary: |
         OpenVPN CA certificate expires in less than 7 days.
       severity: "5"
@@ -5997,7 +5997,7 @@ alerts:
       moduleUrl: 500-openvpn
       module: openvpn
       edition: ce
-      description: "The OpenVPN CA certificate is set to expire in {{ $value }} days.\n\nRenew the CA certificate if necessary.\nAfter renewing the certificate, **you will need to reissue all client and server certificates**.\nCheck [the documentation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/openvpn/faq.html#how-to-rotate-a-root-certificate-ca) for details.\n\nView certificate details to display the exact expiration date:\n\n```shell\nkubectl -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\\.crt}' | base64 -d | openssl x509 -text -noout\n```                              "
+      description: "The OpenVPN CA certificate is set to expire in {{ $value }} days.\n\nRenew the CA certificate if necessary.\nAfter renewing the certificate, **you will need to reissue all client and server certificates**.\nCheck [the documentation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/openvpn/faq.html#how-to-rotate-a-root-certificate-ca) for details.\n\nView certificate details to display the exact expiration date:\n\n```shell\nd8 k -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\\.crt}' | base64 -d | openssl x509 -text -noout\n```                              "
       summary: |
         OpenVPN CA certificate expires in less than 30 days.
       severity: "5"
@@ -6007,7 +6007,7 @@ alerts:
       moduleUrl: 500-openvpn
       module: openvpn
       edition: ce
-      description: "The OpenVPN server certificate has expired.\n\nOpenVPN server certificate renews automatically 1 days before expiration.  \nAutomatic rotation did not work.  \nCheck the module status or perform [manual rotation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/openvpn/faq.html#how-to-rotate-a-server-certificate).\n\nCheck the certificate information and make sure it actually expires.\n```shell\nkubectl -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\\.crt}' | base64 -d | openssl x509 -text -noout\n```          "
+      description: "The OpenVPN server certificate has expired.\n\nOpenVPN server certificate renews automatically 1 days before expiration.  \nAutomatic rotation did not work.  \nCheck the module status or perform [manual rotation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/openvpn/faq.html#how-to-rotate-a-server-certificate).\n\nCheck the certificate information and make sure it actually expires.\n```shell\nd8 k -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\\.crt}' | base64 -d | openssl x509 -text -noout\n```          "
       summary: |
         OpenVPN server certificate has expired.
       severity: "4"
@@ -6017,7 +6017,7 @@ alerts:
       moduleUrl: 500-openvpn
       module: openvpn
       edition: ce
-      description: "The OpenVPN server certificate is set to expire in less than 1 day.\n\nOpenVPN server certificate renews automatically 1 days before expiration.  \nAutomatic rotation did not work.  \nCheck the module status or perform [manual rotation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/openvpn/faq.html#how-to-rotate-a-server-certificate).\n\nCheck the certificate information and make sure it actually expires:\n\n```shell\nkubectl -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\\.crt}' | base64 -d | openssl x509 -text -noout\n```          "
+      description: "The OpenVPN server certificate is set to expire in less than 1 day.\n\nOpenVPN server certificate renews automatically 1 days before expiration.  \nAutomatic rotation did not work.  \nCheck the module status or perform [manual rotation](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/openvpn/faq.html#how-to-rotate-a-server-certificate).\n\nCheck the certificate information and make sure it actually expires:\n\n```shell\nd8 k -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\\.crt}' | base64 -d | openssl x509 -text -noout\n```          "
       summary: |
         OpenVPN server certificate will expire tomorrow.
       severity: "4"
@@ -6034,7 +6034,7 @@ alerts:
 
         - Run the following Prometheus query:
 
-          ```promql
+          ```prometheus
           count by (violating_namespace, violating_kind, violating_name, violation_msg) (
             d8_gatekeeper_exporter_constraint_violations{
               violation_enforcement="deny",
@@ -6136,7 +6136,7 @@ alerts:
 
         - Run the following Prometheus query:
 
-          ```promql
+          ```prometheus
           count by (violating_namespace, violating_name, violation_msg) (
             d8_gatekeeper_exporter_constraint_violations{
               violation_enforcement="deny",
@@ -6167,13 +6167,13 @@ alerts:
         1. Identify all pods with this state:
 
            ```bash
-           kubectl get pod -o json --all-namespaces | jq '.items[] | select(.status.phase == "Running") | select(.status.conditions[] | select(.type == "ContainersReady" and .status == "True")) | select(.status.conditions[] | select(.type == "Ready" and .status == "False")) | "\(.spec.nodeName)/\(.metadata.namespace)/\(.metadata.name)"'
+           d8 k get pod -o json --all-namespaces | jq '.items[] | select(.status.phase == "Running") | select(.status.conditions[] | select(.type == "ContainersReady" and .status == "True")) | select(.status.conditions[] | select(.type == "Ready" and .status == "False")) | "\(.spec.nodeName)/\(.metadata.namespace)/\(.metadata.name)"'
            ```
 
         2. Identify all affected nodes:
 
            ```bash
-           kubectl get pod -o json --all-namespaces | jq '.items[] | select(.status.phase == "Running") | select(.status.conditions[] | select(.type == "ContainersReady" and .status == "True")) | select(.status.conditions[] | select(.type == "Ready" and .status == "False")) | .spec.nodeName' -r | sort | uniq -c
+           d8 k get pod -o json --all-namespaces | jq '.items[] | select(.status.phase == "Running") | select(.status.conditions[] | select(.type == "ContainersReady" and .status == "True")) | select(.status.conditions[] | select(.type == "Ready" and .status == "False")) | .spec.nodeName' -r | sort | uniq -c
            ```
 
         3. Restart kubelet on each node:
@@ -6196,7 +6196,7 @@ alerts:
         To check the current usage, run the following command:
 
         ```shell
-        kubectl -n {{ $labels.namespace }} exec -ti {{ $labels.pod_name }} -c prometheus -- df -PBG /prometheus
+        d8 k -n {{ $labels.namespace }} exec -ti {{ $labels.pod_name }} -c prometheus -- df -PBG /prometheus
         ```
 
         Consider expanding disk size following the [guide](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html#how-to-expand-disk-size).
@@ -6293,7 +6293,7 @@ alerts:
 
         - Run the following Prometheus query:
 
-          ```promql
+          ```prometheus
           count by (violating_namespace, violating_kind, violating_name, violation_msg) (
             d8_gatekeeper_exporter_constraint_violations{
               violation_enforcement="deny",

--- a/ee/fe/modules/340-monitoring-applications/applications/prometheus/prometheus-rules/prometheus.yaml
+++ b/ee/fe/modules/340-monitoring-applications/applications/prometheus/prometheus-rules/prometheus.yaml
@@ -12,7 +12,7 @@
       description: |-
         Prometheus is unable to scrape metrics of the Prometheus {{ $labels.namespace }}/{{ $labels.pod }} Pod
 
-        The recommended course of action is to retrieve details of the Pod: `kubectl -n {{ $labels.namespace }} describe pod {{ $labels.pod }}`.
+        The recommended course of action is to retrieve details of the Pod: `d8 k -n {{ $labels.namespace }} describe pod {{ $labels.pod }}`.
       summary: >
         Prometheus is unable to scrape metrics of another Prometheus instance.
 
@@ -84,7 +84,7 @@
         If the Prometheus database becomes corrupted, you might lose monitoring data.
 
         Consider the following:
-        1. Show prometheus logs: `kubectl -n {{ $labels.namespace}} logs {{ $labels.pod }} -c prometheus`
+        1. Show prometheus logs: `d8 k -n {{ $labels.namespace}} logs {{ $labels.pod }} -c prometheus`
         2. If you see any errors regarding data chunks (/prometheus/* sub-directories) try to restore the old files to these sub-directories from backup (if available). If there are no backup files try to move the coruppted data to a temporary place and recreate the prometheus_server pod.
       summary: Prometheus has issues reloading data blocks from disk.
 
@@ -107,7 +107,7 @@
         If the Prometheus database becomes corrupted, you might lose monitoring data.
 
         Consider the following:
-        1. Show prometheus logs: `kubectl -n {{ $labels.namespace}} logs {{ $labels.pod }} -c prometheus`
+        1. Show prometheus logs: `d8 k -n {{ $labels.namespace}} logs {{ $labels.pod }} -c prometheus`
         2. If you see any errors regarding data chunks (/prometheus/* sub-directories) try to restore the old files to these sub-directories from backup (if available). If there are no backup files try to move the coruppted data to a temporary place and recreate the prometheus_server pod.
       summary: Prometheus has issues compacting sample blocks.
 
@@ -131,7 +131,7 @@
       description: |
         Pod {{$labels.pod}} in namespace {{$labels.namespace}} has failing rule evaluations.
 
-        Please execute `kubectl -n {{$labels.namespace}} logs pod/{{$labels.pod}}` for more info.
+        Please execute `d8 k -n {{$labels.namespace}} logs pod/{{$labels.pod}}` for more info.
       summary: Prometheus has failing rule evaluations.
 
   - alert: PrometheusNotConnectedToAlertmanager

--- a/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/warnings/warnings.yaml
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/warnings/warnings.yaml
@@ -20,5 +20,5 @@
         To list all services labeled with `prometheus-target`, run the following command:
         
         ```bash
-        kubectl get service --all-namespaces --show-labels | grep prometheus-target
+        d8 k get service --all-namespaces --show-labels | grep prometheus-target
         ```

--- a/ee/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
@@ -11,7 +11,7 @@
         To identify orphaned pods, run the following command:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} get pods -l 'service.istio.io/canonical-name' -o json | jq --arg revision {{ $labels.revision }} '.items[] | select(.metadata.annotations."sidecar.istio.io/status" // "{}" | fromjson | .revision == $revision) | .metadata.name'
+        d8 k -n {{ $labels.namespace }} get pods -l 'service.istio.io/canonical-name' -o json | jq --arg revision {{ $labels.revision }} '.items[] | select(.metadata.annotations."sidecar.istio.io/status" // "{}" | fromjson | .revision == $revision) | .metadata.name'
         ```
       plk_create_group_if_not_exists__d8_istio_dataplane_misconfigurations: D8IstioDataplaneMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       plk_grouped_by__d8_istio_dataplane_misconfigurations: D8IstioDataplaneMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
@@ -51,10 +51,10 @@
         ### Namespace-wide configuration
         # `istio.io/rev=vXYZ`: Use a specific revision.
         # `istio-injection=enabled`: Use the global revision.
-        kubectl get ns {{$labels.namespace}} --show-labels
+        d8 k get ns {{$labels.namespace}} --show-labels
 
         ### Pod-wide configuration
-        kubectl -n {{$labels.namespace}} get pods -l istio.io/rev={{$labels.revision}}
+        d8 k -n {{$labels.namespace}} get pods -l istio.io/rev={{$labels.revision}}
         ```
       plk_create_group_if_not_exists__d8_istio_dataplane_misconfigurations: D8IstioDataplaneMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       plk_grouped_by__d8_istio_dataplane_misconfigurations: D8IstioDataplaneMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
@@ -89,7 +89,7 @@
         To identify the affected pods, run the following command:
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pods -o json | jq -r --arg revision {{$labels.revision}} '.items[] | select(.metadata.annotations."sidecar.istio.io/status" // "{}" | fromjson | .revision == $revision) | .metadata.name'
+        d8 k -n {{$labels.namespace}} get pods -o json | jq -r --arg revision {{$labels.revision}} '.items[] | select(.metadata.annotations."sidecar.istio.io/status" // "{}" | fromjson | .revision == $revision) | .metadata.name'
         ```
       plk_create_group_if_not_exists__d8_istio_dataplane_misconfigurations: D8IstioDataplaneMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       plk_grouped_by__d8_istio_dataplane_misconfigurations: D8IstioDataplaneMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
@@ -113,7 +113,7 @@
         To identify the affected pods, run the following command:
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pods -l '!service.istio.io/canonical-name' -o json | jq -r '.items[] | select(.metadata.annotations."sidecar.istio.io/inject" != "false") | .metadata.name'
+        d8 k -n {{$labels.namespace}} get pods -l '!service.istio.io/canonical-name' -o json | jq -r '.items[] | select(.metadata.annotations."sidecar.istio.io/inject" != "false") | .metadata.name'
         ```
       plk_create_group_if_not_exists__d8_istio_dataplane_misconfigurations: D8IstioDataplaneMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       plk_grouped_by__d8_istio_dataplane_misconfigurations: D8IstioDataplaneMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
@@ -142,10 +142,10 @@
         ### Namespace-wide configuration
         # `istio.io/rev=vXYZ`: Use a specific revision.
         # `istio-injection=enabled`: Use the global revision.
-        kubectl get ns {{$labels.namespace}} --show-labels
+        d8 k get ns {{$labels.namespace}} --show-labels
 
         ### Pod-wide configuration
-        kubectl -n {{$labels.namespace}} get pods -l istio.io/rev={{$labels.desired_revision}}
+        d8 k -n {{$labels.namespace}} get pods -l istio.io/rev={{$labels.desired_revision}}
         ```
       plk_create_group_if_not_exists__d8_istio_dataplane_misconfigurations: D8IstioDataplaneMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       plk_grouped_by__d8_istio_dataplane_misconfigurations: D8IstioDataplaneMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
@@ -171,7 +171,7 @@
 
         1. Restart affected pods and use the following PromQL query to get a full list:
 
-           ```promql
+           ```prometheus
            max by (namespace, dataplane_pod) (d8_istio_dataplane_metadata{full_version="{{$labels.full_version}}"})
            ```
 

--- a/ee/modules/110-istio/monitoring/prometheus-rules/federation.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/federation.yaml
@@ -26,7 +26,7 @@
           ```bash
           KEY="$(deckhouse-controller module values istio -o json | jq -r .internal.remoteAuthnKeypair.priv)"
           LOCAL_CLUSTER_UUID="$(deckhouse-controller module values -g istio -o json | jq -r .global.discovery.clusterUUID)"
-          REMOTE_CLUSTER_UUID="$(kubectl get istiofederation {{$labels.federation_name}} -o json | jq -r .status.metadataCache.public.clusterUUID)"
+          REMOTE_CLUSTER_UUID="$(d8 k get istiofederation {{$labels.federation_name}} -o json | jq -r .status.metadataCache.public.clusterUUID)"
           TOKEN="$(deckhouse-controller helper gen-jwt --private-key-path <(echo "$KEY") --claim iss=d8-istio --claim sub=$LOCAL_CLUSTER_UUID --claim aud=$REMOTE_CLUSTER_UUID --claim scope=private-federation --ttl 1h)"
           curl -H "Authorization: Bearer $TOKEN" {{$labels.endpoint}}
           ```

--- a/ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
@@ -48,7 +48,7 @@
           ```bash
           KEY="$(deckhouse-controller module values istio -o json | jq -r .internal.remoteAuthnKeypair.priv)"
           LOCAL_CLUSTER_UUID="$(deckhouse-controller module values -g istio -o json | jq -r .global.discovery.clusterUUID)"
-          REMOTE_CLUSTER_UUID="$(kubectl get istiomulticluster {{$labels.multicluster_name}} -o json | jq -r .status.metadataCache.public.clusterUUID)"
+          REMOTE_CLUSTER_UUID="$(d8 k get istiomulticluster {{$labels.multicluster_name}} -o json | jq -r .status.metadataCache.public.clusterUUID)"
           TOKEN="$(deckhouse-controller helper gen-jwt --private-key-path <(echo "$KEY") --claim iss=d8-istio --claim sub=$LOCAL_CLUSTER_UUID --claim aud=$REMOTE_CLUSTER_UUID --claim scope=private-multicluster --ttl 1h)"
           curl -H "Authorization: Bearer $TOKEN" {{$labels.endpoint}}
           ```

--- a/ee/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+++ b/ee/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
@@ -17,7 +17,7 @@
           To find the cause of the issue, review the controller logs:
 
           ```bash
-          kubectl -n d8-metallb logs deploy/controller -c controller
+          d8 k -n d8-metallb logs deploy/controller -c controller
           ```
         summary: The MetalLB configuration hasn't been loaded.
 
@@ -38,7 +38,7 @@
           To find the cause of the issue, review the controller logs:
 
           ```bash
-          kubectl -n d8-metallb logs deploy/controller -c controller
+          d8 k -n d8-metallb logs deploy/controller -c controller
           ```
         summary: MetalLB is running on a stale configuration.
 
@@ -59,6 +59,6 @@
           Check the logs for details:
 
           ```bash
-          kubectl -n d8-metallb logs daemonset/speaker -c speaker
+          d8 k -n d8-metallb logs daemonset/speaker -c speaker
           ```
         summary: MetalLB BGP session is down.

--- a/ee/modules/650-runtime-audit-engine/monitoring/prometheus-rules/runtime-audit-engine.yaml
+++ b/ee/modules/650-runtime-audit-engine/monitoring/prometheus-rules/runtime-audit-engine.yaml
@@ -23,11 +23,11 @@
         1. Check the status of the DaemonSet `d8-runtime-audit-engine/runtime-audit-engine`:
 
            ```shell
-           kubectl -n d8-runtime-audit-engine get daemonset,pod --selector=app=runtime-audit-engine
+           d8 k -n d8-runtime-audit-engine get daemonset,pod --selector=app=runtime-audit-engine
            ```
 
         2. Get a list of nodes where Pods are not in the Ready state:
 
            ```shell
-           kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+           d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
            ```

--- a/modules/015-admission-policy-engine/monitoring/prometheus-rules/audit.yaml
+++ b/modules/015-admission-policy-engine/monitoring/prometheus-rules/audit.yaml
@@ -18,7 +18,7 @@
 
           - Run the following Prometheus query:
           
-            ```promql
+            ```prometheus
             count by (violating_namespace, violating_name, violation_msg) (
               d8_gatekeeper_exporter_constraint_violations{
                 violation_enforcement="deny",
@@ -48,7 +48,7 @@
 
           - Run the following Prometheus query:
 
-            ```promql
+            ```prometheus
             count by (violating_namespace, violating_kind, violating_name, violation_msg) (
               d8_gatekeeper_exporter_constraint_violations{
                 violation_enforcement="deny",
@@ -76,7 +76,7 @@
 
           - Run the following Prometheus query:
 
-            ```promql
+            ```prometheus
             count by (violating_namespace, violating_kind, violating_name, violation_msg) (
               d8_gatekeeper_exporter_constraint_violations{
                 violation_enforcement="deny",

--- a/modules/015-admission-policy-engine/monitoring/prometheus-rules/bootstrap.yaml
+++ b/modules/015-admission-policy-engine/monitoring/prometheus-rules/bootstrap.yaml
@@ -19,11 +19,11 @@
           1. Verify that the module's components are up and running:
           
              ```bash
-             kubectl get pods -n d8-admission-policy-engine
+             d8 k get pods -n d8-admission-policy-engine
              ```
           
           2. Check logs for issues, such as missing constraint templates or incomplete CRD creation:
           
              ```bash
-             kubectl logs -n d8-system -lapp=deckhouse --tail=1000 | grep admission-policy-engine
+             d8 k logs -n d8-system -lapp=deckhouse --tail=1000 | grep admission-policy-engine
              ```

--- a/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
@@ -28,7 +28,7 @@
         For details, refer to the logs of the agent:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}
+        d8 k -n {{ $labels.namespace }} logs {{ $labels.pod }}
         ```
   - alert: CiliumAgentMetricNotFound
     expr: (count by (namespace,pod) (cilium_unreachable_health_endpoints) OR count by (namespace,pod) (cilium_endpoint_state)) != 1
@@ -50,13 +50,13 @@
         1. Check the logs of the agent:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}
+           d8 k -n {{ $labels.namespace }} logs {{ $labels.pod }}
            ```
         
         1. Verify the agent's health status:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} exec -ti {{ $labels.pod }} cilium-health status
+           d8 k -n {{ $labels.namespace }} exec -ti {{ $labels.pod }} cilium-health status
            ```
 
         1. Compare the metrics with those of a neighboring agent.
@@ -80,7 +80,7 @@
         For details, refer to the logs of the agent:
         
         ```bash
-        kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}
+        d8 k -n {{ $labels.namespace }} logs {{ $labels.pod }}
         ```
   - alert: CiliumAgentMapPressureCritical
     expr: sum by (namespace, pod, map_name) (cilium_bpf_map_pressure > 0.9)
@@ -119,5 +119,5 @@
         For details, refer to the logs of the agent:
         
         ```bash
-        kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}
+        d8 k -n {{ $labels.namespace }} logs {{ $labels.pod }}
         ```

--- a/modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
+++ b/modules/030-cloud-provider-yandex/monitoring/prometheus-rules/deprecated_availability_zone.yaml
@@ -21,7 +21,7 @@
           1. Identify the nodes that need to be migrated by running the following command:
 
              ```bash
-             kubectl get node -l "topology.kubernetes.io/zone=ru-central1-c"
+             d8 k get node -l "topology.kubernetes.io/zone=ru-central1-c"
              ```
 
           2. Migrate your nodes, disks, and load balancers to one of the supported zones: `ru-central1-a`, `ru-central1-b`, or `ru-central1-d`. Refer to the [Yandex migration guide](https://cloud.yandex.com/en/docs/overview/concepts/zone-migration) for detailed instructions.
@@ -48,7 +48,7 @@
           1. Migrate the NAT instance. To get `providerClusterConfiguration.withNATInstance`, run the following command:
 
              ```bash
-             kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values -g cloud-provider-yandex -o json | jq -c | jq '.cloudProviderYandex.internal.providerClusterConfiguration.withNATInstance'
+             d8 k -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values -g cloud-provider-yandex -o json | jq -c | jq '.cloudProviderYandex.internal.providerClusterConfiguration.withNATInstance'
              ```
 
              - If you specified `withNATInstance.natInstanceInternalAddress` and/or `withNATInstance.internalSubnetID` in `providerClusterConfiguration`, remove them using the following command:
@@ -72,8 +72,8 @@
              - Get the appropriate edition and version of Deckhouse:
 
                ```bash
-               DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}')
-               DH_EDITION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}' | tr '[:upper:]' '[:lower:]')
+               DH_VERSION=$(d8 k -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}')
+               DH_EDITION=$(d8 k -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}' | tr '[:upper:]' '[:lower:]')
                echo "DH_VERSION=$DH_VERSION DH_EDITION=$DH_EDITION"
                ```
 
@@ -94,13 +94,13 @@
              - Get the route table name:
 
                ```bash
-               kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values -g cloud-provider-yandex -o json | jq -c | jq '.global.clusterConfiguration.cloud.prefix'
+               d8 k -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values -g cloud-provider-yandex -o json | jq -c | jq '.global.clusterConfiguration.cloud.prefix'
                ```
 
              - Get the NAT instance name:
 
                ```bash
-               kubectl -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values -g cloud-provider-yandex -o json | jq -c | jq '.cloudProviderYandex.internal.providerDiscoveryData.natInstanceName'
+               d8 k -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values -g cloud-provider-yandex -o json | jq -c | jq '.cloudProviderYandex.internal.providerDiscoveryData.natInstanceName'
                ```
 
              - Get the NAT instance internal IP address:

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -34,7 +34,7 @@
         To resolve this issue, check the status of the `kube-system/d8-control-plane-manager` DaemonSet and its pods by running the following command:
 
         ```bash
-        kubectl -n kube-system get daemonset,pod --selector=app=d8-control-plane-manager
+        d8 k -n kube-system get daemonset,pod --selector=app=d8-control-plane-manager
         ```
   - alert: D8KubernetesVersionIsDeprecated
     for: 10m
@@ -95,7 +95,7 @@
         Example of applying an additional audit policy:
 
         ```bash
-        kubectl apply -f - <<EOF
+        d8 k apply -f - <<EOF
         apiVersion: v1
         kind: Secret
         metadata:

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
@@ -21,7 +21,7 @@
           - Defragment the etcd database by running the following command:
 
             ```bash
-            kubectl -n kube-system exec -ti etcd-{{ $labels.node }} -- /usr/bin/etcdctl \
+            d8 k -n kube-system exec -ti etcd-{{ $labels.node }} -- /usr/bin/etcdctl \
               --cacert /etc/kubernetes/pki/etcd/ca.crt \
               --cert /etc/kubernetes/pki/etcd/ca.crt \
               --key /etc/kubernetes/pki/etcd/ca.key \
@@ -61,8 +61,8 @@
           To modify `quota-backend-bytes`, set the `controlPlaneManager.etcd.maxDbSize` parameter. Before setting a new value, check the current database usage on every control plane node by running:
 
           ```
-          for pod in $(kubectl get pod -n kube-system -l component=etcd,tier=control-plane -o name); do
-            kubectl -n kube-system exec -ti "$pod" -- /usr/bin/etcdctl \
+          for pod in $(d8 k get pod -n kube-system -l component=etcd,tier=control-plane -o name); do
+            d8 k -n kube-system exec -ti "$pod" -- /usr/bin/etcdctl \
               --cacert /etc/kubernetes/pki/etcd/ca.crt \
               --cert /etc/kubernetes/pki/etcd/ca.crt \
               --key /etc/kubernetes/pki/etcd/ca.key \
@@ -124,7 +124,7 @@
           To resolve this issue, defragment the etcd database by running the following command:
 
           ```bash
-          kubectl -n kube-system exec -ti etcd-{{ $labels.node }} -- /usr/bin/etcdctl \
+          d8 k -n kube-system exec -ti etcd-{{ $labels.node }} -- /usr/bin/etcdctl \
             --cacert /etc/kubernetes/pki/etcd/ca.crt \
             --cert /etc/kubernetes/pki/etcd/ca.crt \
             --key /etc/kubernetes/pki/etcd/ca.key \

--- a/modules/040-node-manager/monitoring/prometheus-rules/migrate-to-tofu.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/migrate-to-tofu.yaml
@@ -21,19 +21,19 @@
         - Current Terraform version:
 
           ```shell
-          kubectl -n d8-system exec -it deployments/terraform-state-exporter -c exporter -- terraform version
+          d8 k -n d8-system exec -it deployments/terraform-state-exporter -c exporter -- terraform version
           ```
 
         - Version in the Terraform state:
 
           ```shell
-          kubectl -n d8-system get secret d8-cluster-terraform-state -o json | jq -r '.data["cluster-tf-state.json"] | @base64d | fromjson | .terraform_version'
+          d8 k -n d8-system get secret d8-cluster-terraform-state -o json | jq -r '.data["cluster-tf-state.json"] | @base64d | fromjson | .terraform_version'
           ```
 
         - Check for destructive changes:
 
           ```shell
-          kubectl exec -it deploy/terraform-state-exporter -n d8-system -- dhctl terraform check
+          d8 k exec -it deploy/terraform-state-exporter -n d8-system -- dhctl terraform check
           ```
 
         To resolve the issue and migrate to OpenTofu manually, follow these steps:
@@ -62,7 +62,7 @@
         2. In the cluster, remove the `commander-agent` module using the following command:
 
            ```shell
-           kubectl delete mc commander-agent
+           d8 k delete mc commander-agent
            ```
 
         3. Using the `install` container with the previous major Deckhouse release (for example, `1.69.X`, while the cluster is now on `1.70.X`), run the following command to resolve all destructive changes in the cluster:

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -27,13 +27,13 @@
         - Check the expected configuration checksum for the NodeGroup:
         
           ```shell
-          kubectl -n d8-cloud-instance-manager get secret configuration-checksums -o jsonpath={.data.{{ $labels.node_group }}} | base64 -d
+          d8 k -n d8-cloud-instance-manager get secret configuration-checksums -o jsonpath={.data.{{ $labels.node_group }}} | base64 -d
           ```
 
         - Check the current configuration checksum on the Node:
 
           ```shell
-          kubectl get node {{ $labels.node }} -o jsonpath='{.metadata.annotations.node\.deckhouse\.io/configuration-checksum}'
+          d8 k get node {{ $labels.node }} -o jsonpath='{.metadata.annotations.node\.deckhouse\.io/configuration-checksum}'
           ```
 
         - View Bashible logs on the Node:
@@ -197,15 +197,15 @@
         1. To drain the Node and grant the update approval, run the following command:
 
            ```shell
-           kubectl drain {{ $labels.node }} --delete-local-data=true --ignore-daemonsets=true --force=true &&
-             kubectl annotate node {{ $labels.node }} update.node.deckhouse.io/disruption-approved=
+           d8 k drain {{ $labels.node }} --delete-local-data=true --ignore-daemonsets=true --force=true &&
+             d8 k annotate node {{ $labels.node }} update.node.deckhouse.io/disruption-approved=
            ```
         
         2. Uncordon the Node once the update is complete and the annotation `update.node.deckhouse.io/approved` is removed:
 
            ```shell
-           while kubectl get node {{ $labels.node }} -o json | jq -e '.metadata.annotations | has("update.node.deckhouse.io/approved")' > /dev/null; do sleep 1; done
-           kubectl uncordon {{ $labels.node }}
+           while d8 k get node {{ $labels.node }} -o json | jq -e '.metadata.annotations | has("update.node.deckhouse.io/approved")' > /dev/null; do sleep 1; done
+           d8 k uncordon {{ $labels.node }}
            ```
 
         If the NodeGroup has multiple Nodes, repeat this process for each one, since only one Node is updated at a time.
@@ -234,7 +234,7 @@
         To get more details, run the following:
 
         ```shell
-        kubectl -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=ScaleDown --sort-by='.metadata.creationTimestamp'
+        d8 k -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=ScaleDown --sort-by='.metadata.creationTimestamp'
         ```
 
   - alert: NodeStuckInDraining
@@ -261,7 +261,7 @@
         To get more details, run the following:
         
         ```shell
-        kubectl -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=DrainFailed --sort-by='.metadata.creationTimestamp'
+        d8 k -n default get event --field-selector involvedObject.name={{ $labels.node }},reason=DrainFailed --sort-by='.metadata.creationTimestamp'
         ```
 
         Error message: {{ $labels.message }}
@@ -282,5 +282,5 @@
         To resolve the issue, check if the `bashible-apiserver` Pods are up-to-date and running:
         
         ```shell
-        kubectl -n d8-cloud-instance-manager get pods -l app=bashible-apiserver
+        d8 k -n d8-cloud-instance-manager get pods -l app=bashible-apiserver
         ```

--- a/modules/042-kube-dns/monitoring/prometheus-rules/kubernetes/dns.yaml
+++ b/modules/042-kube-dns/monitoring/prometheus-rules/kubernetes/dns.yaml
@@ -18,5 +18,5 @@
         To resolve the issue, review the container logs:
         
         ```bash
-        kubectl -n kube-system logs {{$labels.pod}}
+        d8 k -n kube-system logs {{$labels.pod}}
         ```

--- a/modules/101-cert-manager/monitoring/prometheus-rules/certificate.yaml
+++ b/modules/101-cert-manager/monitoring/prometheus-rules/certificate.yaml
@@ -17,7 +17,7 @@
         To check the certificate details, run the following command:
 
         ```bash
-        kubectl -n <NAMESPACE> describe certificate <CERTIFICATE-NAME>
+        d8 k -n <NAMESPACE> describe certificate <CERTIFICATE-NAME>
         ```
 
   - alert: CertmanagerCertificateExpired
@@ -37,7 +37,7 @@
         To check the certificate details, run the following command:
 
         ```shell
-        kubectl -n {{$labels.exported_namespace}} describe certificate {{$labels.name}}
+        d8 k -n {{$labels.exported_namespace}} describe certificate {{$labels.name}}
         ```
   - alert: CertmanagerCertificateOrderErrors
     expr: |
@@ -60,5 +60,5 @@
         This can affect certificate ordering and prolongation in the future. For details, check the cert-manager logs using the following command:
 
         ```bash
-        kubectl -n d8-cert-manager logs -l app=cert-manager -c cert-manager
+        d8 k -n d8-cert-manager logs -l app=cert-manager -c cert-manager
         ```

--- a/modules/110-istio/monitoring/prometheus-rules/controlplane.yaml
+++ b/modules/110-istio/monitoring/prometheus-rules/controlplane.yaml
@@ -41,7 +41,7 @@
           To check the status of the control plane pods, run the following command:
 
           ```bash
-          kubectl get pods -n d8-istio -l istio.io/rev={{$labels.label_istio_io_rev}}
+          d8 k get pods -n d8-istio -l istio.io/rev={{$labels.label_istio_io_rev}}
           ```
 
     - alert: D8IstioAdditionalControlplaneDoesntWork
@@ -88,5 +88,5 @@
           To check the status of the control plane pods, run the following command:
 
           ```
-          kubectl get pods -n d8-istio -l istio.io/rev={{$labels.label_istio_io_rev}}
+          d8 k get pods -n d8-istio -l istio.io/rev={{$labels.label_istio_io_rev}}
           ```

--- a/modules/110-istio/monitoring/prometheus-rules/operator.yaml
+++ b/modules/110-istio/monitoring/prometheus-rules/operator.yaml
@@ -21,5 +21,5 @@
         To investigate the issue, check the operator logs:
 
         ```bash
-        kubectl -n d8-istio logs -l app=operator,revision={{$labels.revision}}
+        d8 k -n d8-istio logs -l app=operator,revision={{$labels.revision}}
         ```

--- a/modules/200-operator-prometheus/monitoring/prometheus-rules/operator.yaml
+++ b/modules/200-operator-prometheus/monitoring/prometheus-rules/operator.yaml
@@ -28,13 +28,13 @@
         1. Analyze the Deployment details:
         
            ```shell
-           kubectl -n d8-operator-prometheus describe deployment prometheus-operator
+           d8 k -n d8-operator-prometheus describe deployment prometheus-operator
            ```
 
         2. Examine the Pod's to determine why it is not running:
         
            ```shell
-           kubectl -n d8-operator-prometheus describe pod -l app=prometheus-operator
+           d8 k -n d8-operator-prometheus describe pod -l app=prometheus-operator
            ```
 
   - alert: D8PrometheusOperatorTargetAbsent
@@ -59,7 +59,7 @@
         To resolve the issue, analyze the Deployment details:
 
         ```shell
-        kubectl -n d8-operator-prometheus describe deployment prometheus-operator
+        d8 k -n d8-operator-prometheus describe deployment prometheus-operator
         ```
 
   - alert: D8PrometheusOperatorPodIsNotReady
@@ -87,13 +87,13 @@
         1. Analyze the Deployment details:
         
            ```shell
-           kubectl -n d8-operator-prometheus describe deployment prometheus-operator
+           d8 k -n d8-operator-prometheus describe deployment prometheus-operator
            ```
 
         2. Examine the Pod's to determine why it is not running:
         
            ```shell
-           kubectl -n d8-operator-prometheus describe pod -l app=prometheus-operator
+           d8 k -n d8-operator-prometheus describe pod -l app=prometheus-operator
            ```
 
   - alert: D8PrometheusOperatorPodIsNotRunning
@@ -120,11 +120,11 @@
         1. Analyze the Deployment details:
         
            ```shell
-           kubectl -n d8-operator-prometheus describe deployment prometheus-operator
+           d8 k -n d8-operator-prometheus describe deployment prometheus-operator
            ```
 
         2. Examine the Pod's to determine why it is not running:
         
            ```shell
-           kubectl -n d8-operator-prometheus describe pod -l app=prometheus-operator
+           d8 k -n d8-operator-prometheus describe pod -l app=prometheus-operator
            ```

--- a/modules/300-prometheus/monitoring/prometheus-rules/deprecation.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/deprecation.yaml
@@ -67,7 +67,7 @@
 
           To list all deprecated panel intervals, use the following expression:
 
-          ```promql
+          ```prometheus
           sum by (dashboard, panel, interval) (d8_grafana_dashboards_deprecated_interval) > 0
           ```
 
@@ -92,7 +92,7 @@
 
           To list all deprecated alert rules, use the following expression:
 
-          ```promql
+          ```prometheus
           sum by (dashboard, panel, alert_rule) (d8_grafana_dashboards_deprecated_alert_rule) > 0
           ```
 
@@ -117,7 +117,7 @@
 
           To list all potentially outdated plugins, use the following expression:
 
-          ```promql
+          ```prometheus
           sum by (dashboard, panel, plugin) (d8_grafana_dashboards_deprecated_plugin) > 0
           ```
 

--- a/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
@@ -17,7 +17,7 @@
         To check the current usage, run the following command:
 
         ```shell
-        kubectl -n {{ $labels.namespace }} exec -ti {{ $labels.pod_name }} -c prometheus -- df -PBG /prometheus
+        d8 k -n {{ $labels.namespace }} exec -ti {{ $labels.pod_name }} -c prometheus -- df -PBG /prometheus
         ```
 
         Consider expanding disk size following the [guide](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html#how-to-expand-disk-size).

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
@@ -24,13 +24,13 @@
           1. Retrieve the certificate name from the Secret:
 
              ```bash
-             cert=$(kubectl get secret -n {{$labels.secret_namespace}} {{$labels.secret_name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
+             cert=$(d8 k get secret -n {{$labels.secret_namespace}} {{$labels.secret_name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
              ```
 
           2. Check the certificate status and investigate why it hasn't been updated:
 
              ```bash
-             kubectl describe cert -n {{$labels.secret_namespace}} "$cert"
+             d8 k describe cert -n {{$labels.secret_namespace}} "$cert"
              ```
 
   - alert: CertificateSecretExpired
@@ -57,11 +57,11 @@
           1. Retrieve the certificate name from the Secret:
 
              ```bash
-             cert=$(kubectl get secret -n {{$labels.secret_namespace}} {{$labels.secret_name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
+             cert=$(d8 k get secret -n {{$labels.secret_namespace}} {{$labels.secret_name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')
              ```
 
           2. Check the certificate status and investigate why it hasn't been updated:
 
              ```bash
-             kubectl describe cert -m {{$labels.secret_namespace}} "$cert"
+             d8 k describe cert -m {{$labels.secret_namespace}} "$cert"
              ```

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificates-exporter-health.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificates-exporter-health.yaml
@@ -21,13 +21,13 @@
         - Check the pod status:
         
           ```bash
-          kubectl -n d8-monitoring get pod -l app=x509-certificate-exporter
+          d8 k -n d8-monitoring get pod -l app=x509-certificate-exporter
           ```
 
         - Check the pod logs:
         
           ```bash
-          kubectl -n d8-monitoring logs -l app=x509-certificate-exporter -c x509-certificate-exporter
+          d8 k -n d8-monitoring logs -l app=x509-certificate-exporter -c x509-certificate-exporter
           ```
 
   - alert: D8CertExporterTargetAbsent
@@ -50,13 +50,13 @@
         - Check the pod status:
         
           ```bash
-          kubectl -n d8-monitoring get pod -l app=x509-certificate-exporter
+          d8 k -n d8-monitoring get pod -l app=x509-certificate-exporter
           ```
 
         - Check the pod logs:
         
           ```bash
-          kubectl -n d8-monitoring logs -l app=x509-certificate-exporter -c x509-certificate-exporter
+          d8 k -n d8-monitoring logs -l app=x509-certificate-exporter -c x509-certificate-exporter
           ```
 
   - alert: D8CertExporterPodIsNotReady
@@ -79,13 +79,13 @@
         1. Retrieve the deployment details:
            
            ```bash
-           kubectl -n d8-monitoring describe deploy x509-certificate-exporter
+           d8 k -n d8-monitoring describe deploy x509-certificate-exporter
            ```
 
         2. Check the pod status and investigate why it's not ready:
         
            ```bash
-           kubectl -n d8-monitoring describe pod -l app=x509-certificate-exporter
+           d8 k -n d8-monitoring describe pod -l app=x509-certificate-exporter
            ```
 
   - alert: D8CertExporterPodIsNotRunning
@@ -107,11 +107,11 @@
         1. Retrieve the deployment details:
            
            ```bash
-           kubectl -n d8-monitoring describe deploy x509-certificate-exporter
+           d8 k -n d8-monitoring describe deploy x509-certificate-exporter
            ```
 
         2. Check the pod status and investigate why it's not running:
         
            ```bash
-           kubectl -n d8-monitoring describe pod -l app=x509-certificate-exporter
+           d8 k -n d8-monitoring describe pod -l app=x509-certificate-exporter
            ```

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -91,7 +91,7 @@
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```
 
   - alert: KubernetesDaemonSetReplicasUnavailable
@@ -125,7 +125,7 @@
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```
 
   - alert: KubernetesDaemonSetNotUpToDate
@@ -149,19 +149,19 @@
         1. Check the DaemonSet's status:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} get ds {{ $labels.daemonset }}
+           d8 k -n {{ $labels.namespace }} get ds {{ $labels.daemonset }}
            ```
 
         2. Analyze the DaemonSet's description:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} describe ds {{ $labels.daemonset }}
+           d8 k -n {{ $labels.namespace }} describe ds {{ $labels.daemonset }}
            ```
 
         3. If the parameter `Number of Nodes Scheduled with Up-to-date Pods` does not match `Current Number of Nodes Scheduled`, check the DaemonSet's `updateStrategy`:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} get ds {{ $labels.daemonset }} -o json | jq '.spec.updateStrategy'
+           d8 k -n {{ $labels.namespace }} get ds {{ $labels.daemonset }} -o json | jq '.spec.updateStrategy'
            ```
 
            If `updateStrategy` is set to `OnDelete`, the DaemonSet is updated only when pods are deleted.

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
@@ -39,19 +39,19 @@
         1. Print the job details:
 
            ```bash
-           kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}
+           d8 k -n {{$labels.namespace}} describe job {{$labels.job_name}}
            ```
 
         1. Check the job status:
 
            ```bash
-           kubectl -n {{$labels.namespace}} get job {{$labels.job_name}}
+           d8 k -n {{$labels.namespace}} get job {{$labels.job_name}}
            ```
 
         1. Check the status of pods created by the job:
 
            ```bash
-           kubectl -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}
+           d8 k -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}
            ```
 
   - alert: CronJobPodsNotCreated
@@ -89,19 +89,19 @@
         1. Print the job details:
 
            ```bash
-           kubectl -n {{$labels.namespace}} describe job {{$labels.job_name}}
+           d8 k -n {{$labels.namespace}} describe job {{$labels.job_name}}
            ```
 
         1. Check the job status:
 
            ```bash
-           kubectl -n {{$labels.namespace}} get job {{$labels.job_name}}
+           d8 k -n {{$labels.namespace}} get job {{$labels.job_name}}
            ```
 
         1. Check the status of pods created by the job:
 
            ```bash
-           kubectl -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}
+           d8 k -n {{$labels.namespace}} get pods -l job-name={{$labels.job_name}}
            ```
 
   - alert: CronJobSchedulingError

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/self.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/self.yaml
@@ -27,11 +27,11 @@
         1. Print detailed information about the `extended-monitoring-exporter` deployment:
 
            ```bash
-           kubectl -n d8-monitoring describe deploy extended-monitoring-exporter
+           d8 k -n d8-monitoring describe deploy extended-monitoring-exporter
            ```
 
         2. Print detailed information about the pods associated with the `extended-monitoring-exporter`:
 
            ```bash
-           kubectl -n d8-monitoring describe pod -l app=extended-monitoring-exporter
+           d8 k -n d8-monitoring describe pod -l app=extended-monitoring-exporter
            ```

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/image-availability-exporter-health.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/image-availability-exporter-health.yaml
@@ -24,13 +24,13 @@
         1. Check the pod status:
         
            ```bash
-           kubectl -n d8-monitoring get pod -l app=image-availability-exporter
+           d8 k -n d8-monitoring get pod -l app=image-availability-exporter
            ```
 
         1. Check the pod logs:
         
            ```bash
-           kubectl -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter
+           d8 k -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter
            ```
 
   - alert: D8ImageAvailabilityExporterTargetAbsent
@@ -56,13 +56,13 @@
         1. Check the pod status:
         
            ```bash
-           kubectl -n d8-monitoring get pod -l app=image-availability-exporter
+           d8 k -n d8-monitoring get pod -l app=image-availability-exporter
            ```
 
         1. Check the pod logs:
         
            ```bash
-           kubectl -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter
+           d8 k -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter
            ```
 
   - alert: D8ImageAvailabilityExporterPodIsNotReady
@@ -88,13 +88,13 @@
         1. Retrieve the deployment details:
 
            ```bash
-           kubectl -n d8-monitoring describe deploy image-availability-exporter
+           d8 k -n d8-monitoring describe deploy image-availability-exporter
            ```
 
         2. Check the pod status and investigate why it isn't `Ready`:
         
            ```bash
-           kubectl -n d8-monitoring describe pod -l app=image-availability-exporter
+           d8 k -n d8-monitoring describe pod -l app=image-availability-exporter
            ```
 
   - alert: D8ImageAvailabilityExporterPodIsNotRunning
@@ -119,13 +119,13 @@
         1. Retrieve the deployment details:
 
            ```bash
-           kubectl -n d8-monitoring describe deploy image-availability-exporter
+           d8 k -n d8-monitoring describe deploy image-availability-exporter
            ```
 
         2. Check the pod status and investigate why it isn't running:
         
            ```bash
-           kubectl -n d8-monitoring describe pod -l app=image-availability-exporter
+           d8 k -n d8-monitoring describe pod -l app=image-availability-exporter
            ```
 
 - name: d8.extended-monitoring.image-availability-exporter.malfunctioning
@@ -152,5 +152,5 @@
         To investigate the issue, review the exporter's logs:
         
         ```bash
-        kubectl -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter
+        d8 k -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter
         ```

--- a/modules/340-monitoring-custom/monitoring/prometheus-rules/warnings/warnings.yaml
+++ b/modules/340-monitoring-custom/monitoring/prometheus-rules/warnings/warnings.yaml
@@ -19,7 +19,7 @@
         To list all ServiceMonitors in the Deckhouse namespace, run the following command:
         
         ```bash
-        kubectl get servicemonitors --all-namespaces -l heritage!=deckhouse
+        d8 k get servicemonitors --all-namespaces -l heritage!=deckhouse
         ```
 
         For more information on metric collection, refer to the [Prometheus module FAQ](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html).
@@ -43,7 +43,7 @@
         To list all PodMonitors in the Deckhouse namespace, run the following command:
         
         ```bash
-        kubectl get podmonitors --all-namespaces -l heritage!=deckhouse
+        d8 k get podmonitors --all-namespaces -l heritage!=deckhouse
         ```
 
         For more information on metric collection, refer to the [Prometheus module FAQ](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html).
@@ -67,7 +67,7 @@
         To list all PrometheusRules in the Deckhouse namespace, run the following command:
         
         ```bash
-        kubectl get prometheusrules --all-namespaces -l heritage!=deckhouse
+        d8 k get prometheusrules --all-namespaces -l heritage!=deckhouse
         ```
 
         For details on adding alerts and recording rules, refer to the [Prometheus module FAQ](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html#how-do-i-add-alerts-andor-recording-rules).
@@ -91,7 +91,7 @@
         To list all services labeled with `prometheus-custom-target`, run the following command:
         
         ```bash
-        kubectl get service --all-namespaces --show-labels | grep prometheus-custom-target
+        d8 k get service --all-namespaces --show-labels | grep prometheus-custom-target
         ```
 
         For more information on metric collection, refer to the [Prometheus module FAQ](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/prometheus/faq.html).

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -19,7 +19,7 @@
         1. Check the current release channel used in the cluster:
 
            ```bash
-           kubectl -n d8-system  get deploy deckhouse -o json | jq '.spec.template.spec.containers[0].image' -r
+           d8 k -n d8-system  get deploy deckhouse -o json | jq '.spec.template.spec.containers[0].image' -r
            ```
 
         1. Subscribe to one of the regular release channels by adjusting the [`deckhouse` module configuration](https://deckhouse.io/products/kubernetes-platform/documentation/latest/modules/deckhouse/configuration.html#parameters-releasechannel).
@@ -43,7 +43,7 @@
         To approve the release, run the following command:
 
         ```bash
-        kubectl patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'
+        d8 k patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'
         ```
 
   - alert: DeckhouseReleaseIsWaitingManualApproval
@@ -65,7 +65,7 @@
         To approve the release, run the following command:
 
         ```bash
-        kubectl patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'
+        d8 k patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'
         ```
 
   - alert: DeckhouseReleaseIsWaitingManualApproval
@@ -87,7 +87,7 @@
         To approve the release, run the following command:
 
         ```bash
-        kubectl patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'
+        d8 k patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'
         ```
 
   - alert: DeckhouseReleaseIsBlocked
@@ -108,7 +108,7 @@
         To check the details, run the following command:
 
         ```bash
-        kubectl describe DeckhouseRelease {{ $labels.name }}
+        d8 k describe DeckhouseRelease {{ $labels.name }}
         ```
 
   - alert: DeckhouseReleaseDisruptionApprovalRequired
@@ -129,13 +129,13 @@
         To check the details, run the following command:
 
         ```bash
-        kubectl describe DeckhouseRelease {{ $labels.name }}
+        d8 k describe DeckhouseRelease {{ $labels.name }}
         ```
 
         To approve the disruptive update, run the following command:
 
         ```bash
-        kubectl annotate DeckhouseRelease {{ $labels.name }} release.deckhouse.io/disruption-approved=true
+        d8 k annotate DeckhouseRelease {{ $labels.name }} release.deckhouse.io/disruption-approved=true
         ```
 
   - alert: ModuleReleaseIsWaitingManualApproval
@@ -154,7 +154,7 @@
         To approve the module release, run the following command:
 
         ```bash
-        kubectl annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
+        d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```
 
   - alert: ModuleReleaseIsOutdated
@@ -177,7 +177,7 @@
         To approve the module release update, run the following command:
 
         ```bash
-        kubectl annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
+        d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```
 
   - alert: ModuleReleaseIsOutdated
@@ -200,7 +200,7 @@
         To approve the module release update, run the following command:
 
         ```bash
-        kubectl annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
+        d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```
 
   - alert: ModuleReleaseIsOutdated
@@ -225,7 +225,7 @@
         To approve the module release update, run the following command:
 
         ```bash
-        kubectl annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
+        d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```
 
   - alert: ModuleIsInMaintenanceMode
@@ -244,7 +244,7 @@
         To switch the module back to normal mode, edit the corresponding ModuleConfig resource with the following command:
 
         ```bash
-        kubectl patch moduleconfig {{ $labels.moduleName }} --type=json -p='[{"op": "remove", "path": "/spec/maintenance"}]'
+        d8 k patch moduleconfig {{ $labels.moduleName }} --type=json -p='[{"op": "remove", "path": "/spec/maintenance"}]'
         ```
 
   - alert: DeckhouseReleaseNotificationNotSent
@@ -265,7 +265,7 @@
         To check the notification webhook address, run the following command:
 
         ```bash
-        kubectl get mc deckhouse -o yaml
+        d8 k get mc deckhouse -o yaml
         ```
 
   - alert: ModuleReleaseIsBlockedByRequirements
@@ -284,7 +284,7 @@
         To check the requirements, run the following command:
 
         ```bash
-        kubectl  get mr {{ $labels.name }} -o json | jq .spec.requirements
+        d8 k  get mr {{ $labels.name }} -o json | jq .spec.requirements
         ```
 
   - alert: D8HasModuleConfigAllowedToDisable
@@ -310,7 +310,7 @@
         To resolve this issue and stop the alert, run the following command:
 
         ```bash
-        kubectl annotate moduleconfig {{ $labels.module }} modules.deckhouse.io/allow-disabling-
+        d8 k annotate moduleconfig {{ $labels.module }} modules.deckhouse.io/allow-disabling-
         ```
 
   - alert: ModuleAtConflict
@@ -356,13 +356,13 @@
         To specify the update policy in the module configuration, run the following command:
 
         ```bash
-        kubectl patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
+        d8 k patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
         ```
 
         After resolving all alerts related to the update policy `{{ $labels.updatePolicy }}`, clear the selector by running the following command:
 
         ```bash
-        kubectl patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
+        d8 k patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
         ```
 
   - alert: DeckhouseHighMemoryUsage
@@ -379,9 +379,9 @@
         Please, if possible, get the dumps for debugging purposes (it will take around 30 seconds):
 
         ```bash
-        curl -s "http://$(kubectl -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/heap" -o /tmp/heap.pprof
-        curl -s "http://$(kubectl -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/goroutine" -o /tmp/goroutine.pprof
-        curl -s "http://$(kubectl -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/profile?seconds=30" -o /tmp/cpu.pprof
+        curl -s "http://$(d8 k -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/heap" -o /tmp/heap.pprof
+        curl -s "http://$(d8 k -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/goroutine" -o /tmp/goroutine.pprof
+        curl -s "http://$(d8 k -n d8-system get pod {{ $labels.pod }} -o jsonpath='{.status.hostIP}'):4222/debug/pprof/profile?seconds=30" -o /tmp/cpu.pprof
         ```
 
         and send these files (/tmp/heap.pprof, /tmp/cpu.pprof and /tmp/goroutine.pprof) to the support team.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/cni-checks.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/cni-checks.yaml
@@ -36,7 +36,7 @@
           1. Find the desired settings in the ConfigMap `d8-system/desired-cni-moduleconfig` by running the following command:
 
              ```bash
-             kubectl -n d8-system get configmap desired-cni-moduleconfig -o yaml
+             d8 k -n d8-system get configmap desired-cni-moduleconfig -o yaml
              ```
 
           1. Update the conflicting settings in the CNI `{{ $labels.cni }}` ModuleConfig to match the desired configuration.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -142,7 +142,7 @@
         To investigate the issue, check the logs by running the following command:
 
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
 
   - alert: D8DeckhouseHasNoAccessToRegistry
@@ -186,7 +186,7 @@
         To investigate the issue, check the logs by running the following command:
 
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
 
   - alert: D8DeckhouseGlobalHookFailsTooOften
@@ -215,7 +215,7 @@
         To investigate the issue, check the logs by running the following command:
         
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
 
   - alert: D8DeckhouseModuleHookFailsTooOften
@@ -244,7 +244,7 @@
         To investigate the issue, check the logs by running the following command:
 
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
 
   - alert: D8DeckhouseCouldNotDiscoverModules
@@ -266,7 +266,7 @@
         To investigate the issue, check the logs by running the following command:
         
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
 
   - alert: D8DeckhouseCouldNotRunModule
@@ -288,7 +288,7 @@
         To investigate the issue, check the logs by running the following command:
         
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
 
   - alert: D8DeckhouseCouldNotDeleteModule
@@ -310,7 +310,7 @@
         To investigate the issue, check the logs by running the following command:
         
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
 
   - alert: D8DeckhouseCouldNotRunGlobalHook
@@ -332,7 +332,7 @@
         To investigate the issue, check the logs by running the following command:
         
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
 
   - alert: D8DeckhouseCouldNotRunModuleHook
@@ -354,7 +354,7 @@
         To investigate the issue, check the logs by running the following command:
         
         ```bash
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
 
   - alert: D8DeckhouseConfigInvalid
@@ -380,19 +380,19 @@
         1. Check Deckhouse logs by running the following command:
         
            ```bash
-           kubectl -n d8-system logs -f -l app=deckhouse
+           d8 k -n d8-system logs -f -l app=deckhouse
            ```
 
         1. Edit the Deckhouse global configuration:
 
            ```bash
-           kubectl edit mc global
+           d8 k edit mc global
            ```
            
            Or edit configuration of a specific module:
 
            ```bash
-           kubectl edit mc <MODULE_NAME>
+           d8 k edit mc <MODULE_NAME>
            ```
 
   - alert: DeckhouseUpdating
@@ -496,7 +496,7 @@
         1. Check Deckhouse logs for more information by running:
 
            ```bash
-           kubectl -n d8-system logs deploy/deckhouse | grep error | grep -i watch
+           d8 k -n d8-system logs deploy/deckhouse | grep error | grep -i watch
            ```
 
         1. This alert attempts to detect a correlation between the faulty snapshot invalidation and API server connection errors, specifically for the `handle-node-template` hook in the `node-manager` module.
@@ -504,7 +504,7 @@
            To compare the snapshot with the actual node objects for this hook, run the following command:
 
            ```bash
-           diff -u <(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'|sort) <(kubectl -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module snapshots node-manager -o json | jq '."040-node-manager/hooks/handle_node_templates.go"' | jq '.nodes.snapshot[] | .filterResult.Name' -r | sort)
+           diff -u <(d8 k get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'|sort) <(d8 k -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module snapshots node-manager -o json | jq '."040-node-manager/hooks/handle_node_templates.go"' | jq '.nodes.snapshot[] | .filterResult.Name' -r | sort)
            ```
 
   - alert: D8DeckhouseDeprecatedConfigmapManagedByArgoCD
@@ -541,7 +541,7 @@
         To resolve this issue, remove the label from the module release using the following command:
         
         ```bash
-        kubectl label mr {{ $labels.module_release }} modules.deckhouse.io/update-policy-
+        d8 k label mr {{ $labels.module_release }} modules.deckhouse.io/update-policy-
         ```
 
         A new suitable policy will be detected automatically.
@@ -561,9 +561,9 @@
         Initial config for module {{ $labels.module }} is not valid. 
         
         You can get more details via
-         
+        
         ```bash
-        kubectl get mr -l module={{ $labels.module }}
+        d8 k get mr -l module={{ $labels.module }}
         ```
 
         Provided error: {{ $labels.error }}
@@ -590,7 +590,7 @@
         - There is a network issue preventing access to the registry.
         
         Please check:
-        1. ModuleSource configurations: `kubectl get modulesources`.
+        1. ModuleSource configurations: `d8 k get modulesources`.
         2. Registry accessibility and credentials.
         3. Module availability in the configured registries.
         
@@ -598,14 +598,14 @@
         
         ```bash
         # Check ModuleSource status
-        kubectl get modulesources
+        d8 k get modulesources
         
         # Check available modules in all sources
-        kubectl -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get sources
-        kubectl -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get modules <source_name>
+        d8 k -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get sources
+        d8 k -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get modules <source_name>
         
         # Check Deckhouse logs for more details
-        kubectl -n d8-system logs -f -l app=deckhouse
+        d8 k -n d8-system logs -f -l app=deckhouse
         ```
   - alert: DeckhouseEditionNotFound
     expr: |

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/node-os-requirements.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/node-os-requirements.yaml
@@ -18,7 +18,7 @@
 
           1. Get a list of affected nodes by running the following Prometheus query:
           
-             ```promql
+             ```prometheus
              kube_node_info{os_image=~"Ubuntu 18.04.*|Debian GNU/Linux 10.*|CentOS Linux 7.*"}
              ```
 

--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kube-etcd3.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kube-etcd3.yaml
@@ -20,13 +20,13 @@
         1. Check the status of the etcd Pods:
         
            ```bash
-           kubectl -n kube-system get pod -l component=etcd
+           d8 k -n kube-system get pod -l component=etcd
            ```
 
         1. Review Prometheus logs:
         
            ```bash
-           kubectl -n d8-monitoring logs -l app.kubernetes.io/name=prometheus -c prometheus
+           d8 k -n d8-monitoring logs -l app.kubernetes.io/name=prometheus -c prometheus
            ```
 
   - alert: KubeEtcdTargetAbsent
@@ -48,13 +48,13 @@
         1. Check the status of the etcd Pods:
         
            ```bash
-           kubectl -n kube-system get pod -l component=etcd
+           d8 k -n kube-system get pod -l component=etcd
            ```
 
         1. Review Prometheus logs:
         
            ```bash
-           kubectl -n d8-monitoring logs -l app.kubernetes.io/name=prometheus -c prometheus
+           d8 k -n d8-monitoring logs -l app.kubernetes.io/name=prometheus -c prometheus
            ```
 
   - alert: KubeEtcdNoLeader
@@ -73,7 +73,7 @@
         To resolve this issue, check the status of the etcd Pods:
         
         ```bash
-        kubectl -n kube-system get pod -l component=etcd | grep {{ $labels.node }}
+        d8 k -n kube-system get pod -l component=etcd | grep {{ $labels.node }}
         ```
 
 - name: d8.control-plane.etcd.malfunctioning
@@ -118,7 +118,7 @@
         To resolve this issue, check the status of etcd Pods:
         
         ```bash
-        kubectl -n kube-system get pod -l component=etcd
+        d8 k -n kube-system get pod -l component=etcd
         ```
 
   - alert: KubeEtcdHighFsyncDurations

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kube-state-metrics.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kube-state-metrics.yaml
@@ -30,13 +30,13 @@
         1. Check the `kube-state-metrics` pods:
         
            ```bash
-           kubectl -n d8-monitoring describe pod -l app=kube-state-metrics
+           d8 k -n d8-monitoring describe pod -l app=kube-state-metrics
            ```
 
         2. Check the deployment logs:
         
            ```bash
-           kubectl -n d8-monitoring describe deploy kube-state-metrics
+           d8 k -n d8-monitoring describe deploy kube-state-metrics
            ```
 
   # kube_persistentvolume_is_local migration.

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/helm/deprecated-versions.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/helm/deprecated-versions.yaml
@@ -13,7 +13,7 @@
       description: |
         To list all affected resources, run the following Prometheus query:
         
-        ```promql
+        ```prometheus
         max by (helm_release_namespace, helm_release_name, helm_version, resource_namespace, resource_name, api_version, kind, k8s_version) (resource_versions_compatibility) == 1
         ```
 
@@ -35,7 +35,7 @@
       description: |
         To list all affected resources, run the following Prometheus query:
         
-        ```promql
+        ```prometheus
         max by (helm_release_namespace, helm_release_name, helm_version, resource_namespace, resource_name, api_version, kind, k8s_version) (resource_versions_compatibility) == 2
         ```
 

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/loadbalancer.yaml
@@ -17,7 +17,7 @@
           To list affected services, run the following command:
 
           ```bash
-          kubectl get svc -Ao json | jq -r '.items[] | select(.spec.type == "LoadBalancer") | select(.status.loadBalancer.ingress[0].ip == null) | "namespace: \(.metadata.namespace), name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
+          d8 k get svc -Ao json | jq -r '.items[] | select(.spec.type == "LoadBalancer") | select(.status.loadBalancer.ingress[0].ip == null) | "namespace: \(.metadata.namespace), name: \(.metadata.name), ip: \(.status.loadBalancer.ingress[0].ip)"'
           ```
           
           Steps to troubleshoot:

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node.yaml
@@ -34,13 +34,13 @@
         1. Find the `node-exporter` Pod running on the affected node:
         
            ```bash
-           kubectl -n d8-monitoring get pod -l app=node-exporter -o json | jq -r ".items[] | select(.spec.nodeName==\"{{$labels.node}}\") | .metadata.name"
+           d8 k -n d8-monitoring get pod -l app=node-exporter -o json | jq -r ".items[] | select(.spec.nodeName==\"{{$labels.node}}\") | .metadata.name"
            ```
 
         2. Describe the `node-exporter` Pod:
         
            ```bash
-           kubectl -n d8-monitoring describe pod <POD_NAME>
+           d8 k -n d8-monitoring describe pod <POD_NAME>
            ```
 
         3. Verify that the kubelet is running on node `{{ $labels.node }}`.
@@ -101,13 +101,13 @@
         - To cordon the node:
         
           ```bash
-          kubectl cordon {{ $labels.node }}
+          d8 k cordon {{ $labels.node }}
           ```
 
         - To drain the node (if draining has been running for more than 20 minutes):
         
           ```bash
-          kubectl drain {{ $labels.node }}
+          d8 k drain {{ $labels.node }}
           ```
 
         The was likely caused by the scheduled maintenance of that node.

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/pod-status.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/pod-status.yaml
@@ -26,13 +26,13 @@
           1. Identify all pods with this state:
           
              ```bash
-             kubectl get pod -o json --all-namespaces | jq '.items[] | select(.status.phase == "Running") | select(.status.conditions[] | select(.type == "ContainersReady" and .status == "True")) | select(.status.conditions[] | select(.type == "Ready" and .status == "False")) | "\(.spec.nodeName)/\(.metadata.namespace)/\(.metadata.name)"'
+             d8 k get pod -o json --all-namespaces | jq '.items[] | select(.status.phase == "Running") | select(.status.conditions[] | select(.type == "ContainersReady" and .status == "True")) | select(.status.conditions[] | select(.type == "Ready" and .status == "False")) | "\(.spec.nodeName)/\(.metadata.namespace)/\(.metadata.name)"'
              ```
 
           2. Identify all affected nodes:
           
              ```bash
-             kubectl get pod -o json --all-namespaces | jq '.items[] | select(.status.phase == "Running") | select(.status.conditions[] | select(.type == "ContainersReady" and .status == "True")) | select(.status.conditions[] | select(.type == "Ready" and .status == "False")) | .spec.nodeName' -r | sort | uniq -c
+             d8 k get pod -o json --all-namespaces | jq '.items[] | select(.status.phase == "Running") | select(.status.conditions[] | select(.type == "ContainersReady" and .status == "True")) | select(.status.conditions[] | select(.type == "Ready" and .status == "False")) | .spec.nodeName' -r | sort | uniq -c
              ```
 
           3. Restart kubelet on each node:

--- a/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
@@ -25,13 +25,13 @@
         1. Check the controller logs:
 
            ```bash
-           kubectl -n {{ $labels.controller_namespace }} logs {{ $labels.controller_pod }} -c controller
+           d8 k -n {{ $labels.controller_namespace }} logs {{ $labels.controller_pod }} -c controller
            ```
 
         2. Find the most recently created Ingress in the cluster:
 
            ```bash
-           kubectl get ingress --all-namespaces --sort-by="metadata.creationTimestamp"
+           d8 k get ingress --all-namespaces --sort-by="metadata.creationTimestamp"
            ```
 
         3. Check for errors in the `configuration-snippet` or `server-snippet` annotations.
@@ -50,7 +50,7 @@
         To verify the certificate, run the following command:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
+        d8 k -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
         ```
 
   - alert: NginxIngressSslExpired
@@ -68,7 +68,7 @@
         To verify the certificate, run the following command:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
+        d8 k -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
         ```
 
         The site at `https://{{ $labels.host }}` is not accessible.
@@ -87,7 +87,7 @@
         To resolve the issue, check the Ingress controller's logs:
 
         ```bash
-        kubectl -n d8-ingress-nginx logs $(kubectl -n d8-ingress-nginx get pods -l app=controller,name={{ $labels.controller }} -o wide | grep {{ $labels.node }} | awk '{print $1}') -c protobuf-exporter
+        d8 k -n d8-ingress-nginx logs $(d8 k -n d8-ingress-nginx get pods -l app=controller,name={{ $labels.controller }} -o wide | grep {{ $labels.node }} | awk '{print $1}') -c protobuf-exporter
         ```
 
   - alert: NginxIngressPodIsRestartingTooOften
@@ -126,19 +126,19 @@
         1. Check events associated with `kruise-controller-manager` in the `d8-ingress-nginx` namespace. Look for issues related to node failures or memory shortages (OOM events):
 
            ```bash
-           kubectl -n d8-ingress-nginx get events | grep kruise-controller-manager
+           d8 k -n d8-ingress-nginx get events | grep kruise-controller-manager
            ```
 
         2. Analyze the controller's pod descriptions to identify restarted containers and possible causes. Pay attention to exit codes and other details:
 
            ```bash
-           kubectl -n d8-ingress-nginx describe pod -lapp=kruise,control-plane=controller-manager
+           d8 k -n d8-ingress-nginx describe pod -lapp=kruise,control-plane=controller-manager
            ```
 
         3. In case the `kruise` container has restarted, get a list of relevant container logs to identify any meaningful errors:
 
            ```bash
-           kubectl -n d8-ingress-nginx logs -lapp=kruise,control-plane=controller-manager -c kruise
+           d8 k -n d8-ingress-nginx logs -lapp=kruise,control-plane=controller-manager -c kruise
            ```
 
   - alert: NginxIngressDaemonSetReplicasUnavailable
@@ -168,7 +168,7 @@
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```
 
   - alert: NginxIngressDaemonSetReplicasUnavailable
@@ -196,7 +196,7 @@
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```
 
   - alert: NginxIngressDaemonSetNotUpToDate
@@ -220,13 +220,13 @@
         1. Check the DaemonSet's status:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} get ads {{ $labels.daemonset }}
+           d8 k -n {{ $labels.namespace }} get ads {{ $labels.daemonset }}
            ```
 
         2. Analyze the DaemonSet's description:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} describe ads {{ $labels.daemonset }}
+           d8 k -n {{ $labels.namespace }} describe ads {{ $labels.daemonset }}
            ```
 
         3. If the parameter `Number of Nodes Scheduled with Up-to-date Pods` does not match

--- a/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
+++ b/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
@@ -51,19 +51,19 @@
         1. Check the state of the `d8-log-shipper/log-shipper-agent` DaemonSet:
 
            ```shell
-           kubectl -n d8-log-shipper get daemonsets --selector=app=log-shipper
+           d8 k -n d8-log-shipper get daemonsets --selector=app=log-shipper
            ```
 
         1. Check the state of the `d8-log-shipper/log-shipper-agent` pods:
 
            ```shell
-           kubectl -n d8-log-shipper get pods --selector=app=log-shipper-agent
+           d8 k -n d8-log-shipper get pods --selector=app=log-shipper-agent
            ```
 
         1. If you know where the DaemonSet should be scheduled, run the following command to identify the problematic nodes:
 
            ```shell
-           kubectl -n d8-log-shipper get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="log-shipper-agent")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+           d8 k -n d8-log-shipper get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="log-shipper-agent")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
            ```
 
   - alert: D8LogShipperDestinationErrors
@@ -90,7 +90,7 @@
         To resolve this, check the pod logs or follow advanced instructions:
 
         ```bash
-        kubectl -n d8-log-shipper logs {{ $labels.host }}` -c vector
+        d8 k -n d8-log-shipper logs {{ $labels.host }}` -c vector
         ```
 
   - alert: D8LogShipperCollectLogErrors
@@ -117,7 +117,7 @@
         To resolve this, check the pod logs or follow advanced instructions:
 
         ```bash
-        kubectl -n d8-log-shipper logs {{ $labels.host }}` -c vector
+        d8 k -n d8-log-shipper logs {{ $labels.host }}` -c vector
         ```
 
   - alert: D8LogShipperLogsDroppedByRateLimit
@@ -143,5 +143,5 @@
         To resolve this, check the pod logs or follow advanced instructions:
 
         ```bash
-        kubectl -n d8-log-shipper get pods -o wide | grep {{ $labels.node }}
+        d8 k -n d8-log-shipper get pods -o wide | grep {{ $labels.node }}
         ```

--- a/modules/470-chrony/monitoring/prometheus-rules/chrony.yaml
+++ b/modules/470-chrony/monitoring/prometheus-rules/chrony.yaml
@@ -21,13 +21,13 @@
         1. Check if the chrony pod is running on the node by executing the following command:
 
            ```bash
-           kubectl -n d8-chrony --field-selector spec.nodeName="{{$labels.node}}" get pods
+           d8 k -n d8-chrony --field-selector spec.nodeName="{{$labels.node}}" get pods
            ```
 
         2. Verify the chrony daemon's status by executing the following command:
 
            ```bash
-           kubectl -n d8-chrony exec <POD_NAME> -- /opt/chrony-static/bin/chronyc sources
+           d8 k -n d8-chrony exec <POD_NAME> -- /opt/chrony-static/bin/chronyc sources
            ```
 
         3. Resolve the time synchronization issues:

--- a/modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
+++ b/modules/500-openvpn/monitoring/prometheus-rules/ovpn-admin.yaml
@@ -15,7 +15,7 @@
           Check the certificate information and make sure it actually expires:
 
           ```shell
-          kubectl -n d8-openvpn get secrets -l name="{{ $labels.client }}"  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+          d8 k -n d8-openvpn get secrets -l name="{{ $labels.client }}"  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
           ```
 
           Renew or delete the expired certificate.
@@ -39,7 +39,7 @@
           View certificate details to display the exact expiration date:
 
           ```shell
-          kubectl -n d8-openvpn get secrets -l name={{ $labels.client }}  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+          d8 k -n d8-openvpn get secrets -l name={{ $labels.client }}  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
           ```
 
     - alert: OpenVPNClientCertificateExpired
@@ -60,7 +60,7 @@
           View certificate details to display the exact expiration date:
 
           ```shell
-          kubectl -n d8-openvpn get secrets -l name={{ $labels.client }}  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+          d8 k -n d8-openvpn get secrets -l name={{ $labels.client }}  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
           ```
 
     - alert: OpenVPNServerCertificateExpiresTomorrow
@@ -82,7 +82,7 @@
           Check the certificate information and make sure it actually expires:
 
           ```shell
-          kubectl -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+          d8 k -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
           ```          
 
     - alert: OpenVPNServerCertificateExpired
@@ -103,7 +103,7 @@
 
           Check the certificate information and make sure it actually expires.
           ```shell
-          kubectl -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+          d8 k -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
           ```          
 
     - alert: OpenVPNServerCACertificateExpiringSoon
@@ -125,7 +125,7 @@
           View certificate details to display the exact expiration date:
 
           ```shell
-          kubectl -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+          d8 k -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
           ```                              
 
     - alert: OpenVPNServerCACertificateExpiringInAWeek
@@ -147,7 +147,7 @@
           View certificate details to display the exact expiration date:
 
           ```shell
-          kubectl -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+          d8 k -n d8-openvpn get secrets -l name=server  -o jsonpath='{.items[0].data.tls\.crt}' | base64 -d | openssl x509 -text -noout
           ```               
 
     - alert: OpenVPNServerCACertificateExpiresTomorrow 
@@ -168,7 +168,7 @@
           View certificate details to display the exact expiration date:
 
           ```shell
-          kubectl -n d8-openvpn get secrets openvpn-pki-ca  -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+          d8 k -n d8-openvpn get secrets openvpn-pki-ca  -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout
           ```       
 
           The hook should rotate CA and server certificates before expiry.
@@ -191,7 +191,7 @@
           View certificate details to display the exact expiration date:
 
           ```shell
-          kubectl -n d8-openvpn get secrets openvpn-pki-ca  -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+          d8 k -n d8-openvpn get secrets openvpn-pki-ca  -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout
           ```       
 
           The hook should rotate CA and server certificates before expiry.

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -73,13 +73,13 @@
           - Check the StatefulSet status:
 
             ```shell
-            kubectl -n d8-upmeter get statefulset upmeter -o json | jq .status
+            d8 k -n d8-upmeter get statefulset upmeter -o json | jq .status
             ```
 
           - Check the Pod status:
 
             ```shell
-            kubectl -n d8-upmeter get pods upmeter-0 -o json | jq '.items[] | {(.metadata.name):.status}'
+            d8 k -n d8-upmeter get pods upmeter-0 -o json | jq '.items[] | {(.metadata.name):.status}'
             ```
 
     - alert: D8UpmeterAgentReplicasUnavailable
@@ -115,13 +115,13 @@
           - Check the DaemonSet status:
 
             ```shell
-            kubectl -n d8-upmeter get daemonset upmeter-agent -o json | jq .status
+            d8 k -n d8-upmeter get daemonset upmeter-agent -o json | jq .status
             ```
 
           - Check the Pod status:
 
             ```shell
-            kubectl -n d8-upmeter get pods -l app=upmeter-agent -o json | jq '.items[] | {(.metadata.name):.status}'
+            d8 k -n d8-upmeter get pods -l app=upmeter-agent -o json | jq '.items[] | {(.metadata.name):.status}'
             ```
 
 - name: d8.upmeter.malfunctioning
@@ -157,7 +157,7 @@
           To investigate the cause, check the logs:
 
           ```shell
-          kubectl -n d8-upmeter logs -f upmeter-0 upmeter
+          d8 k -n d8-upmeter logs -f upmeter-0 upmeter
           ```
 
 - name: d8.upmeter.smoke-mini
@@ -191,7 +191,7 @@
           To investigate the cause, check the PersistentVolumeClaim phase:
 
           ```shell
-          kubectl -n d8-upmeter get pvc {{ $labels.persistentvolumeclaim }}
+          d8 k -n d8-upmeter get pvc {{ $labels.persistentvolumeclaim }}
           ```
 
           If your cluster doesn't have a disk provisioning system,
@@ -236,7 +236,7 @@
           1. Check the `upmeter-agent` logs:
 
              ```shell
-             kubectl -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "basic-functionality") | [.time, .level, .msg] | @tsv'
+             d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "basic-functionality") | [.time, .level, .msg] | @tsv'
              ```
 
           2. Ensure the control plane is operating normally.
@@ -244,7 +244,7 @@
           3. Delete stale ConfigMaps manually:
 
              ```shell
-             kubectl -n d8-upmeter delete cm -l heritage=upmeter
+             d8 k -n d8-upmeter delete cm -l heritage=upmeter
              ```
 
     - alert: D8UpmeterProbeGarbageDeployment
@@ -284,7 +284,7 @@
           1. Check the `upmeter-agent` logs:
 
              ```shell
-             kubectl -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "controller-manager") | [.time, .level, .msg] | @tsv'
+             d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "controller-manager") | [.time, .level, .msg] | @tsv'
              ```
 
           2. Ensure the control plane is operating normally. Pay close attention to `kube-controller-manager`.
@@ -292,7 +292,7 @@
           3. Delete stale Deployments manually:
 
              ```shell
-             kubectl -n d8-upmeter delete deployment -l heritage=upmeter
+             d8 k -n d8-upmeter delete deployment -l heritage=upmeter
              ```
 
     - alert: D8UpmeterProbeGarbagePodsFromDeployments
@@ -333,7 +333,7 @@
           1. Check the `upmeter-agent` logs:
 
              ```shell
-             kubectl -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "controller-manager") | [.time, .level, .msg] | @tsv'
+             d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "controller-manager") | [.time, .level, .msg] | @tsv'
              ```
 
           2. Ensure the control plane is operating normally. Pay close attention to `kube-controller-manager`.
@@ -341,7 +341,7 @@
           3. Delete stale Pods manually:
 
              ```shell
-             kubectl -n d8-upmeter delete pods -l upmeter-probe=controller-manager
+             d8 k -n d8-upmeter delete pods -l upmeter-probe=controller-manager
              ```
 
     - alert: D8UpmeterProbeGarbagePods
@@ -381,7 +381,7 @@
           1. Check `upmeter-agent` logs:
 
              ```shell
-             kubectl -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "scheduler") | [.time, .level, .msg] | @tsv'
+             d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "scheduler") | [.time, .level, .msg] | @tsv'
              ```
 
           2. Ensure the control plane is operating normally.
@@ -389,7 +389,7 @@
           3. Delete stale Pods manually:
 
              ```shell
-             kubectl -n d8-upmeter delete pods -l upmeter-probe=scheduler
+             d8 k -n d8-upmeter delete pods -l upmeter-probe=scheduler
              ```
 
     - alert: D8UpmeterProbeGarbageNamespaces
@@ -428,7 +428,7 @@
           1. Check `upmeter-agent` logs:
 
              ```shell
-             kubectl -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "namespace") | [.time, .level, .msg] | @tsv'
+             d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "namespace") | [.time, .level, .msg] | @tsv'
              ```
 
           2. Ensure the control plane is operating normally.
@@ -436,7 +436,7 @@
           3. Delete stale namespaces manually:
           
              ```shell
-             kubectl -n d8-upmeter delete ns -l heritage=upmeter
+             d8 k -n d8-upmeter delete ns -l heritage=upmeter
              ```
 
     - alert: D8UpmeterTooManyHookProbeObjects
@@ -469,7 +469,7 @@
           To view all `UpmeterHookProbe` objects, run the following command:
 
           ```shell
-          kubectl get upmeterhookprobes.deckhouse.io
+          d8 k get upmeterhookprobes.deckhouse.io
           ```
 
     - alert: D8UpmeterSmokeMiniMoreThanOnePVxPVC
@@ -509,7 +509,7 @@
           To list all the PVs, run the following command:
 
           ```shell
-          kubectl get pv | grep disk-smoke-mini
+          d8 k get pv | grep disk-smoke-mini
           ```
 
     - alert: D8UpmeterProbeGarbageSecretsByCertManager
@@ -548,7 +548,7 @@
           1. Check `upmeter-agent` logs:
 
              ```shell
-             kubectl -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "cert-manager") | [.time, .level, .msg] | @tsv'
+             d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "cert-manager") | [.time, .level, .msg] | @tsv'
              ```
 
           2. Check that the control plane and `cert-manager` are operating normally.
@@ -556,8 +556,8 @@
           3. Delete stale certificates and Secrets manually:
 
              ```shell
-             kubectl -n d8-upmeter delete certificate -l upmeter-probe=cert-manager
-             kubectl -n d8-upmeter get secret -ojson | jq -r '.items[] | .metadata.name' | grep upmeter-cm-probe | xargs -n 1 -- kubectl -n d8-upmeter delete secret
+             d8 k -n d8-upmeter delete certificate -l upmeter-probe=cert-manager
+             d8 k -n d8-upmeter get secret -ojson | jq -r '.items[] | .metadata.name' | grep upmeter-cm-probe | xargs -n 1 -- d8 k -n d8-upmeter delete secret
              ```
 
     - alert: D8UpmeterDiskUsage
@@ -585,11 +585,11 @@
           1. Delete the PVC and restart the `upmeter` Pod:
 
              ```shell
-             kubectl -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0
+             d8 k -n d8-upmeter delete persistentvolumeclaim/data-upmeter-0 pod/upmeter-0
              ```
 
           1. Check the status of the created PVC:
 
              ```shell
-             kubectl -n d8-upmeter get pvc
+             d8 k -n d8-upmeter get pvc
              ```

--- a/modules/810-documentation/monitoring/prometheus-rules/deprecated-mc.yaml
+++ b/modules/810-documentation/monitoring/prometheus-rules/deprecated-mc.yaml
@@ -20,5 +20,5 @@
         1. Delete it using the following command:
 
            ```bash
-           kubectl delete mc deckhouse-web
+           d8 k delete mc deckhouse-web
            ```


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Replace kubectl to d8 k in alerts.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Replaced kubectl to d8 k in alerts.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
