### PR TITLE
[deckhouse-controller] Fix null pointer error

### DIFF
--- a/modules/500-upmeter/hooks/smokemini/internal/snapshot/gen_parse.go
+++ b/modules/500-upmeter/hooks/smokemini/internal/snapshot/gen_parse.go
@@ -96,7 +96,7 @@ import (
 
 // {{ $m.Name }} parses {{ $m.Type }} slice from snapshots
 func {{ $m.Name }}(rs []sdkpkg.Snapshot) ([]{{ $m.Type }}, error) {
-	ret := make([]{{ $m.Type }}, len(rs))
+	ret := make([]{{ $m.Type }}, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[{{ $m.Type }}](rs) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse {{ $m.Type }}: %w", err)	

--- a/modules/500-upmeter/hooks/smokemini/internal/snapshot/parse.generated.go
+++ b/modules/500-upmeter/hooks/smokemini/internal/snapshot/parse.generated.go
@@ -31,12 +31,12 @@ import (
 
 // ParseNodeSlice parses Node slice from snapshots
 func ParseNodeSlice(rs []sdkpkg.Snapshot) ([]Node, error) {
-	ret := make([]Node, len(rs))
+	ret := make([]Node, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[Node](rs) {
 		if err != nil {
-			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse Node: %w", err)	
+			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse Node: %w", err)
 		}
-			
+
 		ret = append(ret, snap)
 	}
 	return ret, nil
@@ -44,12 +44,12 @@ func ParseNodeSlice(rs []sdkpkg.Snapshot) ([]Node, error) {
 
 // ParseStatefulSetSlice parses StatefulSet slice from snapshots
 func ParseStatefulSetSlice(rs []sdkpkg.Snapshot) ([]StatefulSet, error) {
-	ret := make([]StatefulSet, len(rs))
+	ret := make([]StatefulSet, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[StatefulSet](rs) {
 		if err != nil {
-			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse StatefulSet: %w", err)	
+			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse StatefulSet: %w", err)
 		}
-			
+
 		ret = append(ret, snap)
 	}
 	return ret, nil
@@ -57,12 +57,12 @@ func ParseStatefulSetSlice(rs []sdkpkg.Snapshot) ([]StatefulSet, error) {
 
 // ParsePodSlice parses Pod slice from snapshots
 func ParsePodSlice(rs []sdkpkg.Snapshot) ([]Pod, error) {
-	ret := make([]Pod, len(rs))
+	ret := make([]Pod, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[Pod](rs) {
 		if err != nil {
-			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse Pod: %w", err)	
+			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse Pod: %w", err)
 		}
-			
+
 		ret = append(ret, snap)
 	}
 	return ret, nil
@@ -70,12 +70,12 @@ func ParsePodSlice(rs []sdkpkg.Snapshot) ([]Pod, error) {
 
 // ParseStorageClassSlice parses StorageClass slice from snapshots
 func ParseStorageClassSlice(rs []sdkpkg.Snapshot) ([]StorageClass, error) {
-	ret := make([]StorageClass, len(rs))
+	ret := make([]StorageClass, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[StorageClass](rs) {
 		if err != nil {
-			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse StorageClass: %w", err)	
+			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse StorageClass: %w", err)
 		}
-			
+
 		ret = append(ret, snap)
 	}
 	return ret, nil
@@ -83,12 +83,12 @@ func ParseStorageClassSlice(rs []sdkpkg.Snapshot) ([]StorageClass, error) {
 
 // ParsePodPhaseSlice parses PodPhase slice from snapshots
 func ParsePodPhaseSlice(rs []sdkpkg.Snapshot) ([]PodPhase, error) {
-	ret := make([]PodPhase, len(rs))
+	ret := make([]PodPhase, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[PodPhase](rs) {
 		if err != nil {
-			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse PodPhase: %w", err)	
+			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse PodPhase: %w", err)
 		}
-			
+
 		ret = append(ret, snap)
 	}
 	return ret, nil
@@ -96,12 +96,12 @@ func ParsePodPhaseSlice(rs []sdkpkg.Snapshot) ([]PodPhase, error) {
 
 // ParsePvcTerminationSlice parses PvcTermination slice from snapshots
 func ParsePvcTerminationSlice(rs []sdkpkg.Snapshot) ([]PvcTermination, error) {
-	ret := make([]PvcTermination, len(rs))
+	ret := make([]PvcTermination, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[PvcTermination](rs) {
 		if err != nil {
-			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse PvcTermination: %w", err)	
+			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse PvcTermination: %w", err)
 		}
-			
+
 		ret = append(ret, snap)
 	}
 	return ret, nil

--- a/modules/500-upmeter/hooks/smokemini/internal/snapshot/parse.generated.go
+++ b/modules/500-upmeter/hooks/smokemini/internal/snapshot/parse.generated.go
@@ -34,9 +34,9 @@ func ParseNodeSlice(rs []sdkpkg.Snapshot) ([]Node, error) {
 	ret := make([]Node, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[Node](rs) {
 		if err != nil {
-			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse Node: %w", err)
+			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse Node: %w", err)	
 		}
-
+			
 		ret = append(ret, snap)
 	}
 	return ret, nil
@@ -47,9 +47,9 @@ func ParseStatefulSetSlice(rs []sdkpkg.Snapshot) ([]StatefulSet, error) {
 	ret := make([]StatefulSet, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[StatefulSet](rs) {
 		if err != nil {
-			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse StatefulSet: %w", err)
+			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse StatefulSet: %w", err)	
 		}
-
+			
 		ret = append(ret, snap)
 	}
 	return ret, nil
@@ -60,9 +60,9 @@ func ParsePodSlice(rs []sdkpkg.Snapshot) ([]Pod, error) {
 	ret := make([]Pod, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[Pod](rs) {
 		if err != nil {
-			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse Pod: %w", err)
+			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse Pod: %w", err)	
 		}
-
+			
 		ret = append(ret, snap)
 	}
 	return ret, nil
@@ -73,9 +73,9 @@ func ParseStorageClassSlice(rs []sdkpkg.Snapshot) ([]StorageClass, error) {
 	ret := make([]StorageClass, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[StorageClass](rs) {
 		if err != nil {
-			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse StorageClass: %w", err)
+			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse StorageClass: %w", err)	
 		}
-
+			
 		ret = append(ret, snap)
 	}
 	return ret, nil
@@ -86,9 +86,9 @@ func ParsePodPhaseSlice(rs []sdkpkg.Snapshot) ([]PodPhase, error) {
 	ret := make([]PodPhase, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[PodPhase](rs) {
 		if err != nil {
-			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse PodPhase: %w", err)
+			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse PodPhase: %w", err)	
 		}
-
+			
 		ret = append(ret, snap)
 	}
 	return ret, nil
@@ -99,9 +99,9 @@ func ParsePvcTerminationSlice(rs []sdkpkg.Snapshot) ([]PvcTermination, error) {
 	ret := make([]PvcTermination, 0, len(rs))
 	for snap, err := range sdkobjectpatch.SnapshotIter[PvcTermination](rs) {
 		if err != nil {
-			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse PvcTermination: %w", err)
+			return nil, fmt.Errorf("failed to iterate over snapshots - failed to parse PvcTermination: %w", err)	
 		}
-
+			
 		ret = append(ret, snap)
 	}
 	return ret, nil


### PR DESCRIPTION
## Description

An error occurred, which is why the deckhouse does not start
```
{"level":"info","logger":"addon-operator","msg":"ModuleHookRun task for 'main' group binding, trigger is Schedule","binding":"schedule","binding.name":"reschedule","event.id":"03c78233-554b-4e7f-84d5-20be886e6802","hook":"500-upmeter/hooks/smokemini/reschedule.go","hook.type":"module","module":"upmeter","queue":"/modules/upmeter/update_selector","task.flow":"start","task.id":"b682eff9-6e87-4ed1-8558-f42a050244f9","time":"2025-09-05T10:12:00Z"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x2ce4b8c]
goroutine 6511 [running]:
github.com/deckhouse/deckhouse/modules/500-upmeter/hooks/smokemini/internal/scheduler.(*filterByMinSts).selectNodes(0xc00a3c6a88, {0xc0066a9a40, 0x4, 0x39205e0?}, {0x0, 0x0})/deckhouse/modules/500-upmeter/hooks/smokemini/internal/scheduler/node_by_sts.go:41 +0xec
github.com/deckhouse/deckhouse/modules/500-upmeter/hooks/smokemini/internal/scheduler.(*filterByMinSts).Filter(0x0?, {0xc0066a9a40, 0x4, 0x2ce8075?}, {0x0?, 0xc000073808?})/deckhouse/modules/500-upmeter/hooks/smokemini/internal/scheduler/node_by_sts.go:32 +0x37
github.com/deckhouse/deckhouse/modules/500-upmeter/hooks/smokemini/internal/scheduler.NodeFilterPipe.Filter(...)/deckhouse/modules/500-upmeter/hooks/smokemini/internal/scheduler/pipeline_node.go:47
github.com/deckhouse/deckhouse/modules/500-upmeter/hooks/smokemini/internal/scheduler.(*Scheduler).Schedule(0xc00b8d83e8, 0xc00b8243c0, {0xc0084c1e00, 0x8, 0x8})/deckhouse/modules/500-upmeter/hooks/smokemini/internal/scheduler/scheduler.go:52 +0xd9
github.com/deckhouse/deckhouse/modules/500-upmeter/hooks/smokemini.reschedule(0xc006fa9110)/deckhouse/modules/500-upmeter/hooks/smokemini/reschedule.go:181 +0x833
github.com/flant/addon-operator/pkg/module_manager/models/hooks/kind.(*GoHook).Run(...)/go/pkg/mod/github.com/flant/addon-operator@v1.11.4/pkg/module_manager/models/hooks/kind/gohook.go:66
github.com/flant/addon-operator/pkg/module_manager/models/hooks/kind.(*GoHook).Execute(0xc000d40c80, {0xd?, 0xc00b8d8d68?}, {0x1?, 0x1?}, {0xc0088e30a0, 0x1, 0x819e3d?}, {0xc013e38a88, 0x7}, ...)/go/pkg/mod/github.com/flant/addon-operator@v1.11.4/pkg/module_manager/models/hooks/kind/gohook.go:149 +0x469
github.com/flant/addon-operator/pkg/module_manager/models/modules.(*BasicModule).executeHook(0xc000c245a0, {0x45542b8, 0xc00b47d3b0}, 0xc0054a9020, {0x3d3aa49, 0x8}, {0xc0088e30a0, 0x1, 0x1}, 0xc00b1f3bc0, ...)/go/pkg/mod/
github.com/flant/addon-operator@v1.11.4/pkg/module_manager/models/modules/basic.go:1035 +0xdea
github.com/flant/addon-operator/pkg/module_manager/models/modules.(*BasicModule).RunHookByName(0xc000c245a0, {0x45542b8, 0xc00b47d3b0}, {0x51b643c, 0x29}, {0x3d3aa49, 0x8}, {0xc0083e5420, 0x1, 0x1}, ...)/go/pkg/mod/
github.com/flant/addon-operator@v1.11.4/pkg/module_manager/models/modules/basic.go:694 +0x407
github.com/flant/addon-operator/pkg/module_manager.(*ModuleManager).RunModuleHook(0xc007013810?, {0x45542b8, 0xc00b47d3b0}, {0xc00138b804?, 0xa?}, {0x51b643c, 0x29}, {0x3d3aa49, 0x8}, {0xc0083e5420, ...}, ...)/go/pkg/mod/
github.com/flant/addon-operator@v1.11.4/pkg/module_manager/module_manager.go:804 +0xb7
github.com/flant/addon-operator/pkg/task/tasks/module-hook-run.(*Task).Handle(0xc0065a2050, {0x45542f0, 0xc0008ae7d0})/go/pkg/mod/
github.com/flant/addon-operator@v1.11.4/pkg/task/tasks/module-hook-run/task.go:200 +0xba5
github.com/flant/addon-operator/pkg/task/service.(*TaskHandlerService).Handle(0xc001757c20, {0x45542f0, 0xc0008ae7d0}, {0x4581f90, 0xc007013810})/go/pkg/mod/github.com/flant/addon-operator@v1.11.4/pkg/task/service/service.go:136 +0x168
github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start.func1()/go/pkg/mod/github.com/flant/shell-operator@v1.10.4/pkg/task/queue/task_queue_list.go:860 +0x343
created by github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start in goroutine 791
/go/pkg/mod/github.com/flant/shell-operator@v1.10.4/pkg/task/queue/task_queue_list.go:814 +0xa5
```
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Fix null pointer situation, which caused the error
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

<!---
## Why do we need it in the patch release (if we do)?
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: fix null pointer error
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
