### PR TITLE
[deckhouse] Fix edition list in hook check_deckhouse_edition.go

### DIFF
--- a/modules/002-deckhouse/hooks/check_deckhouse_edition.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_edition.go
@@ -43,12 +43,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			FilterFunc: applyModuleConfigFilter,
 		},
 	},
-	Schedule: []go_hook.ScheduleConfig{
-		{
-			Name:    "moduleconfigs",
-			Crontab: "*/1 * * * *", // every minute
-		},
-	},
 }, handleModuleConfigWrap())
 
 var reEditionFromPath = regexp.MustCompile(`^/deckhouse/(.+)$`)

--- a/modules/002-deckhouse/hooks/check_deckhouse_edition.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_edition.go
@@ -52,7 +52,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, handleModuleConfigWrap())
 
 var reEditionFromPath = regexp.MustCompile(`^/deckhouse/(.+)$`)
-var allExpectedEditions = []string{"ce", "be", "ee", "se", "se-plus"}
+var allExpectedEditions = []string{"ce", "be", "ee", "se", "se-plus", "fe"}
 
 func applyModuleConfigFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	edition, _, _ := unstructured.NestedString(obj.Object, "spec", "settings", "license", "edition")


### PR DESCRIPTION
## Description
Fix alert `DeckhouseEditionNotFound` for edition, that not included in editions list.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: fix editions list in check deckhouse edition hook
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
