### PR TITLE
[kube-dns] enable readOnlyRootFilesystem

### DIFF
--- a/modules/000-common/images/coredns/mount-points.yaml
+++ b/modules/000-common/images/coredns/mount-points.yaml
@@ -1,0 +1,2 @@
+dirs:
+- /etc/coredns

--- a/modules/000-common/images/coredns/werf.inc.yaml
+++ b/modules/000-common/images/coredns/werf.inc.yaml
@@ -46,6 +46,8 @@ import:
     add: /coredns
     to: /coredns
     before: setup
+git:
+{{- include "image mount points" . }}
 imageSpec:
   config:
     entrypoint: ["/coredns"]

--- a/modules/042-kube-dns/images/sts-pods-hosts-appender-webhook/src/main.go
+++ b/modules/042-kube-dns/images/sts-pods-hosts-appender-webhook/src/main.go
@@ -96,6 +96,7 @@ func addInitContainerToPod(_ context.Context, _ *kwhmodel.AdmissionReview, obj m
 
 	runAsUser := int64(65534)
 	runAsGroup := int64(65534)
+	readOnlyRootFileSystem := true
 	initContainer := corev1.Container{
 		Name:         "render-etc-hosts-with-cluster-domain-aliases",
 		Image:        os.Getenv("INIT_CONTAINER_IMAGE"),
@@ -113,8 +114,9 @@ func addInitContainerToPod(_ context.Context, _ *kwhmodel.AdmissionReview, obj m
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"all"},
 			},
-			RunAsUser:  &runAsUser,
-			RunAsGroup: &runAsGroup,
+			RunAsUser:              &runAsUser,
+			RunAsGroup:             &runAsGroup,
+			ReadOnlyRootFilesystem: &readOnlyRootFileSystem,
 		},
 	}
 

--- a/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/deployment.yaml
+++ b/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/deployment.yaml
@@ -56,7 +56,7 @@ spec:
       - name: deckhouse-registry
       containers:
         - name: webhook
-          {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+          {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 10 }}
           image: {{ include "helm_lib_module_image" (list . "stsPodsHostsAppenderWebhook") }}
           command:
           - /sts-pods-hosts-appender-webhook

--- a/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/deployment.yaml
+++ b/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/deployment.yaml
@@ -56,6 +56,7 @@ spec:
       - name: deckhouse-registry
       containers:
         - name: webhook
+          {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
           image: {{ include "helm_lib_module_image" (list . "stsPodsHostsAppenderWebhook") }}
           command:
           - /sts-pods-hosts-appender-webhook


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

All containers of the kube-dns module have the readOnlyRootFilesystem setting set to true.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need it to meet security concerns and overall hardening of the DKP platform.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: kube-dns
type: chore
summary: The readOnlyRootFilesystem security option is set to true for all containers.
impact: The kube-dns webhook pod will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
