### PR TITLE
[dhctl] Refactor resources: reduce APIResources calls

### DIFF
--- a/dhctl/pkg/kubernetes/actions/resources/resouce_ready.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resouce_ready.go
@@ -83,8 +83,13 @@ func (c *resourceReadinessChecker) IsReady(ctx context.Context) (bool, error) {
 		c.logger.LogDebugF("Skip resource % readiness checking for waiting set status\n", name)
 		return false, nil
 	}
+	apiRes, err := c.kubeCl.APIResource(c.resource.GVK.Group+"/"+c.resource.GVK.Version, kind)
+	if err != nil {
+		c.logger.LogDebugF("Could not get APIResource %s with Kind %s: %s\n", c.resource.GVK.Group+"/"+c.resource.GVK.Version, kind, err.Error())
+		return false, nil
+	}
 
-	gvr, doc, err := resourceToGVR(c.kubeCl, c.resource)
+	gvr, doc, err := resourceToGVR(c.resource, *apiRes)
 	if err != nil {
 		logNotReadyYet()
 		c.logger.LogDebugF("Resource %s to GVR failed: %s\n", name, err)

--- a/dhctl/pkg/kubernetes/client/client.go
+++ b/dhctl/pkg/kubernetes/client/client.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+
 	// oidc allows using oidc provider in kubeconfig
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
@@ -42,6 +43,7 @@ type KubeClient interface {
 	APIResourceList(apiVersion string) ([]*metav1.APIResourceList, error)
 	APIResource(apiVersion, kind string) (*metav1.APIResource, error)
 	GroupVersionResource(apiVersion, kind string) (schema.GroupVersionResource, error)
+	InvalidateDiscoveryCache()
 }
 
 // KubernetesClient connects to kubernetes API server through ssh tunnel and kubectl proxy.


### PR DESCRIPTION
## Description

Refactor resources processing in dhctl: reduce APIResources/APIResourcesList api calls

## Why do we need it, and what problem does it solve?

By single resource creation, we calls APIResources/APIResourcesList up to 4 time for the same data.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Refactoring of resources creation in dhctl.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
