### PR TITLE
[docs][cloud-provider-yandex] Clear placement for NAT-instance

### DIFF
--- a/candi/cloud-providers/yandex/docs/LAYOUTS.md
+++ b/candi/cloud-providers/yandex/docs/LAYOUTS.md
@@ -164,6 +164,10 @@ If you need to create a new subnet, specify the `withNATInstance.internalSubnetC
 
 One of the parameters — `withNATInstance.internalSubnetID` or `withNATInstance.internalSubnetCIDR` — is required.
 
+When the `withNATInstance.internalSubnetCIDR` parameter is specified, the NAT instance will be created in a single instance in zone `a`.
+
+When the `withNATInstance.internalSubnetID` parameter is specified, the NAT instance will be created in a single instance in the zone specified in the designated network settings.
+
 If the `withNATInstance.externalSubnetID` is provided in addition to previous ones, the NAT instance will be attached to it via secondary interface.
 
 ![Yandex Cloud WithNATInstance Layout scheme](../../images/cloud-provider-yandex/yandex-withnatinstance.png)

--- a/candi/cloud-providers/yandex/docs/LAYOUTS_RU.md
+++ b/candi/cloud-providers/yandex/docs/LAYOUTS_RU.md
@@ -164,6 +164,10 @@ dhcpOptions:
 
 Обязателен один из параметров: `withNATInstance.internalSubnetID` или `withNATInstance.internalSubnetCIDR`.
 
+При указании параметра `withNATInstance.internalSubnetCIDR` NAT-инстанс будет создан в единственном экземпляре в зоне `a`.
+
+При указании параметра `withNATInstance.internalSubnetID` NAT-инстанс будет создан в единственном экземпляре в зоне, указанной в настройках обозначенной сети.
+
 Если `withNATInstance.externalSubnetID` указан в дополнение к предыдущим, NAT-инстанс будет подключен к нему через вторичный интерфейс.
 
 ![Схема размещения WithNATInstance в Yandex Cloud](../../images/cloud-provider-yandex/yandex-withnatinstance.png)


### PR DESCRIPTION
## Description
This PR updates the documentation for the Yandex Cloud provider module to clarify how NAT instance zone selection works when using the WithNatInstance layout. The changes specify the zone selection behavior based on different configuration parameters.

## Why do we need it, and what problem does it solve?
The current documentation lacks clarity on how zone selection works for NAT instances in different configuration scenarios. This leads to:

1. User confusion: Uncertainty about where NAT instances will be deployed

2. Unexpected behavior: Users may not realize zone selection differs based on subnet configuration

3. Planning difficulties: Hard to design multi-zone architectures without clear documentation

This update provides explicit documentation on zone selection behavior:

- When using internalSubnetCIDR (new subnet creation)

- When using internalSubnetID (existing subnet usage)
-->

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Document NAT instance deployment zones for different subnet configurations
impact: Improved documentation clarity for Yandex Cloud NAT instance deployment scenarios
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
