### PR TITLE
[deckhouse-controller] Fix panic on snapshotIter

### DIFF
--- a/modules/500-upmeter/hooks/remove_old_sts.go
+++ b/modules/500-upmeter/hooks/remove_old_sts.go
@@ -60,18 +60,18 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func applyStsFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	var sts appsv1.StatefulSet
 	if err := sdk.FromUnstructured(obj, &sts); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if len(sts.Spec.VolumeClaimTemplates) == 0 {
 		log.Debug("StatefulSet has no VolumeClaimTemplates", slog.String("namespace", sts.Namespace), slog.String("name", sts.Name))
-		return "", nil
+		return nil, nil
 	}
 
 	quantity, ok := sts.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage]
 	if !ok {
 		log.Debug("No storage resource request found in VolumeClaimTemplate", slog.String("namespace", sts.Namespace), slog.String("name", sts.Name))
-		return "", nil
+		return nil, nil
 	}
 
 	return &StatefulSetStorage{


### PR DESCRIPTION
## Description

Fixed filter func, which return several types (string and custom struct).

Error occurred:
```
panic: reflect.Set: value of type string is not assignable to type hooks.StatefulSetStorage

goroutine 5754 [running]:
reflect.Value.assignTo({0x3375340?, 0x4512860?, 0xc000382240?}, {0x3d4a7c8, 0xb}, 0x3a55320, 0x0)
    /usr/local/go/src/reflect/value.go:3072 +0x28b
reflect.Value.Set({0x3a55320?, 0xc004acfea0?, 0x8080808080808057?}, {0x3375340?, 0x4512860?, 0x6994280?})
    /usr/local/go/src/reflect/value.go:2057 +0xe6
github.com/flant/addon-operator/pkg/module_manager/go_hook.(*Wrapped).UnmarshalTo(0x160?, {0x3269f40?, 0xc004acfea0?})
    /go/pkg/mod/github.com/flant/addon-operator@v1.11.4/pkg/module_manager/go_hook/filter_result.go:41 +0x405
github.com/deckhouse/deckhouse/modules/500-upmeter/hooks.removeStsUpmeter.SnapshotIter[...].func1(...)
    /go/pkg/mod/github.com/deckhouse/module-sdk@v0.3.7/pkg/object-patch/snapshots.go:31
github.com/deckhouse/deckhouse/modules/500-upmeter/hooks.removeStsUpmeter(0xc0003e63f0)
    /deckhouse/modules/500-upmeter/hooks/remove_old_sts.go:89 +0x119
github.com/flant/addon-operator/pkg/module_manager/models/hooks/kind.(*GoHook).Run(...)
    /go/pkg/mod/github.com/flant/addon-operator@v1.11.4/pkg/module_manager/models/hooks/kind/gohook.go:66
github.com/flant/addon-operator/pkg/module_manager/models/hooks/kind.(*GoHook).Execute(0xc000d40000, {0xd?, 0xc000382d68?}, {0x1?, 0x1?}, {0xc005423960, 0x1, 0x819e3d?}, {0xc009dc7c28, 0x7}, ...)
    /go/pkg/mod/github.com/flant/addon-operator@v1.11.4/pkg/module_manager/models/hooks/kind/gohook.go:149 +0x469
github.com/flant/addon-operator/pkg/module_manager/models/modules.(*BasicModule).executeHook(0xc001211e00, {0x45542b8, 0xc005891a40}, 0xc004c8e420, {0x3d443cd, 0xa}, {0xc005423960, 0x1, 0x1}, 0xc004abd2f0, ...)
    /go/pkg/mod/github.com/flant/addon-operator@v1.11.4/pkg/module_manager/models/modules/basic.go:1035 +0xdea
github.com/flant/addon-operator/pkg/module_manager/models/modules.(*BasicModule).RunHookByName(0xc001211e00, {0x45542b8, 0xc005891a40}, {0x51b5d6a, 0x23}, {0x3d443cd, 0xa}, {0xc00399fc00, 0x1, 0x1}, ...)
    /go/pkg/mod/github.com/flant/addon-operator@v1.11.4/pkg/module_manager/models/modules/basic.go:694 +0x407
github.com/flant/addon-operator/pkg/module_manager.(*ModuleManager).RunModuleHook(0xc006299b80?, {0x45542b8, 0xc005891a40}, {0xc001504954?, 0x0?}, {0x51b5d6a, 0x23}, {0x3d443cd, 0xa}, {0xc00399fc00, ...}, ...)
    /go/pkg/mod/github.com/flant/addon-operator@v1.11.4/pkg/module_manager/module_manager.go:804 +0xb7
github.com/flant/addon-operator/pkg/task/tasks/module-hook-run.(*Task).Handle(0xc004ace4b0, {0x45542f0, 0xc0004f64b0})
    /go/pkg/mod/github.com/flant/addon-operator@v1.11.4/pkg/task/tasks/module-hook-run/task.go:200 +0xba5
github.com/flant/addon-operator/pkg/task/service.(*TaskHandlerService).Handle(0xc00238caa0, {0x45542f0, 0xc0004f64b0}, {0x4581f90, 0xc006299b80})
    /go/pkg/mod/github.com/flant/addon-operator@v1.11.4/pkg/task/service/service.go:136 +0x168
github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start.func1()
    /go/pkg/mod/github.com/flant/shell-operator@v1.10.4/pkg/task/queue/task_queue_list.go:860 +0x343
created by github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start in goroutine 734
    /go/pkg/mod/github.com/flant/shell-operator@v1.10.4/pkg/task/queue/task_queue_list.go:814 +0xa5
```

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: fix panic on snapshotIter
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
