### PR TITLE
[user-authn] Hotfix password connectors issue

### DIFF
--- a/modules/150-user-authn/images/dex/patches/010-fix-password-connector.patch
+++ b/modules/150-user-authn/images/dex/patches/010-fix-password-connector.patch
@@ -1,0 +1,234 @@
+diff --git a/server/handlers.go b/server/handlers.go
+index b3289261..1cfb0848 100644
+--- a/server/handlers.go
++++ b/server/handlers.go
+@@ -373,22 +373,32 @@ func (s *Server) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
+ 		password := r.FormValue("password")
+ 		scopes := parseScopes(authReq.Scopes)
+ 
+-		p, err := s.storage.GetPassword(ctx, username)
+-		if err != nil {
+-			s.logger.ErrorContext(r.Context(), "failed to get password", "err", err)
+-			s.renderError(r, w, http.StatusInternalServerError, "Login error.")
+-			return
++		var localConnector bool
++		_, ok := pwConn.(passwordDB)
++		if ok {
++			localConnector = true
+ 		}
+ 
+-		if s.passwordPolicy != nil && s.passwordPolicy.IsPasswordLocked(p) {
+-			s.logger.WarnContext(r.Context(),
+-				"login attempt for locked account",
+-				"username", username,
+-				"locked_until", p.LockedUntil,
+-			)
+-			// TODO: maybe need to render error field in the login page (like incorrect pass error)
+-			s.renderError(r, w, http.StatusTooManyRequests, "Account temporarily locked")
+-			return
++		var p storage.Password
++		// Fetch local password in case of local connector for the further password policies validation
++		if localConnector && s.passwordPolicy != nil {
++			p, err = s.storage.GetPassword(ctx, username)
++			if err != nil {
++				s.logger.ErrorContext(r.Context(), "failed to get password", "err", err)
++				s.renderError(r, w, http.StatusInternalServerError, "Login error.")
++				return
++			}
++
++			if s.passwordPolicy.IsPasswordLocked(p) {
++				s.logger.WarnContext(r.Context(),
++					"login attempt for locked account",
++					"username", username,
++					"locked_until", p.LockedUntil,
++				)
++				// TODO: maybe need to render error field in the login page (like incorrect pass error)
++				s.renderError(r, w, http.StatusTooManyRequests, "Account temporarily locked")
++				return
++			}
+ 		}
+ 
+ 		identity, ok, err := pwConn.Login(r.Context(), scopes, username, password)
+@@ -398,7 +408,8 @@ func (s *Server) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
+ 			return
+ 		}
+ 		if !ok {
+-			if s.passwordPolicy != nil && s.passwordPolicy.IsMaxLoginAttemptsExeeded(p.IncorrectPasswordLoginAttempts+1) {
++			// Validate login incorrect attempts for local connector with configured password policy
++			if localConnector && s.passwordPolicy != nil && s.passwordPolicy.IsMaxLoginAttemptsExeeded(p.IncorrectPasswordLoginAttempts+1) {
+ 				lockedUntil := time.Now().Add(s.passwordPolicy.lockout.lockDuration)
+ 				updader := func(p storage.Password) (storage.Password, error) {
+ 					p.LockedUntil = &lockedUntil
+@@ -432,27 +443,31 @@ func (s *Server) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
+ 			return
+ 		}
+ 
+-		if s.passwordPolicy != nil && GetPasswordComplexity(password).level < s.passwordPolicy.complexity.level {
+-			redirectURL, err := buildPasswordChangeURI(s.issuerURL.String(), username, r.URL.String(), complexityPolicyReason)
+-			if err != nil {
+-				s.logger.ErrorContext(r.Context(), "cannot build password change redirect URL", "err", err)
+-				s.renderError(r, w, http.StatusInternalServerError, "Login error.")
+-				return
++		if localConnector && s.passwordPolicy != nil {
++			// Validate password complexity with configured password policy
++			if GetPasswordComplexity(password).level < s.passwordPolicy.complexity.level {
++				redirectURL, err := buildPasswordChangeURI(s.issuerURL.String(), username, r.URL.String(), complexityPolicyReason)
++				if err != nil {
++					s.logger.ErrorContext(r.Context(), "cannot build password change redirect URL", "err", err)
++					s.renderError(r, w, http.StatusInternalServerError, "Login error.")
++					return
++				}
++				http.Redirect(w, r, redirectURL, http.StatusSeeOther)
++				s.logger.InfoContext(r.Context(), "user was forced to change password due to password complexity policy settings", "user", username)
+ 			}
+-			http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+-			s.logger.InfoContext(r.Context(), "user was forced to change password due to password complexity policy settings", "user", username)
+-		}
+ 
+-		if s.passwordPolicy != nil && s.passwordPolicy.IsPasswordExpired(p.HashUpdatedAt) {
+-			redirectURL, err := buildPasswordChangeURI(s.issuerURL.String(), username, r.URL.String(), rotationPolicyReason)
+-			if err != nil {
+-				s.logger.ErrorContext(r.Context(), "cannot build password change redirect URL", "err", err)
+-				s.renderError(r, w, http.StatusInternalServerError, "Login error.")
++			// Validate password expiry with configured password policy
++			if s.passwordPolicy.IsPasswordExpired(p.HashUpdatedAt) {
++				redirectURL, err := buildPasswordChangeURI(s.issuerURL.String(), username, r.URL.String(), rotationPolicyReason)
++				if err != nil {
++					s.logger.ErrorContext(r.Context(), "cannot build password change redirect URL", "err", err)
++					s.renderError(r, w, http.StatusInternalServerError, "Login error.")
++					return
++				}
++				http.Redirect(w, r, redirectURL, http.StatusSeeOther)
++				s.logger.InfoContext(r.Context(), "user was forced to change password due to password rotation policy settings", "user", username)
+ 				return
+ 			}
+-			http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+-			s.logger.InfoContext(r.Context(), "user was forced to change password due to password rotation policy settings", "user", username)
+-			return
+ 		}
+ 
+ 		redirectURL, canSkipApproval, err := s.finalizeLogin(r.Context(), identity, authReq, conn.Connector)
+diff --git a/server/passwordpolicy.go b/server/passwordpolicy.go
+index 4720277b..322d6584 100644
+--- a/server/passwordpolicy.go
++++ b/server/passwordpolicy.go
+@@ -315,12 +315,12 @@ func (pp PasswordPolicy) IsMaxLoginAttemptsExeeded(attempts uint64) bool {
+ 	return false
+ }
+ 
+-func (pp PasswordPolicy) IsPasswordExpired(passwordCreatedAt time.Time) bool {
++func (pp PasswordPolicy) IsPasswordExpired(passwordUpdatedAt time.Time) bool {
+ 	if pp.rotation == nil {
+ 		return false
+ 	}
+ 
+-	passwordExpirationDate := passwordCreatedAt.Add(pp.rotation.passwordRotationInterval)
++	passwordExpirationDate := passwordUpdatedAt.Add(pp.rotation.passwordRotationInterval)
+ 
+ 	return passwordExpirationDate.Before(time.Now())
+ }
+diff --git a/storage/sql/crud.go b/storage/sql/crud.go
+index ec06e2d4..84ace050 100644
+--- a/storage/sql/crud.go
++++ b/storage/sql/crud.go
+@@ -4,6 +4,7 @@ import (
+ 	"context"
+ 	"database/sql"
+ 	"database/sql/driver"
++	"encoding/base64"
+ 	"encoding/json"
+ 	"errors"
+ 	"fmt"
+@@ -64,12 +65,23 @@ func (j jsonDecoder) Scan(dest interface{}) error {
+ 	if dest == nil {
+ 		return errors.New("nil value")
+ 	}
+-	b, ok := dest.([]byte)
+-	if !ok {
+-		return fmt.Errorf("expected []byte got %T", dest)
+-	}
+-	if err := json.Unmarshal(b, &j.i); err != nil {
+-		return fmt.Errorf("unmarshal: %v", err)
++
++	switch b := dest.(type) {
++	case []byte:
++		if err := json.Unmarshal(b, &j.i); err != nil {
++			return fmt.Errorf("unmarshal: %v", err)
++		}
++	case string:
++		bb, err := base64.StdEncoding.DecodeString(b)
++		if err != nil {
++			return fmt.Errorf("decodeString: %v", err)
++		}
++
++		if err := json.Unmarshal(bb, &j.i); err != nil {
++			return fmt.Errorf("unmarshal: %v", err)
++		}
++	default:
++		return fmt.Errorf("expected []byte or string got %T", dest)
+ 	}
+ 	return nil
+ }
+@@ -630,7 +642,7 @@ func (c *conn) UpdatePassword(ctx context.Context, email string, updater func(p
+ 		_, err = tx.Exec(`
+ 			update password
+ 			set
+-				hash = $1, username = $2, user_id = $3, groups = $4
++				hash = $1, username = $2, user_id = $3, groups = $4,
+ 				incorrect_password_login_attempts = $5, locked_until = $6, hash_updated_at = $7,
+ 				previous_hashes = $8
+ 			where email = $9;
+diff --git a/storage/sql/migrate.go b/storage/sql/migrate.go
+index c2755c98..5d8672bf 100644
+--- a/storage/sql/migrate.go
++++ b/storage/sql/migrate.go
+@@ -225,6 +225,14 @@ var migrations = []migration{
+ 			alter table offline_session
+ 				add column connector_data bytea;
+ 			`,
++			`
++			alter table offline_session
++				add column totp text;
++			`,
++			`
++			alter table offline_session
++				add column totp_confirmed boolean;
++			`,
+ 		},
+ 	},
+ 	{
+@@ -296,6 +304,8 @@ var migrations = []migration{
+ 			`
+ 			alter table auth_request
+ 				add column hmac_key bytea;`,
++			`alter table auth_request
++				add column totp_validated boolean;`,
+ 		},
+ 	},
+ 	{
+@@ -306,8 +316,9 @@ var migrations = []migration{
+ 				add column locked_until timestamptz default null`,
+ 			`alter table password
+ 				add column hash_updated_at timestamptz default current_timestamp`,
+-			`alter table password
+-				add column previous_hashes text default "" not null`,
++			`-- DEFAULT 'W10=' - base64 encoded []
++			alter table password
++				add column previous_hashes text default "W10=" not null`,
+ 			`alter table password
+ 				add column complexity_level text default "none" not null`,
+ 		},
+@@ -318,4 +329,10 @@ var migrations = []migration{
+ 				drop column complexity_level`,
+ 		},
+ 	},
++	{
++		stmts: []string{
++			`alter table password
++				add column groups bytea`,
++		},
++	},
+ }
+-- 
+2.39.5 (Apple Git-154)
+

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -52,3 +52,7 @@ This patch also includes refactored password complexity checks - making them muc
 ### 009-oauth2-cve.patch
 
 Fixes CVE-2025-22868
+
+### 010-fix-password-connector.patch
+
+This patch fixes a critical bug in the password connector. Previously, the login logic assumed that all password connectors must have a locally stored password in the database, which is incorrect. This functionality should only be executed for password connectors with a passwordDB implementation.


### PR DESCRIPTION
## Description
This patch fixes a critical bug in the password connector. Previously, the login logic assumed that all password connectors must have a locally stored password in the database, which is incorrect. As a result, local connectors without a passwordDB (such as LDAP, Crowd, and Keystone) could fail during login. The patch ensures that login and password policy validation logic is executed only for password connectors with a passwordDB implementation, preventing login failures for other connectors.

## Why do we need it, and what problem does it solve?

The bug affected **all users of user-authn module** who use LDAP, Crowd, or Keystone connectors. Login attempts could fail because the code incorrectly required a local stored password. This patch prevent login errors and ensures proper handling for connectors without a local password store.


## Why do we need it in the patch release (if we do)?
This should be included in a patch release because it fixes a critical bug that impacts all users relying on Dex with LDAP, Crowd, or Keystone connectors.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: user-authn
type: fix
summary: "Fix critical bug in password connector that caused login failures for LDAP, Crowd, and Keystone connectors."
```
