### PR TITLE
[docs] Add a note about enabling Rosetta on macOS 26 when installing DKP

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
@@ -76,7 +76,7 @@ Scheme of Deckhouse installation in a private environment:<br />
    {% offtopic title="Requirements..." %}
    - OS: Windows 10+, macOS 10.15+, Linux (e.g. Ubuntu 18.04+, Fedora 35+);
    - installed docker to run the installer (here are the instructions for [Ubuntu](https://docs.docker.com/engine/install/ubuntu/), [macOS](https://docs.docker.com/desktop/mac/install/), [Windows](https://docs.docker.com/desktop/windows/install/));
-     - on macOS 26 Tahoe, enable the option "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in the docker settings, to avoid possible issues running `ssh-agent` during the installation;
+     - on computers with Apple Silicon processors, enable the option "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings to avoid possible issues running `ssh-agent` during the installation;
 {% if page.platform_code == "bm-private" %}
    - access to a proxy registry ([read more](/products/kubernetes-platform/documentation/v1/deckhouse-faq.html#tips-for-configuring-the-third-party-registry) about setting them up) or to a private container image registry containing Deckhouse images;
 {%- else %}

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
@@ -76,6 +76,7 @@ Scheme of Deckhouse installation in a private environment:<br />
    {% offtopic title="Requirements..." %}
    - OS: Windows 10+, macOS 10.15+, Linux (e.g. Ubuntu 18.04+, Fedora 35+);
    - installed docker to run the installer (here are the instructions for [Ubuntu](https://docs.docker.com/engine/install/ubuntu/), [macOS](https://docs.docker.com/desktop/mac/install/), [Windows](https://docs.docker.com/desktop/windows/install/));
+     - on macOS 26 Tahoe, enable the option "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in the docker settings, to avoid possible issues running `ssh-agent` during the installation;
 {% if page.platform_code == "bm-private" %}
    - access to a proxy registry ([read more](/products/kubernetes-platform/documentation/v1/deckhouse-faq.html#tips-for-configuring-the-third-party-registry) about setting them up) or to a private container image registry containing Deckhouse images;
 {%- else %}

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
@@ -83,7 +83,7 @@
    {% offtopic title="Требования..." %}
    - ОС: Windows 10+, macOS 10.15+, Linux (Ubuntu 18.04+, Fedora 35+);
    - установленный docker для запуска инсталлятора Deckhouse (инструкции для [Ubuntu](https://docs.docker.com/engine/install/ubuntu/), [macOS](https://docs.docker.com/desktop/mac/install/), [Windows](https://docs.docker.com/desktop/windows/install/));
-     - на macOS 26 Tahoe включите опцию «Use Rosetta for x86_64/amd64 emulation on Apple Silicon» в настройках docker, чтобы избежать возможных проблем с запуском `ssh-agent` во время установки;
+     - на компьютерах с процессорами семейства Apple Silicon включите опцию «Use Rosetta for x86_64/amd64 emulation on Apple Silicon» в настройках Docker Desktop, чтобы избежать возможных проблем с запуском `ssh-agent` во время установки;
 {% if page.platform_code == "bm-private" %}
    - доступ до проксирующего registry ([читайте подробнее](/products/kubernetes-platform/documentation/v1/deckhouse-faq.html#особенности-настройки-сторонних-registry) про их настройку) или до частного хранилища образов контейнеров с образами контейнеров Deckhouse;
 {%- else %}

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
@@ -83,6 +83,7 @@
    {% offtopic title="Требования..." %}
    - ОС: Windows 10+, macOS 10.15+, Linux (Ubuntu 18.04+, Fedora 35+);
    - установленный docker для запуска инсталлятора Deckhouse (инструкции для [Ubuntu](https://docs.docker.com/engine/install/ubuntu/), [macOS](https://docs.docker.com/desktop/mac/install/), [Windows](https://docs.docker.com/desktop/windows/install/));
+     - на macOS 26 Tahoe включите опцию «Use Rosetta for x86_64/amd64 emulation on Apple Silicon» в настройках docker, чтобы избежать возможных проблем с запуском `ssh-agent` во время установки;
 {% if page.platform_code == "bm-private" %}
    - доступ до проксирующего registry ([читайте подробнее](/products/kubernetes-platform/documentation/v1/deckhouse-faq.html#особенности-настройки-сторонних-registry) про их настройку) или до частного хранилища образов контейнеров с образами контейнеров Deckhouse;
 {%- else %}


### PR DESCRIPTION
## Description

This PR adds a note about enabling Rosetta option on macOS 26 when installing DKP.

## Changelog entries

```changes
section: docs
type: chore
summary: Added a note about enabling Rosetta option on macOS 26 when installing DKP.
impact_level: low
```